### PR TITLE
test: make cy.type blazingly fast

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -43,3 +43,10 @@ Cypress.Commands.add('login', (email: string, password: string) => {
   cy.get('[data-test="submit"]').click()
   cy.url().should('be.equal', Cypress.config().baseUrl + '/')
 })
+
+// https://docs.cypress.io/api/cypress-api/custom-commands#Overwrite-type-command
+// @ts-ignore
+Cypress.Commands.overwrite('type', (originalFn, element, text, options) => {
+  // @ts-ignore
+  return originalFn(element, text, { ...options, delay: 0 })
+})


### PR DESCRIPTION
This PR overrides the `cy.type` method to perform the command with a `delay: 0` by default.

All TS errors have been overridden as the command comes from their documentation ans should be safe to use as is.

See https://docs.cypress.io/api/cypress-api/custom-commands#Overwrite-type-command for more infos

We pass from ~3'38 to 2'47, small gain but will prevent to increase too much when adding new tests

---

https://www.youtube.com/embed/Sp5_d6coiqU?start=4&amp;end=5%22
