### PR TITLE
fix(signup): special char regex should accept - and _

### DIFF
--- a/src/pages/Invitation.tsx
+++ b/src/pages/Invitation.tsx
@@ -91,7 +91,7 @@ const Invitation = () => {
           .matches(RegExp('(.*[a-z].*)'), FORM_ERRORS.LOWERCASE)
           .matches(RegExp('(.*[A-Z].*)'), FORM_ERRORS.UPPERCASE)
           .matches(RegExp('(.*\\d.*)'), FORM_ERRORS.NUMBER)
-          .matches(RegExp('[!@#$%^&*(),.?":{}|<>]'), FORM_ERRORS.SPECIAL),
+          .matches(RegExp('[/_!@#$%^&*(),.?":{}|<>/-]'), FORM_ERRORS.SPECIAL),
       }),
     []
   )

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -79,7 +79,7 @@ const SignUp = () => {
           .matches(RegExp('(.*[a-z].*)'), FORM_ERRORS.LOWERCASE)
           .matches(RegExp('(.*[A-Z].*)'), FORM_ERRORS.UPPERCASE)
           .matches(RegExp('(.*\\d.*)'), FORM_ERRORS.NUMBER)
-          .matches(RegExp('[!@#$%^&*(),.?":{}|<>]'), FORM_ERRORS.SPECIAL),
+          .matches(RegExp('[/_!@#$%^&*(),.?":{}|<>/-]'), FORM_ERRORS.SPECIAL),
       }),
     []
   )


### PR DESCRIPTION
## Context

We don't accept `_` and `-` as special char in signup and invitation flows

## Description 

Now we do :)

We need to refactor this two form to use the same regex in the future