### PR TITLE
feat(subscription): display external id if present

### DIFF
--- a/src/components/customers/subscriptions/AddSubscriptionDrawer.tsx
+++ b/src/components/customers/subscriptions/AddSubscriptionDrawer.tsx
@@ -11,6 +11,7 @@ import {
   TextInputField,
   DatePickerField,
   ButtonSelectorField,
+  TextInput,
 } from '~/components/form'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import {
@@ -226,13 +227,27 @@ export const AddSubscriptionDrawer = forwardRef<
             </PlanBlock>
             {!!formikProps?.values?.planId && (
               <>
-                <TextInputField
-                  name="externalId"
-                  formikProps={formikProps}
-                  label={translate('text_642a94e522316cd9e1875224')}
-                  placeholder={translate('text_642ac1d1407baafb9e4390ee')}
-                  helperText={translate('text_642ac28c65c2180085afe31a')}
-                />
+                {!existingSubscription ? (
+                  <TextInputField
+                    name="externalId"
+                    formikProps={formikProps}
+                    label={translate('text_642a94e522316cd9e1875224')}
+                    placeholder={translate('text_642ac1d1407baafb9e4390ee')}
+                    helperText={translate('text_642ac28c65c2180085afe31a')}
+                  />
+                ) : (
+                  (!!existingSubscription?.subscriptionExternalId ||
+                    !!formikProps.values.externalId) && (
+                    <TextInput
+                      disabled
+                      label={translate('text_642a94e522316cd9e1875224')}
+                      value={
+                        formikProps.values.externalId ||
+                        existingSubscription?.subscriptionExternalId
+                      }
+                    />
+                  )
+                )}
 
                 <TextInputField
                   name="name"

--- a/src/components/customers/subscriptions/EditCustomerSubscriptionDrawer.tsx
+++ b/src/components/customers/subscriptions/EditCustomerSubscriptionDrawer.tsx
@@ -4,7 +4,7 @@ import { gql } from '@apollo/client'
 
 import { Button, DrawerRef, Drawer, Typography } from '~/components/designSystem'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { TextInputField, DatePickerField } from '~/components/form'
+import { TextInputField, DatePickerField, TextInput } from '~/components/form'
 import { addToast } from '~/core/apolloClient'
 import {
   useUpdateCustomerSubscriptionMutation,
@@ -28,6 +28,7 @@ gql`
 type SubscriptionInfos = {
   id: string
   name?: string | null
+  externalId?: string | null
   startDate: string
   status?: StatusTypeEnum
 }
@@ -95,6 +96,15 @@ export const EditCustomerSubscriptionDrawer = forwardRef<EditCustomerSubscriptio
               placeholder={translate('text_62d7f6178ec94cd09370e393')}
               formikProps={formikProps}
             />
+
+            {!!subscription?.externalId && (
+              <TextInput
+                disabled
+                name="externalId"
+                label={translate('text_642a94e522316cd9e1875224')}
+                value={subscription?.externalId}
+              />
+            )}
 
             <DatePickerField
               disabled={subscription?.status === StatusTypeEnum.Active}

--- a/src/components/customers/subscriptions/SubscriptionLine.tsx
+++ b/src/components/customers/subscriptions/SubscriptionLine.tsx
@@ -128,6 +128,7 @@ export const SubscriptionLine = forwardRef<SubscriptionLineRef, SubscriptionLine
                       editSubscriptionDrawerRef as MutableRefObject<EditCustomerSubscriptionDrawerRef>
                     )?.current?.openDrawer({
                       id: subscriptionId,
+                      externalId: subscriptionExternalId,
                       name: subscriptionName,
                       startDate: date,
                       status: status as StatusTypeEnum,
@@ -147,6 +148,7 @@ export const SubscriptionLine = forwardRef<SubscriptionLineRef, SubscriptionLine
                       addSubscriptionDialogRef as MutableRefObject<AddSubscriptionDrawerRef>
                     )?.current?.openDialog({
                       subscriptionId,
+                      subscriptionExternalId,
                       existingPlanId: plan.id,
                       periodEndDate: periodEndDate,
                       startDate: date,

--- a/src/core/apolloClient/reactiveVars/overwritePlanVar.ts
+++ b/src/core/apolloClient/reactiveVars/overwritePlanVar.ts
@@ -8,6 +8,7 @@ export const OVERWRITE_PLAN_LS_KEY = 'overwritePlan'
 
 export type SubscriptionUpdateInfo = {
   subscriptionId?: string
+  subscriptionExternalId?: string
   existingPlanId?: string
   periodEndDate?: string
   startDate?: string

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3527,7 +3527,7 @@ export type UpdateCustomerSubscriptionMutationVariables = Exact<{
 }>;
 
 
-export type UpdateCustomerSubscriptionMutation = { __typename?: 'Mutation', updateSubscription?: { __typename?: 'Subscription', id: string, name?: string | null, status?: StatusTypeEnum | null, startedAt?: any | null, subscriptionAt?: any | null } | null };
+export type UpdateCustomerSubscriptionMutation = { __typename?: 'Mutation', updateSubscription?: { __typename?: 'Subscription', id: string, name?: string | null, status?: StatusTypeEnum | null, startedAt?: any | null, externalId: string, subscriptionAt?: any | null } | null };
 
 export type SubscriptionItemFragment = { __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextPendingStartDate?: any | null, name?: string | null, nextName?: string | null, externalId: string, periodEndDate?: any | null, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string, code: string }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string } | null };
 
@@ -6598,6 +6598,7 @@ export const UpdateCustomerSubscriptionDocument = gql`
     name
     status
     startedAt
+    externalId
     subscriptionAt
   }
 }


### PR DESCRIPTION
We decided to always show the external id in those situations.
Note that the input has different behaviours

- Create subscription - input is editable
- Edit subscription - input is disabled and current value is displayed
- Upgrade / downgrade - input is disabled and current value is displayed