### PR TITLE
bug(combobox) fix option display for long values

### DIFF
--- a/cypress/e2e/10-resources/t50-edit-plan.cy.ts
+++ b/cypress/e2e/10-resources/t50-edit-plan.cy.ts
@@ -73,7 +73,7 @@ describe('Edit plan', () => {
     cy.get('[data-test="open-charge"]').eq(1).click({ force: true })
 
     cy.get('[data-test="add-metered-charge"]').last().click({ force: true })
-    cy.get('[data-option-index="1"]').click({ force: true })
+    cy.get('[data-option-index="1"]').click()
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('[data-test="remove-charge"]').should('exist').and('not.be.disabled')
     cy.get('input[name="chargeModel"]').last().should('have.value', 'Standard pricing')

--- a/src/components/coupons/AddBillableMetricToCouponDialog.tsx
+++ b/src/components/coupons/AddBillableMetricToCouponDialog.tsx
@@ -12,6 +12,8 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { theme } from '~/styles'
 
+import { Item } from '../form/ComboBox/ComboBoxItem'
+
 gql`
   fragment BillableMetricsForCoupons on BillableMetric {
     id
@@ -56,9 +58,15 @@ export const AddBillableMetricToCouponDialog = forwardRef<
       return {
         label: `${name} - (${code})`,
         labelNode: (
-          <BillableMetricItem>
-            {name} <Typography color="textPrimary">({code})</Typography>
-          </BillableMetricItem>
+          <Item>
+            <Typography color="grey700" noWrap>
+              {name}
+            </Typography>
+            &nbsp;
+            <Typography color="textPrimary" noWrap>
+              ({code})
+            </Typography>
+          </Item>
         ),
         value: id,
         disabled: attachedBillableMetricsIds?.includes(id),
@@ -130,10 +138,6 @@ export const AddBillableMetricToCouponDialog = forwardRef<
 
 AddBillableMetricToCouponDialog.displayName = 'AddBillableMetricToCouponDialog'
 
-const BillableMetricItem = styled.span`
-  display: flex;
-  white-space: pre;
-`
 const StyledComboBox = styled(ComboBox)`
   margin-bottom: ${theme.spacing(8)};
 `

--- a/src/components/coupons/AddPlanToCouponDialog.tsx
+++ b/src/components/coupons/AddPlanToCouponDialog.tsx
@@ -12,6 +12,8 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { theme } from '~/styles'
 
+import { Item } from '../form/ComboBox/ComboBoxItem'
+
 gql`
   fragment PlansForCoupons on Plan {
     id
@@ -53,9 +55,15 @@ export const AddPlanToCouponDialog = forwardRef<DialogRef, AddPlanToCouponDialog
         return {
           label: `${name} - (${code})`,
           labelNode: (
-            <PlanItem>
-              {name} <Typography color="textPrimary">({code})</Typography>
-            </PlanItem>
+            <Item>
+              <Typography color="grey700" noWrap>
+                {name}
+              </Typography>
+              &nbsp;
+              <Typography color="textPrimary" noWrap>
+                ({code})
+              </Typography>
+            </Item>
           ),
           value: id,
           disabled: attachedPlansIds?.includes(id),
@@ -127,10 +135,6 @@ export const AddPlanToCouponDialog = forwardRef<DialogRef, AddPlanToCouponDialog
 
 AddPlanToCouponDialog.displayName = 'AddPlanToCouponDialog'
 
-const PlanItem = styled.span`
-  display: flex;
-  white-space: pre;
-`
 const StyledComboBox = styled(ComboBox)`
   margin-bottom: ${theme.spacing(8)};
 `

--- a/src/components/plans/ChargesSection.tsx
+++ b/src/components/plans/ChargesSection.tsx
@@ -144,7 +144,13 @@ export const ChargesSection = memo(
           label: `${name} (${code})`,
           labelNode: (
             <Item>
-              {name}&nbsp;<Typography color="textPrimary">({code})</Typography>
+              <Typography color="grey700" noWrap>
+                {name}
+              </Typography>
+              &nbsp;
+              <Typography color="textPrimary" noWrap>
+                ({code})
+              </Typography>
             </Item>
           ),
           value: id,
@@ -165,7 +171,11 @@ export const ChargesSection = memo(
           label: `${name} (${code})`,
           labelNode: (
             <Item>
-              {name}&nbsp;<Typography color="textPrimary">({code})</Typography>
+              <Typography color="grey700" noWrap>
+                {name}
+              </Typography>
+              &nbsp;
+              <Typography color="textPrimary">({code})</Typography>
             </Item>
           ),
           value: id,

--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -235,7 +235,10 @@ const CreateInvoice = () => {
         label: name,
         labelNode: (
           <Item>
-            {name} -&nbsp;
+            <Typography color="grey700" noWrap>
+              {name}
+            </Typography>
+            &nbsp;-&nbsp;
             <Typography color="textPrimary">
               (
               {intlFormatNumber(deserializeAmount(amountCents, amountCurrency) || 0, {


### PR DESCRIPTION
Same as https://github.com/getlago/lago-front/pull/1295

Fixing some combo box options displays when data is long enough to overlap the container and be wrongly displayed.