### PR TITLE
chore: lint error on alert and debugger

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,9 @@
     "sourceType": "module"
   },
   "rules": {
+    "no-alert": "error",
     "no-console": 2,
+    "no-debugger": "error",
     "@typescript-eslint/no-explicit-any": 2,
     "@typescript-eslint/no-non-null-assertion": 2,
     "react/react-in-jsx-scope": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,23 +19,23 @@
   },
   "rules": {
     "no-alert": "error",
-    "no-console": 2,
+    "no-console": "error",
     "no-debugger": "error",
-    "@typescript-eslint/no-explicit-any": 2,
-    "@typescript-eslint/no-non-null-assertion": 2,
-    "react/react-in-jsx-scope": 0,
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "react/react-in-jsx-scope": "off",
     "no-shadow": "off", // replaced by ts-eslint rule below
     "@typescript-eslint/no-shadow": "error",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",
     "newline-after-var": ["warn"],
     "import/order": [
-      2,
+      "error",
       {
         "groups": ["builtin", "external", "internal", "unknown", "sibling", "parent", "index"],
         "newlines-between": "always"
       }
     ],
-    "react/display-name": 1
+    "react/display-name": "warn"
   }
 }


### PR DESCRIPTION
This MR adds 2 eslint rules to prevent us having `alert` and `debugger` in the code.

I also took the opportunity to use explicit lint behaviour definition string instead of using integer 
https://eslint.org/docs/latest/user-guide/configuring/rules