### PR TITLE
bug(invoices) prevent faking values to wrong number by default

### DIFF
--- a/src/components/invoices/details/InvoiceDetailsTableBodyLine.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableBodyLine.tsx
@@ -162,7 +162,7 @@ export const InvoiceDetailsTableBodyLine = memo(
             <>
               <td>
                 <Typography variant="body" color="grey700">
-                  {fee?.units || 1}
+                  {fee?.units || 0}
                 </Typography>
               </td>
               {canHaveUnitPrice && (

--- a/src/components/invoices/details/InvoiceDetailsTableBodyLinePackage.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableBodyLinePackage.tsx
@@ -45,13 +45,13 @@ export const InvoiceDetailsTableBodyLinePackage = memo(
             <td>
               <Typography variant="body" color="grey600">
                 {translate('text_659e67cd63512ef53284303c', {
-                  freeUnits: Number(amountDetails?.freeUnits || 1),
+                  freeUnits: Number(amountDetails?.freeUnits || 0),
                 })}
               </Typography>
             </td>
             <td>
               <Typography variant="body" color="grey600">
-                {Number(amountDetails?.freeUnits || 1)}
+                {Number(amountDetails?.freeUnits || 0)}
               </Typography>
             </td>
             <td>
@@ -102,7 +102,7 @@ export const InvoiceDetailsTableBodyLinePackage = memo(
           </td>
           <td>
             <Typography variant="body" color="grey600">
-              {Number(amountDetails?.paidUnits || 1)}
+              {Number(amountDetails?.paidUnits || 0)}
             </Typography>
           </td>
           <td>
@@ -115,7 +115,7 @@ export const InvoiceDetailsTableBodyLinePackage = memo(
                     currency,
                   },
                 ),
-                perPackageSize: Number(amountDetails?.perPackageSize || 1),
+                perPackageSize: Number(amountDetails?.perPackageSize || 0),
               })}
             </Typography>
           </td>

--- a/src/components/invoices/details/InvoiceDetailsTableBodyLinePercentage.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableBodyLinePercentage.tsx
@@ -70,7 +70,7 @@ export const InvoiceDetailsTableBodyLinePercentage = memo(
             </td>
             <td>
               <Typography variant="body" color="grey600">
-                {Number(freeUnits || 1)}
+                {Number(freeUnits || 0)}
               </Typography>
             </td>
             <td>
@@ -121,7 +121,7 @@ export const InvoiceDetailsTableBodyLinePercentage = memo(
           </td>
           <td>
             <Typography variant="body" color="grey600">
-              {Number(paidUnits || 1)}
+              {Number(paidUnits || 0)}
             </Typography>
           </td>
           <td>
@@ -172,7 +172,7 @@ export const InvoiceDetailsTableBodyLinePercentage = memo(
             </td>
             <td>
               <Typography variant="body" color="grey600">
-                {paidEvents || 1}
+                {paidEvents || 0}
               </Typography>
             </td>
             <td>

--- a/src/components/invoices/details/InvoiceDetailsTableBodyLineVolume.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableBodyLineVolume.tsx
@@ -45,7 +45,7 @@ export const InvoiceDetailsTableBodyLineVolume = memo(
           </td>
           <td>
             <Typography variant="body" color="grey600">
-              {Number(fee?.units || 1)}
+              {Number(fee?.units || 0)}
             </Typography>
           </td>
           <td>


### PR DESCRIPTION
## Context

In the past, we were optimistic about the values displayed in the invoices' detail page.

Bug since the recent edit-draft-invoice feature, we can have fee lines with 0 units displayed in invoice details.

## Description

This PR make sure 1 is not the default value anymore, and let 0 be displayed if needed instead.

We could simply remove the `||` condition but as BE is supposed to always populate those values. But I keep the `OR 0` approach jut in case, to prevent displaying NaN