### PR TITLE
bug(subscription) hide parent on upgrade/downgrade

### DIFF
--- a/src/pages/CreateSubscription.tsx
+++ b/src/pages/CreateSubscription.tsx
@@ -20,6 +20,7 @@ import {
   Typography,
 } from '~/components/designSystem'
 import {
+  BasicComboBoxData,
   ButtonSelectorField,
   ComboBoxField,
   DatePickerField,
@@ -253,21 +254,29 @@ const CreateSubscription = () => {
       localPlanCollection.unshift(subscription?.plan)
     }
 
-    return localPlanCollection.map(({ id, name, code }) => {
-      return {
-        label: `${name} - (${code})`,
-        labelNode: (
-          <PlanItem>
-            {name} <Typography color="textPrimary">({code})</Typography>
-          </PlanItem>
-        ),
-        value: id,
-        disabled:
-          formType === FORM_TYPE_ENUM.upgradeDowngrade &&
-          !!subscription?.plan.id &&
-          subscription?.plan.id === id,
+    return localPlanCollection.reduce<BasicComboBoxData[]>((acc, { id, name, code }) => {
+      // Hide parent plan
+      if (formType === FORM_TYPE_ENUM.upgradeDowngrade && id === subscription?.plan?.parent?.id) {
+        return acc
       }
-    })
+
+      return [
+        ...acc,
+        {
+          label: `${name} - (${code})`,
+          labelNode: (
+            <PlanItem>
+              {name} <Typography color="textPrimary">({code})</Typography>
+            </PlanItem>
+          ),
+          value: id,
+          disabled:
+            formType === FORM_TYPE_ENUM.upgradeDowngrade &&
+            !!subscription?.plan.id &&
+            subscription?.plan.id === id,
+        },
+      ]
+    }, [])
   }, [formType, planData?.plans?.collection, subscription?.plan])
 
   const billingTimeHelper = useMemo(() => {


### PR DESCRIPTION
## Context

You can create a plan override when creating a subscription.

This means a plan `A` can be assigned to a customer and create a subscription.
If you edit this plan `A` attribute, we create a child plan `A'` behind the scenes, containing those overrides


## Description

If you decide to upgrade/downgrade this plan `A'`, the plan parent `A` should not be in the list of available plans to select