### PR TITLE
chore(plan-form): move first section into a memo component

### DIFF
--- a/src/components/plans/PlanSettings.tsx
+++ b/src/components/plans/PlanSettings.tsx
@@ -1,0 +1,88 @@
+import { memo, useEffect } from 'react'
+import { FormikProps } from 'formik'
+import styled from 'styled-components'
+import { gql } from '@apollo/client'
+
+import { TextInputField } from '~/components/form'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { Typography } from '~/components/designSystem'
+import { theme, Card } from '~/styles'
+import { PLAN_FORM_TYPE_ENUM, FORM_ERRORS_ENUM } from '~/hooks/plans/usePlanForm'
+import { Line } from '~/styles/mainObjectsForm'
+
+import { PlanFormInput } from './types'
+
+gql`
+  fragment PlanSettings on Plan {
+    id
+    name
+    code
+    description
+  }
+`
+
+interface PlanSettingsProps {
+  canBeEdited: boolean
+  errorCode: string | undefined
+  formikProps: FormikProps<PlanFormInput>
+  type: keyof typeof PLAN_FORM_TYPE_ENUM
+}
+export const PlanSettings = memo(
+  ({ canBeEdited, errorCode, formikProps, type }: PlanSettingsProps) => {
+    const { translate } = useInternationalization()
+    const isEdition = type === PLAN_FORM_TYPE_ENUM.edition
+
+    useEffect(() => {
+      if (errorCode === FORM_ERRORS_ENUM.existingCode) {
+        formikProps.setFieldError('code', 'text_632a2d437e341dcc76817556')
+        const rootElement = document.getElementById('root')
+
+        if (!rootElement) return
+        rootElement.scrollTo({ top: 0 })
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [errorCode])
+
+    return (
+      <Card>
+        <SectionTitle variant="subhead">{translate('text_624453d52e945301380e4992')}</SectionTitle>
+
+        <Line>
+          <TextInputField
+            name="name"
+            label={translate('text_624453d52e945301380e4998')}
+            placeholder={translate('text_624453d52e945301380e499c')}
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            formikProps={formikProps}
+          />
+          <TextInputField
+            name="code"
+            beforeChangeFormatter="code"
+            disabled={isEdition && !canBeEdited}
+            label={translate('text_624453d52e945301380e499a')}
+            placeholder={translate('text_624453d52e945301380e499e')}
+            formikProps={formikProps}
+            infoText={translate('text_624d9adba93343010cd14ca1')}
+          />
+        </Line>
+        <TextInputField
+          name="description"
+          label={translate('text_624c5eadff7db800acc4c99f')}
+          placeholder={translate('text_624453d52e945301380e49a2')}
+          rows="3"
+          multiline
+          formikProps={formikProps}
+        />
+      </Card>
+    )
+  }
+)
+
+PlanSettings.displayName = 'PlanSettings'
+
+const SectionTitle = styled(Typography)`
+  > div:first-child {
+    margin-bottom: ${theme.spacing(3)};
+  }
+`

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3672,6 +3672,8 @@ export type PackageChargeFragment = { __typename?: 'Charge', id: string, propert
 
 export type PlanItemFragment = { __typename?: 'Plan', id: string, name: string, code: string, chargeCount: number, customerCount: number, createdAt: any, draftInvoicesCount: number, activeSubscriptionsCount: number };
 
+export type PlanSettingsFragment = { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null };
+
 export type VolumeRangesFragment = { __typename?: 'Charge', properties?: { __typename?: 'Properties', volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, values: { __typename?: 'Properties', volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null };
 
 export type UpdateDocumentLocaleOrganizationMutationVariables = Exact<{
@@ -5278,6 +5280,14 @@ export const ChargeAccordionFragmentDoc = gql`
 ${VolumeRangesFragmentDoc}
 ${PackageChargeFragmentDoc}
 ${PercentageChargeFragmentDoc}`;
+export const PlanSettingsFragmentDoc = gql`
+    fragment PlanSettings on Plan {
+  id
+  name
+  code
+  description
+}
+    `;
 export const EditPlanFragmentDoc = gql`
     fragment EditPlan on Plan {
   id
@@ -5300,8 +5310,10 @@ export const EditPlanFragmentDoc = gql`
     ...ChargeAccordion
     chargeModel
   }
+  ...PlanSettings
 }
-    ${ChargeAccordionFragmentDoc}`;
+    ${ChargeAccordionFragmentDoc}
+${PlanSettingsFragmentDoc}`;
 export const CustomerMainInfosFragmentDoc = gql`
     fragment CustomerMainInfos on Customer {
   id

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -12,6 +12,7 @@ import {
   ChargeModelEnum,
   ChargeAccordionFragmentDoc,
   PropertiesInput,
+  PlanSettingsFragmentDoc,
 } from '~/generated/graphql'
 import {
   TextInputField,
@@ -41,12 +42,12 @@ import {
   Title,
   Subtitle,
   Side,
-  Line,
   SkeletonHeader,
   ButtonContainer,
   LineAmount,
 } from '~/styles/mainObjectsForm'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { PlanSettings } from '~/components/plans/PlanSettings'
 
 import { PlanFormInput, LocalChargeInput } from '../components/plans/types'
 
@@ -72,9 +73,12 @@ gql`
       ...ChargeAccordion
       chargeModel
     }
+
+    ...PlanSettings
   }
 
   ${ChargeAccordionFragmentDoc}
+  ${PlanSettingsFragmentDoc}
 `
 
 const getNewChargeId = (id: string, index: number) => `plan-charge-${id}-${index}`
@@ -278,39 +282,14 @@ const CreatePlan = () => {
                     )}
                   </Subtitle>
                 </div>
-                <Card>
-                  <SectionTitle variant="subhead">
-                    {translate('text_624453d52e945301380e4992')}
-                  </SectionTitle>
 
-                  <Line>
-                    <TextInputField
-                      name="name"
-                      label={translate('text_624453d52e945301380e4998')}
-                      placeholder={translate('text_624453d52e945301380e499c')}
-                      // eslint-disable-next-line jsx-a11y/no-autofocus
-                      autoFocus
-                      formikProps={formikProps}
-                    />
-                    <TextInputField
-                      name="code"
-                      beforeChangeFormatter="code"
-                      disabled={isEdition && !canBeEdited}
-                      label={translate('text_624453d52e945301380e499a')}
-                      placeholder={translate('text_624453d52e945301380e499e')}
-                      formikProps={formikProps}
-                      infoText={translate('text_624d9adba93343010cd14ca1')}
-                    />
-                  </Line>
-                  <TextInputField
-                    name="description"
-                    label={translate('text_624c5eadff7db800acc4c99f')}
-                    placeholder={translate('text_624453d52e945301380e49a2')}
-                    rows="3"
-                    multiline
-                    formikProps={formikProps}
-                  />
-                </Card>
+                <PlanSettings
+                  canBeEdited={canBeEdited}
+                  errorCode={errorCode}
+                  formikProps={formikProps}
+                  type={type}
+                />
+
                 <Card>
                   <SectionTitle variant="subhead">
                     {translate('text_624453d52e945301380e49a6')}


### PR DESCRIPTION
## Context

We plan to refactor the plan form very soon.

In order to ease the work and improve performances (prevent too many re-render), I wanted to perform preliminary work

## Description

This PR moves the first `<Card>` section into a component. This component returns the component with `memo`