### PR TITLE
misc(invoice-details) show subscription fee group first

### DIFF
--- a/src/components/invoices/details/InvoiceFeeAdvanceDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceFeeAdvanceDetailsTable.tsx
@@ -1,0 +1,159 @@
+import { gql } from '@apollo/client'
+import { Collapse } from '@mui/material'
+import { memo, RefObject, useState } from 'react'
+
+import { Button } from '~/components/designSystem'
+import { TSubscriptionDataForDisplay } from '~/core/formats/formatInvoiceItemsMap'
+import { formatDateToTZ } from '~/core/timezone'
+import {
+  CurrencyEnum,
+  Customer,
+  FeeForDeleteAdjustmentFeeDialogFragmentDoc,
+  FeeForEditfeeDrawerFragmentDoc,
+  FeeForInvoiceDetailsTableBodyLineFragmentDoc,
+} from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+import { DeleteAdjustedFeeDialogRef } from './DeleteAdjustedFeeDialog'
+import { EditFeeDrawerRef } from './EditFeeDrawer'
+import { InvoiceDetailsTableBodyLine } from './InvoiceDetailsTableBodyLine'
+import { InvoiceDetailsTableHeader } from './InvoiceDetailsTableHeader'
+import { InvoiceDetailsTablePeriodLine } from './InvoiceDetailsTablePeriodLine'
+
+gql`
+  fragment FeeForInvoiceFeeAdvanceDetailsTable on Fee {
+    id
+    ...FeeForInvoiceDetailsTableBodyLine
+    ...FeeForDeleteAdjustmentFeeDialog
+    ...FeeForEditfeeDrawer
+  }
+
+  ${FeeForInvoiceDetailsTableBodyLineFragmentDoc}
+  ${FeeForDeleteAdjustmentFeeDialogFragmentDoc}
+  ${FeeForEditfeeDrawerFragmentDoc}
+`
+
+interface InvoiceFeeAdvanceDetailsTableProps {
+  subscription: TSubscriptionDataForDisplay['subscription']
+  customer: Customer
+  canHaveUnitPrice: boolean
+  isDraftInvoice: boolean
+  currency: CurrencyEnum
+  editFeeDrawerRef: RefObject<EditFeeDrawerRef>
+  deleteAdjustedFeeDialogRef: RefObject<DeleteAdjustedFeeDialogRef>
+}
+
+export const InvoiceFeeAdvanceDetailsTable = memo(
+  ({
+    subscription,
+    customer,
+    canHaveUnitPrice,
+    isDraftInvoice,
+    currency,
+    editFeeDrawerRef,
+    deleteAdjustedFeeDialogRef,
+  }: InvoiceFeeAdvanceDetailsTableProps) => {
+    const { translate } = useInternationalization()
+    const [areZeroFeesVisible, setAreZeroFeesVisible] = useState<boolean>(false)
+
+    return (
+      <>
+        {(subscription.feesInAdvance.length > 0 || subscription.feesInAdvanceZero.length > 0) && (
+          <>
+            <InvoiceDetailsTablePeriodLine
+              canHaveUnitPrice={canHaveUnitPrice}
+              isDraftInvoice={isDraftInvoice}
+              period={translate('text_6499a4e4db5730004703f36b', {
+                from: formatDateToTZ(
+                  subscription?.metadata?.differentBoundariesForSubscriptionAndCharges
+                    ? subscription?.metadata.fromDatetime
+                    : subscription?.metadata?.inAdvanceChargesFromDatetime ||
+                        subscription?.metadata?.chargesFromDatetime,
+                  customer?.applicableTimezone,
+                  'LLL. dd, yyyy',
+                ),
+                to: formatDateToTZ(
+                  subscription?.metadata?.differentBoundariesForSubscriptionAndCharges
+                    ? subscription?.metadata.toDatetime
+                    : subscription?.metadata?.inAdvanceChargesToDatetime ||
+                        subscription?.metadata?.chargesToDatetime,
+                  customer?.applicableTimezone,
+                  'LLL. dd, yyyy',
+                ),
+              })}
+            />
+            {subscription.feesInAdvance.map((feeInAdvance) => {
+              return (
+                <InvoiceDetailsTableBodyLine
+                  key={`fee-in-advance-${feeInAdvance.id}`}
+                  canHaveUnitPrice={canHaveUnitPrice}
+                  currency={currency}
+                  displayName={feeInAdvance?.metadata?.displayName}
+                  editFeeDrawerRef={editFeeDrawerRef}
+                  deleteAdjustedFeeDialogRef={deleteAdjustedFeeDialogRef}
+                  fee={feeInAdvance}
+                  isDraftInvoice={isDraftInvoice}
+                />
+              )
+            })}
+            {/* Should be only displayed for draft invoices */}
+            {subscription.feesInAdvanceZero.length > 0 && (
+              <>
+                <tr className="collapse">
+                  <td colSpan={6}>
+                    <div className="collapse-header">
+                      <Button
+                        variant="quaternary"
+                        size="small"
+                        startIcon={areZeroFeesVisible ? 'eye-hidden' : 'eye'}
+                        onClick={() => setAreZeroFeesVisible(!areZeroFeesVisible)}
+                      >
+                        {translate(
+                          areZeroFeesVisible
+                            ? 'text_65b116a266d90732cac8b3bc'
+                            : 'text_65b116a266d90732cac8b39b',
+                          {
+                            count: subscription.feesInAdvanceZero.length,
+                          },
+                          subscription.feesInAdvanceZero.length,
+                        )}
+                      </Button>
+                    </div>
+                    <Collapse in={areZeroFeesVisible} easing="cubic-bezier(0.4, 0, 0.2, 1)">
+                      <table className="inner-table">
+                        {/* This header is hidden in css. Only present to give the body the correct shape */}
+                        <InvoiceDetailsTableHeader
+                          canHaveUnitPrice={canHaveUnitPrice}
+                          displayName={subscription?.metadata?.subscriptionDisplayName}
+                          isDraftInvoice={isDraftInvoice}
+                        />
+                        <tbody>
+                          {subscription.feesInAdvanceZero.map((feeInAdvanceZero) => {
+                            return (
+                              <InvoiceDetailsTableBodyLine
+                                key={`fee-in-advance-zero-${feeInAdvanceZero.id}`}
+                                canHaveUnitPrice={canHaveUnitPrice}
+                                currency={currency}
+                                displayName={feeInAdvanceZero?.metadata?.displayName}
+                                editFeeDrawerRef={editFeeDrawerRef}
+                                deleteAdjustedFeeDialogRef={deleteAdjustedFeeDialogRef}
+                                fee={feeInAdvanceZero}
+                                isDraftInvoice={isDraftInvoice}
+                              />
+                            )
+                          })}
+                        </tbody>
+                      </table>
+                    </Collapse>
+                  </td>
+                </tr>
+              </>
+            )}
+          </>
+        )}
+      </>
+    )
+  },
+)
+
+InvoiceFeeAdvanceDetailsTable.displayName = 'InvoiceFeeAdvanceDetailsTable'

