### PR TITLE
bug(combobox-item): fix spacing between element and it's parent

### DIFF
--- a/src/components/form/ComboBox/ComboBoxItem.tsx
+++ b/src/components/form/ComboBox/ComboBoxItem.tsx
@@ -74,6 +74,7 @@ export const Item = styled.div<{ $virtualized?: boolean }>`
     align-items: center;
     border-radius: 12px;
     cursor: pointer;
+    margin: 0 ${theme.spacing(2)};
     width: ${({ $virtualized }) => ($virtualized ? 'initial' : 'inherit')};
     box-sizing: border-box;
   }


### PR DESCRIPTION
Margin was wrong, this PR fixes it

BEFORE


<img width="612" alt="image" src="https://user-images.githubusercontent.com/5517077/237044952-edd897df-7a60-40f0-9fcb-d4ecfa6ffbda.png">



AFTER

<img width="666" alt="image" src="https://user-images.githubusercontent.com/5517077/237044679-b5276121-beff-400d-886a-c47a2c87aa1b.png">
