### PR TITLE
bug: fix plan percentage charge serialization

### DIFF
--- a/src/core/serializers/serializePlanInput.ts
+++ b/src/core/serializers/serializePlanInput.ts
@@ -9,7 +9,7 @@ const serializeProperties = (properties: Properties, chargeModel: ChargeModelEnu
   return {
     ...properties,
     ...([ChargeModelEnum.Package, ChargeModelEnum.Standard].includes(chargeModel)
-      ? { amount: String(properties?.amount) }
+      ? { amount: !!properties?.amount ? String(properties?.amount) : undefined }
       : {}),
     ...(chargeModel === ChargeModelEnum.Graduated
       ? {
@@ -45,10 +45,12 @@ const serializeProperties = (properties: Properties, chargeModel: ChargeModelEnu
       : { packageSize: undefined, freeUnits: undefined }),
     ...(chargeModel === ChargeModelEnum.Percentage
       ? {
+          amount: undefined,
           freeUnitsPerEvents: Number(properties?.freeUnitsPerEvents) || undefined,
-          fixedAmount: String(properties?.fixedAmount) || undefined,
-          freeUnitsPerTotalAggregation:
-            String(properties?.freeUnitsPerTotalAggregation) || undefined,
+          fixedAmount: !!properties?.fixedAmount ? String(properties?.fixedAmount) : undefined,
+          freeUnitsPerTotalAggregation: !!properties?.freeUnitsPerTotalAggregation
+            ? String(properties?.freeUnitsPerTotalAggregation)
+            : undefined,
         }
       : {}),
   }


### PR DESCRIPTION
## Context

We have a regression in plan creation.

If you add a percentage charge while creating a plan. You receive a backend error

## Description

This PR fixed the serialization of the plan data sent to BE, hence fixing the error