### PR TITLE
fix(customer): prevent error by resetting providerCustomerId to empty…

### DIFF
--- a/src/components/customers/AddCustomerDialog.tsx
+++ b/src/components/customers/AddCustomerDialog.tsx
@@ -122,7 +122,7 @@ export const AddCustomerDialog = forwardRef<DialogRef, AddCustomerDialogProps>(
     useEffect(() => {
       if (!formikProps.values.paymentProvider) {
         // If no payment provider, reset stripe customer
-        formikProps.setFieldValue('stripeCustomer.providerCustomerId', null)
+        formikProps.setFieldValue('stripeCustomer.providerCustomerId', '')
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [formikProps.values.paymentProvider])


### PR DESCRIPTION
## Context

When opening the edit customer dialog, we have most of the time a console warning about data type assigned to an inpoout not being correct

## Description

This issue is due to a manual reset we perform on `providerCustomerId` attribute, being reset to a `null` value instead of an empty string