### PR TITLE
fix(LAGO_DISABLE_SIGNUP): env var should be interpreted as a string

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -3,7 +3,7 @@ declare type AppEnvEnum = import('./src/globalTypes').AppEnvEnum
 declare var APP_ENV: AppEnvEnum
 declare var API_URL: string;
 declare var APP_VERSION: string;
-declare var LAGO_DISABLE_SIGNUP: boolean;
+declare var LAGO_DISABLE_SIGNUP: string;
 
 declare module "*.svg" {
   const content: any;

--- a/jest.config.js
+++ b/jest.config.js
@@ -54,6 +54,6 @@ module.exports = {
     API_URL: 'http://localhost:3000',
     APP_VERSION: '1.0.0',
     IS_REACT_ACT_ENVIRONMENT: true,
-    LAGO_DISABLE_SIGNUP: false,
+    LAGO_DISABLE_SIGNUP: 'false',
   },
 }

--- a/src/core/apolloClient/reactiveVars/envGlobalVar.ts
+++ b/src/core/apolloClient/reactiveVars/envGlobalVar.ts
@@ -12,6 +12,6 @@ interface EnvGlobal {
 export const envGlobalVar = makeVar<EnvGlobal>({
   appEnv: window.APP_ENV || APP_ENV,
   apiUrl: window.API_URL || API_URL,
-  disableSignUp: window.LAGO_DISABLE_SIGNUP || LAGO_DISABLE_SIGNUP || false,
+  disableSignUp: (window.LAGO_DISABLE_SIGNUP || LAGO_DISABLE_SIGNUP) === 'true',
   appVersion: APP_VERSION,
 })

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -30,7 +30,7 @@ module.exports = () => {
         APP_ENV: JSON.stringify(APP_ENV),
         API_URL: JSON.stringify(process.env.API_URL),
         APP_VERSION: JSON.stringify(version),
-        LAGO_DISABLE_SIGNUP: Boolean(process.env.LAGO_DISABLE_SIGNUP),
+        LAGO_DISABLE_SIGNUP: JSON.stringify(process.env.LAGO_DISABLE_SIGNUP),
       }),
     ],
   }


### PR DESCRIPTION
## Context

The env const is always a string, It lead to not be able to "read" the variable value properly

## Description

This PR changes the env type to string and fixes the fallbacks associated

This this change, `disableSignUp` remains a `boolean` but `LAGO_DISABLE_SIGNUP` is now a string