### PR TITLE
chore: create artifact for no modules and delay jobs that needs it

### DIFF
--- a/.github/workflows/build-dependencies.yml
+++ b/.github/workflows/build-dependencies.yml
@@ -1,0 +1,31 @@
+name: Build node_modules
+
+on:
+  pull_request:
+    types: [opened, reopened, review_requested, ready_for_review, synchronize]
+
+jobs:
+  build-dependencies:
+    if: github.event.pull_request.draft == false
+    name: Build node_modules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+
+      - name: Install Node.js dependencies
+        run: yarn
+
+      - name: Zip node_modules artifact for other jobs
+        run: zip node_modules.zip ./node_modules/* -r
+
+      - name: Upload node_modules artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: node-modules-artifact
+          path: node_modules.zip

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,12 +1,15 @@
 name: Run Codegen
 
 on:
-  pull_request:
-    types: [opened, reopened, review_requested, ready_for_review, synchronize]
+  workflow_run:
+    branches:
+      - '**'
+    workflows: [Build node_modules]
+    types:
+      - completed
 
 jobs:
   codegen:
-    if: github.event.pull_request.draft == false
     name: Run Codegen
     runs-on: ubuntu-latest
     steps:
@@ -36,9 +39,14 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 14
+      
+      - name: Download node_modules artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: node-modules-artifact
 
-      - name: Install Node.js dependencies
-        run: yarn
+      - name: unzip artifact for node_modules
+        run: unzip node_modules.zip
 
       - name: Run codegen
         env:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,12 +1,15 @@
 name: TestE2E
 
 on:
-  pull_request:
-    types: [opened, reopened, review_requested, ready_for_review, synchronize]
+  workflow_run:
+    branches:
+      - '**'
+    workflows: [Build node_modules]        
+    types:
+      - completed
 
 jobs:
   cypress-run: 
-    if: github.event.pull_request.draft == false
     name: Run Test E2E
     runs-on: ubuntu-latest
     steps:
@@ -18,8 +21,13 @@ jobs:
         with:
           node-version: 14
 
-      - name: Install Node.js dependencies
-        run: yarn
+      - name: Download node_modules artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: node-modules-artifact
+
+      - name: unzip artifact for node_modules
+        run: unzip node_modules.zip
 
       - name: Build Front local image
         run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,8 +1,12 @@
 name: Lint
 
 on:
-  pull_request:
-    types: [opened, reopened, review_requested, ready_for_review, synchronize]
+  workflow_run:
+    branches:
+      - '**'
+    workflows: [Build node_modules]        
+    types:
+      - completed
 
 jobs:
   run-linters:
@@ -18,8 +22,13 @@ jobs:
           node-version: 14
 
       # ESLint and Prettier must be in `package.json`
-      - name: Install Node.js dependencies
-        run: yarn
+      - name: Download node_modules artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: node-modules-artifact
+
+      - name: unzip artifact for node_modules
+        run: unzip node_modules.zip
 
       - name: Run linters
         uses: wearerequired/lint-action@v2

--- a/.github/workflows/stories.yml
+++ b/.github/workflows/stories.yml
@@ -7,7 +7,6 @@ on:
       - 'src/components/designSystem/**'
 jobs:
   build-and-deploy:
-    if: github.event.pull_request.draft == false
     name: Build ad Deploy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,12 @@
 name: Tests
 
 on:
-  pull_request:
-    types: [opened, reopened, review_requested, ready_for_review, synchronize]
+  workflow_run:
+    branches:
+      - '**'
+    workflows: [Build node_modules]        
+    types:
+      - completed
 
 jobs:
   run-tests:
@@ -17,8 +21,13 @@ jobs:
         with:
           node-version: 14
 
-      - name: Install Node.js dependencies
-        run: yarn
+      - name: Download node_modules artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: node-modules-artifact
+
+      - name: unzip artifact for node_modules
+        run: unzip node_modules.zip
 
       - name: Run tests
         run: |

--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -1,8 +1,12 @@
 name: Translation Check
 
 on:
-  pull_request:
-    types: [opened, reopened, review_requested, ready_for_review, synchronize]
+  workflow_run:
+    branches:
+      - '**'
+    workflows: [Build node_modules]        
+    types:
+      - completed
 
 jobs:
   run-translation-check:
@@ -17,8 +21,13 @@ jobs:
         with:
           node-version: 14
 
-      - name: Install Node.js dependencies
-        run: yarn
+      - name: Download node_modules artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: node-modules-artifact
+
+      - name: unzip artifact for node_modules
+        run: unzip node_modules.zip
 
       - name: Run Translation Check
         run: |

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,8 +1,12 @@
 name: Typescript
 
 on:
-  pull_request:
-    types: [opened, reopened, review_requested, ready_for_review, synchronize]
+  workflow_run:
+    branches:
+      - '**'
+    workflows: [Build node_modules]        
+    types:
+      - completed
 
 jobs:
   run-typescript:
@@ -17,8 +21,13 @@ jobs:
         with:
           node-version: 14
 
-      - name: Install Node.js dependencies
-        run: yarn
+      - name: Download node_modules artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: node-modules-artifact
+
+      - name: unzip artifact for node_modules
+        run: unzip node_modules.zip
 
       - name: Run typescript
         run: |


### PR DESCRIPTION
This PR improves the CI pipeline by creating an artifact for node_modules, used by many other jobs.

It aims to makes the CI shorter of ~1min per jobs that uses it