### PR TITLE
chore(coupon-item): move looped modal into parent dom

### DIFF
--- a/src/components/coupons/CouponItem.tsx
+++ b/src/components/coupons/CouponItem.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { RefObject } from 'react'
 import { gql } from '@apollo/client'
 import styled from 'styled-components'
 import { generatePath } from 'react-router-dom'
@@ -27,13 +27,10 @@ import { UPDATE_COUPON_ROUTE } from '~/core/router'
 import { ListKeyNavigationItemProps } from '~/hooks/ui/useListKeyNavigation'
 import { CouponStatusEnum, CouponItemFragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { DeleteCouponDialog, DeleteCouponDialogRef } from '~/components/coupons/DeleteCouponDialog'
+import { DeleteCouponDialogRef } from '~/components/coupons/DeleteCouponDialog'
 import { CouponCaption } from '~/components/coupons/CouponCaption'
 import { ConditionalWrapper } from '~/components/ConditionalWrapper'
-import {
-  TerminateCouponDialog,
-  TerminateCouponDialogRef,
-} from '~/components/coupons/TerminateCouponDialog'
+import { TerminateCouponDialogRef } from '~/components/coupons/TerminateCouponDialog'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
 gql`
@@ -56,7 +53,9 @@ gql`
 
 interface CouponItemProps {
   coupon: CouponItemFragment
+  deleteDialogRef: RefObject<DeleteCouponDialogRef>
   navigationProps?: ListKeyNavigationItemProps
+  terminateDialogRef: RefObject<TerminateCouponDialogRef>
 }
 
 const mapStatus = (type?: CouponStatusEnum | undefined) => {
@@ -74,10 +73,13 @@ const mapStatus = (type?: CouponStatusEnum | undefined) => {
   }
 }
 
-export const CouponItem = ({ coupon, navigationProps }: CouponItemProps) => {
+export const CouponItem = ({
+  coupon,
+  deleteDialogRef,
+  navigationProps,
+  terminateDialogRef,
+}: CouponItemProps) => {
   const { id, name, customerCount, status, appliedCouponsCount, expirationAt } = coupon
-  const deleteDialogRef = useRef<DeleteCouponDialogRef>(null)
-  const terminateDialogRef = useRef<TerminateCouponDialogRef>(null)
   const { translate } = useInternationalization()
   const formattedStatus = mapStatus(status)
   const { formatTimeOrgaTZ } = useOrganizationInfos()
@@ -169,7 +171,7 @@ export const CouponItem = ({ coupon, navigationProps }: CouponItemProps) => {
                 fullWidth
                 align="left"
                 onClick={() => {
-                  terminateDialogRef.current?.openDialog()
+                  terminateDialogRef.current?.openDialog(coupon)
                   closePopper()
                 }}
               >
@@ -188,7 +190,7 @@ export const CouponItem = ({ coupon, navigationProps }: CouponItemProps) => {
                 align="left"
                 fullWidth
                 onClick={() => {
-                  deleteDialogRef.current?.openDialog()
+                  deleteDialogRef.current?.openDialog(coupon)
                   closePopper()
                 }}
               >
@@ -198,8 +200,6 @@ export const CouponItem = ({ coupon, navigationProps }: CouponItemProps) => {
           </MenuPopper>
         )}
       </Popper>
-      <DeleteCouponDialog ref={deleteDialogRef} coupon={coupon} />
-      <TerminateCouponDialog ref={terminateDialogRef} coupon={coupon} />
     </ItemContainer>
   )
 }

--- a/src/pages/CouponsList.tsx
+++ b/src/pages/CouponsList.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { gql } from '@apollo/client'
 import styled from 'styled-components'
 import { useNavigate, generatePath } from 'react-router-dom'
@@ -18,6 +19,11 @@ import {
 import { useListKeysNavigation } from '~/hooks/ui/useListKeyNavigation'
 import { useDebouncedSearch } from '~/hooks/useDebouncedSearch'
 import { SearchInput } from '~/components/SearchInput'
+import { DeleteCouponDialog, DeleteCouponDialogRef } from '~/components/coupons/DeleteCouponDialog'
+import {
+  TerminateCouponDialog,
+  TerminateCouponDialogRef,
+} from '~/components/coupons/TerminateCouponDialog'
 
 gql`
   query coupons($page: Int, $limit: Int, $searchTerm: String) {
@@ -40,6 +46,8 @@ gql`
 const CouponsList = () => {
   const { translate } = useInternationalization()
   let navigate = useNavigate()
+  const deleteDialogRef = useRef<DeleteCouponDialogRef>(null)
+  const terminateDialogRef = useRef<TerminateCouponDialogRef>(null)
   const { onKeyDown } = useListKeysNavigation({
     getElmId: (i) => `coupon-item-${i}`,
     navigate: (id) => navigate(generatePath(UPDATE_COUPON_ROUTE, { id: String(id) })),
@@ -155,6 +163,8 @@ const CouponsList = () => {
                     <CouponItem
                       key={coupon.id}
                       coupon={coupon}
+                      deleteDialogRef={deleteDialogRef}
+                      terminateDialogRef={terminateDialogRef}
                       navigationProps={{
                         id: `coupon-item-${index}`,
                         'data-id': coupon.id,
@@ -168,6 +178,9 @@ const CouponsList = () => {
           </InfiniteScroll>
         )}
       </ListContainer>
+
+      <DeleteCouponDialog ref={deleteDialogRef} />
+      <TerminateCouponDialog ref={terminateDialogRef} />
     </div>
   )
 }


### PR DESCRIPTION
## Context

Chasing for perf issues in lists, noticed that Coupon items (rendered in loop) was rendering two modal multiple time

## Description

Moved this modal invocation in parent's DOM to prevent useless re-render.

Those modal can now be invoked by passing the Coupon directly