### PR TITLE
bug(plan-form) fix non-dirty form to close easilly

### DIFF
--- a/cypress/e2e/t6-edit-plan.cy.ts
+++ b/cypress/e2e/t6-edit-plan.cy.ts
@@ -1,6 +1,16 @@
 import { planWithChargesName, customerName } from '../support/reusableConstants'
 
 describe('Edit plan', () => {
+  describe('when no data has changed', () => {
+    it('should be able to close the form without warning dialog', () => {
+      cy.visit('/plans')
+      cy.get(`[data-test="${planWithChargesName}"]`).click()
+      cy.get('[data-test="close-create-plan-button"]').click()
+      cy.get('[data-test="close-create-plan-button"]').should('not.exist')
+      cy.url().should('be.equal', Cypress.config().baseUrl + '/plans')
+    })
+  })
+
   it('should be able to update all information of unused plan', () => {
     cy.visit('/plans')
     cy.get(`[data-test="${planWithChargesName}"]`).click()

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -115,7 +115,7 @@ const CreatePlan = () => {
       interval: plan?.interval || PlanInterval.Monthly,
       payInAdvance: plan?.payInAdvance || false,
       amountCents: isNaN(plan?.amountCents)
-        ? undefined
+        ? ''
         : String(
             deserializeAmount(plan?.amountCents || 0, plan?.amountCurrency || CurrencyEnum.Usd)
           ),
@@ -211,6 +211,7 @@ const CreatePlan = () => {
           variant="quaternary"
           icon="close"
           onClick={() => (formikProps.dirty ? warningDialogRef.current?.openDialog() : onClose())}
+          data-test="close-create-plan-button"
         />
       </PageHeader>
 


### PR DESCRIPTION
If there is no dirty attributes, user should see no warning when closing the plan form