### PR TITLE
bug: 🏷️ fix coupons alert wrongly displayed

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -1691,7 +1691,6 @@ export type Invoice = {
   legacy: Scalars['Boolean'];
   number: Scalars['String'];
   paymentStatus: InvoicePaymentStatusTypeEnum;
-  plan?: Maybe<Plan>;
   refundableAmountCents: Scalars['BigInt'];
   sequentialId: Scalars['ID'];
   status: InvoiceStatusTypeEnum;

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -297,9 +297,10 @@ const CreateCoupon = () => {
                     formikProps={formikProps}
                   />
 
-                  {formikProps.values.frequency === CouponFrequency.Forever && (
-                    <Alert type="info">{translate('text_63c83a3476e46bc6ab9d85da')}</Alert>
-                  )}
+                  {formikProps.values.frequency === CouponFrequency.Forever &&
+                    formikProps.values.couponType === CouponTypeEnum.FixedAmount && (
+                      <Alert type="info">{translate('text_63c83a3476e46bc6ab9d85da')}</Alert>
+                    )}
 
                   {formikProps.values.frequency === CouponFrequency.Recurring && (
                     <TextInputField


### PR DESCRIPTION
## Context

An alert is shown when creating a forever coupon with percentage. Which should not happen as the error mentions a situation with fixed amount

## Description

This PR adds a condition to display the alert correctly