### PR TITLE
chore(plan-item): move looped modal into parent dom

### DIFF
--- a/src/components/plans/DeletePlanDialog.tsx
+++ b/src/components/plans/DeletePlanDialog.tsx
@@ -1,9 +1,9 @@
 import { gql } from '@apollo/client'
-import { forwardRef } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { DialogRef } from '~/components/designSystem'
 import { DeletePlanDialogFragment, useDeletePlanMutation } from '~/generated/graphql'
-import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
+import { WarningDialog } from '~/components/WarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { addToast } from '~/core/apolloClient'
 
@@ -22,85 +22,93 @@ gql`
   }
 `
 
-export interface DeletePlanDialogRef extends WarningDialogRef {}
-
-interface DeletePlanDialogProps {
-  plan: DeletePlanDialogFragment
+export interface DeletePlanDialogRef {
+  openDialog: (billableMetric: DeletePlanDialogFragment) => unknown
+  closeDialog: () => unknown
 }
 
-export const DeletePlanDialog = forwardRef<DialogRef, DeletePlanDialogProps>(
-  ({ plan }: DeletePlanDialogProps, ref) => {
-    const { id, name, draftInvoicesCount, activeSubscriptionsCount } = plan
-    const [deletePlan] = useDeletePlanMutation({
-      onCompleted(data) {
-        if (data && data.destroyPlan) {
-          addToast({
-            message: translate('text_625fd165963a7b00c8f59879'),
-            severity: 'success',
-          })
-        }
-      },
-      update(cache, { data }) {
-        if (!data?.destroyPlan) return
+export const DeletePlanDialog = forwardRef<DeletePlanDialogRef>((_, ref) => {
+  const { translate } = useInternationalization()
+  const dialogRef = useRef<DialogRef>(null)
+  const [plan, setPlan] = useState<DeletePlanDialogFragment | undefined>(undefined)
+  const { id = '', name = '', draftInvoicesCount = 0, activeSubscriptionsCount = 0 } = plan || {}
 
-        const cacheId = cache.identify({
-          id: data?.destroyPlan.id,
-          __typename: 'Plan',
+  const [deletePlan] = useDeletePlanMutation({
+    onCompleted(data) {
+      if (data && data.destroyPlan) {
+        addToast({
+          message: translate('text_625fd165963a7b00c8f59879'),
+          severity: 'success',
         })
+      }
+    },
+    update(cache, { data }) {
+      if (!data?.destroyPlan) return
 
-        cache.evict({ id: cacheId })
-      },
-    })
-    const { translate } = useInternationalization()
+      const cacheId = cache.identify({
+        id: data?.destroyPlan.id,
+        __typename: 'Plan',
+      })
 
-    return (
-      <WarningDialog
-        ref={ref}
-        title={translate('text_625fd165963a7b00c8f59797', {
-          planName: name,
-        })}
-        description={translate(
-          'text_63d18bdc54f8380e7a97351a',
-          draftInvoicesCount > 0 && activeSubscriptionsCount > 0
-            ? {
-                usedObject1: translate(
-                  'text_63d18d34f90cc83a038f843b',
-                  { count: activeSubscriptionsCount },
-                  activeSubscriptionsCount
-                ),
-                usedObject2: translate(
-                  'text_63d18d3edaed7e11710b4d25',
-                  { count: draftInvoicesCount },
-                  draftInvoicesCount
-                ),
-              }
-            : {
-                usedObject1:
-                  activeSubscriptionsCount > 0
-                    ? translate(
-                        'text_63d18d34f90cc83a038f843b',
-                        { count: activeSubscriptionsCount },
-                        activeSubscriptionsCount
-                      )
-                    : draftInvoicesCount > 0
-                    ? translate(
-                        'text_63d18d3edaed7e11710b4d25',
-                        { count: draftInvoicesCount },
-                        draftInvoicesCount
-                      )
-                    : translate('text_63d18d34f90cc83a038f843b', { count: 0 }, 0),
-              },
-          draftInvoicesCount > 0 && activeSubscriptionsCount > 0 ? 2 : 0
-        )}
-        onContinue={async () =>
-          await deletePlan({
-            variables: { input: { id } },
-          })
-        }
-        continueText={translate('text_625fd165963a7b00c8f597b5')}
-      />
-    )
-  }
-)
+      cache.evict({ id: cacheId })
+    },
+  })
+
+  useImperativeHandle(ref, () => ({
+    openDialog: (data) => {
+      setPlan(data)
+      dialogRef.current?.openDialog()
+    },
+    closeDialog: () => dialogRef.current?.closeDialog(),
+  }))
+
+  return (
+    <WarningDialog
+      ref={dialogRef}
+      title={translate('text_625fd165963a7b00c8f59797', {
+        planName: name,
+      })}
+      description={translate(
+        'text_63d18bdc54f8380e7a97351a',
+        draftInvoicesCount > 0 && activeSubscriptionsCount > 0
+          ? {
+              usedObject1: translate(
+                'text_63d18d34f90cc83a038f843b',
+                { count: activeSubscriptionsCount },
+                activeSubscriptionsCount
+              ),
+              usedObject2: translate(
+                'text_63d18d3edaed7e11710b4d25',
+                { count: draftInvoicesCount },
+                draftInvoicesCount
+              ),
+            }
+          : {
+              usedObject1:
+                activeSubscriptionsCount > 0
+                  ? translate(
+                      'text_63d18d34f90cc83a038f843b',
+                      { count: activeSubscriptionsCount },
+                      activeSubscriptionsCount
+                    )
+                  : draftInvoicesCount > 0
+                  ? translate(
+                      'text_63d18d3edaed7e11710b4d25',
+                      { count: draftInvoicesCount },
+                      draftInvoicesCount
+                    )
+                  : translate('text_63d18d34f90cc83a038f843b', { count: 0 }, 0),
+            },
+        draftInvoicesCount > 0 && activeSubscriptionsCount > 0 ? 2 : 0
+      )}
+      onContinue={async () =>
+        await deletePlan({
+          variables: { input: { id } },
+        })
+      }
+      continueText={translate('text_625fd165963a7b00c8f597b5')}
+    />
+  )
+})
 
 DeletePlanDialog.displayName = 'DeletePlanDialog'

--- a/src/components/plans/PlanItem.tsx
+++ b/src/components/plans/PlanItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef } from 'react'
+import { memo, RefObject } from 'react'
 import styled from 'styled-components'
 import { gql } from '@apollo/client'
 import { generatePath } from 'react-router-dom'
@@ -27,7 +27,7 @@ import { UPDATE_PLAN_ROUTE } from '~/core/router'
 import { ListKeyNavigationItemProps } from '~/hooks/ui/useListKeyNavigation'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
-import { DeletePlanDialog, DeletePlanDialogRef } from './DeletePlanDialog'
+import { DeletePlanDialogRef } from './DeletePlanDialog'
 
 gql`
   fragment PlanItem on Plan {
@@ -44,12 +44,12 @@ gql`
 `
 
 interface PlanItemProps {
-  plan: PlanItemFragment
+  deleteDialogRef: RefObject<DeletePlanDialogRef>
   navigationProps?: ListKeyNavigationItemProps
+  plan: PlanItemFragment
 }
 
-export const PlanItem = memo(({ plan, navigationProps }: PlanItemProps) => {
-  const deleteDialogRef = useRef<DeletePlanDialogRef>(null)
+export const PlanItem = memo(({ deleteDialogRef, navigationProps, plan }: PlanItemProps) => {
   const { id, name, code, customerCount, chargeCount, createdAt } = plan
   const { translate } = useInternationalization()
   const { formatTimeOrgaTZ } = useOrganizationInfos()
@@ -117,7 +117,7 @@ export const PlanItem = memo(({ plan, navigationProps }: PlanItemProps) => {
               variant="quaternary"
               align="left"
               onClick={() => {
-                deleteDialogRef.current?.openDialog()
+                deleteDialogRef.current?.openDialog(plan)
                 closePopper()
               }}
             >
@@ -126,7 +126,6 @@ export const PlanItem = memo(({ plan, navigationProps }: PlanItemProps) => {
           </MenuPopper>
         )}
       </Popper>
-      <DeletePlanDialog ref={deleteDialogRef} plan={plan} />
     </ItemContainer>
   )
 })

--- a/src/pages/PlansList.tsx
+++ b/src/pages/PlansList.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { gql } from '@apollo/client'
 import styled from 'styled-components'
 import { useNavigate, generatePath } from 'react-router-dom'
@@ -14,6 +15,7 @@ import { PlanItem, PlanItemSkeleton } from '~/components/plans/PlanItem'
 import { useListKeysNavigation } from '~/hooks/ui/useListKeyNavigation'
 import { useDebouncedSearch } from '~/hooks/useDebouncedSearch'
 import { SearchInput } from '~/components/SearchInput'
+import { DeletePlanDialog, DeletePlanDialogRef } from '~/components/plans/DeletePlanDialog'
 
 gql`
   query plans($page: Int, $limit: Int, $searchTerm: String) {
@@ -34,6 +36,7 @@ gql`
 const PlansList = () => {
   const { translate } = useInternationalization()
   let navigate = useNavigate()
+  const deleteDialogRef = useRef<DeletePlanDialogRef>(null)
   const [getPlans, { data, error, loading, fetchMore, variables }] = usePlansLazyQuery({
     variables: { limit: 20 },
     notifyOnNetworkStatusChange: true,
@@ -150,6 +153,7 @@ const PlansList = () => {
                     <PlanItem
                       key={plan.id}
                       plan={plan}
+                      deleteDialogRef={deleteDialogRef}
                       navigationProps={{
                         id: `plan-item-${index}`,
                         'data-id': plan.id,
@@ -163,6 +167,8 @@ const PlansList = () => {
           </InfiniteScroll>
         )}
       </ListContainer>
+
+      <DeletePlanDialog ref={deleteDialogRef} />
     </div>
   )
 }


### PR DESCRIPTION
## Context

Chasing for perf issues in lists, noticed that plan items (rendered in loop) was rendering a modal multiple time

## Description

Moved this modal invocation in parent's DOM to prevent useless re-render.

This modal can now be invoked by passing the plan directly