### PR TITLE
bug(applied-coupons) fix add and delete behaviours

### DIFF
--- a/src/components/customers/AddCouponToCustomerDialog.tsx
+++ b/src/components/customers/AddCouponToCustomerDialog.tsx
@@ -311,7 +311,7 @@ export const AddCouponToCustomerDialog = forwardRef<
       <Container>
         <ComboBox
           name="selectCoupon"
-          value={String(formikProps.values.couponId)}
+          value={formikProps.values.couponId ? String(formikProps.values.couponId) : ''}
           label={translate('text_628b8c693e464200e00e4677')}
           data={coupons}
           loading={loading}

--- a/src/components/customers/CustomerCoupons.tsx
+++ b/src/components/customers/CustomerCoupons.tsx
@@ -76,16 +76,7 @@ export const CustomerCoupons = memo(() => {
         })
       }
     },
-    update(cache, { data: updatedData }) {
-      if (!updatedData?.terminateAppliedCoupon) return
-
-      const cacheId = cache.identify({
-        id: updatedData?.terminateAppliedCoupon.id,
-        __typename: 'AppliedCoupon',
-      })
-
-      cache.evict({ id: cacheId })
-    },
+    refetchQueries: ['getCustomerCoupons'],
   })
 
   return (


### PR DESCRIPTION
2 issues are fixed here
- while applying a coupon, if you pressed enter while selecting a coupon you had a console warning and the input value became `'undefined'`
- When deleting an applied coupon, after page reload you got a cache issue warning.

Those two are now fixed