### PR TITLE
chore(Accordion): allow transitionProps as props

### DIFF
--- a/src/components/designSystem/Accordion.tsx
+++ b/src/components/designSystem/Accordion.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { ReactNode } from 'react'
 import { Accordion as MuiAccordion, AccordionSummary, AccordionDetails } from '@mui/material'
+import { TransitionProps } from '@mui/material/transitions'
 import styled from 'styled-components'
 
 import { theme, NAV_HEIGHT } from '~/styles'
@@ -23,6 +24,7 @@ interface AccordionProps {
   initiallyOpen?: boolean
   size?: AccordionSize
   noContentMargin?: boolean
+  transitionProps?: TransitionProps
 }
 
 export const Accordion = ({
@@ -32,6 +34,7 @@ export const Accordion = ({
   initiallyOpen = false,
   size = AccordionSizeEnum.medium,
   noContentMargin = false,
+  transitionProps = {},
 }: AccordionProps) => {
   const [isOpen, setIsOpen] = useState(initiallyOpen)
   const { translate } = useInternationalization()
@@ -41,7 +44,7 @@ export const Accordion = ({
       <StyledAccordion
         expanded={isOpen}
         onChange={(_, expanded) => setIsOpen(expanded)}
-        TransitionProps={{ unmountOnExit: true }}
+        TransitionProps={{ unmountOnExit: true, ...transitionProps }}
         square
       >
         <Summary $size={size}>

--- a/src/components/wallets/WalletAccordion.tsx
+++ b/src/components/wallets/WalletAccordion.tsx
@@ -91,6 +91,7 @@ export const WalletAccordion = forwardRef<TopupWalletDialogRef, WalletAccordionP
     return (
       <Accordion
         noContentMargin
+        transitionProps={{ unmountOnExit: false }}
         summary={
           <SummaryContainer>
             <SummaryLeft>


### PR DESCRIPTION
## Context

We recently added an option to make the accordion content un-mount when the accordion is closed

This can be an issue when accordion is responsible to load data.

## Description

This PR make the accordion API accept props to remove this option, as disabling `unmountOnExit` in wallet accordion