### PR TITLE
misc(invoice-details) improve hidden fee animation

### DIFF
--- a/src/components/invoices/details/InvoiceDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTable.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
-import clsns from 'classnames'
-import React, { memo, RefObject, useState } from 'react'
+import { Collapse } from '@mui/material'
+import { memo, RefObject, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Button } from '~/components/designSystem'
@@ -355,10 +355,9 @@ export const InvoiceDetailsTable = memo(
                                     )}
                                   </Button>
                                 </div>
-                                <div
-                                  className={clsns('collapsed-table-wrapper', {
-                                    open: !!feeZeroIsOpenMatrice[subscriptionIndex][0],
-                                  })}
+                                <Collapse
+                                  in={!!feeZeroIsOpenMatrice[subscriptionIndex][0]}
+                                  easing="cubic-bezier(0.4, 0, 0.2, 1)"
                                 >
                                   <table className="inner-table">
                                     {/* This header is hidden in css. Only present to give the body the correct shape */}
@@ -384,7 +383,7 @@ export const InvoiceDetailsTable = memo(
                                       })}
                                     </tbody>
                                   </table>
-                                </div>
+                                </Collapse>
                               </td>
                             </tr>
                           </>
@@ -465,10 +464,9 @@ export const InvoiceDetailsTable = memo(
                                     )}
                                   </Button>
                                 </div>
-                                <div
-                                  className={clsns('collapsed-table-wrapper', {
-                                    open: !!feeZeroIsOpenMatrice[subscriptionIndex][1],
-                                  })}
+                                <Collapse
+                                  in={!!feeZeroIsOpenMatrice[subscriptionIndex][1]}
+                                  easing="cubic-bezier(0.4, 0, 0.2, 1)"
                                 >
                                   <table className="inner-table">
                                     {/* This header is hidden in css. Only present to give the body the correct shape */}
@@ -494,7 +492,7 @@ export const InvoiceDetailsTable = memo(
                                       })}
                                     </tbody>
                                   </table>
-                                </div>
+                                </Collapse>
                               </td>
                             </tr>
                           </>
@@ -696,29 +694,18 @@ export const InvoiceWrapper = styled.section<{
         padding: 0 !important;
       }
 
+      .inner-table {
+        thead {
+          /* hide header */
+          visibility: collapse;
+        }
+      }
+
       .collapse-header {
         display: block;
         width: 100%;
         padding: ${theme.spacing(3)} 0;
         box-shadow: ${theme.shadows[7]};
-      }
-
-      .collapsed-table-wrapper {
-        overflow: hidden;
-        transition: max-height 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-        max-height: 0px;
-
-        &.open {
-          /* Allows to animate height, keep it big */
-          max-height: 9999999999999999999999999999px;
-        }
-
-        .inner-table {
-          thead {
-            /* hide header */
-            visibility: collapse;
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
The MUI components got the animation better

### Issue with the current state

The implemented animation does have a fixed max height, making the animation weird when few elements are displayed.

On close, the container assume the height is huge, leading to a little delay before the elements hides

### Why using this MUI collapse

This MUI components has build in the JS calculation of the hidden elements's height, leading to a better case by case animation.

It does have max-height 0 when hidden, during the animation, it does set the inner elements' height as the max height values, removing any delay. And once open the max-height is set to auto.

I does the other way around when closing, leading to have an animation with no glitch.

Way better then implementing that by hand.