### PR TITLE
bug(drawer-button): inherit text color from button wrapper

### DIFF
--- a/src/components/customers/subscriptions/AddSubscriptionDrawer.tsx
+++ b/src/components/customers/subscriptions/AddSubscriptionDrawer.tsx
@@ -325,7 +325,7 @@ export const AddSubscriptionDrawer = forwardRef<
               onClick={formikProps.submitForm}
               data-test="submit"
             >
-              <Typography noWrap>
+              <Typography color="inherit" noWrap>
                 {existingSubscription
                   ? translate('text_6328e70de459381ed4ba50da')
                   : translate('text_6328e70de459381ed4ba50d4', { customerName })}


### PR DESCRIPTION
Simple button text color fix.

Happened because I added an inner typography and the color was not inherited from parent anymore