### PR TITLE
chore: 🦷 EnvGlobalVar expose env variables

### DIFF
--- a/.env.sh
+++ b/.env.sh
@@ -5,6 +5,8 @@ touch ./env-config.js
 
 api_url_value=$(echo $API_URL)
 app_env_value=$(echo $APP_ENV)
+lago_signup_disabled_value=$(echo $LAGO_SIGNUP_DISABLED)
 
 echo "window.API_URL = \"$api_url_value\"" >> ./env-config.js
 echo "window.APP_ENV = \"$app_env_value\"" >> ./env-config.js
+echo "window.LAGO_SIGNUP_DISABLED = \"$lago_signup_disabled_value\"" >> ./env-config.js

--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,3 @@
 API_URL=http://localhost:3000
-APP_VERSION=0.0.1
 APP_ENV=development
 CODEGEN_API=http://api.lago.dev/graphql

--- a/src/components/addOns/AddOnCodeSnippet.tsx
+++ b/src/components/addOns/AddOnCodeSnippet.tsx
@@ -1,11 +1,14 @@
 import { CodeSnippet } from '~/components/CodeSnippet'
 import { CreateAddOnInput } from '~/generated/graphql'
+import { envGlobalVar } from '~/core/apolloClient'
+
+const { apiUrl } = envGlobalVar()
 
 const getSnippets = (addOn?: CreateAddOnInput) => {
   if (!addOn || !addOn.code) return '# Fill the form to generate the code snippet'
 
   return `# Assign an add on to a customer
-curl --location --request POST "${API_URL}/api/v1/applied_add_ons" \\
+curl --location --request POST "${apiUrl}/api/v1/applied_add_ons" \\
   --header "Authorization: Bearer $API_KEY" \\
   --header 'Content-Type: application/json' \\
   --data-raw '{

--- a/src/components/billableMetrics/BillableMetricCodeSnippet.tsx
+++ b/src/components/billableMetrics/BillableMetricCodeSnippet.tsx
@@ -1,5 +1,8 @@
 import { AggregationTypeEnum, CreateBillableMetricInput } from '~/generated/graphql'
 import { CodeSnippet } from '~/components/CodeSnippet'
+import { envGlobalVar } from '~/core/apolloClient'
+
+const { apiUrl } = envGlobalVar()
 
 const getSnippets = (billableMetric?: CreateBillableMetricInput) => {
   if (!billableMetric) return '# Fill the form to generate the code snippet'
@@ -8,7 +11,7 @@ const getSnippets = (billableMetric?: CreateBillableMetricInput) => {
 
   switch (aggregationType) {
     case AggregationTypeEnum.CountAgg:
-      return `curl --location --request POST "${API_URL}/api/v1/events" \\
+      return `curl --location --request POST "${apiUrl}/api/v1/events" \\
   --header "Authorization: Bearer $__YOUR_API_KEY__" \\
   --header 'Content-Type: application/json' \\
   --data-raw '{
@@ -42,7 +45,7 @@ const getSnippets = (billableMetric?: CreateBillableMetricInput) => {
 # To use the snippet, don’t forget to edit your __YOUR_API_KEY__, __UNIQUE_ID__, __SUBSCRIPTION_ID__ and __CUSTOMER_ID__`
     case AggregationTypeEnum.SumAgg:
     case AggregationTypeEnum.MaxAgg:
-      return `curl --location --request POST "${API_URL}/api/v1/events" \\
+      return `curl --location --request POST "${apiUrl}/api/v1/events" \\
   --header "Authorization: Bearer $__YOUR_API_KEY__" \\
   --header 'Content-Type: application/json' \\
   --data-raw '{

--- a/src/components/coupons/CouponCodeSnippet.tsx
+++ b/src/components/coupons/CouponCodeSnippet.tsx
@@ -1,11 +1,14 @@
 import { CodeSnippet } from '~/components/CodeSnippet'
 import { CreateCouponInput } from '~/generated/graphql'
+import { envGlobalVar } from '~/core/apolloClient'
+
+const { apiUrl } = envGlobalVar()
 
 const getSnippets = (coupon?: CreateCouponInput) => {
   if (!coupon || !coupon.code) return '# Fill the form to generate the code snippet'
 
   return `# Assign a coupon to a customer
-curl --location --request POST "${API_URL}/api/v1/applied_coupons" \\
+curl --location --request POST "${apiUrl}/api/v1/applied_coupons" \\
   --header "Authorization: Bearer $YOUR_API_KEY" \\
   --header 'Content-Type: application/json' \\
   --data-raw '{

--- a/src/components/plans/PlanCodeSnippet.tsx
+++ b/src/components/plans/PlanCodeSnippet.tsx
@@ -1,12 +1,15 @@
 import { CodeSnippet } from '~/components/CodeSnippet'
+import { envGlobalVar } from '~/core/apolloClient'
 
 import { PlanFormInput } from './types'
+
+const { apiUrl } = envGlobalVar()
 
 const getSnippets = (plan?: PlanFormInput) => {
   if (!plan) return '# Fill the form to generate the code snippet'
 
   return `# Assign a plan to a customer
-curl --location --request POST "${API_URL}/api/v1/subscriptions" \\
+curl --location --request POST "${apiUrl}/api/v1/subscriptions" \\
   --header "Authorization: Bearer $YOUR_API_KEY" \\
   --header 'Content-Type: application/json' \\
   --data-raw '{

--- a/src/core/apolloClient/init.ts
+++ b/src/core/apolloClient/init.ts
@@ -9,7 +9,7 @@ import localForage from 'localforage'
 import { Lago_Api_Error } from '~/generated/graphql'
 
 import { cache } from './cache'
-import { AUTH_TOKEN_LS_KEY, ORGANIZATION_LS_KEY, addToast } from './reactiveVars'
+import { AUTH_TOKEN_LS_KEY, ORGANIZATION_LS_KEY, addToast, envGlobalVar } from './reactiveVars'
 import { logOut, getItemFromLS, omitDeep } from './utils'
 import { typeDefs, resolvers } from './graphqlResolvers'
 
@@ -23,8 +23,8 @@ export interface LagoGQLError extends GraphQLError {
 let globalApolloClient: ApolloClient<NormalizedCacheObject> | null = null
 
 const TIMEOUT = 300000 // 5 minutes timeout
-
 const timeoutLink = new ApolloLinkTimeout(TIMEOUT)
+const { apiUrl, appVersion } = envGlobalVar()
 
 export const initializeApolloClient = async () => {
   if (globalApolloClient) return globalApolloClient
@@ -100,7 +100,7 @@ export const initializeApolloClient = async () => {
     }),
     // afterwareLink.concat(
     createUploadLink({
-      uri: `${API_URL || window.API_URL}/graphql`,
+      uri: `${apiUrl}/graphql`,
     }) as unknown as ApolloLink,
     // ),
   ]
@@ -109,14 +109,14 @@ export const initializeApolloClient = async () => {
     cache,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     storage: new LocalForageWrapper(localForage),
-    key: `apollo-cache-persist-${APP_VERSION || '0.0.0'}`,
+    key: `apollo-cache-persist-lago-${appVersion}`,
   })
 
   const client = new ApolloClient({
     cache,
     link: ApolloLink.from(links),
     name: 'lago-app',
-    version: APP_VERSION,
+    version: appVersion,
     typeDefs,
     resolvers,
     defaultOptions: {

--- a/src/core/apolloClient/reactiveVars/envGlobalVar.ts
+++ b/src/core/apolloClient/reactiveVars/envGlobalVar.ts
@@ -1,0 +1,17 @@
+import { makeVar } from '@apollo/client'
+
+import { AppEnvEnum } from '~/globalTypes'
+
+interface EnvGlobal {
+  appEnv: AppEnvEnum
+  apiUrl: string
+  disableSignUp: boolean
+  appVersion: string
+}
+
+export const envGlobalVar = makeVar<EnvGlobal>({
+  appEnv: window.APP_ENV || APP_ENV,
+  apiUrl: window.API_URL || API_URL,
+  disableSignUp: window.LAGO_SIGNUP_DISABLED || LAGO_SIGNUP_DISABLED || false,
+  appVersion: APP_VERSION,
+})

--- a/src/core/apolloClient/reactiveVars/index.ts
+++ b/src/core/apolloClient/reactiveVars/index.ts
@@ -7,6 +7,7 @@ export const isAuthenticatedVar = makeVar<boolean>(!!getItemFromLS(AUTH_TOKEN_LS
 
 export * from './authTokenVar'
 export * from './currentUserInfosVar'
+export * from './envGlobalVar'
 export * from './internationalizationVar'
 export * from './locationHistoryVar'
 export * from './toastVar'

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -2,6 +2,9 @@ import { lazy } from 'react'
 import type { RouteObject } from 'react-router-dom'
 
 import { AppEnvEnum } from '~/globalTypes'
+import { envGlobalVar } from '~/core/apolloClient'
+
+const { appEnv, disableSignUp } = envGlobalVar()
 
 const Error404 = lazy(() => import(/* webpackChunkName: 'error-404' */ '~/pages/Error404'))
 const Login = lazy(() => import(/* webpackChunkName: 'login' */ '~/pages/auth/Login'))
@@ -213,7 +216,7 @@ export const routes: CustomRouteObject[] = [
         private: true,
         element: <AddOnsList />,
       },
-      ...([AppEnvEnum.qa, AppEnvEnum.development].includes(window.APP_ENV || APP_ENV)
+      ...([AppEnvEnum.qa, AppEnvEnum.development].includes(appEnv)
         ? [
             {
               path: [ONLY_DEV_DESIGN_SYSTEM_ROUTE, ONLY_DEV_DESIGN_SYSTEM_TAB_ROUTE],
@@ -253,7 +256,7 @@ export const routes: CustomRouteObject[] = [
     element: <ForgotPassword />,
     onlyPublic: true,
   },
-  ...(!LAGO_SIGNUP_DISABLED
+  ...(!disableSignUp
     ? [
         {
           path: SIGN_UP_ROUTE,

--- a/src/hooks/core/useInternationalization.ts
+++ b/src/hooks/core/useInternationalization.ts
@@ -2,6 +2,9 @@ import { useCallback } from 'react'
 
 import { IntlLocale, useInternationalizationVar, updateIntlLocale } from '~/core/apolloClient'
 import { AppEnvEnum } from '~/globalTypes'
+import { envGlobalVar } from '~/core/apolloClient'
+
+const { appEnv } = envGlobalVar()
 
 type UseInternationalization = () => {
   locale: IntlLocale
@@ -46,7 +49,7 @@ export const useInternationalization: UseInternationalization = () => {
         }
 
         if (!translations || !translations[key]) {
-          if ([AppEnvEnum.qa, AppEnvEnum.development].includes(window.APP_ENV || APP_ENV)) {
+          if ([AppEnvEnum.qa, AppEnvEnum.development].includes(appEnv)) {
             // eslint-disable-next-line no-console
             console.warn(`Translation '${key}' for locale '${locale}' not found.`)
           }

--- a/src/index.js
+++ b/src/index.js
@@ -3,16 +3,17 @@ import * as Sentry from '@sentry/react'
 import { BrowserTracing } from '@sentry/tracing'
 
 import App from '~/App'
+import { envGlobalVar } from '~/core/apolloClient'
 
 import { AppEnvEnum } from './globalTypes'
 
-const environment = window.APP_ENV || APP_ENV
+const { appEnv } = envGlobalVar()
 
-if (environment !== AppEnvEnum.development) {
+if (appEnv !== AppEnvEnum.development) {
   Sentry.init({
     dsn: 'https://3dedf10cc2614403886aa3784388a366@o554090.ingest.sentry.io/6458937',
     integrations: [new BrowserTracing()],
-    environment,
+    environment: appEnv,
   })
 }
 

--- a/src/layouts/SideNavLayout.tsx
+++ b/src/layouts/SideNavLayout.tsx
@@ -7,7 +7,7 @@ import { useApolloClient } from '@apollo/client'
 import { useLocation, Location } from 'react-router-dom'
 
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { logOut, useCurrentUserInfosVar } from '~/core/apolloClient'
+import { logOut, useCurrentUserInfosVar, envGlobalVar } from '~/core/apolloClient'
 import { AppEnvEnum } from '~/globalTypes'
 import {
   Avatar,
@@ -39,6 +39,7 @@ import {
 import { useCurrentVersionQuery } from '~/generated/graphql'
 
 const NAV_WIDTH = 240
+const { appEnv } = envGlobalVar()
 
 gql`
   query CurrentVersion {
@@ -196,7 +197,7 @@ const SideNav = () => {
               <NavigationTab
                 onClick={() => setOpen(false)}
                 tabs={[
-                  ...([AppEnvEnum.qa, AppEnvEnum.development].includes(window.APP_ENV || APP_ENV)
+                  ...([AppEnvEnum.qa, AppEnvEnum.development].includes(appEnv)
                     ? [
                         {
                           title: 'Design System',

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -7,11 +7,13 @@ import { theme } from '~/styles'
 import { Typography, Button, Alert } from '~/components/designSystem'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useLoginUserMutation, Lago_Api_Error, CurrentUserFragmentDoc } from '~/generated/graphql'
-import { onLogIn } from '~/core/apolloClient'
+import { onLogIn, envGlobalVar } from '~/core/apolloClient'
 import { TextInputField } from '~/components/form'
 import { FORGOT_PASSWORD_ROUTE, SIGN_UP_ROUTE } from '~/core/router'
 import { Page, Title, Subtitle, StyledLogo, Card } from '~/styles/auth'
 import { useShortcuts } from '~/hooks/ui/useShortcuts'
+
+const { disableSignUp } = envGlobalVar()
 
 gql`
   mutation loginUser($input: LoginUserInput!) {
@@ -110,7 +112,7 @@ const Login = () => {
             linkForgetPassword: FORGOT_PASSWORD_ROUTE,
           })}
         />
-        {!LAGO_SIGNUP_DISABLED && (
+        {!disableSignUp && (
           <UsefullLink
             variant="caption"
             html={translate('text_62c84d0029355c83db4dd186', {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -3,6 +3,8 @@ const path = require('path')
 
 const webpack = require('webpack')
 
+const { version } = require('./package.json')
+
 const APP_ENV = process.env.APP_ENV ?? 'development'
 
 module.exports = () => {
@@ -27,7 +29,7 @@ module.exports = () => {
       new webpack.DefinePlugin({
         APP_ENV: JSON.stringify(APP_ENV),
         API_URL: JSON.stringify(process.env.API_URL),
-        APP_VERSION: JSON.stringify(process.env.APP_VERSION), // TODO - not passed on the cloud
+        APP_VERSION: JSON.stringify(version),
         LAGO_SIGNUP_DISABLED: process.env.LAGO_SIGNUP_DISABLED,
       }),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4556,7 +4556,7 @@ auto-bind@~4.0.0:
   resolved "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz"
   integrity sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==
 
-auto-changelog@^2.4.0:
+auto-changelog@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/auto-changelog/-/auto-changelog-2.4.0.tgz#a2d57d49b70ada7ca2e7c6a20a71572561d19cd9"
   integrity sha512-vh17hko1c0ItsEcw6m7qPRf3m45u+XK5QyCrrBFViElZ8jnKrPC1roSznrd1fIB/0vR/zawdECCRJtTuqIXaJw==


### PR DESCRIPTION
Avoid the need to check `window.` vs global variables in the app and get the variables from the `envGlobalVar` reactivevar