### PR TITLE
feat(billable-metric) add Last aggregation type

### DIFF
--- a/ditto/base.json
+++ b/ditto/base.json
@@ -55,6 +55,8 @@
   "text_633336532bdf72cb62dc0692": "Add-on successfully created",
   "text_633336532bdf72cb62dc0694": "Plan successfully created",
   "text_633336532bdf72cb62dc0696": "Billable metric successfully created",
+  "text_64f8823d75521b6faaee8549": "Last",
+  "text_64f8823d75521b6faaee854b": "Record the value of the property from the latest received event",
   "text_637b4da08cd0118cd0c4486f": "{{amount}} remaining",
   "text_644b9f17623605a945cafdb9": "Pro-rated amount based on the total fees",
   "text_644b9f17623605a945cafdbb": "Coupons",

--- a/ditto/config.yml
+++ b/ditto/config.yml
@@ -289,5 +289,7 @@ sources:
       fileName: 👍 [Ready for dev] - Plans - Min & max per transaction
     - name: Duplicate plan
       id: 64fa170c8bbf9b0e6adc8b02
+    - name: 👍 [Ready for dev] - B.Metrics - Add last aggregation type
+      id: 64f8823bc0558274c87c6e0e
 format: flat
 variants: true

--- a/ditto/index.js
+++ b/ditto/index.js
@@ -14,6 +14,9 @@ module.exports = {
   "project_633336529ca3243d15ac9df4": {
     "base": require('./-ready-for-dev---all---replace-success-screen-by-success-toast__base.json')
   },
+  "project_64f8823bc0558274c87c6e0e": {
+    "base": require('./-ready-for-dev---b.metrics---add-last-aggregation-type__base.json')
+  },
   "project_637b4d9f764dcb190431ad4d": {
     "base": require('./-ready-for-dev---coupons---apply-several-coupons-to-customer__base.json')
   },

--- a/src/components/billableMetrics/BillableMetricCodeSnippet.tsx
+++ b/src/components/billableMetrics/BillableMetricCodeSnippet.tsx
@@ -107,6 +107,32 @@ ${groupDimensionMessage}
 # To use the snippet, don’t forget to edit your __YOUR_API_KEY__, __UNIQUE_ID__, __EXTERNAL_SUBSCRIPTION_ID__ and __EXTERNAL_CUSTOMER_ID__
 ${groupDimensionMessage}
 `
+
+    case AggregationTypeEnum.LatestAgg:
+      return `curl --location --request POST "${apiUrl}/api/v1/events" \\
+  --header "Authorization: Bearer $__YOUR_API_KEY__" \\
+  --header 'Content-Type: application/json' \\
+  --data-raw '{
+    "event": { 
+      "transaction_id": "__UNIQUE_ID__", 
+      "external_subscription_id": "__EXTERNAL_SUBSCRIPTION_ID__",
+      "external_customer_id": "__EXTERNAL_CUSTOMER_ID__", 
+      "code": "${code}",
+      "timestamp": $(date +%s), 
+      "properties":  { 
+        "${fieldName}": 12${
+        groupDimension > 0
+          ? `,
+        ${propertiesForGroup}`
+          : ''
+      }
+      }
+    }
+  }'
+
+# To use the snippet, don’t forget to edit your __YOUR_API_KEY__, __UNIQUE_ID__, __EXTERNAL_SUBSCRIPTION_ID__ and __EXTERNAL_CUSTOMER_ID__
+${groupDimensionMessage}
+`
     default:
       return '# Fill the form to generate the code snippet'
   }

--- a/src/components/plans/ChargeAccordion.tsx
+++ b/src/components/plans/ChargeAccordion.tsx
@@ -207,6 +207,7 @@ export const ChargeAccordion = memo(
           if (
             value === ChargeModelEnum.Volume ||
             localCharge.billableMetric.aggregationType === AggregationTypeEnum.MaxAgg ||
+            localCharge.billableMetric.aggregationType === AggregationTypeEnum.LatestAgg ||
             localCharge.billableMetric.aggregationType === AggregationTypeEnum.RecurringCountAgg
           ) {
             formikProps.setFieldValue(`charges.${index}.payInAdvance`, false)
@@ -429,29 +430,40 @@ export const ChargeAccordion = memo(
                 },
                 ...(!localCharge.billableMetric.recurring
                   ? [
-                      {
-                        labelNode: (
-                          <InlineComboboxLabelForPremiumWrapper>
-                            <InlineComboboxLabel>
-                              <Typography variant="body" color="grey700">
-                                {translate('text_64de472463e2da6b31737db0')}
-                              </Typography>
-                              <BetaChip size="xsmall" />
-                            </InlineComboboxLabel>
-                            {!isPremium && <Icon name="sparkles" />}
-                          </InlineComboboxLabelForPremiumWrapper>
-                        ),
-                        label: translate('text_64de472463e2da6b31737db0'),
-                        value: ChargeModelEnum.GraduatedPercentage,
-                      },
+                      ...(localCharge.billableMetric.aggregationType !==
+                      AggregationTypeEnum.LatestAgg
+                        ? [
+                            {
+                              labelNode: (
+                                <InlineComboboxLabelForPremiumWrapper>
+                                  <InlineComboboxLabel>
+                                    <Typography variant="body" color="grey700">
+                                      {translate('text_64de472463e2da6b31737db0')}
+                                    </Typography>
+                                    <BetaChip size="xsmall" />
+                                  </InlineComboboxLabel>
+                                  {!isPremium && <Icon name="sparkles" />}
+                                </InlineComboboxLabelForPremiumWrapper>
+                              ),
+                              label: translate('text_64de472463e2da6b31737db0'),
+                              value: ChargeModelEnum.GraduatedPercentage,
+                            },
+                          ]
+                        : []),
                       {
                         label: translate('text_6282085b4f283b0102655868'),
                         value: ChargeModelEnum.Package,
                       },
-                      {
-                        label: translate('text_62a0b7107afa2700a65ef6e2'),
-                        value: ChargeModelEnum.Percentage,
-                      },
+
+                      ...(localCharge.billableMetric.aggregationType !==
+                      AggregationTypeEnum.LatestAgg
+                        ? [
+                            {
+                              label: translate('text_62a0b7107afa2700a65ef6e2'),
+                              value: ChargeModelEnum.Percentage,
+                            },
+                          ]
+                        : []),
                     ]
                   : []),
                 {
@@ -766,6 +778,7 @@ export const ChargeAccordion = memo(
                   disabled:
                     localCharge.chargeModel === ChargeModelEnum.Volume ||
                     localCharge.billableMetric.aggregationType === AggregationTypeEnum.MaxAgg ||
+                    localCharge.billableMetric.aggregationType === AggregationTypeEnum.LatestAgg ||
                     localCharge.billableMetric.aggregationType ===
                       AggregationTypeEnum.RecurringCountAgg,
                 },

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -95,6 +95,7 @@ export type AdyenProvider = {
 
 export enum AggregationTypeEnum {
   CountAgg = 'count_agg',
+  LatestAgg = 'latest_agg',
   MaxAgg = 'max_agg',
   RecurringCountAgg = 'recurring_count_agg',
   SumAgg = 'sum_agg',

--- a/src/pages/CreateBillableMetric.tsx
+++ b/src/pages/CreateBillableMetric.tsx
@@ -97,9 +97,11 @@ const CreateBillableMetric = () => {
 
   useEffect(() => {
     if (
-      ![AggregationTypeEnum.SumAgg, AggregationTypeEnum.UniqueCountAgg].includes(
-        formikProps.values.aggregationType
-      )
+      ![
+        AggregationTypeEnum.SumAgg,
+        AggregationTypeEnum.UniqueCountAgg,
+        AggregationTypeEnum.LatestAgg,
+      ].includes(formikProps.values.aggregationType)
     ) {
       formikProps.setFieldValue('recurring', false)
     }
@@ -228,6 +230,7 @@ const CreateBillableMetric = () => {
                   </Typography>
 
                   <ComboBoxField
+                    sortValues={false}
                     formikProps={formikProps}
                     name="aggregationType"
                     disabled={isEdition && !canBeEdited}
@@ -245,6 +248,10 @@ const CreateBillableMetric = () => {
                         value: AggregationTypeEnum.UniqueCountAgg,
                       },
                       {
+                        label: translate('text_64f8823d75521b6faaee8549'),
+                        value: AggregationTypeEnum.LatestAgg,
+                      },
+                      {
                         label: translate('text_62694d9181be8d00a33f20f8'),
                         value: AggregationTypeEnum.MaxAgg,
                       },
@@ -258,6 +265,8 @@ const CreateBillableMetric = () => {
                         ? translate('text_6241cc759211e600ea57f4f1')
                         : formikProps.values?.aggregationType === AggregationTypeEnum.UniqueCountAgg
                         ? translate('text_62694d9181be8d00a33f20f6')
+                        : formikProps.values?.aggregationType === AggregationTypeEnum.LatestAgg
+                        ? translate('text_64f8823d75521b6faaee854b')
                         : formikProps.values?.aggregationType === AggregationTypeEnum.MaxAgg
                         ? translate('text_62694d9181be8d00a33f20f2')
                         : formikProps.values?.aggregationType === AggregationTypeEnum.SumAgg


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/billing-based-on-last-event-received

## Context

We want to allow having an aggregation type that would get the last event sent's value in order to compute pricing.

## Description

This PR allow to select a new "Last" aggregation type when setting up a Billable Metric.

You can then select this BM while creating a plan