### PR TITLE
feat(locale): add Norwegian as available value

### DIFF
--- a/src/core/documentLocales.ts
+++ b/src/core/documentLocales.ts
@@ -5,4 +5,5 @@ type documentLocalesType = {
 export const DocumentLocales: documentLocalesType = {
   fr: 'French',
   en: 'English',
+  nb: 'Norwegian (Bokmål)',
 }


### PR DESCRIPTION
## Context

For legal reason, some companies had to generate invoices in their own languages.

## Description

This PR adds a new option available and handled by BE to generate invoices' PDF in different locale: `Norwegian (Bokmål)`