### PR TITLE
bug(plan-form): disable add mini amount

### DIFF
--- a/src/components/plans/ChargeAccordion.tsx
+++ b/src/components/plans/ChargeAccordion.tsx
@@ -382,6 +382,7 @@ export const ChargeAccordion = memo(
                 <Button
                   variant="quaternary"
                   startIcon="plus"
+                  disabled={disabled}
                   endIcon={isPremium ? undefined : 'sparkles'}
                   onClick={() => {
                     if (isPremium) {


### PR DESCRIPTION
Adding a minimum amount is not possible when plan is assigned to a customer.

There is no point showing a button user can click but that show disabled actions

This PR makes the first button disabled 