### PR TITLE
chore(customer-vat) rename all occurences to tax

### DIFF
--- a/cypress/e2e/t2-create-customer.cy.ts
+++ b/cypress/e2e/t2-create-customer.cy.ts
@@ -31,7 +31,7 @@ describe('Create customer', () => {
 
       cy.get('[data-test="tab-internal-button-link-settings"]').last().click()
       cy.get('[data-test="add-vat-rate-button"]').last().click()
-      cy.get('[data-test="edit-customer-vat-rate-dialog"]').should('exist')
+      cy.get('[data-test="edit-customer-taxes-rate-dialog"]').should('exist')
     })
   })
 })

--- a/ditto/base.json
+++ b/ditto/base.json
@@ -845,7 +845,7 @@
   "text_64639f5e63a5cc0076779d37": "Remove {{name}}",
   "text_64639f5e63a5cc0076779d3b": "By removing this tax rate from the customer, all current & next invoices will not be impacted by this rate anymore. Are you sure?",
   "text_64639f5e63a5cc0076779d43": "Remove tax rate",
-  "text_64639f5e63a5cc0076779db7": "Tax rate undefined, the customer's invoice will automatically use rates from organization level. However, you can override inherited rates by adding a specific rate here.",
+  "text_64639f5e63a5cc0076779db7": "Tax rate is not defined, the customer's invoice will automatically use rates from organization level. However, you can override inherited rates by adding a specific rate here.",
   "text_64639f5e63a5cc0076779dd9": "Tax rate successfully removed",
   "text_6464a12047f2dd00affa924f": "Edit {{name}}?",
   "text_6464a12047f2dd00affa9250": "Please note that the tax rate has been applied on {{customersCount}} customer. If you make any changes, all draft and upcoming invoices will be affected. Are you certain you want to proceed?|Please note that the tax rate has been applied on {{customersCount}} customers. If you make any changes, all draft and upcoming invoices will be affected. Are you certain you want to proceed?",

--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -19,14 +19,14 @@ import {
   DeleteCustomerGracePeriodFragmentDoc,
   EditCustomerDocumentLocaleFragmentDoc,
   EditCustomerInvoiceGracePeriodFragmentDoc,
-  EditCustomerVatRateFragmentDoc,
+  EditCustomerTaxesFragmentDoc,
   useGetCustomerSettingsQuery,
 } from '~/generated/graphql'
 import { INVOICE_SETTINGS_ROUTE } from '~/core/router'
 import {
-  EditCustomerVatRateDialog,
-  EditCustomerVatRateDialogRef,
-} from '~/components/customers/EditCustomerVatRateDialog'
+  EditCustomerTaxesDialog,
+  EditCustomerTaxesDialogRef,
+} from '~/components/customers/EditCustomerTaxesDialog'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import ErrorImage from '~/public/images/maneki/error.svg'
@@ -37,10 +37,7 @@ import {
   EditCustomerInvoiceGracePeriodDialog,
   EditCustomerInvoiceGracePeriodDialogRef,
 } from './EditCustomerInvoiceGracePeriodDialog'
-import {
-  DeleteCustomerVatRateDialog,
-  DeleteCustomerVatRateDialogRef,
-} from './DeleteCustomerVatRateDialog'
+import { DeleteCustomerTaxDialog, DeleteCustomerTaxDialogRef } from './DeleteCustomerTaxesDialog'
 import {
   DeleteCustomerGracePeriodeDialog,
   DeleteCustomerGracePeriodeDialogRef,
@@ -78,7 +75,7 @@ gql`
 
       ...CustomerAppliedTaxRatesForSettings
 
-      ...EditCustomerVatRate
+      ...EditCustomerTaxes
       ...EditCustomerDocumentLocale
       ...EditCustomerInvoiceGracePeriod
       ...DeleteCustomerGracePeriod
@@ -95,7 +92,7 @@ gql`
     }
   }
 
-  ${EditCustomerVatRateFragmentDoc}
+  ${EditCustomerTaxesFragmentDoc}
   ${EditCustomerInvoiceGracePeriodFragmentDoc}
   ${EditCustomerDocumentLocaleFragmentDoc}
   ${DeleteCustomerGracePeriodFragmentDoc}
@@ -115,8 +112,8 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
   })
   const customer = data?.customer
   const organization = data?.organization
-  const editVATDialogRef = useRef<EditCustomerVatRateDialogRef>(null)
-  const deleteVatRateDialogRef = useRef<DeleteCustomerVatRateDialogRef>(null)
+  const editVATDialogRef = useRef<EditCustomerTaxesDialogRef>(null)
+  const deleteVatRateDialogRef = useRef<DeleteCustomerTaxDialogRef>(null)
   const editInvoiceGracePeriodDialogRef = useRef<EditCustomerInvoiceGracePeriodDialogRef>(null)
   const deleteGracePeriodDialogRef = useRef<DeleteCustomerGracePeriodeDialogRef>(null)
   const editCustomerDocumentLocale = useRef<EditCustomerDocumentLocaleDialogRef>(null)
