### PR TITLE
fix: ✂️ prevent focus ring cut in plan form

### DIFF
--- a/src/components/plans/ChargeAccordion.tsx
+++ b/src/components/plans/ChargeAccordion.tsx
@@ -184,7 +184,7 @@ const StyledAccordion = styled(Accordion)`
     height: 0;
   }
   &.MuiAccordion-root.Mui-expanded {
-    margin: 0 0 ${theme.spacing(4)};
+    margin: 0;
   }
 
   .MuiAccordionSummary-content {
@@ -225,7 +225,7 @@ const Details = styled(AccordionDetails)`
   box-shadow: ${theme.shadows[5]};
 
   &.MuiAccordionDetails-root {
-    padding: ${theme.spacing(4)} ${theme.spacing(4)} 0 ${theme.spacing(4)};
+    padding: ${theme.spacing(4)};
 
     > *:not(:last-child) {
       margin-bottom: ${theme.spacing(6)};


### PR DESCRIPTION
Fix focus ring cut on plan form

BEFORE
![CleanShot 2022-08-10 at 14 24 53@2x](https://user-images.githubusercontent.com/5517077/183918288-b88712e0-cda0-471d-9a24-d754c267afbf.png)



AFTER


<img width="660" alt="image" src="https://user-images.githubusercontent.com/5517077/183918344-e43cee2c-dfe5-4d1b-8f72-5beb4fab2a20.png">
