### PR TITLE
bug: set loading to true by default

### DIFF
--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -19,7 +19,7 @@ export type UseDebouncedSearch = (
 }
 
 export const useDebouncedSearch: UseDebouncedSearch = (searchQuery, loading) => {
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
   const startLoading = useRef<DateTime | null>(null)
 
   // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
On large dataset, loading were first showing empty state screen before triggering the loading.

It appear that when debouncing, the default loading state value was false, even tho once the hook is ready we imediatly trigger the query, leading to a blink before first loading.

This PR changes the default state value to be true