### PR TITLE
fix: 📅 Date picker error formik

### DIFF
--- a/src/components/form/DatePicker/DatePicker.tsx
+++ b/src/components/form/DatePicker/DatePicker.tsx
@@ -12,8 +12,14 @@ import { theme } from '~/styles'
 import { Button, Tooltip } from '~/components/designSystem'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
+export enum DATE_PICKER_ERROR_ENUM {
+  invalid = 'invalid',
+}
 export interface DatePickerProps
-  extends Omit<TextInputProps, 'value' | 'onChange' | 'beforeChangeFormatter' | 'password'> {
+  extends Omit<
+    TextInputProps,
+    'value' | 'onChange' | 'beforeChangeFormatter' | 'password' | 'onError'
+  > {
   className?: string
   value?: string | null
   placeholder?: string
@@ -22,6 +28,7 @@ export interface DatePickerProps
   disableFuture?: boolean
   disablePast?: boolean
   placement?: MuiPopperProps['placement']
+  onError?: (err: keyof typeof DATE_PICKER_ERROR_ENUM | undefined) => void
   onChange: (value?: string | null) => void
 }
 
@@ -38,6 +45,7 @@ export const DatePicker = ({
   placeholder,
   disabled,
   placement = 'bottom-end',
+  onError,
   onChange,
   ...props
 }: DatePickerProps) => {
@@ -99,7 +107,10 @@ export const DatePicker = ({
             const formattedDate = (date as unknown as DateTime)?.toISO()
 
             if ((date as unknown as DateTime)?.isValid || !date) {
+              onError && onError(undefined)
               onChange(formattedDate)
+            } else {
+              onError && onError(DATE_PICKER_ERROR_ENUM.invalid)
             }
           }}
           renderInput={({ inputRef, inputProps, InputProps }) => {

--- a/src/components/form/DatePicker/DatePickerField.tsx
+++ b/src/components/form/DatePicker/DatePickerField.tsx
@@ -5,7 +5,7 @@ import _get from 'lodash/get'
 
 import { DatePicker, DatePickerProps } from './DatePicker'
 
-interface DatePickerFieldFormProps extends Omit<DatePickerProps, 'name' | 'onChange'> {
+interface DatePickerFieldFormProps extends Omit<DatePickerProps, 'name' | 'onChange' | 'onError'> {
   name: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   formikProps: FormikProps<any>
@@ -13,7 +13,7 @@ interface DatePickerFieldFormProps extends Omit<DatePickerProps, 'name' | 'onCha
 
 export const DatePickerField = memo(
   ({ name, formikProps, ...props }: DatePickerFieldFormProps) => {
-    const { values, errors, touched, handleBlur, setFieldValue } = formikProps
+    const { values, errors, touched, handleBlur, setFieldValue, setFieldError } = formikProps
 
     return (
       <DatePicker
@@ -21,6 +21,7 @@ export const DatePickerField = memo(
         onBlur={handleBlur}
         value={_get(values, name)}
         error={touched[name] ? (errors[name] as string) : undefined}
+        onError={(err) => setFieldError(name, err)}
         onChange={(value: string | null | undefined) => {
           setFieldValue(name, value)
         }}


### PR DESCRIPTION
When used with formik, DatePicker does not give the information that the date is invalid