### PR TITLE
bug(billable-metrics): fix pagination

### DIFF
--- a/src/core/apolloClient/cache.ts
+++ b/src/core/apolloClient/cache.ts
@@ -20,6 +20,7 @@ export const cache = new InMemoryCache({
     Query: {
       fields: {
         billableMetrics: {
+          keyArgs: false,
           merge: mergePaginatedCollection,
         },
         plans: {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -218,6 +218,8 @@ export enum ChargeModelEnum {
 
 export type ChargeOverridesInput = {
   groupProperties?: InputMaybe<Array<GroupPropertiesInput>>;
+  id: Scalars['ID']['input'];
+  invoiceDisplayName?: InputMaybe<Scalars['String']['input']>;
   minAmountCents?: InputMaybe<Scalars['BigInt']['input']>;
   properties?: InputMaybe<PropertiesInput>;
   taxCodes?: InputMaybe<Array<Scalars['String']['input']>>;


### PR DESCRIPTION
Cache needs a keyArgs definition, even if it's false