### PR TITLE
Uniform formik usage 🥋

### DIFF
--- a/src/components/addOns/AddOnForm.tsx
+++ b/src/components/addOns/AddOnForm.tsx
@@ -149,7 +149,6 @@ export const AddOnForm = ({ isEdition, loading, addOn, onSave }: AddOnFormProps)
                   disabled={!formikProps.isValid || (isEdition && !formikProps.dirty)}
                   fullWidth
                   size="large"
-                  loading={formikProps.isSubmitting}
                   onClick={formikProps.submitForm}
                 >
                   {translate(

--- a/src/components/billableMetrics/BillableMetricForm.tsx
+++ b/src/components/billableMetrics/BillableMetricForm.tsx
@@ -203,7 +203,6 @@ export const BillableMetricForm = ({
                   disabled={!formikProps.isValid || (isEdition && !formikProps.dirty)}
                   fullWidth
                   size="large"
-                  loading={formikProps.isSubmitting}
                   onClick={formikProps.submitForm}
                 >
                   {translate(

--- a/src/components/coupons/CouponForm.tsx
+++ b/src/components/coupons/CouponForm.tsx
@@ -191,7 +191,6 @@ export const CouponForm = ({ isEdition, loading, coupon, onSave }: CouponFormPro
                   disabled={!formikProps.isValid || (isEdition && !formikProps.dirty)}
                   fullWidth
                   size="large"
-                  loading={formikProps.isSubmitting}
                   onClick={formikProps.submitForm}
                 >
                   {translate(

--- a/src/components/customers/AddAddOnToCustomerDialog.tsx
+++ b/src/components/customers/AddAddOnToCustomerDialog.tsx
@@ -155,10 +155,7 @@ export const AddAddOnToCustomerDialog = forwardRef<
           >
             {translate('text_629781ec7c6c1500d94fbb1c')}
           </Button>
-          <Button
-            disabled={!formikProps.isValid}
-            onClick={async () => await formikProps.handleSubmit()}
-          >
+          <Button disabled={!formikProps.isValid} onClick={formikProps.submitForm}>
             {translate('text_629781ec7c6c1500d94fbb24')}
           </Button>
         </>

--- a/src/components/customers/AddCouponToCustomerDialog.tsx
+++ b/src/components/customers/AddCouponToCustomerDialog.tsx
@@ -161,10 +161,7 @@ export const AddCouponToCustomerDialog = forwardRef<
           >
             {translate('text_628b8c693e464200e00e4693')}
           </Button>
-          <Button
-            disabled={!formikProps.isValid}
-            onClick={async () => await formikProps.handleSubmit()}
-          >
+          <Button disabled={!formikProps.isValid} onClick={formikProps.submitForm}>
             {translate('text_628b8c693e464200e00e46a1')}
           </Button>
         </>

--- a/src/components/customers/AddCustomerDialog.tsx
+++ b/src/components/customers/AddCustomerDialog.tsx
@@ -165,7 +165,7 @@ export const AddCustomerDialog = forwardRef<DialogRef, AddCustomerDialogProps>(
             <Button
               disabled={!formikProps.isValid || (isEdition && !formikProps.dirty)}
               loading={formikProps.isSubmitting}
-              onClick={async () => await formikProps.handleSubmit()}
+              onClick={formikProps.submitForm}
             >
               {translate(
                 isEdition ? 'text_6261712bff79eb00ed02907b' : 'text_624efab67eb2570101d117eb'

--- a/src/components/plans/PlanForm.tsx
+++ b/src/components/plans/PlanForm.tsx
@@ -391,7 +391,6 @@ export const PlanForm = ({ loading, plan, children, onSave, isEdition }: PlanFor
                     disabled={!formikProps.isValid || (isEdition && !formikProps.dirty)}
                     fullWidth
                     size="large"
-                    loading={formikProps.isSubmitting}
                     onClick={formikProps.submitForm}
                   >
                     {translate(

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -100,12 +100,7 @@ const Login = () => {
             placeholder={translate('text_620bc4d4269a55014d493f5b')}
           />
 
-          <SubmitButton
-            fullWidth
-            size="large"
-            loading={formikProps.isSubmitting}
-            onClick={formikProps.submitForm}
-          >
+          <SubmitButton fullWidth size="large" onClick={formikProps.submitForm}>
             {translate('text_620bc4d4269a55014d493f6d')}
           </SubmitButton>
         </form>


### PR DESCRIPTION
This MR aims to refactor and uniform some of our form usage and the way we display loading spinners on submit buttons.

`Button` components does show loading spinner automatically if the `onClick` function returns a promise.

Which mean we can remove the `async` / `await` usage in the and run the `submitForm` method everywhere.


This refactor was initiated by this comment: https://github.com/getlago/lago-front/pull/194#discussion_r907458657 