### PR TITLE
bug: 🐟 fix edition rule for BM in plan form

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -1328,6 +1328,7 @@ export type Customer = {
   /** Number of available credits from credit notes per customer */
   creditNotesCreditsAvailableCount: Scalars['Int'];
   currency?: Maybe<CurrencyEnum>;
+  deletedAt?: Maybe<Scalars['ISO8601DateTime']>;
   email?: Maybe<Scalars['String']>;
   externalId: Scalars['String'];
   /** Define if a customer has an active wallet */
@@ -1382,6 +1383,7 @@ export type CustomerDetails = {
   /** Number of available credits from credit notes per customer */
   creditNotesCreditsAvailableCount: Scalars['Int'];
   currency?: Maybe<CurrencyEnum>;
+  deletedAt?: Maybe<Scalars['ISO8601DateTime']>;
   email?: Maybe<Scalars['String']>;
   externalId: Scalars['String'];
   /** Define if a customer has an active wallet */

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -155,7 +155,7 @@ const CreatePlan = () => {
     validateOnMount: true,
     onSubmit: onSave,
   })
-  const chargeEditIndexLimit = plan?.charges?.length || 0
+
   const canBeEdited = !plan?.subscriptionsCount
 
   useEffect(() => {
@@ -399,7 +399,7 @@ const CreatePlan = () => {
                             isUsedInSubscription={!isNew && !canBeEdited}
                             currency={formikProps.values.amountCurrency || CurrencyEnum.Usd}
                             index={i}
-                            disabled={isEdition && !canBeEdited && chargeEditIndexLimit > i}
+                            disabled={isEdition && !canBeEdited && !isNew}
                             formikProps={formikProps}
                           />
                         )


### PR DESCRIPTION
This rule changed with the recent plan edition being allowed.

If a BM is not attached to a plan yet (the plan has not been saved with this BM yet), the charge does not have and ID yet.

We now rely on the `isNew` condition, that performs a find and pretty much do the job of knowing if the charge has an ID or not