### PR TITLE
fix(timezone): subscription default date start of day

### DIFF
--- a/src/components/customers/subscriptions/AddSubscriptionDrawer.tsx
+++ b/src/components/customers/subscriptions/AddSubscriptionDrawer.tsx
@@ -51,7 +51,9 @@ export const AddSubscriptionDrawer = forwardRef<
   const navigate = useNavigate()
   const drawerRef = useRef<DrawerRef>(null)
   const { timezone, timezoneConfig: orgaTimezoneConfig, formatTimeOrgaTZ } = useOrganizationInfos()
-  const currentDateRef = useRef<string>(DateTime.now().setZone(orgaTimezoneConfig.name).toISO())
+  const currentDateRef = useRef<string>(
+    DateTime.now().setZone(orgaTimezoneConfig.name).startOf('day').toISO()
+  )
   const [existingSubscription, setExistingSubscription] = useState<
     SubscriptionUpdateInfo | undefined
   >(undefined)


### PR DESCRIPTION
When adding a subscription to a customer, the default date should start at the beginning of the day 