### PR TITLE
chore: 🚢 fix warning peer deps not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "clsx": "1.2.1",
     "crypto-hash": "2.0.1",
     "formik": "2.2.9",
+    "graphql": "^16.6.0",
     "localforage": "1.10.0",
     "lodash": "4.17.21",
     "luxon": "3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9444,10 +9444,10 @@ graphql-ws@5.11.2:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.11.2.tgz#d5e0acae8b4d4a4cf7be410a24135cfcefd7ddc0"
   integrity sha512-4EiZ3/UXYcjm+xFGP544/yW1+DVI8ZpKASFbzrV5EDTFWJp0ZvLl4Dy2fSZAzz9imKp5pZMIcjB0x/H69Pv/6w==
 
-"graphql@14 - 16":
-  version "16.5.0"
-  resolved "https://registry.npmjs.org/graphql/-/graphql-16.5.0.tgz"
-  integrity sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==
+"graphql@14 - 16", graphql@^16.6.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 gzip-size@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Fixed build warning 

```
npm WARN @apollo/client@3.7.6 requires a peer of graphql@^14.0.0 || ^15.0.0 || ^16.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @graphql-typed-document-node/core@3.1.1 requires a peer of graphql@^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN apollo-upload-client@17.0.0 requires a peer of graphql@14 - 16 but none is installed. You must install peer dependencies yourself.
npm WARN graphql-tag@2.12.6 requires a peer of graphql@^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 but none is installed. You must install peer dependencies yourself.
```

This does not changes the build size. We probably rely on a sub-package version that includes `graphql` as a dependency yet, but will probably change.

[Also the apollo documentation recommands to install graphql in the package setup](https://www.apollographql.com/docs/react/get-started/#step-2-install-dependencies)