### PR TITLE
feat (invoice-numbering): remove document numbering alert

### DIFF
--- a/ditto/base.json
+++ b/ditto/base.json
@@ -1423,7 +1423,6 @@
   "text_6566f920a1d6c35693d6ccd8": "Dynamic sequence",
   "text_6566f920a1d6c35693d6cce0": "cust. sequential ID",
   "text_6566f920a1d6c35693d6cce8": "Invoice nb",
-  "text_6566f920a1d6c35693d6cd9c": "When scoped across your organization, the invoice number will reset at the end of each month.",
   "text_6566f920a1d6c35693d6cdca": "(sequentially for each customer)",
   "text_6566f920a1d6c35693d6cdd2": "The invoice number increases uniquely for every individual customer rather than being a global sequence applied at the organizational level.",
   "text_6566f920a1d6c35693d6ce0f": "Invoice numbering successfully edited",

--- a/src/components/settings/EditOrganizationInvoiceNumberingDialog.tsx
+++ b/src/components/settings/EditOrganizationInvoiceNumberingDialog.tsx
@@ -166,10 +166,6 @@ export const EditOrganizationInvoiceNumberingDialog = forwardRef<
             </Typography>
             <TextInput disabled label={translate('text_6566f920a1d6c35693d6cce8')} value={'001'} />
           </InlineInputsWrapper>
-
-          {formikProps.values.documentNumbering === DocumentNumberingEnum.PerOrganization && (
-            <Alert type="info">{translate('text_6566f920a1d6c35693d6cd9c')}</Alert>
-          )}
         </Content>
       </Dialog>
     )


### PR DESCRIPTION
## Context

From now on the default invoice numbering system will be `per_organization`

## Description

This PR removes unnecessary alert in invoice numbering modal
