### PR TITLE
bug(one-off) Fix tax rate assignment

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -198,7 +198,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
               variant="caption"
               color="grey600"
               html={
-                !customer?.vatRate
+                typeof customer?.vatRate !== 'number'
                   ? translate('text_638e13576861f3be8a3d448a', {
                       link: INVOICE_SETTINGS_ROUTE,
                     })

--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -110,7 +110,12 @@ const CreateInvoice = () => {
     notifyOnNetworkStatusChange: true,
   })
   const { customer, organization } = data || {}
-  const localVatRate = customer?.vatRate || organization?.billingConfiguration?.vatRate || 0
+  const localVatRate =
+    typeof customer?.vatRate === 'number'
+      ? customer?.vatRate
+      : typeof organization?.billingConfiguration?.vatRate === 'number'
+      ? organization?.billingConfiguration?.vatRate
+      : 0
 
   const [getAddOns, { data: addOnData }] = useGetAddonListForInfoiceLazyQuery({
     variables: { limit: 20 },


### PR DESCRIPTION
As a tax rate can be equal to `0%`, the current check on value is wrong and can lead to unexpected results.

This PR fixed the way we check the customer and orga vat rate value

Also, the customer settings display was having the same kind of issue and it's now fixed