### PR TITLE
bug(textarea) fix multiline input behaviour

### DIFF
--- a/src/components/plans/PlanSettingsSection.tsx
+++ b/src/components/plans/PlanSettingsSection.tsx
@@ -359,12 +359,6 @@ const InlineTaxesWrapper = styled.div`
 const TextArea = styled(TextInputField)`
   flex: 1;
   margin-right: ${theme.spacing(3)};
-
-  textarea {
-    min-height: 38px;
-    resize: vertical;
-    white-space: pre-wrap;
-  }
 `
 
 const CloseDescriptionTooltip = styled(Tooltip)`

--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -244,11 +244,11 @@ const CreateAddOn = () => {
                   {shouldDisplayDescription ? (
                     <InlineDescription>
                       <TextArea
+                        multiline
                         name="description"
                         label={translate('text_629728388c4d2300e2d380f1')}
                         placeholder={translate('text_629728388c4d2300e2d38103')}
                         rows="3"
-                        multiline
                         formikProps={formikProps}
                       />
                       <CloseDescriptionTooltip
@@ -437,12 +437,6 @@ const SectionTitle = styled(Typography)`
 const TextArea = styled(TextInputField)`
   flex: 1;
   margin-right: ${theme.spacing(3)};
-
-  textarea {
-    min-height: 38px;
-    resize: vertical;
-    white-space: pre-wrap;
-  }
 `
 
 const CloseDescriptionTooltip = styled(Tooltip)`

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -710,12 +710,6 @@ const InlineDescription = styled.div`
 const TextArea = styled(TextInputField)`
   flex: 1;
   margin-right: ${theme.spacing(3)};
-
-  textarea {
-    min-height: 38px;
-    resize: vertical;
-    white-space: pre-wrap;
-  }
 `
 
 const CloseDescriptionTooltip = styled(Tooltip)`

--- a/src/pages/CreateTax.tsx
+++ b/src/pages/CreateTax.tsx
@@ -279,12 +279,6 @@ const InlineDescription = styled.div`
 const TextArea = styled(TextInputField)`
   flex: 1;
   margin-right: ${theme.spacing(3)};
-
-  textarea {
-    min-height: 38px;
-    resize: vertical;
-    white-space: pre-wrap;
-  }
 `
 
 const CloseDescriptionTooltip = styled(Tooltip)`

--- a/src/styles/muiTheme.ts
+++ b/src/styles/muiTheme.ts
@@ -161,6 +161,9 @@ export const theme = createTheme({
           },
           textarea: {
             padding: '5px 11px',
+            'min-height': '38px',
+            resize: 'vertical',
+            'white-space': 'pre-wrap',
           },
         },
         notchedOutline: {


### PR DESCRIPTION
Unify all textarea style over the app.

By default, text was staying on one line and overlapped the container.

It now go back to line at EOL