### PR TITLE
chore(plan-override) prevent sending parentId to BE

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -960,7 +960,6 @@ export type CreatePlanInput = {
   interval: PlanInterval;
   invoiceDisplayName?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
-  parentId?: InputMaybe<Scalars['ID']['input']>;
   payInAdvance: Scalars['Boolean']['input'];
   taxCodes?: InputMaybe<Array<Scalars['String']['input']>>;
   trialPeriod?: InputMaybe<Scalars['Float']['input']>;
@@ -4004,8 +4003,6 @@ export type WebhookLogItemFragment = { __typename?: 'Webhook', id: string, statu
 
 export type OrganizationForDatePickerFragment = { __typename?: 'Organization', id: string, timezone?: TimezoneEnum | null };
 
-export type OrganizationForTimePickerFragment = { __typename?: 'Organization', id: string, timezone?: TimezoneEnum | null };
-
 export type InvoiceMetadatasForMetadataDrawerFragment = { __typename?: 'Invoice', id: string, metadata?: Array<{ __typename?: 'InvoiceMetadata', id: string, key: string, value: string }> | null };
 
 export type UpdateInvoiceMetadataMutationVariables = Exact<{
@@ -5300,12 +5297,6 @@ export const WebhookForCreateAndEditFragmentDoc = gql`
   id
   webhookUrl
   signatureAlgo
-}
-    `;
-export const OrganizationForTimePickerFragmentDoc = gql`
-    fragment OrganizationForTimePicker on Organization {
-  id
-  timezone
 }
     `;
 export const TaxForInvoiceEditTaxDialogFragmentDoc = gql`

--- a/src/hooks/plans/usePlanForm.tsx
+++ b/src/hooks/plans/usePlanForm.tsx
@@ -101,7 +101,6 @@ export const usePlanForm: () => UsePlanFormReturn = () => {
           await create({
             variables: {
               input: {
-                ...(type === PLAN_FORM_TYPE_ENUM.override ? { parentId } : {}),
                 ...serializePlanInput(values),
               },
             },


### PR DESCRIPTION
BE do not needs this ID anymore.

However, we keep using it on FE for the duplicate and override logic (mainly to fetch related plan infos) so I won't remove all the related logic yet.

Incoming feature release will fix that 