### PR TITLE
chore: ✍️ Manually update cache on revoke object

### DIFF
--- a/src/components/settings/members/RevokeInviteDialog.tsx
+++ b/src/components/settings/members/RevokeInviteDialog.tsx
@@ -32,6 +32,15 @@ export const RevokeInviteDialog = forwardRef<RevokeInviteDialogRef>((_, ref) => 
         })
       }
     },
+    update(cache, { data }) {
+      if (!data?.revokeInvite) return
+      const cacheId = cache.identify({
+        id: data?.revokeInvite.id,
+        __typename: 'Invite',
+      })
+
+      cache.evict({ id: cacheId })
+    },
   })
 
   const [inviteInfos, setInviteInfos] = useState<
@@ -61,7 +70,6 @@ export const RevokeInviteDialog = forwardRef<RevokeInviteDialogRef>((_, ref) => 
       onContinue={async () =>
         await revokeInvite({
           variables: { input: { id: inviteInfos?.id as string } },
-          refetchQueries: ['getInvites'],
         })
       }
       continueText={translate('text_63208c701ce25db78140745e')}

--- a/src/components/settings/members/RevokeMembershipDialog.tsx
+++ b/src/components/settings/members/RevokeMembershipDialog.tsx
@@ -32,6 +32,15 @@ export const RevokeMembershipDialog = forwardRef<RevokeMembershipDialogRef>((_, 
         })
       }
     },
+    update(cache, { data }) {
+      if (!data?.revokeMembership) return
+      const cacheId = cache.identify({
+        id: data?.revokeMembership.id,
+        __typename: 'Membership',
+      })
+
+      cache.evict({ id: cacheId })
+    },
   })
 
   const [membershipInfos, setMembershipInfos] = useState<
@@ -61,7 +70,6 @@ export const RevokeMembershipDialog = forwardRef<RevokeMembershipDialogRef>((_, 
       onContinue={async () =>
         await revokeMembership({
           variables: { input: { id: membershipInfos?.id as string } },
-          refetchQueries: ['getMembers'],
         })
       }
       continueText={translate('text_63208bfc99e69a28211ec7b4')}


### PR DESCRIPTION
Update cache manually after removing an object from a list to avoid loading glitch