### PR TITLE
misc: fix timezone usage

### DIFF
--- a/src/components/customers/AddCustomerDrawer.tsx
+++ b/src/components/customers/AddCustomerDrawer.tsx
@@ -190,7 +190,7 @@ export const AddCustomerDrawer = forwardRef<DrawerRef, AddCustomerDrawerProps>(
                   variant="caption"
                   html={translate('text_6390a4ffef9227ba45daca94', {
                     timezone: translate('text_638f743fa9a2a9545ee6409a', {
-                      zone: translate(timezoneConfig.name),
+                      zone: timezoneConfig.name,
                       offset: timezoneConfig.offset,
                     }),
                     link: ORGANIZATION_INFORMATIONS_ROUTE,

--- a/src/pages/settings/OrganizationInformations.tsx
+++ b/src/pages/settings/OrganizationInformations.tsx
@@ -11,6 +11,7 @@ import {
   useGetOrganizationInformationsQuery,
   EditOrganizationInformationsDialogFragmentDoc,
   EditOrganizationInformationsDialogFragment,
+  TimezoneEnum,
 } from '~/generated/graphql'
 import {
   EditOrganizationInformationsDialog,
@@ -117,7 +118,7 @@ const OrganizationInformations = () => {
           <TimezoneBlock>
             <Timezone color="grey700">
               {translate('text_638f743fa9a2a9545ee6409a', {
-                zone: translate(timezone || 'TZ_UTC'),
+                zone: translate(timezone || TimezoneEnum.TzUtc),
                 offset: timezoneConfig.offset,
               })}
             </Timezone>


### PR DESCRIPTION
## Context

Fix miscellaneous code around timezone

Was first looking how to fix a translation warning, took time to remove an hardcoded value.

## Description

This PR does 2 things:
- uses an enum instead of hardcoded value
- fixes a translation warning. We were trying to translate an already translated value, so the `translate` method were returning a warning while prompting the correct value on the screen. User were not impacted and wont see any change after this merge