### PR TITLE
bug(subscription) fix CTA wording on cancel

### DIFF
--- a/src/components/customers/subscriptions/TerminateCustomerSubscriptionDialog.tsx
+++ b/src/components/customers/subscriptions/TerminateCustomerSubscriptionDialog.tsx
@@ -110,7 +110,7 @@ export const TerminateCustomerSubscriptionDialog =
           })
         }
         continueText={
-          status === StatusTypeEnum.Pending
+          subscription?.status === StatusTypeEnum.Pending
             ? translate('text_64a6d736c23125004817627f')
             : translate('text_62d7f6178ec94cd09370e351')
         }


### PR DESCRIPTION
When canceling a subscription, the wording was showing "terminate" instead of "cancel"

Due to a wrong attribute reading