### PR TITLE
bug(plan) make sure groupBy is undefined if not defined

### DIFF
--- a/src/core/serializers/__tests__/serializePlanInput.test.ts
+++ b/src/core/serializers/__tests__/serializePlanInput.test.ts
@@ -145,6 +145,7 @@ describe('serializePlanInput()', () => {
                 },
               ],
               graduatedPercentageRanges: undefined,
+              groupedBy: undefined,
               packageSize: undefined,
               perTransactionMinAmount: undefined,
               perTransactionMaxAmount: undefined,
@@ -224,6 +225,7 @@ describe('serializePlanInput()', () => {
                 },
               ],
               graduatedRanges: undefined,
+              groupedBy: undefined,
               packageSize: undefined,
               perTransactionMinAmount: undefined,
               perTransactionMaxAmount: undefined,
@@ -288,6 +290,7 @@ describe('serializePlanInput()', () => {
               freeUnitsPerTotalAggregation: '1',
               graduatedRanges: undefined,
               graduatedPercentageRanges: undefined,
+              groupedBy: undefined,
               packageSize: 12,
               perTransactionMinAmount: undefined,
               perTransactionMaxAmount: undefined,
@@ -352,6 +355,7 @@ describe('serializePlanInput()', () => {
               freeUnitsPerEvents: undefined,
               freeUnitsPerTotalAggregation: '1',
               graduatedRanges: undefined,
+              groupedBy: undefined,
               graduatedPercentageRanges: undefined,
               packageSize: undefined,
               perTransactionMinAmount: '1',
@@ -436,6 +440,67 @@ describe('serializePlanInput()', () => {
         taxCodes: [],
       })
     })
+
+    it('formats correctly the groupedBy', () => {
+      const plan = serializePlanInput({
+        amountCents: '1',
+        amountCurrency: CurrencyEnum.Eur,
+        billChargesMonthly: true,
+        charges: [
+          {
+            chargeModel: ChargeModelEnum.Standard,
+            billableMetric: {
+              id: '1234',
+              name: 'simpleBM',
+              code: 'simple-bm',
+              recurring: false,
+              aggregationType: AggregationTypeEnum.CountAgg,
+            },
+            // @ts-ignore
+            properties: { groupedBy: 'one,two' },
+            taxCodes: [],
+          },
+        ],
+        code: 'my-plan',
+        interval: PlanInterval.Monthly,
+        name: 'My plan',
+        payInAdvance: true,
+        trialPeriod: 1,
+        taxCodes: [],
+      })
+
+      expect(plan).toStrictEqual({
+        amountCents: 100,
+        amountCurrency: 'EUR',
+        billChargesMonthly: true,
+        charges: [
+          {
+            billableMetricId: '1234',
+            chargeModel: 'standard',
+            minAmountCents: 0,
+            groupProperties: [],
+            properties: {
+              amount: undefined,
+              freeUnits: undefined,
+              graduatedRanges: undefined,
+              groupedBy: ['one', 'two'],
+              graduatedPercentageRanges: undefined,
+              packageSize: undefined,
+              perTransactionMinAmount: undefined,
+              perTransactionMaxAmount: undefined,
+              volumeRanges: undefined,
+            },
+            taxCodes: [],
+          },
+        ],
+        code: 'my-plan',
+        interval: 'monthly',
+        name: 'My plan',
+        payInAdvance: true,
+        trialPeriod: 1,
+        taxCodes: [],
+      })
+    })
   })
 
   describe('a plan with volume charge', () => {
@@ -484,6 +549,7 @@ describe('serializePlanInput()', () => {
               freeUnitsPerTotalAggregation: '1',
               graduatedRanges: undefined,
               graduatedPercentageRanges: undefined,
+              groupedBy: undefined,
               packageSize: undefined,
               perTransactionMinAmount: undefined,
               perTransactionMaxAmount: undefined,

--- a/src/core/serializers/serializePlanInput.ts
+++ b/src/core/serializers/serializePlanInput.ts
@@ -17,7 +17,7 @@ const serializeProperties = (properties: Properties, chargeModel: ChargeModelEnu
     ...([ChargeModelEnum.Standard].includes(chargeModel)
       ? // @ts-ignore EDIT: groupedBy is a string at this stage. need to send string[] to BE
         { groupedBy: !!properties?.groupedBy ? properties?.groupedBy.split(',') : undefined }
-      : {}),
+      : { groupedBy: undefined }),
     ...([ChargeModelEnum.Package, ChargeModelEnum.Standard].includes(chargeModel)
       ? { amount: !!properties?.amount ? String(properties?.amount) : undefined }
       : {}),


### PR DESCRIPTION
## Context

We perform some manual operations on this field

We receive it as an array of string, but we manipulate it as a string in the UI.

This value has to be re-transformed before sending it to the BE

## Description

All those manipulations makes is less predictable and lead to have the value empty for the charge models that are not standard.

This PR ensure the value is undefined in such case.