### PR TITLE
bug: Fix plan limit

### DIFF
--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -69,7 +69,9 @@ export const useAddSubscription: UseAddSubscription = ({
   existingSubscription,
   subscriptionDate,
 }) => {
-  const [getPlans, { loading, data }] = useGetPlansLazyQuery()
+  const [getPlans, { loading, data }] = useGetPlansLazyQuery({
+    variables: { limit: 500 },
+  })
   const { translate } = useInternationalization()
   const [create, { error }] = useCreateSubscriptionMutation({
     context: {


### PR DESCRIPTION
This endpoint didn't had any limit

This PR set it's to a large number, until we're able to fetch via the combobox component when no results displays