### PR TITLE
bug(dates) remove hardcoded dot in date format

### DIFF
--- a/src/components/TimezoneDate.tsx
+++ b/src/components/TimezoneDate.tsx
@@ -23,7 +23,7 @@ interface TimezoneDateProps {
 }
 
 export const TimezoneDate = ({
-  mainDateFormat = 'LLL. dd, yyyy',
+  mainDateFormat = 'LLL dd, yyyy',
   date,
   mainTimezone = MainTimezoneEnum.organization,
   customerTimezone,

--- a/src/components/customers/subscriptions/SubscriptionDatesOffsetHelperComponent.tsx
+++ b/src/components/customers/subscriptions/SubscriptionDatesOffsetHelperComponent.tsx
@@ -30,7 +30,7 @@ export const SubscriptionDatesOffsetHelperComponent = ({
 
     const date = DateTime.fromISO(subscriptionAt)
       .setZone(customerTimezoneConfig?.name || orgaTimezoneConfig.name)
-      .toFormat('LLL. dd, yyyy')
+      .toFormat('LLL dd, yyyy')
     const time = `${DateTime.fromISO(subscriptionAt)
       .setZone(customerTimezoneConfig?.name || orgaTimezoneConfig.name)
       .setLocale('en')
@@ -59,7 +59,7 @@ export const SubscriptionDatesOffsetHelperComponent = ({
 
     const date = DateTime.fromISO(endingAt)
       .setZone(customerTimezoneConfig?.name || orgaTimezoneConfig.name)
-      .toFormat('LLL. dd, yyyy')
+      .toFormat('LLL dd, yyyy')
     const time = `${DateTime.fromISO(endingAt)
       .setZone(customerTimezoneConfig?.name || orgaTimezoneConfig.name)
       .setLocale('en')

--- a/src/components/developers/DebuggerEventDetails.tsx
+++ b/src/components/developers/DebuggerEventDetails.tsx
@@ -79,7 +79,7 @@ export const DebuggerEventDetails = ({ event }: DebuggerEventDetailsProps) => {
             date={timestamp}
             customerTimezone={customerTimezone}
             mainTimezone="utc0"
-            mainDateFormat="LLL. dd, yyyy HH:mm:ss 'UTC'"
+            mainDateFormat="LLL dd, yyyy HH:mm:ss 'UTC'"
           />
         </PropertyValue>
 

--- a/src/components/developers/WebhookLogDetails.tsx
+++ b/src/components/developers/WebhookLogDetails.tsx
@@ -94,7 +94,7 @@ export const WebhookLogDetails = ({ log }: WebhookLogDetailsProps) => {
           {translate('text_63e27c56dfe64b846474ef6c')}
         </PropertyLabel>
         <PropertyValue color="grey700">
-          {formatTimeOrgaTZ(updatedAt, 'LLL. dd, yyyy HH:mm:ss')}
+          {formatTimeOrgaTZ(updatedAt, 'LLL dd, yyyy HH:mm:ss')}
         </PropertyValue>
 
         <PropertyLabel variant="caption">

--- a/src/components/graphs/utils.ts
+++ b/src/components/graphs/utils.ts
@@ -6,7 +6,7 @@ import { CurrencyEnum } from '~/generated/graphql'
 
 import { AreaChartDataType } from '../designSystem/graphs/types'
 
-export const GRAPH_YEAR_MONTH_DATE_FORMAT = 'LLL. yyyy'
+export const GRAPH_YEAR_MONTH_DATE_FORMAT = 'LLL yyyy'
 
 export type TAreaChartDataResult = {
   amountCents: string | number

--- a/src/components/invoices/FinalizeInvoiceDialog.tsx
+++ b/src/components/invoices/FinalizeInvoiceDialog.tsx
@@ -69,7 +69,7 @@ export const FinalizeInvoiceDialog = forwardRef<FinalizeInvoiceDialogRef>((_, re
         issuingDate: formatDateToTZ(
           invoice?.issuingDate,
           invoice?.customer?.applicableTimezone,
-          "LLL. dd, yyyy U'T'CZ",
+          "LLL dd, yyyy U'T'CZ",
         ),
       })}
       actions={({ closeDialog }) => (

--- a/src/components/invoices/InvoiceCustomerInfos.tsx
+++ b/src/components/invoices/InvoiceCustomerInfos.tsx
@@ -209,7 +209,7 @@ export const InvoiceCustomerInfos = memo(({ invoice }: InvoiceCustomerInfosProps
               {formatDateToTZ(
                 invoice?.issuingDate,
                 customer?.applicableTimezone,
-                "LLL. dd, yyyy U'T'CZ",
+                "LLL dd, yyyy U'T'CZ",
               )}
             </Typography>
           </InfoLine>
@@ -223,7 +223,7 @@ export const InvoiceCustomerInfos = memo(({ invoice }: InvoiceCustomerInfosProps
               {formatDateToTZ(
                 invoice?.paymentDueDate,
                 customer?.applicableTimezone,
-                "LLL. dd, yyyy U'T'CZ",
+                "LLL dd, yyyy U'T'CZ",
               )}
             </Typography>
           </InfoLine>
@@ -266,7 +266,7 @@ export const InvoiceCustomerInfos = memo(({ invoice }: InvoiceCustomerInfosProps
               <Status
                 type="disputeLost"
                 label={translate('text_66141e30699a0631f0b2ed2c', {
-                  date: DateTime.fromISO(invoice?.paymentDisputeLostAt).toFormat('LLL. dd, yyyy'),
+                  date: DateTime.fromISO(invoice?.paymentDisputeLostAt).toFormat('LLL dd, yyyy'),
                 })}
               />
             </Typography>

--- a/src/components/invoices/details/InvoiceDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTable.tsx
@@ -232,12 +232,12 @@ export const InvoiceDetailsTable = memo(
                           from: formatDateToTZ(
                             subscription?.metadata?.fromDatetime,
                             customer?.applicableTimezone,
-                            'LLL. dd, yyyy',
+                            'LLL dd, yyyy',
                           ),
                           to: formatDateToTZ(
                             subscription?.metadata?.toDatetime,
                             customer?.applicableTimezone,
-                            'LLL. dd, yyyy',
+                            'LLL dd, yyyy',
                           ),
                         })}
                       />

--- a/src/components/invoices/details/InvoiceFeeAdvanceDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceFeeAdvanceDetailsTable.tsx
@@ -70,7 +70,7 @@ export const InvoiceFeeAdvanceDetailsTable = memo(
                     : subscription?.metadata?.inAdvanceChargesFromDatetime ||
                         subscription?.metadata?.chargesFromDatetime,
                   customer?.applicableTimezone,
-                  'LLL. dd, yyyy',
+                  'LLL dd, yyyy',
                 ),
                 to: formatDateToTZ(
                   subscription?.metadata?.differentBoundariesForSubscriptionAndCharges
@@ -78,7 +78,7 @@ export const InvoiceFeeAdvanceDetailsTable = memo(
                     : subscription?.metadata?.inAdvanceChargesToDatetime ||
                         subscription?.metadata?.chargesToDatetime,
                   customer?.applicableTimezone,
-                  'LLL. dd, yyyy',
+                  'LLL dd, yyyy',
                 ),
               })}
             />

--- a/src/components/invoices/details/InvoiceFeeArrearsDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceFeeArrearsDetailsTable.tsx
@@ -72,14 +72,14 @@ export const InvoiceFeeArrearsDetailsTable = memo(
                     ? subscription?.metadata?.chargesFromDatetime
                     : subscription?.metadata?.fromDatetime,
                   customer?.applicableTimezone,
-                  'LLL. dd, yyyy',
+                  'LLL dd, yyyy',
                 ),
                 to: formatDateToTZ(
                   subscription?.metadata?.differentBoundariesForSubscriptionAndCharges
                     ? subscription?.metadata?.chargesToDatetime
                     : subscription?.metadata?.toDatetime,
                   customer?.applicableTimezone,
-                  'LLL. dd, yyyy',
+                  'LLL dd, yyyy',
                 ),
               })}
             />

--- a/src/components/plans/details/PlanSubscriptionListItem.tsx
+++ b/src/components/plans/details/PlanSubscriptionListItem.tsx
@@ -80,11 +80,11 @@ export const PlanSubscriptionListItem = ({
             : translate('text_65281f686a80b400c8e2f6d1')}
         </Typography>
         <Typography variant="body" color="grey700">
-          {DateTime.fromISO(subscriptionItem?.subscriptionAt).toFormat('LLL. dd, yyyy')}
+          {DateTime.fromISO(subscriptionItem?.subscriptionAt).toFormat('LLL dd, yyyy')}
         </Typography>
         <Typography variant="body" color="grey700">
           {!!subscriptionItem?.endingAt
-            ? DateTime.fromISO(subscriptionItem?.endingAt).toFormat('LLL. dd, yyyy')
+            ? DateTime.fromISO(subscriptionItem?.endingAt).toFormat('LLL dd, yyyy')
             : '-'}
         </Typography>
       </GridItem>

--- a/src/components/subscriptions/SubscriptionInformations.tsx
+++ b/src/components/subscriptions/SubscriptionInformations.tsx
@@ -102,12 +102,12 @@ const SubscriptionInformations = ({
             },
             {
               label: translate('text_65201c5a175a4b0238abf29e'),
-              value: DateTime.fromISO(subscription?.subscriptionAt).toFormat('LLL. dd, yyyy'),
+              value: DateTime.fromISO(subscription?.subscriptionAt).toFormat('LLL dd, yyyy'),
             },
             {
               label: translate('text_65201c5a175a4b0238abf2a0'),
               value: !!subscription?.endingAt
-                ? DateTime.fromISO(subscription?.endingAt).toFormat('LLL. dd, yyyy')
+                ? DateTime.fromISO(subscription?.endingAt).toFormat('LLL dd, yyyy')
                 : '-',
             },
             !!subscription?.plan?.parent?.id && {

--- a/src/components/wallets/utils.ts
+++ b/src/components/wallets/utils.ts
@@ -88,11 +88,11 @@ export const getWordingForWalletCreationAlert = ({
 
       if (isDayPotentiallyNotReachableOnAllPeriods && isFebruary) {
         text += translate('text_6560809d38fb9de88d8a542a', {
-          dateOfTheMonth: nextRecurringTopUpDate.toFormat('LLL. dd'),
+          dateOfTheMonth: nextRecurringTopUpDate.toFormat('LLL dd'),
         })
       } else {
         text += translate('text_6560809c38fb9de88d8a5414', {
-          dateOfTheMonth: nextRecurringTopUpDate.toFormat('LLL. dd'),
+          dateOfTheMonth: nextRecurringTopUpDate.toFormat('LLL dd'),
         })
       }
     }
@@ -125,28 +125,28 @@ export const getWordingForWalletEditionAlert = ({
     const dateRefForDisplay = DateTime.fromISO(gmtDateRef).setZone(customerZone).startOf('day')
 
     if (rulesValues?.interval === RecurringTransactionIntervalEnum.Weekly) {
-      const nextRecurringTopUpDate = dateRefForDisplay.plus({ days: 7 }).toFormat('LLL. dd, yyyy')
+      const nextRecurringTopUpDate = dateRefForDisplay.plus({ days: 7 }).toFormat('LLL dd, yyyy')
 
       return translate('text_6560809c38fb9de88d8a5370', {
         totalCreditCount,
         nextRecurringTopUpDate,
       })
     } else if (rulesValues?.interval === RecurringTransactionIntervalEnum.Monthly) {
-      const nextRecurringTopUpDate = dateRefForDisplay.plus({ months: 1 }).toFormat('LLL. dd, yyyy')
+      const nextRecurringTopUpDate = dateRefForDisplay.plus({ months: 1 }).toFormat('LLL dd, yyyy')
 
       return translate('text_6560809c38fb9de88d8a5360', {
         totalCreditCount,
         nextRecurringTopUpDate,
       })
     } else if (rulesValues?.interval === RecurringTransactionIntervalEnum.Quarterly) {
-      const nextRecurringTopUpDate = dateRefForDisplay.plus({ months: 3 }).toFormat('LLL. dd, yyyy')
+      const nextRecurringTopUpDate = dateRefForDisplay.plus({ months: 3 }).toFormat('LLL dd, yyyy')
 
       return translate('text_6560809c38fb9de88d8a535e', {
         totalCreditCount,
         nextRecurringTopUpDate,
       })
     } else if (rulesValues?.interval === RecurringTransactionIntervalEnum.Yearly) {
-      const nextRecurringTopUpDate = dateRefForDisplay.plus({ years: 1 }).toFormat('LLL. dd, yyyy')
+      const nextRecurringTopUpDate = dateRefForDisplay.plus({ years: 1 }).toFormat('LLL dd, yyyy')
 
       return translate('text_6560809c38fb9de88d8a5408', {
         totalCreditCount,

--- a/src/core/timezone/utils.ts
+++ b/src/core/timezone/utils.ts
@@ -15,5 +15,5 @@ export const formatDateToTZ = (
 ) => {
   return DateTime.fromISO(date, {
     zone: getTimezoneConfig(timezone).name,
-  }).toFormat(format || 'LLL. dd, yyyy')
+  }).toFormat(format || 'LLL dd, yyyy')
 }

--- a/src/hooks/useOrganizationInfos.ts
+++ b/src/hooks/useOrganizationInfos.ts
@@ -51,6 +51,6 @@ export const useOrganizationInfos: UseOrganizationInfos = () => {
     timezone: orgaTimezone || TimezoneEnum.TzUtc,
     timezoneConfig,
     formatTimeOrgaTZ: (date, format) =>
-      formatDateToTZ(date, orgaTimezone, format || 'LLL. dd, yyyy'),
+      formatDateToTZ(date, orgaTimezone, format || 'LLL dd, yyyy'),
   }
 }

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -142,7 +142,7 @@ const CreateCoupon = () => {
             .min(
               DateTime.now().plus({ days: -1 }),
               translate('text_632d68358f1fedc68eed3ef2', {
-                date: DateTime.now().plus({ days: -1 }).toFormat('LLL. dd, yyyy').toLocaleString(),
+                date: DateTime.now().plus({ days: -1 }).toFormat('LLL dd, yyyy').toLocaleString(),
               }),
             )
             .required(''),

--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -390,7 +390,7 @@ const CreateInvoice = () => {
                   <Typography variant="caption" color="grey600">
                     {translate('text_6453819268763979024ad01b')}
                   </Typography>
-                  <Typography>{DateTime.now().toFormat('LLL. dd, yyyy')}</Typography>
+                  <Typography>{DateTime.now().toFormat('LLL dd, yyyy')}</Typography>
                 </InlineTopInfo>
 
                 <FromToInfoWrapper>

--- a/src/pages/CreateSubscription.tsx
+++ b/src/pages/CreateSubscription.tsx
@@ -319,7 +319,7 @@ const CreateSubscription = () => {
           ? translate('text_62ea7cd44cd4b14bb9ac1d92')
           : formattedCurrentDate === february29
             ? translate('text_62ea7cd44cd4b14bb9ac1d9a')
-            : translate('text_62ea7cd44cd4b14bb9ac1d96', { date: currentDate.toFormat('LLL. dd') })
+            : translate('text_62ea7cd44cd4b14bb9ac1d96', { date: currentDate.toFormat('LLL dd') })
 
       case PlanInterval.Quarterly:
         if (billingTime === BillingTimeEnum.Calendar)

--- a/src/pages/InvoiceOverview.tsx
+++ b/src/pages/InvoiceOverview.tsx
@@ -200,7 +200,7 @@ const InvoiceOverview = memo(
                       issuingDate: formatDateToTZ(
                         invoice.issuingDate,
                         customer?.applicableTimezone,
-                        "LLL. dd, yyyy U'T'CZ",
+                        "LLL dd, yyyy U'T'CZ",
                       ),
                     })}
                   </Alert>

--- a/src/pages/WalletForm.tsx
+++ b/src/pages/WalletForm.tsx
@@ -536,7 +536,7 @@ const WalletForm = () => {
                       error={
                         formikProps.errors.expirationAt === dateErrorCodes.shouldBeInFuture
                           ? translate('text_630ccd87b251590eaa5f9831', {
-                              date: DateTime.now().toFormat('LLL. dd, yyyy'),
+                              date: DateTime.now().toFormat('LLL dd, yyyy'),
                             })
                           : undefined
                       }


### PR DESCRIPTION
Dates format almost all contain this hardcoded dot.

It lead to wring notation for May, cause it displays `May.`.

The plan is the following:
1. Update all formatting to remove this hardcoded dit (this PR)
2. Later, have a scaling task to centralise all formatting, improve the system and change the method to format. I would love to use `toLocaleString` with `DATE_MED` preset instead of `.toFormat` ([see doc](https://github.com/moment/luxon/blob/master/docs/formatting.md#presets))



Fixes DLVRY-295