### PR TITLE
chore: workflows to be run on pull_request

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,8 @@
 name: Lint
 
-on: push
+on:
+  pull_request:
+    types: [opened, reopened, review_requested, ready_for_review, synchronize]
 
 jobs:
   run-linters:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: Tests
 
-on: push
+on:
+  pull_request:
+    types: [opened, reopened, review_requested, ready_for_review, synchronize]
 
 jobs:
   run-tests:

--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -1,6 +1,8 @@
 name: Translation Check
 
-on: push
+on:
+  pull_request:
+    types: [opened, reopened, review_requested, ready_for_review, synchronize]
 
 jobs:
   run-translation-check:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,6 +1,8 @@
 name: Typescript
 
-on: push
+on:
+  pull_request:
+    types: [opened, reopened, review_requested, ready_for_review, synchronize]
 
 jobs:
   run-typescript:


### PR DESCRIPTION
This PR udpates workflows to be run on pull request instead of push, so it can run on forked lago projects