### PR TITLE
misc: Allow customisation of premium warning dialog copy

### DIFF
--- a/src/components/PremiumWarningDialog.tsx
+++ b/src/components/PremiumWarningDialog.tsx
@@ -1,28 +1,52 @@
-import { forwardRef } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import { Button, Dialog, DialogRef } from '~/components/designSystem'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
+type TProps = {
+  title?: string
+  description?: string
+  mailtoSubject?: string
+  mailtoBody?: string
+}
+
 export interface PremiumWarningDialogRef extends DialogRef {}
 
-export const PremiumWarningDialog = forwardRef<DialogRef>(({}, ref) => {
+export interface PremiumWarningDialogRef {
+  openDialog: (data?: TProps) => unknown
+  closeDialog: () => unknown
+}
+
+export const PremiumWarningDialog = forwardRef<PremiumWarningDialogRef>((_, ref) => {
+  const dialogRef = useRef<DialogRef>(null)
   const { translate } = useInternationalization()
+  const [localData, setLocalData] = useState<TProps | null>(null)
+
+  useImperativeHandle(ref, () => ({
+    openDialog: (data) => {
+      !!data?.description && setLocalData(data)
+      dialogRef.current?.openDialog()
+    },
+    closeDialog: () => {
+      dialogRef.current?.closeDialog()
+    },
+  }))
 
   return (
     <Dialog
-      ref={ref}
-      title={translate('text_63b3155768489ee342482f4f')}
-      description={translate('text_63b3155768489ee342482f51')}
+      ref={dialogRef}
+      title={localData?.title || translate('text_63b3155768489ee342482f4f')}
+      description={localData?.description || translate('text_63b3155768489ee342482f51')}
       actions={({ closeDialog }) => (
         <>
           <Button variant="quaternary" onClick={closeDialog}>
             {translate('text_62f50d26c989ab03196884ae')}
           </Button>
           <LinkTo
-            href={`mailto:hello@getlago.com?subject=${translate(
-              'text_63b3f676d44671bf24d81411',
-            )}&body=${translate('text_63b3f676d44671bf24d81413')}`}
+            href={`mailto:hello@getlago.com?subject=${
+              localData?.mailtoSubject || translate('text_63b3f676d44671bf24d81411')
+            }&body=${localData?.mailtoBody || translate('text_63b3f676d44671bf24d81413')}`}
           >
             <FullWidthButton>{translate('text_63b3155768489ee342482f55')}</FullWidthButton>
           </LinkTo>

--- a/src/layouts/CustomerInvoiceDetails.tsx
+++ b/src/layouts/CustomerInvoiceDetails.tsx
@@ -388,7 +388,7 @@ const CustomerInvoiceDetails = () => {
                         ) : (
                           <Button
                             variant="quaternary"
-                            onClick={premiumWarningDialogRef.current?.openDialog}
+                            onClick={() => premiumWarningDialogRef.current?.openDialog()}
                             endIcon="sparkles"
                           >
                             {translate('text_6386589e4e82fa85eadcaa7a')}

--- a/src/pages/InvoiceCreditNoteList.tsx
+++ b/src/pages/InvoiceCreditNoteList.tsx
@@ -86,7 +86,7 @@ const InvoiceCreditNoteList = () => {
                   ) : (
                     <Button
                       variant="quaternary"
-                      onClick={premiumWarningDialogRef.current?.openDialog}
+                      onClick={() => premiumWarningDialogRef.current?.openDialog()}
                       endIcon="sparkles"
                     >
                       {translate('text_636bdef6565341dcb9cfb127')}

--- a/src/pages/settings/InvoiceSettings.tsx
+++ b/src/pages/settings/InvoiceSettings.tsx
@@ -247,11 +247,11 @@ const InvoiceSettings = () => {
             variant="quaternary"
             endIcon={isPremium ? undefined : 'sparkles'}
             disabled={loading}
-            onClick={
+            onClick={() => {
               isPremium
-                ? editGracePeriodDialogRef?.current?.openDialog
-                : premiumWarningDialogRef.current?.openDialog
-            }
+                ? editGracePeriodDialogRef?.current?.openDialog()
+                : premiumWarningDialogRef.current?.openDialog()
+            }}
           >
             {translate('text_637f819eff19cd55a56d55e4')}
           </Button>

--- a/src/pages/settings/OrganizationInformations.tsx
+++ b/src/pages/settings/OrganizationInformations.tsx
@@ -109,11 +109,11 @@ const OrganizationInformations = () => {
             variant="quaternary"
             disabled={!!loading}
             endIcon={isPremium ? undefined : 'sparkles'}
-            onClick={
+            onClick={() => {
               isPremium
-                ? editTimezoneDialogRef?.current?.openDialog
-                : premiumWarningDialogRef.current?.openDialog
-            }
+                ? editTimezoneDialogRef?.current?.openDialog()
+                : premiumWarningDialogRef.current?.openDialog()
+            }}
           >
             {translate('text_638906e7b4f1a919cb61d0f2')}
           </Button>


### PR DESCRIPTION
## Context

We often display a warning dialog when non-premium user tried to access to a premium feature

This modal shows text and can open a pre-filled mail with custom text

## Description

This PR makes sure the premium warning dialog and the mail copy can be customised during invocation

It's new type definition makes it needed to be specifically called on invocation. It cannot be passed as method to a button onClick anymore for example.