### PR TITLE
misc(plan) allow to edit tax on created plan

### DIFF
--- a/cypress/e2e/10-resources/t50-edit-plan.cy.ts
+++ b/cypress/e2e/10-resources/t50-edit-plan.cy.ts
@@ -58,7 +58,6 @@ describe('Edit plan', () => {
     })
     cy.get('[data-test="tab-internal-button-link-update-plan"]').click({ force: true })
     cy.get('input[name="name"]').should('not.be.disabled')
-    cy.get('input[name="code"]').should('be.disabled')
     cy.get('textarea[name="description"]', { timeout: 10000 }).should('not.be.disabled')
     cy.get(`[data-test="fixed-fee-section-accordion"]`).within(() => {
       cy.get(`.MuiAccordionSummary-root`).click({ force: true })

--- a/src/components/plans/ChargeAccordion.tsx
+++ b/src/components/plans/ChargeAccordion.tsx
@@ -948,14 +948,11 @@ export const ChargeAccordion = memo(
                     <Chip
                       key={localTaxId}
                       label={`${name} (${rate}%)`}
-                      disabled={disabled}
                       variant="secondary"
                       size="medium"
                       closeIcon="trash"
                       icon="percentage"
-                      onCloseLabel={
-                        disabled ? undefined : translate('text_63aa085d28b8510cd46443ff')
-                      }
+                      onCloseLabel={translate('text_63aa085d28b8510cd46443ff')}
                       onClose={() => {
                         const newTaxedArray =
                           localCharge.taxes?.filter((tax) => tax.id !== localTaxId) || []
@@ -1033,7 +1030,6 @@ export const ChargeAccordion = memo(
                 <Button
                   startIcon="plus"
                   variant="quaternary"
-                  disabled={subscriptionFormType === FORM_TYPE_ENUM.edition || disabled}
                   onClick={() => {
                     setShouldDisplayTaxesInput(true)
 

--- a/src/components/plans/ChargesSection.tsx
+++ b/src/components/plans/ChargesSection.tsx
@@ -576,6 +576,7 @@ export const ChargesSection = memo(
       oldProps.isInSubscriptionForm === newProps.isInSubscriptionForm &&
       oldProps.isEdition === newProps.isEdition &&
       oldProps.subscriptionFormType === newProps.subscriptionFormType &&
+      oldProps.formikProps.values.taxes === newProps.formikProps.values.taxes &&
       oldProps.formikProps.values.interval === newProps.formikProps.values.interval &&
       oldProps.formikProps.values.billChargesMonthly ===
         newProps.formikProps.values.billChargesMonthly &&

--- a/src/components/plans/PlanSettingsSection.tsx
+++ b/src/components/plans/PlanSettingsSection.tsx
@@ -233,9 +233,6 @@ export const PlanSettingsSection = memo(
                 <Chip
                   key={id}
                   label={`${name} (${rate}%)`}
-                  disabled={
-                    subscriptionFormType === FORM_TYPE_ENUM.edition || (isEdition && !canBeEdited)
-                  }
                   variant="secondary"
                   size="medium"
                   closeIcon="trash"
@@ -267,9 +264,6 @@ export const PlanSettingsSection = memo(
               <ComboBox
                 className={SEARCH_TAX_INPUT_FOR_PLAN_CLASSNAME}
                 data={taxesDataForCombobox}
-                disabled={
-                  subscriptionFormType === FORM_TYPE_ENUM.edition || (isEdition && !canBeEdited)
-                }
                 searchQuery={getTaxes}
                 loading={taxesLoading}
                 placeholder={translate('text_64be910fba8ef9208686a8e7')}
@@ -287,9 +281,6 @@ export const PlanSettingsSection = memo(
                 <Button
                   icon="trash"
                   variant="quaternary"
-                  disabled={
-                    subscriptionFormType === FORM_TYPE_ENUM.edition || (isEdition && !canBeEdited)
-                  }
                   onClick={() => {
                     setShouldDisplayTaxesInput(false)
                   }}
@@ -301,9 +292,6 @@ export const PlanSettingsSection = memo(
           <Button
             startIcon="plus"
             variant="quaternary"
-            disabled={
-              subscriptionFormType === FORM_TYPE_ENUM.edition || (isEdition && !canBeEdited)
-            }
             onClick={() => {
               setShouldDisplayTaxesInput(true)
               setTimeout(() => {

--- a/src/components/plans/details/PlanDetailsChargesSectionAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsChargesSectionAccordion.tsx
@@ -131,7 +131,7 @@ const PlanDetailsChargesSectionAccordion = ({
                     <div key={`plan-details-charges-section-accordion-tax-${i}`}>
                       {tax.name} (
                       {intlFormatNumber(Number(tax.rate) / 100 || 0, {
-                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
                         style: 'percent',
                       })}
                       )

--- a/src/components/plans/details/PlanDetailsFixedFeeAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsFixedFeeAccordion.tsx
@@ -52,7 +52,7 @@ const PlanDetailsFixedFeeAccordion = ({ plan }: { plan?: EditPlanFragment | null
                       <Typography variant="body" color="grey700">
                         {tax.name} (
                         {intlFormatNumber(Number(tax.rate) / 100 || 0, {
-                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2,
                           style: 'percent',
                         })}
                         )

--- a/src/hooks/plans/usePlanForm.tsx
+++ b/src/hooks/plans/usePlanForm.tsx
@@ -86,7 +86,11 @@ export const usePlanForm: ({
     skip: !id && !parentId && !planIdToFetch,
   })
   const isDuplicate = actionType === 'duplicate' && !!parentId
-  const type = !!id ? 'edition' : isDuplicate ? 'duplicate' : 'creation'
+  const type = !!id
+    ? FORM_TYPE_ENUM.edition
+    : isDuplicate
+    ? FORM_TYPE_ENUM.duplicate
+    : FORM_TYPE_ENUM.creation
 
   const isEdition = type === FORM_TYPE_ENUM.edition
   const plan = data?.plan


### PR DESCRIPTION
We decided to allow the tax edition on a plan and it's charges.

No matted if the plan is already attached to a subscription or not.