### PR TITLE
chore(inspectTranslations) add flag to replace TODO: copy

### DIFF
--- a/scripts/InspectTranslationKeys.js
+++ b/scripts/InspectTranslationKeys.js
@@ -9,7 +9,7 @@ const { GettextExtractor, JsExtractors } = require('gettext-extractor')
 const SRC_DIR = './src/'
 const TRANSLATION_FILES_PATH = './ditto/base.json' // './ditto/**.json' for when we'll support several languages
 
-async function extract() {
+async function extract(replaceMode) {
   // Extract all the translation keys by parsing the 'translate' function
   const extracts = new GettextExtractor()
     .createJsParser([
@@ -44,9 +44,8 @@ async function extract() {
   translationFiles.forEach((file) => {
     // Get all translation keys from the ditto file
     const dittoTranslations = JSON.parse(fs.readFileSync(file), 'utf-8')
-    const dittoKeys = Object.keys(dittoTranslations)
-      // Ignore timzeone keys as they're used in the config without calling translate
-      .filter((key) => key.split('_')[0] !== 'TZ')
+    // Ignore timzeone keys as they're used in the config without calling translate
+    const dittoKeys = Object.keys(dittoTranslations).filter((key) => key.split('_')[0] !== 'TZ')
     const keysNotInDitto = _.uniq(_.difference(foundKeys, dittoKeys))
     const dittoKeysNotUsed = _.uniq(_.difference(dittoKeys, foundKeys))
 
@@ -70,6 +69,32 @@ async function extract() {
             '\u001b[0m',
         )
         console.info(dittoKeysNotUsed.join('\n'))
+
+        if (replaceMode) {
+          for (let i = 0; i < dittoKeysNotUsed.length; i++) {
+            const key = dittoKeysNotUsed[i]
+            const translation = dittoTranslations[key]
+
+            // Iterate through each file to replace the translation string
+            for (let j = 0; j < files.length; j++) {
+              const filePath = files[j]
+              let fileContent = fs.readFileSync(filePath, 'utf-8')
+
+              // Perform a global replace for all occurrences of the translation string
+              const regex = new RegExp(`TODO: ${translation}`, 'g')
+              const replacedContent = fileContent.replace(regex, key)
+
+              // Check if replacement occurred in this file
+              if (replacedContent !== fileContent) {
+                console.info(`Replacing '${translation}' with '${key}' in: ${filePath}`)
+                // Write the modified content back to the file
+                fs.writeFileSync(filePath, replacedContent, 'utf-8')
+              }
+            }
+          }
+
+          console.info('\u001b[' + 32 + 'm' + '✔ Replacements done' + '\u001b[0m')
+        }
       }
 
       throw Error
@@ -84,7 +109,9 @@ async function extract() {
  */
 async function main() {
   try {
-    await extract()
+    const replaceMode = process.argv.includes('--replace')
+
+    await extract(replaceMode)
   } catch (e) {
     console.info('\u001b[' + 31 + 'm' + '\nTranslation check failed' + '\u001b[0m', e)
     process.exit(1)

--- a/scripts/InspectTranslationKeys.js
+++ b/scripts/InspectTranslationKeys.js
@@ -44,7 +44,7 @@ async function extract(replaceMode) {
   translationFiles.forEach((file) => {
     // Get all translation keys from the ditto file
     const dittoTranslations = JSON.parse(fs.readFileSync(file), 'utf-8')
-    // Ignore timzeone keys as they're used in the config without calling translate
+    // Ignore timezone keys as they're used in the config without calling translate
     const dittoKeys = Object.keys(dittoTranslations).filter((key) => key.split('_')[0] !== 'TZ')
     const keysNotInDitto = _.uniq(_.difference(foundKeys, dittoKeys))
     const dittoKeysNotUsed = _.uniq(_.difference(dittoKeys, foundKeys))


### PR DESCRIPTION
While implementing a feature, we often take care of the copy management as a last step.

We often write them in our templates as "TODO: Final Copy wording here", so prefixed with TODO: 

This PR allow to flag the inspectTranslations script to find and replace those copy, and replace them with the value present in base.json, for it's corresponding wording.

NOTE: This script is not fully working yet, and only replace one file.