### PR TITLE
bug: fix credit note tab display for draft invoice

### DIFF
--- a/src/layouts/CustomerInvoiceDetails.tsx
+++ b/src/layouts/CustomerInvoiceDetails.tsx
@@ -65,6 +65,9 @@ gql`
     totalAmountCurrency
     refundableAmountCents
     creditableAmountCents
+    creditNotes {
+      id
+    }
     ...InvoiceDetailsForInvoiceOverview
     ...InvoiceForCreditNotesTable
     ...InvoiceForDetailsTable
@@ -170,12 +173,14 @@ const CustomerInvoiceDetails = () => {
     totalAmountCents,
     totalAmountCurrency,
     status,
-    // creditableAmountCents,
-    // refundableAmountCents,
+    creditableAmountCents,
+    refundableAmountCents,
+    creditNotes,
   } = (data?.invoice as AllInvoiceDetailsForCustomerInvoiceDetailsFragment) || {}
 
   const formattedStatus = mapStatus(paymentStatus)
   const hasError = (!!error || !data?.invoice) && !loading
+  const hasCreditNotes = !!creditNotes?.length
 
   const tabsOptions = useMemo(() => {
     const tabs = [
@@ -208,7 +213,10 @@ const CustomerInvoiceDetails = () => {
       },
     ]
 
-    if (invoiceType !== InvoiceTypeEnum.Credit) {
+    if (
+      invoiceType !== InvoiceTypeEnum.Credit &&
+      (status !== InvoiceStatusTypeEnum.Draft || hasCreditNotes)
+    ) {
       tabs.push({
         title: translate('text_636bdef6565341dcb9cfb125'),
         link: generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
@@ -241,6 +249,8 @@ const CustomerInvoiceDetails = () => {
     hasError,
     loading,
     data,
+    hasCreditNotes,
+    status,
   ])
 
   return (
@@ -316,9 +326,7 @@ const CustomerInvoiceDetails = () => {
                     <Button
                       variant="quaternary"
                       align="left"
-                      disabled={
-                        true /* TODO - change this when licences are released creditableAmountCents === 0 && refundableAmountCents === 0 */
-                      }
+                      disabled={creditableAmountCents === 0 && refundableAmountCents === 0}
                       onClick={async () => {
                         navigate(
                           generatePath(CUSTOMER_INVOICE_CREATE_CREDIT_NOTE_ROUTE, {


### PR DESCRIPTION
Hide credit note tab if invoice is in draft, unless it already has credit notes