--- a/src/components/invoices/details/InvoiceFeeArrearsDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceFeeArrearsDetailsTable.tsx
@@ -1,0 +1,163 @@
+import { gql } from '@apollo/client'
+import { Collapse } from '@mui/material'
+import { memo, RefObject, useState } from 'react'
+
+import { Button } from '~/components/designSystem'
+import {
+  TExtendedRemainingFee,
+  TSubscriptionDataForDisplay,
+} from '~/core/formats/formatInvoiceItemsMap'
+import { formatDateToTZ } from '~/core/timezone'
+import {
+  CurrencyEnum,
+  Customer,
+  FeeForDeleteAdjustmentFeeDialogFragmentDoc,
+  FeeForEditfeeDrawerFragmentDoc,
+  FeeForInvoiceDetailsTableBodyLineFragmentDoc,
+} from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+import { DeleteAdjustedFeeDialogRef } from './DeleteAdjustedFeeDialog'
+import { EditFeeDrawerRef } from './EditFeeDrawer'
+import { InvoiceDetailsTableBodyLine } from './InvoiceDetailsTableBodyLine'
+import { InvoiceDetailsTableHeader } from './InvoiceDetailsTableHeader'
+import { InvoiceDetailsTablePeriodLine } from './InvoiceDetailsTablePeriodLine'
+
+gql`
+  fragment FeeForInvoiceFeeArrearsDetailsTable on Fee {
+    id
+    ...FeeForInvoiceDetailsTableBodyLine
+    ...FeeForDeleteAdjustmentFeeDialog
+    ...FeeForEditfeeDrawer
+  }
+
+  ${FeeForInvoiceDetailsTableBodyLineFragmentDoc}
+  ${FeeForDeleteAdjustmentFeeDialogFragmentDoc}
+  ${FeeForEditfeeDrawerFragmentDoc}
+`
+
+interface InvoiceFeeArrearsDetailsTableProps {
+  subscription: TSubscriptionDataForDisplay['subscription']
+  customer: Customer
+  canHaveUnitPrice: boolean
+  isDraftInvoice: boolean
+  currency: CurrencyEnum
+  editFeeDrawerRef: RefObject<EditFeeDrawerRef>
+  deleteAdjustedFeeDialogRef: RefObject<DeleteAdjustedFeeDialogRef>
+}
+
+export const InvoiceFeeArrearsDetailsTable = memo(
+  ({
+    subscription,
+    customer,
+    canHaveUnitPrice,
+    isDraftInvoice,
+    currency,
+    editFeeDrawerRef,
+    deleteAdjustedFeeDialogRef,
+  }: InvoiceFeeArrearsDetailsTableProps) => {
+    const { translate } = useInternationalization()
+    const [areZeroFeesVisible, setAreZeroFeesVisible] = useState<boolean>(false)
+
+    return (
+      <>
+        {(subscription.feesInArrears.length > 0 || subscription.feesInArrearsZero.length > 0) && (
+          <>
+            <InvoiceDetailsTablePeriodLine
+              canHaveUnitPrice={canHaveUnitPrice}
+              isDraftInvoice={isDraftInvoice}
+              period={translate('text_6499a4e4db5730004703f36b', {
+                from: formatDateToTZ(
+                  subscription?.metadata?.differentBoundariesForSubscriptionAndCharges
+                    ? subscription?.metadata?.chargesFromDatetime
+                    : subscription?.metadata?.fromDatetime,
+                  customer?.applicableTimezone,
+                  'LLL. dd, yyyy',
+                ),
+                to: formatDateToTZ(
+                  subscription?.metadata?.differentBoundariesForSubscriptionAndCharges
+                    ? subscription?.metadata?.chargesToDatetime
+                    : subscription?.metadata?.toDatetime,
+                  customer?.applicableTimezone,
+                  'LLL. dd, yyyy',
+                ),
+              })}
+            />
+
+            {(subscription.feesInArrears as TExtendedRemainingFee[]).map((feeInArrear) => {
+              return (
+                <InvoiceDetailsTableBodyLine
+                  key={`fee-in-arrears-${feeInArrear.id}`}
+                  canHaveUnitPrice={canHaveUnitPrice}
+                  currency={currency}
+                  displayName={feeInArrear?.metadata?.displayName}
+                  editFeeDrawerRef={editFeeDrawerRef}
+                  deleteAdjustedFeeDialogRef={deleteAdjustedFeeDialogRef}
+                  fee={feeInArrear}
+                  isDraftInvoice={isDraftInvoice}
+                />
+              )
+            })}
+            {/* Should be only displayed for draft invoices */}
+            {subscription.feesInArrearsZero.length > 0 && (
+              <>
+                <tr className="collapse">
+                  <td colSpan={6}>
+                    <div className="collapse-header">
+                      <Button
+                        variant="quaternary"
+                        size="small"
+                        startIcon={areZeroFeesVisible ? 'eye-hidden' : 'eye'}
+                        onClick={() => setAreZeroFeesVisible(!areZeroFeesVisible)}
+                      >
+                        {translate(
+                          areZeroFeesVisible
+                            ? 'text_65b116a266d90732cac8b3bc'
+                            : 'text_65b116a266d90732cac8b39b',
+                          {
+                            count: subscription.feesInArrearsZero.length,
+                          },
+                          subscription.feesInArrearsZero.length,
+                        )}
+                      </Button>
+                    </div>
+                    <Collapse in={areZeroFeesVisible} easing="cubic-bezier(0.4, 0, 0.2, 1)">
+                      <table className="inner-table">
+                        {/* This header is hidden in css. Only present to give the body the correct shape */}
+                        <InvoiceDetailsTableHeader
+                          canHaveUnitPrice={canHaveUnitPrice}
+                          displayName={subscription?.metadata?.subscriptionDisplayName}
+                          isDraftInvoice={isDraftInvoice}
+                        />
+                        <tbody>
+                          {(subscription.feesInArrearsZero as TExtendedRemainingFee[]).map(
+                            (feeInArrearZero) => {
+                              return (
+                                <InvoiceDetailsTableBodyLine
+                                  key={`fee-in-arrears-zero-${feeInArrearZero.id}`}
+                                  canHaveUnitPrice={canHaveUnitPrice}
+                                  currency={currency}
+                                  displayName={feeInArrearZero?.metadata?.displayName}
+                                  editFeeDrawerRef={editFeeDrawerRef}
+                                  deleteAdjustedFeeDialogRef={deleteAdjustedFeeDialogRef}
+                                  fee={feeInArrearZero}
+                                  isDraftInvoice={isDraftInvoice}
+                                />
+                              )
+                            },
+                          )}
+                        </tbody>
+                      </table>
+                    </Collapse>
+                  </td>
+                </tr>
+              </>
+            )}
+          </>
+        )}
+      </>
+    )
+  },
+)
+
+InvoiceFeeArrearsDetailsTable.displayName = 'InvoiceFeeArrearsDetailsTable'

