### PR TITLE
chore: 🥑 Remove material on Checkboxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "apollo-upload-client": "17.0.0",
     "apollo3-cache-persist": "0.14.1",
     "classnames": "2.3.2",
-    "clsx": "1.2.1",
     "crypto-hash": "2.0.1",
     "formik": "2.2.9",
     "graphql": "^16.6.0",

--- a/src/components/customers/AddCustomerDrawer.tsx
+++ b/src/components/customers/AddCustomerDrawer.tsx
@@ -329,7 +329,7 @@ export const AddCustomerDrawer = forwardRef<DrawerRef, AddCustomerDrawerProps>(
                   />
                   <Checkbox
                     name="providerCustomer.syncWithProvider"
-                    value={formikProps.values.providerCustomer?.syncWithProvider}
+                    value={!!formikProps.values.providerCustomer?.syncWithProvider}
                     label={
                       formikProps.values.paymentProvider === ProviderTypeEnum.Gocardless
                         ? translate('text_635bdbda84c98758f9bba8aa')

--- a/src/components/designSystem/ButtonLink.tsx
+++ b/src/components/designSystem/ButtonLink.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, MouseEvent, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import styled, { css } from 'styled-components'
-import { clsx } from 'clsx'
+import clsns from 'classnames'
 
 import { ConditionalWrapper } from '~/components/ConditionalWrapper'
 
@@ -71,7 +71,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
           }
         : buttonProps || {}
 
-    const classNames = clsx(className, {
+    const classNames = clsns(className, {
       'button-link-disabled': (active && !canBeClickedOnActive) || disabled,
     })
 

--- a/src/components/form/Checkbox/Checkbox.tsx
+++ b/src/components/form/Checkbox/Checkbox.tsx
@@ -1,82 +1,104 @@
-import { Checkbox as MuiCheckbox, FormControlLabel } from '@mui/material'
+import { useRef, ChangeEvent, useState } from 'react'
 import styled from 'styled-components'
-import clsx from 'clsx'
+import clsns from 'classnames'
 
-import { Typography } from '~/components/designSystem'
 import CheckedIcon from '~/public/icons/forms/checkbox-checked.svg'
 import IndeterminateIcon from '~/public/icons/forms/checkbox-indeterminate.svg'
 import Icon from '~/public/icons/forms/checkbox.svg'
 import { theme } from '~/styles'
+import { Typography } from '~/components/designSystem'
 
 enum LabelAlignmentEnum {
   top = 'top',
   center = 'center',
 }
+
 export interface CheckboxProps {
   canBeIndeterminate?: boolean
-  value?: boolean | null
-  disabled?: boolean
-  label?: string | React.ReactNode
-  name?: string
-  error?: string
   className?: string
+  disabled?: boolean
+  error?: string
+  label: string | React.ReactNode
   labelAlignment?: keyof typeof LabelAlignmentEnum
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void
+  name?: string
+  value?: boolean | undefined
+  onChange?: (event: ChangeEvent<HTMLInputElement>, checked: boolean) => void
 }
 
-/**
- * If checkbox 'canBeIndeterminate, the value can either be 'true', 'false', or 'undefined'
- * Otherwise, value can only be a boolean
- *
- * The checkbox will have the following behaviour on click if it canBeIndeterminate :
- * - if 'value === true' --> the new value will be false
- * - if value is undefined or null --> new value will be true
- * - if 'value === false' --> the new value will be true
- * The only way to set the value to 'undefined' is from the parent component.
- *
- * For example, the 'undefined' (aka undetermined) state could be to show that only some sub checkboxes are checked
- */
 export const Checkbox = ({
   canBeIndeterminate,
-  value,
-  disabled,
-  label,
-  name,
-  error,
   className,
-  labelAlignment,
+  disabled,
+  error,
+  label,
+  labelAlignment = LabelAlignmentEnum.top,
+  name,
+  value,
   onChange,
 }: CheckboxProps) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [focused, setFocused] = useState(false)
+
   return (
     <Container
-      className={clsx(className, {
-        'checkbox-align--center': labelAlignment === LabelAlignmentEnum.center,
-      })}
+      data-test={`checkbox-${name}`}
+      className={className}
+      onClick={() => inputRef.current?.click()}
     >
-      <FormControlLabel
-        disabled={disabled}
-        control={
-          <MuiCheckbox
-            color="default"
-            checked={canBeIndeterminate && typeof value !== 'boolean' ? true : !!value}
-            onChange={onChange}
-            name={name}
-            indeterminate={canBeIndeterminate && typeof value !== 'boolean'}
-            checkedIcon={<CheckedIcon />}
-            icon={<Icon />}
-            indeterminateIcon={<IndeterminateIcon />}
-            disableRipple
-            data-test={`checkbox-${name}`}
+      <Main
+        className={clsns({
+          'checkbox--disabled': disabled,
+          'checkbox--focused': focused,
+          [`checkbox-align--${labelAlignment}`]: true,
+        })}
+      >
+        <InputContainer>
+          <input
+            aria-checked={value === undefined ? 'mixed' : value}
+            aria-labelledby={typeof label === 'string' ? label : name}
+            type="checkbox"
+            readOnly
+            ref={inputRef}
+            disabled={disabled}
+            checked={!!value}
+            onChange={(e) => {
+              if (disabled || !onChange) return
+
+              if (value === undefined) {
+                onChange(e, true)
+              } else {
+                onChange(e, (e.target as HTMLInputElement).checked)
+              }
+            }}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
           />
-        }
-        label={
-          typeof label === 'string' ? (
-            <Typography color={disabled ? 'disabled' : 'textSecondary'}>{label}</Typography>
+          {!!value ? (
+            <CheckedIcon
+              aria-hidden="true"
+              className="checkbox-checked-icon"
+              color={disabled ? theme.palette.grey[400] : theme.palette.primary[600]}
+            />
+          ) : value === undefined && canBeIndeterminate ? (
+            <IndeterminateIcon
+              aria-hidden="true"
+              className="checkbox-indeterminate-icon"
+              color={disabled ? theme.palette.grey[400] : theme.palette.primary[600]}
+            />
           ) : (
-            label
-          )
-        }
-      />
+            <Icon
+              aria-hidden="true"
+              className="checkbox-unchecked-icon"
+              color={theme.palette.common.white}
+            />
+          )}
+        </InputContainer>
+        {typeof label === 'string' ? (
+          <Typography color={disabled ? 'disabled' : 'textSecondary'}>{label}</Typography>
+        ) : (
+          label
+        )}
+      </Main>
       {!!error && (
         <StyledTypography variant="caption" color="danger600">
           {error}
@@ -86,12 +108,100 @@ export const Checkbox = ({
   )
 }
 
+const InputContainer = styled.div`
+  margin-right: ${theme.spacing(4)};
+  display: inline-flex;
+  align-items: center;
+
+  input {
+    opacity: 0;
+    position: absolute;
+    width: 0;
+    height: 0;
+    margin: 0;
+    padding: 0;
+  }
+`
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
+`
 
-  &.checkbox-align--center > * {
+const Main = styled.div`
+  cursor: pointer;
+  display: inline-flex;
+
+  > * {
+    line-height: 28px;
+  }
+
+  &.checkbox--disabled {
+    cursor: initial;
+
+    .checkbox-unchecked-icon rect {
+      stroke: ${theme.palette.grey[400]};
+    }
+  }
+
+  &:hover:not(.checkbox--disabled) {
+    .checkbox-unchecked-icon {
+      color: ${theme.palette.grey[200]};
+    }
+    .checkbox-indeterminate-icon {
+      color: ${theme.palette.primary[700]};
+    }
+    .checkbox-checked-icon {
+      color: ${theme.palette.primary[700]};
+    }
+  }
+
+  &:active:not(.checkbox--disabled) {
+    .checkbox-unchecked-icon {
+      color: ${theme.palette.grey[300]};
+    }
+    .checkbox-indeterminate-icon {
+      color: ${theme.palette.primary[800]};
+    }
+    .checkbox-checked-icon {
+      color: ${theme.palette.primary[800]};
+    }
+  }
+
+  &.checkbox--focused {
+    .checkbox-unchecked-icon,
+    .checkbox-indeterminate-icon,
+    .checkbox-checked-icon {
+      box-shadow: 0px 0px 0px 4px ${theme.palette.primary[200]};
+      border-radius: 4px;
+    }
+  }
+
+  &.checkbox-align--${LabelAlignmentEnum.center} {
     align-items: center;
+
+    .MuiCheckbox-root {
+      margin-top: 0;
+    }
+  }
+
+  &.checkbox-align--${LabelAlignmentEnum.top} {
+    align-items: flex-start;
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+    margin-left: -11px;
+    margin-right: 16px;
+    margin-left: 0;
+    margin-right: 0;
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+
+    > *:first-child {
+      padding-top: 6px;
+    }
 
     .MuiCheckbox-root {
       margin-top: 0;

--- a/src/components/form/Checkbox/CheckboxField.tsx
+++ b/src/components/form/Checkbox/CheckboxField.tsx
@@ -10,28 +10,18 @@ interface CheckboxFieldProps extends Omit<CheckboxProps, 'onChange' | 'name'> {
   onChange?: (value: boolean) => unknown
 }
 
-export const CheckboxField = ({
-  name,
-  canBeIndeterminate,
-  formikProps,
-  onChange,
-  ...props
-}: CheckboxFieldProps) => {
+export const CheckboxField = ({ name, formikProps, onChange, ...props }: CheckboxFieldProps) => {
   const { values, errors, touched, setFieldValue } = formikProps
 
   return (
     <Checkbox
       name={name}
       value={_get(values, name)}
-      onChange={(event) => {
-        if (canBeIndeterminate && typeof values[name] !== 'boolean') {
-          setFieldValue(name, false)
-        }
-        setFieldValue(name, event.target.checked)
+      onChange={(_, newValue) => {
+        setFieldValue(name, newValue)
 
-        onChange && onChange(event.target.checked)
+        onChange && onChange(newValue)
       }}
-      canBeIndeterminate={canBeIndeterminate}
       error={_get(touched, name) ? (_get(errors, name) as string) : undefined}
       {...props}
     />

--- a/src/components/form/ComboBox/ComboBoxPopperFactory.tsx
+++ b/src/components/form/ComboBox/ComboBoxPopperFactory.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 import { Popper, PopperProps } from '@mui/material'
 import styled from 'styled-components'
-import clsx from 'clsx'
+import clsns from 'classnames'
 
 import { theme } from '~/styles'
 
@@ -42,7 +42,7 @@ export const ComboBoxPopperFactory =
         {...props}
       >
         <div
-          className={clsx({
+          className={clsns({
             'combobox-popper--virtualized': virtualized,
             'combobox-popper--grouped': grouped,
           })}

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -360,7 +360,7 @@ const CreateCoupon = () => {
                   <Settings>
                     <Checkbox
                       name="isReusable"
-                      value={formikProps.values.reusable}
+                      value={!!formikProps.values.reusable}
                       disabled={isEdition && !!coupon?.appliedCouponsCount}
                       label={translate('text_638f48274d41e3f1d01fc16a')}
                       onChange={(_, checked) => {

--- a/src/pages/__devOnly/DesignSystem.tsx
+++ b/src/pages/__devOnly/DesignSystem.tsx
@@ -28,6 +28,7 @@ import {
 } from '~/components/designSystem'
 import { theme, PageHeader, MenuPopper } from '~/styles'
 import {
+  Checkbox,
   CheckboxField,
   DatePickerField,
   TextInputField,
@@ -99,6 +100,8 @@ const DesignSystem = () => {
       radio: false,
       buttonSelector: undefined,
       buttonSelector2: 'time',
+      checkboxCond1: true,
+      checkboxCond2: true,
       json: undefined,
     },
     validationSchema: object().shape({
@@ -649,6 +652,90 @@ const DesignSystem = () => {
                 <Form onSubmit={(e) => e.preventDefault()}>
                   <GroupTitle variant="headline">Form</GroupTitle>
 
+                  <GroupTitle variant="subhead">Checkbox</GroupTitle>
+
+                  <Block $marginBottom={theme.spacing(6)}>
+                    <Checkbox
+                      name="checkboxCond3"
+                      canBeIndeterminate
+                      value={
+                        formikProps.values.checkboxCond1 && formikProps.values.checkboxCond2
+                          ? true
+                          : !formikProps.values.checkboxCond1 && !formikProps.values.checkboxCond2
+                          ? false
+                          : undefined
+                      }
+                      onChange={(e, value) => {
+                        if (value) {
+                          formikProps.setFieldValue('checkboxCond1', true)
+                          formikProps.setFieldValue('checkboxCond2', true)
+                        } else {
+                          formikProps.setFieldValue('checkboxCond1', false)
+                          formikProps.setFieldValue('checkboxCond2', false)
+                        }
+                      }}
+                      label="Accept all conditions or else you won't be able to become the incredibly talented person you want to become (we know, life is unfair)"
+                      error={
+                        !formikProps.values.checkboxCond1 || !formikProps.values.checkboxCond2
+                          ? 'Sorry you need to accept both'
+                          : undefined
+                      }
+                    />
+
+                    <Checkbox
+                      name="checkboxCond3"
+                      canBeIndeterminate
+                      value={
+                        formikProps.values.checkboxCond1 && formikProps.values.checkboxCond2
+                          ? true
+                          : !formikProps.values.checkboxCond1 && !formikProps.values.checkboxCond2
+                          ? false
+                          : undefined
+                      }
+                      onChange={(e, value) => {
+                        if (value) {
+                          formikProps.setFieldValue('checkboxCond1', true)
+                          formikProps.setFieldValue('checkboxCond2', true)
+                        } else {
+                          formikProps.setFieldValue('checkboxCond1', false)
+                          formikProps.setFieldValue('checkboxCond2', false)
+                        }
+                      }}
+                      label="Same with center alignment - Accept all conditions or else you won't be able to become the incredibly talented person you want to become (we know, life is unfair)"
+                      labelAlignment="center"
+                    />
+
+                    <CheckboxField
+                      name="checkboxCond1"
+                      formikProps={formikProps}
+                      value={formikProps.values.checkboxCond1}
+                      label="Accept the insane condition"
+                    />
+
+                    <CheckboxField
+                      name="checkboxCond2"
+                      formikProps={formikProps}
+                      value={formikProps.values.checkboxCond2}
+                      label="Accept the smart condition"
+                    />
+
+                    <CheckboxField
+                      name="checkboxCond1"
+                      formikProps={formikProps}
+                      disabled
+                      value={formikProps.values.checkboxCond1}
+                      label="Insane condition you can't remove"
+                    />
+
+                    <CheckboxField
+                      name="checkboxCond2"
+                      formikProps={formikProps}
+                      disabled
+                      value={formikProps.values.checkboxCond2}
+                      label="Smart condition you can't remove"
+                    />
+                  </Block>
+
                   <GroupTitle variant="subhead">Code Editor</GroupTitle>
                   <Block $marginBottom={theme.spacing(6)}>
                     <JsonEditorField
@@ -892,38 +979,6 @@ const DesignSystem = () => {
                       formikProps={formikProps}
                       label="Disabled"
                       disabled
-                    />
-                  </Block>
-
-                  <GroupTitle variant="subhead">Checkbox</GroupTitle>
-                  <Block $marginBottom={theme.spacing(6)}>
-                    <CheckboxField
-                      name="checkbox"
-                      formikProps={formikProps}
-                      value={formikProps.values.checkbox}
-                      label="Surf"
-                    />
-                    <CheckboxField
-                      name="checkbox"
-                      formikProps={formikProps}
-                      canBeIndeterminate={true}
-                      value={undefined}
-                      label="Kite surf"
-                    />
-                    <CheckboxField
-                      value={formikProps.values.checkbox}
-                      name="checkbox"
-                      formikProps={formikProps}
-                      label="Skate"
-                      error="You should learn first"
-                    />
-                    <CheckboxField
-                      disabled
-                      value={formikProps.values.checkbox}
-                      name="checkbox"
-                      formikProps={formikProps}
-                      canBeIndeterminate={true}
-                      label="Roller blade"
                     />
                   </Block>
 

--- a/src/styles/muiTheme.ts
+++ b/src/styles/muiTheme.ts
@@ -172,67 +172,6 @@ export const theme = createTheme({
         },
       },
     },
-    MuiFormControlLabel: {
-      styleOverrides: {
-        root: {
-          marginLeft: 0,
-          marginRight: 0,
-          alignItems: 'flex-start',
-          '& .MuiCheckbox-root': {
-            marginTop: '6px',
-            padding: '0 16px 0 0',
-          },
-          '&:hover': {
-            // ------- Checkboxes
-            '& .MuiCheckbox-root.MuiButtonBase-root:not(.Mui-checked)': {
-              background: 'none',
-              color: palette.grey[200],
-            },
-            '& .MuiCheckbox-root.MuiButtonBase-root.Mui-checked': {
-              background: 'none',
-              color: palette.primary[700],
-            },
-          },
-          '&:active:active': {
-            // ------- Checkbox
-            '& .MuiCheckbox-root.MuiButtonBase-root:not(.Mui-checked)': {
-              color: palette.grey[300],
-            },
-            '& .MuiCheckbox-root.MuiButtonBase-root.Mui-checked': {
-              color: palette.primary[800],
-            },
-          },
-          '&.Mui-disabled': {
-            // ------- Checkbox
-            '& .MuiCheckbox-root.MuiButtonBase-root.Mui-disabled:not(.Mui-checked) svg rect': {
-              color: palette.common.white,
-              stroke: palette.grey[400],
-            },
-            '& .MuiCheckbox-root.MuiButtonBase-root.Mui-disabled.Mui-disabled.Mui-checked': {
-              transition: 'none',
-              color: palette.grey[400],
-            },
-          },
-        },
-      },
-    },
-    MuiCheckbox: {
-      styleOverrides: {
-        root: {
-          transition: 'color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-          '&.Mui-focusVisible svg': {
-            boxShadow: `0px 0px 0px 4px ${palette.primary[200]}`,
-            borderRadius: 4,
-          },
-          '&:not(.Mui-checked)': {
-            color: palette.common.white,
-          },
-          '&.Mui-checked, &.MuiCheckbox-indeterminate': {
-            color: palette.primary.main,
-          },
-        },
-      },
-    },
     MuiTooltip: {
       styleOverrides: {
         tooltip: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6434,7 +6434,7 @@ clsx@1.1.0:
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.1.0.tgz"
   integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
 
-clsx@1.2.1, clsx@^1.0.4, clsx@^1.2.1:
+clsx@^1.0.4, clsx@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==


### PR DESCRIPTION
- [x] Remove the use of Material in the checkbox component and use the native implementation instead
- [x] Follow the accessibility rules https://www.accede-web.com/en/guidelines/rich-interface-components/checkboxes-customized-using-aria/#ancre-03
- [x] Also remove the `clsx` as we already have classnames in the app