### PR TITLE
fix: 👵 Wallet top up

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -145,7 +145,8 @@ export const CustomerSettings = ({ customer }: CustomerSettingsProps) => {
         />
       </InfoBlock>
 
-      <InlineSectionTitle>
+      {/* TODO - Release when pricing is out
+       <InlineSectionTitle>
         <Typography variant="subhead" color="grey700">
           {translate('text_638dff9779fb99299bee912e')}
         </Typography>
@@ -220,7 +221,7 @@ export const CustomerSettings = ({ customer }: CustomerSettingsProps) => {
               : translate('text_638dff9779fb99299bee9136')
           }
         />
-      </InfoBlock>
+      </InfoBlock> */}
 
       <EditCustomerVatRateDialog ref={editDialogRef} customer={customer} />
       <DeleteCustomerVatRateDialog ref={deleteVatRateDialogRef} customer={customer} />

--- a/src/components/form/AmountInput/AmountInput.tsx
+++ b/src/components/form/AmountInput/AmountInput.tsx
@@ -41,8 +41,6 @@ const defineNewBeforeChangeFormatter = (
     newBeforeChangeFormatter.push('decimal')
   }
 
-  newBeforeChangeFormatter.push('number')
-
   return newBeforeChangeFormatter
 }
 

--- a/src/components/form/TextInput/TextInput.tsx
+++ b/src/components/form/TextInput/TextInput.tsx
@@ -13,7 +13,6 @@ import { theme } from '~/styles'
 
 export enum ValueFormatter {
   int = 'int',
-  number = 'number',
   decimal = 'decimal', // Truncate numbers to 2 decimals
   triDecimal = 'triDecimal', // Truncate numbers to 3 decimals
   positiveNumber = 'positiveNumber',
@@ -92,10 +91,6 @@ export const formatValue = (
 
   if (formatterFunctions.includes(ValueFormatter.code)) {
     formattedValue = String(value).replace(/\s/g, '_')
-  }
-
-  if (formatterFunctions.includes(ValueFormatter.number)) {
-    formattedValue = Number(formattedValue)
   }
 
   return !formattedValue && formattedValue !== 0 ? '' : formattedValue

--- a/src/components/wallets/TopupWalletDialog.tsx
+++ b/src/components/wallets/TopupWalletDialog.tsx
@@ -80,8 +80,8 @@ export const TopupWalletDialog = forwardRef<DialogRef, TopupWalletDialogProps>(
           variables: {
             input: {
               walletId: wallet.id,
-              grantedCredits: grantedCredits === '' ? '0' : grantedCredits,
-              paidCredits: paidCredits === '' ? '0' : paidCredits,
+              grantedCredits: grantedCredits === '' ? '0' : String(grantedCredits),
+              paidCredits: paidCredits === '' ? '0' : String(paidCredits),
             },
           },
           refetchQueries: ['getCustomerWalletList', 'getWalletTransactions'],

--- a/src/pages/settings/InvoiceSettings.tsx
+++ b/src/pages/settings/InvoiceSettings.tsx
@@ -101,6 +101,7 @@ const InvoiceSettings = () => {
         )}
       </InfoBlock>
 
+      {/* TODO - Release when pricing is out
       <InlineSectionTitle>
         <Typography variant="subhead" color="grey700">
           {translate('text_638dc196fb209d551f3d8141')}
@@ -136,7 +137,7 @@ const InvoiceSettings = () => {
             </Typography>
           </>
         )}
-      </InfoBlock>
+      </InfoBlock> */}
 
       <InlineSectionTitle>
         <Typography variant="subhead" color="grey700">


### PR DESCRIPTION
# Wallets edit is not working properly

## Context

- By topping up a wallet, there is an error
    
    <aside>
    ⚠️ **Message**
    
    *"Variable $input of type CreateCustomerWalletTransactionInput! was provided invalid value for grantedCredits (Could not coerce value 10 to String)"*
    
    </aside>
    
- Frontend is sending an integer while backend expects a ************string************
- For info, when creating a wallet, frontend sends a string

## Expected behavior

- Frontend must always send a string for **************creating a wallet************** and **************************************topping up a wallet**************************************
- Frontend must accept credit values with decimals as we can send strings (let’s block to 2 decimals)