### PR TITLE
bug(customer-infos) better display for multiple emails

### DIFF
--- a/src/components/customers/CustomerMainInfos.tsx
+++ b/src/components/customers/CustomerMainInfos.tsx
@@ -163,7 +163,11 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
       {email && (
         <div>
           <Typography variant="caption">{translate('text_626c0c301a16a600ea061479')}</Typography>
-          <Typography color="textSecondary">{email}</Typography>
+          {email.split(',').map((mail) => (
+            <Typography key={`customer-email-${mail}`} color="textSecondary" noWrap>
+              {mail}
+            </Typography>
+          ))}
         </div>
       )}
       {url && (


### PR DESCRIPTION
We can apparently chain them to have multiple mail sent. In such case, let's display each on a different line 