### PR TITLE
breaking(router): remove support for old /tax-rate route

### DIFF
--- a/src/core/router/SettingRoutes.tsx
+++ b/src/core/router/SettingRoutes.tsx
@@ -39,7 +39,6 @@ const EmailScenarioConfig = lazy(
 // ----------- Routes -----------
 export const SETTINGS_ROUTE = '/settings'
 export const INVOICE_SETTINGS_ROUTE = `${SETTINGS_ROUTE}/invoice`
-export const VAT_RATE_ROUTE = `${SETTINGS_ROUTE}/tax-rate` // TODO - to maintain old route for now
 export const ORGANIZATION_INFORMATIONS_ROUTE = `${SETTINGS_ROUTE}/organization-informations`
 export const INTEGRATIONS_ROUTE = `${SETTINGS_ROUTE}/integrations`
 export const STRIPE_INTEGRATION_ROUTE = `${SETTINGS_ROUTE}/integrations/stripe`
@@ -59,7 +58,7 @@ export const settingRoutes: CustomRouteObject[] = [
         element: <OrganizationInformations />,
       },
       {
-        path: [INVOICE_SETTINGS_ROUTE, VAT_RATE_ROUTE],
+        path: [INVOICE_SETTINGS_ROUTE],
         private: true,
         element: <InvoiceSettings />,
       },

--- a/src/layouts/Settings.tsx
+++ b/src/layouts/Settings.tsx
@@ -11,7 +11,6 @@ import {
   SETTINGS_ROUTE,
   INVOICE_SETTINGS_ROUTE,
   EMAILS_SETTINGS_ROUTE,
-  VAT_RATE_ROUTE,
 } from '~/core/router'
 import { NAV_HEIGHT } from '~/styles'
 
@@ -26,7 +25,7 @@ const Settings = () => {
     {
       title: translate('text_62bb10ad2a10bd182d00202d'),
       link: INVOICE_SETTINGS_ROUTE,
-      match: [VAT_RATE_ROUTE, INVOICE_SETTINGS_ROUTE],
+      match: [INVOICE_SETTINGS_ROUTE],
     },
     {
       title: translate('text_6407684eaf41130074c4b2a1'),


### PR DESCRIPTION
The `settings/invoice` route was previously named `settings/tax-rate` and been renames since few versions, and is no longer "supporter".

It was mainly to not break potential user bookmarks at by the time.

It's time to let it go 🕊️