### PR TITLE
fix: allow negative threshold

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -1013,6 +1013,7 @@ export type CreateCustomerInput = {
   metadata?: InputMaybe<Array<CustomerMetadataInput>>;
   name: Scalars['String']['input'];
   netPaymentTerm?: InputMaybe<Scalars['Int']['input']>;
+  netsuiteCustomer?: InputMaybe<IntegrationCustomerInput>;
   paymentProvider?: InputMaybe<ProviderTypeEnum>;
   paymentProviderCode?: InputMaybe<Scalars['String']['input']>;
   phone?: InputMaybe<Scalars['String']['input']>;
@@ -1570,7 +1571,7 @@ export type CurrentOrganization = {
   addressLine1?: Maybe<Scalars['String']['output']>;
   addressLine2?: Maybe<Scalars['String']['output']>;
   adyenPaymentProviders?: Maybe<Array<AdyenProvider>>;
-  apiKey: Scalars['String']['output'];
+  apiKey?: Maybe<Scalars['String']['output']>;
   billingConfiguration?: Maybe<OrganizationBillingConfiguration>;
   city?: Maybe<Scalars['String']['output']>;
   country?: Maybe<CountryCode>;
@@ -2224,6 +2225,14 @@ export type IntegrationCollection = {
   __typename?: 'IntegrationCollection';
   collection: Array<Integration>;
   metadata: CollectionMetadata;
+};
+
+export type IntegrationCustomerInput = {
+  externalCustomerId?: InputMaybe<Scalars['String']['input']>;
+  integrationCode?: InputMaybe<Scalars['String']['input']>;
+  integrationType?: InputMaybe<IntegrationTypeEnum>;
+  subsidiaryId?: InputMaybe<Scalars['String']['input']>;
+  syncWithProvider?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type IntegrationItem = {
@@ -3147,6 +3156,8 @@ export type NetsuiteCustomer = {
   __typename?: 'NetsuiteCustomer';
   externalCustomerId?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
+  integrationCode?: Maybe<Scalars['String']['output']>;
+  integrationType?: Maybe<IntegrationTypeEnum>;
   subsidiaryId?: Maybe<Scalars['String']['output']>;
   syncWithProvider?: Maybe<Scalars['Boolean']['output']>;
 };
@@ -4454,6 +4465,7 @@ export type UpdateCustomerInput = {
   metadata?: InputMaybe<Array<CustomerMetadataInput>>;
   name: Scalars['String']['input'];
   netPaymentTerm?: InputMaybe<Scalars['Int']['input']>;
+  netsuiteCustomer?: InputMaybe<IntegrationCustomerInput>;
   paymentProvider?: InputMaybe<ProviderTypeEnum>;
   paymentProviderCode?: InputMaybe<Scalars['String']['input']>;
   phone?: InputMaybe<Scalars['String']['input']>;
@@ -6302,7 +6314,7 @@ export type GetPortalOrgaInfosQuery = { __typename?: 'Query', customerPortalOrga
 export type GetOrganizationApiKeyQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetOrganizationApiKeyQuery = { __typename?: 'Query', organization?: { __typename?: 'CurrentOrganization', id: string, apiKey: string } | null };
+export type GetOrganizationApiKeyQuery = { __typename?: 'Query', organization?: { __typename?: 'CurrentOrganization', id: string, apiKey?: string | null } | null };
 
 export type EventListFragment = { __typename?: 'Event', id: string, code: string, externalCustomerId?: string | null, transactionId?: string | null, timestamp?: any | null, receivedAt: any, payload: any, billableMetricName?: string | null, matchBillableMetric: boolean, matchCustomField: boolean, apiClient?: string | null, ipAddress?: string | null, externalSubscriptionId?: string | null, customerTimezone: TimezoneEnum };
 

--- a/src/pages/WalletForm.tsx
+++ b/src/pages/WalletForm.tsx
@@ -768,7 +768,6 @@ const WalletForm = () => {
                       <AmountInputField
                         name="recurringTransactionRules.0.thresholdCredits"
                         currency={formikProps.values.currency}
-                        beforeChangeFormatter={['positiveNumber']}
                         label={translate('text_6560809c38fb9de88d8a5315')}
                         formikProps={formikProps}
                         silentError={true}


### PR DESCRIPTION
## Roadmap Task

https://linear.app/getlago/issue/DLVRY-311/allow-negative-value-in-recurring-top-up-threshold

## Context

Recurring wallet creation/edition

## Description

<img width="1015" alt="Capture d’écran 2024-05-14 à 15 16 42" src="https://github.com/getlago/lago-front/assets/17253055/0eb9823b-f920-4317-bf26-3973bc49b6c1">


We should be able to submit negative/0/positive threshold.


QA: https://fix-threshold-wallet-app.staging.getlago.com/ 
