### PR TITLE
bug: fix amount cents type

### DIFF
--- a/src/components/customers/CustomerCreditNotesList.tsx
+++ b/src/components/customers/CustomerCreditNotesList.tsx
@@ -42,7 +42,7 @@ gql`
 interface CustomerCreditNotesListProps {
   customerId: string
   creditNotesCreditsAvailableCount?: number
-  creditNotesBalanceAmountCents?: number
+  creditNotesBalanceAmountCents?: string
   userCurrency?: CurrencyEnum
   customerTimezone: TimezoneEnum
 }

--- a/src/hooks/useCreateCreditNote.ts
+++ b/src/hooks/useCreateCreditNote.ts
@@ -131,7 +131,7 @@ export const useCreateCreditNote: () => UseCreateCreditNoteReturn = () => {
   if (
     !invoiceId ||
     hasDefinedGQLError('NotFound', error, 'invoice') ||
-    (data?.invoice?.refundableAmountCents === 0 && data?.invoice?.creditableAmountCents === 0)
+    (data?.invoice?.refundableAmountCents === '0' && data?.invoice?.creditableAmountCents === '0')
   ) {
     navigate(ERROR_404_ROUTE)
   }
@@ -204,7 +204,7 @@ export const useCreateCreditNote: () => UseCreateCreditNoteReturn = () => {
           }
           const grouped = feeGroup.reduce((accFee, feeGrouped) => {
             if (
-              feeGrouped?.creditableAmountCents === 0 ||
+              feeGrouped?.creditableAmountCents === '0' ||
               ![FeeTypesEnum.Charge, FeeTypesEnum.Subscription].includes(feeGrouped.feeType)
             ) {
               return accFee

--- a/src/layouts/CustomerInvoiceDetails.tsx
+++ b/src/layouts/CustomerInvoiceDetails.tsx
@@ -337,7 +337,7 @@ const CustomerInvoiceDetails = () => {
                       <Button
                         variant="quaternary"
                         align="left"
-                        disabled={creditableAmountCents === 0 && refundableAmountCents === 0}
+                        disabled={creditableAmountCents === '0' && refundableAmountCents === '0'}
                         onClick={async () => {
                           navigate(
                             generatePath(CUSTOMER_INVOICE_CREATE_CREDIT_NOTE_ROUTE, {

--- a/src/pages/InvoiceCreditNoteList.tsx
+++ b/src/pages/InvoiceCreditNoteList.tsx
@@ -71,8 +71,8 @@ const InvoiceCreditNoteList = () => {
                 <ButtonLink
                   type="button"
                   disabled={
-                    data?.invoice?.creditableAmountCents === 0 &&
-                    data?.invoice?.refundableAmountCents === 0
+                    data?.invoice?.creditableAmountCents === '0' &&
+                    data?.invoice?.refundableAmountCents === '0'
                   }
                   buttonProps={{ variant: 'quaternary' }}
                   to={generatePath(CUSTOMER_INVOICE_CREATE_CREDIT_NOTE_ROUTE, { id, invoiceId })}


### PR DESCRIPTION
## Context

Customers should not have the possibility to issue a credit note when the invoice has no `creditableAmountCents` and `refundableAmountCents`.

## Description

This PR does read those values as string, as they are returned by the BE