### PR TITLE
fix(customer) ✍️ Drawer title should only be displayed if data is pre…

### DIFF
--- a/src/components/customers/AddCustomerDrawer.tsx
+++ b/src/components/customers/AddCustomerDrawer.tsx
@@ -100,7 +100,14 @@ export const AddCustomerDrawer = forwardRef<DrawerRef, AddCustomerDrawerProps>(
       <Drawer
         ref={ref}
         title={translate(
-          isEdition ? 'text_632b4acf0c41206cbcb8c2f6' : 'text_632b49e2620ea4c6d96c9650'
+          isEdition
+            ? 'text_632b4acf0c41206cbcb8c2f6'
+            : customer?.name
+            ? 'text_632b49e2620ea4c6d96c9650'
+            : 'text_632b49e2620ea4c6d96c9652',
+          {
+            customerName: customer?.name || '',
+          }
         )}
         onClose={() => {
           formikProps.resetForm({


### PR DESCRIPTION
## Context

A drawer had a wrong title when the customer name was not present. Basically the drawer is used in 3 situations, and one of them were not providing the expected datas
1. Edit a customer plan
2. Add a plan to a customer
3. Create a new customer    <-- When the bug occurs

## Description

This PR makes sure the datas are present before displaying the title

Also, Drawer title is non longer mandatory to be given to the component