### PR TITLE
fix: 🫡 rename LAGO_SIGNUP_DISABLED const

### DIFF
--- a/.env.sh
+++ b/.env.sh
@@ -5,8 +5,8 @@ touch ./env-config.js
 
 api_url_value=$(echo $API_URL)
 app_env_value=$(echo $APP_ENV)
-lago_signup_disabled_value=$(echo $LAGO_SIGNUP_DISABLED)
+lago_disable_signup_value=$(echo $LAGO_DISABLE_SIGNUP)
 
 echo "window.API_URL = \"$api_url_value\"" >> ./env-config.js
 echo "window.APP_ENV = \"$app_env_value\"" >> ./env-config.js
-echo "window.LAGO_SIGNUP_DISABLED = \"$lago_signup_disabled_value\"" >> ./env-config.js
+echo "window.LAGO_DISABLE_SIGNUP = \"$lago_disable_signup_value\"" >> ./env-config.js

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -43,7 +43,7 @@ module.exports = {
       new webpack.DefinePlugin({
         APP_ENV: JSON.stringify('production'),
         API_URL: JSON.stringify(process.env.API_URL),
-        LAGO_SIGNUP_DISABLED: process.env.LAGO_SIGNUP_DISABLED,
+        LAGO_DISABLE_SIGNUP: process.env.LAGO_DISABLE_SIGNUP,
         APP_VERSION: JSON.stringify('0.0'),
       })
     )

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -3,7 +3,7 @@ declare type AppEnvEnum = import('./src/globalTypes').AppEnvEnum
 declare var APP_ENV: AppEnvEnum
 declare var API_URL: string;
 declare var APP_VERSION: string;
-declare var LAGO_SIGNUP_DISABLED: boolean;
+declare var LAGO_DISABLE_SIGNUP: boolean;
 
 declare module "*.svg" {
   const content: any;

--- a/jest.config.js
+++ b/jest.config.js
@@ -54,6 +54,6 @@ module.exports = {
     API_URL: 'http://localhost:3000',
     APP_VERSION: '1.0.0',
     IS_REACT_ACT_ENVIRONMENT: true,
-    LAGO_SIGNUP_DISABLED: false,
+    LAGO_DISABLE_SIGNUP: false,
   },
 }

--- a/src/core/apolloClient/reactiveVars/envGlobalVar.ts
+++ b/src/core/apolloClient/reactiveVars/envGlobalVar.ts
@@ -12,6 +12,6 @@ interface EnvGlobal {
 export const envGlobalVar = makeVar<EnvGlobal>({
   appEnv: window.APP_ENV || APP_ENV,
   apiUrl: window.API_URL || API_URL,
-  disableSignUp: window.LAGO_SIGNUP_DISABLED || LAGO_SIGNUP_DISABLED || false,
+  disableSignUp: window.LAGO_DISABLE_SIGNUP || LAGO_DISABLE_SIGNUP || false,
   appVersion: APP_VERSION,
 })

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -30,7 +30,7 @@ module.exports = () => {
         APP_ENV: JSON.stringify(APP_ENV),
         API_URL: JSON.stringify(process.env.API_URL),
         APP_VERSION: JSON.stringify(version),
-        LAGO_SIGNUP_DISABLED: process.env.LAGO_SIGNUP_DISABLED,
+        LAGO_DISABLE_SIGNUP: process.env.LAGO_DISABLE_SIGNUP,
       }),
     ],
   }


### PR DESCRIPTION
This PR renames `LAGO_SIGNUP_DISABLED` env variable into `LAGO_DISABLE_SIGNUP`.

Reason is that the lago docker compose uses `LAGO_DISABLE_SIGNUP` so the signup disabling was never properly working.

We decided to rename the variable on frontend side to prevent any user to update their configuration after this renaming