### PR TITLE
bug(list) fix duplicated items

### DIFF
--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -75,5 +75,5 @@ export const useDebouncedSearch: UseDebouncedSearch = (searchQuery, loading) => 
     }
   }, [debouncedSearch])
 
-  return { debouncedSearch: debouncedSearch || undefined, isLoading: isLoading || false }
+  return { debouncedSearch: debouncedSearch || undefined, isLoading: isLoading || loading || false }
 }


### PR DESCRIPTION
## Context

This one is a bit nasty and has not been spotted earlier for some reason.

The main observation is: in some lists, elements on the next pages are duplicated when scrolling.

This means that each time a customer has more than 20 elements in the list and scrolls down to fetch the next page, the current array of items and the incoming are merged twice together and exponentially increase the number of items in the list.

After considering an issue with Apollo cache and the way we flag/merge collections, it appears that the issue is related to some page implementation that uses a search bar at the same time

## Why it happens

The bug occurs in lists where
- the `useDebounceSearch` hook is used (used for search)
- the returned loading boolean value of this hook is used to trigger the `fetchMore` method of the list query

The issue comes from the fact that this `useDebounceSearch` does return a denounced loading state, but does not consider the loading at all in the return

In other words, there is a moment when the query loading is true and the debounce loading is false.
As this debounce loading is used to trigger the fetch more when the user is at the end of the list, we trigger twice the fetch.

## How to fix it

A potential fix would have been to update all pages using lists in such condition, in order to update the isLoading condition above the fetchMore to use the main query loading boolean value. It was a mistake to use the debounce loading value instead in the current implementation.

However, I find it more easy and logic to update the useDebounce hook to return either its internal loading value (as today) OR the main loading value (new) OR false (as today, default value)

So the fix ends up being very small.