### PR TITLE
feat: improve copy-to-clipboard behaviour 

### DIFF
--- a/ditto/base.json
+++ b/ditto/base.json
@@ -630,6 +630,7 @@
   "text_6244277fe0975300fe3fb946": "By clicking ‘Leave’, the plan and data you’re creating will be deleted. Are you sure you want to leave?",
   "text_6244277fe0975300fe3fb94a": "Cancel",
   "text_6244277fe0975300fe3fb94c": "Leave",
+  "text_63a5ba11eb4e7e17ef88e9f0": "You're running this app in an <a rel=\"noopener noreferrer external\" target=\"_blank\" href=\"https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts\">unsecure context</a>. Clipboard access is disabled",
   "text_628b8c693e464200e00e465b": "Apply a coupon to this customer",
   "text_628b8c693e464200e00e4669": "By applying a coupon to this customer, they will benefit instantly from the discount defined on this coupon.",
   "text_628b8c693e464200e00e4677": "Coupon",

--- a/ditto/config.yml
+++ b/ditto/config.yml
@@ -101,10 +101,12 @@ projects:
     id: 636bdeec2ea28ae182faa50e
   - name: 👍 [Ready for dev] - Settings Customers - Lago x Data Warehouse connection
     id: 639c334bcee914d26afecf69
-  - name: "\U0001F44D [Ready for dev] - All - Custom ≠ timezones"
+  - name: 👍 [Ready for dev] - All - Custom ≠ timezones
     id: 638906e129a144b0c4c27c83
   - name: Amount placeholder
     id: 639710434b2a96dba29b9140
+  - name: Copy to clipboard
+    id: 63a5ba118e83e2c695c6f7c6
 format: flat
 variants: true
 components: true

