### PR TITLE
bug(analytics) fix condition that prevents unauthorised call

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -166,23 +166,23 @@ const Analytics = () => {
       <ContentWrapper>
         <Gross className="analytics-graph" currency={selectedCurrency} period={periodScope} />
         <Mrr
-          demoMode={!isPremium && !!currentUser}
+          demoMode={!isPremium || !currentUser}
           className="analytics-graph"
-          blur={!isPremium && !!currentUser}
+          blur={!isPremium || !currentUser}
           currency={selectedCurrency}
           period={periodScope}
         />
         <Usage
-          demoMode={!isPremium && !!currentUser}
+          demoMode={!isPremium || !currentUser}
           className="analytics-graph"
-          blur={!isPremium && !!currentUser}
+          blur={!isPremium || !currentUser}
           currency={selectedCurrency}
           period={periodScope}
         />
         <Invoices
-          demoMode={!isPremium && !!currentUser}
+          demoMode={!isPremium || !currentUser}
           className="analytics-graph"
-          blur={!isPremium && !!currentUser}
+          blur={!isPremium || !currentUser}
           currency={selectedCurrency}
           period={periodScope}
         />


### PR DESCRIPTION
## Context

Some OSS freemium users experience a logout right after they login

It's due to a non expected API call to be performed, that returns in such situation an `unauthorized` response, loggin out the user

## Description

This PR updated the condition that lead to perform this call or not 