### PR TITLE
bug(currency) IDR has 2 decimal for display

### DIFF
--- a/src/core/serializers/serializeAmount.ts
+++ b/src/core/serializers/serializeAmount.ts
@@ -6,7 +6,6 @@ const CURRENCIES_WITH_0_DECIMALS = [
   'CVE',
   'DJF',
   'GNF',
-  'IDR',
   'ISK',
   'JPY',
   'KMF',


### PR DESCRIPTION
## Context

IDR currency has decimal but was in our 0 decimal list of currencies

## Description

This PR removes IDR from this list making it a 2 decimal again