### PR TITLE
bug(currency): CLP supports 0 decimal

### DIFF
--- a/src/core/serializers/serializeAmount.ts
+++ b/src/core/serializers/serializeAmount.ts
@@ -11,6 +11,7 @@ const CURRENCIES_WITH_0_DECIMALS = [
   'KMF',
   'KRW',
   'PYG',
+  'CLP',
   'RWF',
   'UGX',
   'VND',


### PR DESCRIPTION
CLP supports 0 decimal but was defined as it in our app.

This PR fixes that