### PR TITLE
bug(nav) plan sub route should allow nav button click

### DIFF
--- a/src/layouts/SideNavLayout.tsx
+++ b/src/layouts/SideNavLayout.tsx
@@ -224,6 +224,7 @@ const SideNav = () => {
                     title: translate('text_62442e40cea25600b0b6d85a'),
                     icon: 'board',
                     link: PLANS_ROUTE,
+                    canBeClickedOnActive: true,
                     match: [PLANS_ROUTE, PLAN_DETAILS_ROUTE, CUSTOMER_SUBSCRIPTION_PLAN_DETAILS],
                   },
                   {


### PR DESCRIPTION
The Nav link for Plans now has sub-routes.

We must provide the buttonLink the instruction that the link can be clicked again even tho you're into a children's route.

We use this behaviour to redirect to the "main" route of the item (here plan list route)