### PR TITLE
bug(test) remove time-shifting TZ test

### DIFF
--- a/src/core/timezone/__tests__/config.test.ts
+++ b/src/core/timezone/__tests__/config.test.ts
@@ -3,10 +3,10 @@ import { TimeZonesConfig } from '../config'
 describe('Timezone fongis', () => {
   describe('TimeZonesConfig', () => {
     it('returns expected config values', () => {
-      expect(TimeZonesConfig['TZ_EUROPE_PARIS']).toStrictEqual({
-        name: 'Europe/Paris',
-        offset: '+2:00',
-        offsetInMinute: 120,
+      expect(TimeZonesConfig['TZ_ASIA_TOKYO']).toStrictEqual({
+        name: 'Asia/Tokyo',
+        offset: '+9:00',
+        offsetInMinute: 540,
       })
       expect(TimeZonesConfig['TZ_AMERICA_LOS_ANGELES']).toStrictEqual({
         name: 'America/Los_Angeles',


### PR DESCRIPTION
## Context

We have a test checking some timezone helper values.

But Paris timezone has summer and winter time, leading to this value changing every 6 months and the test to fail.

## Description

This PR changes the TZ test to one that does not have this summer/winter time switch