### PR TITLE
chore: update cache when coupon is terminated

### DIFF
--- a/src/components/customers/CustomerCoupons.tsx
+++ b/src/components/customers/CustomerCoupons.tsx
@@ -61,6 +61,15 @@ export const CustomerCoupons = memo(
           })
         }
       },
+      update(cache, { data }) {
+        if (!data?.terminateAppliedCoupon) return
+        const cacheId = cache.identify({
+          id: data?.terminateAppliedCoupon.id,
+          __typename: 'AppliedCoupon',
+        })
+
+        cache.evict({ id: cacheId })
+      },
     })
 
     return (
@@ -123,7 +132,6 @@ export const CustomerCoupons = memo(
             if (deleteCouponId.current) {
               await removeCoupon({
                 variables: { input: { id: deleteCouponId.current } },
-                refetchQueries: ['getCustomer'],
               })
             }
           }}


### PR DESCRIPTION
## Context

When a coupon is terminated, we fetch all customer infos to retrieve back this list without the element

It does
- makes us perform an unnecessary call
- Makes the UI blink as the list is only updated when we receive the data for the query that retrieve back all customer infos. At this stage the "Delete coupon" dialog is already gone so users see the list being updated with a latency

## Description

We now evict the item from the cache, making the list update instantaneous