### PR TITLE
bug: adjust picker position in edit modal

### DIFF
--- a/src/components/form/DatePicker/DatePicker.tsx
+++ b/src/components/form/DatePicker/DatePicker.tsx
@@ -86,7 +86,16 @@ export const DatePicker = ({
                 name: 'offset',
                 enabled: true,
                 options: {
-                  offset: [0, 8],
+                  // @ts-ignore
+                  offset: ({ reference }) => {
+                    // Re-calculate picker position if placed on the left.
+                    // Removes the input width and twice the picker icon "box" (24*2)
+                    if (placement.includes('left')) {
+                      return [0, -(reference.width - 48)]
+                    } else {
+                      return [0, 8]
+                    }
+                  },
                 },
               },
             ],

--- a/src/components/wallets/UpdateCustomerWalletDialog.tsx
+++ b/src/components/wallets/UpdateCustomerWalletDialog.tsx
@@ -115,7 +115,7 @@ export const UpdateCustomerWalletDialog = forwardRef<DialogRef, UpdateCustomerWa
           <DatePickerField
             disablePast
             name="expirationDate"
-            placement="top-end"
+            placement="left-start"
             label={translate('text_62d94fc982c82f068d3753c7')}
             placeholder={translate('text_62d94fc982c82f068d3753c9')}
             helperText={translate('text_62d94fc982c82f068d3753cb')}


### PR DESCRIPTION
This MR fixed the datePicker position in wallet edit modal.

As the picker position is calculated based on the input size and position (not the calendar icon), I had to manually adjust the picker offset when the picker had to be displayed on the left.

It takes the width of the input (`reference.width`) and removes twice the width of the icon "box" (24*2)

Before

<img width="612" alt="image" src="https://user-images.githubusercontent.com/5517077/182409980-224f0cd5-5faa-4a57-bae5-b9ccb93a6eb8.png">


After 

<img width="606" alt="image" src="https://user-images.githubusercontent.com/5517077/182565194-7cd0749a-0955-4027-8f12-778d5ec36c2a.png">

