### PR TITLE
chore(input) add default border radius

### DIFF
--- a/src/styles/muiTheme.ts
+++ b/src/styles/muiTheme.ts
@@ -92,9 +92,11 @@ export const theme = createTheme({
           },
           '& .MuiInputBase-inputAdornedStart': {
             paddingLeft: '8px',
+            borderRadius: '0 12px 12px 0',
           },
           '& .MuiInputBase-inputAdornedEnd': {
             paddingRight: '0px',
+            borderRadius: '12px 0 0 12px',
           },
           '.MuiInputAdornment-positionEnd': {
             marginRight: '16px',
@@ -134,6 +136,7 @@ export const theme = createTheme({
           boxSizing: 'border-box',
           padding: '10px 16px',
           color: palette.grey[700],
+          borderRadius: '12px',
           '&::placeholder': {
             color: palette.grey[500],
             opacity: 1,


### PR DESCRIPTION
## Context

When fields are auto-filed by an external tool (like a password manager for example), the input focus stayed squared even tho all our inputs are rounded with 12px

## Description

This PR updated the theme's input definition to round them by default.

Inputs with adornment receive special rounding depending on it's position

## Screenshots

|BEFORE|AFTER|
|-|-|
|<img width="542" alt="Monosnap Lago - Cloud 2023-10-19 15-02-19" src="https://github.com/getlago/lago-front/assets/5517077/ad851931-e920-4e3c-853e-75301f7ae074">|<img width="530" alt="Monosnap Lago - Local 2023-10-19 15-03-14" src="https://github.com/getlago/lago-front/assets/5517077/119ae8c2-d14a-4b74-8cdb-46e721e3426e">|