### PR TITLE
chore(typography): manage note and noteHl

### DIFF
--- a/materialUiTheme.d.ts
+++ b/materialUiTheme.d.ts
@@ -53,6 +53,7 @@ declare module '@mui/material/styles' {
     captionCode: React.CSSProperties
     button: React.CSSProperties
     note: React.CSSProperties
+    noteHl: React.CSSProperties
     button: React.CSSProperties
     caption: React.CSSProperties
   }
@@ -67,6 +68,7 @@ declare module '@mui/material/styles' {
     captionCode: React.CSSProperties
     button: React.CSSProperties
     note: React.CSSProperties
+    noteHl: React.CSSProperties
     button: React.CSSProperties
     caption: React.CSSProperties
   }
@@ -104,6 +106,7 @@ declare module '@mui/material/Typography' {
     captionCode: true
     button: true
     note: true
+    noteHl: true
     button: true
     h1: false
     h2: false

--- a/src/components/designSystem/Avatar.tsx
+++ b/src/components/designSystem/Avatar.tsx
@@ -52,7 +52,7 @@ export interface AvatarGenericProps {
 const mapTypographyVariant = (size: AvatarSize) => {
   switch (size) {
     case 'small':
-      return 'note'
+      return 'noteHl'
     case 'large':
       return 'subhead'
     default:

--- a/src/components/designSystem/Typography.tsx
+++ b/src/components/designSystem/Typography.tsx
@@ -54,6 +54,7 @@ const mapColor = (variant: TypographyProps['variant'], color?: Color): ColorType
     case 'body':
     case 'captionHl':
     case 'note':
+    case 'noteHl':
     case 'caption':
     default:
       return ColorTypeEnum.textPrimary
@@ -132,6 +133,7 @@ export const Typography = memo(
           subhead: 'div',
           caption: 'div',
           note: 'div',
+          noteHl: 'div',
           captionCode: 'code',
         }}
         $code={variant === 'captionCode'}

--- a/src/components/form/Switch/Switch.tsx
+++ b/src/components/form/Switch/Switch.tsx
@@ -95,10 +95,10 @@ export const Switch = ({
           onBlur={() => setFocused(false)}
         />
         {loading && <Loader animation="spin" name="processing" color="light" />}
-        <StyledTypography color={disabled ? 'inherit' : 'contrast'} variant="note">
+        <StyledTypography color={disabled ? 'inherit' : 'contrast'} variant="noteHl">
           On
         </StyledTypography>
-        <StyledTypography color={disabled ? 'inherit' : 'disabled'} variant="note">
+        <StyledTypography color={disabled ? 'inherit' : 'disabled'} variant="noteHl">
           Off
         </StyledTypography>
         <SwitchElement width="24" height="24" viewBox="0 0 24 24" $checked={!!checked}>

--- a/src/pages/__devOnly/DesignSystem.tsx
+++ b/src/pages/__devOnly/DesignSystem.tsx
@@ -540,6 +540,7 @@ const DesignSystem = () => {
                     <Typography variant="captionHl">CaptionHl</Typography>
                     <Typography variant="captionCode">CaptionCode</Typography>
                     <Typography variant="note">Note</Typography>
+                    <Typography variant="noteHl">NoteHl</Typography>
                     <Typography
                       color="textSecondary"
                       html="I'm a bit <b>special</b>, I <i>understand</i> html"

--- a/src/pages/auth/PortalInit.tsx
+++ b/src/pages/auth/PortalInit.tsx
@@ -72,7 +72,7 @@ const PortalInit = () => {
           </Avatar>
           <Typography variant="subhead">{translate('text_641c6acee4bc20004e62c534')}</Typography>
           <InlineItems>
-            <InlinePoweredByTypography variant="note" color="grey500">
+            <InlinePoweredByTypography variant="noteHl" color="grey500">
               {translate('text_6419c64eace749372fc72b03')}
             </InlinePoweredByTypography>
             <StyledLogo />

--- a/src/pages/customerPortal/CustomerPortal.tsx
+++ b/src/pages/customerPortal/CustomerPortal.tsx
@@ -47,7 +47,7 @@ const CustomerPortal = ({ translate }: CutsomerPortalProps) => {
           </InlineItems>
         )}
         <InlineItems>
-          <InlinePoweredByTypography variant="note" color="grey500">
+          <InlinePoweredByTypography variant="noteHl" color="grey500">
             {translate('text_6419c64eace749372fc72b03')}
           </InlinePoweredByTypography>
           <StyledLogo />

--- a/src/styles/muiTheme.ts
+++ b/src/styles/muiTheme.ts
@@ -512,6 +512,12 @@ export const theme = createTheme({
     note: {
       fontSize: '12px',
       lineHeight: '16px',
+      fontWeight: 400,
+      textTransform: 'none',
+    },
+    noteHl: {
+      fontSize: '12px',
+      lineHeight: '16px',
       fontWeight: 600,
       textTransform: 'none',
     },


### PR DESCRIPTION
## Context

We needed to have more granularity on the note typography

## Description

This does 
- Renames the `note` typography variant into `noteHL`. So all it's occurrences are updated
- Introduces the new `note` typography with a lower `fontWeight`