### PR TITLE
bug: increase fetched BMs limit

### DIFF
--- a/src/components/plans/AddChargeDialog.tsx
+++ b/src/components/plans/AddChargeDialog.tsx
@@ -40,7 +40,7 @@ export const AddChargeDialog = forwardRef<DialogRef, AddChargeDialogProps>(
     const [selectedId, setSelectedId] = useState<string>()
     const { translate } = useInternationalization()
     const [getBillableMetrics, { loading, data }] = useGetbillableMetricsLazyQuery({
-      variables: { limit: 50 },
+      variables: { limit: 500 },
     })
     const billableMetrics = useMemo(() => {
       if (!data || !data?.billableMetrics || !data?.billableMetrics?.collection) return []


### PR DESCRIPTION
## Context

Users could have a very large numbers of Billable metrics. If they have more than 50 they are currently blocked

## Description

This PR is a quick fix. A long term fix will be to implement lazy search when users type value in the input