--- a/src/core/formats/formatInvoiceItemsMap.ts
+++ b/src/core/formats/formatInvoiceItemsMap.ts
@@ -59,7 +59,7 @@ export type TExtendedRemainingFee = Fee & {
     isNormalFee?: boolean
   }
 }
-type TSubscriptionDataForDisplay = {
+export type TSubscriptionDataForDisplay = {
   [invoiceSubscriptionId: string]: {
     feesInArrears: TExtendedRemainingFee[]
     feesInArrearsZero: TExtendedRemainingFee[]

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -4611,6 +4611,10 @@ export type FeeForInvoiceDetailsTableBodyLineVolumeFragment = { __typename?: 'Fe
 
 export type InvoiceForDetailsTableFooterFragment = { __typename?: 'Invoice', couponsAmountCents: any, creditNotesAmountCents: any, subTotalExcludingTaxesAmountCents: any, subTotalIncludingTaxesAmountCents: any, totalAmountCents: any, currency?: CurrencyEnum | null, invoiceType: InvoiceTypeEnum, status: InvoiceStatusTypeEnum, prepaidCreditAmountCents: any, versionNumber: number, appliedTaxes?: Array<{ __typename?: 'InvoiceAppliedTax', id: string, amountCents: any, feesAmountCents: any, taxRate: number, taxName: string }> | null };
 
+export type FeeForInvoiceFeeAdvanceDetailsTableFragment = { __typename?: 'Fee', id: string, units: number, preciseUnitAmount: number, amountCents: any, eventsCount?: any | null, adjustedFee: boolean, adjustedFeeType?: AdjustedFeeTypeEnum | null, currency: CurrencyEnum, charge?: { __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, minAmountCents: any, payInAdvance: boolean, prorated: boolean } | null, appliedTaxes?: Array<{ __typename?: 'FeeAppliedTax', id: string, taxRate: number }> | null, amountDetails?: { __typename?: 'FeeAmountDetails', flatUnitAmount?: string | null, perUnitAmount?: string | null, perUnitTotalAmount?: string | null, freeUnits?: string | null, paidUnits?: string | null, perPackageSize?: number | null, perPackageUnitAmount?: string | null, fixedFeeTotalAmount?: string | null, fixedFeeUnitAmount?: string | null, freeEvents?: number | null, minMaxAdjustmentTotalAmount?: string | null, paidEvents?: number | null, rate?: string | null, units?: string | null, graduatedRanges?: Array<{ __typename?: 'FeeAmountDetailsGraduatedRange', flatUnitAmount?: string | null, fromValue?: number | null, perUnitAmount?: string | null, perUnitTotalAmount?: string | null, toValue?: number | null, totalWithFlatAmount?: string | null, units?: string | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'FeeAmountDetailsGraduatedPercentageRange', flatUnitAmount?: string | null, fromValue?: number | null, perUnitTotalAmount?: string | null, rate?: string | null, toValue?: number | null, totalWithFlatAmount?: string | null, units?: string | null }> | null } | null };
+
+export type FeeForInvoiceFeeArrearsDetailsTableFragment = { __typename?: 'Fee', id: string, units: number, preciseUnitAmount: number, amountCents: any, eventsCount?: any | null, adjustedFee: boolean, adjustedFeeType?: AdjustedFeeTypeEnum | null, currency: CurrencyEnum, charge?: { __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, minAmountCents: any, payInAdvance: boolean, prorated: boolean } | null, appliedTaxes?: Array<{ __typename?: 'FeeAppliedTax', id: string, taxRate: number }> | null, amountDetails?: { __typename?: 'FeeAmountDetails', flatUnitAmount?: string | null, perUnitAmount?: string | null, perUnitTotalAmount?: string | null, freeUnits?: string | null, paidUnits?: string | null, perPackageSize?: number | null, perPackageUnitAmount?: string | null, fixedFeeTotalAmount?: string | null, fixedFeeUnitAmount?: string | null, freeEvents?: number | null, minMaxAdjustmentTotalAmount?: string | null, paidEvents?: number | null, rate?: string | null, units?: string | null, graduatedRanges?: Array<{ __typename?: 'FeeAmountDetailsGraduatedRange', flatUnitAmount?: string | null, fromValue?: number | null, perUnitAmount?: string | null, perUnitTotalAmount?: string | null, toValue?: number | null, totalWithFlatAmount?: string | null, units?: string | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'FeeAmountDetailsGraduatedPercentageRange', flatUnitAmount?: string | null, fromValue?: number | null, perUnitTotalAmount?: string | null, rate?: string | null, toValue?: number | null, totalWithFlatAmount?: string | null, units?: string | null }> | null } | null };
+
 export type TaxForPlanChargeAccordionFragment = { __typename?: 'Tax', id: string, code: string, name: string, rate: number };
 
 export type ChargeAccordionFragment = { __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, prorated: boolean, invoiceDisplayName?: string | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, groupedBy?: Array<string> | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, groupedBy?: Array<string> | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null };
@@ -6941,6 +6945,26 @@ ${FeeForInvoiceDetailsTableBodyLinePackageFragmentDoc}
 ${FeeForInvoiceDetailsTableBodyLinePercentageFragmentDoc}
 ${FeeForEditfeeDrawerFragmentDoc}
 ${FeeForDeleteAdjustmentFeeDialogFragmentDoc}`;
+export const FeeForInvoiceFeeArrearsDetailsTableFragmentDoc = gql`
+    fragment FeeForInvoiceFeeArrearsDetailsTable on Fee {
+  id
+  ...FeeForInvoiceDetailsTableBodyLine
+  ...FeeForDeleteAdjustmentFeeDialog
+  ...FeeForEditfeeDrawer
+}
+    ${FeeForInvoiceDetailsTableBodyLineFragmentDoc}
+${FeeForDeleteAdjustmentFeeDialogFragmentDoc}
+${FeeForEditfeeDrawerFragmentDoc}`;
+export const FeeForInvoiceFeeAdvanceDetailsTableFragmentDoc = gql`
+    fragment FeeForInvoiceFeeAdvanceDetailsTable on Fee {
+  id
+  ...FeeForInvoiceDetailsTableBodyLine
+  ...FeeForDeleteAdjustmentFeeDialog
+  ...FeeForEditfeeDrawer
+}
+    ${FeeForInvoiceDetailsTableBodyLineFragmentDoc}
+${FeeForDeleteAdjustmentFeeDialogFragmentDoc}
+${FeeForEditfeeDrawerFragmentDoc}`;
 export const FeeForInvoiceDetailsTableFragmentDoc = gql`
     fragment FeeForInvoiceDetailsTable on Fee {
   id
@@ -6979,8 +7003,12 @@ export const FeeForInvoiceDetailsTableFragmentDoc = gql`
     value
   }
   ...FeeForInvoiceDetailsTableBodyLine
+  ...FeeForInvoiceFeeArrearsDetailsTable
+  ...FeeForInvoiceFeeAdvanceDetailsTable
 }
-    ${FeeForInvoiceDetailsTableBodyLineFragmentDoc}`;
+    ${FeeForInvoiceDetailsTableBodyLineFragmentDoc}
+${FeeForInvoiceFeeArrearsDetailsTableFragmentDoc}
+${FeeForInvoiceFeeAdvanceDetailsTableFragmentDoc}`;
 export const InvoiceSubscriptionFormatingFragmentDoc = gql`
     fragment InvoiceSubscriptionFormating on InvoiceSubscription {
   fromDatetime


### PR DESCRIPTION
## Context

The current fee ordering logic is the following.

For each subscription:
- We first render the fees in arrears group
- We then render fees in advance group

Each group having their own periods and showing potentially the fees with 0 unit of the invoice is in draft.
Also note that the subscription fee is always displayed at the top of it's group

However I could lead to have the subscription fee "lost" in the subscription details, as it could be part of the fees in advance group inside an invoice with fees in arrears

## Description

I order to make the subscription fee appear at the top of all fees listed in the invoice details, we now packed those two big groups of fees in an array, and reverse this array depending on a flag.

This flag comes from the fee formating login, that looks id the subscription's subscription dee period missmatch the fee period, meaning the subscription is in advance (on not!)

It also allows to delete this ugly logic I had before, with a huge state matrice used to handle the subscription 0 show/hide 