### PR TITLE
chore(column width): adapt customer list column size

### DIFF
--- a/src/components/customers/CustomerItem.tsx
+++ b/src/components/customers/CustomerItem.tsx
@@ -71,7 +71,7 @@ export const CustomerItem = memo(({ rowId, customer }: CustomerItemProps) => {
           </NameBlock>
         </CustomerNameSection>
         <PlanInfosSection>
-          <MediumCell align="right">{activeSubscriptionCount}</MediumCell>
+          <Typography align="right">{activeSubscriptionCount}</Typography>
           <SmallCell align="right">
             {DateTime.fromISO(createdAt).toFormat('LLL. dd, yyyy')}
           </SmallCell>
@@ -149,10 +149,6 @@ const Item = styled(ListItemLink)`
   > *:not(:last-child) {
     margin-right: ${theme.spacing(6)};
   }
-`
-
-const MediumCell = styled(Typography)`
-  width: 200px;
 `
 
 const SmallCell = styled(Typography)<{ $alignLeft?: boolean }>`

--- a/src/pages/CustomersList.tsx
+++ b/src/pages/CustomersList.tsx
@@ -143,7 +143,7 @@ const ListHead = styled(ListHeader)`
 
 const MediumCell = styled(Typography)`
   text-align: right;
-  width: 200px;
+  width: 140px;
 `
 
 const SmallCell = styled(Typography)<{ $alignLeft?: boolean }>`


### PR DESCRIPTION
## Context

On small screen, just before the breakpoint, the customer name is not shown in customer list

## Description 

This PR reduce the subscriptions column size that don't needs to be that big, in order to give more space to the customer name column.

|before|after|
|-|-|
|<img width="537" alt="image" src="https://user-images.githubusercontent.com/5517077/200530097-5551310e-62ce-4173-a1a1-9dc7f89b829c.png">|<img width="540" alt="image" src="https://user-images.githubusercontent.com/5517077/200529972-185ed65d-51be-45bd-810a-38ec0841865e.png">|

