### PR TITLE
bug(remove-charge) don't show delete-charge warning dialog in duplicate

### DIFF
--- a/src/components/plans/ChargeAccordion.tsx
+++ b/src/components/plans/ChargeAccordion.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from '~/components/designSystem'
 import { AmountInput, ButtonSelector, ComboBox, Switch } from '~/components/form'
+import { useDuplicatePlanVar } from '~/core/apolloClient'
 import {
   FORM_TYPE_ENUM,
   MUI_INPUT_BASE_ROOT_CLASSNAME,
@@ -171,6 +172,7 @@ export const ChargeAccordion = memo(
   }: ChargeAccordionProps) => {
     const { translate } = useInternationalization()
     const { isPremium } = useCurrentUser()
+    const { type: actionType } = useDuplicatePlanVar()
     const chargeErrors = formikProps?.errors?.charges
 
     const { localCharge, initialLocalCharge, hasDefaultPropertiesErrors, hasErrorInCharges } =
@@ -440,7 +442,7 @@ export const ChargeAccordion = memo(
                         formikProps.setFieldValue('charges', charges)
                       }
 
-                      if (isUsedInSubscription) {
+                      if (actionType !== 'duplicate' && isUsedInSubscription) {
                         removeChargeWarningDialogRef?.current?.openDialog(index)
                       } else {
                         deleteCharge()


### PR DESCRIPTION
A warning dialog is shown when trying to delete a charge on a plan that is attached to a subscription.

This dialog should not be shown if the form is currently about duplicating a plan 