### PR TITLE
chore(PlanCodeSnippet): add missing attribute

### DIFF
--- a/src/components/plans/PlanCodeSnippet.tsx
+++ b/src/components/plans/PlanCodeSnippet.tsx
@@ -15,11 +15,12 @@ curl --location --request POST "${apiUrl}/api/v1/subscriptions" \\
   --data-raw '{
     "subscription": {
       "external_customer_id": "__EXTERNAL_CUSTOMER_ID__",
+      "external_id": "__EXTERNAL_SUBSCRIPTION_ID__",
       "plan_code": "${plan.code}"
     }
   }'
   
-# To use the snippet, don’t forget to edit your __YOUR_API_KEY__ and  __EXTERNAL_CUSTOMER_ID__`
+# To use the snippet, don’t forget to edit your __YOUR_API_KEY__, __EXTERNAL_SUBSCRIPTION_ID__ and  __EXTERNAL_CUSTOMER_ID__`
 }
 
 interface PlanCodeSnippetProps {


### PR DESCRIPTION
## Context

[Documentation](https://doc.getlago.com/docs/api/subscriptions/create-subscription) mentions external ID is mandatory to assign a subscription to a customer.

UI snippet shown does not mentions that.

## Description

This PR adds the `external_id` in the attribute list