### PR TITLE
chore(Customer): remove all CustomerDetails occurences

### DIFF
--- a/src/components/customers/AddAddOnToCustomerDialog.tsx
+++ b/src/components/customers/AddAddOnToCustomerDialog.tsx
@@ -70,7 +70,7 @@ export const AddAddOnToCustomerDialog = forwardRef<
     update(cache, { data: addData }) {
       if (!addData?.createAppliedAddOn) return
 
-      const cacheId = `CustomerDetails:${customerId}`
+      const cacheId = `Customer:${customerId}`
 
       const previousData: CustomerAppliedAddOnsFragment | null = cache.readFragment({
         id: cacheId,

--- a/src/components/customers/AddCouponToCustomerDialog.tsx
+++ b/src/components/customers/AddCouponToCustomerDialog.tsx
@@ -106,7 +106,7 @@ export const AddCouponToCustomerDialog = forwardRef<
     update(cache, { data: addData }) {
       if (!addData?.createAppliedCoupon) return
 
-      const cacheId = `CustomerDetails:${customerId}`
+      const cacheId = `Customer:${customerId}`
 
       const previousData: CustomerAppliedCouponsFragment | null = cache.readFragment({
         id: cacheId,

--- a/src/components/customers/AddCustomerDrawer.tsx
+++ b/src/components/customers/AddCustomerDrawer.tsx
@@ -20,7 +20,6 @@ import { hasDefinedGQLError } from '~/core/apolloClient'
 import { theme, Card, DrawerTitle, DrawerContent, DrawerSubmitButton } from '~/styles'
 import {
   AddCustomerDrawerFragment,
-  AddCustomerDrawerDetailFragment,
   CreateCustomerInput,
   UpdateCustomerInput,
   ProviderTypeEnum,
@@ -53,7 +52,7 @@ const providerData: { value: ProviderTypeEnum; label: string }[] = Object.keys(
 export interface AddCustomerDrawerRef extends DrawerRef {}
 
 interface AddCustomerDrawerProps {
-  customer?: AddCustomerDrawerFragment | AddCustomerDrawerDetailFragment | null
+  customer?: AddCustomerDrawerFragment | null
 }
 
 export const AddCustomerDrawer = forwardRef<DrawerRef, AddCustomerDrawerProps>(

--- a/src/components/customers/CustomerAddOns.tsx
+++ b/src/components/customers/CustomerAddOns.tsx
@@ -2,8 +2,9 @@
 import { forwardRef, memo, MutableRefObject } from 'react'
 import { gql } from '@apollo/client'
 import styled from 'styled-components'
+import { useParams } from 'react-router-dom'
 
-import { CustomerAddOnsFragment, TimezoneEnum } from '~/generated/graphql'
+import { TimezoneEnum, useGetCustomerAddonsQuery } from '~/generated/graphql'
 import { SectionHeader } from '~/styles/customer'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { Typography, Avatar, Icon, Button } from '~/components/designSystem'
@@ -25,17 +26,36 @@ gql`
       name
     }
   }
+
+  fragment CustomerAppliedAddOns on Customer {
+    id
+    appliedAddOns {
+      ...CustomerAddOns
+    }
+  }
+
+  query getCustomerAddons($id: ID!) {
+    customer(id: $id) {
+      id
+      ...CustomerAppliedAddOns
+    }
+  }
 `
 
 interface CustomerAddOnsProps {
-  addOns?: CustomerAddOnsFragment[] | null | undefined
   customerTimezone: TimezoneEnum
 }
 
 export const CustomerAddOns = memo(
   forwardRef<AddAddOnToCustomerDialogRef, CustomerAddOnsProps>(
-    ({ addOns, customerTimezone }: CustomerAddOnsProps, ref) => {
+    ({ customerTimezone }: CustomerAddOnsProps, ref) => {
+      const { id: customerId } = useParams()
       const { translate } = useInternationalization()
+      const { data } = useGetCustomerAddonsQuery({
+        variables: { id: customerId as string },
+        skip: !customerId,
+      })
+      const addOns = data?.customer?.appliedAddOns
 
       return (
         <>

--- a/src/components/customers/CustomerMainInfos.tsx
+++ b/src/components/customers/CustomerMainInfos.tsx
@@ -10,7 +10,7 @@ import { CountryCodes } from '~/core/countryCodes'
 import { getTimezoneConfig } from '~/core/timezone'
 
 gql`
-  fragment CustomerMainInfos on CustomerDetails {
+  fragment CustomerMainInfos on Customer {
     id
     name
     externalId

--- a/src/components/customers/DeleteCustomerDialog.tsx
+++ b/src/components/customers/DeleteCustomerDialog.tsx
@@ -47,13 +47,7 @@ export const DeleteCustomerDialog = forwardRef<DialogRef, DeleteCustomerDialogPr
           __typename: 'Customer',
         })
 
-        const cacheIdDetails = cache.identify({
-          id: data?.destroyCustomer.id,
-          __typename: 'CustomerDetails',
-        })
-
         cache.evict({ id: cacheId })
-        cache.evict({ id: cacheIdDetails })
       },
     })
     const { translate } = useInternationalization()

--- a/src/components/customers/DeleteCustomerDocumentLocaleDialog.tsx
+++ b/src/components/customers/DeleteCustomerDocumentLocaleDialog.tsx
@@ -11,7 +11,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { addToast } from '~/core/apolloClient'
 
 gql`
-  fragment DeleteCustomerDocumentLocale on CustomerDetails {
+  fragment DeleteCustomerDocumentLocale on Customer {
     id
     name
     externalId

--- a/src/components/customers/DeleteCustomerGracePeriodeDialog.tsx
+++ b/src/components/customers/DeleteCustomerGracePeriodeDialog.tsx
@@ -11,7 +11,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { addToast } from '~/core/apolloClient'
 
 gql`
-  fragment DeleteCustomerGracePeriod on CustomerDetails {
+  fragment DeleteCustomerGracePeriod on Customer {
     id
     name
   }

--- a/src/components/customers/DeleteCustomerVatRateDialog.tsx
+++ b/src/components/customers/DeleteCustomerVatRateDialog.tsx
@@ -11,7 +11,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { addToast } from '~/core/apolloClient'
 
 gql`
-  fragment DeleteCustomerVatRate on CustomerDetails {
+  fragment DeleteCustomerVatRate on Customer {
     id
     name
   }

--- a/src/components/customers/EditCustomerDocumentLocaleDialog.tsx
+++ b/src/components/customers/EditCustomerDocumentLocaleDialog.tsx
@@ -17,7 +17,7 @@ import { DocumentLocales } from '~/core/documentLocales'
 import { addToast } from '~/core/apolloClient'
 
 gql`
-  fragment EditCustomerDocumentLocale on CustomerDetails {
+  fragment EditCustomerDocumentLocale on Customer {
     id
     name
     externalId

--- a/src/components/customers/EditCustomerInvoiceGracePeriodDialog.tsx
+++ b/src/components/customers/EditCustomerInvoiceGracePeriodDialog.tsx
@@ -17,7 +17,7 @@ import { theme } from '~/styles'
 import { addToast } from '~/core/apolloClient'
 
 gql`
-  fragment EditCustomerInvoiceGracePeriod on CustomerDetails {
+  fragment EditCustomerInvoiceGracePeriod on Customer {
     id
     invoiceGracePeriod
   }

--- a/src/components/customers/EditCustomerVatRateDialog.tsx
+++ b/src/components/customers/EditCustomerVatRateDialog.tsx
@@ -15,7 +15,7 @@ import { theme } from '~/styles'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 
 gql`
-  fragment EditCustomerVatRate on CustomerDetails {
+  fragment EditCustomerVatRate on Customer {
     id
     name
     vatRate

--- a/src/components/customers/usage/UsageItem.tsx
+++ b/src/components/customers/usage/UsageItem.tsx
@@ -7,7 +7,7 @@ import {
   ChargeUsage,
   CurrencyEnum,
   CustomerUsageForUsageDetailsFragmentDoc,
-  CustomerUsageSubscriptionFragment,
+  CustomerSubscriptionForUsageFragment,
   useCustomerUsageLazyQuery,
   TimezoneEnum,
 } from '~/generated/graphql'
@@ -51,7 +51,7 @@ gql`
 
 interface UsageItemProps {
   customerId: string
-  subscription: CustomerUsageSubscriptionFragment
+  subscription: CustomerSubscriptionForUsageFragment
   customerTimezone: TimezoneEnum
 }
 

--- a/src/components/wallets/TerminateCustomerWalletDialog.tsx
+++ b/src/components/wallets/TerminateCustomerWalletDialog.tsx
@@ -4,7 +4,12 @@ import { gql } from '@apollo/client'
 import { DialogRef } from '~/components/designSystem'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { useTerminateCustomerWalletMutation, WalletAccordionFragmentDoc } from '~/generated/graphql'
+import {
+  CustomerDetailsFragment,
+  CustomerDetailsFragmentDoc,
+  useTerminateCustomerWalletMutation,
+  WalletAccordionFragmentDoc,
+} from '~/generated/graphql'
 import { addToast } from '~/core/apolloClient'
 
 gql`
@@ -13,6 +18,10 @@ gql`
       id
       status
       ...WalletAccordion
+      customer {
+        id
+        hasActiveWallet
+      }
     }
   }
 
@@ -38,6 +47,27 @@ export const TerminateCustomerWalletDialog = forwardRef<
           translateKey: 'text_62e257c032ae895bbfead62e',
         })
       }
+    },
+    update(cache, { data }) {
+      if (!data?.terminateCustomerWallet) return
+
+      const cacheId = `Customer:${data.terminateCustomerWallet.customer?.id}`
+
+      const previousData: CustomerDetailsFragment | null = cache.readFragment({
+        id: cacheId,
+        fragment: CustomerDetailsFragmentDoc,
+        fragmentName: 'CustomerDetails',
+      })
+
+      cache.writeFragment({
+        id: cacheId,
+        fragment: CustomerDetailsFragmentDoc,
+        fragmentName: 'CustomerDetails',
+        data: {
+          ...previousData,
+          hasActiveWallet: data.terminateCustomerWallet.customer?.hasActiveWallet,
+        },
+      })
     },
   })
 

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -1261,68 +1261,6 @@ export type Customer = {
   addressLine1?: Maybe<Scalars['String']>;
   addressLine2?: Maybe<Scalars['String']>;
   applicableTimezone: TimezoneEnum;
-  billingConfiguration?: Maybe<CustomerBillingConfiguration>;
-  /** Check if customer attributes are editable */
-  canEditAttributes: Scalars['Boolean'];
-  city?: Maybe<Scalars['String']>;
-  country?: Maybe<CountryCode>;
-  createdAt: Scalars['ISO8601DateTime'];
-  /** Credit notes credits balance available per customer */
-  creditNotesBalanceAmountCents: Scalars['BigInt'];
-  /** Number of available credits from credit notes per customer */
-  creditNotesCreditsAvailableCount: Scalars['Int'];
-  currency?: Maybe<CurrencyEnum>;
-  deletedAt?: Maybe<Scalars['ISO8601DateTime']>;
-  email?: Maybe<Scalars['String']>;
-  externalId: Scalars['String'];
-  /** Define if a customer has an active wallet */
-  hasActiveWallet: Scalars['Boolean'];
-  /** Define if a customer has any credit note */
-  hasCreditNotes: Scalars['Boolean'];
-  id: Scalars['ID'];
-  invoiceGracePeriod?: Maybe<Scalars['Int']>;
-  legalName?: Maybe<Scalars['String']>;
-  legalNumber?: Maybe<Scalars['String']>;
-  logoUrl?: Maybe<Scalars['String']>;
-  metadata?: Maybe<Array<CustomerMetadata>>;
-  name?: Maybe<Scalars['String']>;
-  paymentProvider?: Maybe<ProviderTypeEnum>;
-  phone?: Maybe<Scalars['String']>;
-  providerCustomer?: Maybe<ProviderCustomer>;
-  sequentialId: Scalars['String'];
-  slug: Scalars['String'];
-  state?: Maybe<Scalars['String']>;
-  subscriptions?: Maybe<Array<Subscription>>;
-  timezone?: Maybe<TimezoneEnum>;
-  updatedAt: Scalars['ISO8601DateTime'];
-  url?: Maybe<Scalars['String']>;
-  vatRate?: Maybe<Scalars['Float']>;
-  zipcode?: Maybe<Scalars['String']>;
-};
-
-export type CustomerBillingConfiguration = {
-  __typename?: 'CustomerBillingConfiguration';
-  documentLocale?: Maybe<Scalars['String']>;
-  id: Scalars['ID'];
-};
-
-export type CustomerBillingConfigurationInput = {
-  documentLocale?: InputMaybe<Scalars['String']>;
-};
-
-export type CustomerCollection = {
-  __typename?: 'CustomerCollection';
-  collection: Array<Customer>;
-  metadata: CollectionMetadata;
-};
-
-export type CustomerDetails = {
-  __typename?: 'CustomerDetails';
-  /** Number of active subscriptions per customer */
-  activeSubscriptionCount: Scalars['Int'];
-  addressLine1?: Maybe<Scalars['String']>;
-  addressLine2?: Maybe<Scalars['String']>;
-  applicableTimezone: TimezoneEnum;
   appliedAddOns?: Maybe<Array<AppliedAddOn>>;
   appliedCoupons?: Maybe<Array<AppliedCoupon>>;
   billingConfiguration?: Maybe<CustomerBillingConfiguration>;
@@ -1368,8 +1306,24 @@ export type CustomerDetails = {
 };
 
 
-export type CustomerDetailsSubscriptionsArgs = {
+export type CustomerSubscriptionsArgs = {
   status?: InputMaybe<Array<StatusTypeEnum>>;
+};
+
+export type CustomerBillingConfiguration = {
+  __typename?: 'CustomerBillingConfiguration';
+  documentLocale?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+};
+
+export type CustomerBillingConfigurationInput = {
+  documentLocale?: InputMaybe<Scalars['String']>;
+};
+
+export type CustomerCollection = {
+  __typename?: 'CustomerCollection';
+  collection: Array<Customer>;
+  metadata: CollectionMetadata;
 };
 
 export type CustomerMetadata = {
@@ -1896,9 +1850,9 @@ export type Mutation = {
   /** Updates an existing Customer */
   updateCustomer?: Maybe<Customer>;
   /** Assign the invoice grace period to Customers */
-  updateCustomerInvoiceGracePeriod?: Maybe<CustomerDetails>;
+  updateCustomerInvoiceGracePeriod?: Maybe<Customer>;
   /** Assign the vat rate to Customers */
-  updateCustomerVatRate?: Maybe<CustomerDetails>;
+  updateCustomerVatRate?: Maybe<Customer>;
   /** Updates a new Customer Wallet */
   updateCustomerWallet?: Maybe<Wallet>;
   /** Update an existing invoice */
@@ -2299,7 +2253,7 @@ export type Query = {
   /** Retrieve the version of the application */
   currentVersion: CurrentVersion;
   /** Query a single customer of an organization */
-  customer?: Maybe<CustomerDetails>;
+  customer?: Maybe<Customer>;
   /** Query customer's credit note */
   customerCreditNotes?: Maybe<CreditNoteCollection>;
   /** Query invoices of a customer */
@@ -3314,14 +3268,14 @@ export type GetCustomerInvoicesQuery = { __typename?: 'Query', customerInvoices:
 
 export type CustomerItemFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, createdAt: any, activeSubscriptionCount: number, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, canEditAttributes: boolean, city?: string | null, zipcode?: string | null, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
 
-export type CustomerMainInfosFragment = { __typename?: 'CustomerDetails', id: string, name?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, currency?: CurrencyEnum | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string }> | null };
+export type CustomerMainInfosFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, currency?: CurrencyEnum | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string }> | null };
 
 export type GetCustomerSettingsQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetCustomerSettingsQuery = { __typename?: 'Query', customer?: { __typename?: 'CustomerDetails', id: string, vatRate?: number | null, invoiceGracePeriod?: number | null, name?: string | null, externalId: string, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', id: string, documentLocale?: string | null } | null } | null, organization?: { __typename?: 'Organization', id: string, billingConfiguration?: { __typename?: 'OrganizationBillingConfiguration', id: string, vatRate: number, invoiceGracePeriod: number, documentLocale?: string | null } | null } | null };
+export type GetCustomerSettingsQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, vatRate?: number | null, invoiceGracePeriod?: number | null, name?: string | null, externalId: string, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', id: string, documentLocale?: string | null } | null } | null, organization?: { __typename?: 'Organization', id: string, billingConfiguration?: { __typename?: 'OrganizationBillingConfiguration', id: string, vatRate: number, invoiceGracePeriod: number, documentLocale?: string | null } | null } | null };
 
 export type DeleteCustomerDialogFragment = { __typename?: 'Customer', id: string, name?: string | null };
 
@@ -3332,7 +3286,7 @@ export type DeleteCustomerMutationVariables = Exact<{
 
 export type DeleteCustomerMutation = { __typename?: 'Mutation', destroyCustomer?: { __typename?: 'DestroyCustomerPayload', id?: string | null } | null };
 
-export type DeleteCustomerDocumentLocaleFragment = { __typename?: 'CustomerDetails', id: string, name?: string | null, externalId: string };
+export type DeleteCustomerDocumentLocaleFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string };
 
 export type DeleteCustomerDocumentLocaleMutationVariables = Exact<{
   input: UpdateCustomerInput;
@@ -3341,25 +3295,25 @@ export type DeleteCustomerDocumentLocaleMutationVariables = Exact<{
 
 export type DeleteCustomerDocumentLocaleMutation = { __typename?: 'Mutation', updateCustomer?: { __typename?: 'Customer', id: string, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', id: string, documentLocale?: string | null } | null } | null };
 
-export type DeleteCustomerGracePeriodFragment = { __typename?: 'CustomerDetails', id: string, name?: string | null };
+export type DeleteCustomerGracePeriodFragment = { __typename?: 'Customer', id: string, name?: string | null };
 
 export type DeleteCustomerGracePeriodMutationVariables = Exact<{
   input: UpdateCustomerInvoiceGracePeriodInput;
 }>;
 
 
-export type DeleteCustomerGracePeriodMutation = { __typename?: 'Mutation', updateCustomerInvoiceGracePeriod?: { __typename?: 'CustomerDetails', id: string, invoiceGracePeriod?: number | null } | null };
+export type DeleteCustomerGracePeriodMutation = { __typename?: 'Mutation', updateCustomerInvoiceGracePeriod?: { __typename?: 'Customer', id: string, invoiceGracePeriod?: number | null } | null };
 
-export type DeleteCustomerVatRateFragment = { __typename?: 'CustomerDetails', id: string, name?: string | null };
+export type DeleteCustomerVatRateFragment = { __typename?: 'Customer', id: string, name?: string | null };
 
 export type DeleteCustomerVatRateMutationVariables = Exact<{
   input: UpdateCustomerVatRateInput;
 }>;
 
 
-export type DeleteCustomerVatRateMutation = { __typename?: 'Mutation', updateCustomerVatRate?: { __typename?: 'CustomerDetails', id: string, vatRate?: number | null } | null };
+export type DeleteCustomerVatRateMutation = { __typename?: 'Mutation', updateCustomerVatRate?: { __typename?: 'Customer', id: string, vatRate?: number | null } | null };
 
-export type EditCustomerDocumentLocaleFragment = { __typename?: 'CustomerDetails', id: string, name?: string | null, externalId: string, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', id: string, documentLocale?: string | null } | null };
+export type EditCustomerDocumentLocaleFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', id: string, documentLocale?: string | null } | null };
 
 export type UpdateCustomerDocumentLocaleMutationVariables = Exact<{
   input: UpdateCustomerInput;
@@ -3368,23 +3322,23 @@ export type UpdateCustomerDocumentLocaleMutationVariables = Exact<{
 
 export type UpdateCustomerDocumentLocaleMutation = { __typename?: 'Mutation', updateCustomer?: { __typename?: 'Customer', id: string, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', id: string, documentLocale?: string | null } | null } | null };
 
-export type EditCustomerInvoiceGracePeriodFragment = { __typename?: 'CustomerDetails', id: string, invoiceGracePeriod?: number | null };
+export type EditCustomerInvoiceGracePeriodFragment = { __typename?: 'Customer', id: string, invoiceGracePeriod?: number | null };
 
 export type UpdateCustomerInvoiceGracePeriodMutationVariables = Exact<{
   input: UpdateCustomerInvoiceGracePeriodInput;
 }>;
 
 
-export type UpdateCustomerInvoiceGracePeriodMutation = { __typename?: 'Mutation', updateCustomerInvoiceGracePeriod?: { __typename?: 'CustomerDetails', id: string, invoiceGracePeriod?: number | null } | null };
+export type UpdateCustomerInvoiceGracePeriodMutation = { __typename?: 'Mutation', updateCustomerInvoiceGracePeriod?: { __typename?: 'Customer', id: string, invoiceGracePeriod?: number | null } | null };
 
-export type EditCustomerVatRateFragment = { __typename?: 'CustomerDetails', id: string, name?: string | null, vatRate?: number | null };
+export type EditCustomerVatRateFragment = { __typename?: 'Customer', id: string, name?: string | null, vatRate?: number | null };
 
 export type UpdateCustomerVatRateMutationVariables = Exact<{
   input: UpdateCustomerVatRateInput;
 }>;
 
 
-export type UpdateCustomerVatRateMutation = { __typename?: 'Mutation', updateCustomerVatRate?: { __typename?: 'CustomerDetails', id: string, name?: string | null, vatRate?: number | null } | null };
+export type UpdateCustomerVatRateMutation = { __typename?: 'Mutation', updateCustomerVatRate?: { __typename?: 'Customer', id: string, name?: string | null, vatRate?: number | null } | null };
 
 export type CreditNotesForListFragment = { __typename?: 'CreditNoteCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'CreditNote', id: string, canBeVoided: boolean, createdAt: any, creditStatus?: CreditNoteCreditStatusEnum | null, number: string, totalAmountCents: any, totalAmountCurrency: CurrencyEnum }> };
 
@@ -3817,7 +3771,7 @@ export type UpdateCouponMutation = { __typename?: 'Mutation', updateCoupon?: { _
 
 export type AddCustomerDrawerFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, canEditAttributes: boolean, city?: string | null, zipcode?: string | null, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
 
-export type AddCustomerDrawerDetailFragment = { __typename?: 'CustomerDetails', id: string, name?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, currency?: CurrencyEnum | null, canEditAttributes: boolean, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
+export type AddCustomerDrawerDetailFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, currency?: CurrencyEnum | null, canEditAttributes: boolean, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
 
 export type CreateCustomerMutationVariables = Exact<{
   input: CreateCustomerInput;
@@ -3917,18 +3871,18 @@ export type GetCreditNoteQuery = { __typename?: 'Query', creditNote?: { __typena
 
 export type CustomerSubscriptionFragment = { __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null };
 
-export type CustomerAppliedAddOnsFragment = { __typename?: 'CustomerDetails', id: string, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null };
+export type CustomerAppliedAddOnsFragment = { __typename?: 'Customer', id: string, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null };
 
-export type CustomerAppliedCouponsFragment = { __typename?: 'CustomerDetails', id: string, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null };
+export type CustomerAppliedCouponsFragment = { __typename?: 'Customer', id: string, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null };
 
-export type CustomerDetailsFragment = { __typename?: 'CustomerDetails', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, canEditAttributes: boolean, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null }>, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
+export type CustomerDetailsFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, canEditAttributes: boolean, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null }>, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
 
 export type GetCustomerQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetCustomerQuery = { __typename?: 'Query', customer?: { __typename?: 'CustomerDetails', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, canEditAttributes: boolean, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null }>, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
+export type GetCustomerQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, canEditAttributes: boolean, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null }>, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
 
 export type GetCustomerDraftInvoicesQueryVariables = Exact<{
   customerId: Scalars['ID'];
@@ -3947,7 +3901,7 @@ export type GetCustomerInfosForDraftInvoicesListQueryVariables = Exact<{
 }>;
 
 
-export type GetCustomerInfosForDraftInvoicesListQuery = { __typename?: 'Query', customer?: { __typename?: 'CustomerDetails', id: string, name?: string | null, applicableTimezone: TimezoneEnum } | null, customerInvoices: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'CollectionMetadata', totalCount: number } } };
+export type GetCustomerInfosForDraftInvoicesListQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, name?: string | null, applicableTimezone: TimezoneEnum } | null, customerInvoices: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'CollectionMetadata', totalCount: number } } };
 
 export type CustomersQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']>;
@@ -4302,26 +4256,26 @@ export const DeleteCustomerDialogFragmentDoc = gql`
 }
     `;
 export const DeleteCustomerDocumentLocaleFragmentDoc = gql`
-    fragment DeleteCustomerDocumentLocale on CustomerDetails {
+    fragment DeleteCustomerDocumentLocale on Customer {
   id
   name
   externalId
 }
     `;
 export const DeleteCustomerGracePeriodFragmentDoc = gql`
-    fragment DeleteCustomerGracePeriod on CustomerDetails {
+    fragment DeleteCustomerGracePeriod on Customer {
   id
   name
 }
     `;
 export const DeleteCustomerVatRateFragmentDoc = gql`
-    fragment DeleteCustomerVatRate on CustomerDetails {
+    fragment DeleteCustomerVatRate on Customer {
   id
   name
 }
     `;
 export const EditCustomerDocumentLocaleFragmentDoc = gql`
-    fragment EditCustomerDocumentLocale on CustomerDetails {
+    fragment EditCustomerDocumentLocale on Customer {
   id
   name
   externalId
@@ -4332,13 +4286,13 @@ export const EditCustomerDocumentLocaleFragmentDoc = gql`
 }
     `;
 export const EditCustomerInvoiceGracePeriodFragmentDoc = gql`
-    fragment EditCustomerInvoiceGracePeriod on CustomerDetails {
+    fragment EditCustomerInvoiceGracePeriod on Customer {
   id
   invoiceGracePeriod
 }
     `;
 export const EditCustomerVatRateFragmentDoc = gql`
-    fragment EditCustomerVatRate on CustomerDetails {
+    fragment EditCustomerVatRate on Customer {
   id
   name
   vatRate
@@ -5098,7 +5052,7 @@ export const CustomerCouponFragmentDoc = gql`
 }
     ${AppliedCouponCaptionFragmentDoc}`;
 export const CustomerAppliedCouponsFragmentDoc = gql`
-    fragment CustomerAppliedCoupons on CustomerDetails {
+    fragment CustomerAppliedCoupons on Customer {
   id
   appliedCoupons {
     ...CustomerCoupon
@@ -5118,7 +5072,7 @@ export const CustomerAddOnsFragmentDoc = gql`
 }
     `;
 export const CustomerAppliedAddOnsFragmentDoc = gql`
-    fragment CustomerAppliedAddOns on CustomerDetails {
+    fragment CustomerAppliedAddOns on Customer {
   id
   appliedAddOns {
     ...CustomerAddOns
@@ -5126,7 +5080,7 @@ export const CustomerAppliedAddOnsFragmentDoc = gql`
 }
     ${CustomerAddOnsFragmentDoc}`;
 export const AddCustomerDrawerDetailFragmentDoc = gql`
-    fragment AddCustomerDrawerDetail on CustomerDetails {
+    fragment AddCustomerDrawerDetail on Customer {
   id
   name
   externalId
@@ -5159,7 +5113,7 @@ export const AddCustomerDrawerDetailFragmentDoc = gql`
 }
     `;
 export const CustomerMainInfosFragmentDoc = gql`
-    fragment CustomerMainInfos on CustomerDetails {
+    fragment CustomerMainInfos on Customer {
   id
   name
   externalId
@@ -5188,7 +5142,7 @@ export const CustomerMainInfosFragmentDoc = gql`
 }
     `;
 export const CustomerDetailsFragmentDoc = gql`
-    fragment CustomerDetails on CustomerDetails {
+    fragment CustomerDetails on Customer {
   id
   name
   externalId

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3356,6 +3356,13 @@ export type VoidCreditNoteMutationVariables = Exact<{
 
 export type VoidCreditNoteMutation = { __typename?: 'Mutation', voidCreditNote?: { __typename?: 'CreditNote', id: string } | null };
 
+export type GetCustomerSubscriptionForListQueryVariables = Exact<{
+  id: Scalars['ID'];
+}>;
+
+
+export type GetCustomerSubscriptionForListQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null }> } | null };
+
 export type UpdateCustomerSubscriptionMutationVariables = Exact<{
   input: UpdateSubscriptionInput;
 }>;
@@ -3372,9 +3379,16 @@ export type TerminateCustomerSubscriptionMutationVariables = Exact<{
 }>;
 
 
-export type TerminateCustomerSubscriptionMutation = { __typename?: 'Mutation', terminateSubscription?: { __typename?: 'Subscription', id: string } | null };
+export type TerminateCustomerSubscriptionMutation = { __typename?: 'Mutation', terminateSubscription?: { __typename?: 'Subscription', id: string, customer: { __typename?: 'Customer', id: string, activeSubscriptionCount: number } } | null };
 
-export type CustomerUsageSubscriptionFragment = { __typename?: 'Subscription', id: string, name?: string | null, status?: StatusTypeEnum | null, plan: { __typename?: 'Plan', id: string, name: string, code: string } };
+export type CustomerSubscriptionForUsageFragment = { __typename?: 'Subscription', id: string, name?: string | null, status?: StatusTypeEnum | null, plan: { __typename?: 'Plan', id: string, name: string, code: string } };
+
+export type GetCustomerSubscriptionForUsageQueryVariables = Exact<{
+  id: Scalars['ID'];
+}>;
+
+
+export type GetCustomerSubscriptionForUsageQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, subscriptions: Array<{ __typename?: 'Subscription', id: string, name?: string | null, status?: StatusTypeEnum | null, plan: { __typename?: 'Plan', id: string, name: string, code: string } }> } | null };
 
 export type CustomerUsageForUsageDetailsFragment = { __typename?: 'CustomerUsage', fromDatetime: any, toDatetime: any, chargesUsage: Array<{ __typename?: 'ChargeUsage', billableMetric: { __typename?: 'BillableMetric', name: string }, groups?: Array<{ __typename?: 'GroupUsage', id: string, amountCents: any, key?: string | null, units: number, value: string }> | null }> };
 
@@ -3661,7 +3675,7 @@ export type CreateSubscriptionMutationVariables = Exact<{
 }>;
 
 
-export type CreateSubscriptionMutation = { __typename?: 'Mutation', createSubscription?: { __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null } | null };
+export type CreateSubscriptionMutation = { __typename?: 'Mutation', createSubscription?: { __typename?: 'Subscription', id: string, customer: { __typename?: 'Customer', id: string, activeSubscriptionCount: number } } | null };
 
 export type GetSinglePlanQueryVariables = Exact<{
   id: Scalars['ID'];
@@ -3867,20 +3881,18 @@ export type GetCreditNoteQueryVariables = Exact<{
 
 export type GetCreditNoteQuery = { __typename?: 'Query', creditNote?: { __typename?: 'CreditNote', id: string, balanceAmountCents: any, canBeVoided: boolean, createdAt: any, creditAmountCents: any, creditAmountCurrency: CurrencyEnum, creditStatus?: CreditNoteCreditStatusEnum | null, number: string, refundAmountCents: any, refundedAt?: any | null, refundStatus?: CreditNoteRefundStatusEnum | null, subTotalVatExcludedAmountCents: any, subTotalVatExcludedAmountCurrency: CurrencyEnum, totalAmountCents: any, totalAmountCurrency: CurrencyEnum, vatAmountCents: any, vatAmountCurrency: CurrencyEnum, customer: { __typename?: 'Customer', id: string, name?: string | null, deletedAt?: any | null, applicableTimezone: TimezoneEnum }, invoice?: { __typename?: 'Invoice', id: string, number: string } | null, items: Array<{ __typename?: 'CreditNoteItem', amountCents: any, amountCurrency: CurrencyEnum, fee: { __typename?: 'Fee', id: string, amountCents: any, amountCurrency: CurrencyEnum, eventsCount?: any | null, units: number, feeType: FeeTypesEnum, itemName: string, charge?: { __typename?: 'Charge', id: string, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum } } | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, group?: { __typename?: 'Group', id: string, key?: string | null, value: string } | null } }> } | null };
 
-export type CustomerSubscriptionFragment = { __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null };
-
 export type CustomerAppliedAddOnsFragment = { __typename?: 'Customer', id: string, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null };
 
 export type CustomerAppliedCouponsFragment = { __typename?: 'Customer', id: string, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null };
 
-export type CustomerDetailsFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null }>, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
+export type CustomerDetailsFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, activeSubscriptionCount: number, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
 
 export type GetCustomerQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetCustomerQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null }>, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
+export type GetCustomerQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, activeSubscriptionCount: number, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
 
 export type GetCustomerDraftInvoicesQueryVariables = Exact<{
   customerId: Scalars['ID'];
@@ -4310,6 +4322,44 @@ export const CreditNotesForListFragmentDoc = gql`
     number
     totalAmountCents
     totalAmountCurrency
+  }
+}
+    `;
+export const SubscriptionLinePlanFragmentDoc = gql`
+    fragment SubscriptionLinePlan on Plan {
+  id
+  name
+  code
+}
+    `;
+export const SubscriptionItemFragmentDoc = gql`
+    fragment SubscriptionItem on Subscription {
+  id
+  status
+  startedAt
+  nextPendingStartDate
+  name
+  nextName
+  externalId
+  periodEndDate
+  subscriptionAt
+  plan {
+    ...SubscriptionLinePlan
+  }
+  nextPlan {
+    ...SubscriptionLinePlan
+  }
+}
+    ${SubscriptionLinePlanFragmentDoc}`;
+export const CustomerSubscriptionForUsageFragmentDoc = gql`
+    fragment CustomerSubscriptionForUsage on Subscription {
+  id
+  name
+  status
+  plan {
+    id
+    name
+    code
   }
 }
     `;
@@ -4977,56 +5027,6 @@ export const EditPlanFragmentDoc = gql`
   }
 }
     ${ChargeAccordionFragmentDoc}`;
-export const SubscriptionLinePlanFragmentDoc = gql`
-    fragment SubscriptionLinePlan on Plan {
-  id
-  name
-  code
-}
-    `;
-export const SubscriptionItemFragmentDoc = gql`
-    fragment SubscriptionItem on Subscription {
-  id
-  status
-  startedAt
-  nextPendingStartDate
-  name
-  nextName
-  externalId
-  periodEndDate
-  subscriptionAt
-  plan {
-    ...SubscriptionLinePlan
-  }
-  nextPlan {
-    ...SubscriptionLinePlan
-  }
-}
-    ${SubscriptionLinePlanFragmentDoc}`;
-export const CustomerUsageSubscriptionFragmentDoc = gql`
-    fragment CustomerUsageSubscription on Subscription {
-  id
-  name
-  status
-  plan {
-    id
-    name
-    code
-  }
-}
-    `;
-export const CustomerSubscriptionFragmentDoc = gql`
-    fragment CustomerSubscription on Subscription {
-  id
-  plan {
-    id
-    amountCurrency
-  }
-  ...SubscriptionItem
-  ...CustomerUsageSubscription
-}
-    ${SubscriptionItemFragmentDoc}
-${CustomerUsageSubscriptionFragmentDoc}`;
 export const AppliedCouponCaptionFragmentDoc = gql`
     fragment AppliedCouponCaption on AppliedCoupon {
   id
@@ -5117,16 +5117,13 @@ export const CustomerDetailsFragmentDoc = gql`
   creditNotesCreditsAvailableCount
   creditNotesBalanceAmountCents
   applicableTimezone
-  subscriptions(status: [active, pending]) {
-    ...CustomerSubscription
-  }
+  activeSubscriptionCount
   ...CustomerAppliedCoupons
   ...CustomerAppliedAddOns
   ...AddCustomerDrawer
   ...CustomerMainInfos
 }
-    ${CustomerSubscriptionFragmentDoc}
-${CustomerAppliedCouponsFragmentDoc}
+    ${CustomerAppliedCouponsFragmentDoc}
 ${CustomerAppliedAddOnsFragmentDoc}
 ${AddCustomerDrawerFragmentDoc}
 ${CustomerMainInfosFragmentDoc}`;
@@ -6106,6 +6103,49 @@ export function useVoidCreditNoteMutation(baseOptions?: Apollo.MutationHookOptio
 export type VoidCreditNoteMutationHookResult = ReturnType<typeof useVoidCreditNoteMutation>;
 export type VoidCreditNoteMutationResult = Apollo.MutationResult<VoidCreditNoteMutation>;
 export type VoidCreditNoteMutationOptions = Apollo.BaseMutationOptions<VoidCreditNoteMutation, VoidCreditNoteMutationVariables>;
+export const GetCustomerSubscriptionForListDocument = gql`
+    query getCustomerSubscriptionForList($id: ID!) {
+  customer(id: $id) {
+    id
+    subscriptions(status: [active, pending]) {
+      id
+      plan {
+        id
+        amountCurrency
+      }
+      ...SubscriptionItem
+    }
+  }
+}
+    ${SubscriptionItemFragmentDoc}`;
+
+/**
+ * __useGetCustomerSubscriptionForListQuery__
+ *
+ * To run a query within a React component, call `useGetCustomerSubscriptionForListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCustomerSubscriptionForListQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetCustomerSubscriptionForListQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetCustomerSubscriptionForListQuery(baseOptions: Apollo.QueryHookOptions<GetCustomerSubscriptionForListQuery, GetCustomerSubscriptionForListQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetCustomerSubscriptionForListQuery, GetCustomerSubscriptionForListQueryVariables>(GetCustomerSubscriptionForListDocument, options);
+      }
+export function useGetCustomerSubscriptionForListLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetCustomerSubscriptionForListQuery, GetCustomerSubscriptionForListQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetCustomerSubscriptionForListQuery, GetCustomerSubscriptionForListQueryVariables>(GetCustomerSubscriptionForListDocument, options);
+        }
+export type GetCustomerSubscriptionForListQueryHookResult = ReturnType<typeof useGetCustomerSubscriptionForListQuery>;
+export type GetCustomerSubscriptionForListLazyQueryHookResult = ReturnType<typeof useGetCustomerSubscriptionForListLazyQuery>;
+export type GetCustomerSubscriptionForListQueryResult = Apollo.QueryResult<GetCustomerSubscriptionForListQuery, GetCustomerSubscriptionForListQueryVariables>;
 export const UpdateCustomerSubscriptionDocument = gql`
     mutation updateCustomerSubscription($input: UpdateSubscriptionInput!) {
   updateSubscription(input: $input) {
@@ -6147,6 +6187,10 @@ export const TerminateCustomerSubscriptionDocument = gql`
     mutation terminateCustomerSubscription($input: TerminateSubscriptionInput!) {
   terminateSubscription(input: $input) {
     id
+    customer {
+      id
+      activeSubscriptionCount
+    }
   }
 }
     `;
@@ -6176,6 +6220,45 @@ export function useTerminateCustomerSubscriptionMutation(baseOptions?: Apollo.Mu
 export type TerminateCustomerSubscriptionMutationHookResult = ReturnType<typeof useTerminateCustomerSubscriptionMutation>;
 export type TerminateCustomerSubscriptionMutationResult = Apollo.MutationResult<TerminateCustomerSubscriptionMutation>;
 export type TerminateCustomerSubscriptionMutationOptions = Apollo.BaseMutationOptions<TerminateCustomerSubscriptionMutation, TerminateCustomerSubscriptionMutationVariables>;
+export const GetCustomerSubscriptionForUsageDocument = gql`
+    query getCustomerSubscriptionForUsage($id: ID!) {
+  customer(id: $id) {
+    id
+    subscriptions(status: [active, pending]) {
+      id
+      ...CustomerSubscriptionForUsage
+    }
+  }
+}
+    ${CustomerSubscriptionForUsageFragmentDoc}`;
+
+/**
+ * __useGetCustomerSubscriptionForUsageQuery__
+ *
+ * To run a query within a React component, call `useGetCustomerSubscriptionForUsageQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCustomerSubscriptionForUsageQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetCustomerSubscriptionForUsageQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetCustomerSubscriptionForUsageQuery(baseOptions: Apollo.QueryHookOptions<GetCustomerSubscriptionForUsageQuery, GetCustomerSubscriptionForUsageQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetCustomerSubscriptionForUsageQuery, GetCustomerSubscriptionForUsageQueryVariables>(GetCustomerSubscriptionForUsageDocument, options);
+      }
+export function useGetCustomerSubscriptionForUsageLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetCustomerSubscriptionForUsageQuery, GetCustomerSubscriptionForUsageQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetCustomerSubscriptionForUsageQuery, GetCustomerSubscriptionForUsageQueryVariables>(GetCustomerSubscriptionForUsageDocument, options);
+        }
+export type GetCustomerSubscriptionForUsageQueryHookResult = ReturnType<typeof useGetCustomerSubscriptionForUsageQuery>;
+export type GetCustomerSubscriptionForUsageLazyQueryHookResult = ReturnType<typeof useGetCustomerSubscriptionForUsageLazyQuery>;
+export type GetCustomerSubscriptionForUsageQueryResult = Apollo.QueryResult<GetCustomerSubscriptionForUsageQuery, GetCustomerSubscriptionForUsageQueryVariables>;
 export const CustomerUsageDocument = gql`
     query customerUsage($customerId: ID!, $subscriptionId: ID!) {
   customerUsage(customerId: $customerId, subscriptionId: $subscriptionId) {
@@ -7230,10 +7313,14 @@ export type GetPlansQueryResult = Apollo.QueryResult<GetPlansQuery, GetPlansQuer
 export const CreateSubscriptionDocument = gql`
     mutation createSubscription($input: CreateSubscriptionInput!) {
   createSubscription(input: $input) {
-    ...CustomerSubscription
+    id
+    customer {
+      id
+      activeSubscriptionCount
+    }
   }
 }
-    ${CustomerSubscriptionFragmentDoc}`;
+    `;
 export type CreateSubscriptionMutationFn = Apollo.MutationFunction<CreateSubscriptionMutation, CreateSubscriptionMutationVariables>;
 
 /**

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3592,7 +3592,7 @@ export type CreateCustomerWalletMutationVariables = Exact<{
 }>;
 
 
-export type CreateCustomerWalletMutation = { __typename?: 'Mutation', createCustomerWallet?: { __typename?: 'Wallet', id: string, currency: CurrencyEnum, rateAmount: string, name?: string | null, expirationAt?: any | null, balance: string, consumedAmount: string, consumedCredits: string, createdAt: any, creditsBalance: string, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, status: WalletStatusEnum, terminatedAt?: any | null } | null };
+export type CreateCustomerWalletMutation = { __typename?: 'Mutation', createCustomerWallet?: { __typename?: 'Wallet', id: string, currency: CurrencyEnum, rateAmount: string, name?: string | null, expirationAt?: any | null, balance: string, consumedAmount: string, consumedCredits: string, createdAt: any, creditsBalance: string, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, status: WalletStatusEnum, terminatedAt?: any | null, customer?: { __typename?: 'Customer', id: string, hasActiveWallet: boolean } | null } | null };
 
 export type CustomerWalletFragment = { __typename?: 'Wallet', id: string, currency: CurrencyEnum, rateAmount: string, name?: string | null, expirationAt?: any | null, balance: string, consumedAmount: string, consumedCredits: string, createdAt: any, creditsBalance: string, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, status: WalletStatusEnum, terminatedAt?: any | null };
 
@@ -3610,7 +3610,7 @@ export type TerminateCustomerWalletMutationVariables = Exact<{
 }>;
 
 
-export type TerminateCustomerWalletMutation = { __typename?: 'Mutation', terminateCustomerWallet?: { __typename?: 'Wallet', id: string, status: WalletStatusEnum, balance: string, consumedAmount: string, consumedCredits: string, createdAt: any, creditsBalance: string, currency: CurrencyEnum, expirationAt?: any | null, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, name?: string | null, rateAmount: string, terminatedAt?: any | null } | null };
+export type TerminateCustomerWalletMutation = { __typename?: 'Mutation', terminateCustomerWallet?: { __typename?: 'Wallet', id: string, status: WalletStatusEnum, balance: string, consumedAmount: string, consumedCredits: string, createdAt: any, creditsBalance: string, currency: CurrencyEnum, expirationAt?: any | null, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, name?: string | null, rateAmount: string, terminatedAt?: any | null, customer?: { __typename?: 'Customer', id: string, hasActiveWallet: boolean } | null } | null };
 
 export type CreateCustomerWalletTransactionMutationVariables = Exact<{
   input: CreateCustomerWalletTransactionInput;
@@ -6955,6 +6955,10 @@ export const CreateCustomerWalletDocument = gql`
   createCustomerWallet(input: $input) {
     id
     ...CustomerWallet
+    customer {
+      id
+      hasActiveWallet
+    }
   }
 }
     ${CustomerWalletFragmentDoc}`;
@@ -7033,6 +7037,10 @@ export const TerminateCustomerWalletDocument = gql`
     id
     status
     ...WalletAccordion
+    customer {
+      id
+      hasActiveWallet
+    }
   }
 }
     ${WalletAccordionFragmentDoc}`;

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3245,6 +3245,15 @@ export type GetCustomerAddonsQuery = { __typename?: 'Query', customer?: { __type
 
 export type CustomerCouponFragment = { __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } };
 
+export type CustomerAppliedCouponsFragment = { __typename?: 'Customer', id: string, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null };
+
+export type GetCustomerCouponsQueryVariables = Exact<{
+  id: Scalars['ID'];
+}>;
+
+
+export type GetCustomerCouponsQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, name?: string | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null } | null };
+
 export type RemoveCouponMutationVariables = Exact<{
   input: TerminateAppliedCouponInput;
 }>;
@@ -3890,16 +3899,14 @@ export type GetCreditNoteQueryVariables = Exact<{
 
 export type GetCreditNoteQuery = { __typename?: 'Query', creditNote?: { __typename?: 'CreditNote', id: string, balanceAmountCents: any, canBeVoided: boolean, createdAt: any, creditAmountCents: any, creditAmountCurrency: CurrencyEnum, creditStatus?: CreditNoteCreditStatusEnum | null, number: string, refundAmountCents: any, refundedAt?: any | null, refundStatus?: CreditNoteRefundStatusEnum | null, subTotalVatExcludedAmountCents: any, subTotalVatExcludedAmountCurrency: CurrencyEnum, totalAmountCents: any, totalAmountCurrency: CurrencyEnum, vatAmountCents: any, vatAmountCurrency: CurrencyEnum, customer: { __typename?: 'Customer', id: string, name?: string | null, deletedAt?: any | null, applicableTimezone: TimezoneEnum }, invoice?: { __typename?: 'Invoice', id: string, number: string } | null, items: Array<{ __typename?: 'CreditNoteItem', amountCents: any, amountCurrency: CurrencyEnum, fee: { __typename?: 'Fee', id: string, amountCents: any, amountCurrency: CurrencyEnum, eventsCount?: any | null, units: number, feeType: FeeTypesEnum, itemName: string, charge?: { __typename?: 'Charge', id: string, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum } } | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, group?: { __typename?: 'Group', id: string, key?: string | null, value: string } | null } }> } | null };
 
-export type CustomerAppliedCouponsFragment = { __typename?: 'Customer', id: string, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null };
-
-export type CustomerDetailsFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, activeSubscriptionCount: number, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
+export type CustomerDetailsFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, activeSubscriptionCount: number, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
 
 export type GetCustomerQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetCustomerQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, activeSubscriptionCount: number, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
+export type GetCustomerQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, activeSubscriptionCount: number, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
 
 export type GetCustomerDraftInvoicesQueryVariables = Exact<{
   customerId: Scalars['ID'];
@@ -4191,6 +4198,36 @@ export const CustomerAppliedAddOnsFragmentDoc = gql`
   }
 }
     ${CustomerAddOnsFragmentDoc}`;
+export const AppliedCouponCaptionFragmentDoc = gql`
+    fragment AppliedCouponCaption on AppliedCoupon {
+  id
+  amountCurrency
+  amountCents
+  amountCentsRemaining
+  percentageRate
+  frequency
+  frequencyDuration
+  frequencyDurationRemaining
+}
+    `;
+export const CustomerCouponFragmentDoc = gql`
+    fragment CustomerCoupon on AppliedCoupon {
+  id
+  ...AppliedCouponCaption
+  coupon {
+    id
+    name
+  }
+}
+    ${AppliedCouponCaptionFragmentDoc}`;
+export const CustomerAppliedCouponsFragmentDoc = gql`
+    fragment CustomerAppliedCoupons on Customer {
+  id
+  appliedCoupons {
+    ...CustomerCoupon
+  }
+}
+    ${CustomerCouponFragmentDoc}`;
 export const InvoiceForFinalizeInvoiceFragmentDoc = gql`
     fragment InvoiceForFinalizeInvoice on Invoice {
   id
@@ -5054,36 +5091,6 @@ export const EditPlanFragmentDoc = gql`
   }
 }
     ${ChargeAccordionFragmentDoc}`;
-export const AppliedCouponCaptionFragmentDoc = gql`
-    fragment AppliedCouponCaption on AppliedCoupon {
-  id
-  amountCurrency
-  amountCents
-  amountCentsRemaining
-  percentageRate
-  frequency
-  frequencyDuration
-  frequencyDurationRemaining
-}
-    `;
-export const CustomerCouponFragmentDoc = gql`
-    fragment CustomerCoupon on AppliedCoupon {
-  id
-  ...AppliedCouponCaption
-  coupon {
-    id
-    name
-  }
-}
-    ${AppliedCouponCaptionFragmentDoc}`;
-export const CustomerAppliedCouponsFragmentDoc = gql`
-    fragment CustomerAppliedCoupons on Customer {
-  id
-  appliedCoupons {
-    ...CustomerCoupon
-  }
-}
-    ${CustomerCouponFragmentDoc}`;
 export const CustomerMainInfosFragmentDoc = gql`
     fragment CustomerMainInfos on Customer {
   id
@@ -5125,12 +5132,10 @@ export const CustomerDetailsFragmentDoc = gql`
   creditNotesBalanceAmountCents
   applicableTimezone
   activeSubscriptionCount
-  ...CustomerAppliedCoupons
   ...AddCustomerDrawer
   ...CustomerMainInfos
 }
-    ${CustomerAppliedCouponsFragmentDoc}
-${AddCustomerDrawerFragmentDoc}
+    ${AddCustomerDrawerFragmentDoc}
 ${CustomerMainInfosFragmentDoc}`;
 export const EventItemFragmentDoc = gql`
     fragment EventItem on Event {
@@ -5652,6 +5657,43 @@ export function useGetCustomerAddonsLazyQuery(baseOptions?: Apollo.LazyQueryHook
 export type GetCustomerAddonsQueryHookResult = ReturnType<typeof useGetCustomerAddonsQuery>;
 export type GetCustomerAddonsLazyQueryHookResult = ReturnType<typeof useGetCustomerAddonsLazyQuery>;
 export type GetCustomerAddonsQueryResult = Apollo.QueryResult<GetCustomerAddonsQuery, GetCustomerAddonsQueryVariables>;
+export const GetCustomerCouponsDocument = gql`
+    query getCustomerCoupons($id: ID!) {
+  customer(id: $id) {
+    id
+    name
+    ...CustomerAppliedCoupons
+  }
+}
+    ${CustomerAppliedCouponsFragmentDoc}`;
+
+/**
+ * __useGetCustomerCouponsQuery__
+ *
+ * To run a query within a React component, call `useGetCustomerCouponsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCustomerCouponsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetCustomerCouponsQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetCustomerCouponsQuery(baseOptions: Apollo.QueryHookOptions<GetCustomerCouponsQuery, GetCustomerCouponsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetCustomerCouponsQuery, GetCustomerCouponsQueryVariables>(GetCustomerCouponsDocument, options);
+      }
+export function useGetCustomerCouponsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetCustomerCouponsQuery, GetCustomerCouponsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetCustomerCouponsQuery, GetCustomerCouponsQueryVariables>(GetCustomerCouponsDocument, options);
+        }
+export type GetCustomerCouponsQueryHookResult = ReturnType<typeof useGetCustomerCouponsQuery>;
+export type GetCustomerCouponsLazyQueryHookResult = ReturnType<typeof useGetCustomerCouponsLazyQuery>;
+export type GetCustomerCouponsQueryResult = Apollo.QueryResult<GetCustomerCouponsQuery, GetCustomerCouponsQueryVariables>;
 export const RemoveCouponDocument = gql`
     mutation removeCoupon($input: TerminateAppliedCouponInput!) {
   terminateAppliedCoupon(input: $input) {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3266,7 +3266,7 @@ export type GetCustomerInvoicesQueryVariables = Exact<{
 
 export type GetCustomerInvoicesQuery = { __typename?: 'Query', customerInvoices: { __typename?: 'InvoiceCollection', collection: Array<{ __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, paymentStatus: InvoicePaymentStatusTypeEnum, number: string, issuingDate: any, totalAmountCents: any, totalAmountCurrency: CurrencyEnum, customer: { __typename?: 'Customer', id: string, applicableTimezone: TimezoneEnum, name?: string | null } }>, metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalCount: number, totalPages: number } } };
 
-export type CustomerItemFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, createdAt: any, activeSubscriptionCount: number, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, canEditAttributes: boolean, city?: string | null, zipcode?: string | null, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
+export type CustomerItemFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, createdAt: any, activeSubscriptionCount: number, addressLine1?: string | null, addressLine2?: string | null, applicableTimezone: TimezoneEnum, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
 
 export type CustomerMainInfosFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, currency?: CurrencyEnum | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string }> | null };
 
@@ -3769,23 +3769,21 @@ export type UpdateCouponMutationVariables = Exact<{
 
 export type UpdateCouponMutation = { __typename?: 'Mutation', updateCoupon?: { __typename?: 'Coupon', id: string, name: string, customerCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, appliedCouponsCount: number, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null } | null };
 
-export type AddCustomerDrawerFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, canEditAttributes: boolean, city?: string | null, zipcode?: string | null, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
-
-export type AddCustomerDrawerDetailFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, currency?: CurrencyEnum | null, canEditAttributes: boolean, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
+export type AddCustomerDrawerFragment = { __typename?: 'Customer', id: string, addressLine1?: string | null, addressLine2?: string | null, applicableTimezone: TimezoneEnum, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, email?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, name?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
 
 export type CreateCustomerMutationVariables = Exact<{
   input: CreateCustomerInput;
 }>;
 
 
-export type CreateCustomerMutation = { __typename?: 'Mutation', createCustomer?: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, canEditAttributes: boolean, city?: string | null, zipcode?: string | null, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, createdAt: any, activeSubscriptionCount: number, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
+export type CreateCustomerMutation = { __typename?: 'Mutation', createCustomer?: { __typename?: 'Customer', id: string, addressLine1?: string | null, addressLine2?: string | null, applicableTimezone: TimezoneEnum, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, email?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, name?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, createdAt: any, activeSubscriptionCount: number, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
 
 export type UpdateCustomerMutationVariables = Exact<{
   input: UpdateCustomerInput;
 }>;
 
 
-export type UpdateCustomerMutation = { __typename?: 'Mutation', updateCustomer?: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, canEditAttributes: boolean, city?: string | null, zipcode?: string | null, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, createdAt: any, activeSubscriptionCount: number, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
+export type UpdateCustomerMutation = { __typename?: 'Mutation', updateCustomer?: { __typename?: 'Customer', id: string, addressLine1?: string | null, addressLine2?: string | null, applicableTimezone: TimezoneEnum, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, email?: string | null, externalId: string, legalName?: string | null, legalNumber?: string | null, name?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, createdAt: any, activeSubscriptionCount: number, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
 
 export type CurrentUserInfosFragment = { __typename?: 'User', id: string, email?: string | null, premium: boolean, organizations?: Array<{ __typename?: 'Organization', id: string, name: string, logoUrl?: string | null }> | null };
 
@@ -3875,14 +3873,14 @@ export type CustomerAppliedAddOnsFragment = { __typename?: 'Customer', id: strin
 
 export type CustomerAppliedCouponsFragment = { __typename?: 'Customer', id: string, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null };
 
-export type CustomerDetailsFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, canEditAttributes: boolean, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null }>, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
+export type CustomerDetailsFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null }>, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
 
 export type GetCustomerQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetCustomerQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, canEditAttributes: boolean, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null }>, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
+export type GetCustomerQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null }>, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
 
 export type GetCustomerDraftInvoicesQueryVariables = Exact<{
   customerId: Scalars['ID'];
@@ -3910,7 +3908,7 @@ export type CustomersQueryVariables = Exact<{
 }>;
 
 
-export type CustomersQuery = { __typename?: 'Query', customers: { __typename?: 'CustomerCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Customer', id: string, name?: string | null, externalId: string, createdAt: any, activeSubscriptionCount: number, legalName?: string | null, legalNumber?: string | null, phone?: string | null, email?: string | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, canEditAttributes: boolean, city?: string | null, zipcode?: string | null, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null }> } };
+export type CustomersQuery = { __typename?: 'Query', customers: { __typename?: 'CustomerCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Customer', id: string, name?: string | null, externalId: string, createdAt: any, activeSubscriptionCount: number, addressLine1?: string | null, addressLine2?: string | null, applicableTimezone: TimezoneEnum, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null }> } };
 
 export type GetinviteQueryVariables = Exact<{
   token: Scalars['String'];
@@ -4209,23 +4207,23 @@ export const InvoiceForInvoiceListFragmentDoc = gql`
 export const AddCustomerDrawerFragmentDoc = gql`
     fragment AddCustomerDrawer on Customer {
   id
-  name
+  addressLine1
+  addressLine2
+  applicableTimezone
+  canEditAttributes
+  city
+  country
+  currency
+  email
   externalId
   legalName
   legalNumber
-  phone
-  email
-  addressLine1
-  addressLine2
-  state
-  country
-  currency
-  canEditAttributes
-  city
-  zipcode
-  applicableTimezone
+  name
   paymentProvider
+  phone
+  state
   timezone
+  zipcode
   providerCustomer {
     id
     providerCustomerId
@@ -5079,39 +5077,6 @@ export const CustomerAppliedAddOnsFragmentDoc = gql`
   }
 }
     ${CustomerAddOnsFragmentDoc}`;
-export const AddCustomerDrawerDetailFragmentDoc = gql`
-    fragment AddCustomerDrawerDetail on Customer {
-  id
-  name
-  externalId
-  legalName
-  legalNumber
-  phone
-  email
-  currency
-  canEditAttributes
-  addressLine1
-  addressLine2
-  state
-  country
-  city
-  zipcode
-  applicableTimezone
-  paymentProvider
-  timezone
-  providerCustomer {
-    id
-    providerCustomerId
-    syncWithProvider
-  }
-  metadata {
-    id
-    key
-    value
-    displayInInvoice
-  }
-}
-    `;
 export const CustomerMainInfosFragmentDoc = gql`
     fragment CustomerMainInfos on Customer {
   id
@@ -5157,13 +5122,13 @@ export const CustomerDetailsFragmentDoc = gql`
   }
   ...CustomerAppliedCoupons
   ...CustomerAppliedAddOns
-  ...AddCustomerDrawerDetail
+  ...AddCustomerDrawer
   ...CustomerMainInfos
 }
     ${CustomerSubscriptionFragmentDoc}
 ${CustomerAppliedCouponsFragmentDoc}
 ${CustomerAppliedAddOnsFragmentDoc}
-${AddCustomerDrawerDetailFragmentDoc}
+${AddCustomerDrawerFragmentDoc}
 ${CustomerMainInfosFragmentDoc}`;
 export const EventItemFragmentDoc = gql`
     fragment EventItem on Event {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3234,6 +3234,15 @@ export type AddCouponMutation = { __typename?: 'Mutation', createAppliedCoupon?:
 
 export type CustomerAddOnsFragment = { __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } };
 
+export type CustomerAppliedAddOnsFragment = { __typename?: 'Customer', id: string, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null };
+
+export type GetCustomerAddonsQueryVariables = Exact<{
+  id: Scalars['ID'];
+}>;
+
+
+export type GetCustomerAddonsQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null } | null };
+
 export type CustomerCouponFragment = { __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } };
 
 export type RemoveCouponMutationVariables = Exact<{
@@ -3881,18 +3890,16 @@ export type GetCreditNoteQueryVariables = Exact<{
 
 export type GetCreditNoteQuery = { __typename?: 'Query', creditNote?: { __typename?: 'CreditNote', id: string, balanceAmountCents: any, canBeVoided: boolean, createdAt: any, creditAmountCents: any, creditAmountCurrency: CurrencyEnum, creditStatus?: CreditNoteCreditStatusEnum | null, number: string, refundAmountCents: any, refundedAt?: any | null, refundStatus?: CreditNoteRefundStatusEnum | null, subTotalVatExcludedAmountCents: any, subTotalVatExcludedAmountCurrency: CurrencyEnum, totalAmountCents: any, totalAmountCurrency: CurrencyEnum, vatAmountCents: any, vatAmountCurrency: CurrencyEnum, customer: { __typename?: 'Customer', id: string, name?: string | null, deletedAt?: any | null, applicableTimezone: TimezoneEnum }, invoice?: { __typename?: 'Invoice', id: string, number: string } | null, items: Array<{ __typename?: 'CreditNoteItem', amountCents: any, amountCurrency: CurrencyEnum, fee: { __typename?: 'Fee', id: string, amountCents: any, amountCurrency: CurrencyEnum, eventsCount?: any | null, units: number, feeType: FeeTypesEnum, itemName: string, charge?: { __typename?: 'Charge', id: string, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum } } | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, group?: { __typename?: 'Group', id: string, key?: string | null, value: string } | null } }> } | null };
 
-export type CustomerAppliedAddOnsFragment = { __typename?: 'Customer', id: string, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null };
-
 export type CustomerAppliedCouponsFragment = { __typename?: 'Customer', id: string, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null };
 
-export type CustomerDetailsFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, activeSubscriptionCount: number, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
+export type CustomerDetailsFragment = { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, activeSubscriptionCount: number, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null };
 
 export type GetCustomerQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetCustomerQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, activeSubscriptionCount: number, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, appliedAddOns?: Array<{ __typename?: 'AppliedAddOn', id: string, amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, addOn: { __typename?: 'AddOn', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
+export type GetCustomerQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, activeSubscriptionCount: number, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, legalName?: string | null, legalNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', id: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, amountCentsRemaining?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, frequencyDurationRemaining?: number | null, coupon: { __typename?: 'Coupon', id: string, name: string } }> | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } | null };
 
 export type GetCustomerDraftInvoicesQueryVariables = Exact<{
   customerId: Scalars['ID'];
@@ -4164,6 +4171,26 @@ export const CouponPlansForCustomerFragmentDoc = gql`
   name
 }
     `;
+export const CustomerAddOnsFragmentDoc = gql`
+    fragment CustomerAddOns on AppliedAddOn {
+  id
+  amountCents
+  amountCurrency
+  createdAt
+  addOn {
+    id
+    name
+  }
+}
+    `;
+export const CustomerAppliedAddOnsFragmentDoc = gql`
+    fragment CustomerAppliedAddOns on Customer {
+  id
+  appliedAddOns {
+    ...CustomerAddOns
+  }
+}
+    ${CustomerAddOnsFragmentDoc}`;
 export const InvoiceForFinalizeInvoiceFragmentDoc = gql`
     fragment InvoiceForFinalizeInvoice on Invoice {
   id
@@ -5057,26 +5084,6 @@ export const CustomerAppliedCouponsFragmentDoc = gql`
   }
 }
     ${CustomerCouponFragmentDoc}`;
-export const CustomerAddOnsFragmentDoc = gql`
-    fragment CustomerAddOns on AppliedAddOn {
-  id
-  amountCents
-  amountCurrency
-  createdAt
-  addOn {
-    id
-    name
-  }
-}
-    `;
-export const CustomerAppliedAddOnsFragmentDoc = gql`
-    fragment CustomerAppliedAddOns on Customer {
-  id
-  appliedAddOns {
-    ...CustomerAddOns
-  }
-}
-    ${CustomerAddOnsFragmentDoc}`;
 export const CustomerMainInfosFragmentDoc = gql`
     fragment CustomerMainInfos on Customer {
   id
@@ -5119,12 +5126,10 @@ export const CustomerDetailsFragmentDoc = gql`
   applicableTimezone
   activeSubscriptionCount
   ...CustomerAppliedCoupons
-  ...CustomerAppliedAddOns
   ...AddCustomerDrawer
   ...CustomerMainInfos
 }
     ${CustomerAppliedCouponsFragmentDoc}
-${CustomerAppliedAddOnsFragmentDoc}
 ${AddCustomerDrawerFragmentDoc}
 ${CustomerMainInfosFragmentDoc}`;
 export const EventItemFragmentDoc = gql`
@@ -5611,6 +5616,42 @@ export function useAddCouponMutation(baseOptions?: Apollo.MutationHookOptions<Ad
 export type AddCouponMutationHookResult = ReturnType<typeof useAddCouponMutation>;
 export type AddCouponMutationResult = Apollo.MutationResult<AddCouponMutation>;
 export type AddCouponMutationOptions = Apollo.BaseMutationOptions<AddCouponMutation, AddCouponMutationVariables>;
+export const GetCustomerAddonsDocument = gql`
+    query getCustomerAddons($id: ID!) {
+  customer(id: $id) {
+    id
+    ...CustomerAppliedAddOns
+  }
+}
+    ${CustomerAppliedAddOnsFragmentDoc}`;
+
+/**
+ * __useGetCustomerAddonsQuery__
+ *
+ * To run a query within a React component, call `useGetCustomerAddonsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCustomerAddonsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetCustomerAddonsQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetCustomerAddonsQuery(baseOptions: Apollo.QueryHookOptions<GetCustomerAddonsQuery, GetCustomerAddonsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetCustomerAddonsQuery, GetCustomerAddonsQueryVariables>(GetCustomerAddonsDocument, options);
+      }
+export function useGetCustomerAddonsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetCustomerAddonsQuery, GetCustomerAddonsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetCustomerAddonsQuery, GetCustomerAddonsQueryVariables>(GetCustomerAddonsDocument, options);
+        }
+export type GetCustomerAddonsQueryHookResult = ReturnType<typeof useGetCustomerAddonsQuery>;
+export type GetCustomerAddonsLazyQueryHookResult = ReturnType<typeof useGetCustomerAddonsLazyQuery>;
+export type GetCustomerAddonsQueryResult = Apollo.QueryResult<GetCustomerAddonsQuery, GetCustomerAddonsQueryVariables>;
 export const RemoveCouponDocument = gql`
     mutation removeCoupon($input: TerminateAppliedCouponInput!) {
   terminateAppliedCoupon(input: $input) {

--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -179,7 +179,7 @@ export const useAddSubscription: UseAddSubscription = ({
         update(cache, { data: createData }) {
           if (!createData?.createSubscription) return
 
-          const cacheId = `CustomerDetails:${customerId}`
+          const cacheId = `Customer:${customerId}`
 
           const previousData: CustomerDetailsFragment | null = cache.readFragment({
             id: cacheId,

--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -12,8 +12,6 @@ import {
   LagoApiError,
   CreateSubscriptionInput,
   CustomerSubscriptionFragmentDoc,
-  CustomerDetailsFragmentDoc,
-  CustomerDetailsFragment,
 } from '~/generated/graphql'
 import { SubscriptionUpdateInfo, addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { ComboBoxProps } from '~/components/form'
@@ -91,6 +89,7 @@ export const useAddSubscription: UseAddSubscription = ({
         })
       }
     },
+    refetchQueries: ['getCustomer'],
   })
 
   const selectedPlan = useMemo(() => {
@@ -175,33 +174,6 @@ export const useAddSubscription: UseAddSubscription = ({
               : { subscriptionId: existingSubscription.subscriptionId }),
             ...values,
           },
-        },
-        update(cache, { data: createData }) {
-          if (!createData?.createSubscription) return
-
-          const cacheId = `Customer:${customerId}`
-
-          const previousData: CustomerDetailsFragment | null = cache.readFragment({
-            id: cacheId,
-            fragment: CustomerDetailsFragmentDoc,
-            fragmentName: 'CustomerDetails',
-          })
-
-          cache.writeFragment({
-            id: cacheId,
-            fragment: CustomerDetailsFragmentDoc,
-            fragmentName: 'CustomerDetails',
-            data: {
-              ...previousData,
-              subscriptions: [
-                createData?.createSubscription,
-                ...(previousData?.subscriptions || []).map((s) => ({
-                  ...s,
-                  __typename: 'Subscription', // The query has nested fragment and the typename is removed - we need to re-add it for it to work
-                })),
-              ],
-            },
-          })
         },
       })
 

--- a/src/hooks/useCreateEditCustomer.ts
+++ b/src/hooks/useCreateEditCustomer.ts
@@ -51,7 +51,7 @@ gql`
     }
   }
 
-  fragment AddCustomerDrawerDetail on CustomerDetails {
+  fragment AddCustomerDrawerDetail on Customer {
     id
     name
     externalId

--- a/src/hooks/useCreateEditCustomer.ts
+++ b/src/hooks/useCreateEditCustomer.ts
@@ -7,10 +7,9 @@ import {
   useUpdateCustomerMutation,
   CreateCustomerInput,
   UpdateCustomerInput,
-  AddCustomerDrawerDetailFragmentDoc,
+  AddCustomerDrawerFragmentDoc,
   LagoApiError,
   AddCustomerDrawerFragment,
-  AddCustomerDrawerDetailFragment,
   UpdateCustomerMutation,
   CreateCustomerMutation,
 } from '~/generated/graphql'
@@ -21,55 +20,23 @@ import { CUSTOMER_DETAILS_ROUTE } from '~/core/router'
 gql`
   fragment AddCustomerDrawer on Customer {
     id
-    name
+    addressLine1
+    addressLine2
+    applicableTimezone
+    canEditAttributes
+    city
+    country
+    currency
+    email
     externalId
     legalName
     legalNumber
-    phone
-    email
-    addressLine1
-    addressLine2
-    state
-    country
-    currency
-    canEditAttributes
-    city
-    zipcode
-    applicableTimezone
-    paymentProvider
-    timezone
-    providerCustomer {
-      id
-      providerCustomerId
-      syncWithProvider
-    }
-    metadata {
-      id
-      key
-      value
-      displayInInvoice
-    }
-  }
-
-  fragment AddCustomerDrawerDetail on Customer {
-    id
     name
-    externalId
-    legalName
-    legalNumber
-    phone
-    email
-    currency
-    canEditAttributes
-    addressLine1
-    addressLine2
-    state
-    country
-    city
-    zipcode
-    applicableTimezone
     paymentProvider
+    phone
+    state
     timezone
+    zipcode
     providerCustomer {
       id
       providerCustomerId
@@ -100,9 +67,7 @@ gql`
   ${CustomerItemFragmentDoc}
 `
 
-type UseCreateEditCustomer = (props: {
-  customer?: AddCustomerDrawerFragment | AddCustomerDrawerDetailFragment | null
-}) => {
+type UseCreateEditCustomer = (props: { customer?: AddCustomerDrawerFragment | null }) => {
   isEdition: boolean
   onSave: (
     values: CreateCustomerInput | UpdateCustomerInput
@@ -142,7 +107,7 @@ export const useCreateEditCustomer: UseCreateEditCustomer = ({ customer }) => {
 
       cache.writeFragment({
         data: { ...data?.updateCustomer, __typename: 'CustomerDetails' },
-        fragment: AddCustomerDrawerDetailFragmentDoc,
+        fragment: AddCustomerDrawerFragmentDoc,
       })
     },
   })

--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -20,7 +20,6 @@ import {
 import {
   useGetCustomerQuery,
   CustomerMainInfosFragmentDoc,
-  CustomerAddOnsFragmentDoc,
   TimezoneEnum,
   AddCustomerDrawerFragmentDoc,
 } from '~/generated/graphql'
@@ -61,13 +60,6 @@ import {
 import { CustomerCreditNotesList } from '~/components/customers/CustomerCreditNotesList'
 
 gql`
-  fragment CustomerAppliedAddOns on Customer {
-    id
-    appliedAddOns {
-      ...CustomerAddOns
-    }
-  }
-
   fragment CustomerAppliedCoupons on Customer {
     id
     appliedCoupons {
@@ -87,7 +79,6 @@ gql`
     applicableTimezone
     activeSubscriptionCount
     ...CustomerAppliedCoupons
-    ...CustomerAppliedAddOns
     ...AddCustomerDrawer
     ...CustomerMainInfos
   }
@@ -100,7 +91,6 @@ gql`
 
   ${AddCustomerDrawerFragmentDoc}
   ${CustomerCouponFragmentDoc}
-  ${CustomerAddOnsFragmentDoc}
   ${CustomerMainInfosFragmentDoc}
 `
 
@@ -130,7 +120,6 @@ const CustomerDetails = () => {
   })
   const { goBack } = useLocationHistory()
   const {
-    appliedAddOns,
     appliedCoupons,
     creditNotesCreditsAvailableCount,
     creditNotesBalanceAmountCents,
@@ -321,11 +310,7 @@ const CustomerDetails = () => {
                             />
                           )}
                           {!loading && (
-                            <CustomerAddOns
-                              ref={addOnDialogRef}
-                              addOns={appliedAddOns}
-                              customerTimezone={safeTimezone}
-                            />
+                            <CustomerAddOns ref={addOnDialogRef} customerTimezone={safeTimezone} />
                           )}
                           <CustomerSubscriptionsList
                             ref={subscriptionsDialogRef}

--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -60,13 +60,6 @@ import {
 import { CustomerCreditNotesList } from '~/components/customers/CustomerCreditNotesList'
 
 gql`
-  fragment CustomerAppliedCoupons on Customer {
-    id
-    appliedCoupons {
-      ...CustomerCoupon
-    }
-  }
-
   fragment CustomerDetails on Customer {
     id
     name
@@ -78,7 +71,6 @@ gql`
     creditNotesBalanceAmountCents
     applicableTimezone
     activeSubscriptionCount
-    ...CustomerAppliedCoupons
     ...AddCustomerDrawer
     ...CustomerMainInfos
   }
@@ -90,7 +82,6 @@ gql`
   }
 
   ${AddCustomerDrawerFragmentDoc}
-  ${CustomerCouponFragmentDoc}
   ${CustomerMainInfosFragmentDoc}
 `
 
@@ -120,7 +111,6 @@ const CustomerDetails = () => {
   })
   const { goBack } = useLocationHistory()
   const {
-    appliedCoupons,
     creditNotesCreditsAvailableCount,
     creditNotesBalanceAmountCents,
     externalId,
@@ -302,13 +292,7 @@ const CustomerDetails = () => {
                       ],
                       component: (
                         <SideBlock>
-                          {!loading && (
-                            <CustomerCoupons
-                              coupons={appliedCoupons}
-                              customerId={id as string}
-                              customerName={data?.customer?.name as string}
-                            />
-                          )}
+                          {!loading && <CustomerCoupons />}
                           {!loading && (
                             <CustomerAddOns ref={addOnDialogRef} customerTimezone={safeTimezone} />
                           )}

--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -20,13 +20,13 @@ import {
 import {
   useGetCustomerQuery,
   SubscriptionItemFragmentDoc,
-  AddCustomerDrawerDetailFragmentDoc,
   CustomerCouponFragmentDoc,
   CustomerMainInfosFragmentDoc,
   CustomerAddOnsFragmentDoc,
   CustomerUsageSubscriptionFragmentDoc,
   StatusTypeEnum,
   TimezoneEnum,
+  AddCustomerDrawerFragmentDoc,
 } from '~/generated/graphql'
 import { GenericPlaceholder } from '~/components/GenericPlaceholder'
 import ErrorImage from '~/public/images/maneki/error.svg'
@@ -104,7 +104,7 @@ gql`
     }
     ...CustomerAppliedCoupons
     ...CustomerAppliedAddOns
-    ...AddCustomerDrawerDetail
+    ...AddCustomerDrawer
     ...CustomerMainInfos
   }
 
@@ -115,7 +115,7 @@ gql`
   }
 
   ${SubscriptionItemFragmentDoc}
-  ${AddCustomerDrawerDetailFragmentDoc}
+  ${AddCustomerDrawerFragmentDoc}
   ${CustomerCouponFragmentDoc}
   ${CustomerAddOnsFragmentDoc}
   ${CustomerMainInfosFragmentDoc}

--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -75,21 +75,21 @@ gql`
     ...CustomerUsageSubscription
   }
 
-  fragment CustomerAppliedAddOns on CustomerDetails {
+  fragment CustomerAppliedAddOns on Customer {
     id
     appliedAddOns {
       ...CustomerAddOns
     }
   }
 
-  fragment CustomerAppliedCoupons on CustomerDetails {
+  fragment CustomerAppliedCoupons on Customer {
     id
     appliedCoupons {
       ...CustomerCoupon
     }
   }
 
-  fragment CustomerDetails on CustomerDetails {
+  fragment CustomerDetails on Customer {
     id
     name
     externalId


### PR DESCRIPTION
## Context

This is the last item of removing the types `Details` task in app

This one is a bit tricky as it was used a lot on FE side and had different logic for the same attributes depending on the BE type

I tested the app with those changes and I had to add a `refetchQuery` when adding a subscription. This should be fixed in later data and fragment refactor on this part.

This is a good step forward for [cache and fragment improvement](https://github.com/getlago/lago-front/issues/865) for this part of the app

## Description

This PR removes all `CustomerDetails` occurrences in the app to stick with the `Customer` one