### PR TITLE
chore(nginx) update config to support IPV6

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,6 @@
 server {
   listen 80;
+  listen [::]:80;
   
   location / {
     root /usr/share/nginx/html;


### PR DESCRIPTION
PR originally created by @nealfennimore

https://github.com/getlago/lago-front/pull/1214

## Context

I run lago in a dual-stack environment and i have trouble connecting to the lago frontend sometimes due to there not being a ipv6 listener. lago-api already has a ipv6 listener, so I have no trouble connecting to that. 

## Description

Update nginx to support ipv6 on port 80