### PR TITLE
bug(plan) fix redirection when closing a plan duplication form

### DIFF
--- a/cypress/e2e/10-resources/t50-edit-plan.cy.ts
+++ b/cypress/e2e/10-resources/t50-edit-plan.cy.ts
@@ -46,9 +46,8 @@ describe('Edit plan', () => {
     cy.get(`[data-test="add-subscription"]`).click({ force: true })
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('input[name="planId"]').click({ force: true })
-    cy.get('[data-option-index="0"]').click({ force: true })
+    cy.get('[data-option-index="0"]').click()
     cy.get('[data-test="submit"]').click({ force: true })
-    cy.get('[data-test="submit"]').should('not.exist')
     cy.contains(customerName).should('exist')
   })
 

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -12,6 +12,7 @@ import { FixedFeeSection } from '~/components/plans/FixedFeeSection'
 import { PlanCodeSnippet } from '~/components/plans/PlanCodeSnippet'
 import { PlanSettingsSection } from '~/components/plans/PlanSettingsSection'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
+import { useDuplicatePlanVar } from '~/core/apolloClient'
 import { FORM_TYPE_ENUM } from '~/core/constants/form'
 import { PLAN_DETAILS_ROUTE, PLANS_ROUTE } from '~/core/router'
 import {
@@ -103,6 +104,7 @@ gql`
 const CreatePlan = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
+  const { type: actionType } = useDuplicatePlanVar()
   const { errorCode, formikProps, isEdition, loading, plan, type } = usePlanForm({})
   const warningDialogRef = useRef<WarningDialogRef>(null)
   const editInvoiceDisplayNameRef = useRef<EditInvoiceDisplayNameRef>(null)
@@ -110,7 +112,7 @@ const CreatePlan = () => {
   const canBeEdited = !plan?.subscriptionsCount
 
   const planCloseRedirection = () => {
-    if (plan?.id) {
+    if (plan?.id && actionType !== FORM_TYPE_ENUM.duplicate) {
       navigate(
         generatePath(PLAN_DETAILS_ROUTE, {
           planId: plan.id,


### PR DESCRIPTION
If the user closes the form during a plan duplication, we should redirect it to the plan list and not to the duplicated plan details