### PR TITLE
chore: make sure we deduplicate packages after install and update

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "release": "release-it",
     "changelog:update": "auto-changelog --template=.changelog/regular.hbs",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook --no-dll -o storybook-build -s src/stories/assets"
+    "build-storybook": "build-storybook --no-dll -o storybook-build -s src/stories/assets",
+    "postinstall": "npx yarn-deduplicate"
   },
   "devDependencies": {
     "@babel/core": "7.20.12",

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "stabilityDays": 3,
   "addLabels": ["🔗 dependencies"],
   "schedule": ["after 1am before 8am"],
+  "postUpdateOptions": ["yarnDedupeHighest"],
   "dependencyDashboardTitle": "👷‍♀️ Dependency Dashboard",
   "dependencyDashboardHeader": "[👮‍♂️ Do not close]. This issue provides visibility into Renovate updates and their statuses. [Learn more](https://docs.renovatebot.com/key-concepts/dashboard/)",
   "dependencyDashboardLabels": ["🙅 Don't close"],


### PR DESCRIPTION
This PR make sure `yarn-deduplicate` is called on package post-install and post-update