### PR TITLE
chore: 🧹 Remove amountCurrency on charges

### DIFF
--- a/src/components/customers/usage/UsageItem.tsx
+++ b/src/components/customers/usage/UsageItem.tsx
@@ -17,13 +17,12 @@ gql`
   query customerUsage($customerId: ID!, $subscriptionId: ID!) {
     customerUsage(customerId: $customerId, subscriptionId: $subscriptionId) {
       amountCents
-      totalAmountCurrency
+      amountCurrency
       fromDate
       toDate
       chargesUsage {
         units
         amountCents
-        amountCurrency
         billableMetric {
           id
           code
@@ -46,6 +45,7 @@ export const UsageItem = ({ customerId, subscription }: UsageItemProps) => {
   const [fetchUsage, { data, error, loading, refetch }] = useCustomerUsageLazyQuery({
     variables: { customerId: customerId, subscriptionId: id },
   })
+  const currency = data?.customerUsage?.amountCurrency
 
   return (
     <Container>
@@ -146,7 +146,7 @@ export const UsageItem = ({ customerId, subscription }: UsageItemProps) => {
                     <Typography color="textSecondary">
                       {intlFormatNumber(data?.customerUsage?.amountCents || 0, {
                         currencyDisplay: 'code',
-                        currency: data?.customerUsage?.totalAmountCurrency,
+                        currency,
                       })}
                     </Typography>
                   </UsageHeader>
@@ -167,7 +167,7 @@ export const UsageItem = ({ customerId, subscription }: UsageItemProps) => {
                       )
                     })
                   : data?.customerUsage?.chargesUsage?.map((usage, i) => {
-                      const { billableMetric, units, amountCents, amountCurrency } = usage
+                      const { billableMetric, units, amountCents } = usage
 
                       return (
                         <ItemContainer key={`customer-usage-${i}`}>
@@ -182,7 +182,7 @@ export const UsageItem = ({ customerId, subscription }: UsageItemProps) => {
                             <Typography color="textSecondary">
                               {intlFormatNumber(amountCents || 0, {
                                 currencyDisplay: 'code',
-                                currency: amountCurrency,
+                                currency,
                               })}
                             </Typography>
                           </Line>

--- a/src/components/plans/ChargeAccordion.tsx
+++ b/src/components/plans/ChargeAccordion.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, MouseEvent } from 'react'
+import { useState, useCallback, MouseEvent } from 'react'
 import { Accordion, AccordionSummary, AccordionDetails } from '@mui/material'
 import { FormikProps } from 'formik'
 import styled from 'styled-components'
@@ -40,10 +40,6 @@ export const ChargeAccordion = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [index, formikProps.setFieldValue]
   )
-
-  useEffect(() => {
-    handleUpdate('amountCurrency', currency)
-  }, [currency, handleUpdate])
 
   return (
     <Container id={id}>
@@ -142,13 +138,18 @@ export const ChargeAccordion = ({
                   value: currencyType,
                 }))}
                 disableClearable
-                value={localCharge.amountCurrency}
+                value={currency}
                 onChange={() => {}}
               />
             </LineAmount>
           )}
           {localCharge.chargeModel === ChargeModelEnum.Package && (
-            <PackageCharge disabled={disabled} chargeIndex={index} formikProps={formikProps} />
+            <PackageCharge
+              currency={currency}
+              disabled={disabled}
+              chargeIndex={index}
+              formikProps={formikProps}
+            />
           )}
           {localCharge.chargeModel === ChargeModelEnum.Graduated && (
             <GraduatedChargeTable
@@ -159,7 +160,12 @@ export const ChargeAccordion = ({
             />
           )}
           {localCharge.chargeModel === ChargeModelEnum.Percentage && (
-            <ChargePercentage disabled={disabled} chargeIndex={index} formikProps={formikProps} />
+            <ChargePercentage
+              currency={currency}
+              disabled={disabled}
+              chargeIndex={index}
+              formikProps={formikProps}
+            />
           )}
         </Details>
       </StyledAccordion>

--- a/src/components/plans/ChargePercentage.tsx
+++ b/src/components/plans/ChargePercentage.tsx
@@ -8,16 +8,23 @@ import { TextInput } from '~/components/form'
 import { MenuPopper, theme } from '~/styles'
 import { Alert, Typography, Button, Tooltip, Popper } from '~/components/designSystem'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { CurrencyEnum } from '~/generated/graphql'
 
 import { PlanFormInput } from './types'
 
 interface ChargePercentageProps {
   disabled?: boolean
   chargeIndex: number
+  currency: CurrencyEnum
   formikProps: FormikProps<PlanFormInput>
 }
 
-export const ChargePercentage = ({ disabled, chargeIndex, formikProps }: ChargePercentageProps) => {
+export const ChargePercentage = ({
+  currency,
+  disabled,
+  chargeIndex,
+  formikProps,
+}: ChargePercentageProps) => {
   const { translate } = useInternationalization()
   const localCharge = formikProps.values.charges[chargeIndex]
   const showRate = localCharge.rate !== undefined && localCharge.rate !== ''
@@ -31,7 +38,7 @@ export const ChargePercentage = ({ disabled, chargeIndex, formikProps }: ChargeP
   let freeUnitsPerTotalAggregationTranslation = translate('text_6303351deffd2a0d70498677', {
     freeAmountUnits: intlFormatNumber(Number(localCharge.freeUnitsPerTotalAggregation) * 100 || 0, {
       currencyDisplay: 'code',
-      currency: localCharge.amountCurrency,
+      currency,
       maximumFractionDigits: 5,
     }),
   })
@@ -84,7 +91,7 @@ export const ChargePercentage = ({ disabled, chargeIndex, formikProps }: ChargeP
             value={localCharge.fixedAmount || ''}
             onChange={(value) => handleUpdate('fixedAmount', value)}
             InputProps={{
-              endAdornment: <InputEnd color="textSecondary">{localCharge.amountCurrency}</InputEnd>,
+              endAdornment: <InputEnd color="textSecondary">{currency}</InputEnd>,
             }}
             helperText={translate('text_62ff5d01a306e274d4ffcc30')}
           />
@@ -167,7 +174,7 @@ export const ChargePercentage = ({ disabled, chargeIndex, formikProps }: ChargeP
             value={localCharge.freeUnitsPerTotalAggregation || ''}
             onChange={(value) => handleUpdate('freeUnitsPerTotalAggregation', value)}
             InputProps={{
-              endAdornment: <InputEnd color="textSecondary">{localCharge.amountCurrency}</InputEnd>,
+              endAdornment: <InputEnd color="textSecondary">{currency}</InputEnd>,
             }}
           />
           <Tooltip
@@ -273,7 +280,7 @@ export const ChargePercentage = ({ disabled, chargeIndex, formikProps }: ChargeP
               {translate('text_62ff5d01a306e274d4ffcc69', {
                 fixedFeeValue: intlFormatNumber(Number(localCharge.fixedAmount) * 100 || 0, {
                   currencyDisplay: 'code',
-                  currency: localCharge.amountCurrency,
+                  currency,
                   maximumFractionDigits: 5,
                 }),
               })}

--- a/src/components/plans/PackageCharge.tsx
+++ b/src/components/plans/PackageCharge.tsx
@@ -16,10 +16,16 @@ import { PlanFormInput } from './types'
 interface PackageChargeProps {
   disabled?: boolean
   chargeIndex: number
+  currency: CurrencyEnum
   formikProps: FormikProps<PlanFormInput>
 }
 
-export const PackageCharge = ({ disabled, chargeIndex, formikProps }: PackageChargeProps) => {
+export const PackageCharge = ({
+  currency,
+  disabled,
+  chargeIndex,
+  formikProps,
+}: PackageChargeProps) => {
   const { translate } = useInternationalization()
   const localCharge = formikProps.values.charges[chargeIndex]
 
@@ -57,7 +63,7 @@ export const PackageCharge = ({ disabled, chargeIndex, formikProps }: PackageCha
             value: currencyType,
           }))}
           disableClearable
-          value={localCharge.amountCurrency}
+          value={currency}
           onChange={() => {}}
         />
       </LineAmount>
@@ -113,7 +119,7 @@ export const PackageCharge = ({ disabled, chargeIndex, formikProps }: PackageCha
                   currencyDisplay: 'code',
                   initialUnit: 'standard',
                   maximumFractionDigits: 5,
-                  currency: localCharge.amountCurrency,
+                  currency,
                 }),
               })}
             </Typography>
@@ -126,7 +132,7 @@ export const PackageCharge = ({ disabled, chargeIndex, formikProps }: PackageCha
                     currencyDisplay: 'code',
                     initialUnit: 'standard',
                     maximumFractionDigits: 5,
-                    currency: localCharge.amountCurrency,
+                    currency,
                   }),
                 })}
               </Typography>
@@ -140,7 +146,7 @@ export const PackageCharge = ({ disabled, chargeIndex, formikProps }: PackageCha
                   currencyDisplay: 'code',
                   initialUnit: 'standard',
                   maximumFractionDigits: 5,
-                  currency: localCharge.amountCurrency,
+                  currency,
                 }),
               })}
             </Typography>
@@ -152,7 +158,7 @@ export const PackageCharge = ({ disabled, chargeIndex, formikProps }: PackageCha
                   currencyDisplay: 'code',
                   initialUnit: 'standard',
                   maximumFractionDigits: 5,
-                  currency: localCharge.amountCurrency,
+                  currency,
                 }),
               })}
             </Typography>

--- a/src/components/plans/PlanForm.tsx
+++ b/src/components/plans/PlanForm.tsx
@@ -97,12 +97,6 @@ export const PlanForm = ({ loading, plan, children, onSave, isEdition }: PlanFor
               [ChargeModelEnum.Standard, ChargeModelEnum.Package].includes(chargeModel),
             then: number().typeError(translate('text_624ea7c29103fd010732ab7d')).required(''),
           }),
-          amountCurrency: string().when('chargeModel', {
-            is: (chargeModel: ChargeModelEnum) =>
-              !!chargeModel &&
-              [ChargeModelEnum.Standard, ChargeModelEnum.Package].includes(chargeModel),
-            then: string().required(''),
-          }),
           packageSize: number().when('chargeModel', {
             is: (chargeModel: ChargeModelEnum) =>
               !!chargeModel && ChargeModelEnum.Package === chargeModel,
@@ -438,7 +432,6 @@ export const PlanForm = ({ loading, plan, children, onSave, isEdition }: PlanFor
                         billableMetric: newCharge,
                         chargeModel: ChargeModelEnum.Standard,
                         amountCents: undefined,
-                        amountCurrency: formikProps.values.amountCurrency,
                       },
                     ])
                     setNewChargeId(newId)

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -141,7 +141,6 @@ export enum BillingTimeEnum {
 export type Charge = {
   __typename?: 'Charge';
   amount?: Maybe<Scalars['String']>;
-  amountCurrency?: Maybe<CurrencyEnum>;
   billableMetric: BillableMetric;
   chargeModel: ChargeModelEnum;
   createdAt: Scalars['ISO8601DateTime'];
@@ -158,7 +157,6 @@ export type Charge = {
 
 export type ChargeInput = {
   amount?: InputMaybe<Scalars['String']>;
-  amountCurrency: CurrencyEnum;
   billableMetricId: Scalars['ID'];
   chargeModel: ChargeModelEnum;
   fixedAmount?: InputMaybe<Scalars['String']>;
@@ -175,13 +173,13 @@ export enum ChargeModelEnum {
   Graduated = 'graduated',
   Package = 'package',
   Percentage = 'percentage',
-  Standard = 'standard'
+  Standard = 'standard',
+  Volume = 'volume'
 }
 
 export type ChargeUsage = {
   __typename?: 'ChargeUsage';
   amountCents: Scalars['BigInt'];
-  amountCurrency: CurrencyEnum;
   billableMetric: BillableMetric;
   charge: Charge;
   units: Scalars['Float'];
@@ -1394,10 +1392,8 @@ export type Invoice = {
   __typename?: 'Invoice';
   amountCents: Scalars['Int'];
   amountCurrency: CurrencyEnum;
-  chargesFromDate?: Maybe<Scalars['ISO8601Date']>;
   createdAt: Scalars['ISO8601DateTime'];
   fileUrl?: Maybe<Scalars['String']>;
-  fromDate: Scalars['ISO8601Date'];
   id: Scalars['ID'];
   invoiceType: InvoiceTypeEnum;
   issuingDate: Scalars['ISO8601Date'];
@@ -1406,7 +1402,6 @@ export type Invoice = {
   sequentialId: Scalars['ID'];
   status: InvoiceStatusTypeEnum;
   subscription?: Maybe<Subscription>;
-  toDate: Scalars['ISO8601Date'];
   totalAmountCents: Scalars['Int'];
   totalAmountCurrency: CurrencyEnum;
   updatedAt: Scalars['ISO8601DateTime'];
@@ -1981,7 +1976,6 @@ export type Subscription = {
   nextName?: Maybe<Scalars['String']>;
   nextPendingStartDate?: Maybe<Scalars['ISO8601Date']>;
   nextPlan?: Maybe<Plan>;
-  pendingStartDate?: Maybe<Scalars['ISO8601Date']>;
   plan: Plan;
   startedAt?: Maybe<Scalars['ISO8601DateTime']>;
   status?: Maybe<StatusTypeEnum>;
@@ -2420,7 +2414,7 @@ export type CustomerUsageQueryVariables = Exact<{
 }>;
 
 
-export type CustomerUsageQuery = { __typename?: 'Query', customerUsage: { __typename?: 'CustomerUsage', amountCents: any, totalAmountCurrency: CurrencyEnum, fromDate: any, toDate: any, chargesUsage: Array<{ __typename?: 'ChargeUsage', units: number, amountCents: any, amountCurrency: CurrencyEnum, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string } }> } };
+export type CustomerUsageQuery = { __typename?: 'Query', customerUsage: { __typename?: 'CustomerUsage', amountCents: any, amountCurrency: CurrencyEnum, fromDate: any, toDate: any, chargesUsage: Array<{ __typename?: 'ChargeUsage', units: number, amountCents: any, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string } }> } };
 
 export type EventItemFragment = { __typename?: 'Event', id: string, code: string, customerId: string, timestamp?: any | null, matchBillableMetric: boolean, matchCustomField: boolean };
 
@@ -2498,14 +2492,14 @@ export type DeleteStripeMutationVariables = Exact<{
 
 export type DeleteStripeMutation = { __typename?: 'Mutation', destroyPaymentProvider?: { __typename?: 'DestroyPaymentProviderPayload', id?: string | null } | null };
 
-export type EditPlanFragment = { __typename?: 'PlanDetails', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, amountCents: number, amountCurrency: CurrencyEnum, trialPeriod?: number | null, canBeDeleted: boolean, billChargesMonthly?: boolean | null, charges?: Array<{ __typename?: 'Charge', id: string, amount?: string | null, amountCurrency?: CurrencyEnum | null, chargeModel: ChargeModelEnum, freeUnits?: number | null, packageSize?: number | null, rate?: string | null, fixedAmount?: string | null, freeUnitsPerEvents?: number | null, freeUnitsPerTotalAggregation?: string | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, code: string }, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null }> | null };
+export type EditPlanFragment = { __typename?: 'PlanDetails', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, amountCents: number, amountCurrency: CurrencyEnum, trialPeriod?: number | null, canBeDeleted: boolean, billChargesMonthly?: boolean | null, charges?: Array<{ __typename?: 'Charge', id: string, amount?: string | null, chargeModel: ChargeModelEnum, freeUnits?: number | null, packageSize?: number | null, rate?: string | null, fixedAmount?: string | null, freeUnitsPerEvents?: number | null, freeUnitsPerTotalAggregation?: string | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, code: string }, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null }> | null };
 
 export type GetSinglePlanQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetSinglePlanQuery = { __typename?: 'Query', plan?: { __typename?: 'PlanDetails', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, amountCents: number, amountCurrency: CurrencyEnum, trialPeriod?: number | null, canBeDeleted: boolean, billChargesMonthly?: boolean | null, charges?: Array<{ __typename?: 'Charge', id: string, amount?: string | null, amountCurrency?: CurrencyEnum | null, chargeModel: ChargeModelEnum, freeUnits?: number | null, packageSize?: number | null, rate?: string | null, fixedAmount?: string | null, freeUnitsPerEvents?: number | null, freeUnitsPerTotalAggregation?: string | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, code: string }, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null }> | null } | null };
+export type GetSinglePlanQuery = { __typename?: 'Query', plan?: { __typename?: 'PlanDetails', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, amountCents: number, amountCurrency: CurrencyEnum, trialPeriod?: number | null, canBeDeleted: boolean, billChargesMonthly?: boolean | null, charges?: Array<{ __typename?: 'Charge', id: string, amount?: string | null, chargeModel: ChargeModelEnum, freeUnits?: number | null, packageSize?: number | null, rate?: string | null, fixedAmount?: string | null, freeUnitsPerEvents?: number | null, freeUnitsPerTotalAggregation?: string | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, code: string }, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null }> | null } | null };
 
 export type CreatePlanMutationVariables = Exact<{
   input: CreatePlanInput;
@@ -2938,7 +2932,6 @@ export const EditPlanFragmentDoc = gql`
       toValue
     }
     amount
-    amountCurrency
     chargeModel
     freeUnits
     packageSize
@@ -3867,13 +3860,12 @@ export const CustomerUsageDocument = gql`
     query customerUsage($customerId: ID!, $subscriptionId: ID!) {
   customerUsage(customerId: $customerId, subscriptionId: $subscriptionId) {
     amountCents
-    totalAmountCurrency
+    amountCurrency
     fromDate
     toDate
     chargesUsage {
       units
       amountCents
-      amountCurrency
       billableMetric {
         id
         code

--- a/src/hooks/plans/useCreateEditPlan.ts
+++ b/src/hooks/plans/useCreateEditPlan.ts
@@ -42,7 +42,6 @@ gql`
         toValue
       }
       amount
-      amountCurrency
       chargeModel
       freeUnits
       packageSize


### PR DESCRIPTION
Stop using `amountCurrency` on `Charge` Type, use `plan.amountCurrency` instead

https://www.notion.so/getlago/Delivery-cockpit-d3511c278d574a3aa82986b0d7caf8e1?p=f656f3bc8f8f40fb9eee200a90d949f1&pm=s