### PR TITLE
fix: bm code snippet bearer token

### DIFF
--- a/src/components/billableMetrics/BillableMetricCodeSnippet.tsx
+++ b/src/components/billableMetrics/BillableMetricCodeSnippet.tsx
@@ -62,7 +62,7 @@ const getSnippets = (billableMetric?: CreateBillableMetricInput) => {
   switch (aggregationType) {
     case AggregationTypeEnum.CountAgg:
       return `curl --location --request POST "${apiUrl}/api/v1/events" \\
-  --header "Authorization: Bearer $__YOUR_API_KEY__" \\
+  --header "Authorization: Bearer __YOUR_API_KEY__" \\
   --header 'Content-Type: application/json' \\
   --data-raw '{
     "event": {


### PR DESCRIPTION
## Roadmap Task

N/A

## Context

Billable metric code snippet includes a "$" before the api key, which was misleading for a user. Fix this by removing the $ sign
