### PR TITLE
chore: fix react-router-dom index route type definition

### DIFF
--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -1,8 +1,8 @@
 import { Suspense, ReactNode, useEffect } from 'react'
-import { useRoutes } from 'react-router-dom'
+import { IndexRouteProps, useRoutes } from 'react-router-dom'
 import styled from 'styled-components'
 import { useLocation } from 'react-router-dom'
-import type { RouteObject, IndexRouteObject } from 'react-router-dom'
+import type { RouteObject } from 'react-router-dom'
 
 import { Icon } from '~/components/designSystem'
 import { useIsAuthenticated } from '~/hooks/auth/useIsAuthenticated'
@@ -51,7 +51,7 @@ export const routesFormatter: (
       acc.push({
         index: true,
         ...routeConfig,
-      } as IndexRouteObject)
+      } as IndexRouteProps)
     } else if (!route.path) {
       acc.push(routeConfig)
     } else if (typeof route.path === 'string') {


### PR DESCRIPTION
A recent upgrade of react-router-dom updated the way they manage types exported from their package.

For some reason, the ugrade PR did not failed. Hence having this fix now.