--- a/ditto/index.js
+++ b/ditto/index.js
@@ -23,6 +23,9 @@ module.exports = {
   "project_623b42fddc2f2c017440cb5b": {
     "base": require('./Billable metrics - Create a billable metric__base.json')
   },
+  "project_63a5ba118e83e2c695c6f7c6": {
+    "base": require('./Copy to clipboard__base.json')
+  },
   "project_628b8c5f8161d800e7c1c562": {
     "base": require('./Coupons - Apply coupons to customers__base.json')
   },

--- a/src/components/CodeSnippet.tsx
+++ b/src/components/CodeSnippet.tsx
@@ -11,6 +11,7 @@ import { Typography, Button } from '~/components/designSystem'
 import { theme, NAV_HEIGHT } from '~/styles'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { addToast } from '~/core/apolloClient'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
 
 Prism.manual = true
 
@@ -62,7 +63,7 @@ export const CodeSnippet = memo(
                 variant="secondary"
                 startIcon="duplicate"
                 onClick={() => {
-                  navigator.clipboard.writeText(code)
+                  copyToClipboard(code)
 
                   addToast({
                     severity: 'info',

--- a/src/components/DebugInfoDialog.tsx
+++ b/src/components/DebugInfoDialog.tsx
@@ -5,6 +5,7 @@ import { Dialog, DialogRef, Typography, Button } from '~/components/designSystem
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { envGlobalVar, useCurrentUserInfosVar, addToast } from '~/core/apolloClient'
 import { theme } from '~/styles'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
 
 const { appEnv, apiUrl, appVersion } = envGlobalVar()
 
@@ -26,7 +27,7 @@ export const DebugInfoDialog = forwardRef<DialogRef>(({}, ref) => {
           </Button>
           <Button
             onClick={() => {
-              navigator.clipboard.writeText(
+              copyToClipboard(
                 `### Environment informations
 **App environment :** ${appEnv}
 **API URL :** ${apiUrl} 

--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -24,6 +24,7 @@ import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CUSTOMER_INVOICE_DETAILS_ROUTE } from '~/core/router'
 import { getTimezoneConfig, formatDateToTZ } from '~/core/timezone'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
 
 gql`
   fragment CustomerInvoiceList on Invoice {
@@ -196,7 +197,8 @@ export const CustomerInvoicesList = ({
                           variant="quaternary"
                           align="left"
                           onClick={() => {
-                            navigator.clipboard.writeText(id)
+                            copyToClipboard(id)
+
                             addToast({
                               severity: 'info',
                               translateKey: 'text_6253f11816f710014600ba1f',

--- a/src/components/customers/creditNotes/CreditNotesList.tsx
+++ b/src/components/customers/creditNotes/CreditNotesList.tsx
@@ -29,6 +29,7 @@ import {
 } from '~/styles'
 import { getTimezoneConfig, formatDateToTZ } from '~/core/timezone'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
 
 import { VoidCreditNoteDialog, VoidCreditNoteDialogRef } from './VoidCreditNoteDialog'
 
@@ -224,7 +225,8 @@ const CreditNotesList = memo(
                         variant="quaternary"
                         align="left"
                         onClick={() => {
-                          navigator.clipboard.writeText(creditNote.id)
+                          copyToClipboard(creditNote.id)
+
                           addToast({
                             severity: 'info',
                             translateKey: 'text_63720bd734e1344aea75b82d',

--- a/src/components/customers/subscriptions/SubscriptionLine.tsx
+++ b/src/components/customers/subscriptions/SubscriptionLine.tsx
@@ -18,6 +18,7 @@ import {
 } from '~/components/designSystem'
 import { addToast } from '~/core/apolloClient'
 import { TimezoneDate } from '~/components/TimezoneDate'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
 
 import { AddSubscriptionDrawerRef } from './AddSubscriptionDrawer'
 import { EditCustomerSubscriptionDrawerRef } from './EditCustomerSubscriptionDrawer'
@@ -161,7 +162,8 @@ export const SubscriptionLine = forwardRef<SubscriptionLineRef, SubscriptionLine
                   variant="quaternary"
                   align="left"
                   onClick={() => {
-                    navigator.clipboard.writeText(subscriptionExternalId)
+                    copyToClipboard(subscriptionExternalId)
+
                     addToast({
                       severity: 'info',
                       translateKey: 'text_62d94cc9ccc5eebcc03160a0',

--- a/src/components/designSystem/Toasts/Toast.tsx
+++ b/src/components/designSystem/Toasts/Toast.tsx
@@ -2,7 +2,7 @@ import { useState, forwardRef, useImperativeHandle, useRef, useEffect, useCallba
 import styled, { css } from 'styled-components'
 import clsns from 'classnames'
 
-import { theme } from '~/styles'
+import { palette, theme } from '~/styles'
 import { removeToast, TToast, TSeverity, ToastSeverityEnum } from '~/core/apolloClient'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
@@ -72,7 +72,7 @@ export const Toast = forwardRef<ToastRef, ToastProps>(({ toast }: ToastProps, re
       onMouseLeave={() => startTimeout(AUTO_DISMISS_TIME / 2)}
       data-test={`toast/${severity}`}
     >
-      <Message color="inherit">{translateKey ? translate(translateKey) : message}</Message>
+      <Message color="inherit" html={translateKey ? translate(translateKey) : message} />
       <Button
         onClick={() => setClosing(true)}
         variant="quaternary-light"
@@ -146,5 +146,10 @@ const Message = styled(Typography)`
   && {
     margin-right: ${theme.spacing(4)};
     flex: 1;
+
+    a {
+      color: ${palette.common.white};
+      text-decoration: underline;
+    }
   }
 `

--- a/src/components/settings/members/CreateInviteDialog.tsx
+++ b/src/components/settings/members/CreateInviteDialog.tsx
@@ -14,6 +14,7 @@ import ErrorImage from '~/public/images/maneki/error.svg'
 import { addToast, useCurrentUserInfosVar, hasDefinedGQLError } from '~/core/apolloClient'
 import { GenericPlaceholder } from '~/components/GenericPlaceholder'
 import { INVITATION_ROUTE } from '~/core/router'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
 
 gql`
   mutation createInvite($input: CreateInviteInput!) {
@@ -117,7 +118,8 @@ export const CreateInviteDialog = forwardRef<DialogRef>((_, ref) => {
             <Button
               disabled={!!error}
               onClick={() => {
-                navigator.clipboard.writeText(invitationUrl)
+                copyToClipboard(invitationUrl)
+
                 addToast({
                   severity: 'info',
                   translateKey: 'text_63208c711ce25db781407536',

--- a/src/components/settings/members/InviteItem.tsx
+++ b/src/components/settings/members/InviteItem.tsx
@@ -9,6 +9,7 @@ import { InviteItemFragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { addToast } from '~/core/apolloClient'
 import { INVITATION_ROUTE } from '~/core/router'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
 
 import { RevokeInviteDialogRef } from './RevokeInviteDialog'
 
@@ -48,7 +49,7 @@ export const InviteItem = forwardRef<RevokeInviteDialogRef, InviteItemProps>(
               icon="duplicate"
               variant="quaternary"
               onClick={() => {
-                navigator.clipboard.writeText(
+                copyToClipboard(
                   `${window.location.origin}${generatePath(INVITATION_ROUTE, {
                     token,
                   })}`

--- a/src/core/utils/copyToClipboard.ts
+++ b/src/core/utils/copyToClipboard.ts
@@ -1,0 +1,13 @@
+import { addToast } from '~/core/apolloClient'
+
+export const copyToClipboard: (value: string) => void = (value) => {
+  try {
+    navigator.clipboard.writeText(value)
+  } catch (error) {
+    addToast({
+      severity: 'danger',
+      translateKey: 'text_63a5ba11eb4e7e17ef88e9f0',
+    })
+    throw new Error('Browser running in non secure context')
+  }
+}

--- a/src/layouts/CustomerInvoiceDetails.tsx
+++ b/src/layouts/CustomerInvoiceDetails.tsx
@@ -35,6 +35,7 @@ import { theme, PageHeader, MenuPopper } from '~/styles'
 import { addToast } from '~/core/apolloClient'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
 
 gql`
   query getInvoiceDetails($id: ID!) {
@@ -207,7 +208,8 @@ const CustomerInvoiceDetails = () => {
                   variant="quaternary"
                   align="left"
                   onClick={() => {
-                    navigator.clipboard.writeText(invoiceId || '')
+                    copyToClipboard(invoiceId || '')
+
                     addToast({
                       severity: 'info',
                       translateKey: 'text_6253f11816f710014600ba1f',

--- a/src/pages/CreditNoteDetails.tsx
+++ b/src/pages/CreditNoteDetails.tsx
@@ -43,6 +43,7 @@ import {
 import { SectionHeader } from '~/styles/customer'
 import { formatDateToTZ } from '~/core/timezone'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
 
 import { CustomerDetailsTabsOptions } from './CustomerDetails'
 
@@ -274,7 +275,7 @@ const CreditNoteDetails = () => {
                   variant="quaternary"
                   align="left"
                   onClick={() => {
-                    navigator.clipboard.writeText(creditNote?.id || '')
+                    copyToClipboard(creditNote?.id || '')
                     addToast({
                       severity: 'info',
                       translateKey: 'text_63766b1c4eeb35667c48f26d',

--- a/src/pages/developers/ApiKeys.tsx
+++ b/src/pages/developers/ApiKeys.tsx
@@ -5,6 +5,7 @@ import { useCurrentUserInfosVar, addToast } from '~/core/apolloClient'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { Typography, Button } from '~/components/designSystem'
 import { NAV_HEIGHT, theme } from '~/styles'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
 
 gql`
   fragment ApiKeyOrganization on Organization {
@@ -33,7 +34,7 @@ const ApiKeys = () => {
           size="large"
           startIcon="duplicate"
           onClick={() => {
-            navigator.clipboard.writeText(currentOrganization?.apiKey || '')
+            copyToClipboard(currentOrganization?.apiKey || '')
             addToast({
               severity: 'info',
               translateKey: 'text_6227a2e847fcd700e9038952',
@@ -62,7 +63,7 @@ const ApiKeys = () => {
           size="large"
           startIcon="duplicate"
           onClick={() => {
-            navigator.clipboard.writeText(currentOrganization?.id || '')
+            copyToClipboard(currentOrganization?.id || '')
             addToast({
               severity: 'info',
               translateKey: 'text_636df520279a9e1b3c68cc7d',

--- a/src/pages/settings/GocardlessIntegration.tsx
+++ b/src/pages/settings/GocardlessIntegration.tsx
@@ -23,6 +23,7 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import GoCardless from '~/public/images/gocardless-large.svg'
 import { addToast } from '~/core/apolloClient'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
 
 gql`
   query gocardlessIntegrationsSetting {
@@ -176,7 +177,7 @@ const GocardlessIntegration = () => {
                     startIcon="duplicate"
                     variant="quaternary"
                     onClick={() => {
-                      navigator.clipboard.writeText(webhookSecretKey)
+                      copyToClipboard(webhookSecretKey)
                       addToast({
                         severity: 'info',
                         translateKey: 'text_6360ddae753a8b3e11c80c6c',


### PR DESCRIPTION
## Related task 

👉 https://github.com/getlago/lago-front/issues/553

## Context

Application can be run in [unsecure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts), leading to browser disabling the access to clipboard.

When it happen, users clicking on "Copy to clipboard" buttons all over the app will have a success toast displayed, but the information won't be copied.

Over the past few weeks, some places in the app that were displaying copy buttons with information next to them, improved those places to make sure the information is fully visible on the screen, helping users to get the value to copy even if the copy to clipboard don't work.

It does not fix the issue tho.

## Description

In order to improve even more the UX when such bug occur, this PR brings a new `copyToClipboard` helper.

It will replace `navigator.clipboard.writeText` directly called in the app.

Also note, if an error occur, we throw an error in order to prevent any following success toast to be displayed.