### PR TITLE
bug: fix usage of subscription id and externalId

### DIFF
--- a/src/components/customers/subscriptions/CustomerSubscriptionsList.tsx
+++ b/src/components/customers/subscriptions/CustomerSubscriptionsList.tsx
@@ -117,7 +117,8 @@ export const CustomerSubscriptionsList = forwardRef<
                   {isDowngrading && !!nextPlan && (
                     <SubscriptionItem
                       ref={subscriptionItemRef}
-                      subscriptionId={externalId}
+                      subscriptionId={id}
+                      subscriptionExternalId={externalId}
                       subscriptionName={nextName}
                       date={nextPendingStartDate}
                       plan={nextPlan}
@@ -126,7 +127,8 @@ export const CustomerSubscriptionsList = forwardRef<
                   )}
                   <SubscriptionItem
                     ref={subscriptionItemRef}
-                    subscriptionId={externalId}
+                    subscriptionId={id}
+                    subscriptionExternalId={externalId}
                     subscriptionName={name}
                     date={startedAt}
                     plan={plan}

--- a/src/components/customers/subscriptions/SubscriptionItem.tsx
+++ b/src/components/customers/subscriptions/SubscriptionItem.tsx
@@ -33,6 +33,7 @@ gql`
 
 interface SubscriptionItemProps {
   subscriptionId: string
+  subscriptionExternalId: string
   subscriptionName?: string | null
   date: string
   plan: SubscriptionItemPlanFragment
@@ -46,7 +47,17 @@ export interface SubscriptionItemRef {
 }
 
 export const SubscriptionItem = forwardRef<SubscriptionItemRef, SubscriptionItemProps>(
-  ({ subscriptionId, subscriptionName, date, plan, isPending }: SubscriptionItemProps, ref) => {
+  (
+    {
+      subscriptionId,
+      subscriptionExternalId,
+      subscriptionName,
+      date,
+      plan,
+      isPending,
+    }: SubscriptionItemProps,
+    ref
+  ) => {
     const { translate } = useInternationalization()
     const { addSubscriptionDialogRef, editSubscriptionDialogRef, terminateSubscriptionDialogRef } =
       (ref as MutableRefObject<SubscriptionItemRef>)?.current
@@ -134,7 +145,7 @@ export const SubscriptionItem = forwardRef<SubscriptionItemRef, SubscriptionItem
                   variant="quaternary"
                   align="left"
                   onClick={() => {
-                    navigator.clipboard.writeText(subscriptionId)
+                    navigator.clipboard.writeText(subscriptionExternalId)
                     addToast({
                       severity: 'info',
                       translateKey: 'text_62d94cc9ccc5eebcc03160a0',


### PR DESCRIPTION
This PR does 2 things in customer subscription list:
- Uses the subscription id for all transactions with the backend
- Uses the subscription external id for the copy to clipboard