### PR TITLE
test: restore e2e test for subscriptions

### DIFF
--- a/cypress/e2e/t5-add-subscription.cy.ts
+++ b/cypress/e2e/t5-add-subscription.cy.ts
@@ -1,70 +1,90 @@
-// TODO: uncomment, flaky test
-// import { DateTime } from 'luxon'
+import { DateTime } from 'luxon'
 
-// import { customerName, userEmail, userPassword } from '../support/reusableConstants'
+import { customerName, userEmail, userPassword } from '../support/reusableConstants'
 
-// describe('Add and edit subscription', () => {
-//   const subscriptionName = `Subscription-${Math.round(Math.random() * 10000)}`
-//   const subscriptionAt = DateTime.now().plus({ days: 2 }).toISO()
-//   const inputFormatedDate = DateTime.fromISO(subscriptionAt).toFormat('LL/dd/yyyy')
-//   const formatedDate = DateTime.fromISO(subscriptionAt).toFormat('LLL. dd, yyyy')
-//   const newSubscriptionName = `updated-${subscriptionName}`
-//   const newsubscriptionAt = DateTime.now().minus({ days: 10 }).toISO()
-//   const newInputFormatedDate = DateTime.fromISO(newsubscriptionAt).toFormat('LL/dd/yyyy')
-//   const newFormatedDate = DateTime.fromISO(newsubscriptionAt).toFormat('LLL. dd, yyyy')
+describe('Add and edit subscription', () => {
+  const subscriptionName = `Subscription-${Math.round(Math.random() * 10000)}`
+  const subscriptionAt = DateTime.now().plus({ days: 2 }).toISO()
+  const inputFormatedDate = DateTime.fromISO(subscriptionAt).toFormat('LL/dd/yyyy')
+  const formatedDate = DateTime.fromISO(subscriptionAt).toFormat('LLL. dd, yyyy')
+  const newSubscriptionName = `updated-${subscriptionName}`
+  const newsubscriptionAt = DateTime.now().minus({ days: 10 }).toISO()
+  const newInputFormatedDate = DateTime.fromISO(newsubscriptionAt).toFormat('LL/dd/yyyy')
+  const newFormatedDate = DateTime.fromISO(newsubscriptionAt).toFormat('LLL. dd, yyyy')
 
-//   beforeEach(() => {
-//     cy.login(userEmail, userPassword)
-//     cy.visit('/customers')
-//     cy.get(`[data-test="${customerName}"]`).click()
-//   })
+  beforeEach(() => {
+    cy.login(userEmail, userPassword)
+    cy.visit('/customers')
+    cy.get(`[data-test="${customerName}"]`).click()
+  })
 
-//   it('should be able to add a subscription to customer', () => {
-//     cy.get(`[data-test="add-subscription"]`).click()
-//     cy.get('[data-test="submit"]').should('be.disabled')
-//     cy.get('input[name="planId"]').click()
-//     cy.get('[data-option-index="0"]').click()
-//     cy.get('input[name="name"]').type(subscriptionName)
-//     cy.get('input[name="subscriptionAt"]').clear().type(inputFormatedDate)
-//     cy.get('[data-test="submit"]').click()
-//     cy.get('[data-test="submit"]').should('not.exist')
-//     cy.contains(subscriptionName).should('exist')
-//     cy.contains(formatedDate).should('exist')
-//   })
+  it('should be able to add a subscription to customer', () => {
+    cy.get(`[data-test="add-subscription"]`).click()
+    cy.get('[data-test="submit"]').should('be.disabled')
+    cy.get('input[name="planId"]').click()
+    cy.get('[data-option-index="0"]').click()
+    cy.get('input[name="name"]').type(subscriptionName)
+    cy.get('input[name="subscriptionAt"]').clear().type(inputFormatedDate)
+    cy.get('[data-test="submit"]').click()
+    cy.get('[data-test="submit"]').should('not.exist')
+    cy.contains(subscriptionName).should('exist')
+    cy.contains(formatedDate).should('exist')
+  })
 
-//   it('should be able to edit subscription', () => {
-//     cy.get(`[data-test="${subscriptionName}"]`).within(() => {
-//       cy.contains('Pending').should('exist')
-//       cy.get(`[data-test="menu-subscription"]`).click()
-//     })
-//     cy.get(`[data-test="edit-subscription"]`).click()
-//     cy.get('input[name="name"]').should('have.value', subscriptionName)
-//     cy.get('input[name="subscriptionAt"]').should('have.value', inputFormatedDate)
-//     cy.get('[data-test="submit-edit-subscription"]').should('be.disabled')
-//     cy.get('input[name="name"]').clear().type(newSubscriptionName)
-//     cy.get('input[name="subscriptionAt"]').clear().type(newInputFormatedDate)
-//     cy.get('[data-test="submit-edit-subscription"]').click()
-//     cy.contains(subscriptionName).should('exist')
-//     cy.contains(newFormatedDate).should('exist')
-//   })
+  it(
+    'should be able to edit subscription',
+    {
+      // Sligntly increase timeout limit as backend could take time to give results for the SubscriptionItem values
+      defaultCommandTimeout: 5000,
+    },
+    () => {
+      cy.get(`[data-test="${subscriptionName}"]`).within(() => {
+        cy.contains('Pending').should('exist')
+        cy.get(`[data-test="menu-subscription"]`).click()
+      })
+      cy.get(`[data-test="edit-subscription"]`).click()
+      cy.get('input[name="name"]').should('have.value', subscriptionName)
+      cy.get('input[name="subscriptionAt"]').should('have.value', inputFormatedDate)
+      cy.get('[data-test="submit-edit-subscription"]').should('be.disabled')
+      cy.get('input[name="name"]').clear().type(newSubscriptionName)
+      cy.get('input[name="subscriptionAt"]').clear().type(newInputFormatedDate)
+      cy.get('[data-test="submit-edit-subscription"]').click()
+      cy.contains(subscriptionName).should('exist')
+      cy.contains(newFormatedDate).should('exist')
+    }
+  )
 
-//   it('should not be able to edit subscription date on active subscription', () => {
-//     cy.get(`[data-test="${subscriptionName}"]`).within(() => {
-//       cy.contains('Pending').should('exist')
-//       cy.contains('Active').should('not.exist')
-//       cy.get(`[data-test="menu-subscription"]`).click()
-//     })
-//     cy.get(`[data-test="edit-subscription"]`).click()
-//     cy.get('input[name="name"]').should('have.value', newSubscriptionName)
-//     cy.get('input[name="subscriptionAt"]').should('be.disabled')
-//   })
+  it(
+    'should not be able to edit subscription date on active subscription',
+    {
+      // Sligntly increase timeout limit as backend could take time to give results for the SubscriptionItem values
+      defaultCommandTimeout: 5000,
+    },
+    () => {
+      cy.get(`[data-test="${subscriptionName}"]`).within(() => {
+        cy.contains('Pending').should('exist')
+        cy.contains('Active').should('not.exist')
+        cy.get(`[data-test="menu-subscription"]`).click()
+      })
+      cy.get(`[data-test="edit-subscription"]`).click()
+      cy.get('input[name="name"]').should('have.value', newSubscriptionName)
+      cy.get('input[name="subscriptionAt"]').should('be.disabled')
+    }
+  )
 
-//   it('should be able to terminate the subscription', () => {
-//     cy.get(`[data-test="${newSubscriptionName}"]`).within(() => {
-//       cy.get(`[data-test="menu-subscription"]`).click()
-//     })
-//     cy.get(`[data-test="terminate-subscription"]`).click()
-//     cy.get(`[data-test="warning-confirm"]`).click()
-//     cy.contains(newSubscriptionName).should('not.exist')
-//   })
-// })
+  it(
+    'should be able to terminate the subscription',
+    {
+      // Sligntly increase timeout limit as backend could take time to give results for the SubscriptionItem values
+      defaultCommandTimeout: 5000,
+    },
+    () => {
+      cy.get(`[data-test="${newSubscriptionName}"]`).within(() => {
+        cy.get(`[data-test="menu-subscription"]`).click()
+      })
+      cy.get(`[data-test="terminate-subscription"]`).click()
+      cy.get(`[data-test="warning-confirm"]`).click()
+      cy.contains(newSubscriptionName).should('not.exist')
+    }
+  )
+})


### PR DESCRIPTION
## Context

This test was flaky and being commented in the past.

## Description

This PR uncomment the test.

The flaky behaviour was surely due to the backend answer to take time, leading to `data-test="menu-subscription"` button not to trigger anything on click.

I increased the timeout on those tests to make sure the backend can answer on time