### PR TITLE
feat: Big decimal

### DIFF
--- a/src/components/form/TextInput/TextInput.tsx
+++ b/src/components/form/TextInput/TextInput.tsx
@@ -18,7 +18,7 @@ export enum ValueFormatter {
   triDecimal = 'triDecimal', // Truncate numbers to 3 decimals
   positiveNumber = 'positiveNumber',
   code = 'code', // Replace all the spaces by "_"
-  chargeDecimal = 'chargeDecimal', // Truncate charge numbers to 5 decimals
+  chargeDecimal = 'chargeDecimal', // Truncate charge numbers to 15 decimals
 }
 
 export type ValueFormatterType = keyof typeof ValueFormatter
@@ -86,7 +86,7 @@ export const formatValue = (
 
   if (formatterFunctions.includes(ValueFormatter.chargeDecimal)) {
     if (formattedValue !== '-') {
-      formattedValue = (String(formattedValue).match(/^-?\d+(?:\.\d{0,5})?/) || [])[0]
+      formattedValue = (String(formattedValue).match(/^-?\d+(?:\.\d{0,15})?/) || [])[0]
     }
   }
 

--- a/src/components/plans/ChargePercentage.tsx
+++ b/src/components/plans/ChargePercentage.tsx
@@ -61,7 +61,7 @@ export const ChargePercentage = ({
     freeAmountUnits: intlFormatNumber(Number(valuePointer?.freeUnitsPerTotalAggregation) || 0, {
       currencyDisplay: 'symbol',
       currency,
-      maximumFractionDigits: 5,
+      maximumFractionDigits: 15,
     }),
   })
   const handleUpdate = useCallback(
@@ -314,7 +314,7 @@ export const ChargePercentage = ({
               fixedFeeValue: intlFormatNumber(Number(valuePointer?.fixedAmount) || 0, {
                 currencyDisplay: 'symbol',
                 currency,
-                maximumFractionDigits: 5,
+                maximumFractionDigits: 15,
               }),
             })}
           </Typography>

--- a/src/components/plans/GraduatedChargeTable.tsx
+++ b/src/components/plans/GraduatedChargeTable.tsx
@@ -221,7 +221,7 @@ export const GraduatedChargeTable = ({
                     lastRowUnit: calculation.firstUnit,
                     value: intlFormatNumber(calculation.total, {
                       currencyDisplay: 'symbol',
-                      maximumFractionDigits: 5,
+                      maximumFractionDigits: 15,
                       currency,
                     }),
                   })}
@@ -235,17 +235,17 @@ export const GraduatedChargeTable = ({
                     tier1LastUnit: calculation.units,
                     tier1PerUnit: intlFormatNumber(calculation.perUnit, {
                       currencyDisplay: 'symbol',
-                      maximumFractionDigits: 5,
+                      maximumFractionDigits: 15,
                       currency,
                     }),
                     tier1FlatFee: intlFormatNumber(calculation.flatFee, {
                       currencyDisplay: 'symbol',
-                      maximumFractionDigits: 5,
+                      maximumFractionDigits: 15,
                       currency,
                     }),
                     totalTier1: intlFormatNumber(calculation.total, {
                       currencyDisplay: 'symbol',
-                      maximumFractionDigits: 5,
+                      maximumFractionDigits: 15,
                       currency,
                     }),
                   })}
@@ -259,17 +259,17 @@ export const GraduatedChargeTable = ({
                   unitCount: calculation.units,
                   tierPerUnit: intlFormatNumber(calculation.perUnit, {
                     currencyDisplay: 'symbol',
-                    maximumFractionDigits: 5,
+                    maximumFractionDigits: 15,
                     currency,
                   }),
                   tierFlatFee: intlFormatNumber(calculation.flatFee, {
                     currencyDisplay: 'symbol',
-                    maximumFractionDigits: 5,
+                    maximumFractionDigits: 15,
                     currency,
                   }),
                   totalTier: intlFormatNumber(calculation.total, {
                     currencyDisplay: 'symbol',
-                    maximumFractionDigits: 5,
+                    maximumFractionDigits: 15,
                     currency,
                   }),
                 })}

--- a/src/components/plans/PackageCharge.tsx
+++ b/src/components/plans/PackageCharge.tsx
@@ -127,7 +127,7 @@ export const PackageCharge = ({
                 units: valuePointer?.packageSize + (valuePointer?.freeUnits || 0) + 1,
                 cost: intlFormatNumber(Number(valuePointer?.amount || 0) * 2, {
                   currencyDisplay: 'symbol',
-                  maximumFractionDigits: 5,
+                  maximumFractionDigits: 15,
                   currency,
                 }),
               })}
@@ -139,7 +139,7 @@ export const PackageCharge = ({
                   unitInPackage: valuePointer?.freeUnits,
                   cost: intlFormatNumber(0, {
                     currencyDisplay: 'symbol',
-                    maximumFractionDigits: 5,
+                    maximumFractionDigits: 15,
                     currency,
                   }),
                 })}
