### PR TITLE
bug(auth) keep previously connected orga in cache after logout

### DIFF
--- a/src/core/apolloClient/cacheUtils.ts
+++ b/src/core/apolloClient/cacheUtils.ts
@@ -43,8 +43,6 @@ export const removeItem = (key: string) => {
 
 // --------------------- Auth utils ---------------------
 export const logOut = async (client: ApolloClient<object>, resetLocationHistory?: boolean) => {
-  localStorage && localStorage.clear()
-
   await client.cache.reset()
   updateAuthTokenVar()
   resetLocationHistory && resetLocationHistoryVar()
@@ -52,8 +50,18 @@ export const logOut = async (client: ApolloClient<object>, resetLocationHistory?
 
 export const onLogIn = (token: string, user: CurrentUserFragment) => {
   updateAuthTokenVar(token)
-  const organization = (user?.organizations || [])[0]
+  const previousOrganizationId = getItemFromLS(ORGANIZATION_LS_KEY_ID)
+  let organization
 
+  // Check if user has already logged in an orga and find it in the list
+  if (previousOrganizationId) {
+    organization = (user?.organizations || []).find((org) => org.id === previousOrganizationId)
+  }
+
+  // If still not organization, take the first one
+  if (!organization) organization = (user?.organizations || [])[0]
+
+  // Set the organization id in local storage
   setItemFromLS(ORGANIZATION_LS_KEY_ID, organization?.id)
 }
 


### PR DESCRIPTION
## Context

Users can be invited in multiple orga. They can log in and switch between them in the UI interface using the company switcher

The issue is that we clear local storage and don't keep any trace of the previously organization

## Description

This PR prevents clearing the local storage on logout

Also on login, we do check if an organ ID is stored and corresponds to any user's orga.
- if yes, we use this orga and logs in the user
- if no, we use the first orga in the list of the user and logs them in