### PR TITLE
chore: 🦬 Fix CI Events

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -2,7 +2,7 @@ name: Run Codegen
 
 on:
   pull_request:
-    types: [review_requested, ready_for_review, synchronize]
+    types: [opened, reopened, review_requested, ready_for_review, synchronize]
 
 jobs:
   codegen:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,7 +2,7 @@ name: TestE2E
 
 on:
   pull_request:
-    types: [review_requested, ready_for_review, synchronize]
+    types: [opened, reopened, review_requested, ready_for_review, synchronize]
 
 jobs:
   cypress-run: 


### PR DESCRIPTION
Codegen and E2E Tests will be now triggered when a PR is created or reopened (only if not draft)