### PR TITLE
bug(plan-charges): fix validations for volume and graduated

### DIFF
--- a/src/formValidation/chargeSchema.ts
+++ b/src/formValidation/chargeSchema.ts
@@ -32,7 +32,7 @@ const graduatedShape = object().shape({
             return false
           }
 
-          if (i < graduatedRange.length - 1 && (fromValue || 0) > toValue) {
+          if (i < graduatedRange.length - 1 && Number(fromValue || 0) > Number(toValue || 0)) {
             isValid = false
             return false
           }
@@ -59,7 +59,7 @@ const volumeShape = object().shape({
             return false
           }
 
-          if (i < volumeRange.length - 1 && (fromValue || 0) > toValue) {
+          if (i < volumeRange.length - 1 && Number(fromValue || 0) > Number(toValue || 0)) {
             isValid = false
             return false
           }

--- a/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
@@ -96,7 +96,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 2,
+            firstUnit: '2',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -124,21 +124,21 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.tableDatas).toStrictEqual([
           {
-            fromValue: 0,
-            toValue: 1,
+            fromValue: '0',
+            toValue: '1',
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: true,
           },
           {
-            fromValue: 2,
-            toValue: 3,
+            fromValue: '2',
+            toValue: '3',
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: false,
           },
           {
-            fromValue: 4,
+            fromValue: '4',
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -147,7 +147,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 4,
+            firstUnit: '4',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -182,14 +182,14 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.tableDatas).toStrictEqual([
           {
-            fromValue: 0,
-            toValue: 1,
+            fromValue: '0',
+            toValue: '1',
             flatAmount: 4,
             perUnitAmount: undefined,
             disabledDelete: true,
           },
           {
-            fromValue: 2,
+            fromValue: '2',
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: 5,
@@ -199,7 +199,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 2,
+            firstUnit: '2',
             total: 9,
             perUnit: 0,
             flatFee: 0,
@@ -222,7 +222,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'perUnitAmount', '8'))
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 4,
+            firstUnit: '4',
             total: 25,
             perUnit: 0,
             flatFee: 0,
@@ -250,7 +250,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'flatAmount', '9'))
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 4,
+            firstUnit: '4',
             total: 34,
             perUnit: 0,
             flatFee: 0,
@@ -280,18 +280,18 @@ describe('useGraduatedRange()', () => {
       it('should handle update of "toValue" correctly', async () => {
         const { result } = await prepare({})
 
-        await act(async () => await result.current.handleUpdate(0, 'toValue', '4'))
+        await act(async () => await result.current.handleUpdate(0, 'toValue', 4))
 
         expect(result.current.tableDatas).toStrictEqual([
           {
-            fromValue: 0,
-            toValue: 4,
+            fromValue: '0',
+            toValue: '4',
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: true,
           },
           {
-            fromValue: 5,
+            fromValue: '5',
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -300,7 +300,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 5,
+            firstUnit: '5',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -324,7 +324,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'toValue', 8))
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 9,
+            firstUnit: '9',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -356,19 +356,19 @@ describe('useGraduatedRange()', () => {
 
         await act(async () => await result.current.addRange())
         expect(result.current.tableDatas.length).toBe(3)
-        await act(async () => await result.current.handleUpdate(0, 'toValue', '4'))
+        await act(async () => await result.current.handleUpdate(0, 'toValue', 4))
         await act(async () => await result.current.deleteRange(1))
         expect(result.current.tableDatas.length).toBe(2)
         expect(result.current.tableDatas).toStrictEqual([
           {
-            fromValue: 0,
-            toValue: 4,
+            fromValue: '0',
+            toValue: '4',
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: true,
           },
           {
-            fromValue: 5,
+            fromValue: '5',
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -390,7 +390,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 2,
+            firstUnit: '2',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -418,21 +418,21 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.tableDatas).toStrictEqual([
           {
-            fromValue: 0,
-            toValue: 1,
+            fromValue: '0',
+            toValue: '1',
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: true,
           },
           {
-            fromValue: 2,
-            toValue: 3,
+            fromValue: '2',
+            toValue: '3',
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: false,
           },
           {
-            fromValue: 4,
+            fromValue: '4',
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -441,7 +441,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 4,
+            firstUnit: '4',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -476,14 +476,14 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.tableDatas).toStrictEqual([
           {
-            fromValue: 0,
-            toValue: 1,
+            fromValue: '0',
+            toValue: '1',
             flatAmount: 4,
             perUnitAmount: undefined,
             disabledDelete: true,
           },
           {
-            fromValue: 2,
+            fromValue: '2',
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: 5,
@@ -493,7 +493,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 2,
+            firstUnit: '2',
             total: 9,
             perUnit: 0,
             flatFee: 0,
@@ -516,7 +516,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'perUnitAmount', '8'))
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 4,
+            firstUnit: '4',
             total: 25,
             perUnit: 0,
             flatFee: 0,
@@ -544,7 +544,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'flatAmount', '9'))
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 4,
+            firstUnit: '4',
             total: 34,
             perUnit: 0,
             flatFee: 0,
@@ -574,18 +574,18 @@ describe('useGraduatedRange()', () => {
       it('should handle update of "toValue" correctly', async () => {
         const { result } = await prepare({})
 
-        await act(async () => await result.current.handleUpdate(0, 'toValue', '4'))
+        await act(async () => await result.current.handleUpdate(0, 'toValue', 4))
 
         expect(result.current.tableDatas).toStrictEqual([
           {
-            fromValue: 0,
-            toValue: 4,
+            fromValue: '0',
+            toValue: '4',
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: true,
           },
           {
-            fromValue: 5,
+            fromValue: '5',
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -594,7 +594,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 5,
+            firstUnit: '5',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -618,7 +618,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'toValue', 8))
         expect(result.current.infosCaclucation).toStrictEqual([
           {
-            firstUnit: 9,
+            firstUnit: '9',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -650,19 +650,19 @@ describe('useGraduatedRange()', () => {
 
         await act(async () => await result.current.addRange())
         expect(result.current.tableDatas.length).toBe(3)
-        await act(async () => await result.current.handleUpdate(0, 'toValue', '4'))
+        await act(async () => await result.current.handleUpdate(0, 'toValue', 4))
         await act(async () => await result.current.deleteRange(1))
         expect(result.current.tableDatas.length).toBe(2)
         expect(result.current.tableDatas).toStrictEqual([
           {
-            fromValue: 0,
-            toValue: 4,
+            fromValue: '0',
+            toValue: '4',
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: true,
           },
           {
-            fromValue: 5,
+            fromValue: '5',
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,

--- a/src/hooks/plans/__tests__/useVolumeChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useVolumeChargeForm.test.tsx
@@ -98,19 +98,19 @@ describe('useVolumeChargeForm()', () => {
       it('returns in tableDatas the given datas', async () => {
         const volumeRanges = [
           {
-            fromValue: 0,
-            toValue: 1,
+            fromValue: '0',
+            toValue: '1',
             flatAmount: '1',
             perUnitAmount: '2',
           },
           {
-            fromValue: 1,
-            toValue: 2,
+            fromValue: '1',
+            toValue: '2',
             flatAmount: '1',
             perUnitAmount: '1',
           },
           {
-            fromValue: 2,
+            fromValue: '2',
             toValue: null,
             flatAmount: '1',
             perUnitAmount: '1',
@@ -132,19 +132,19 @@ describe('useVolumeChargeForm()', () => {
       it('should all be disabled if disabled props is true', async () => {
         const volumeRanges = [
           {
-            fromValue: 0,
-            toValue: 1,
+            fromValue: '0',
+            toValue: '1',
             flatAmount: '1',
             perUnitAmount: '2',
           },
           {
-            fromValue: 1,
-            toValue: 2,
+            fromValue: '1',
+            toValue: '2',
             flatAmount: '1',
             perUnitAmount: '1',
           },
           {
-            fromValue: 2,
+            fromValue: '2',
             toValue: null,
             flatAmount: '1',
             perUnitAmount: '1',
@@ -168,19 +168,19 @@ describe('useVolumeChargeForm()', () => {
       it('returns expected results with given props', async () => {
         const volumeRanges = [
           {
-            fromValue: 0,
-            toValue: 100,
+            fromValue: '0',
+            toValue: '100',
             flatAmount: '1',
             perUnitAmount: '1',
           },
           {
-            fromValue: 101,
-            toValue: 500,
+            fromValue: '101',
+            toValue: '500',
             flatAmount: '1',
             perUnitAmount: '0.9',
           },
           {
-            fromValue: 501,
+            fromValue: '501',
             toValue: null,
             flatAmount: '1',
             perUnitAmount: '0.2',
@@ -204,19 +204,19 @@ describe('useVolumeChargeForm()', () => {
       it('should add one row in volumeRanges and update infosCalculation', async () => {
         const volumeRanges = [
           {
-            toValue: 100,
-            fromValue: 0,
+            toValue: '100',
+            fromValue: '0',
             flatAmount: '1',
             perUnitAmount: '1',
           },
           {
-            fromValue: 101,
-            toValue: 500,
+            fromValue: '101',
+            toValue: '500',
             flatAmount: '1',
             perUnitAmount: '0.9',
           },
           {
-            fromValue: 501,
+            fromValue: '501',
             toValue: null,
             flatAmount: '1',
             perUnitAmount: '0.3',
@@ -241,15 +241,15 @@ describe('useVolumeChargeForm()', () => {
           { ...volumeRanges[0], disabledDelete: true },
           { ...volumeRanges[1], disabledDelete: false },
           {
-            toValue: 502,
-            fromValue: 501,
+            toValue: '502',
+            fromValue: '501',
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: false,
           },
           {
             toValue: null,
-            fromValue: 503,
+            fromValue: '503',
             flatAmount: volumeRanges[2].flatAmount,
             perUnitAmount: volumeRanges[2].perUnitAmount,
             disabledDelete: true,
@@ -262,19 +262,19 @@ describe('useVolumeChargeForm()', () => {
       it('should correctly udpate data', async () => {
         const volumeRanges = [
           {
-            fromValue: 0,
-            toValue: 100,
+            fromValue: '0',
+            toValue: '100',
             flatAmount: '1',
             perUnitAmount: '1',
           },
           {
-            fromValue: 101,
-            toValue: 500,
+            fromValue: '101',
+            toValue: '500',
             flatAmount: '1',
             perUnitAmount: '0.9',
           },
           {
-            fromValue: 501,
+            fromValue: '501',
             toValue: null,
             flatAmount: '1',
             perUnitAmount: '0.2',
@@ -288,15 +288,15 @@ describe('useVolumeChargeForm()', () => {
         await act(async () => await result.current.handleUpdate(1, 'toValue', ''))
         expect(result.current.tableDatas).toStrictEqual([
           { ...volumeRanges[0], disabledDelete: true },
-          { ...{ ...volumeRanges[1], toValue: 0 }, disabledDelete: false },
-          { ...{ ...volumeRanges[2], fromValue: 1, toValue: null }, disabledDelete: true },
+          { ...{ ...volumeRanges[1], toValue: '0' }, disabledDelete: false },
+          { ...{ ...volumeRanges[2], fromValue: '1', toValue: null }, disabledDelete: true },
         ])
 
         await act(async () => await result.current.handleUpdate(1, 'toValue', 30))
         expect(result.current.tableDatas).toStrictEqual([
           { ...volumeRanges[0], disabledDelete: true },
-          { ...{ ...volumeRanges[1], toValue: 30 }, disabledDelete: false },
-          { ...{ ...volumeRanges[2], fromValue: 31, toValue: null }, disabledDelete: true },
+          { ...{ ...volumeRanges[1], toValue: '30' }, disabledDelete: false },
+          { ...{ ...volumeRanges[2], fromValue: '31', toValue: null }, disabledDelete: true },
         ])
         await act(async () => await result.current.handleUpdate(1, 'toValue', 500))
 
@@ -321,19 +321,19 @@ describe('useVolumeChargeForm()', () => {
       it('should correctly udpate data', async () => {
         const volumeRanges = [
           {
-            fromValue: 0,
-            toValue: 100,
+            fromValue: '0',
+            toValue: '100',
             flatAmount: '1',
             perUnitAmount: '1',
           },
           {
-            fromValue: 101,
-            toValue: 500,
+            fromValue: '101',
+            toValue: '500',
             flatAmount: '1',
             perUnitAmount: '0.9',
           },
           {
-            fromValue: 501,
+            fromValue: '501',
             toValue: null,
             flatAmount: '1',
             perUnitAmount: '0.2',
@@ -351,7 +351,7 @@ describe('useVolumeChargeForm()', () => {
         expect(result.current.tableDatas.length).toBe(2)
         expect(result.current.tableDatas).toStrictEqual([
           { ...volumeRanges[0], disabledDelete: true },
-          { ...{ ...volumeRanges[2], fromValue: 101 }, disabledDelete: true },
+          { ...{ ...volumeRanges[2], fromValue: '101' }, disabledDelete: true },
         ])
       })
     })
@@ -373,19 +373,19 @@ describe('useVolumeChargeForm()', () => {
       it('returns in tableDatas the given datas', async () => {
         const volumeRanges = [
           {
-            fromValue: 0,
-            toValue: 1,
+            fromValue: '0',
+            toValue: '1',
             flatAmount: '1',
             perUnitAmount: '2',
           },
           {
-            fromValue: 1,
-            toValue: 2,
+            fromValue: '1',
+            toValue: '2',
             flatAmount: '1',
             perUnitAmount: '1',
           },
           {
-            fromValue: 2,
+            fromValue: '2',
             toValue: null,
             flatAmount: '1',
             perUnitAmount: '1',
@@ -407,19 +407,19 @@ describe('useVolumeChargeForm()', () => {
       it('should all be disabled if disabled props is true', async () => {
         const volumeRanges = [
           {
-            fromValue: 0,
-            toValue: 1,
+            fromValue: '0',
+            toValue: '1',
             flatAmount: '1',
             perUnitAmount: '2',
           },
           {
-            fromValue: 1,
-            toValue: 2,
+            fromValue: '1',
+            toValue: '2',
             flatAmount: '1',
             perUnitAmount: '1',
           },
           {
-            fromValue: 2,
+            fromValue: '2',
             toValue: null,
             flatAmount: '1',
             perUnitAmount: '1',
@@ -443,19 +443,19 @@ describe('useVolumeChargeForm()', () => {
       it('returns expected results with given props', async () => {
         const volumeRanges = [
           {
-            fromValue: 0,
-            toValue: 100,
+            fromValue: '0',
+            toValue: '100',
             flatAmount: '1',
             perUnitAmount: '1',
           },
           {
-            fromValue: 101,
-            toValue: 500,
+            fromValue: '101',
+            toValue: '500',
             flatAmount: '1',
             perUnitAmount: '0.9',
           },
           {
-            fromValue: 501,
+            fromValue: '501',
             toValue: null,
             flatAmount: '1',
             perUnitAmount: '0.2',
@@ -479,19 +479,19 @@ describe('useVolumeChargeForm()', () => {
       it('should add one row in volumeRanges and update infosCalculation', async () => {
         const volumeRanges = [
           {
-            toValue: 100,
-            fromValue: 0,
+            toValue: '100',
+            fromValue: '0',
             flatAmount: '1',
             perUnitAmount: '1',
           },
           {
-            fromValue: 101,
-            toValue: 500,
+            fromValue: '101',
+            toValue: '500',
             flatAmount: '1',
             perUnitAmount: '0.9',
           },
           {
-            fromValue: 501,
+            fromValue: '501',
             toValue: null,
             flatAmount: '1',
             perUnitAmount: '0.3',
@@ -516,15 +516,15 @@ describe('useVolumeChargeForm()', () => {
           { ...volumeRanges[0], disabledDelete: true },
           { ...volumeRanges[1], disabledDelete: false },
           {
-            toValue: 502,
-            fromValue: 501,
+            toValue: '502',
+            fromValue: '501',
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: false,
           },
           {
             toValue: null,
-            fromValue: 503,
+            fromValue: '503',
             flatAmount: volumeRanges[2].flatAmount,
             perUnitAmount: volumeRanges[2].perUnitAmount,
             disabledDelete: true,
@@ -537,19 +537,19 @@ describe('useVolumeChargeForm()', () => {
       it('should correctly udpate data', async () => {
         const volumeRanges = [
           {
-            fromValue: 0,
-            toValue: 100,
+            fromValue: '0',
+            toValue: '100',
             flatAmount: '1',
             perUnitAmount: '1',
           },
           {
-            fromValue: 101,
-            toValue: 500,
+            fromValue: '101',
+            toValue: '500',
             flatAmount: '1',
             perUnitAmount: '0.9',
           },
           {
-            fromValue: 501,
+            fromValue: '501',
             toValue: null,
             flatAmount: '1',
             perUnitAmount: '0.2',
@@ -563,15 +563,15 @@ describe('useVolumeChargeForm()', () => {
         await act(async () => await result.current.handleUpdate(1, 'toValue', ''))
         expect(result.current.tableDatas).toStrictEqual([
           { ...volumeRanges[0], disabledDelete: true },
-          { ...{ ...volumeRanges[1], toValue: 0 }, disabledDelete: false },
-          { ...{ ...volumeRanges[2], fromValue: 1, toValue: null }, disabledDelete: true },
+          { ...{ ...volumeRanges[1], toValue: '0' }, disabledDelete: false },
+          { ...{ ...volumeRanges[2], fromValue: '1', toValue: null }, disabledDelete: true },
         ])
 
         await act(async () => await result.current.handleUpdate(1, 'toValue', 30))
         expect(result.current.tableDatas).toStrictEqual([
           { ...volumeRanges[0], disabledDelete: true },
-          { ...{ ...volumeRanges[1], toValue: 30 }, disabledDelete: false },
-          { ...{ ...volumeRanges[2], fromValue: 31, toValue: null }, disabledDelete: true },
+          { ...{ ...volumeRanges[1], toValue: '30' }, disabledDelete: false },
+          { ...{ ...volumeRanges[2], fromValue: '31', toValue: null }, disabledDelete: true },
         ])
         await act(async () => await result.current.handleUpdate(1, 'toValue', 500))
 
@@ -596,19 +596,19 @@ describe('useVolumeChargeForm()', () => {
       it('should correctly udpate data', async () => {
         const volumeRanges = [
           {
-            fromValue: 0,
-            toValue: 100,
+            fromValue: '0',
+            toValue: '100',
             flatAmount: '1',
             perUnitAmount: '1',
           },
           {
-            fromValue: 101,
-            toValue: 500,
+            fromValue: '101',
+            toValue: '500',
             flatAmount: '1',
             perUnitAmount: '0.9',
           },
           {
-            fromValue: 501,
+            fromValue: '501',
             toValue: null,
             flatAmount: '1',
             perUnitAmount: '0.2',
@@ -626,7 +626,7 @@ describe('useVolumeChargeForm()', () => {
         expect(result.current.tableDatas.length).toBe(2)
         expect(result.current.tableDatas).toStrictEqual([
           { ...volumeRanges[0], disabledDelete: true },
-          { ...{ ...volumeRanges[2], fromValue: 101 }, disabledDelete: true },
+          { ...{ ...volumeRanges[2], fromValue: '101' }, disabledDelete: true },
         ])
       })
     })

--- a/src/hooks/plans/useGraduatedChargeForm.ts
+++ b/src/hooks/plans/useGraduatedChargeForm.ts
@@ -10,7 +10,7 @@ type InfoCalculationRow = {
   perUnit: number
   flatFee: number
   total: number
-  firstUnit?: number
+  firstUnit?: string
 }
 
 type UseGraduatedChargeForm = ({
@@ -35,13 +35,13 @@ type UseGraduatedChargeForm = ({
 
 export const DEFAULT_GRADUATED_CHARGES = [
   {
-    fromValue: 0,
-    toValue: 1,
+    fromValue: '0',
+    toValue: '1',
     flatAmount: undefined,
     perUnitAmount: undefined,
   },
   {
-    fromValue: 2,
+    fromValue: '2',
     toValue: null,
     flatAmount: undefined,
     perUnitAmount: undefined,
@@ -83,8 +83,8 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
         graduatedRanges.reduce<InfoCalculationRow[]>((acc, range, i) => {
           const units =
             i === 0
-              ? range.toValue || 0
-              : (range.toValue || 0) - (graduatedRanges[i - 1].toValue || 0)
+              ? Number(range.toValue || 0)
+              : Number(range.toValue || 0) - Number(graduatedRanges[i - 1].toValue || 0)
           const perUnit = Number(range.perUnitAmount || 0)
           const flatFee = Number(range.flatAmount || 0)
 
@@ -104,7 +104,7 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
             })
 
             const totalLine = {
-              firstUnit: range.fromValue,
+              firstUnit: String(Number(range.fromValue) || 0),
               total: acc.reduce<number>((accTotal, rangeCost) => {
                 return accTotal + rangeCost.total
               }, 0),
@@ -127,17 +127,20 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
           if (i < addIndex) {
             acc.push(range)
           } else if (i === addIndex) {
-            const newToValue = (graduatedRanges[addIndex - 1]?.toValue || 0) + 1
+            const newToValue = String(Number(graduatedRanges[addIndex - 1]?.toValue || 0) + 1)
 
             acc.push({
               fromValue: newToValue,
-              toValue: newToValue + 1,
+              toValue: String(Number(newToValue) + 1),
               flatAmount: undefined,
               perUnitAmount: undefined,
             })
             acc.push({
               ...range,
-              fromValue: range.fromValue <= newToValue + 1 ? newToValue + 2 : range.fromValue,
+              fromValue:
+                Number(range.fromValue || 0) <= Number(newToValue) + 1
+                  ? String(Number(newToValue) + 2)
+                  : String(range.fromValue),
             })
           }
 
@@ -152,8 +155,6 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
       )
     },
     handleUpdate: (rangeIndex, fieldName, value) => {
-      const safeValue = Number(value || 0)
-
       if (fieldName !== 'toValue') {
         formikProps.setFieldValue(
           `${formikIdentifier}.${rangeIndex}.${fieldName}`,
@@ -163,11 +164,11 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
         const newGraduatedRanges = graduatedRanges.reduce<GraduatedRangeInput[]>(
           (acc, range, i) => {
             if (rangeIndex === i) {
-              acc.push({ ...range, toValue: safeValue })
+              acc.push({ ...range, toValue: String(Number(value || 0)) })
             } else if (i > rangeIndex) {
               // fromValue should always be toValueOfPreviousRange + 1
               const { toValue } = acc[i - 1]
-              const fromValue = (toValue || 0) + 1
+              const fromValue = String(Number(toValue || 0) + 1)
 
               acc.push({
                 ...range,
@@ -175,9 +176,9 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
                 toValue:
                   range.toValue === null
                     ? null
-                    : (range.toValue || 0) <= fromValue
-                    ? fromValue + 1
-                    : range.toValue,
+                    : Number(range.toValue || 0) <= Number(fromValue)
+                    ? String(Number(fromValue) + 1)
+                    : String(range.toValue || 0),
               })
             } else {
               acc.push(range)
@@ -200,7 +201,7 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
 
           acc.push({
             ...range,
-            fromValue: (toValue || 0) + 1,
+            fromValue: String(Number(toValue || 0) + 1),
           })
         }
         return acc

--- a/src/hooks/plans/useVolumeChargeForm.ts
+++ b/src/hooks/plans/useVolumeChargeForm.ts
@@ -6,13 +6,13 @@ import { InputMaybe, PropertiesInput, VolumeRangeInput } from '~/generated/graph
 
 export const DEFAULT_VOLUME_CHARGES = [
   {
-    fromValue: 0,
-    toValue: 1,
+    fromValue: '0',
+    toValue: '1',
     flatAmount: undefined,
     perUnitAmount: undefined,
   },
   {
-    fromValue: 2,
+    fromValue: '2',
     toValue: null,
     flatAmount: undefined,
     perUnitAmount: undefined,
@@ -93,17 +93,20 @@ export const useVolumeChargeForm: UseVolumeChargeForm = ({
         if (i < addIndex) {
           acc.push(range)
         } else if (i === addIndex) {
-          const newToValue = (volumeRanges[addIndex - 1]?.toValue || 0) + 1
+          const newToValue = String(Number(volumeRanges[addIndex - 1]?.toValue || 0) + 1)
 
           acc.push({
             fromValue: newToValue,
-            toValue: newToValue + 1,
+            toValue: String(Number(newToValue) + 1),
             flatAmount: undefined,
             perUnitAmount: undefined,
           })
           acc.push({
             ...range,
-            fromValue: range.fromValue <= newToValue + 1 ? newToValue + 2 : range.fromValue,
+            fromValue:
+              Number(range.fromValue) <= Number(newToValue) + 1
+                ? String(Number(newToValue) + 2)
+                : String(range.fromValue),
           })
         }
 
@@ -116,8 +119,6 @@ export const useVolumeChargeForm: UseVolumeChargeForm = ({
       )
     },
     handleUpdate: (rangeIndex, fieldName, value) => {
-      const safeValue = Number(value || 0)
-
       if (fieldName !== 'toValue') {
         formikProps.setFieldValue(
           `${formikIdentifier}.${rangeIndex}.${fieldName}`,
@@ -126,11 +127,11 @@ export const useVolumeChargeForm: UseVolumeChargeForm = ({
       } else {
         const newVolumeRanges = volumeRanges.reduce<VolumeRangeInput[]>((acc, range, i) => {
           if (rangeIndex === i) {
-            acc.push({ ...range, toValue: safeValue })
+            acc.push({ ...range, toValue: String(Number(value || 0)) })
           } else if (i > rangeIndex) {
             // fromValue should always be toValueOfPreviousRange + 1
             const { toValue } = acc[i - 1]
-            const fromValue = (toValue || 0) + 1
+            const fromValue = String(Number(toValue || 0) + 1)
 
             acc.push({
               ...range,
@@ -138,9 +139,9 @@ export const useVolumeChargeForm: UseVolumeChargeForm = ({
               toValue:
                 range.toValue === null
                   ? null
-                  : (range.toValue || 0) <= fromValue
-                  ? fromValue + 1
-                  : range.toValue,
+                  : Number(range.toValue || 0) <= Number(fromValue)
+                  ? String(Number(fromValue) + 1)
+                  : String(range.toValue || 0),
             })
           } else {
             acc.push(range)
@@ -161,7 +162,7 @@ export const useVolumeChargeForm: UseVolumeChargeForm = ({
 
           acc.push({
             ...range,
-            fromValue: (toValue || 0) + 1,
+            fromValue: String(Number(toValue || 0) + 1),
           })
         }
         return acc


### PR DESCRIPTION
## Context

We recently changed some data of graduated and volume charge from float to bigint

Bitint are represented with strings.

I missed this change the first time

## Description

This PR fixes the volume and graduated validations by turning strings into number before comparing values.