### PR TITLE
bug(invoice) better empty invoice display

### DIFF
--- a/src/components/invoices/InvoiceDetailsTable.tsx
+++ b/src/components/invoices/InvoiceDetailsTable.tsx
@@ -260,6 +260,43 @@ export const InvoiceDetailsTable = memo(
                     }
                   />
                 </table>
+
+                {/* If no positive fees are present in the invoice, display subscription fee placeholder */}
+                {!hasAnyPositiveSubscriptionFee && !hasAnyPositiveRemainingFee && (
+                  <table key={`invoiceSubscription-${i}-fee-placeholder`}>
+                    <tbody>
+                      <tr>
+                        <td>
+                          <Typography variant="body" color="grey700">
+                            {`${currentSubscription?.plan?.interval
+                              ?.charAt(0)
+                              ?.toUpperCase()}${currentSubscription?.plan?.interval?.slice(1)} - ${
+                              currentSubscription.plan.name
+                            }`}
+                          </Typography>
+                        </td>
+                        <td>
+                          <Typography variant="body" color="grey700">
+                            1
+                          </Typography>
+                        </td>
+                        <td>
+                          <Typography variant="body" color="grey700">
+                            0%
+                          </Typography>
+                        </td>
+                        <td>
+                          <Typography variant="body" color="grey700">
+                            {intlFormatNumber(0, {
+                              currencyDisplay: 'symbol',
+                              currency: currentSubscription?.plan?.amountCurrency,
+                            })}
+                          </Typography>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                )}
                 {subscriptionFees?.map((fee, j) => {
                   const plan = currentSubscription?.plan
                   const planInterval = `${plan?.interval


### PR DESCRIPTION
## Context

Invoices can be (among other things) generated when terminating a subscription.

If this subscription is marked as "paid in advance", or received events leading to have 0 as the amount calculated, we can have an invoice generated with either:
- no fees
- fees where all of them have an amountCents equal to 0

Leading to a "not so nice" invoice overview display where only the table header and footer (totals) are visible

## Description

This PR makes sure that if any of those happens, we display a "placeholder" line between table's header and footer, containing the subscription name and all other data being 0.

Doing that, looking at those kinds of invoices makes more sense.

A future feature will make sure we handle those better on both BE and FE sides' templates.