### PR TITLE
misc: add bigNumberShortenNotationFormater helper

### DIFF
--- a/src/core/formats/__tests__/intlFormatNumber.test.ts
+++ b/src/core/formats/__tests__/intlFormatNumber.test.ts
@@ -1,6 +1,11 @@
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { CurrencyEnum } from '~/generated/graphql'
 
-import { getCurrencySymbol, intlFormatNumber } from '../intlFormatNumber'
+import {
+  bigNumberShortenNotationFormater,
+  getCurrencySymbol,
+  intlFormatNumber,
+} from '../intlFormatNumber'
 
 describe('Currency tools', () => {
   describe('intlFormatNumber()', () => {
@@ -45,6 +50,70 @@ describe('Currency tools', () => {
       expect(getCurrencySymbol(CurrencyEnum.Gbp)).toBe('£')
       expect(getCurrencySymbol(CurrencyEnum.Eur)).toBe('€')
       expect(getCurrencySymbol(CurrencyEnum.Jpy)).toBe('¥')
+    })
+  })
+
+  describe('bigNumberShortenNotationFormater()', () => {
+    it.only('should return amount formatted according to currency', () => {
+      expect(bigNumberShortenNotationFormater(1)).toBe('$1')
+      expect(bigNumberShortenNotationFormater(1, { currency: CurrencyEnum.Eur })).toBe('€1')
+      expect(bigNumberShortenNotationFormater(1.1, { currency: CurrencyEnum.Eur })).toBe('€1.1')
+      expect(bigNumberShortenNotationFormater(1.01, { currency: CurrencyEnum.Eur })).toBe('€1')
+      expect(bigNumberShortenNotationFormater(10, { currency: CurrencyEnum.Eur })).toBe('€10')
+      expect(bigNumberShortenNotationFormater(100, { currency: CurrencyEnum.Eur })).toBe('€100')
+      expect(bigNumberShortenNotationFormater(100.01, { currency: CurrencyEnum.Eur })).toBe('€100')
+      expect(bigNumberShortenNotationFormater(1_000, { currency: CurrencyEnum.Eur })).toBe('€1k')
+      expect(bigNumberShortenNotationFormater(1_000.01, { currency: CurrencyEnum.Eur })).toBe('€1k')
+      expect(bigNumberShortenNotationFormater(1_010, { currency: CurrencyEnum.Eur })).toBe('€1k')
+      expect(bigNumberShortenNotationFormater(1_100, { currency: CurrencyEnum.Eur })).toBe('€1.1k')
+      expect(bigNumberShortenNotationFormater(1_111, { currency: CurrencyEnum.Eur })).toBe('€1.1k')
+      expect(bigNumberShortenNotationFormater(10_000, { currency: CurrencyEnum.Eur })).toBe('€10k')
+      expect(bigNumberShortenNotationFormater(100_000, { currency: CurrencyEnum.Eur })).toBe(
+        '€100k'
+      )
+      expect(bigNumberShortenNotationFormater(1_000_000, { currency: CurrencyEnum.Eur })).toBe(
+        '€1M'
+      )
+      expect(bigNumberShortenNotationFormater(10_000_000, { currency: CurrencyEnum.Eur })).toBe(
+        '€10M'
+      )
+      expect(bigNumberShortenNotationFormater(100_000_000, { currency: CurrencyEnum.Eur })).toBe(
+        '€100M'
+      )
+      expect(bigNumberShortenNotationFormater(1_000_000_000, { currency: CurrencyEnum.Eur })).toBe(
+        '€1B'
+      )
+      expect(bigNumberShortenNotationFormater(10_000_000_000, { currency: CurrencyEnum.Eur })).toBe(
+        '€10B'
+      )
+      expect(
+        bigNumberShortenNotationFormater(100_000_000_000, { currency: CurrencyEnum.Eur })
+      ).toBe('€100B')
+      expect(
+        bigNumberShortenNotationFormater(1_000_000_000_000, { currency: CurrencyEnum.Eur })
+      ).toBe('€1T')
+      expect(
+        bigNumberShortenNotationFormater(10_000_000_000_000, { currency: CurrencyEnum.Eur })
+      ).toBe('€10T')
+      expect(
+        bigNumberShortenNotationFormater(100_000_000_000_000, { currency: CurrencyEnum.Eur })
+      ).toBe('€100T')
+      expect(
+        bigNumberShortenNotationFormater(1_000_000_000_000_000, { currency: CurrencyEnum.Eur })
+      ).toBe('€1Q')
+      expect(
+        bigNumberShortenNotationFormater(
+          deserializeAmount(100_000_000_000_000_000, CurrencyEnum.Eur),
+          { currency: CurrencyEnum.Eur }
+        )
+      ).toBe('€1Q')
+      expect(
+        bigNumberShortenNotationFormater(10_000_000_000_000_000, { currency: CurrencyEnum.Eur })
+      ).toBe('€10Q')
+      expect(
+        bigNumberShortenNotationFormater(100_000_000_000_000_000, { currency: CurrencyEnum.Eur })
+      ).toBe('€100Q')
+      expect(bigNumberShortenNotationFormater(100_000_000_000_000_000)).toBe('$100Q')
     })
   })
 })

