### PR TITLE
misc(Dialog): update CTA style to allow full width container

### DIFF
--- a/src/components/designSystem/Dialog.tsx
+++ b/src/components/designSystem/Dialog.tsx
@@ -128,8 +128,8 @@ const Description = styled(Typography)`
 
 const StyledButtonGroup = styled(ButtonGroup)`
   && {
-    margin-left: auto;
     align-items: initial;
+    justify-content: flex-end;
 
     ${theme.breakpoints.down('md')} {
       margin-left: 0;


### PR DESCRIPTION
I need this for an ongoing dev.

Today, the button container is pushed to the right with a margin-left auto. 

That mean the button container cannot really be full width.

I need this to be possible as a button could be introduced to the left side of the actions to add a third action.

Having is placed using justify-content flex-end makes it easier to manipulate on such custom placements, and does not break the current implementation of modals 