### PR TITLE
misc: add new formatters and fix chaining behaviour

### DIFF
--- a/src/components/form/TextInput/TextInput.tsx
+++ b/src/components/form/TextInput/TextInput.tsx
@@ -20,6 +20,8 @@ export enum ValueFormatter {
   code = 'code', // Replace all the spaces by "_"
   chargeDecimal = 'chargeDecimal', // Truncate charge numbers to 15 decimals
   lowercase = 'lowercase',
+  trim = 'trim',
+  dashSeparator = 'dashSeparator',
 }
 
 export type ValueFormatterType = keyof typeof ValueFormatter
@@ -98,11 +100,19 @@ export const formatValue = (
   }
 
   if (formatterFunctions.includes(ValueFormatter.code)) {
-    formattedValue = String(value).replace(/\s/g, '_')
+    formattedValue = String(formattedValue).replace(/\s/g, '_')
   }
 
   if (formatterFunctions.includes(ValueFormatter.lowercase)) {
-    formattedValue = String(value).toLowerCase()
+    formattedValue = String(formattedValue).toLowerCase()
+  }
+
+  if (formatterFunctions.includes(ValueFormatter.trim)) {
+    formattedValue = String(formattedValue).trim()
+  }
+
+  if (formatterFunctions.includes(ValueFormatter.dashSeparator)) {
+    formattedValue = String(formattedValue).replace(/ /g, '-').replace(/_/g, '-')
   }
 
   return !formattedValue && formattedValue !== 0 ? '' : formattedValue
@@ -133,10 +143,6 @@ export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
     const { translate } = useInternationalization()
     const [localValue, setLocalValue] = useState<string | number>('')
     const [isVisible, setIsVisible] = useState(!password)
-    const joinedBeforeChangeFormatter =
-      typeof beforeChangeFormatter === 'string'
-        ? beforeChangeFormatter
-        : (beforeChangeFormatter || ['']).join('')
 
     const udpateValue = (
       newValue: string | number,
@@ -159,13 +165,6 @@ export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
         setLocalValue('')
       }
     }, [value])
-
-    useEffect(() => {
-      if (!joinedBeforeChangeFormatter) return
-
-      udpateValue(value, null)
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [joinedBeforeChangeFormatter])
 
     const handleChange = useCallback(
       (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {

--- a/src/components/form/TextInput/__tests__/FormatValue.test.ts
+++ b/src/components/form/TextInput/__tests__/FormatValue.test.ts
@@ -123,11 +123,25 @@ describe('Text input formatValue', () => {
     expect(number).toBe('938884')
   })
 
+  it('should return a trimmed string for "trim" formatter', () => {
+    const trimmed = formatValue('  va  lue  ', 'trim')
+
+    expect(trimmed).toBe('va  lue')
+  })
+
+  it('should return a dashed string for "dashSeparator" formatter', () => {
+    const trimmed = formatValue(' v alue_-01', 'dashSeparator')
+
+    expect(trimmed).toBe('-v-alue--01')
+  })
+
   it('should return the right value for combined formatters', () => {
     const decimalPositive = formatValue(-13.459484, ['decimal', 'positiveNumber'])
     const intPositive = formatValue(-11.459484, ['int', 'positiveNumber'])
+    const specificCode = formatValue(' CUS_1234 ', ['lowercase', 'trim', 'dashSeparator'])
 
     expect(decimalPositive).toBe('13.45')
     expect(intPositive).toBe(11)
+    expect(specificCode).toBe('cus-1234')
   })
 })


### PR DESCRIPTION
This PR aims for
- Add two new separators, `trim` and `dashSeparator`
- fix the current implementation of the formatted method

The fix is about fixing the formatter chaining that could be flacky when used in form with Formik