### PR TITLE
refactor: ⚙️ Avatar "company" variant always show initials

### DIFF
--- a/src/components/designSystem/Avatar.tsx
+++ b/src/components/designSystem/Avatar.tsx
@@ -4,7 +4,6 @@ import { ReactNode } from 'react'
 import { theme } from '~/styles'
 
 import { Typography } from './Typography'
-import { Icon } from './Icon'
 
 const AVATAR_PALETTE = {
   orange: '#FF9351',
@@ -104,22 +103,13 @@ export const Avatar = ({
   }
 
   const getContent = () => {
-    switch (true) {
-      case size === 'small':
-        return (
-          <Typography color="inherit" variant={mapTypographyVariant(size)}>
-            {initials.substring(0, 1).toUpperCase()}
-          </Typography>
-        )
-      case variant === 'company':
-        return <Icon name="company" size={size as AvatarSize} color="light" />
-      default:
-        return (
-          <Typography color="inherit" variant={mapTypographyVariant(size)}>
-            {initials.substring(0, 2).toUpperCase()}
-          </Typography>
-        )
-    }
+    let cursor = size === 'small' ? 1 : 2
+
+    return (
+      <Typography color="inherit" variant={mapTypographyVariant(size)}>
+        {initials.substring(0, cursor).toUpperCase()}
+      </Typography>
+    )
   }
 
   const backgroundColorKey = getBackgroundColorKey(identifier)


### PR DESCRIPTION
This MR aims to align the Avatar component's behaviour with the design system

## Current situation

Today, Avatar component follows this implementation rule

<img src="https://user-images.githubusercontent.com/5517077/175320820-cacecbf0-8b1c-4081-bb4b-befc1a8ea9b7.png" width="200px" />

Please not that the company column shows an Icon in medium and large size display.

## Changes

According to the design system, company should always show organization's initial.
- Small size should display the first letter
- medium and large sizes should display the first 2 letters

<img src="https://user-images.githubusercontent.com/5517077/175321417-95483a32-97c8-4a0e-b14a-c2561f83c191.png" width="200px" />
 