### PR TITLE
feat(combobox): Display group in startAdorment

### DIFF
--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -33,6 +33,7 @@ export const ComboBox = ({
   disableClearable = false,
   renderGroupHeader,
   virtualized = true,
+  renderGroupInputStartAdornment,
   onChange,
 }: ComboBoxProps) => {
   const { translate } = useInternationalization()
@@ -73,6 +74,13 @@ export const ComboBox = ({
     matchFrom: allowAddValue ? 'start' : 'any',
     stringify: (option) => option.label || option.value,
   })
+  const startAdornmentValue = useMemo(() => {
+    if (!renderGroupInputStartAdornment || !value) return undefined
+
+    let foundGroup = data.find((item) => item.value === value)?.group
+
+    return foundGroup ? renderGroupInputStartAdornment[foundGroup] : undefined
+  }, [data, renderGroupInputStartAdornment, value])
 
   return (
     <Autocomplete
@@ -89,6 +97,7 @@ export const ComboBox = ({
             infoText={infoText}
             name={name}
             placeholder={placeholder}
+            startAdornmentValue={startAdornmentValue}
             params={params}
           />
         )

--- a/src/components/form/ComboBox/ComboBoxInput.tsx
+++ b/src/components/form/ComboBox/ComboBoxInput.tsx
@@ -3,7 +3,8 @@ import { InputAdornment } from '@mui/material'
 import clsns from 'classnames'
 import styled from 'styled-components'
 
-import { Button } from '~/components/designSystem'
+import { Button, Typography } from '~/components/designSystem'
+import { theme } from '~/styles'
 
 import { ComboBoxInputProps } from './types'
 
@@ -19,6 +20,7 @@ export const ComboBoxInput = ({
   infoText,
   params,
   disableClearable,
+  startAdornmentValue,
 }: ComboBoxInputProps) => {
   const { inputProps, InputProps, ...restParams } = params
 
@@ -65,6 +67,14 @@ export const ComboBoxInput = ({
             />
           </InputAdornment>
         ),
+        startAdornment: startAdornmentValue && (
+          <InputAdornment position="start">
+            <StartAdornmentTypography noWrap variant="body" color="grey700">
+              <span>{startAdornmentValue}</span>
+              <span>•</span>
+            </StartAdornmentTypography>
+          </InputAdornment>
+        ),
       }}
       inputProps={_omit(inputProps, 'className')}
       {...restParams}
@@ -88,5 +98,11 @@ const StyledTextInput = styled(TextInput)`
     .MuiAutocomplete-clearIndicatorDirty {
       visibility: visible;
     }
+  }
+`
+
+const StartAdornmentTypography = styled(Typography)`
+  > span:first-child {
+    margin-right: ${theme.spacing(2)};
   }
 `

--- a/src/components/form/ComboBox/types.ts
+++ b/src/components/form/ComboBox/types.ts
@@ -31,6 +31,7 @@ interface BasicComboboxProps extends Omit<ComboBoxInputProps, 'params'> {
   emptyText?: string
   virtualized?: boolean
   disableClearable?: boolean
+  renderGroupInputStartAdornment?: { [key: string]: string }
   PopperProps?: Pick<MuiPopperProps, 'placement'> & {
     minWidth?: number
     maxWidth?: number
@@ -50,7 +51,14 @@ export type ComboBoxProps = BasicComboboxProps | GroupedComboboxProps
 
 export type ComboBoxInputProps = Pick<
   TextInputProps,
-  'error' | 'label' | 'name' | 'placeholder' | 'helperText' | 'className' | 'infoText'
+  | 'error'
+  | 'label'
+  | 'name'
+  | 'placeholder'
+  | 'helperText'
+  | 'className'
+  | 'infoText'
+  | 'startAdornmentValue'
 > & {
   disableClearable?: boolean
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/form/TextInput/TextInput.tsx
+++ b/src/components/form/TextInput/TextInput.tsx
@@ -33,6 +33,7 @@ export interface TextInputProps
   value?: string | number
   beforeChangeFormatter?: ValueFormatterType[] | ValueFormatterType
   infoText?: string
+  startAdornmentValue?: string
   onChange?: (value: string, e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | null) => void
 }
 

--- a/src/pages/CreateBillableMetric.tsx
+++ b/src/pages/CreateBillableMetric.tsx
@@ -244,6 +244,12 @@ const CreateBillableMetric = () => {
                         </ComboboxHeader>
                       ),
                     }}
+                    renderGroupInputStartAdornment={{
+                      [AGGREGATION_GROUP_ENUM.Metered]: translate('text_6310755befed49627644222b'),
+                      [AGGREGATION_GROUP_ENUM.Persistent]: translate(
+                        'text_6310755befed49627644222f'
+                      ),
+                    }}
                     formikProps={formikProps}
                   />
 

--- a/src/pages/__devOnly/DesignSystem.tsx
+++ b/src/pages/__devOnly/DesignSystem.tsx
@@ -772,6 +772,54 @@ const DesignSystem = () => {
                       placeholder="Placeholder"
                       formikProps={formikProps}
                     />
+                    <ComboBoxField
+                      name="combobox"
+                      virtualized={false}
+                      data={'abcdefghijklmnopqrstuvwxyz'.split('').map((letter, i) => ({
+                        value: `${letter}-${i}`,
+                        group: Math.round(i / 5) + '',
+                      }))}
+                      renderGroupHeader={{
+                        '0': (
+                          <ComboboxHeader>
+                            <Typography variant="captionHl" color="textSecondary">
+                              The good •&#32;
+                            </Typography>
+                            <Typography component="span" variant="caption" noWrap>
+                              Based on several survey
+                            </Typography>
+                          </ComboboxHeader>
+                        ),
+                        '1': (
+                          <ComboboxHeader>
+                            <Typography variant="captionHl" color="textSecondary">
+                              The bad •&#32;
+                            </Typography>
+                            <Typography component="span" variant="caption" noWrap>
+                              Because I say so
+                            </Typography>
+                          </ComboboxHeader>
+                        ),
+                        '2': (
+                          <ComboboxHeader>
+                            <Typography variant="captionHl" color="textSecondary">
+                              The ugly •&#32;
+                            </Typography>
+                            <Typography component="span" variant="caption" noWrap>
+                              Don&apos;t look at it
+                            </Typography>
+                          </ComboboxHeader>
+                        ),
+                      }}
+                      renderGroupInputStartAdornment={{
+                        0: 'The good',
+                        1: 'The bad',
+                        2: 'The ugly',
+                      }}
+                      label="Grouped by - normal - custom headers - Input start adornment"
+                      placeholder="Placeholder"
+                      formikProps={formikProps}
+                    />
 
                     <ComboBoxField
                       name="combobox"

--- a/src/stories/Combobox.stories.tsx
+++ b/src/stories/Combobox.stories.tsx
@@ -145,3 +145,32 @@ Grouped.args = {
     { value: 'Vincent', group: 'Backend' },
   ],
 }
+export const GroupedWithAdornment = Template.bind({})
+GroupedWithAdornment.args = {
+  loading: false,
+  disabled: false,
+  allowAddValue: false,
+  sortValues: true,
+  placeholder: 'My values are grouped',
+  loadingText: 'You need to remove the data to see me',
+  emptyText: 'No values',
+  disableClearable: false,
+  virtualized: true,
+  data: [
+    { value: 'Alex', group: 'Frontend' },
+    { value: 'Morguy', group: 'Frontend' },
+    {
+      value: 'Mike',
+      group: 'Designer',
+    },
+    { value: 'Jerem', group: 'Backend' },
+    { value: 'Lovro', group: 'Backend' },
+    { value: 'Romain', group: 'Backend' },
+    { value: 'Vincent', group: 'Backend' },
+  ],
+  renderGroupInputStartAdornment: {
+    Frontend: 'Frontend',
+    Designer: 'Designer',
+    Backend: 'Backend',
+  },
+}


### PR DESCRIPTION
## Context

We're planning the development of a new feature.

During the scoping, we figured out that combobox that displays values with your losses their context once a value is selecter.

## Description

This PR adds the groupe value before the value itself in the input. Its placed in the input `startAdorment` and does not affect the value itself, only the input display.

This "feature" is only enabled if you passe a value to `renderGroupHeader`.

<img width="1004" alt="Monosnap Lago - Local 2022-10-03 16-35-29" src="https://user-images.githubusercontent.com/5517077/193604462-6cce5bd1-fa28-4030-8c2a-3cfe3cc38327.png">


