### PR TITLE
fix: custom agg json serializer

### DIFF
--- a/src/core/serializers/__tests__/serializePlanInput.test.ts
+++ b/src/core/serializers/__tests__/serializePlanInput.test.ts
@@ -786,14 +786,8 @@ describe('serializePlanInput()', () => {
               perTransactionMaxAmount: undefined,
               rate: '5',
               volumeRanges: undefined,
-              customProperties: {
-                ranges: [
-                  { from: 0, to: 100, thirdPart: '0.13', firstPart: '0.12' },
-                  { from: 101, to: 2000, thirdPart: '0.10', firstPart: '0.09' },
-                  { from: 2001, to: 5000, thirdPart: '0.08', firstPart: '0.07' },
-                  { from: 5001, to: null, thirdPart: '0.06', firstPart: '0.05' },
-                ],
-              },
+              customProperties:
+                '{"ranges":[{"from":0,"to":100,"thirdPart":"0.13","firstPart":"0.12"},{"from":101,"to":2000,"thirdPart":"0.10","firstPart":"0.09"},{"from":2001,"to":5000,"thirdPart":"0.08","firstPart":"0.07"},{"from":5001,"to":null,"thirdPart":"0.06","firstPart":"0.05"}]}',
             },
             taxCodes: [],
           },

--- a/src/core/serializers/serializePlanInput.ts
+++ b/src/core/serializers/serializePlanInput.ts
@@ -113,7 +113,7 @@ const serializeProperties = (properties: Properties, chargeModel: ChargeModelEnu
         }
       : { perTransactionMinAmount: undefined, perTransactionMaxAmount: undefined }),
     ...(chargeModel === ChargeModelEnum.Custom
-      ? { customProperties: JSON.parse(properties?.customProperties) }
+      ? { customProperties: properties?.customProperties }
       : { customProperties: undefined }),
   }
 }


### PR DESCRIPTION
## Context

We encountered an error when assigning a plan to a customer because we were trying to parse a json that was already an object on submit.

## Description

Removing the `JSON.parse()` should fix the issue.
It seems that GraphQL in returning `customProperties` as json already so we don't need to parse it twice.