### PR TITLE
fix(invite): check for email error in details

### DIFF
--- a/src/components/settings/members/CreateInviteDialog.tsx
+++ b/src/components/settings/members/CreateInviteDialog.tsx
@@ -68,7 +68,7 @@ export const CreateInviteDialog = forwardRef<DialogRef>((_, ref) => {
       if (
         !!apiError &&
         apiError?.code === Lago_Api_Error.UnprocessableEntity &&
-        !!apiError?.details?.invite
+        (!!apiError?.details?.invite || !!apiError?.details?.email)
       ) {
         formikBag.setFieldError('email', translate('text_63208c701ce25db781407456'))
       }


### PR DESCRIPTION
## Context

If you try to invite a member that has the same email as an existing membership of the organization, a BE error is received but nothing it shown on the FE side 

## Description

This PR reads the error payload to check if an email key is present.

Doing so will display the appropriate error message below the field 