--- a/src/core/formats/intlFormatNumber.ts
+++ b/src/core/formats/intlFormatNumber.ts
@@ -11,16 +11,18 @@ enum AmountStyle {
   decimal = 'decimal',
 }
 
-export const intlFormatNumber: (
-  amount: number,
-  options?: {
-    currency?: CurrencyEnum
-    currencyDisplay?: keyof typeof CurrencyDisplay
-    style?: keyof typeof AmountStyle
-    minimumFractionDigits?: number
-    maximumFractionDigits?: number
-  }
-) => string = (amount, options) => {
+type FormatterOptions = {
+  currency?: CurrencyEnum
+  currencyDisplay?: keyof typeof CurrencyDisplay
+  style?: keyof typeof AmountStyle
+  minimumFractionDigits?: number
+  maximumFractionDigits?: number
+}
+
+export const intlFormatNumber: (amount: number, options?: FormatterOptions) => string = (
+  amount,
+  options
+) => {
   let formattedToUnit = amount
 
   const {
@@ -46,4 +48,47 @@ export const getCurrencySymbol = (currencyCode: CurrencyEnum) => {
       currencyDisplay: 'symbol',
     })
     .replace(/[\d\., ]/g, '')
+}
+
+// Current limitation: does not add the space between amount and currency symbol if the locale notation has one
+export const bigNumberShortenNotationFormater = (
+  amount: number,
+  options?: Omit<FormatterOptions, 'currencyDisplay'>
+) => {
+  const {
+    style = AmountStyle.currency,
+    currency = CurrencyEnum.Usd,
+    ...otherOptions
+  } = options || {}
+
+  if (amount < 1e3) {
+    return intlFormatNumber(amount, {
+      style,
+      currency,
+      currencyDisplay: CurrencyDisplay.symbol,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 1,
+      ...otherOptions,
+    })
+  }
+
+  // Precision is not important anymore
+  amount = Number(amount.toFixed(0))
+
+  const bigNumberLookup = [
+    { value: 1e15, symbol: 'Q' },
+    { value: 1e12, symbol: 'T' },
+    { value: 1e9, symbol: 'B' },
+    { value: 1e6, symbol: 'M' },
+    { value: 1e3, symbol: 'k' },
+  ]
+  const rx = /\.0+$|(\.[0-9]*[1-9])0+$/
+  const item = bigNumberLookup.find(function (localItem) {
+    return amount >= localItem.value
+  })
+  const formatedAmount = item
+    ? (amount / item.value).toFixed(1).replace(rx, '$1') + item.symbol
+    : '0'
+
+  return `${getCurrencySymbol(currency)}${formatedAmount}`
 }


### PR DESCRIPTION
Add new helper to format big numbers

Numbers bellow 1_000 are not formated and keep displaying their precision
Numbers above 1_000 use the k, M, B, ... notation

So 1.32 stays 1,32
And 1_000_000 becomes 1M