### PR TITLE
bug(usage) fix duplicate usage drawer data

### DIFF
--- a/src/components/customers/usage/UsageItem.tsx
+++ b/src/components/customers/usage/UsageItem.tsx
@@ -66,6 +66,8 @@ export const UsageItem = ({
   const customerUsageDetailDrawerRef = useRef<CustomerUsageDetailDrawerRef>(null)
   const [fetchUsage, { data, error, loading, refetch }] = useCustomerUsageLazyQuery({
     variables: { customerId: customerId, subscriptionId: id },
+    // Fixes https://github.com/getlago/lago-front/pull/1243
+    fetchPolicy: 'no-cache',
   })
   const currency = data?.customerUsage?.currency || CurrencyEnum.Usd
 


### PR DESCRIPTION
### Fix duplicate usage data in usage drawer for billable metrics with group

## Steps to reproduce

- Create one Billable Metric (let's call is by it's code `bm_1`). This charge needs to have groups (one or 2 dimensions, not important)
- Create a plan, and add `bm_1` twice. This BM needs to have different `amount_cents` (let's say we use the standard charge model)
- Assign this plan to a customer and send events to this charge (no need to have events for each group/value pair)
- In the usage, open the customer's subscription. You can notice the usage contains two items with a ℹ️ button.
- The price of those usages will be different, but if you open the drawer bu clicking on the ℹ️, the value displayed will be the same (basically the value of the first usage displayed)

This is due to the Apollo cache, relying on the first ID it encounters in the model (Billable Metric) that is the same in both usages.

## Solution

I took the approach of removing the cache on this call.

I did not want to tell Apollo cache to rely on a different (unique) ID, as we're in a usage part of the app and probably we want the data to be somehow renewed often.