### PR TITLE
feat: 🪲 Debug dialog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -24,5 +24,10 @@ assignees: MorganeLecurieux
 **Screenshots**
 <!--- If applicable, add screenshots to help explain your problem. -->
 
+**Environment infos**
+<!--- Please go to the running app and use the Ctrl + I shortcut
+    Then copy/past the given infos here
+  -->
+
 **Additional context**
 <!--- Add any other context about the problem here. -->

--- a/ditto/base.json
+++ b/ditto/base.json
@@ -1,4 +1,13 @@
 {
+  "text_62f50d3cc15266f3bd1d83ce": "Infos copy to clipboard",
+  "text_62f50d26c989ab0319688498": "Environment information",
+  "text_62f50d26c989ab031968849a": "Use and share those information if you’re <a rel=\"external\" target=\"_blank\" href=\"https://github.com/getlago/lago-front/issues/new?labels=%F0%9F%90%9E+bug&template=bug.md&title=%5BBUG%5D\">reporting a bug to Lago</a>",
+  "text_62f50d26c989ab031968849e": "App environment ",
+  "text_62f50d26c989ab03196884a2": "API URL",
+  "text_62f50d26c989ab03196884a6": "User ID",
+  "text_62f50d26c989ab03196884aa": "App version",
+  "text_62f50d26c989ab03196884ac": "Copy all info",
+  "text_62f50d26c989ab03196884ae": "Close",
   "text_62c6c95fe73d08be5b86c334": "Version",
   "text_6295e58352f39200d902b01c": "Documentation",
   "text_6295e58352f39200d902b02a": "Apply add-on",

--- a/ditto/config.yml
+++ b/ditto/config.yml
@@ -57,5 +57,7 @@ projects:
     id: 62c6c95d9333c1ac1be9f938
   - name: 'Plans,Customers - Add multiple plans to a customer'
     id: 62d7f6138ca07e88551c9dde
+  - name: '⚙️ [WIP] - General - FE environment infos'
+    id: 62f50d2512182c6df6c39e37
 format: flat
 variants: true

--- a/ditto/index.js
+++ b/ditto/index.js
@@ -83,6 +83,9 @@ module.exports = {
   "project_6271200612648800e9bdfd47": {
     "base": require('./Settings - Webhooks in app__base.json')
   },
+  "project_62f50d2512182c6df6c39e37": {
+    "base": require('./⚙️ [WIP] - General - FE environment infos__base.json')
+  },
   "project_62c6c95d9333c1ac1be9f938": {
     "base": require('./👍 [Ready for dev] - Navigation - Display app version__base.json')
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from '@mui/material'
 import { ApolloClient, NormalizedCacheObject, ApolloProvider } from '@apollo/client'
@@ -10,9 +10,19 @@ import { ToastContainer } from '~/components/designSystem/Toasts'
 import { inputGlobalStyles } from '~/styles/globalStyle'
 import { ErrorBoundary } from '~/components/ErrorBoundary'
 import { RouteWrapper } from '~/components/RouteWrapper'
+import { useShortcuts } from '~/hooks/ui/useShortcuts'
+import { DebugInfoDialog, DebugInfoDialogRef } from '~/components/DebugInfoDialog'
 
 const App = () => {
   const [client, setClient] = useState<ApolloClient<NormalizedCacheObject> | null>(null)
+  const debugInfoDialogRef = useRef<DebugInfoDialogRef>(null)
+
+  useShortcuts([
+    {
+      keys: ['Ctrl', 'KeyI'],
+      action: () => debugInfoDialogRef.current?.openDialog(),
+    },
+  ])
 
   useEffect(() => {
     async function initApolloClient() {
@@ -37,6 +47,7 @@ const App = () => {
           </ErrorBoundary>
           <UserIdentifier />
           <ToastContainer />
+          <DebugInfoDialog ref={debugInfoDialogRef} />
         </ThemeProvider>
       </ApolloProvider>
     </BrowserRouter>

--- a/src/components/DebugInfoDialog.tsx
+++ b/src/components/DebugInfoDialog.tsx
@@ -1,0 +1,94 @@
+import { forwardRef } from 'react'
+import styled from 'styled-components'
+
+import { Dialog, DialogRef, Typography, Button } from '~/components/designSystem'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { envGlobalVar, useCurrentUserInfosVar, addToast } from '~/core/apolloClient'
+import { theme } from '~/styles'
+
+const { appEnv, apiUrl, appVersion } = envGlobalVar()
+
+export interface DebugInfoDialogRef extends DialogRef {}
+
+export const DebugInfoDialog = forwardRef<DialogRef>(({}, ref) => {
+  const { translate } = useInternationalization()
+  const { user } = useCurrentUserInfosVar()
+
+  return (
+    <Dialog
+      ref={ref}
+      title={translate('text_62f50d26c989ab0319688498')}
+      description={<Typography html={translate('text_62f50d26c989ab031968849a')} />}
+      actions={({ closeDialog }) => (
+        <>
+          <Button
+            variant="quaternary"
+            onClick={() => {
+              navigator.clipboard.writeText(
+                `### Environment informations
+**App environment :** ${appEnv}
+**API URL :** ${apiUrl} 
+**Version :** ${appVersion}` +
+                  (!!user?.id
+                    ? `
+**User Id :** ${user?.id}`
+                    : '')
+              )
+
+              addToast({
+                severity: 'info',
+                translateKey: 'text_62f50d3cc15266f3bd1d83ce',
+              })
+            }}
+          >
+            {translate('text_62f50d26c989ab03196884ac')}
+          </Button>
+          <Button onClick={closeDialog}>{translate('text_62f50d26c989ab03196884ae')}</Button>
+        </>
+      )}
+    >
+      <Content>
+        <Line>
+          <Typography variant="caption">{translate('text_62f50d26c989ab031968849e')}</Typography>
+          <Typography color="textSecondary">{appEnv}</Typography>
+        </Line>
+        <Line>
+          <Typography variant="caption">{translate('text_62f50d26c989ab03196884a2')}</Typography>
+          <Typography color="textSecondary">{apiUrl}</Typography>
+        </Line>
+        <Line>
+          <Typography variant="caption">{translate('text_62f50d26c989ab03196884aa')}</Typography>
+          <Typography color="textSecondary">{appVersion}</Typography>
+        </Line>
+        {user?.id && (
+          <Line>
+            <Typography variant="caption">{translate('text_62f50d26c989ab03196884a6')}</Typography>
+            <Typography color="textSecondary">{user?.id}</Typography>
+          </Line>
+        )}
+      </Content>
+    </Dialog>
+  )
+})
+
+const Content = styled.div`
+  > *:not(:last-child) {
+    margin-bottom: ${theme.spacing(3)};
+  }
+  > *:last-child {
+    margin-bottom: ${theme.spacing(8)};
+  }
+`
+
+const Line = styled.div`
+  display: flex;
+  align-items: baseline;
+
+  > *:first-child {
+    width: 140px;
+    min-width: 140px;
+    margin-right: ${theme.spacing(3)};
+  }
+`
+
+DebugInfoDialog.displayName = 'DebugInfoDialog'

--- a/src/hooks/ui/__tests__/useShortcuts.test.tsx
+++ b/src/hooks/ui/__tests__/useShortcuts.test.tsx
@@ -83,6 +83,32 @@ describe('useShortcuts()', () => {
     })
   })
 
+  describe('when additionnal keys are pressed', () => {
+    let action = jest.fn()
+    let shortcuts: Shortcut[] = [
+      {
+        action,
+        keys: ['Cmd', 'KeyD'],
+        disabled: false,
+      },
+    ]
+
+    it('should not fire the action', () => {
+      render(
+        <div>
+          <MyTestComponentThatUsesShortcuts shortcuts={shortcuts} />
+        </div>
+      )
+
+      // cf: https://testing-library.com/docs/ecosystem-user-event#keyboardtext-options
+      userEvent.keyboard('{Meta}')
+      userEvent.keyboard('I')
+      userEvent.keyboard('D')
+
+      expect(action).not.toHaveBeenCalled()
+    })
+  })
+
   describe('getCleanKey()', () => {
     it('should clean keys correctly', () => {
       expect(getCleanKey('MetaLeft')).toEqual('Cmd')


### PR DESCRIPTION
<img width="1095" alt="image" src="https://user-images.githubusercontent.com/9316820/184181514-fcaa8187-6df4-4a25-9f19-2d3fc9c0ccba.png">


## Context

While a UI problem is reported by a user, today we have no way to easily know some informations. An option would be to have a debug dialog with useful informations in it.

## Spec

- [ ]  Dialog is openable on any page through a shortcut (CTRL + I)
- [ ]  Dialogs hold the following infos :
- App environnement (Production, Dev, Staging, Qa)
- Api URL
- Current user id (if logged)
- App version (need a loading state and error state)
- [ ]  There is a button that allow to copy to clipboard all those informations
- [ ]  There is a button that close the dialog

→ Dialog is openable on Self-hosted and Cloud version

→ Dialog is openable on any page even if a dialog or a drawer is already displayed.

→ By closing the Env. dialog, the dialog or the drawer remains open

Notion : https://www.notion.so/getlago/Dialog-FE-environment-infos-c618f8db22ea42988e4af446c62da890