### PR TITLE
chore(BM-item): move looped modal into parent dom

### DIFF
--- a/src/components/billableMetrics/BillableMetricItem.tsx
+++ b/src/components/billableMetrics/BillableMetricItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef } from 'react'
+import { memo, RefObject } from 'react'
 import { gql } from '@apollo/client'
 import styled from 'styled-components'
 import { generatePath } from 'react-router-dom'
@@ -30,10 +30,7 @@ import { UPDATE_BILLABLE_METRIC_ROUTE } from '~/core/router'
 import { ListKeyNavigationItemProps } from '~/hooks/ui/useListKeyNavigation'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
-import {
-  DeleteBillableMetricDialog,
-  DeleteBillableMetricDialogRef,
-} from './DeleteBillableMetricDialog'
+import { DeleteBillableMetricDialogRef } from './DeleteBillableMetricDialog'
 
 gql`
   fragment BillableMetricItem on BillableMetric {
@@ -49,13 +46,13 @@ gql`
 
 interface BillableMetricItemProps {
   billableMetric: BillableMetricItemFragment
+  deleteDialogRef: RefObject<DeleteBillableMetricDialogRef>
   navigationProps?: ListKeyNavigationItemProps
 }
 
 export const BillableMetricItem = memo(
-  ({ billableMetric, navigationProps }: BillableMetricItemProps) => {
+  ({ billableMetric, deleteDialogRef, navigationProps }: BillableMetricItemProps) => {
     const { id, name, code, createdAt } = billableMetric
-    const deleteDialogRef = useRef<DeleteBillableMetricDialogRef>(null)
     const { translate } = useInternationalization()
     const { formatTimeOrgaTZ } = useOrganizationInfos()
 
@@ -116,7 +113,7 @@ export const BillableMetricItem = memo(
                 variant="quaternary"
                 align="left"
                 onClick={() => {
-                  deleteDialogRef.current?.openDialog()
+                  deleteDialogRef.current?.openDialog(billableMetric)
                   closePopper()
                 }}
               >
@@ -125,7 +122,6 @@ export const BillableMetricItem = memo(
             </MenuPopper>
           )}
         </Popper>
-        <DeleteBillableMetricDialog ref={deleteDialogRef} billableMetric={billableMetric} />
       </ItemContainer>
     )
   }

--- a/src/components/billableMetrics/DeleteBillableMetricDialog.tsx
+++ b/src/components/billableMetrics/DeleteBillableMetricDialog.tsx
@@ -1,12 +1,9 @@
 import { gql } from '@apollo/client'
-import { forwardRef } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { Typography, DialogRef } from '~/components/designSystem'
-import {
-  DeleteBillableMetricDialogFragment,
-  useDeleteBillableMetricMutation,
-} from '~/generated/graphql'
-import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
+import { BillableMetricItemFragment, useDeleteBillableMetricMutation } from '~/generated/graphql'
+import { WarningDialog } from '~/components/WarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { addToast } from '~/core/apolloClient'
 
@@ -25,88 +22,106 @@ gql`
   }
 `
 
-export interface DeleteBillableMetricDialogRef extends WarningDialogRef {}
-
-interface DeleteBillableMetricDialogProps {
-  billableMetric: DeleteBillableMetricDialogFragment
+export interface DeleteBillableMetricDialogRef {
+  openDialog: (billableMetric: BillableMetricItemFragment) => unknown
+  closeDialog: () => unknown
 }
 
-export const DeleteBillableMetricDialog = forwardRef<DialogRef, DeleteBillableMetricDialogProps>(
-  ({ billableMetric }: DeleteBillableMetricDialogProps, ref) => {
-    const { id, name, draftInvoicesCount, activeSubscriptionsCount } = billableMetric
-    const [deleteBillableMetric] = useDeleteBillableMetricMutation({
-      onCompleted(data) {
-        if (data && data.destroyBillableMetric) {
-          addToast({
-            message: translate('text_6256f9f1184d3301290c7299'),
-            severity: 'success',
-          })
-        }
-      },
-      update(cache, { data }) {
-        if (!data?.destroyBillableMetric) return
-        const cacheId = cache.identify({
-          id: data?.destroyBillableMetric.id,
-          __typename: 'BillableMetric',
+export const DeleteBillableMetricDialog = forwardRef<DeleteBillableMetricDialogRef>((_, ref) => {
+  const dialogRef = useRef<DialogRef>(null)
+  const { translate } = useInternationalization()
+  const [billableMetric, setBillableMetric] = useState<BillableMetricItemFragment | undefined>(
+    undefined
+  )
+
+  const {
+    id = '',
+    name = '',
+    draftInvoicesCount = 0,
+    activeSubscriptionsCount = 0,
+  } = billableMetric || {}
+
+  const [deleteBillableMetric] = useDeleteBillableMetricMutation({
+    onCompleted(data) {
+      if (data && data.destroyBillableMetric) {
+        addToast({
+          message: translate('text_6256f9f1184d3301290c7299'),
+          severity: 'success',
         })
+      }
+    },
+    update(cache, { data }) {
+      if (!data?.destroyBillableMetric) return
+      const cacheId = cache.identify({
+        id: data?.destroyBillableMetric.id,
+        __typename: 'BillableMetric',
+      })
 
-        cache.evict({ id: cacheId })
-      },
-    })
-    const { translate } = useInternationalization()
+      cache.evict({ id: cacheId })
+    },
+  })
 
-    return (
-      <WarningDialog
-        ref={ref}
-        title={translate('text_6256f824b6368e01153caa47', {
-          billableMetricName: name,
-        })}
-        description={
-          draftInvoicesCount > 0 || activeSubscriptionsCount || 0 ? (
-            translate(
-              'text_63c842d84a91637c3acf0395',
-              draftInvoicesCount > 0 && activeSubscriptionsCount > 0
-                ? {
-                    usedObject1: translate(
-                      'text_63c842ee2cd5dfeb173c2726',
-                      { count: activeSubscriptionsCount },
-                      activeSubscriptionsCount
-                    ),
-                    usedObject2: translate(
-                      'text_63c8431193e8aca80f14cced',
-                      { count: draftInvoicesCount },
-                      draftInvoicesCount
-                    ),
-                  }
-                : {
-                    usedObject1:
-                      activeSubscriptionsCount > 0
-                        ? translate(
-                            'text_63c842ee2cd5dfeb173c2726',
-                            { count: activeSubscriptionsCount },
-                            activeSubscriptionsCount
-                          )
-                        : translate(
-                            'text_63c8431193e8aca80f14cced',
-                            { count: draftInvoicesCount },
-                            draftInvoicesCount
-                          ),
-                  },
-              draftInvoicesCount > 0 && activeSubscriptionsCount > 0 ? 2 : 0
-            )
-          ) : (
-            <Typography html={translate('text_6256f824b6368e01153caa49')} />
+  useImperativeHandle(ref, () => ({
+    openDialog: (infos) => {
+      setBillableMetric(infos)
+      dialogRef.current?.openDialog()
+    },
+    closeDialog: () => dialogRef.current?.closeDialog(),
+  }))
+
+  return (
+    <WarningDialog
+      ref={dialogRef}
+      title={translate('text_6256f824b6368e01153caa47', {
+        billableMetricName: name,
+      })}
+      description={
+        (billableMetric?.draftInvoicesCount || 0) > 0 ||
+        billableMetric?.activeSubscriptionsCount ||
+        0 ? (
+          translate(
+            'text_63c842d84a91637c3acf0395',
+            draftInvoicesCount > 0 && activeSubscriptionsCount > 0
+              ? {
+                  usedObject1: translate(
+                    'text_63c842ee2cd5dfeb173c2726',
+                    { count: activeSubscriptionsCount },
+                    activeSubscriptionsCount
+                  ),
+                  usedObject2: translate(
+                    'text_63c8431193e8aca80f14cced',
+                    { count: draftInvoicesCount },
+                    draftInvoicesCount
+                  ),
+                }
+              : {
+                  usedObject1:
+                    activeSubscriptionsCount > 0
+                      ? translate(
+                          'text_63c842ee2cd5dfeb173c2726',
+                          { count: activeSubscriptionsCount },
+                          activeSubscriptionsCount
+                        )
+                      : translate(
+                          'text_63c8431193e8aca80f14cced',
+                          { count: draftInvoicesCount },
+                          draftInvoicesCount
+                        ),
+                },
+            draftInvoicesCount > 0 && activeSubscriptionsCount > 0 ? 2 : 0
           )
-        }
-        onContinue={async () =>
-          await deleteBillableMetric({
-            variables: { input: { id } },
-          })
-        }
-        continueText={translate('text_6256f824b6368e01153caa4d')}
-      />
-    )
-  }
-)
+        ) : (
+          <Typography html={translate('text_6256f824b6368e01153caa49')} />
+        )
+      }
+      onContinue={async () =>
+        await deleteBillableMetric({
+          variables: { input: { id } },
+        })
+      }
+      continueText={translate('text_6256f824b6368e01153caa4d')}
+    />
+  )
+})
 
 DeleteBillableMetricDialog.displayName = 'DeleteBillableMetricDialog'

--- a/src/pages/BillableMetricsList.tsx
+++ b/src/pages/BillableMetricsList.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { gql } from '@apollo/client'
 import styled from 'styled-components'
 import { useNavigate, generatePath } from 'react-router-dom'
@@ -17,6 +18,10 @@ import {
 import { useListKeysNavigation } from '~/hooks/ui/useListKeyNavigation'
 import { SearchInput } from '~/components/SearchInput'
 import { useDebouncedSearch } from '~/hooks/useDebouncedSearch'
+import {
+  DeleteBillableMetricDialog,
+  DeleteBillableMetricDialogRef,
+} from '~/components/billableMetrics/DeleteBillableMetricDialog'
 
 gql`
   query billableMetrics($page: Int, $limit: Int, $searchTerm: String) {
@@ -37,6 +42,7 @@ gql`
 const BillableMetricsList = () => {
   const { translate } = useInternationalization()
   let navigate = useNavigate()
+  const deleteDialogRef = useRef<DeleteBillableMetricDialogRef>(null)
   const [getBillableMetrics, { data, error, loading, fetchMore, variables }] =
     useBillableMetricsLazyQuery({
       variables: { limit: 20 },
@@ -143,6 +149,7 @@ const BillableMetricsList = () => {
                   <BillableMetricItem
                     key={billableMetric.id}
                     billableMetric={billableMetric}
+                    deleteDialogRef={deleteDialogRef}
                     navigationProps={{
                       id: `billable-metric-item-${index}`,
                       'data-id': billableMetric.id,
@@ -157,6 +164,8 @@ const BillableMetricsList = () => {
           </InfiniteScroll>
         )}
       </ListContainer>
+
+      <DeleteBillableMetricDialog ref={deleteDialogRef} />
     </div>
   )
 }


### PR DESCRIPTION
## Context

Chasing for perf issues in lists, noticed that bm items (rendered in loop) was rendering a modal multiple time

## Description

Moved this modal invocation in parent's DOM to prevent useless re-render.

This modal can now be invoked by passing the BM directly