### PR TITLE
chore(addon-item): move looped modal into parent dom

### DIFF
--- a/src/components/addOns/AddOnItem.tsx
+++ b/src/components/addOns/AddOnItem.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { RefObject } from 'react'
 import { gql } from '@apollo/client'
 import styled from 'styled-components'
 import { generatePath } from 'react-router-dom'
@@ -26,7 +26,7 @@ import { ListKeyNavigationItemProps } from '~/hooks/ui/useListKeyNavigation'
 import { AddOnItemFragment } from '~/generated/graphql'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { DeleteAddOnDialog, DeleteAddOnDialogRef } from '~/components/addOns/DeleteAddOnDialog'
+import { DeleteAddOnDialogRef } from '~/components/addOns/DeleteAddOnDialog'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 
@@ -44,13 +44,14 @@ gql`
 
 interface AddOnItemProps {
   addOn: AddOnItemFragment
+  deleteDialogRef: RefObject<DeleteAddOnDialogRef>
   navigationProps?: ListKeyNavigationItemProps
 }
 
-export const AddOnItem = ({ addOn, navigationProps }: AddOnItemProps) => {
+export const AddOnItem = ({ addOn, deleteDialogRef, navigationProps }: AddOnItemProps) => {
   const { id, name, amountCurrency, amountCents, customerCount, createdAt, appliedAddOnsCount } =
     addOn
-  const deleteDialogRef = useRef<DeleteAddOnDialogRef>(null)
+
   const { translate } = useInternationalization()
   const { formatTimeOrgaTZ } = useOrganizationInfos()
 
@@ -129,7 +130,7 @@ export const AddOnItem = ({ addOn, navigationProps }: AddOnItemProps) => {
                 align="left"
                 fullWidth
                 onClick={() => {
-                  deleteDialogRef.current?.openDialog()
+                  deleteDialogRef.current?.openDialog(addOn)
                   closePopper()
                 }}
               >
@@ -139,7 +140,6 @@ export const AddOnItem = ({ addOn, navigationProps }: AddOnItemProps) => {
           </MenuPopper>
         )}
       </Popper>
-      <DeleteAddOnDialog ref={deleteDialogRef} addOn={addOn} />
     </ItemContainer>
   )
 }

--- a/src/components/addOns/DeleteAddOnDialog.tsx
+++ b/src/components/addOns/DeleteAddOnDialog.tsx
@@ -1,9 +1,9 @@
 import { gql } from '@apollo/client'
-import { forwardRef } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { Typography, DialogRef } from '~/components/designSystem'
 import { DeleteAddOnFragment, useDeleteAddOnMutation } from '~/generated/graphql'
-import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
+import { WarningDialog } from '~/components/WarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { addToast } from '~/core/apolloClient'
 
@@ -20,51 +20,60 @@ gql`
   }
 `
 
-export interface DeleteAddOnDialogRef extends WarningDialogRef {}
-
-interface DeleteAddOnDialogProps {
-  addOn: DeleteAddOnFragment
+export interface DeleteAddOnDialogRef {
+  openDialog: (addOn: DeleteAddOnFragment) => unknown
+  closeDialog: () => unknown
 }
 
-export const DeleteAddOnDialog = forwardRef<DialogRef, DeleteAddOnDialogProps>(
-  ({ addOn }: DeleteAddOnDialogProps, ref) => {
-    const [deleteAddOn] = useDeleteAddOnMutation({
-      onCompleted(data) {
-        if (data && data.destroyAddOn) {
-          addToast({
-            message: translate('text_629728388c4d2300e2d3815f'),
-            severity: 'success',
-          })
-        }
-      },
-      update(cache, { data }) {
-        if (!data?.destroyAddOn) return
-        const cacheId = cache.identify({
-          id: data?.destroyAddOn.id,
-          __typename: 'AddOn',
+export const DeleteAddOnDialog = forwardRef<DeleteAddOnDialogRef>((_, ref) => {
+  const { translate } = useInternationalization()
+  const dialogRef = useRef<DialogRef>(null)
+  const [addOn, setAddOn] = useState<DeleteAddOnFragment | undefined>(undefined)
+  const [deleteAddOn] = useDeleteAddOnMutation({
+    onCompleted(data) {
+      if (data && data.destroyAddOn) {
+        addToast({
+          message: translate('text_629728388c4d2300e2d3815f'),
+          severity: 'success',
         })
+      }
+    },
+    update(cache, { data }) {
+      if (!data?.destroyAddOn) return
+      const cacheId = cache.identify({
+        id: data?.destroyAddOn.id,
+        __typename: 'AddOn',
+      })
 
-        cache.evict({ id: cacheId })
-      },
-    })
-    const { translate } = useInternationalization()
+      cache.evict({ id: cacheId })
+    },
+  })
 
-    return (
-      <WarningDialog
-        ref={ref}
-        title={translate('text_629728388c4d2300e2d380ad', {
-          addOnName: addOn.name,
-        })}
-        description={<Typography html={translate('text_629728388c4d2300e2d380c5')} />}
-        onContinue={async () =>
-          await deleteAddOn({
-            variables: { input: { id: addOn.id } },
-          })
-        }
-        continueText={translate('text_629728388c4d2300e2d380f5')}
-      />
-    )
-  }
-)
+  useImperativeHandle(ref, () => ({
+    openDialog: (data) => {
+      setAddOn(data)
+      dialogRef.current?.openDialog()
+    },
+    closeDialog: () => {
+      dialogRef.current?.closeDialog()
+    },
+  }))
+
+  return (
+    <WarningDialog
+      ref={dialogRef}
+      title={translate('text_629728388c4d2300e2d380ad', {
+        addOnName: addOn?.name,
+      })}
+      description={<Typography html={translate('text_629728388c4d2300e2d380c5')} />}
+      onContinue={async () =>
+        await deleteAddOn({
+          variables: { input: { id: addOn?.id || '' } },
+        })
+      }
+      continueText={translate('text_629728388c4d2300e2d380f5')}
+    />
+  )
+})
 
 DeleteAddOnDialog.displayName = 'DeleteAddOnDialog'

--- a/src/pages/AddOnsList.tsx
+++ b/src/pages/AddOnsList.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { gql } from '@apollo/client'
 import styled from 'styled-components'
 import { useNavigate, generatePath } from 'react-router-dom'
@@ -14,6 +15,7 @@ import { AddOnItemFragmentDoc, useAddOnsLazyQuery } from '~/generated/graphql'
 import { useListKeysNavigation } from '~/hooks/ui/useListKeyNavigation'
 import { useDebouncedSearch } from '~/hooks/useDebouncedSearch'
 import { SearchInput } from '~/components/SearchInput'
+import { DeleteAddOnDialog, DeleteAddOnDialogRef } from '~/components/addOns/DeleteAddOnDialog'
 
 gql`
   query addOns($page: Int, $limit: Int, $searchTerm: String) {
@@ -35,6 +37,7 @@ gql`
 const AddOnsList = () => {
   const { translate } = useInternationalization()
   let navigate = useNavigate()
+  const deleteDialogRef = useRef<DeleteAddOnDialogRef>(null)
   const { onKeyDown } = useListKeysNavigation({
     getElmId: (i) => `add-on-item-${i}`,
     navigate: (id) => navigate(generatePath(UPDATE_ADD_ON_ROUTE, { id: String(id) })),
@@ -147,6 +150,7 @@ const AddOnsList = () => {
                     <AddOnItem
                       key={addOn.id}
                       addOn={addOn}
+                      deleteDialogRef={deleteDialogRef}
                       navigationProps={{
                         id: `add-on-item-${index}`,
                         'data-id': addOn.id,
@@ -160,6 +164,8 @@ const AddOnsList = () => {
           </InfiniteScroll>
         )}
       </ListContainer>
+
+      <DeleteAddOnDialog ref={deleteDialogRef} />
     </div>
   )
 }


### PR DESCRIPTION
## Context

Chasing for perf issues in lists, noticed that AddOn items (rendered in loop) was rendering a modal multiple time

## Description

Moved this modal invocation in parent's DOM to prevent useless re-render.

This modal can now be invoked by passing the AddOn directly