### PR TITLE
fix(webpack): force process env variable to return a boolean

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -30,7 +30,7 @@ module.exports = () => {
         APP_ENV: JSON.stringify(APP_ENV),
         API_URL: JSON.stringify(process.env.API_URL),
         APP_VERSION: JSON.stringify(version),
-        LAGO_DISABLE_SIGNUP: process.env.LAGO_DISABLE_SIGNUP,
+        LAGO_DISABLE_SIGNUP: Boolean(process.env.LAGO_DISABLE_SIGNUP),
       }),
     ],
   }


### PR DESCRIPTION
## Context

App renders a blank page when a process env is not defined (default behaviour)

When Webpack runs, it removes all usages of this variable leading to syntax issues

## Description

We force the interpretation of an undefined variable to return a boolean. So we always have a value.

Note we'll also put a default value in lago docker-compose 