### PR TITLE
bug(credit_notes): fix multiple plan display

### DIFF
--- a/src/components/invoices/InvoiceCreditNotesTable.tsx
+++ b/src/components/invoices/InvoiceCreditNotesTable.tsx
@@ -101,8 +101,8 @@ export const InvoiceCreditNotesTable = memo(
           return (
             <React.Fragment key={`formatedCreditNote-${i}`}>
               {formatedCreditNote?.items.map((subscriptionItem, j) => {
-                const subscription = subscriptionItem[j][0]
-                  ? subscriptionItem[j][0]?.fee.subscription
+                const subscription = subscriptionItem[0][0]
+                  ? subscriptionItem[0][0]?.fee.subscription
                   : undefined
                 const creditNoteDisplayName = !!subscription
                   ? subscription?.name || subscription?.plan?.name


### PR DESCRIPTION
## Context

Invoices with multiple plan are not displayed in the app

## Description

This PR fix the subscription display.

The data was wrongly found within loop. We can simply check on the first item to get the subscription. 

We could otherwise have a missmatch between the object looked at and the array size