### PR TITLE
bug(Customer): fix vat button click not working

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -127,7 +127,8 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
           <Button
             disabled={loading}
             variant="quaternary"
-            onClick={editDialogRef?.current?.openDialog}
+            // it needs to be an anonymous function to be re-rendered on customer fetch
+            onClick={() => editDialogRef?.current?.openDialog()}
           >
             {translate('text_62728ff857d47b013204cab3')}
           </Button>


### PR DESCRIPTION
## Context

Right after a customer is created, the VAT rate button to edit the value is not clickable.

Mostly due to the fact that a template condition is not rendered and that the edit modal ref is not udpated then.

## Description

This PR turns the onClick to use an anonymous function, so it's re-rendered when the template reloads