### PR TITLE
chore: remove axios package resolution version

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "styled-components": "5.3.6",
     "@mui/styled-engine": "5.11.0",
     "lodash": "4.17.21",
-    "axios": "0.27.2",
     "trim-newlines": "4.0.2",
     "glob-parent": "6.0.2",
     "trim": "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6842,7 +6842,7 @@ axe-core@^4.6.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.6.2.tgz#6e566ab2a3d29e415f5115bc0fd2597a5eb3e5e3"
   integrity sha512-b1WlTV8+XKLj9gZy2DZXgQiyDp9xkkoe2a6U6UbYccScq2wgH/YwCeI2/Jq2mgo0HzQxqJOjWZBLeA/mqsk5Mg==
 
-axios@0.27.2, axios@^0.27.2:
+axios@^0.27.2:
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
   integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==


### PR DESCRIPTION
## Context

We do have a PR to update the axios package version, with a large diff https://github.com/getlago/lago-front/pull/495

We do have a package resolution for axios, after we had a dependabot security alert https://github.com/getlago/lago-front/security/dependabot/13

It seems that axios package is used by `dittowords/cli` package internally, with the version `0.27.2`.

As the security concern was for versions `< 0.21.2`, there is no need to keep this resolution anymore

## Description

This PR simply remove the version resolution for axios, letting other packages using their own version.