### PR TITLE
chore(renovate) update schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "prCreation": "not-pending",
   "stabilityDays": 3,
   "addLabels": ["🔗 dependencies"],
-  "schedule": ["after 10pm and before 5:00am"],
+  "schedule": ["after 10pm and before 5am every weekday", "every weekend"],
   "postUpdateOptions": ["yarnDedupeHighest"],
   "dependencyDashboardTitle": "👷‍♀️ Dependency Dashboard",
   "dependencyDashboardHeader": "[👮‍♂️ Do not close]. This issue provides visibility into Renovate updates and their statuses. [Learn more](https://docs.renovatebot.com/key-concepts/dashboard/)",


### PR DESCRIPTION
Renovate does not create PR anymore. Even tho the config seems ok.

Trying to fix it by updating the schedule. 