### PR TITLE
bug(plan) overriding a plan should keep it's subscription date

### DIFF
--- a/src/components/customers/subscriptions/AddSubscriptionDrawer.tsx
+++ b/src/components/customers/subscriptions/AddSubscriptionDrawer.tsx
@@ -100,9 +100,10 @@ export const AddSubscriptionDrawer = forwardRef<
     const { subscriptionInput, updateInfo } = overwritePlanVar()
 
     if (!!subscriptionInput) {
-      const { planId, name, billingTime } = subscriptionInput
+      const { planId, name, billingTime, subscriptionDate } = subscriptionInput
 
       formikProps.setValues({
+        subscriptionDate: subscriptionDate || currentDateRef?.current,
         planId: planId || '',
         name: name || undefined,
         billingTime: billingTime || BillingTimeEnum.Calendar,


### PR DESCRIPTION
## Context

When overriding a plan, the subscription date was empty

## Description

This PR makes the subscription date persistent