### PR TITLE
feat: udpate edit coupon and addon disabled logic

### DIFF
--- a/src/components/addOns/AddOnItem.tsx
+++ b/src/components/addOns/AddOnItem.tsx
@@ -38,7 +38,7 @@ gql`
     amountCents
     customerCount
     createdAt
-    canBeDeleted
+    appliedAddOnsCount
   }
 `
 
@@ -48,7 +48,8 @@ interface AddOnItemProps {
 }
 
 export const AddOnItem = ({ addOn, navigationProps }: AddOnItemProps) => {
-  const { id, name, amountCurrency, amountCents, customerCount, createdAt, canBeDeleted } = addOn
+  const { id, name, amountCurrency, amountCents, customerCount, createdAt, appliedAddOnsCount } =
+    addOn
   const deleteDialogRef = useRef<DeleteAddOnDialogRef>(null)
   const { translate } = useInternationalization()
   const { formatTimeOrgaTZ } = useOrganizationInfos()
@@ -117,14 +118,14 @@ export const AddOnItem = ({ addOn, navigationProps }: AddOnItemProps) => {
               {translate('text_629728388c4d2300e2d3816a')}
             </ButtonLink>
             <Tooltip
-              disableHoverListener={canBeDeleted}
+              disableHoverListener={!appliedAddOnsCount}
               title={translate('text_629791022a75b60089e98ea7')}
               placement="bottom-end"
             >
               <Button
                 startIcon="trash"
                 variant="quaternary"
-                disabled={!canBeDeleted}
+                disabled={!!appliedAddOnsCount}
                 align="left"
                 fullWidth
                 onClick={() => {

--- a/src/components/coupons/CouponItem.tsx
+++ b/src/components/coupons/CouponItem.tsx
@@ -44,7 +44,7 @@ gql`
     status
     amountCurrency
     amountCents
-    canBeDeleted
+    appliedCouponsCount
     expiration
     expirationAt
     couponType
@@ -75,7 +75,7 @@ const mapStatus = (type?: CouponStatusEnum | undefined) => {
 }
 
 export const CouponItem = ({ coupon, navigationProps }: CouponItemProps) => {
-  const { id, name, customerCount, status, canBeDeleted, expirationAt } = coupon
+  const { id, name, customerCount, status, appliedCouponsCount, expirationAt } = coupon
   const deleteDialogRef = useRef<DeleteCouponDialogRef>(null)
   const terminateDialogRef = useRef<TerminateCouponDialogRef>(null)
   const { translate } = useInternationalization()
@@ -177,14 +177,14 @@ export const CouponItem = ({ coupon, navigationProps }: CouponItemProps) => {
               </Button>
             </Tooltip>
             <Tooltip
-              disableHoverListener={canBeDeleted}
+              disableHoverListener={!appliedCouponsCount}
               title={translate('text_62876a50ea3bba00b56d2cee')}
               placement="bottom-end"
             >
               <Button
                 startIcon="trash"
                 variant="quaternary"
-                disabled={!canBeDeleted}
+                disabled={!!appliedCouponsCount}
                 align="left"
                 fullWidth
                 onClick={() => {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -44,8 +44,7 @@ export type AddOn = {
   __typename?: 'AddOn';
   amountCents: Scalars['BigInt'];
   amountCurrency: CurrencyEnum;
-  /** Check if add-on is deletable */
-  canBeDeleted: Scalars['Boolean'];
+  appliedAddOnsCount: Scalars['Int'];
   code: Scalars['String'];
   createdAt: Scalars['ISO8601DateTime'];
   /** Number of customers using this add-on */
@@ -67,8 +66,7 @@ export type AddOnDetails = {
   __typename?: 'AddOnDetails';
   amountCents: Scalars['BigInt'];
   amountCurrency: CurrencyEnum;
-  /** Check if add-on is deletable */
-  canBeDeleted: Scalars['Boolean'];
+  appliedAddOnsCount: Scalars['Int'];
   code: Scalars['String'];
   createdAt: Scalars['ISO8601DateTime'];
   /** Number of customers using this add-on */
@@ -719,8 +717,7 @@ export type Coupon = {
   __typename?: 'Coupon';
   amountCents?: Maybe<Scalars['BigInt']>;
   amountCurrency?: Maybe<CurrencyEnum>;
-  /** Check if coupon is deletable */
-  canBeDeleted: Scalars['Boolean'];
+  appliedCouponsCount: Scalars['Int'];
   code?: Maybe<Scalars['String']>;
   couponType: CouponTypeEnum;
   createdAt: Scalars['ISO8601DateTime'];
@@ -750,8 +747,7 @@ export type CouponDetails = {
   __typename?: 'CouponDetails';
   amountCents?: Maybe<Scalars['BigInt']>;
   amountCurrency?: Maybe<CurrencyEnum>;
-  /** Check if coupon is deletable */
-  canBeDeleted: Scalars['Boolean'];
+  appliedCouponsCount: Scalars['Int'];
   code?: Maybe<Scalars['String']>;
   couponType: CouponTypeEnum;
   createdAt: Scalars['ISO8601DateTime'];
@@ -3179,7 +3175,7 @@ export type UserIdentifierQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type UserIdentifierQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string, email?: string | null, premium: boolean, organizations?: Array<{ __typename?: 'Organization', id: string, name: string, logoUrl?: string | null }> | null }, organization?: { __typename?: 'Organization', id: string, name: string, logoUrl?: string | null, timezone?: TimezoneEnum | null, vatRate: number, invoiceGracePeriod: number } | null };
 
-export type AddOnItemFragment = { __typename?: 'AddOn', id: string, name: string, amountCurrency: CurrencyEnum, amountCents: any, customerCount: number, createdAt: any, canBeDeleted: boolean };
+export type AddOnItemFragment = { __typename?: 'AddOn', id: string, name: string, amountCurrency: CurrencyEnum, amountCents: any, customerCount: number, createdAt: any, appliedAddOnsCount: number };
 
 export type DeleteAddOnFragment = { __typename?: 'AddOn', id: string, name: string };
 
@@ -3205,7 +3201,7 @@ export type CouponCaptionFragment = { __typename?: 'Coupon', id: string, amountC
 
 export type AppliedCouponCaptionFragment = { __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null };
 
-export type CouponItemFragment = { __typename?: 'Coupon', id: string, name: string, customerCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, canBeDeleted: boolean, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null };
+export type CouponItemFragment = { __typename?: 'Coupon', id: string, name: string, customerCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, appliedCouponsCount: number, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null };
 
 export type DeleteCouponFragment = { __typename?: 'Coupon', id: string, name: string };
 
@@ -3663,14 +3659,14 @@ export type CreateCreditNoteMutationVariables = Exact<{
 
 export type CreateCreditNoteMutation = { __typename?: 'Mutation', createCreditNote?: { __typename?: 'CreditNote', id: string } | null };
 
-export type EditAddOnFragment = { __typename?: 'AddOnDetails', id: string, name: string, code: string, description?: string | null, amountCents: any, amountCurrency: CurrencyEnum };
+export type EditAddOnFragment = { __typename?: 'AddOnDetails', id: string, name: string, code: string, description?: string | null, amountCents: any, amountCurrency: CurrencyEnum, appliedAddOnsCount: number };
 
 export type GetSingleAddOnQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetSingleAddOnQuery = { __typename?: 'Query', addOn?: { __typename?: 'AddOnDetails', id: string, name: string, code: string, description?: string | null, amountCents: any, amountCurrency: CurrencyEnum } | null };
+export type GetSingleAddOnQuery = { __typename?: 'Query', addOn?: { __typename?: 'AddOnDetails', id: string, name: string, code: string, description?: string | null, amountCents: any, amountCurrency: CurrencyEnum, appliedAddOnsCount: number } | null };
 
 export type CreateAddOnMutationVariables = Exact<{
   input: CreateAddOnInput;
@@ -3684,7 +3680,7 @@ export type UpdateAddOnMutationVariables = Exact<{
 }>;
 
 
-export type UpdateAddOnMutation = { __typename?: 'Mutation', updateAddOn?: { __typename?: 'AddOn', id: string, name: string, amountCurrency: CurrencyEnum, amountCents: any, customerCount: number, createdAt: any, canBeDeleted: boolean } | null };
+export type UpdateAddOnMutation = { __typename?: 'Mutation', updateAddOn?: { __typename?: 'AddOn', id: string, name: string, amountCurrency: CurrencyEnum, amountCents: any, customerCount: number, createdAt: any, appliedAddOnsCount: number } | null };
 
 export type GetSingleBillableMetricQueryVariables = Exact<{
   id: Scalars['ID'];
@@ -3707,14 +3703,14 @@ export type UpdateBillableMetricMutationVariables = Exact<{
 
 export type UpdateBillableMetricMutation = { __typename?: 'Mutation', updateBillableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, createdAt: any, draftInvoicesCount: number, activeSubscriptionsCount: number } | null };
 
-export type EditCouponFragment = { __typename?: 'CouponDetails', id: string, amountCents?: any | null, name: string, amountCurrency?: CurrencyEnum | null, code?: string | null, reusable: boolean, expiration: CouponExpiration, expirationAt?: any | null, canBeDeleted: boolean, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null };
+export type EditCouponFragment = { __typename?: 'CouponDetails', id: string, amountCents?: any | null, name: string, amountCurrency?: CurrencyEnum | null, code?: string | null, reusable: boolean, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, appliedCouponsCount: number };
 
 export type GetSingleCouponQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetSingleCouponQuery = { __typename?: 'Query', coupon?: { __typename?: 'CouponDetails', id: string, amountCents?: any | null, name: string, amountCurrency?: CurrencyEnum | null, code?: string | null, reusable: boolean, expiration: CouponExpiration, expirationAt?: any | null, canBeDeleted: boolean, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null } | null };
+export type GetSingleCouponQuery = { __typename?: 'Query', coupon?: { __typename?: 'CouponDetails', id: string, amountCents?: any | null, name: string, amountCurrency?: CurrencyEnum | null, code?: string | null, reusable: boolean, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, appliedCouponsCount: number } | null };
 
 export type CreateCouponMutationVariables = Exact<{
   input: CreateCouponInput;
@@ -3728,7 +3724,7 @@ export type UpdateCouponMutationVariables = Exact<{
 }>;
 
 
-export type UpdateCouponMutation = { __typename?: 'Mutation', updateCoupon?: { __typename?: 'Coupon', id: string, name: string, customerCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, canBeDeleted: boolean, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null } | null };
+export type UpdateCouponMutation = { __typename?: 'Mutation', updateCoupon?: { __typename?: 'Coupon', id: string, name: string, customerCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, appliedCouponsCount: number, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null } | null };
 
 export type AddCustomerDrawerFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, canBeDeleted: boolean, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, canEditAttributes: boolean, city?: string | null, zipcode?: string | null, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null };
 
@@ -3797,7 +3793,7 @@ export type AddOnsQueryVariables = Exact<{
 }>;
 
 
-export type AddOnsQuery = { __typename?: 'Query', addOns: { __typename?: 'AddOnCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'AddOn', id: string, name: string, amountCurrency: CurrencyEnum, amountCents: any, customerCount: number, createdAt: any, canBeDeleted: boolean }> } };
+export type AddOnsQuery = { __typename?: 'Query', addOns: { __typename?: 'AddOnCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'AddOn', id: string, name: string, amountCurrency: CurrencyEnum, amountCents: any, customerCount: number, createdAt: any, appliedAddOnsCount: number }> } };
 
 export type BillableMetricsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']>;
@@ -3815,7 +3811,7 @@ export type CouponsQueryVariables = Exact<{
 }>;
 
 
-export type CouponsQuery = { __typename?: 'Query', coupons: { __typename?: 'CouponCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Coupon', id: string, name: string, customerCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, canBeDeleted: boolean, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null }> } };
+export type CouponsQuery = { __typename?: 'Query', coupons: { __typename?: 'CouponCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Coupon', id: string, name: string, customerCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, appliedCouponsCount: number, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null }> } };
 
 export type EditBillableMetricFragment = { __typename?: 'BillableMetricDetail', id: string, name: string, code: string, description?: string | null, group?: any | null, aggregationType: AggregationTypeEnum, fieldName?: string | null, subscriptionsCount: number };
 
@@ -4022,7 +4018,7 @@ export const AddOnItemFragmentDoc = gql`
   amountCents
   customerCount
   createdAt
-  canBeDeleted
+  appliedAddOnsCount
 }
     `;
 export const DeleteAddOnFragmentDoc = gql`
@@ -4067,7 +4063,7 @@ export const CouponItemFragmentDoc = gql`
   status
   amountCurrency
   amountCents
-  canBeDeleted
+  appliedCouponsCount
   expiration
   expirationAt
   couponType
@@ -4432,6 +4428,7 @@ export const EditAddOnFragmentDoc = gql`
   description
   amountCents
   amountCurrency
+  appliedAddOnsCount
 }
     `;
 export const EditCouponFragmentDoc = gql`
@@ -4444,11 +4441,11 @@ export const EditCouponFragmentDoc = gql`
   reusable
   expiration
   expirationAt
-  canBeDeleted
   couponType
   percentageRate
   frequency
   frequencyDuration
+  appliedCouponsCount
 }
     `;
 export const CurrentUserInfosFragmentDoc = gql`

--- a/src/hooks/useCreateEditAddOn.ts
+++ b/src/hooks/useCreateEditAddOn.ts
@@ -28,6 +28,7 @@ gql`
     description
     amountCents
     amountCurrency
+    appliedAddOnsCount
   }
 
   query getSingleAddOn($id: ID!) {

--- a/src/hooks/useCreateEditCoupon.ts
+++ b/src/hooks/useCreateEditCoupon.ts
@@ -34,11 +34,11 @@ gql`
     reusable
     expiration
     expirationAt
-    canBeDeleted
     couponType
     percentageRate
     frequency
     frequencyDuration
+    appliedCouponsCount
   }
 
   query getSingleCoupon($id: ID!) {

--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -40,7 +40,7 @@ const CreateAddOn = () => {
       description: addOn?.description || '',
       // @ts-ignore
       amountCents: addOn?.amountCents
-        ? deserializeAmount(addOn?.amountCents, addOn?.amountCurrency)
+        ? String(deserializeAmount(addOn?.amountCents, addOn?.amountCurrency))
         : addOn?.amountCents || undefined,
       amountCurrency: addOn?.amountCurrency || CurrencyEnum.Usd,
     },
@@ -150,6 +150,7 @@ const CreateAddOn = () => {
                     />
                     <TextInputField
                       name="code"
+                      disabled={isEdition && !!addOn?.appliedAddOnsCount}
                       beforeChangeFormatter="code"
                       label={translate('text_629728388c4d2300e2d380b7')}
                       placeholder={translate('text_629728388c4d2300e2d380d9')}
@@ -174,6 +175,7 @@ const CreateAddOn = () => {
                   <LineAmount>
                     <AmountInputField
                       name="amountCents"
+                      disabled={isEdition && !!addOn?.appliedAddOnsCount}
                       currency={formikProps.values.amountCurrency || CurrencyEnum.Usd}
                       beforeChangeFormatter={['positiveNumber']}
                       label={translate('text_629728388c4d2300e2d3812d')}
@@ -181,6 +183,7 @@ const CreateAddOn = () => {
                     />
                     <ComboBoxField
                       name="amountCurrency"
+                      disabled={isEdition && !!addOn?.appliedAddOnsCount}
                       data={Object.values(CurrencyEnum).map((currencyType) => ({
                         value: currencyType,
                       }))}

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -206,7 +206,7 @@ const CreateCoupon = () => {
                   <TextInputField
                     name="code"
                     beforeChangeFormatter="code"
-                    disabled={isEdition && !coupon?.canBeDeleted}
+                    disabled={isEdition && !!coupon?.appliedCouponsCount}
                     label={translate('text_62876e85e32e0300e1803127')}
                     placeholder={translate('text_62876e85e32e0300e180312d')}
                     formikProps={formikProps}
@@ -222,7 +222,7 @@ const CreateCoupon = () => {
                     disableClearable
                     name="couponType"
                     label={translate('text_632d68358f1fedc68eed3e5a')}
-                    disabled={isEdition && !coupon?.canBeDeleted}
+                    disabled={isEdition && !!coupon?.appliedCouponsCount}
                     data={[
                       {
                         value: CouponTypeEnum.FixedAmount,
@@ -242,12 +242,12 @@ const CreateCoupon = () => {
                         name="amountCents"
                         currency={formikProps.values.amountCurrency || CurrencyEnum.Usd}
                         beforeChangeFormatter={['positiveNumber']}
-                        disabled={isEdition && !coupon?.canBeDeleted}
+                        disabled={isEdition && !!coupon?.appliedCouponsCount}
                         label={translate('text_62978f2c197cea009ab0b7d0')}
                         formikProps={formikProps}
                       />
                       <ComboBoxField
-                        disabled={isEdition && !coupon?.canBeDeleted}
+                        disabled={isEdition && !!coupon?.appliedCouponsCount}
                         name="amountCurrency"
                         data={Object.values(CurrencyEnum).map((currencyType) => ({
                           value: currencyType,
@@ -260,7 +260,7 @@ const CreateCoupon = () => {
                     <TextInputField
                       name="percentageRate"
                       beforeChangeFormatter={['positiveNumber', 'decimal']}
-                      disabled={isEdition && !coupon?.canBeDeleted}
+                      disabled={isEdition && !!coupon?.appliedCouponsCount}
                       label={translate('text_632d68358f1fedc68eed3e76')}
                       placeholder={translate('text_632d68358f1fedc68eed3e86')}
                       formikProps={formikProps}
@@ -275,7 +275,7 @@ const CreateCoupon = () => {
                   )}
 
                   <ComboBoxField
-                    disabled={isEdition && !coupon?.canBeDeleted}
+                    disabled={isEdition && !!coupon?.appliedCouponsCount}
                     name="frequency"
                     label={translate('text_632d68358f1fedc68eed3e9d')}
                     helperText={translate('text_632d68358f1fedc68eed3eab')}
@@ -306,7 +306,7 @@ const CreateCoupon = () => {
                     <TextInputField
                       name="frequencyDuration"
                       beforeChangeFormatter={['positiveNumber', 'int']}
-                      disabled={isEdition && !coupon?.canBeDeleted}
+                      disabled={isEdition && !!coupon?.appliedCouponsCount}
                       label={translate('text_632d68358f1fedc68eed3e80')}
                       placeholder={translate('text_632d68358f1fedc68eed3e88')}
                       formikProps={formikProps}
@@ -333,7 +333,7 @@ const CreateCoupon = () => {
                     <Checkbox
                       name="isReusable"
                       value={formikProps.values.reusable}
-                      disabled={isEdition && !coupon?.canBeDeleted}
+                      disabled={isEdition && !!coupon?.appliedCouponsCount}
                       label={translate('text_638f48274d41e3f1d01fc16a')}
                       onChange={(_, checked) => {
                         formikProps.setFieldValue('reusable', checked)


### PR DESCRIPTION
## Context

We change the logic allowing if a user can delete or not an add on or a coupon

Goal is to align with BE logic used too

## Description

This PR uses the new `appliedCouponsCount` and `appliedAddOnsCount` attributes to handle disable logic