### PR TITLE
bug(bm-group) fix display order

### DIFF
--- a/src/components/plans/ConditionalChargeWrapper.tsx
+++ b/src/components/plans/ConditionalChargeWrapper.tsx
@@ -35,12 +35,12 @@ export const ConditionalChargeWrapper = memo(
     return (
       <>
         {localCharge?.groupProperties?.map((group, groupPropertyIndex) => {
-          const groupKey =
-            localCharge?.billableMetric?.flatGroups &&
-            localCharge?.billableMetric?.flatGroups[groupPropertyIndex].key
-          const groupName =
-            localCharge?.billableMetric?.flatGroups &&
-            localCharge?.billableMetric?.flatGroups[groupPropertyIndex].value
+          const associatedFlagGroup = localCharge?.billableMetric?.flatGroups?.find(
+            (flatGroup) => flatGroup.id === group.groupId
+          )
+
+          const groupKey = associatedFlagGroup?.key
+          const groupName = associatedFlagGroup?.value
           const hasErrorInGroup =
             typeof chargeErrors === 'object' &&
             typeof chargeErrors[chargeIndex] === 'object' &&


### PR DESCRIPTION
## Context

Group properties display can be messed in plan form

## Description

We were assuming that the group and flatGroup values had the same order so we could have situations where we used wrong information for a specific group property

We not get values by their group ID so we are sure to get the correct ones