@@ -389,12 +386,12 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
 
       {!!customer && (
         <>
-          <EditCustomerVatRateDialog
+          <EditCustomerTaxesDialog
             ref={editVATDialogRef}
             customer={customer}
             appliedTaxRatesTaxesIds={customer.appliedTaxes?.map((t) => t.tax.id)}
           />
-          <DeleteCustomerVatRateDialog ref={deleteVatRateDialogRef} />
+          <DeleteCustomerTaxDialog ref={deleteVatRateDialogRef} />
 
           <EditCustomerInvoiceGracePeriodDialog
             ref={editInvoiceGracePeriodDialogRef}

--- a/src/components/customers/DeleteCustomerTaxesDialog.tsx
+++ b/src/components/customers/DeleteCustomerTaxesDialog.tsx
@@ -5,7 +5,7 @@ import { DialogRef } from '~/components/designSystem'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import {
   CustomerAppliedTaxRatesForSettingsFragmentDoc,
-  TaxRateForDeleteCustomerVatRateDialogFragment,
+  TaxForDeleteCustomerTaxDialogFragment,
   useRemoveAppliedTaxRateOnCustomerMutation,
 } from '~/generated/graphql'
 import { addToast } from '~/core/apolloClient'
@@ -13,7 +13,7 @@ import { addToast } from '~/core/apolloClient'
 import { WarningDialog } from '../WarningDialog'
 
 gql`
-  fragment TaxRateForDeleteCustomerVatRateDialog on Tax {
+  fragment TaxForDeleteCustomerTaxDialog on Tax {
     id
     name
   }
@@ -30,19 +30,16 @@ gql`
   ${CustomerAppliedTaxRatesForSettingsFragmentDoc}
 `
 
-export interface DeleteCustomerVatRateDialogRef {
-  openDialog: (
-    appliedTaxRateId: string,
-    taxRate: TaxRateForDeleteCustomerVatRateDialogFragment
-  ) => unknown
+export interface DeleteCustomerTaxDialogRef {
+  openDialog: (appliedTaxRateId: string, taxRate: TaxForDeleteCustomerTaxDialogFragment) => unknown
   closeDialog: () => unknown
 }
 
-export const DeleteCustomerVatRateDialog = forwardRef<DeleteCustomerVatRateDialogRef>((_, ref) => {
+export const DeleteCustomerTaxDialog = forwardRef<DeleteCustomerTaxDialogRef>((_, ref) => {
   const { translate } = useInternationalization()
   const dialogRef = useRef<DialogRef>(null)
   const [appliedTaxRateId, setAppliedTaxRateId] = useState<string>('')
-  const [taxRate, setTaxRate] = useState<TaxRateForDeleteCustomerVatRateDialogFragment>()
+  const [taxRate, setTaxRate] = useState<TaxForDeleteCustomerTaxDialogFragment>()
   const [removeAppliedTaxRateOnCustomer] = useRemoveAppliedTaxRateOnCustomerMutation({
     onCompleted({ destroyCustomerAppliedTax }) {
       if (destroyCustomerAppliedTax?.id) {
@@ -83,4 +80,4 @@ export const DeleteCustomerVatRateDialog = forwardRef<DeleteCustomerVatRateDialo
   )
 })
 
-DeleteCustomerVatRateDialog.displayName = 'forwardRef'
+DeleteCustomerTaxDialog.displayName = 'forwardRef'

--- a/src/components/customers/EditCustomerTaxesDialog.tsx
+++ b/src/components/customers/EditCustomerTaxesDialog.tsx
@@ -8,7 +8,7 @@ import { ComboBox } from '~/components/form'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import {
   CustomerAppliedTaxRatesForSettingsFragmentDoc,
-  EditCustomerVatRateFragment,
+  EditCustomerTaxesFragment,
   useCreateCustomerAppliedTaxMutation,
   useGetTaxRatesForEditCustomerLazyQuery,
 } from '~/generated/graphql'
@@ -19,7 +19,7 @@ import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { Item } from '../form/ComboBox/ComboBoxItem'
 
 gql`
-  fragment EditCustomerVatRate on Customer {
+  fragment EditCustomerTaxes on Customer {
     id
     name
   }
@@ -50,15 +50,15 @@ gql`
   ${CustomerAppliedTaxRatesForSettingsFragmentDoc}
 `
 
-export interface EditCustomerVatRateDialogRef extends DialogRef {}
+export interface EditCustomerTaxesDialogRef extends DialogRef {}
 
-interface EditCustomerVatRateDialogProps {
-  customer: EditCustomerVatRateFragment
+interface EditCustomerTaxesDialogProps {
+  customer: EditCustomerTaxesFragment
   appliedTaxRatesTaxesIds?: string[]
 }
 
-export const EditCustomerVatRateDialog = forwardRef<DialogRef, EditCustomerVatRateDialogProps>(
-  ({ appliedTaxRatesTaxesIds, customer }: EditCustomerVatRateDialogProps, ref) => {
+export const EditCustomerTaxesDialog = forwardRef<DialogRef, EditCustomerTaxesDialogProps>(
+  ({ appliedTaxRatesTaxesIds, customer }: EditCustomerTaxesDialogProps, ref) => {
     const { translate } = useInternationalization()
     const [localTax, setLocalTaxRate] = useState<string>('')
     const [getTaxRates, { loading, data }] = useGetTaxRatesForEditCustomerLazyQuery({
@@ -142,7 +142,7 @@ export const EditCustomerVatRateDialog = forwardRef<DialogRef, EditCustomerVatRa
           </>
         )}
       >
-        <Content data-test="edit-customer-vat-rate-dialog">
+        <Content data-test="edit-customer-taxes-rate-dialog">
           <ComboBox
             allowAddValue
             addValueProps={{
@@ -168,4 +168,4 @@ const Content = styled.div`
   margin-bottom: ${theme.spacing(8)};
 `
 
-EditCustomerVatRateDialog.displayName = 'forwardRef'
+EditCustomerTaxesDialog.displayName = 'forwardRef'

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3708,7 +3708,7 @@ export type DeleteCustomerGracePeriodMutationVariables = Exact<{
 
 export type DeleteCustomerGracePeriodMutation = { __typename?: 'Mutation', updateCustomerInvoiceGracePeriod?: { __typename?: 'Customer', id: string, invoiceGracePeriod?: number | null } | null };
 
-export type TaxRateForDeleteCustomerVatRateDialogFragment = { __typename?: 'Tax', id: string, name: string };
+export type TaxForDeleteCustomerTaxDialogFragment = { __typename?: 'Tax', id: string, name: string };
 
 export type RemoveAppliedTaxRateOnCustomerMutationVariables = Exact<{
   input: DestroyCustomerAppliedTaxInput;
@@ -3735,7 +3735,7 @@ export type UpdateCustomerInvoiceGracePeriodMutationVariables = Exact<{
 
 export type UpdateCustomerInvoiceGracePeriodMutation = { __typename?: 'Mutation', updateCustomerInvoiceGracePeriod?: { __typename?: 'Customer', id: string, invoiceGracePeriod?: number | null } | null };
 
-export type EditCustomerVatRateFragment = { __typename?: 'Customer', id: string, name?: string | null };
+export type EditCustomerTaxesFragment = { __typename?: 'Customer', id: string, name?: string | null };
 
 export type GetTaxRatesForEditCustomerQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -4925,8 +4925,8 @@ export const DeleteCustomerGracePeriodFragmentDoc = gql`
   name
 }
     `;
-export const TaxRateForDeleteCustomerVatRateDialogFragmentDoc = gql`
-    fragment TaxRateForDeleteCustomerVatRateDialog on Tax {
+export const TaxForDeleteCustomerTaxDialogFragmentDoc = gql`
+    fragment TaxForDeleteCustomerTaxDialog on Tax {
   id
   name
 }
@@ -4948,8 +4948,8 @@ export const EditCustomerInvoiceGracePeriodFragmentDoc = gql`
   invoiceGracePeriod
 }
     `;
-export const EditCustomerVatRateFragmentDoc = gql`
-    fragment EditCustomerVatRate on Customer {
+export const EditCustomerTaxesFragmentDoc = gql`
+    fragment EditCustomerTaxes on Customer {
   id
   name
 }
@@ -6676,7 +6676,7 @@ export const GetCustomerSettingsDocument = gql`
       documentLocale
     }
     ...CustomerAppliedTaxRatesForSettings
-    ...EditCustomerVatRate
+    ...EditCustomerTaxes
     ...EditCustomerDocumentLocale
     ...EditCustomerInvoiceGracePeriod
     ...DeleteCustomerGracePeriod
@@ -6692,7 +6692,7 @@ export const GetCustomerSettingsDocument = gql`
   }
 }
     ${CustomerAppliedTaxRatesForSettingsFragmentDoc}
-${EditCustomerVatRateFragmentDoc}
+${EditCustomerTaxesFragmentDoc}
 ${EditCustomerDocumentLocaleFragmentDoc}
 ${EditCustomerInvoiceGracePeriodFragmentDoc}
 ${DeleteCustomerGracePeriodFragmentDoc}


### PR DESCRIPTION
Aim to remove all `vat rate` occurrences in the app in favor of `tax`.

This is the new naming and some have not been updated during feature development

Others will follow