### PR TITLE
bug: fix scrollbar always shown

### DIFF
--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -216,7 +216,7 @@ const ListWrapper = styled.div`
 `
 
 const ScrollWrapper = styled.div`
-  overflow: scroll;
+  overflow: auto;
 `
 
 const PlusButtonWrapper = styled.div`

--- a/src/layouts/SideNavLayout.tsx
+++ b/src/layouts/SideNavLayout.tsx
@@ -431,7 +431,7 @@ const OrganizationList = styled.div`
   flex-direction: column;
   padding: ${theme.spacing(2)};
   max-height: calc(100vh - 80px);
-  overflow: scroll;
+  overflow: auto;
 
   > *:not(:last-child) {
     margin-bottom: ${theme.spacing(1)};


### PR DESCRIPTION
## Context

In some parts of the app, we use `overflow: scroll` that have the disadvantage to [always show the scroll bar](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#syntax)

![image (2)](https://user-images.githubusercontent.com/5517077/220569116-e31caf3d-cf28-4fb5-9793-a087ad335bb5.png)


## Description

This PR turn them into `overflow: auto` that fixes this issue