### PR TITLE
breaking(node): minimal node version is now v16

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install Node.js dependencies
         run: yarn

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install Node.js dependencies
         run: yarn

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       # ESLint and Prettier must be in `package.json`
       - name: Install Node.js dependencies

--- a/.github/workflows/stories.yml
+++ b/.github/workflows/stories.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Install and Build 🔧
         run: | # Install npm packages and build the Storybook files
           yarn install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install Node.js dependencies
         run: yarn

--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install Node.js dependencies
         run: yarn

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install Node.js dependencies
         run: yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine as build
+FROM node:16-alpine as build
 
 WORKDIR /app
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/node:14-alpine as build
+FROM arm64v8/node:16-alpine as build
 
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:16-alpine
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "trim": "1.0.1"
   },
   "engines": {
-    "node": ">=14.13"
+    "node": ">=16"
   },
   "alias": {
     "@mui/styled-engine": "@mui/styled-engine-sc"


### PR DESCRIPTION
## Context

Since end of last year, [github CI dropped support for node versions olders than v16](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

We currently ue v14 in all our project

## Description

This PR forces usage of v16 in our project