### PR TITLE
feat(AddOnDetailsPage): new page

### DIFF
--- a/ditto/base.json
+++ b/ditto/base.json
@@ -758,6 +758,8 @@
   "text_65940198687ce7b05cd62b63": "Please connect an Adyen account in the Settings -> Integration section",
   "text_65940198687ce7b05cd62b64": "Please connect a Stripe account in the Settings -> Integration section",
   "text_65940198687ce7b05cd62b65": "Please connect a Gocardless account in the Settings -> Integration section",
+  "text_6627e7b9732dbfb6c472e027": "Add-on details",
+  "text_6627e7b9732dbfb6c472e02d": "Add-on code",
   "text_64c7a89b6c67eb6c98898167": "Net payment term",
   "text_64c7a89b6c67eb6c98898182": "Period within which a customer is expected to pay for an invoice after it has been issued.\nNeed more flexibility? Set a payment term at the customer level to override the one above.",
   "text_64c7a89b6c67eb6c988980eb": "The duration within which a customer is expected to remit payment after the invoice is issued. Note that it may impact all invoices already in draft.",

--- a/ditto/config.yml
+++ b/ditto/config.yml
@@ -346,7 +346,11 @@ sources:
       fileName: 👍 [Ready for dev] - Plans - Invoice minimum spending
     - name: 👍 [Ready for dev] - Onboarding - Create/Connect Lago orga via SSO
       id: 660bf95b851f012f6f11ecd0
+      fileName: 👍 [Ready for dev] - Onboarding - Create/Connect Lago orga via SSO
     - name: ⚙️ [WIP] - Invoices - Dispute payment intent
       id: 66141e2ffa16c75cb553dbc1
+      fileName: ⚙️ [WIP] - Invoices - Dispute payment intent
+    - name: 👍 [Ready for dev] - Settings - Role Base Access Control
+      id: 6627e7b722eb1147b8c7eccc
 format: flat
 variants: true

