### PR TITLE
bug(invoice) hide metadata section if invoice is draft

### DIFF
--- a/src/pages/InvoiceOverview.tsx
+++ b/src/pages/InvoiceOverview.tsx
@@ -172,7 +172,9 @@ export const InvoiceOverview = memo(
                   />
                 )}
 
-              <Metadatas customer={customer} invoice={invoice} />
+              {invoice?.status !== InvoiceStatusTypeEnum.Draft && (
+                <Metadatas customer={customer} invoice={invoice} />
+              )}
             </>
           )}
         </>


### PR DESCRIPTION
## Context

User should not be able to add a metadata on a draft invoice.

Adding one result in a BE error.

## Description

As metadata is empty at this stage, we hide the whole invoice metadata section if invoice status is draft