### PR TITLE
bug(cache) fine tune customer cache policy

### DIFF
--- a/src/core/apolloClient/cache.ts
+++ b/src/core/apolloClient/cache.ts
@@ -27,7 +27,7 @@ export const cache = new InMemoryCache({
           merge: mergePaginatedCollection,
         },
         customers: {
-          keyArgs: false,
+          keyArgs: ['id', 'externalId'],
           merge: mergePaginatedCollection,
         },
         coupons: {


### PR DESCRIPTION
## Context

Some users had the experience of duplicated customer in their list

## Description

This change ensures that all cached customers are identified by their ID and External ID