### PR TITLE
test: set 0ms timeout in cypress env

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,3 +1,5 @@
+interface Window { Cypress: any; }
+
 declare type AppEnvEnum = import('./src/globalTypes').AppEnvEnum
 
 declare var APP_ENV: AppEnvEnum

--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -3,7 +3,7 @@ import { debounce, DebouncedFunc } from 'lodash'
 import { LazyQueryExecFunction } from '@apollo/client'
 import { DateTime } from 'luxon'
 
-export const DEBOUNCE_SEARCH_MS = 500
+export const DEBOUNCE_SEARCH_MS = window.Cypress ? 0 : 500
 
 export type UseDebouncedSearch = (
   searchQuery?: LazyQueryExecFunction<


### PR DESCRIPTION
## Context

In a search of improving our test suite, I wanted to reduce the timeout value to 0 in e2e tests

## Description

This RP does check on window.Cypress to know if the app is running in e2e test env
[Doc](https://docs.cypress.io/faq/questions/using-cypress-faq#Is-there-any-way-to-detect-if-my-app-is-running-under-Cypress)

Also, we now declare any type for this Cypress object