### PR TITLE
Prevent Credit Note details from always displaying hardcoded USD

### DIFF
--- a/src/pages/CreditNoteDetails.tsx
+++ b/src/pages/CreditNoteDetails.tsx
@@ -85,6 +85,7 @@ gql`
       }
       items {
         amountCents
+        amountCurrency
         fee {
           id
           amountCents


### PR DESCRIPTION
A hardcoded USD currency is shown because accountCurrency is never fetched using GraphQL, this PR fixes this bug.

## Context

Even if my credit note is in EUR, USD is shown for the item

## Description

The issue is that the `amountCurrency` is used in the code to render the item, however it isn't fetched using GraphQL, defaulting to USD.
See screenshot.

![Screenshot 2023-12-28 at 18 16 44](https://github.com/getlago/lago-front/assets/1686739/a6ba5e27-17e9-4498-aeee-2f5f7deafee5)

