### PR TITLE
bug(credit-notes) fix form inline validation for addOn fees

### DIFF
--- a/src/components/creditNote/CreditNoteFormCalculation.tsx
+++ b/src/components/creditNote/CreditNoteFormCalculation.tsx
@@ -52,7 +52,7 @@ export const CreditNoteFormCalculation = ({
 }: CreditNoteFormCalculationProps) => {
   const { translate } = useInternationalization()
   const canOnlyCredit = invoice?.paymentStatus !== InvoicePaymentStatusTypeEnum.Succeeded
-  const hasFeeError = !!formikProps.errors.fees
+  const hasFeeError = !!formikProps.errors.fees || !!formikProps.errors.addOnFee
   const currency = invoice?.currency || CurrencyEnum.Usd
   const currencyPrecision = getCurrencyPrecision(currency)
   const isLegacyInvoice = (invoice?.versionNumber || 0) < 3

--- a/src/formValidation/feesSchema.ts
+++ b/src/formValidation/feesSchema.ts
@@ -1,4 +1,4 @@
-import { object, number, boolean } from 'yup'
+import { object, number, boolean, ISchema, tuple } from 'yup'
 import _get from 'lodash/get'
 
 import {
@@ -77,3 +77,13 @@ export const generateFeesSchema = (formikInitialFees: FeesPerInvoice, currency: 
       return accSub
     }, {})
   )
+
+export const generateAddOnFeesSchema = (formikInitialFees: FromFee[], currency: CurrencyEnum) => {
+  const validationObject: [ISchema<unknown>] = [{} as unknown as ISchema<unknown>]
+
+  formikInitialFees.forEach((fee, i) => {
+    validationObject[i] = simpleFeeSchema(fee.maxAmount, currency)
+  })
+
+  return tuple(validationObject)
+}


### PR DESCRIPTION
## Context

The inline validation was somehow broken since a recent refactor. 
This PR fixes it.

## Bug description

Let's say you have 2 items: A:$100 and B:$300.

The Credit Note item's `maxValue` validation was not scoped to each element's value.
Meaning that the `maxAmount` validation for A and B was at $400 (A+B).

