### PR TITLE
bug(subscription) fix plan list display if long name and code

### DIFF
--- a/src/pages/CreateSubscription.tsx
+++ b/src/pages/CreateSubscription.tsx
@@ -26,6 +26,7 @@ import {
   DatePickerField,
   TextInputField,
 } from '~/components/form'
+import { Item } from '~/components/form/ComboBox/ComboBoxItem'
 import {
   EditInvoiceDisplayName,
   EditInvoiceDisplayNameRef,
@@ -266,9 +267,15 @@ const CreateSubscription = () => {
         {
           label: `${name} - (${code})`,
           labelNode: (
-            <PlanItem>
-              {name} <Typography color="textPrimary">({code})</Typography>
-            </PlanItem>
+            <Item>
+              <Typography color="grey700" noWrap>
+                {name}
+              </Typography>
+              &nbsp;
+              <Typography color="textPrimary" noWrap>
+                ({code})
+              </Typography>
+            </Item>
           ),
           value: id,
           disabled:
@@ -857,11 +864,6 @@ const ResponsiveButtonWrapper = styled.div`
   height: fit-content;
   background-color: ${theme.palette.common.white};
   padding: ${theme.spacing(3)} ${theme.spacing(12)};
-`
-
-const PlanItem = styled.span`
-  display: flex;
-  white-space: pre;
 `
 
 const FreemiumCard = styled(Card)`


### PR DESCRIPTION
## Context

In the subscription's plan list dropdown, we could have a case where the plan name was not shown.

This was due to element wrong wrapping if all lines overlap and break.

## Description

We decided to go with a double text ellipsis in this case, as the name is important but not unique, and the code might be needed to choose


|BEFORE|AFTER|
|-|-|
|![Screenshot 2023-11-06 at 15 02 56](https://github.com/getlago/lago-front/assets/5517077/0e3c9222-cb31-4d64-8ef7-1d82e5055f4d)|<img width="1510" alt="image" src="https://github.com/getlago/lago-front/assets/5517077/7411c0bc-fafa-4bc7-94a7-9f6cb94fd078">|