### PR TITLE
bug(billable-metric) fix condition when no real change are performed

### DIFF
--- a/src/core/utils/BMGroupUtils.ts
+++ b/src/core/utils/BMGroupUtils.ts
@@ -1,3 +1,5 @@
+import _isEqual from 'lodash/isEqual'
+
 export const GroupLevelEnum = {
   NoChange: 'NoChange',
   AddOrRemove: 'AddOrRemove',
@@ -79,8 +81,8 @@ export const determineGroupDiffLevel: (
   group2: groupType | string
 ) => determineGroupDiffLevelReturnType = (group1 = {}, group2 = {}) => {
   // Groups can be empty, replace them with empty object
-  if (group1 === '') group1 = '{}'
-  if (group2 === '') group2 = '{}'
+  if (!group1 || group1 === '') group1 = '{}'
+  if (!group2 || group2 === '') group2 = '{}'
 
   // Key stringify/parse to shallow copy the value
   const parsedGroup1 =
@@ -91,6 +93,10 @@ export const determineGroupDiffLevel: (
   // Check if one of the groups are both valid
   if (!isGroupValid(parsedGroup1) || !isGroupValid(parsedGroup2)) {
     return GroupLevelEnum.StructuralChange
+  }
+
+  if (_isEqual(parsedGroup1, parsedGroup2)) {
+    return GroupLevelEnum.NoChange
   }
 
   // Check if groups have the same dimension

--- a/src/core/utils/__tests__/BMGroupUtils.test.ts
+++ b/src/core/utils/__tests__/BMGroupUtils.test.ts
@@ -41,6 +41,14 @@ describe('BMGroupUtils', () => {
 
         expect(result).toEqual(GroupLevelEnum.NoChange)
       })
+
+      it('should return NoChange if groups are undefined and empty', () => {
+        const group1 = {}
+        const group2 = '{}'
+        const result = determineGroupDiffLevel(group1, group2)
+
+        expect(result).toEqual(GroupLevelEnum.NoChange)
+      })
     })
 
     describe("when groups don't have the same type", () => {


### PR DESCRIPTION
## Context

An issue occurred when editing a BM linked to a plan and/or subscription.

We do display a warning modal when the group is changed, but it was always displayed even tho you were changing only the BM name.

## Description

This PR adds a case handling empty object and empty object string being wrongly compared and returning a "structural change", leading to show the warning modal every time a BM was saved