### PR TITLE
chore: refactor combobox to send either value or null

### DIFF
--- a/src/components/customers/AddCustomerDialog.tsx
+++ b/src/components/customers/AddCustomerDialog.tsx
@@ -77,7 +77,6 @@ export const AddCustomerDialog = forwardRef<DialogRef, AddCustomerDialogProps>(
       validateOnMount: true,
       enableReinitialize: true,
       onSubmit: async (values, formikBag) => {
-        values.country = values?.country || null
         const answer = await onSave(values)
         const { errors } = answer
         const error = !errors ? undefined : (errors[0]?.extensions as LagoGQLError['extensions'])

--- a/src/components/form/ComboBox/ComboBoxField.tsx
+++ b/src/components/form/ComboBox/ComboBoxField.tsx
@@ -18,7 +18,7 @@ export const ComboBoxField = ({ name, formikProps, ...props }: ComboBoxFieldProp
     <ComboBox
       name={name}
       value={_get(values, name)}
-      onChange={(newValue) => setFieldValue(name, newValue)}
+      onChange={(newValue) => setFieldValue(name, newValue || null)}
       {...props}
     />
   )

--- a/src/components/settings/EditOrganizationInformationsDialog.tsx
+++ b/src/components/settings/EditOrganizationInformationsDialog.tsx
@@ -96,7 +96,6 @@ export const EditOrganizationInformationsDialog = forwardRef<
     enableReinitialize: true,
     validateOnMount: true,
     onSubmit: async (values) => {
-      values.country = values?.country || null
       await updateOrganizationInformations({
         variables: {
           input: {

--- a/src/hooks/useCreateEditCustomer.ts
+++ b/src/hooks/useCreateEditCustomer.ts
@@ -173,23 +173,21 @@ export const useCreateEditCustomer: UseCreateEditCustomer = ({ customer }) => {
     billingInfos: data?.customer,
     loadBillingInfos: !!customer ? getBillingInfos : undefined,
     onSave: !!customer
-      ? async ({ stripeCustomer, paymentProvider, ...values }) =>
+      ? async ({ stripeCustomer, ...values }) =>
           await update({
             variables: {
               input: {
                 id: customer?.id as string,
-                paymentProvider: paymentProvider || null,
                 stripeCustomer: { ..._omit(stripeCustomer, 'id') },
                 ...values,
               },
             },
           })
-      : async ({ stripeCustomer, paymentProvider, ...values }) =>
+      : async ({ stripeCustomer, ...values }) =>
           await create({
             variables: {
               input: {
                 ...values,
-                paymentProvider: paymentProvider || null,
                 stripeCustomer: { ..._omit(stripeCustomer, 'id') },
               },
             },


### PR DESCRIPTION
This MR fixes a behaviour of the combobox component.

We agreed on setting either the value or null when using this component.

So there is no need to force null on each usages.