### PR TITLE
fix: 🐹 Charge accordion display

### DIFF
--- a/src/components/form/Radio/Radio.tsx
+++ b/src/components/form/Radio/Radio.tsx
@@ -51,7 +51,6 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(
           )}
         </RadioContainer>
         <Typography
-          variant="captionHl"
           color={disabled ? 'disabled' : 'textSecondary'}
           component={(labelProps) => <label htmlFor={name} {...labelProps} />}
         >

--- a/src/components/plans/ChargeAccordion.tsx
+++ b/src/components/plans/ChargeAccordion.tsx
@@ -238,6 +238,7 @@ const Title = styled.div`
   flex-direction: column;
   white-space: pre;
   min-width: 20px;
+  margin-right: auto;
 `
 
 const LineAmount = styled.div`


### PR DESCRIPTION
<img width="743" alt="image" src="https://user-images.githubusercontent.com/9316820/183701632-cdf311f2-e8d8-4428-89ba-99928c404f2b.png">

https://www.notion.so/getlago/Charge-s-trash-should-be-display-on-the-right-side-of-the-selector-a926555a55cc406e97d4280310d66e72