### PR TITLE
fix: credit notes tab should not be shown for credit invoice types

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3233,7 +3233,7 @@ export type GetInvoiceDetailsQueryVariables = Exact<{
 }>;
 
 
-export type GetInvoiceDetailsQuery = { __typename?: 'Query', invoice?: { __typename?: 'Invoice', id: string, number: string, status: InvoiceStatusTypeEnum, totalAmountCents: number, totalAmountCurrency: CurrencyEnum } | null };
+export type GetInvoiceDetailsQuery = { __typename?: 'Query', invoice?: { __typename?: 'Invoice', id: string, invoiceType: InvoiceTypeEnum, number: string, status: InvoiceStatusTypeEnum, totalAmountCents: number, totalAmountCurrency: CurrencyEnum } | null };
 
 export type CurrentVersionQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -6055,6 +6055,7 @@ export const GetInvoiceDetailsDocument = gql`
     query getInvoiceDetails($id: ID!) {
   invoice(id: $id) {
     id
+    invoiceType
     number
     status
     totalAmountCents

--- a/src/layouts/CustomerInvoiceDetails.tsx
+++ b/src/layouts/CustomerInvoiceDetails.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { gql } from '@apollo/client'
 import { useParams, generatePath, Outlet } from 'react-router-dom'
 import styled from 'styled-components'
@@ -23,6 +24,7 @@ import {
 } from '~/core/router'
 import {
   InvoiceStatusTypeEnum,
+  InvoiceTypeEnum,
   useDownloadInvoiceMutation,
   useGetInvoiceDetailsQuery,
 } from '~/generated/graphql'
@@ -36,6 +38,7 @@ gql`
   query getInvoiceDetails($id: ID!) {
     invoice(id: $id) {
       id
+      invoiceType
       number
       status
       totalAmountCents
@@ -110,21 +113,29 @@ const CustomerInvoiceDetails = () => {
     variables: { id: invoiceId as string },
     skip: !invoiceId,
   })
-  const { number, status, totalAmountCents, totalAmountCurrency } = data?.invoice || {}
+  const { invoiceType, number, status, totalAmountCents, totalAmountCurrency } = data?.invoice || {}
   const formattedStatus = mapStatus(status)
   const hasError = (!!error || !data?.invoice) && !loading
 
-  const tabsOptions = [
-    {
-      title: translate('text_634687079be251fdb43833b7'),
-      link: generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, { id, invoiceId }),
-      match: [CUSTOMER_INVOICE_DETAILS_ROUTE, CUSTOMER_INVOICE_OVERVIEW_ROUTE],
-    },
-    {
-      title: translate('text_636bdef6565341dcb9cfb125'),
-      link: generatePath(CUSTOMER_INVOICE_CREDIT_NOTES_LIST_ROUTE, { id, invoiceId }),
-    },
-  ]
+  const tabsOptions = useMemo(() => {
+    const tabs = [
+      {
+        title: translate('text_634687079be251fdb43833b7'),
+        link: generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, { id, invoiceId }),
+        match: [CUSTOMER_INVOICE_DETAILS_ROUTE, CUSTOMER_INVOICE_OVERVIEW_ROUTE],
+      },
+    ]
+
+    if (invoiceType !== InvoiceTypeEnum.Credit) {
+      tabs.push({
+        title: translate('text_636bdef6565341dcb9cfb125'),
+        link: generatePath(CUSTOMER_INVOICE_CREDIT_NOTES_LIST_ROUTE, { id, invoiceId }),
+        match: [CUSTOMER_INVOICE_CREDIT_NOTES_LIST_ROUTE],
+      })
+    }
+
+    return tabs
+  }, [id, invoiceId, invoiceType, translate])
 
   return (
     <>


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

This PR is part of the development of credit notes

## Description

Credit notes tab should not be shown for invoice with `invoiceType === credit`.

This PR fixes that