@@ -152,7 +152,7 @@ export const PackageCharge = ({
                 unitInPackage: valuePointer?.packageSize + (valuePointer?.freeUnits || 0),
                 cost: intlFormatNumber(Number(valuePointer?.amount || 0), {
                   currencyDisplay: 'symbol',
-                  maximumFractionDigits: 5,
+                  maximumFractionDigits: 15,
                   currency,
                 }),
               })}
@@ -163,7 +163,7 @@ export const PackageCharge = ({
                 unitInPackage: valuePointer?.packageSize * 2 + (valuePointer?.freeUnits || 0),
                 cost: intlFormatNumber(Number(valuePointer?.amount || 0) * 2, {
                   currencyDisplay: 'symbol',
-                  maximumFractionDigits: 5,
+                  maximumFractionDigits: 15,
                   currency,
                 }),
               })}

--- a/src/components/plans/VolumeChargeTable.tsx
+++ b/src/components/plans/VolumeChargeTable.tsx
@@ -215,7 +215,7 @@ export const VolumeChargeTable = ({
             lastRowFirstUnit: infosCalculation.lastRowFirstUnit,
             value: intlFormatNumber(infosCalculation.value, {
               currencyDisplay: 'symbol',
-              maximumFractionDigits: 5,
+              maximumFractionDigits: 15,
               currency,
             }),
           })}
@@ -225,17 +225,17 @@ export const VolumeChargeTable = ({
             lastRowFirstUnit: infosCalculation.lastRowFirstUnit,
             lastRowPerUnit: intlFormatNumber(infosCalculation.lastRowPerUnit, {
               currencyDisplay: 'symbol',
-              maximumFractionDigits: 5,
+              maximumFractionDigits: 15,
               currency,
             }),
             lastRowFlatFee: intlFormatNumber(infosCalculation.lastRowFlatFee, {
               currencyDisplay: 'symbol',
-              maximumFractionDigits: 5,
+              maximumFractionDigits: 15,
               currency,
             }),
             value: intlFormatNumber(infosCalculation.value, {
               currencyDisplay: 'symbol',
-              maximumFractionDigits: 5,
+              maximumFractionDigits: 15,
               currency,
             }),
           })}

--- a/src/components/wallets/WalletTransactionList.tsx
+++ b/src/components/wallets/WalletTransactionList.tsx
@@ -185,7 +185,7 @@ export const WalletTransactionList = forwardRef<TopupWalletDialogRef, WalletTran
                           'text_62da6ec24a8e24e44f812896',
                           {
                             amount: intlFormatNumber(Number(creditAmount) || 0, {
-                              maximumFractionDigits: 5,
+                              maximumFractionDigits: 15,
                               style: 'decimal',
                             }),
                           },
@@ -195,7 +195,7 @@ export const WalletTransactionList = forwardRef<TopupWalletDialogRef, WalletTran
                       <Typography variant="caption" color="grey600">
                         {intlFormatNumber(Number(amount) || 0, {
                           currencyDisplay: 'symbol',
-                          maximumFractionDigits: 5,
+                          maximumFractionDigits: 15,
                           currency: wallet?.currency,
                         })}
                       </Typography>

--- a/src/formValidationSchemas/chargeSchema.ts
+++ b/src/formValidationSchemas/chargeSchema.ts
@@ -15,7 +15,7 @@ const packageShape = object().shape({
 
 const percentageShape = object().shape({
   rate: number().min(0.001, 'text_62a0b7107afa2700a65ef70e').required(''),
-  fixedAmount: number().min(0.001, 'text_62a0b7107afa2700a65ef70e'),
+  fixedAmount: number().min(0.0000000000000001, 'text_62a0b7107afa2700a65ef70e'),
   freeUnitsPerEvents: number(),
   freeUnitsPerTotalAggregation: number(),
 })

--- a/src/formValidationSchemas/feesSchema.ts
+++ b/src/formValidationSchemas/feesSchema.ts
@@ -21,7 +21,7 @@ export const simpleFeeSchema = (maxAmount: number, currency: CurrencyEnum) =>
         (checked: boolean, schema: NumberSchema) => {
           return !!checked
             ? number()
-                .min(0.000001, CreditNoteFeeErrorEnum.minZero)
+                .min(0.0000000000000001, CreditNoteFeeErrorEnum.minZero)
                 .max(deserializeAmount(maxAmount, currency), CreditNoteFeeErrorEnum.overMax)
                 .required('')
             : schema


### PR DESCRIPTION
## Context

Some charges needs to have 15 decimal numbers

## Description

This PR increases the limit and some validations for the fields that uses today 5 decimal, to handle 15

Note: the change in `src/formValidationSchemas/chargeSchema.ts` is a bugfix. It' allowed to send big decimal here even tho it was considered as a currency precision before