### PR TITLE
chore: remove useless section in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,3 @@
-## Roadmap Task
-
-👉 https://github.com/getlago/lago/issues/{{NUMBER}}
-
 ## Context
 
 Include relevant motivation and context.


### PR DESCRIPTION
## Context

We do not rely on Github projects anymore, so this section about a project link in PR template is useless now

## Description

This PR removes the section in the `PULL_REQUEST_TEMPLATE.md`