### PR TITLE
chore(invoice): move looped modal into parent dom

### DIFF
--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { gql, FetchMoreQueryOptions } from '@apollo/client'
 import styled from 'styled-components'
 
@@ -20,6 +21,11 @@ import {
 } from '~/components/invoices/InvoiceListItem'
 
 import { GenericPlaceholder } from '../GenericPlaceholder'
+import { FinalizeInvoiceDialog, FinalizeInvoiceDialogRef } from '../invoices/FinalizeInvoiceDialog'
+import {
+  UpdateInvoicePaymentStatusDialog,
+  UpdateInvoicePaymentStatusDialogRef,
+} from '../invoices/EditInvoicePaymentStatusDialog'
 
 gql`
   fragment InvoiceForInvoiceList on InvoiceCollection {
@@ -69,6 +75,8 @@ export const CustomerInvoicesList = ({
   onSeeAll,
   fetchMore,
 }: InvoiceListProps) => {
+  const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
+  const updateInvoicePaymentStatusDialog = useRef<UpdateInvoicePaymentStatusDialogRef>(null)
   const { metadata, collection } = invoiceData || {}
   const { translate } = useInternationalization()
 
@@ -156,6 +164,8 @@ export const CustomerInvoicesList = ({
                     to={link}
                     invoice={invoice}
                     context="customer"
+                    finalizeInvoiceRef={finalizeInvoiceRef}
+                    updateInvoicePaymentStatusDialog={updateInvoicePaymentStatusDialog}
                   />
                 )
               })}
@@ -177,6 +187,9 @@ export const CustomerInvoicesList = ({
           </PlusButtonWrapper>
         )}
       </ListWrapper>
+
+      <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
+      <UpdateInvoicePaymentStatusDialog ref={updateInvoicePaymentStatusDialog} />
     </ScrollWrapper>
   )
 }

--- a/src/components/invoices/InvoiceListItem.tsx
+++ b/src/components/invoices/InvoiceListItem.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { RefObject } from 'react'
 import styled, { css } from 'styled-components'
 import { gql } from '@apollo/client'
 
@@ -22,11 +22,8 @@ import { ListKeyNavigationItemProps } from '~/hooks/ui/useListKeyNavigation'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 
-import { FinalizeInvoiceDialog, FinalizeInvoiceDialogRef } from './FinalizeInvoiceDialog'
-import {
-  UpdateInvoicePaymentStatusDialog,
-  UpdateInvoicePaymentStatusDialogRef,
-} from './EditInvoicePaymentStatusDialog'
+import { FinalizeInvoiceDialogRef } from './FinalizeInvoiceDialog'
+import { UpdateInvoicePaymentStatusDialogRef } from './EditInvoicePaymentStatusDialog'
 
 gql`
   fragment InvoiceListItem on Invoice {
@@ -77,6 +74,8 @@ interface InvoiceListItemProps {
   to: string
   navigationProps?: ListKeyNavigationItemProps
   className?: string
+  finalizeInvoiceRef: RefObject<FinalizeInvoiceDialogRef>
+  updateInvoicePaymentStatusDialog: RefObject<UpdateInvoicePaymentStatusDialogRef>
 }
 
 const mapStatusConfig = (
@@ -112,10 +111,10 @@ export const InvoiceListItem = ({
   invoice,
   to,
   navigationProps,
+  finalizeInvoiceRef,
+  updateInvoicePaymentStatusDialog,
 }: InvoiceListItemProps) => {
   const { translate } = useInternationalization()
-  const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
-  const updateInvoicePaymentStatusDialog = useRef<UpdateInvoicePaymentStatusDialogRef>(null)
   const {
     id,
     status,
@@ -286,8 +285,6 @@ export const InvoiceListItem = ({
           </MenuPopper>
         )}
       </Popper>
-      <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
-      <UpdateInvoicePaymentStatusDialog ref={updateInvoicePaymentStatusDialog} />
     </Container>
   )
 }

--- a/src/pages/InvoicesList.tsx
+++ b/src/pages/InvoicesList.tsx
@@ -34,6 +34,14 @@ import { useListKeysNavigation } from '~/hooks/ui/useListKeyNavigation'
 import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/layouts/CustomerInvoiceDetails'
 import { useDebouncedSearch } from '~/hooks/useDebouncedSearch'
 import { SearchInput } from '~/components/SearchInput'
+import {
+  FinalizeInvoiceDialog,
+  FinalizeInvoiceDialogRef,
+} from '~/components/invoices/FinalizeInvoiceDialog'
+import {
+  UpdateInvoicePaymentStatusDialog,
+  UpdateInvoicePaymentStatusDialogRef,
+} from '~/components/invoices/EditInvoicePaymentStatusDialog'
 
 gql`
   query invoicesList(
@@ -88,6 +96,8 @@ const InvoicesList = () => {
   const { tab } = useParams<{ tab?: InvoiceListTabEnum }>()
   const { translate } = useInternationalization()
   const navigate = useNavigate()
+  const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
+  const updateInvoicePaymentStatusDialog = useRef<UpdateInvoicePaymentStatusDialogRef>(null)
   const [getInvoices, { data, loading, error, fetchMore, variables }] = useInvoicesListLazyQuery({
     notifyOnNetworkStatusChange: true,
     fetchPolicy: 'network-only',
@@ -316,6 +326,8 @@ const InvoicesList = () => {
                       invoiceId: invoice.id,
                       tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
                     })}
+                    finalizeInvoiceRef={finalizeInvoiceRef}
+                    updateInvoicePaymentStatusDialog={updateInvoicePaymentStatusDialog}
                   />
                 )
               })}
@@ -330,6 +342,9 @@ const InvoicesList = () => {
           )}
         </List>
       </ScrollContainer>
+
+      <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
+      <UpdateInvoicePaymentStatusDialog ref={updateInvoicePaymentStatusDialog} />
     </div>
   )
 }


### PR DESCRIPTION
## Context

Chasing for perf issues in lists, noticed that invoice items (rendered in loop in 2 pages) was rendering two modal multiple time.

## Description

Moved this modal invocation in both parent's DOM to prevent useless re-render.

Those modal invocation didn't change as they were already using useImperativeHandle and state to manage their data display