### PR TITLE
feat(subscription) display appropriate message if external id already exists

### DIFF
--- a/ditto/base.json
+++ b/ditto/base.json
@@ -1079,6 +1079,7 @@
   "text_64d27277ee75720056d78622": "This billable metric is metered, the calculated value is reset to 0 at the beginning of each period",
   "text_64d27292062d9600b089aacb": "The calculated value is not reset to 0, it is persistent over all billable periods",
   "text_64d272b4df12dc008076e232": "The calculated value is reset to 0 at the beginning of each period",
+  "text_64dd2711d878ad007212de91": "Subscription external id already existing on another subscription, please type a new one",
   "text_6295e58352f39200d902b01c": "Documentation",
   "text_629728388c4d2300e2d3801a": "Add-ons",
   "text_629728388c4d2300e2d38085": "Add an add-on",

--- a/ditto/de.json
+++ b/ditto/de.json
@@ -1,6 +1,4 @@
 {
-  "__variant-name": "German",
-  "__variant-description": "",
   "text_641d6ae1d947c400671e6abb": "Etwas ist schiefgelaufen",
   "text_641d6aee014c8d00c1425cdd": "Bitte aktualisieren Sie die Seite oder kontaktieren Sie uns, wenn der Fehler weiterhin besteht.",
   "text_641d6b00ef96c1008754734d": "Seite aktualisieren",
@@ -31,6 +29,8 @@
   "text_6419c64eace749372fc72b54": "Bezahlt",
   "text_6419c64eace749372fc72b62": "PDF herunterladen",
   "text_641c6acee4bc20004e62c534": "Es ist ein Problem aufgetreten, die Url ist ungültig oder abgelaufen.",
+  "__variant-name": "German",
+  "__variant-description": "",
   "text_64188b3d9735d5007d712249": "730,00 $",
   "text_64188b3d9735d5007d71225c": "Deine Rechnung von {{organization}} #LAG-1234-567-981",
   "text_64188b3d9735d5007d712260": "<invoice@getlago.com>",

--- a/ditto/fr.json
+++ b/ditto/fr.json
@@ -1,6 +1,4 @@
 {
-  "__variant-name": "French",
-  "__variant-description": "",
   "text_641d6ae1d947c400671e6abb": "Quelque chose n'a pas fonctionné",
   "text_641d6aee014c8d00c1425cdd": "Veuillez actualiser la page ou nous contacter si l'erreur persiste.",
   "text_641d6b00ef96c1008754734d": "Actualiser la page",
@@ -31,6 +29,8 @@
   "text_6419c64eace749372fc72b54": "Payé",
   "text_6419c64eace749372fc72b62": "Télécharger le PDF",
   "text_641c6acee4bc20004e62c534": "Un problème s'est produit, l’url n'est pas valide ou a expiré.",
+  "__variant-name": "French",
+  "__variant-description": "",
   "text_64188b3d9735d5007d712249": "730.00 $",
   "text_64188b3d9735d5007d71225c": "Votre facture nº LAG-1234-567-981 de {{organization}}",
   "text_64188b3d9735d5007d712260": "<invoice@getlago.com>",

--- a/ditto/index.js
+++ b/ditto/index.js
@@ -198,10 +198,7 @@ module.exports = {
     "base": require('./customers---edit--delete-a-customer__base.json')
   },
   "ditto_component_library": {
-    "base": require('./ditto-component-library__base.json'),
-    "de": require('./ditto-component-library__de.json'),
-    "fr": require('./ditto-component-library__fr.json'),
-    "nb": require('./ditto-component-library__nb.json')
+    "base": require('./ditto-component-library__base.json')
   },
   "project_623b3ac9459a5d00df324533": {
     "base": require('./documentation-asset__base.json')

--- a/ditto/nb.json
+++ b/ditto/nb.json
@@ -1,6 +1,4 @@
 {
-  "__variant-name": "Norwegian",
-  "__variant-description": "",
   "text_641d6ae1d947c400671e6abb": "Noe gikk galt",
   "text_641d6aee014c8d00c1425cdd": "Oppdater siden eller kontakt oss hvis feilen vedvarer.",
   "text_641d6b00ef96c1008754734d": "Oppdater siden",
@@ -31,6 +29,8 @@
   "text_6419c64eace749372fc72b54": "Betalt",
   "text_6419c64eace749372fc72b62": "Last ned PDF",
   "text_641c6acee4bc20004e62c534": "Noe gikk galt, token er ugyldig eller utløpt.",
+  "__variant-name": "Norwegian",
+  "__variant-description": "",
   "text_64188b3d9735d5007d712249": "$730,00",
   "text_64188b3d9735d5007d71225c": "Faktura fra {{organization}} #LAG-1234-567-981",
   "text_64188b3d9735d5007d712262": "Til kundene dine",

--- a/src/components/customers/subscriptions/AddSubscriptionDrawer.tsx
+++ b/src/components/customers/subscriptions/AddSubscriptionDrawer.tsx
@@ -28,6 +28,7 @@ import {
   PlanInterval,
   StatusTypeEnum,
   TimezoneEnum,
+  LagoApiError,
 } from '~/generated/graphql'
 import { useAddSubscription } from '~/hooks/customer/useAddSubscription'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
@@ -80,12 +81,16 @@ export const AddSubscriptionDrawer = forwardRef<
     validateOnMount: true,
     enableReinitialize: true,
     onSubmit: async (values, formikBag) => {
-      const canClose = await onCreate(customerId, values)
+      const errorsString = await onCreate(customerId, values)
 
-      if (canClose) {
-        drawerRef?.current?.closeDrawer()
-        formikBag.resetForm()
+      if (errorsString === 'CurrenciesDoesNotMatch') {
+        return formikBag.setFieldError('currency', translate('text_632dbaf1d577afb32ae751f5'))
+      } else if (errorsString === 'ValueAlreadyExist') {
+        return formikBag.setFieldError('externalId', translate('text_64dd2711d878ad007212de91'))
       }
+
+      drawerRef?.current?.closeDrawer()
+      formikBag.resetForm()
     },
   })
   const {
@@ -336,7 +341,7 @@ export const AddSubscriptionDrawer = forwardRef<
               </>
             )}
 
-            {!!errorCode ? (
+            {errorCode === LagoApiError.CurrenciesDoesNotMatch ? (
               <Alert type="danger">{translate('text_632dbaf1d577afb32ae751f5')}</Alert>
             ) : (
               <>

--- a/src/components/customers/subscriptions/AddSubscriptionDrawer.tsx
+++ b/src/components/customers/subscriptions/AddSubscriptionDrawer.tsx
@@ -201,8 +201,14 @@ export const AddSubscriptionDrawer = forwardRef<
         existingSubscription ? 'text_6328e70de459381ed4ba50be' : 'text_6328e70de459381ed4ba50bc',
         { customerName }
       )}
-      onClose={formikProps.resetForm}
-      onOpen={onOpenDrawer}
+      onClose={() => {
+        formikProps.resetForm()
+        formikProps.validateForm()
+      }}
+      onOpen={() => {
+        onOpenDrawer()
+        formikProps.validateForm()
+      }}
     >
       <>
         <DrawerContent>

--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -58,7 +58,7 @@ interface UseAddSubscriptionReturn {
   onCreate: (
     customerId: string,
     values: Omit<CreateSubscriptionInput, 'customerId'>
-  ) => Promise<boolean>
+  ) => Promise<string | undefined>
 }
 
 type UseAddSubscription = (args: {
@@ -197,6 +197,8 @@ export const useAddSubscription: UseAddSubscription = ({
     }, [selectedPlan, billingTime, subscriptionAt, translate]),
     errorCode: hasDefinedGQLError('CurrenciesDoesNotMatch', error)
       ? LagoApiError.CurrenciesDoesNotMatch
+      : hasDefinedGQLError('ValueAlreadyExist', error)
+      ? LagoApiError.ValueAlreadyExist
       : undefined,
     onOpenDrawer: () => {
       !loading && getPlans()
@@ -216,11 +218,13 @@ export const useAddSubscription: UseAddSubscription = ({
         },
       })
 
-      if (!hasDefinedGQLError('CurrenciesDoesNotMatch', errors)) {
-        return true
+      if (hasDefinedGQLError('CurrenciesDoesNotMatch', errors)) {
+        return 'CurrenciesDoesNotMatch'
+      } else if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
+        return 'ValueAlreadyExist'
       }
 
-      return false
+      return
     },
   }
 }


### PR DESCRIPTION
## Context

If you create a subscription with an already-existing external id, the BE returns an error

## Description

This PR uses this error to show an error message bellow the externalId input.