### PR TITLE
chore: update chip styles

### DIFF
--- a/src/components/designSystem/Chip.tsx
+++ b/src/components/designSystem/Chip.tsx
@@ -27,11 +27,11 @@ type ChipProps = ChipPropsAvatar | ChipPropsIcon
 export const Chip = ({ label, icon, avatarProps, onClose }: ChipProps) => {
   return (
     <Container>
-      {icon && <StyledIcon name={icon} size="small" />}
-      {avatarProps && <StyledAvatar size="small" variant="user" {...avatarProps} />}
-      <Label variant="captionHl" color="textSecondary" $withClose={!!onClose}>
+      {icon && <Icon name={icon} size="small" />}
+      {avatarProps && <Avatar size="small" variant="user" {...avatarProps} />}
+      <Typography variant="captionHl" color="textSecondary">
         {label}
-      </Label>
+      </Typography>
       {onClose && (
         <Button size="small" variant="quaternary" icon="close-circle-filled" onClick={onClose} />
       )}
@@ -40,24 +40,22 @@ export const Chip = ({ label, icon, avatarProps, onClose }: ChipProps) => {
 }
 
 const Container = styled.div`
-  height: 32px;
+  min-height: 32px;
   border: 1px solid ${theme.palette.grey[300]};
   background-color: ${theme.palette.grey[100]};
-  padding: 0 ${theme.spacing(2)};
+  padding: ${theme.spacing(1)} ${theme.spacing(2)};
   box-sizing: border-box;
   border-radius: 8px;
   display: flex;
   align-items: center;
-`
 
-const Label = styled(Typography)<{ $withClose?: boolean }>`
-  margin-right: ${({ $withClose }) => ($withClose ? theme.spacing(2) : 0)};
-`
+  > *:not(:last-child) {
+    margin-right: ${theme.spacing(2)};
+  }
 
-const StyledIcon = styled(Icon)`
-  margin-right: ${theme.spacing(2)};
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(2)};
+  button.button-icon-only {
+    width: 16px;
+    height: 16px;
+    padding: 0;
+  }
 `


### PR DESCRIPTION
Update Chip component style in order to adapt if multiple lines are displayed

So it can look like this 
<img width="638" alt="image" src="https://user-images.githubusercontent.com/5517077/214330160-e0e7070c-3762-4824-8c2e-3b0b361456b7.png">

Also took the opportunity to clean some repetitive style such as all `margin-right`