### PR TITLE
fix: remove excess margin on chip icon

### DIFF
--- a/src/components/designSystem/Chip.tsx
+++ b/src/components/designSystem/Chip.tsx
@@ -1,5 +1,6 @@
 import { ChipOwnProps, Chip as MuiChip } from '@mui/material'
 import { clsx } from 'clsx'
+import styled from 'styled-components'
 
 import { Button } from './Button'
 import { Icon, IconName } from './Icon'
@@ -50,7 +51,7 @@ export const Chip = ({
         'chip-size--small': size === 'small',
         'chip-size--big': size === 'big',
       })}
-      icon={icon ? <Icon name={icon} /> : undefined}
+      icon={icon ? <StyledIcon name={icon} /> : undefined}
       label={
         <Typography
           variant={!!beta ? 'captionCode' : 'captionHl'}
@@ -84,3 +85,7 @@ export const Chip = ({
     />
   )
 }
+
+const StyledIcon = styled(Icon)`
+  margin: 0px !important;
+`


### PR DESCRIPTION
## Context

There was a excess margin on the chip icon. See before/after:

**Before**
<img width="392" alt="Capture d’écran 2024-05-14 à 11 01 12" src="https://github.com/getlago/lago-front/assets/17253055/b1e0f9fc-8f63-44ff-bfeb-0a139186d71d">

**After**
<img width="392" alt="Capture d’écran 2024-05-14 à 11 03 51" src="https://github.com/getlago/lago-front/assets/17253055/7ea868c9-028d-4ac2-adfc-df730963d5a4">

