### PR TITLE
bug(combobox) should allowAddValue if no emptyText is defined

### DIFF
--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -164,7 +164,7 @@ export const ComboBox = ({
             )
 
         // Suggest the creation of a new value
-        if (filtered.length === 0 && params.inputValue !== '' && allowAddValue && addValueProps) {
+        if (filtered.length === 0 && !emptyText && allowAddValue && addValueProps) {
           filtered.push({
             value: params.inputValue,
             label: addValueProps.label || `Add "${params.inputValue}"`,


### PR DESCRIPTION
## Context

When a user wants to set a tax on a customer and no tax exists, the combobox component shows an empty line

## Description

This PR fixes the component so it can
- show a "+ Add value" if the props are present and no emptyText is defined
- show the empty text if it's defined