### PR TITLE
bug: fix charge percentage delete messing with attributes value

### DIFF
--- a/src/components/plans/ChargePercentage.tsx
+++ b/src/components/plans/ChargePercentage.tsx
@@ -53,7 +53,6 @@ export const ChargePercentage = ({
   valuePointer,
 }: ChargePercentageProps) => {
   const { translate } = useInternationalization()
-  const localCharge = formikProps.values.charges[chargeIndex]
   const showFixedAmount = valuePointer?.fixedAmount !== undefined
   const showFreeUnitsPerEvents = valuePointer?.freeUnitsPerEvents !== undefined
   const showFreeUnitsPerTotalAggregation = valuePointer?.freeUnitsPerTotalAggregation !== undefined
@@ -131,7 +130,7 @@ export const ChargePercentage = ({
               variant="quaternary"
               onClick={() => {
                 formikProps.setFieldValue(`charges.${chargeIndex}.${propertyCursor}`, {
-                  ...localCharge,
+                  ...valuePointer,
                   fixedAmount: undefined,
                 })
               }}
@@ -173,7 +172,7 @@ export const ChargePercentage = ({
               variant="quaternary"
               onClick={() => {
                 formikProps.setFieldValue(`charges.${chargeIndex}.${propertyCursor}`, {
-                  ...localCharge,
+                  ...valuePointer,
                   freeUnitsPerEvents: undefined,
                 })
               }}
@@ -219,7 +218,7 @@ export const ChargePercentage = ({
               variant="quaternary"
               onClick={() => {
                 formikProps.setFieldValue(`charges.${chargeIndex}.${propertyCursor}`, {
-                  ...localCharge,
+                  ...valuePointer,
                   freeUnitsPerTotalAggregation: undefined,
                 })
               }}


### PR DESCRIPTION
## Context

We have a bug when deleting extra attributes on a charge percentage

## Description

We were spreading the whole charge into itself, when deleting a line in a percentage charge.

This was leading to have the same object spread with the same structure, so all attributes values were reset (as the .properties was "deeper" so not accessed by the form)

Not we spread the exact same values and just update the expected value, keeping the others' values