### PR TITLE
chore(global): export form error enum globally

### DIFF
--- a/src/components/plans/FixedFeeSection.tsx
+++ b/src/components/plans/FixedFeeSection.tsx
@@ -8,9 +8,9 @@ import { TextInputField, SwitchField, AmountInputField } from '~/components/form
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { Button, Chip, Icon, Tooltip, Typography } from '~/components/designSystem'
 import { theme, Card, NAV_HEIGHT } from '~/styles'
-import { FORM_ERRORS_ENUM } from '~/hooks/plans/usePlanForm'
 import { getCurrencySymbol } from '~/core/formats/intlFormatNumber'
 import { CurrencyEnum, PlanInterval } from '~/generated/graphql'
+import { FORM_ERRORS_ENUM } from '~/core/formErrors'
 
 import { PlanFormInput } from './types'
 

--- a/src/components/plans/PlanSettingsSection.tsx
+++ b/src/components/plans/PlanSettingsSection.tsx
@@ -7,9 +7,10 @@ import { ButtonSelectorField, ComboBoxField, TextInputField } from '~/components
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { Button, Tooltip, Typography } from '~/components/designSystem'
 import { theme, Card } from '~/styles'
-import { PLAN_FORM_TYPE_ENUM, FORM_ERRORS_ENUM } from '~/hooks/plans/usePlanForm'
+import { PLAN_FORM_TYPE_ENUM } from '~/hooks/plans/usePlanForm'
 import { LineSplit } from '~/styles/mainObjectsForm'
 import { CurrencyEnum, PlanInterval } from '~/generated/graphql'
+import { FORM_ERRORS_ENUM } from '~/core/formErrors'
 
 import { PlanFormInput } from './types'
 

--- a/src/core/formErrors.ts
+++ b/src/core/formErrors.ts
@@ -1,0 +1,4 @@
+export enum FORM_ERRORS_ENUM {
+  existingCode = 'existingCode',
+  invalidGroupValue = 'invalidGroupValue',
+}

--- a/src/hooks/plans/usePlanForm.tsx
+++ b/src/hooks/plans/usePlanForm.tsx
@@ -22,10 +22,7 @@ import {
 } from '~/core/apolloClient'
 import { ERROR_404_ROUTE, PLANS_ROUTE, CUSTOMER_DETAILS_ROUTE } from '~/core/router'
 import { serializePlanInput } from '~/core/serializers'
