### PR TITLE
chore(sentry) update deprecated BrowserTracing usage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-import { createRoot } from 'react-dom/client'
+import { BrowserTracing } from '@sentry/browser'
 import * as Sentry from '@sentry/react'
-import { BrowserTracing } from '@sentry/tracing'
+import { createRoot } from 'react-dom/client'
 
 import App from '~/App'
 import { envGlobalVar } from '~/core/apolloClient'


### PR DESCRIPTION
## Context

BrowserTracing have been moved in latest versions https://github.com/getsentry/sentry-javascript/issues/7342

## Description

Just updating the import