--- a/ditto/index.js
+++ b/ditto/index.js
@@ -68,6 +68,7 @@ const ready_for_dev___settings___add_redirect_url_to_psp = require('./ready-for-
 const ready_for_dev___settings___customers___lago_gocardless_connection = require('./ready-for-dev---settings---customers---lago-gocardless-connection__base.json');
 const ready_for_dev___settings___define_invoice_number = require('./ready-for-dev---settings---define-invoice-number__base.json');
 const ready_for_dev___settings___net_payment_term = require('./ready-for-dev---settings---net-payment-term__base.json');
+const ready_for_dev___settings___role_base_access_control = require('./ready-for-dev---settings---role-base-access-control__base.json');
 const ready_for_dev___settings___several_psp_accounts = require('./ready-for-dev---settings---several-psp-accounts__base.json');
 const ready_for_dev___settings_customers___lago_x_data_warehouse_connection = require('./ready-for-dev---settings-customers---lago-x-data-warehouse-connection__base.json');
 const ready_for_dev___settings_customers___lago_x_osso_connection = require('./ready-for-dev---settings-customers---lago-x-osso-connection__base.json');
@@ -102,6 +103,7 @@ const wip___customers___real_time_prepaid_credits = require('./wip---customers--
 const wip___customers___subscription_on_anniversary_date = require('./wip---customers---subscription-on-anniversary-date__base.json');
 const wip___general___fe_environment_infos = require('./wip---general---fe-environment-infos__base.json');
 const wip___integration___lago_eu_tax_integration = require('./wip---integration---lago-eu-tax-integration__base.json');
+const wip___invoices___dispute_payment_intent = require('./wip---invoices---dispute-payment-intent__base.json');
 const wip___plan___charges_paid_in_advance = require('./wip---plan---charges-paid-in-advance__base.json');
 const wip___settings___create_tax_rate_object_apply_on_org_cus = require('./wip---settings---create-tax-rate-object-apply-on-org-cus__base.json');
 const wip___settings___define_preferred_doc_language_generation = require('./wip---settings---define-preferred-doc-language-generation__base.json');
@@ -324,6 +326,9 @@ module.exports = {
   "project_64c7a896197f1907cbc6371c": {
     "base": {...ready_for_dev___settings___net_payment_term}
   },
+  "project_6627e7b722eb1147b8c7eccc": {
+    "base": {...ready_for_dev___settings___role_base_access_control}
+  },
   "project_6584550ac28443047853c17f": {
     "base": {...ready_for_dev___settings___several_psp_accounts}
   },
@@ -413,6 +418,9 @@ module.exports = {
   },
   "project_657078becf8335e0955b5bf4": {
     "base": {...wip___integration___lago_eu_tax_integration}
+  },
+  "project_66141e2ffa16c75cb553dbc1": {
+    "base": {...wip___invoices___dispute_payment_intent}
   },
   "project_646e2d05cf47b79ad4b5ccf5": {
     "base": {...wip___plan___charges_paid_in_advance}

--- a/src/components/addOns/AddOnItem.tsx
+++ b/src/components/addOns/AddOnItem.tsx
@@ -15,7 +15,7 @@ import {
   Typography,
 } from '~/components/designSystem'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
-import { ADD_ONS_ROUTE, UPDATE_ADD_ON_ROUTE } from '~/core/router'
+import { ADD_ON_DETAILS_ROUTE, ADD_ONS_ROUTE, UPDATE_ADD_ON_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { AddOnItemFragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -57,7 +57,7 @@ export const AddOnItem = ({ addOn, deleteDialogRef, navigationProps }: AddOnItem
   return (
     <ItemContainer>
       <ListItemLink
-        to={generatePath(UPDATE_ADD_ON_ROUTE, { addOnId })}
+        to={generatePath(ADD_ON_DETAILS_ROUTE, { addOnId })}
         tabIndex={0}
         data-test={name}
         {...navigationProps}

--- a/src/components/addOns/AddOnItem.tsx
+++ b/src/components/addOns/AddOnItem.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { RefObject } from 'react'
-import { generatePath } from 'react-router-dom'
+import { generatePath, useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { DeleteAddOnDialogRef } from '~/components/addOns/DeleteAddOnDialog'
@@ -15,7 +15,7 @@ import {
   Typography,
 } from '~/components/designSystem'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
-import { UPDATE_ADD_ON_ROUTE } from '~/core/router'
+import { ADD_ONS_ROUTE, UPDATE_ADD_ON_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { AddOnItemFragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -52,6 +52,7 @@ export const AddOnItem = ({ addOn, deleteDialogRef, navigationProps }: AddOnItem
 
   const { translate } = useInternationalization()
   const { formatTimeOrgaTZ } = useOrganizationInfos()
+  const navigate = useNavigate()
 
   return (
     <ItemContainer>
@@ -123,7 +124,12 @@ export const AddOnItem = ({ addOn, deleteDialogRef, navigationProps }: AddOnItem
               align="left"
               fullWidth
               onClick={() => {
-                deleteDialogRef.current?.openDialog(addOn)
+                deleteDialogRef.current?.openDialog({
+                  addOn,
+                  callback: () => {
+                    navigate(ADD_ONS_ROUTE)
+                  },
+                })
                 closePopper()
               }}
             >

--- a/src/components/addOns/DeleteAddOnDialog.tsx
+++ b/src/components/addOns/DeleteAddOnDialog.tsx
@@ -20,15 +20,23 @@ gql`
   }
 `
 
+interface DeleteAddOnDialogProps {
+  addOn: DeleteAddOnFragment
+  callback?: () => void
+}
+
 export interface DeleteAddOnDialogRef {
-  openDialog: (addOn: DeleteAddOnFragment) => unknown
+  openDialog: ({ addOn, callback }: DeleteAddOnDialogProps) => unknown
   closeDialog: () => unknown
 }
 
 export const DeleteAddOnDialog = forwardRef<DeleteAddOnDialogRef>((_, ref) => {
   const { translate } = useInternationalization()
   const dialogRef = useRef<DialogRef>(null)
-  const [addOn, setAddOn] = useState<DeleteAddOnFragment | undefined>(undefined)
+  const [localData, setLocalData] = useState<DeleteAddOnDialogProps | undefined>(undefined)
+
+  const { id = '', name = '' } = localData?.addOn || {}
+
   const [deleteAddOn] = useDeleteAddOnMutation({
     onCompleted(data) {
       if (data && data.destroyAddOn) {
@@ -36,6 +44,8 @@ export const DeleteAddOnDialog = forwardRef<DeleteAddOnDialogRef>((_, ref) => {
           message: translate('text_629728388c4d2300e2d3815f'),
           severity: 'success',
         })
+
+        localData?.callback && localData.callback()
       }
     },
     update(cache, { data }) {
@@ -51,7 +61,7 @@ export const DeleteAddOnDialog = forwardRef<DeleteAddOnDialogRef>((_, ref) => {
 
   useImperativeHandle(ref, () => ({
     openDialog: (data) => {
-      setAddOn(data)
+      setLocalData(data)
       dialogRef.current?.openDialog()
     },
     closeDialog: () => {
@@ -63,12 +73,12 @@ export const DeleteAddOnDialog = forwardRef<DeleteAddOnDialogRef>((_, ref) => {
     <WarningDialog
       ref={dialogRef}
       title={translate('text_629728388c4d2300e2d380ad', {
-        addOnName: addOn?.name,
+        addOnName: name,
       })}
       description={<Typography html={translate('text_629728388c4d2300e2d380c5')} />}
       onContinue={async () =>
         await deleteAddOn({
-          variables: { input: { id: addOn?.id || '' } },
+          variables: { input: { id: id || '' } },
         })
       }
       continueText={translate('text_629728388c4d2300e2d380f5')}

--- a/src/components/details/DetailsHeader.tsx
+++ b/src/components/details/DetailsHeader.tsx
@@ -1,0 +1,65 @@
+import { FC } from 'react'
+import styled from 'styled-components'
+
+import { Avatar, Icon, IconName, Skeleton, Typography } from '~/components/designSystem'
+import { theme } from '~/styles'
+
+interface DetailsHeaderProps {
+  icon: IconName
+  title: string
+  description: string
+}
+export const DetailsHeader: FC<DetailsHeaderProps> = ({ icon, title, description }) => {
+  return (
+    <HeaderWrapper>
+      <Avatar variant="connector" size="large">
+        <Icon name={icon} color="dark" size="large" />
+      </Avatar>
+
+      <HeaderDetailsWrapper>
+        <>
+          <Typography variant="headline" color="grey700" noWrap>
+            {title}
+          </Typography>
+          <Typography variant="body" color="grey600" noWrap>
+            {description}
+          </Typography>
+        </>
+      </HeaderDetailsWrapper>
+    </HeaderWrapper>
+  )
+}
+
+export const DetailsHeaderSkeleton = () => {
+  return (
+    <HeaderWrapper>
+      <Skeleton variant="connectorAvatar" size="large" />
+
+      <HeaderDetailsWrapper>
+        <LoadingWrapper>
+          <Skeleton variant="text" width={200} height={12} marginBottom={20} />
+          <Skeleton variant="text" width={200} height={12} />
+        </LoadingWrapper>
+      </HeaderDetailsWrapper>
+    </HeaderWrapper>
+  )
+}
+
+const HeaderWrapper = styled.div`
+  display: flex;
+  gap: ${theme.spacing(4)};
+  align-items: center;
+  padding: ${theme.spacing(8)} ${theme.spacing(12)};
+  box-shadow: ${theme.shadows[7]};
+`
+
+const HeaderDetailsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(1)};
+  /* Used to hide text overflow */
+  overflow: hidden;
+`
+const LoadingWrapper = styled.div`
+  width: 200px;
+`

--- a/src/components/details/DetailsTableDisplay.tsx
+++ b/src/components/details/DetailsTableDisplay.tsx
@@ -3,18 +3,18 @@ import styled from 'styled-components'
 
 import { HEADER_TABLE_HEIGHT, theme } from '~/styles'
 
-type ChargeTableDisplayData = {
+type DetailsTableDisplayData = {
   header: Array<string>
   body: Array<Array<string | number>>
 }
 
-const PlanDetailsChargeTableDisplay = (data: ChargeTableDisplayData) => {
+const DetailsTableDisplay = (data: DetailsTableDisplayData) => {
   return (
-    <Table $dataLength={data.header.length || 1}>
+    <StyledTable $dataLength={data.header.length || 1}>
       <thead>
         <tr>
           {data.header.map((header, index) => (
-            <th key={`plan-details-charge-table-display-header-${index}`}>
+            <th key={`details-table-display-header-${index}`}>
               <Typography variant="captionHl">{header}</Typography>
             </th>
           ))}
@@ -22,20 +22,20 @@ const PlanDetailsChargeTableDisplay = (data: ChargeTableDisplayData) => {
       </thead>
       <tbody>
         {data.body.map((values, i) => (
-          <tr key={`plan-details-charge-table-display-body-tr-${i}`}>
+          <tr key={`details-table-display-body-tr-${i}`}>
             {values.map((value, j) => (
-              <td key={`plan-details-charge-table-display-tr-${i}-td-${j}`}>
+              <td key={`details-table-display-tr-${i}-td-${j}`}>
                 <Typography variant="body">{value}</Typography>
               </td>
             ))}
           </tr>
         ))}
       </tbody>
-    </Table>
+    </StyledTable>
   )
 }
 
-const Table = styled.table<{ $dataLength: number }>`
+const StyledTable = styled.table<{ $dataLength: number }>`
   width: 100%;
   border-spacing: 0;
   table-layout: ${({ $dataLength }) => ($dataLength > 3 ? 'auto' : 'fixed')};
@@ -76,4 +76,4 @@ const Table = styled.table<{ $dataLength: number }>`
   }
 `
 
-export default PlanDetailsChargeTableDisplay
+export default DetailsTableDisplay

--- a/src/components/plans/details/PlanDetailsChargeWrapperSwitch.tsx
+++ b/src/components/plans/details/PlanDetailsChargeWrapperSwitch.tsx
@@ -8,7 +8,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { theme } from '~/styles'
 import { DetailsInfoGrid, DetailsInfoItem } from '~/styles/detailsPage'
 
-import PlanDetailsChargeTableDisplay from './PlanDetailsChargeTableDisplay'
+import DetailsTableDisplay from '../../details/DetailsTableDisplay'
 
 const PlanDetailsChargeWrapperSwitch = ({
   currency,
@@ -27,7 +27,7 @@ const PlanDetailsChargeWrapperSwitch = ({
     <div>
       {chargeModel === ChargeModelEnum.Standard && (
         <ChargeContentWrapper>
-          <PlanDetailsChargeTableDisplay
+          <DetailsTableDisplay
             header={[translate('text_624453d52e945301380e49b6')]}
             body={[
               [
@@ -55,7 +55,7 @@ const PlanDetailsChargeWrapperSwitch = ({
       )}
       {chargeModel === ChargeModelEnum.Package && (
         <ChargeContentWrapper>
-          <PlanDetailsChargeTableDisplay
+          <DetailsTableDisplay
             header={[
               translate('text_624453d52e945301380e49b6'),
               translate('text_65201b8216455901fe273de7'),
@@ -77,7 +77,7 @@ const PlanDetailsChargeWrapperSwitch = ({
       )}
       {chargeModel === ChargeModelEnum.Graduated && !!values?.graduatedRanges?.length && (
         <ChargeContentWrapper>
-          <PlanDetailsChargeTableDisplay
+          <DetailsTableDisplay
             header={[
               translate('text_62793bbb599f1c01522e91ab'),
               translate('text_62793bbb599f1c01522e91b1'),
@@ -108,7 +108,7 @@ const PlanDetailsChargeWrapperSwitch = ({
       {chargeModel === ChargeModelEnum.GraduatedPercentage &&
         !!values?.graduatedPercentageRanges?.length && (
           <ChargeContentWrapper>
-            <PlanDetailsChargeTableDisplay
+            <DetailsTableDisplay
               header={[
                 translate('text_62793bbb599f1c01522e91ab'),
                 translate('text_62793bbb599f1c01522e91b1'),
@@ -138,7 +138,7 @@ const PlanDetailsChargeWrapperSwitch = ({
         )}
       {chargeModel === ChargeModelEnum.Percentage && (
         <ChargeContentWrapper>
-          <PlanDetailsChargeTableDisplay
+          <DetailsTableDisplay
             header={[
               translate('text_64de472463e2da6b31737de0'),
               translate('text_62ff5d01a306e274d4ffcc1e'),
@@ -187,7 +187,7 @@ const PlanDetailsChargeWrapperSwitch = ({
       )}
       {chargeModel === ChargeModelEnum.Volume && !!values?.volumeRanges?.length && (
         <ChargeContentWrapper>
-          <PlanDetailsChargeTableDisplay
+          <DetailsTableDisplay
             header={[
               translate('text_62793bbb599f1c01522e91ab'),
               translate('text_62793bbb599f1c01522e91b1'),

--- a/src/components/plans/details/PlanDetailsChargeWrapperSwitch.tsx
+++ b/src/components/plans/details/PlanDetailsChargeWrapperSwitch.tsx
@@ -165,22 +165,24 @@ const PlanDetailsChargeWrapperSwitch = ({
             ]}
           />
 
-          <DetailsInfoGrid>
-            <DetailsInfoItem
-              label={translate('text_65201b8216455901fe273e01')}
-              value={intlFormatNumber(Number(values?.perTransactionMinAmount || 0), {
-                currency: currency,
-                minimumFractionDigits: 2,
-              })}
-            />
-            <DetailsInfoItem
-              label={translate('text_65201b8216455901fe273e03')}
-              value={intlFormatNumber(Number(values?.perTransactionMaxAmount || 0), {
-                currency: currency,
-                minimumFractionDigits: 2,
-              })}
-            />
-          </DetailsInfoGrid>
+          <DetailsInfoGrid
+            grid={[
+              {
+                label: translate('text_65201b8216455901fe273e01'),
+                value: intlFormatNumber(Number(values?.perTransactionMinAmount || 0), {
+                  currency: currency,
+                  minimumFractionDigits: 2,
+                }),
+              },
+              {
+                label: translate('text_65201b8216455901fe273e03'),
+                value: intlFormatNumber(Number(values?.perTransactionMaxAmount || 0), {
+                  currency: currency,
+                  minimumFractionDigits: 2,
+                }),
+              },
+            ]}
+          />
         </ChargeContentWrapper>
       )}
       {chargeModel === ChargeModelEnum.Volume && !!values?.volumeRanges?.length && (

--- a/src/components/plans/details/PlanDetailsChargesSection.tsx
+++ b/src/components/plans/details/PlanDetailsChargesSection.tsx
@@ -12,7 +12,7 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { theme } from '~/styles'
-import { DetailsInfoGrid, DetailsInfoItem } from '~/styles/detailsPage'
+import { DetailsInfoGrid } from '~/styles/detailsPage'
 
 import PlanDetailsChargesSectionAccordion from './PlanDetailsChargesSectionAccordion'
 
@@ -81,82 +81,83 @@ const PlanDetailsChargesSection = ({
               <ChargeSectionWrapper>
                 {/* Charge main infos */}
                 <PaddedChargeModelWrapper>
-                  <DetailsInfoGrid>
-                    <DetailsInfoItem
-                      label={translate('text_65201b8216455901fe273dd5')}
-                      value={translate(chargeModelLookupTranslation[charge.chargeModel])}
-                    />
-                    <DetailsInfoItem
-                      label={translate('text_65201b8216455901fe273dc1')}
-                      value={translate(
-                        mapChargeIntervalCopy(
-                          plan?.interval as PlanInterval,
-                          (plan?.interval === PlanInterval.Yearly && !!plan?.billChargesMonthly) ||
-                            false,
+                  <DetailsInfoGrid
+                    grid={[
+                      {
+                        label: translate('text_65201b8216455901fe273dd5'),
+                        value: translate(chargeModelLookupTranslation[charge.chargeModel]),
+                      },
+                      {
+                        label: translate('text_65201b8216455901fe273dc1'),
+                        value: translate(
+                          mapChargeIntervalCopy(
+                            plan?.interval as PlanInterval,
+                            (plan?.interval === PlanInterval.Yearly &&
+                              !!plan?.billChargesMonthly) ||
+                              false,
+                          ),
                         ),
-                      )}
-                    />
-                  </DetailsInfoGrid>
+                      },
+                    ]}
+                  />
                 </PaddedChargeModelWrapper>
                 {/* Propertiers accordion */}
                 <PlanDetailsChargesSectionAccordion currency={currency} charge={charge as Charge} />
                 {/* Options */}
                 <PaddedOptionsWrapper>
-                  <DetailsInfoGrid>
-                    <DetailsInfoItem
-                      label={translate('text_65201b8216455901fe273dd9')}
-                      value={
-                        charge?.payInAdvance
+                  <DetailsInfoGrid
+                    grid={[
+                      {
+                        label: translate('text_65201b8216455901fe273dd9'),
+                        value: charge?.payInAdvance
                           ? translate('text_646e2d0cc536351b62ba6faa')
-                          : translate('text_646e2d0cc536351b62ba6f8c')
-                      }
-                    />
-                    <DetailsInfoItem
-                      label={translate('text_65201b8216455901fe273ddb')}
-                      value={intlFormatNumber(deserializeAmount(charge.minAmountCents, currency), {
-                        currencyDisplay: 'symbol',
-                        currency,
-                        maximumFractionDigits: 15,
-                      })}
-                    />
-                    <DetailsInfoItem
-                      label={translate('text_65201b8216455901fe273df0')}
-                      value={
-                        charge.prorated
+                          : translate('text_646e2d0cc536351b62ba6f8c'),
+                      },
+                      {
+                        label: translate('text_65201b8216455901fe273ddb'),
+                        value: intlFormatNumber(
+                          deserializeAmount(charge.minAmountCents, currency),
+                          {
+                            currencyDisplay: 'symbol',
+                            currency,
+                            maximumFractionDigits: 15,
+                          },
+                        ),
+                      },
+                      {
+                        label: translate('text_65201b8216455901fe273df0'),
+                        value: charge.prorated
                           ? translate('text_65251f46339c650084ce0d57')
-                          : translate('text_65251f4cd55aeb004e5aa5ef')
-                      }
-                    />
-                    <DetailsInfoItem
-                      label={translate('text_646e2d0cc536351b62ba6f16')}
-                      value={
-                        charge.invoiceable
+                          : translate('text_65251f4cd55aeb004e5aa5ef'),
+                      },
+                      {
+                        label: translate('text_646e2d0cc536351b62ba6f16'),
+                        value: charge.invoiceable
                           ? translate('text_65251f46339c650084ce0d57')
-                          : translate('text_65251f4cd55aeb004e5aa5ef')
-                      }
-                    />
-                    <DetailsInfoItem
-                      label={translate('text_645bb193927b375079d28a8f')}
-                      value={
-                        !!charge?.taxes?.length || !!plan?.taxes?.length
-                          ? (charge.taxes?.length ? charge.taxes : plan?.taxes)?.map(
-                              (tax, taxIndex) => (
-                                <div
-                                  key={`plan-details-charge-${i}-section-accordion-tax-${taxIndex}`}
-                                >
-                                  {tax.name} (
-                                  {intlFormatNumber(Number(tax.rate) / 100 || 0, {
-                                    maximumFractionDigits: 2,
-                                    style: 'percent',
-                                  })}
-                                  )
-                                </div>
-                              ),
-                            )
-                          : '-'
-                      }
-                    />
-                  </DetailsInfoGrid>
+                          : translate('text_65251f4cd55aeb004e5aa5ef'),
+                      },
+                      {
+                        label: translate('text_645bb193927b375079d28a8f'),
+                        value:
+                          !!charge?.taxes?.length || !!plan?.taxes?.length
+                            ? (charge.taxes?.length ? charge.taxes : plan?.taxes)?.map(
+                                (tax, taxIndex) => (
+                                  <div
+                                    key={`plan-details-charge-${i}-section-accordion-tax-${taxIndex}`}
+                                  >
+                                    {tax.name} (
+                                    {intlFormatNumber(Number(tax.rate) / 100 || 0, {
+                                      maximumFractionDigits: 2,
+                                      style: 'percent',
+                                    })}
+                                    )
+                                  </div>
+                                ),
+                              )
+                            : '-',
+                      },
+                    ]}
+                  />
                 </PaddedOptionsWrapper>
               </ChargeSectionWrapper>
             </Accordion>
@@ -191,82 +192,83 @@ const PlanDetailsChargesSection = ({
               <ChargeSectionWrapper>
                 {/* Charge main infos */}
                 <PaddedChargeModelWrapper>
-                  <DetailsInfoGrid>
-                    <DetailsInfoItem
-                      label={translate('text_65201b8216455901fe273dd5')}
-                      value={translate(chargeModelLookupTranslation[charge.chargeModel])}
-                    />
-                    <DetailsInfoItem
-                      label={translate('text_65201b8216455901fe273dc1')}
-                      value={translate(
-                        mapChargeIntervalCopy(
-                          plan?.interval as PlanInterval,
-                          (plan?.interval === PlanInterval.Yearly && !!plan?.billChargesMonthly) ||
-                            false,
+                  <DetailsInfoGrid
+                    grid={[
+                      {
+                        label: translate('text_65201b8216455901fe273dd5'),
+                        value: translate(chargeModelLookupTranslation[charge.chargeModel]),
+                      },
+                      {
+                        label: translate('text_65201b8216455901fe273dc1'),
+                        value: translate(
+                          mapChargeIntervalCopy(
+                            plan?.interval as PlanInterval,
+                            (plan?.interval === PlanInterval.Yearly &&
+                              !!plan?.billChargesMonthly) ||
+                              false,
+                          ),
                         ),
-                      )}
-                    />
-                  </DetailsInfoGrid>
+                      },
+                    ]}
+                  />
                 </PaddedChargeModelWrapper>
                 {/* Propertiers accordion */}
                 <PlanDetailsChargesSectionAccordion currency={currency} charge={charge as Charge} />
                 {/* Options */}
                 <PaddedOptionsWrapper>
-                  <DetailsInfoGrid>
-                    <DetailsInfoItem
-                      label={translate('text_65201b8216455901fe273dd9')}
-                      value={
-                        charge?.payInAdvance
+                  <DetailsInfoGrid
+                    grid={[
+                      {
+                        label: translate('text_65201b8216455901fe273dd9'),
+                        value: charge?.payInAdvance
                           ? translate('text_646e2d0cc536351b62ba6faa')
-                          : translate('text_646e2d0cc536351b62ba6f8c')
-                      }
-                    />
-                    <DetailsInfoItem
-                      label={translate('text_65201b8216455901fe273ddb')}
-                      value={intlFormatNumber(deserializeAmount(charge.minAmountCents, currency), {
-                        currencyDisplay: 'symbol',
-                        currency,
-                        maximumFractionDigits: 15,
-                      })}
-                    />
-                    <DetailsInfoItem
-                      label={translate('text_65201b8216455901fe273df0')}
-                      value={
-                        charge.prorated
+                          : translate('text_646e2d0cc536351b62ba6f8c'),
+                      },
+                      {
+                        label: translate('text_65201b8216455901fe273ddb'),
+                        value: intlFormatNumber(
+                          deserializeAmount(charge.minAmountCents, currency),
+                          {
+                            currencyDisplay: 'symbol',
+                            currency,
+                            maximumFractionDigits: 15,
+                          },
+                        ),
+                      },
+                      {
+                        label: translate('text_65201b8216455901fe273df0'),
+                        value: charge.prorated
                           ? translate('text_65251f46339c650084ce0d57')
-                          : translate('text_65251f4cd55aeb004e5aa5ef')
-                      }
-                    />
-                    <DetailsInfoItem
-                      label={translate('text_646e2d0cc536351b62ba6f16')}
-                      value={
-                        charge.invoiceable
+                          : translate('text_65251f4cd55aeb004e5aa5ef'),
+                      },
+                      {
+                        label: translate('text_646e2d0cc536351b62ba6f16'),
+                        value: charge.invoiceable
                           ? translate('text_65251f46339c650084ce0d57')
-                          : translate('text_65251f4cd55aeb004e5aa5ef')
-                      }
-                    />
-                    <DetailsInfoItem
-                      label={translate('text_645bb193927b375079d28a8f')}
-                      value={
-                        !!charge?.taxes?.length || !!plan?.taxes?.length
-                          ? (charge.taxes?.length ? charge.taxes : plan?.taxes)?.map(
-                              (tax, taxIndex) => (
-                                <div
-                                  key={`plan-details-charge-${i}-section-accordion-tax-${taxIndex}`}
-                                >
-                                  {tax.name} (
-                                  {intlFormatNumber(Number(tax.rate) / 100 || 0, {
-                                    maximumFractionDigits: 2,
-                                    style: 'percent',
-                                  })}
-                                  )
-                                </div>
-                              ),
-                            )
-                          : '-'
-                      }
-                    />
-                  </DetailsInfoGrid>
+                          : translate('text_65251f4cd55aeb004e5aa5ef'),
+                      },
+                      {
+                        label: translate('text_645bb193927b375079d28a8f'),
+                        value:
+                          !!charge?.taxes?.length || !!plan?.taxes?.length
+                            ? (charge.taxes?.length ? charge.taxes : plan?.taxes)?.map(
+                                (tax, taxIndex) => (
+                                  <div
+                                    key={`plan-details-charge-${i}-section-accordion-tax-${taxIndex}`}
+                                  >
+                                    {tax.name} (
+                                    {intlFormatNumber(Number(tax.rate) / 100 || 0, {
+                                      maximumFractionDigits: 2,
+                                      style: 'percent',
+                                    })}
+                                    )
+                                  </div>
+                                ),
+                              )
+                            : '-',
+                      },
+                    ]}
+                  />
                 </PaddedOptionsWrapper>
               </ChargeSectionWrapper>
             </Accordion>

--- a/src/components/plans/details/PlanDetailsCommitmentsSection.tsx
+++ b/src/components/plans/details/PlanDetailsCommitmentsSection.tsx
@@ -1,5 +1,4 @@
 import { Stack } from '@mui/material'
-import React from 'react'
 
 import { Accordion, Typography } from '~/components/designSystem'
 import { getIntervalTranslationKey } from '~/core/constants/form'
@@ -7,7 +6,7 @@ import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { CurrencyEnum, EditPlanFragment, PlanInterval } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { DetailsInfoGrid, DetailsInfoItem } from '~/styles/detailsPage'
+import { DetailsInfoGrid } from '~/styles/detailsPage'
 
 import PlanDetailsChargeTableDisplay from './PlanDetailsChargeTableDisplay'
 
@@ -64,15 +63,15 @@ const PlanDetailsCommitmentsSection = ({
             ]}
           />
 
-          <DetailsInfoGrid>
-            <DetailsInfoItem
-              label={translate('text_65201b8216455901fe273dc1')}
-              value={translate(getIntervalTranslationKey[plan?.interval as PlanInterval])}
-            />
-            <DetailsInfoItem
-              label={translate('text_645bb193927b375079d28a8f')}
-              value={
-                !!plan?.minimumCommitment?.taxes?.length
+          <DetailsInfoGrid
+            grid={[
+              {
+                label: translate('text_65201b8216455901fe273dc1'),
+                value: translate(getIntervalTranslationKey[plan?.interval as PlanInterval]),
+              },
+              {
+                label: translate('text_645bb193927b375079d28a8f'),
+                value: !!plan?.minimumCommitment?.taxes?.length
                   ? plan?.minimumCommitment?.taxes?.map((tax, i) => (
                       <Typography
                         key={`plan-details-fixed-fee-taxe-${i}`}
@@ -87,10 +86,10 @@ const PlanDetailsCommitmentsSection = ({
                         )
                       </Typography>
                     ))
-                  : '-'
-              }
-            />
-          </DetailsInfoGrid>
+                  : '-',
+              },
+            ]}
+          />
         </Stack>
       </Accordion>
     </Stack>

--- a/src/components/plans/details/PlanDetailsCommitmentsSection.tsx
+++ b/src/components/plans/details/PlanDetailsCommitmentsSection.tsx
@@ -8,7 +8,7 @@ import { CurrencyEnum, EditPlanFragment, PlanInterval } from '~/generated/graphq
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { DetailsInfoGrid } from '~/styles/detailsPage'
 
-import PlanDetailsChargeTableDisplay from './PlanDetailsChargeTableDisplay'
+import DetailsTableDisplay from '../../details/DetailsTableDisplay'
 
 export const intervalDescriptionLookupTranslation = {
   [PlanInterval.Monthly]: 'text_65d620fda73c6f007f6f238c',
@@ -46,7 +46,7 @@ const PlanDetailsCommitmentsSection = ({
         }
       >
         <Stack direction="column" spacing={4}>
-          <PlanDetailsChargeTableDisplay
+          <DetailsTableDisplay
             header={[translate('text_65d601bffb11e0f9d1d9f571')]}
             body={[
               [

--- a/src/components/plans/details/PlanDetailsFixedFeeAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsFixedFeeAccordion.tsx
@@ -3,7 +3,7 @@ import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { CurrencyEnum, EditPlanFragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { DetailsAccordionWrapper, DetailsInfoGrid, DetailsInfoItem } from '~/styles/detailsPage'
+import { DetailsAccordionWrapper, DetailsInfoGrid } from '~/styles/detailsPage'
 
 import PlanDetailsChargeTableDisplay from './PlanDetailsChargeTableDisplay'
 
@@ -30,23 +30,21 @@ const PlanDetailsFixedFeeAccordion = ({ plan }: { plan?: EditPlanFragment | null
             ],
           ]}
         />
-        <DetailsInfoGrid>
-          <DetailsInfoItem
-            label={translate('text_65201b8216455901fe273dd9')}
-            value={
-              plan?.payInAdvance
+        <DetailsInfoGrid
+          grid={[
+            {
+              label: translate('text_65201b8216455901fe273dd9'),
+              value: plan?.payInAdvance
                 ? translate('text_646e2d0cc536351b62ba6faa')
-                : translate('text_646e2d0cc536351b62ba6f8c')
-            }
-          />
-          <DetailsInfoItem
-            label={translate('text_65201b8216455901fe273dcd')}
-            value={plan?.trialPeriod}
-          />
-          <DetailsInfoItem
-            label={translate('text_645bb193927b375079d28a8f')}
-            value={
-              !!plan?.taxes?.length
+                : translate('text_646e2d0cc536351b62ba6f8c'),
+            },
+            {
+              label: translate('text_65201b8216455901fe273dcd'),
+              value: plan?.trialPeriod,
+            },
+            {
+              label: translate('text_645bb193927b375079d28a8f'),
+              value: !!plan?.taxes?.length
                 ? plan?.taxes?.map((tax, i) => (
                     <div key={`plan-details-fixed-fee-taxe-${i}`}>
                       <Typography variant="body" color="grey700">
@@ -59,10 +57,10 @@ const PlanDetailsFixedFeeAccordion = ({ plan }: { plan?: EditPlanFragment | null
                       </Typography>
                     </div>
                   ))
-                : '-'
-            }
-          />
-        </DetailsInfoGrid>
+                : '-',
+            },
+          ]}
+        />
       </DetailsAccordionWrapper>
     </Accordion>
   )

--- a/src/components/plans/details/PlanDetailsFixedFeeAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsFixedFeeAccordion.tsx
@@ -5,7 +5,7 @@ import { CurrencyEnum, EditPlanFragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { DetailsAccordionWrapper, DetailsInfoGrid } from '~/styles/detailsPage'
 
-import PlanDetailsChargeTableDisplay from './PlanDetailsChargeTableDisplay'
+import DetailsTableDisplay from '../../details/DetailsTableDisplay'
 
 const PlanDetailsFixedFeeAccordion = ({ plan }: { plan?: EditPlanFragment | null }) => {
   const { translate } = useInternationalization()
@@ -19,7 +19,7 @@ const PlanDetailsFixedFeeAccordion = ({ plan }: { plan?: EditPlanFragment | null
       }
     >
       <DetailsAccordionWrapper>
-        <PlanDetailsChargeTableDisplay
+        <DetailsTableDisplay
           header={[translate('text_624453d52e945301380e49b6')]}
           body={[
             [

--- a/src/components/plans/details/PlanDetailsOverview.tsx
+++ b/src/components/plans/details/PlanDetailsOverview.tsx
@@ -46,24 +46,26 @@ const PlanDetailsOverview = ({ planId }: { planId?: string }) => {
           {translate('text_642d5eb2783a2ad10d67031a')}
         </DetailsSectionTitle>
         <ContentWrapper>
-          <DetailsInfoGrid>
-            <DetailsInfoItem
-              label={translate('text_62442e40cea25600b0b6d852')}
-              value={plan?.name}
-            />
-            <DetailsInfoItem
-              label={translate('text_642d5eb2783a2ad10d670320')}
-              value={plan?.code}
-            />
-            <DetailsInfoItem
-              label={translate('text_65201b8216455901fe273dc1')}
-              value={translate(getIntervalTranslationKey[plan?.interval as PlanInterval])}
-            />
-            <DetailsInfoItem
-              label={translate('text_632b4acf0c41206cbcb8c324')}
-              value={plan?.amountCurrency}
-            />
-          </DetailsInfoGrid>
+          <DetailsInfoGrid
+            grid={[
+              {
+                label: translate('text_62442e40cea25600b0b6d852'),
+                value: plan?.name,
+              },
+              {
+                label: translate('text_642d5eb2783a2ad10d670320'),
+                value: plan?.code,
+              },
+              {
+                label: translate('text_65201b8216455901fe273dc1'),
+                value: translate(getIntervalTranslationKey[plan?.interval as PlanInterval]),
+              },
+              {
+                label: translate('text_632b4acf0c41206cbcb8c324'),
+                value: plan?.amountCurrency,
+              },
+            ]}
+          />
 
           {!!plan?.description && (
             <DetailsInfoItem

--- a/src/components/subscriptions/SubscriptionInformations.tsx
+++ b/src/components/subscriptions/SubscriptionInformations.tsx
@@ -69,54 +69,50 @@ const SubscriptionInformations = ({
           label={translate('text_65201c5a175a4b0238abf298')}
           value={subscription?.externalId}
         />
-        <DetailsInfoGrid>
-          <DetailsInfoItem
-            label={translate('text_65201c5a175a4b0238abf29a')}
-            value={
-              <Link
-                to={generatePath(CUSTOMER_DETAILS_ROUTE, {
-                  customerId: subscription?.customer?.id as string,
-                })}
-              >
-                {subscription?.customer?.name}
-              </Link>
-            }
-          />
-          <DetailsInfoItem
-            label={translate('text_62d7f6178ec94cd09370e5fb')}
-            value={
-              <Status
-                type={
-                  subscription?.status === StatusTypeEnum.Pending
-                    ? StatusEnum.paused
-                    : StatusEnum.running
-                }
-                label={
-                  subscription?.status === StatusTypeEnum.Pending
-                    ? translate('text_624efab67eb2570101d117f6')
-                    : translate('text_624efab67eb2570101d1180e')
-                }
-              />
-            }
-          />
-          <DetailsInfoItem
-            label={translate('text_65201c5a175a4b0238abf29e')}
-            value={DateTime.fromISO(subscription?.subscriptionAt).toFormat('LLL. dd, yyyy')}
-          />
-
-          <DetailsInfoItem
-            label={translate('text_65201c5a175a4b0238abf2a0')}
-            value={
-              !!subscription?.endingAt
+        <DetailsInfoGrid
+          grid={[
+            {
+              label: translate('text_65201c5a175a4b0238abf29a'),
+              value: (
+                <Link
+                  to={generatePath(CUSTOMER_DETAILS_ROUTE, {
+                    customerId: subscription?.customer?.id as string,
+                  })}
+                >
+                  {subscription?.customer?.name}
+                </Link>
+              ),
+            },
+            {
+              label: translate('text_62d7f6178ec94cd09370e5fb'),
+              value: (
+                <Status
+                  type={
+                    subscription?.status === StatusTypeEnum.Pending
+                      ? StatusEnum.paused
+                      : StatusEnum.running
+                  }
+                  label={
+                    subscription?.status === StatusTypeEnum.Pending
+                      ? translate('text_624efab67eb2570101d117f6')
+                      : translate('text_624efab67eb2570101d1180e')
+                  }
+                />
+              ),
+            },
+            {
+              label: translate('text_65201c5a175a4b0238abf29e'),
+              value: DateTime.fromISO(subscription?.subscriptionAt).toFormat('LLL. dd, yyyy'),
+            },
+            {
+              label: translate('text_65201c5a175a4b0238abf2a0'),
+              value: !!subscription?.endingAt
                 ? DateTime.fromISO(subscription?.endingAt).toFormat('LLL. dd, yyyy')
-                : '-'
-            }
-          />
-
-          {!!subscription?.plan?.parent?.id && (
-            <DetailsInfoItem
-              label={translate('text_65201c5a175a4b0238abf2a2')}
-              value={
+                : '-',
+            },
+            !!subscription?.plan?.parent?.id && {
+              label: translate('text_65201c5a175a4b0238abf2a2'),
+              value: (
                 <Link
                   to={generatePath(CUSTOMER_SUBSCRIPTION_PLAN_DETAILS, {
                     customerId: subscription?.customer?.id as string,
@@ -127,10 +123,10 @@ const SubscriptionInformations = ({
                 >
                   {subscription?.plan?.parent?.name}
                 </Link>
-              }
-            />
-          )}
-        </DetailsInfoGrid>
+              ),
+            },
+          ]}
+        />
       </ContentWrapper>
     </section>
   )

--- a/src/core/router/ObjectsRoutes.tsx
+++ b/src/core/router/ObjectsRoutes.tsx
@@ -48,6 +48,9 @@ const SubscriptionDetails = lazyLoad(
 const PlanDetails = lazyLoad(
   () => import(/* webpackChunkName: 'plan-details' */ '~/pages/PlanDetails'),
 )
+const AddOnDetails = lazyLoad(
+  () => import(/* webpackChunkName: 'add-on-details' */ '~/pages/AddOnDetails'),
+)
 
 // ----------- Routes -----------
 // Lists
@@ -91,6 +94,7 @@ export const PLAN_SUBSCRIPTION_DETAILS_ROUTE = '/plan/:planId/subscription/:subs
 export const PLAN_DETAILS_ROUTE = '/plan/:planId/:tab'
 export const CUSTOMER_SUBSCRIPTION_PLAN_DETAILS =
   '/customer/:customerId/subscription/:subscriptionId/plan/:planId/:tab'
+export const ADD_ON_DETAILS_ROUTE = '/add-on/:addOnId'
 
 export const objectListRoutes: CustomRouteObject[] = [
   {
@@ -173,5 +177,10 @@ export const objectDetailsRoutes: CustomRouteObject[] = [
     path: [PLAN_DETAILS_ROUTE, CUSTOMER_SUBSCRIPTION_PLAN_DETAILS],
     private: true,
     element: <PlanDetails />,
+  },
+  {
+    path: [ADD_ON_DETAILS_ROUTE],
+    private: true,
+    element: <AddOnDetails />,
   },
 ]

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -5697,6 +5697,13 @@ export type SideNavInfosQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type SideNavInfosQuery = { __typename?: 'Query', currentVersion: { __typename?: 'CurrentVersion', githubUrl: string, number: string } };
 
+export type GetAddOnForDetailsQueryVariables = Exact<{
+  addOn: Scalars['ID']['input'];
+}>;
+
+
+export type GetAddOnForDetailsQuery = { __typename?: 'Query', addOn?: { __typename?: 'AddOn', id: string, name: string, amountCents: any, amountCurrency: CurrencyEnum, code: string, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null } | null };
+
 export type AddOnsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -13179,6 +13186,56 @@ export type SideNavInfosQueryHookResult = ReturnType<typeof useSideNavInfosQuery
 export type SideNavInfosLazyQueryHookResult = ReturnType<typeof useSideNavInfosLazyQuery>;
 export type SideNavInfosSuspenseQueryHookResult = ReturnType<typeof useSideNavInfosSuspenseQuery>;
 export type SideNavInfosQueryResult = Apollo.QueryResult<SideNavInfosQuery, SideNavInfosQueryVariables>;
+export const GetAddOnForDetailsDocument = gql`
+    query getAddOnForDetails($addOn: ID!) {
+  addOn(id: $addOn) {
+    id
+    name
+    amountCents
+    amountCurrency
+    code
+    taxes {
+      id
+      code
+      name
+      rate
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetAddOnForDetailsQuery__
+ *
+ * To run a query within a React component, call `useGetAddOnForDetailsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAddOnForDetailsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAddOnForDetailsQuery({
+ *   variables: {
+ *      addOn: // value for 'addOn'
+ *   },
+ * });
+ */
+export function useGetAddOnForDetailsQuery(baseOptions: Apollo.QueryHookOptions<GetAddOnForDetailsQuery, GetAddOnForDetailsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetAddOnForDetailsQuery, GetAddOnForDetailsQueryVariables>(GetAddOnForDetailsDocument, options);
+      }
+export function useGetAddOnForDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetAddOnForDetailsQuery, GetAddOnForDetailsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetAddOnForDetailsQuery, GetAddOnForDetailsQueryVariables>(GetAddOnForDetailsDocument, options);
+        }
+export function useGetAddOnForDetailsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetAddOnForDetailsQuery, GetAddOnForDetailsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetAddOnForDetailsQuery, GetAddOnForDetailsQueryVariables>(GetAddOnForDetailsDocument, options);
+        }
+export type GetAddOnForDetailsQueryHookResult = ReturnType<typeof useGetAddOnForDetailsQuery>;
+export type GetAddOnForDetailsLazyQueryHookResult = ReturnType<typeof useGetAddOnForDetailsLazyQuery>;
+export type GetAddOnForDetailsSuspenseQueryHookResult = ReturnType<typeof useGetAddOnForDetailsSuspenseQuery>;
+export type GetAddOnForDetailsQueryResult = Apollo.QueryResult<GetAddOnForDetailsQuery, GetAddOnForDetailsQueryVariables>;
 export const AddOnsDocument = gql`
     query addOns($page: Int, $limit: Int, $searchTerm: String) {
   addOns(page: $page, limit: $limit, searchTerm: $searchTerm) {

--- a/src/hooks/useCreateEditAddOn.ts
+++ b/src/hooks/useCreateEditAddOn.ts
@@ -1,11 +1,11 @@
 import { gql } from '@apollo/client'
 import { useEffect, useMemo } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { generatePath, useNavigate, useParams } from 'react-router-dom'
 
 import { AddOnFormInput } from '~/components/addOns/types'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { FORM_ERRORS_ENUM } from '~/core/constants/form'
-import { ADD_ONS_ROUTE, ERROR_404_ROUTE } from '~/core/router'
+import { ADD_ON_DETAILS_ROUTE, ERROR_404_ROUTE } from '~/core/router'
 import { serializeAmount } from '~/core/serializers/serializeAmount'
 import {
   AddOnItemFragmentDoc,
@@ -96,7 +96,7 @@ export const useCreateEditAddOn: () => UseCreateEditAddOnReturn = () => {
           severity: 'success',
           translateKey: 'text_633336532bdf72cb62dc0692',
         })
-        navigate(ADD_ONS_ROUTE)
+        navigate(generatePath(ADD_ON_DETAILS_ROUTE, { addOnId: createAddOn.id }))
       }
     },
   })
@@ -108,7 +108,7 @@ export const useCreateEditAddOn: () => UseCreateEditAddOnReturn = () => {
           severity: 'success',
           translateKey: 'text_629728388c4d2300e2d3818a',
         })
-        navigate(ADD_ONS_ROUTE)
+        navigate(generatePath(ADD_ON_DETAILS_ROUTE, { addOnId: updateAddOn.id }))
       }
     },
   })

--- a/src/pages/AddOnDetails.tsx
+++ b/src/pages/AddOnDetails.tsx
@@ -1,0 +1,233 @@
+import { gql } from '@apollo/client'
+import { useRef } from 'react'
+import { generatePath, useNavigate, useParams } from 'react-router-dom'
+import styled from 'styled-components'
+
+import { DeleteAddOnDialog, DeleteAddOnDialogRef } from '~/components/addOns/DeleteAddOnDialog'
+import { Button, Popper, Skeleton, Typography } from '~/components/designSystem'
+import { DetailsHeader, DetailsHeaderSkeleton } from '~/components/details/DetailsHeader'
+import DetailsTableDisplay from '~/components/details/DetailsTableDisplay'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { ADD_ONS_ROUTE, UPDATE_ADD_ON_ROUTE } from '~/core/router'
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { CurrencyEnum, useGetAddOnForDetailsQuery } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { MenuPopper, PageHeader, theme } from '~/styles'
+import { DetailsInfoGrid, DetailsSectionTitle } from '~/styles/detailsPage'
+
+gql`
+  query getAddOnForDetails($addOn: ID!) {
+    addOn(id: $addOn) {
+      id
+      name
+      amountCents
+      amountCurrency
+      code
+      taxes {
+        id
+        code
+        name
+        rate
+      }
+    }
+  }
+`
+
+const AddOnDetails = () => {
+  const navigate = useNavigate()
+  const { translate } = useInternationalization()
+  const { addOnId } = useParams()
+
+  const deleteDialogRef = useRef<DeleteAddOnDialogRef>(null)
+
+  const { data: addOnResult, loading: isAddOnLoading } = useGetAddOnForDetailsQuery({
+    variables: {
+      addOn: addOnId as string,
+    },
+  })
+
+  const addOn = addOnResult?.addOn
+
+  const amountWithCurrency = intlFormatNumber(
+    deserializeAmount(addOn?.amountCents, addOn?.amountCurrency || CurrencyEnum.Usd) || 0,
+    {
+      currencyDisplay: 'symbol',
+      currency: addOn?.amountCurrency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 15,
+    },
+  )
+
+  return (
+    <>
+      <PageHeader $withSide>
+        <HeaderInlineBreadcrumbBlock>
+          <Button
+            icon="arrow-left"
+            variant="quaternary"
+            onClick={() => {
+              navigate(ADD_ONS_ROUTE)
+            }}
+          />
+          {isAddOnLoading && !addOn ? (
+            <AddOnTitleLoadingWrapper>
+              <Skeleton variant="text" width={200} height={12} />
+            </AddOnTitleLoadingWrapper>
+          ) : (
+            <Typography variant="bodyHl" color="textSecondary" noWrap>
+              {addOn?.name}
+            </Typography>
+          )}
+          <Typography variant="bodyHl" color="textSecondary" noWrap></Typography>
+        </HeaderInlineBreadcrumbBlock>
+        <Popper
+          PopperProps={{ placement: 'bottom-end' }}
+          opener={
+            <Button endIcon="chevron-down">{translate('text_626162c62f790600f850b6fe')}</Button>
+          }
+        >
+          {({ closePopper }) => (
+            <MenuPopper>
+              <Button
+                variant="quaternary"
+                align="left"
+                onClick={() => {
+                  navigate(generatePath(UPDATE_ADD_ON_ROUTE, { addOnId: addOnId as string }))
+                  closePopper()
+                }}
+              >
+                {translate('text_625fd39a15394c0117e7d792')}
+              </Button>
+              {addOn && (
+                <Button
+                  variant="quaternary"
+                  align="left"
+                  onClick={() => {
+                    deleteDialogRef.current?.openDialog({
+                      addOn,
+                      callback: () => {
+                        navigate(ADD_ONS_ROUTE)
+                      },
+                    })
+                    closePopper()
+                  }}
+                >
+                  {translate('text_629728388c4d2300e2d38182')}
+                </Button>
+              )}
+            </MenuPopper>
+          )}
+        </Popper>
+      </PageHeader>
+
+      {isAddOnLoading ? (
+        <DetailsHeaderSkeleton />
+      ) : (
+        <DetailsHeader
+          icon="puzzle"
+          title={addOn?.name || ''}
+          description={translate('text_629728388c4d2300e2d3810b', { amountWithCurrency })}
+        />
+      )}
+
+      <Container>
+        <section>
+          <DetailsSectionTitle variant="subhead" noWrap>
+            {translate('text_6627e7b9732dbfb6c472e027')}
+          </DetailsSectionTitle>
+          <DetailsInfoGrid
+            grid={[
+              {
+                label: translate('text_629728388c4d2300e2d380bd'),
+                value: addOn?.name,
+              },
+              {
+                label: translate('text_6627e7b9732dbfb6c472e02d'),
+                value: addOn?.code,
+              },
+              {
+                label: translate('text_632b4acf0c41206cbcb8c324'),
+                value: addOn?.amountCurrency,
+              },
+            ]}
+          />
+        </section>
+
+        <section>
+          <DetailsSectionTitle variant="subhead" noWrap>
+            {translate('text_629728388c4d2300e2d38117')}
+          </DetailsSectionTitle>
+          <DetailsCard>
+            <DetailsSectionWrapperWithBorder>
+              <DetailsTableDisplay
+                header={[translate('text_624453d52e945301380e49b6')]}
+                body={[[amountWithCurrency]]}
+              />
+            </DetailsSectionWrapperWithBorder>
+
+            <DetailsSectionWrapper>
+              <DetailsInfoGrid
+                grid={[
+                  {
+                    label: translate('text_64be910fba8ef9208686a8e3'),
+                    value: !!addOn?.taxes?.length
+                      ? addOn.taxes?.map((tax, taxIndex) => (
+                          <div key={`add-on-details-tax-${taxIndex}`}>
+                            {tax.name} (
+                            {intlFormatNumber(Number(tax.rate) / 100 || 0, {
+                              maximumFractionDigits: 2,
+                              style: 'percent',
+                            })}
+                            )
+                          </div>
+                        ))
+                      : '-',
+                  },
+                ]}
+              />
+            </DetailsSectionWrapper>
+          </DetailsCard>
+        </section>
+      </Container>
+
+      <DeleteAddOnDialog ref={deleteDialogRef} />
+    </>
+  )
+}
+
+export default AddOnDetails
+
+const HeaderInlineBreadcrumbBlock = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing(3)};
+
+  /* Prevent long name to not overflow in header */
+  overflow: hidden;
+`
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(12)};
+
+  padding: 0 ${theme.spacing(12)};
+  max-width: 672px;
+`
+
+const AddOnTitleLoadingWrapper = styled.div`
+  width: 200px;
+`
+
+const DetailsCard = styled.div`
+  border: 1px solid ${theme.palette.grey[400]};
+  border-radius: 12px;
+`
+
+const DetailsSectionWrapper = styled.div`
+  padding: ${theme.spacing(4)};
+`
+
+const DetailsSectionWrapperWithBorder = styled(DetailsSectionWrapper)`
+  box-shadow: ${theme.shadows[7]};
+`

--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 import { useFormik } from 'formik'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { generatePath, useNavigate, useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { number, object, string } from 'yup'
 
@@ -16,7 +16,7 @@ import {
   SEARCH_TAX_INPUT_FOR_ADD_ON_CLASSNAME,
 } from '~/core/constants/form'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
-import { ADD_ONS_ROUTE } from '~/core/router'
+import { ADD_ON_DETAILS_ROUTE, ADD_ONS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import {
   CurrencyEnum,
@@ -26,8 +26,7 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCreateEditAddOn } from '~/hooks/useCreateEditAddOn'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
-import { PageHeader } from '~/styles'
-import { Card, theme } from '~/styles'
+import { Card, PageHeader, theme } from '~/styles'
 import {
   ButtonContainer,
   Content,
@@ -65,6 +64,7 @@ const CreateAddOn = () => {
   const { translate } = useInternationalization()
   let navigate = useNavigate()
   const { organization } = useOrganizationInfos()
+  const { addOnId } = useParams()
   const { isEdition, loading, addOn, errorCode, onSave } = useCreateEditAddOn()
   const warningDialogRef = useRef<WarningDialogRef>(null)
   const [getTaxes, { data: taxesData, loading: taxesLoading }] = useGetTaxesForAddOnFormLazyQuery({
@@ -159,7 +159,11 @@ const CreateAddOn = () => {
           variant="quaternary"
           icon="close"
           onClick={() =>
-            formikProps.dirty ? warningDialogRef.current?.openDialog() : navigate(ADD_ONS_ROUTE)
+            formikProps.dirty
+              ? warningDialogRef.current?.openDialog()
+              : isEdition && addOnId
+                ? navigate(generatePath(ADD_ON_DETAILS_ROUTE, { addOnId }))
+                : navigate(ADD_ONS_ROUTE)
           }
         />
       </PageHeader>

--- a/src/styles/detailsPage.tsx
+++ b/src/styles/detailsPage.tsx
@@ -4,7 +4,11 @@ import styled from 'styled-components'
 import { Typography } from '~/components/designSystem'
 import { NAV_HEIGHT, theme } from '~/styles'
 
-export const DetailsInfoItem = ({ label, value }: { label: string; value: ReactNode | string }) => {
+interface DetailsInfoItemProps {
+  label: string
+  value: ReactNode | string
+}
+export const DetailsInfoItem = ({ label, value }: DetailsInfoItemProps) => {
   return (
     <div>
       <Typography variant="caption">{label}</Typography>
@@ -21,7 +25,25 @@ export const DetailsSectionTitle = styled(Typography)`
   height: ${NAV_HEIGHT}px;
 `
 
-export const DetailsInfoGrid = styled.div`
+export const DetailsInfoGrid = ({ grid }: { grid: Array<DetailsInfoItemProps | false> }) => {
+  return (
+    <StyledDetailsInfoGrid>
+      {grid.map((item, index) => {
+        if (item) {
+          return (
+            <DetailsInfoItem
+              key={`details-info-grid-${item.label}-${index}`}
+              label={item.label}
+              value={item.value}
+            />
+          )
+        }
+      })}
+    </StyledDetailsInfoGrid>
+  )
+}
+
+const StyledDetailsInfoGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(2, minmax(auto, 1fr));
   gap: ${theme.spacing(4)} ${theme.spacing(8)};


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/{{FEATURE_SLUG}}

## Context

This PR should create a new detail page for add-ons

<img width="1792" alt="Capture d’écran 2024-04-24 à 11 41 29" src="https://github.com/getlago/lago-front/assets/17253055/5b68c983-35a1-43af-af06-a540d47b96db">

## Description

It should:
- refactor plan related code to reuse component and make them agnostic
- redirect to a new detail page by clicking in the list item or after closing the edition form
- create the new page

