### PR TITLE
chore(login) change item DOM order for better tab xp

### DIFF
--- a/src/components/form/TextInput/TextInput.tsx
+++ b/src/components/form/TextInput/TextInput.tsx
@@ -30,7 +30,6 @@ export interface TextInputProps
   error?: string | boolean
   name?: string
   label?: string | ReactNode
-  labelRight?: ReactNode
   cleanable?: boolean
   password?: boolean
   value?: string | number
@@ -111,7 +110,6 @@ export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
       value = '',
       name,
       label,
-      labelRight,
       helperText,
       infoText,
       maxRows,
@@ -176,7 +174,7 @@ export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
 
     return (
       <Container className={className}>
-        {(!!label || !!labelRight) && (
+        {!!label && (
           <InlineLabelContainer>
             {label && (
               <Label $withInfo={!!infoText}>
@@ -194,7 +192,6 @@ export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
                 )}
               </Label>
             )}
-            {!!labelRight && <>{labelRight}</>}
           </InlineLabelContainer>
         )}
         <MuiTextField

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -95,20 +95,20 @@ const Login = () => {
             autoFocus
           />
 
-          <PasswordInput
-            name="password"
-            formikProps={formikProps}
-            password
-            label={translate('text_620bc4d4269a55014d493f32')}
-            labelRight={
-              <Typography variant="caption">
-                <Link to={generatePath(FORGOT_PASSWORD_ROUTE)}>
-                  {translate('text_642707b0da1753a9bb6672b5')}
-                </Link>
-              </Typography>
-            }
-            placeholder={translate('text_620bc4d4269a55014d493f5b')}
-          />
+          <PasswordInputWrapper>
+            <PasswordInput
+              name="password"
+              formikProps={formikProps}
+              password
+              label={translate('text_620bc4d4269a55014d493f32')}
+              placeholder={translate('text_620bc4d4269a55014d493f5b')}
+            />
+            <PasswordForgottenLinkTypo variant="caption">
+              <Link to={generatePath(FORGOT_PASSWORD_ROUTE)}>
+                {translate('text_642707b0da1753a9bb6672b5')}
+              </Link>
+            </PasswordForgottenLinkTypo>
+          </PasswordInputWrapper>
 
           <SubmitButton data-test="submit" fullWidth size="large" onClick={formikProps.submitForm}>
             {translate('text_620bc4d4269a55014d493f6d')}
@@ -134,6 +134,15 @@ const EmailInput = styled(TextInputField)`
   && {
     margin-bottom: ${theme.spacing(4)};
   }
+`
+
+const PasswordInputWrapper = styled.div`
+  position: relative;
+`
+const PasswordForgottenLinkTypo = styled(Typography)`
+  position: absolute;
+  top: 0;
+  right: 0;
 `
 
 const PasswordInput = styled(TextInputField)`


### PR DESCRIPTION
## Context

If you're focused on the mail and press tab, you then focus the forgot password link, and you need to tab again to focus the password input.

We want to change the tab order to have the two inputs with one tab press distance, and then focus on the reset password link in last position, without changing the UI

## Description

I preferred the DOM manipulation + elements position rather than applying different `tabindex` values on elements to create a sequence (as adding positive elements to this attribute is deprecated)

The reset password link is now placed after the password input elements but is visually placed above it using position absolute.