### PR TITLE
Fix back navigation after close tax add/edit form

### DIFF
--- a/src/layouts/Settings.tsx
+++ b/src/layouts/Settings.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import { Button, NavigationTab, Typography } from '~/components/designSystem'
 import {
+  CREATE_TAX_ROUTE,
   EMAILS_SETTINGS_ROUTE,
   HOME_ROUTE,
   INTEGRATIONS_ROUTE,
@@ -14,6 +15,7 @@ import {
   settingRoutes,
   SETTINGS_ROUTE,
   TAXES_SETTINGS_ROUTE,
+  UPDATE_TAX_ROUTE
 } from '~/core/router'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useLocationHistory } from '~/hooks/core/useLocationHistory'
@@ -67,7 +69,7 @@ const Settings = () => {
       }
       return acc
     },
-    [],
+    [CREATE_TAX_ROUTE, UPDATE_TAX_ROUTE],
   )
 
   return (


### PR DESCRIPTION
## Context

After closing the create/edit tax form in the settings, I noticed that the back button wasn't functioning as intended. Instead of navigating the user back to the Home page, it was directing them back to the tax form.

## Description

This PR modifies the back redirection URLs on the settings layout to exclude the create and update routes, ensuring that the back button now correctly redirects users to the Home page.