### PR TITLE
chore: 🫀 Add APP_ENV to env config

### DIFF
--- a/.env.sh
+++ b/.env.sh
@@ -4,5 +4,7 @@ rm -rf ./env-config.js
 touch ./env-config.js
 
 api_url_value=$(echo $API_URL)
+app_env_value=$(echo $APP_ENV)
 
 echo "window.API_URL = \"$api_url_value\"" >> ./env-config.js
+echo "window.APP_ENV = \"$app_env_value\"" >> ./env-config.js


### PR DESCRIPTION
This is to be able to have `APP_ENV` available from the env var