### PR TITLE
feat (edit-plan): allow plan amount cents edition

### DIFF
--- a/src/components/plans/FixedFeeSection.tsx
+++ b/src/components/plans/FixedFeeSection.tsx
@@ -140,9 +140,6 @@ export const FixedFeeSection = memo(
               name="amountCents"
               currency={formikProps.values.amountCurrency}
               beforeChangeFormatter={['positiveNumber']}
-              disabled={
-                subscriptionFormType === FORM_TYPE_ENUM.edition || (isEdition && !canBeEdited)
-              }
               label={translate('text_624453d52e945301380e49b6')}
               formikProps={formikProps}
               InputProps={{


### PR DESCRIPTION
## Context

Currently it is not possible to edit plan amount cents on edit plan page and on edit subscription page.

## Description

We want to allow users to edit plan/subscription amount cents so that they don't need to create new plan with each change.

This PR enables `amountCents` field in `FixedFeeSection`