### PR TITLE
bug(DatePicker): apply flip modifier if placement is auto

### DIFF
--- a/src/components/form/DatePicker/DatePicker.tsx
+++ b/src/components/form/DatePicker/DatePicker.tsx
@@ -103,7 +103,7 @@ export const DatePicker = ({
             modifiers: [
               {
                 name: 'flip',
-                enabled: false,
+                enabled: placement === 'auto',
               },
               {
                 name: 'offset',


### PR DESCRIPTION
## Context

Having an "auto" placement makes the DataPicker trigger an error on open

The reason is that we need to enable the `flip` modifier if the `placement: 'auto'` is applied. So it can change the placement "on the flight" if the opened element overflows. 

[Doc link](https://popper.js.org/docs/v2/modifiers/flip/)

## Description

This PR enables the `flip` modifier only if the placement prop is `"auto"`