### PR TITLE
test: reduce Drawer transition duration during tests

### DIFF
--- a/src/components/designSystem/Drawer.tsx
+++ b/src/components/designSystem/Drawer.tsx
@@ -27,6 +27,9 @@ export interface DrawerRef {
   closeDrawer: () => unknown
 }
 
+// @ts-ignore
+const transitionDuration = window.Cypress ? 0 : 250
+
 export const Drawer = forwardRef<DrawerRef, DrawerProps>(
   (
     { forceOpen = false, children, opener, anchor = 'right', title, onOpen, onClose }: DrawerProps,
@@ -53,7 +56,7 @@ export const Drawer = forwardRef<DrawerRef, DrawerProps>(
             onClose && onClose()
             setIsOpen(false)
           }}
-          transitionDuration={250}
+          transitionDuration={transitionDuration}
           PaperProps={{ className: 'drawerPaper' }}
         >
           <Header>

--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -3,7 +3,8 @@ import { debounce, DebouncedFunc } from 'lodash'
 import { LazyQueryExecFunction } from '@apollo/client'
 import { DateTime } from 'luxon'
 
-export const DEBOUNCE_SEARCH_MS = 500
+// @ts-ignore
+const DEBOUNCE_SEARCH_MS = window.Cypress ? 0 : 500
 
 export type UseDebouncedSearch = (
   searchQuery?: LazyQueryExecFunction<


### PR DESCRIPTION
## Context

Out test suite is taking a lot of time.

Trying to find way to reduce it a bit

## Description

This PR removed the timer when Drawer component opens for it to be instant