### PR TITLE
Set webSocketURL for dev env

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -74,6 +74,9 @@ module.exports = (env) =>
       },
       client: {
         overlay: true,
+        webSocketURL: {
+          port: 443,
+        },
       },
       allowedHosts: ['app.lago.dev'],
     },


### PR DESCRIPTION
This MR fixes the websocket in dev env.

It simply sets the websocket port to use the one already allowed by traefik

Fixes https://github.com/getlago/lago-front/issues/142