### PR TITLE
chore: 📏 change the genericPlaceholder default margin-top

### DIFF
--- a/src/components/GenericPlaceholder.tsx
+++ b/src/components/GenericPlaceholder.tsx
@@ -49,7 +49,7 @@ export const GenericPlaceholder = ({
 const Container = styled.div<{ $noMargins?: boolean }>`
   margin: ${({ $noMargins }) => ($noMargins ? 0 : '0 auto')};
   padding: ${({ $noMargins }) =>
-    $noMargins ? 0 : `${theme.spacing(20)} ${theme.spacing(4)} ${theme.spacing(4)}`};
+    $noMargins ? 0 : `${theme.spacing(12)} ${theme.spacing(4)} ${theme.spacing(4)}`};
   max-width: 496px;
 
   img {


### PR DESCRIPTION
We decided, in agreement with product, to change the default margin-top value for all `GenericPlaceholder` components.

This have and impact on both Error and Empty states.

Please note that all custom implementations existing today (`noMargin`) haven't been changed