-
-export enum FORM_ERRORS_ENUM {
-  existingCode = 'existingCode',
-}
+import { FORM_ERRORS_ENUM } from '~/core/formErrors'
 
 gql`
   query getSinglePlan($id: ID!) {

--- a/src/hooks/useCreateEditAddOn.ts
+++ b/src/hooks/useCreateEditAddOn.ts
@@ -15,10 +15,7 @@ import {
 import { ERROR_404_ROUTE, ADD_ONS_ROUTE } from '~/core/router'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { serializeAmount } from '~/core/serializers/serializeAmount'
-
-export enum FORM_ERRORS_ENUM {
-  existingCode = 'existingCode',
-}
+import { FORM_ERRORS_ENUM } from '~/core/formErrors'
 
 gql`
   fragment EditAddOn on AddOn {

--- a/src/hooks/useCreateEditBillableMetric.ts
+++ b/src/hooks/useCreateEditBillableMetric.ts
@@ -16,6 +16,7 @@ import {
 } from '~/generated/graphql'
 import { ERROR_404_ROUTE, BILLABLE_METRICS_ROUTE } from '~/core/router'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
+import { FORM_ERRORS_ENUM } from '~/core/formErrors'
 
 gql`
   query getSingleBillableMetric($id: ID!) {
@@ -49,11 +50,6 @@ type UseCreateEditBillableMetricReturn = {
   billableMetric?: EditBillableMetricFragment
   errorCode?: string
   onSave: (value: CreateBillableMetricInput | UpdateBillableMetricInput) => Promise<void>
-}
-
-export enum FORM_ERRORS_ENUM {
-  existingCode = 'existingCode',
-  invalidGroupValue = 'invalidGroupValue',
 }
 
 export const useCreateEditBillableMetric: () => UseCreateEditBillableMetricReturn = () => {

--- a/src/hooks/useCreateEditCoupon.ts
+++ b/src/hooks/useCreateEditCoupon.ts
@@ -23,10 +23,7 @@ import {
 import { ERROR_404_ROUTE, COUPONS_ROUTE } from '~/core/router'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { serializeAmount } from '~/core/serializers/serializeAmount'
-
-export enum FORM_ERRORS_ENUM {
-  existingCode = 'existingCode',
-}
+import { FORM_ERRORS_ENUM } from '~/core/formErrors'
 
 gql`
   fragment EditCoupon on Coupon {

--- a/src/hooks/useCreateEditTaxRate.ts
+++ b/src/hooks/useCreateEditTaxRate.ts
@@ -11,10 +11,7 @@ import {
 import { ERROR_404_ROUTE, TAXES_SETTINGS_ROUTE } from '~/core/router'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { TaxRateFormInput } from '~/components/taxRates/types'
-
-export enum FORM_ERRORS_ENUM {
-  existingCode = 'existingCode',
-}
+import { FORM_ERRORS_ENUM } from '~/core/formErrors'
 
 gql`
   fragment TaxRateForm on TaxRate {

--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -4,7 +4,7 @@ import { useFormik } from 'formik'
 import { object, string, number } from 'yup'
 import styled from 'styled-components'
 
-import { useCreateEditAddOn, FORM_ERRORS_ENUM } from '~/hooks/useCreateEditAddOn'
+import { useCreateEditAddOn } from '~/hooks/useCreateEditAddOn'
 import { PageHeader } from '~/styles'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
@@ -25,6 +25,7 @@ import {
   LineAmount,
 } from '~/styles/mainObjectsForm'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { FORM_ERRORS_ENUM } from '~/core/formErrors'
 
 import { AddOnCodeSnippet } from '../components/addOns/AddOnCodeSnippet'
 

--- a/src/pages/CreateBillableMetric.tsx
+++ b/src/pages/CreateBillableMetric.tsx
@@ -12,7 +12,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { TextInputField, ComboBoxField, JsonEditorField } from '~/components/form'
 import { BILLABLE_METRICS_ROUTE } from '~/core/router'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
-import { useCreateEditBillableMetric, FORM_ERRORS_ENUM } from '~/hooks/useCreateEditBillableMetric'
+import { useCreateEditBillableMetric } from '~/hooks/useCreateEditBillableMetric'
 import { BillableMetricCodeSnippet } from '~/components/billableMetrics/BillableMetricCodeSnippet'
 import {
   Main,
@@ -24,6 +24,7 @@ import {
   SkeletonHeader,
   ButtonContainer,
 } from '~/styles/mainObjectsForm'
+import { FORM_ERRORS_ENUM } from '~/core/formErrors'
 
 gql`
   fragment EditBillableMetric on BillableMetric {

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -7,7 +7,7 @@ import { InputAdornment } from '@mui/material'
 import styled from 'styled-components'
 import isEqual from 'lodash/isEqual'
 
-import { useCreateEditCoupon, FORM_ERRORS_ENUM } from '~/hooks/useCreateEditCoupon'
+import { useCreateEditCoupon } from '~/hooks/useCreateEditCoupon'
 import { PageHeader, Card, theme, ButtonGroup } from '~/styles'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import {
@@ -56,6 +56,7 @@ import {
   AddBillableMetricToCouponDialog,
   AddBillableMetricToCouponDialogRef,
 } from '~/components/coupons/AddBillableMetricToCouponDialog'
+import { FORM_ERRORS_ENUM } from '~/core/formErrors'
 
 import { CouponCodeSnippet } from '../components/coupons/CouponCodeSnippet'
 

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -17,7 +17,7 @@ import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import { Typography, Button, Skeleton } from '~/components/designSystem'
 import { theme, PageHeader, Card } from '~/styles'
 import { PlanCodeSnippet } from '~/components/plans/PlanCodeSnippet'
-import { usePlanForm, PLAN_FORM_TYPE_ENUM, FORM_ERRORS_ENUM } from '~/hooks/plans/usePlanForm'
+import { usePlanForm, PLAN_FORM_TYPE_ENUM } from '~/hooks/plans/usePlanForm'
 import { chargeSchema } from '~/formValidation/chargeSchema'
 import {
   Main,
@@ -32,6 +32,7 @@ import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { PlanSettingsSection } from '~/components/plans/PlanSettingsSection'
 import { FixedFeeSection } from '~/components/plans/FixedFeeSection'
 import { ChargesSection } from '~/components/plans/ChargesSection'
+import { FORM_ERRORS_ENUM } from '~/core/formErrors'
 
 import { PlanFormInput, LocalChargeInput } from '../components/plans/types'
 

--- a/src/pages/CreateTaxRate.tsx
+++ b/src/pages/CreateTaxRate.tsx
@@ -19,10 +19,11 @@ import {
   SectionTitle,
   LineSplit,
 } from '~/styles/mainObjectsForm'
-import { FORM_ERRORS_ENUM, useCreateEditTaxRate } from '~/hooks/useCreateEditTaxRate'
+import { useCreateEditTaxRate } from '~/hooks/useCreateEditTaxRate'
 import { TaxRateCodeSnippet } from '~/components/taxRates/TaxRateCodeSnippet'
 import { TextInputField } from '~/components/form'
 import { TaxRateFormInput } from '~/components/taxRates/types'
+import { FORM_ERRORS_ENUM } from '~/core/formErrors'
 
 const CreateTaxRate = () => {
   const { isEdition, errorCode, loading, onClose, onSave, taxRate } = useCreateEditTaxRate()


### PR DESCRIPTION
Reuse the same exported error form enum all over the app