### PR TITLE
bug(subscription) fix copy with undefined variable

### DIFF
--- a/ditto/base.json
+++ b/ditto/base.json
@@ -1596,7 +1596,7 @@
   "text_62d7f6178ec94cd09370e32d": "Subscription name (optional)",
   "text_62e38a4631937146a6d6d5dd": "Subscription name successfully edited",
   "text_62d7f6178ec94cd09370e2f3": "Terminate subscription?",
-  "text_62d7f6178ec94cd09370e313": "You’re about to terminate {{invoice_display_name}} subscription. The customer will pay usage fees and pro rata of subscription fees. Are you sure?",
+  "text_62d7f6178ec94cd09370e313": "You’re about to terminate {{subscriptionName}} subscription. The customer will pay usage fees and pro rata of subscription fees. Are you sure?",
   "text_62d7f6178ec94cd09370e351": "Terminate subscription",
   "text_62d953aa13c166a6a24cbaf4": "Subscription successfully terminated",
   "text_62d95e42c1e1dfe7376fdf35": "# subscriptions",

--- a/ditto/config.yml
+++ b/ditto/config.yml
@@ -104,9 +104,6 @@ sources:
     - name: ⚙️ [WIP] - Credits - Create prepaid credits
       id: 62d175018d4659c9a3eec929
       fileName: ⚙️ [WIP] - Credits - Create prepaid credits
-    - name: 👍 [Ready for dev] - B.metrics - Persistent bm in aggregation type
-      id: 63105dba2074ec779d08c6b4
-      fileName: 👍 [Ready for dev] - B.metrics - Persistent bm in aggregation type
     - name: 👍 [Ready for dev] - Onboarding - Invite member to organisation
       id: 63208b60a9b2a4c6186bbd26
       fileName: 👍 [Ready for dev] - Onboarding - Invite member to organisation

--- a/ditto/index.js
+++ b/ditto/index.js
@@ -11,9 +11,6 @@ module.exports = {
   "project_633336529ca3243d15ac9df4": {
     "base": require('./-ready-for-dev---all---replace-success-screen-by-success-toast__base.json')
   },
-  "project_63105dba2074ec779d08c6b4": {
-    "base": require('./-ready-for-dev---b.metrics---persistent-bm-in-aggregation-type__base.json')
-  },
   "project_637b4d9f764dcb190431ad4d": {
     "base": require('./-ready-for-dev---coupons---apply-several-coupons-to-customer__base.json')
   },

--- a/src/components/customers/subscriptions/TerminateCustomerSubscriptionDialog.tsx
+++ b/src/components/customers/subscriptions/TerminateCustomerSubscriptionDialog.tsx
@@ -86,7 +86,9 @@ export const TerminateCustomerSubscriptionDialog =
       <WarningDialog
         ref={dialogRef}
         title={translate('text_62d7f6178ec94cd09370e2f3')}
-        description={translate('text_62d7f6178ec94cd09370e313', { name: subscription?.name })}
+        description={translate('text_62d7f6178ec94cd09370e313', {
+          subscriptionName: subscription?.name,
+        })}
         onContinue={async () =>
           await terminate({
             variables: { input: { id: subscription?.id as string } },


### PR DESCRIPTION
## Context

A copy was given the wrong variable name, resulting in "undefined" being prompted

## Description

This PR fixes the copy shown and the variable name given to the translate method.

At some point, in non e2e tests, later, I would love to test copy prompt.

Anyway, let's just fix it for now