### PR TITLE
feat: add RBAC core features

### DIFF
--- a/ditto/base.json
+++ b/ditto/base.json
@@ -2072,5 +2072,7 @@
   "text_65771fa3f4ab9a00720726ce": "Units",
   "text_65d8d71a640c5400917f8a13": "Beta",
   "text_65df4fc6314ffd006ce0a537": "Back",
-  "text_6638a3538de76801ac2f451b": "Invalid JSON"
+  "text_6638a3538de76801ac2f451b": "Invalid JSON",
+  "text_66474faf77c70900619567c7": "Forbidden access",
+  "text_66474fb55f1b6901c7ac7683": "It seems you don’t have the permission to access this page. If you think this is an error contact an admin of your organization."
 }

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -26,6 +26,7 @@ const SideNavLayout = lazyLoad(
 
 // ----------- Pages -----------
 const Error404 = lazyLoad(() => import(/* webpackChunkName: 'error-404' */ '~/pages/Error404'))
+const Forbidden = lazyLoad(() => import(/* webpackChunkName: 'forbidden' */ '~/pages/Forbidden'))
 const Analytic = lazyLoad(() => import(/* webpackChunkName: 'analytics' */ '~/pages/Analytics'))
 
 // Route Available only on dev mode
@@ -34,6 +35,7 @@ const DesignSystem = lazyLoad(
 )
 
 export const HOME_ROUTE = '/'
+export const FORBIDDEN_ROUTE = '/forbidden'
 export const ANALYTIC_ROUTE = '/analytics'
 export const ERROR_404_ROUTE = '/404'
 
@@ -49,6 +51,10 @@ export const routes: CustomRouteObject[] = [
   {
     path: ERROR_404_ROUTE,
     element: <Error404 />,
+  },
+  {
+    path: FORBIDDEN_ROUTE,
+    element: <Forbidden />,
   },
   ...settingRoutes,
   {

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -25,6 +25,7 @@ const SideNavLayout = lazyLoad(
 )
 
 // ----------- Pages -----------
+const Home = lazyLoad(() => import(/* webpackChunkName: 'home' */ '~/pages/Home'))
 const Error404 = lazyLoad(() => import(/* webpackChunkName: 'error-404' */ '~/pages/Error404'))
 const Forbidden = lazyLoad(() => import(/* webpackChunkName: 'forbidden' */ '~/pages/Forbidden'))
 const Analytic = lazyLoad(() => import(/* webpackChunkName: 'analytics' */ '~/pages/Analytics'))
@@ -62,7 +63,12 @@ export const routes: CustomRouteObject[] = [
     private: true,
     children: [
       {
-        path: [ANALYTIC_ROUTE, HOME_ROUTE],
+        path: [HOME_ROUTE],
+        private: true,
+        element: <Home />,
+      },
+      {
+        path: [ANALYTIC_ROUTE],
         private: true,
         element: <Analytic />,
       },

--- a/src/core/router/types.ts
+++ b/src/core/router/types.ts
@@ -1,5 +1,7 @@
 import type { RouteObject } from 'react-router-dom'
 
+import { TMembershipPermissions } from '~/hooks/usePermissions'
+
 export interface CustomRouteObject extends Omit<RouteObject, 'children' | 'path'> {
   path?: string | string[]
   private?: boolean
@@ -7,4 +9,5 @@ export interface CustomRouteObject extends Omit<RouteObject, 'children' | 'path'
   invitation?: boolean
   redirect?: string
   children?: CustomRouteObject[]
+  permissions?: [keyof TMembershipPermissions]
 }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -4835,7 +4835,7 @@ export enum WeightedIntervalEnum {
 export type UserIdentifierQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type UserIdentifierQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string, email?: string | null, premium: boolean, memberships: Array<{ __typename?: 'Membership', organization: { __typename?: 'Organization', id: string, name: string, logoUrl?: string | null } }> }, organization?: { __typename?: 'CurrentOrganization', id: string, name: string, logoUrl?: string | null, timezone?: TimezoneEnum | null, defaultCurrency: CurrencyEnum } | null };
+export type UserIdentifierQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string, email?: string | null, premium: boolean, memberships: Array<{ __typename?: 'Membership', id: string, organization: { __typename?: 'Organization', id: string, name: string, logoUrl?: string | null }, permissions: { __typename?: 'Permissions', addonsCreate: boolean, addonsDelete: boolean, addonsUpdate: boolean, addonsView: boolean, analyticsView: boolean, billableMetricsCreate: boolean, billableMetricsDelete: boolean, billableMetricsUpdate: boolean, billableMetricsView: boolean, couponsAttach: boolean, couponsCreate: boolean, couponsDelete: boolean, couponsDetach: boolean, couponsUpdate: boolean, couponsView: boolean, creditNotesCreate: boolean, creditNotesUpdate: boolean, creditNotesView: boolean, creditNotesVoid: boolean, customerSettingsUpdateGracePeriod: boolean, customerSettingsUpdateLang: boolean, customerSettingsUpdatePaymentTerms: boolean, customerSettingsUpdateTaxRates: boolean, customerSettingsView: boolean, customersCreate: boolean, customersDelete: boolean, customersUpdate: boolean, customersView: boolean, developersKeysManage: boolean, developersManage: boolean, draftInvoicesUpdate: boolean, invoicesCreate: boolean, invoicesSend: boolean, invoicesUpdate: boolean, invoicesView: boolean, invoicesVoid: boolean, organizationEmailsUpdate: boolean, organizationEmailsView: boolean, organizationIntegrationsCreate: boolean, organizationIntegrationsDelete: boolean, organizationIntegrationsUpdate: boolean, organizationIntegrationsView: boolean, organizationInvoicesUpdate: boolean, organizationInvoicesView: boolean, organizationMembersCreate: boolean, organizationMembersDelete: boolean, organizationMembersUpdate: boolean, organizationMembersView: boolean, organizationTaxesUpdate: boolean, organizationTaxesView: boolean, organizationUpdate: boolean, organizationView: boolean, plansCreate: boolean, plansDelete: boolean, plansUpdate: boolean, plansView: boolean, subscriptionsCreate: boolean, subscriptionsDelete: boolean, subscriptionsUpdate: boolean, subscriptionsView: boolean, walletsCreate: boolean, walletsTerminate: boolean, walletsTopUp: boolean, walletsUpdate: boolean } }> }, organization?: { __typename?: 'CurrentOrganization', id: string, name: string, logoUrl?: string | null, timezone?: TimezoneEnum | null, defaultCurrency: CurrencyEnum } | null };
 
 export type AddOnItemFragment = { __typename?: 'AddOn', id: string, name: string, amountCurrency: CurrencyEnum, amountCents: any, customersCount: number, createdAt: any };
 
@@ -5945,12 +5945,12 @@ export type UpdateTaxMutationVariables = Exact<{
 
 export type UpdateTaxMutation = { __typename?: 'Mutation', updateTax?: { __typename?: 'Tax', id: string, code: string, description?: string | null, name: string, rate: number, customersCount: number } | null };
 
-export type CurrentUserInfosFragment = { __typename?: 'User', id: string, email?: string | null, premium: boolean, memberships: Array<{ __typename?: 'Membership', organization: { __typename?: 'Organization', id: string, name: string, logoUrl?: string | null } }> };
+export type CurrentUserInfosFragment = { __typename?: 'User', id: string, email?: string | null, premium: boolean, memberships: Array<{ __typename?: 'Membership', id: string, organization: { __typename?: 'Organization', id: string, name: string, logoUrl?: string | null }, permissions: { __typename?: 'Permissions', addonsCreate: boolean, addonsDelete: boolean, addonsUpdate: boolean, addonsView: boolean, analyticsView: boolean, billableMetricsCreate: boolean, billableMetricsDelete: boolean, billableMetricsUpdate: boolean, billableMetricsView: boolean, couponsAttach: boolean, couponsCreate: boolean, couponsDelete: boolean, couponsDetach: boolean, couponsUpdate: boolean, couponsView: boolean, creditNotesCreate: boolean, creditNotesUpdate: boolean, creditNotesView: boolean, creditNotesVoid: boolean, customerSettingsUpdateGracePeriod: boolean, customerSettingsUpdateLang: boolean, customerSettingsUpdatePaymentTerms: boolean, customerSettingsUpdateTaxRates: boolean, customerSettingsView: boolean, customersCreate: boolean, customersDelete: boolean, customersUpdate: boolean, customersView: boolean, developersKeysManage: boolean, developersManage: boolean, draftInvoicesUpdate: boolean, invoicesCreate: boolean, invoicesSend: boolean, invoicesUpdate: boolean, invoicesView: boolean, invoicesVoid: boolean, organizationEmailsUpdate: boolean, organizationEmailsView: boolean, organizationIntegrationsCreate: boolean, organizationIntegrationsDelete: boolean, organizationIntegrationsUpdate: boolean, organizationIntegrationsView: boolean, organizationInvoicesUpdate: boolean, organizationInvoicesView: boolean, organizationMembersCreate: boolean, organizationMembersDelete: boolean, organizationMembersUpdate: boolean, organizationMembersView: boolean, organizationTaxesUpdate: boolean, organizationTaxesView: boolean, organizationUpdate: boolean, organizationView: boolean, plansCreate: boolean, plansDelete: boolean, plansUpdate: boolean, plansView: boolean, subscriptionsCreate: boolean, subscriptionsDelete: boolean, subscriptionsUpdate: boolean, subscriptionsView: boolean, walletsCreate: boolean, walletsTerminate: boolean, walletsTopUp: boolean, walletsUpdate: boolean } }> };
 
 export type GetCurrentUserInfosQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetCurrentUserInfosQuery = { __typename?: 'Query', currentUser: { __typename?: 'User', id: string, email?: string | null, premium: boolean, memberships: Array<{ __typename?: 'Membership', organization: { __typename?: 'Organization', id: string, name: string, logoUrl?: string | null } }> } };
+export type GetCurrentUserInfosQuery = { __typename?: 'Query', currentUser: { __typename?: 'User', id: string, email?: string | null, premium: boolean, memberships: Array<{ __typename?: 'Membership', id: string, organization: { __typename?: 'Organization', id: string, name: string, logoUrl?: string | null }, permissions: { __typename?: 'Permissions', addonsCreate: boolean, addonsDelete: boolean, addonsUpdate: boolean, addonsView: boolean, analyticsView: boolean, billableMetricsCreate: boolean, billableMetricsDelete: boolean, billableMetricsUpdate: boolean, billableMetricsView: boolean, couponsAttach: boolean, couponsCreate: boolean, couponsDelete: boolean, couponsDetach: boolean, couponsUpdate: boolean, couponsView: boolean, creditNotesCreate: boolean, creditNotesUpdate: boolean, creditNotesView: boolean, creditNotesVoid: boolean, customerSettingsUpdateGracePeriod: boolean, customerSettingsUpdateLang: boolean, customerSettingsUpdatePaymentTerms: boolean, customerSettingsUpdateTaxRates: boolean, customerSettingsView: boolean, customersCreate: boolean, customersDelete: boolean, customersUpdate: boolean, customersView: boolean, developersKeysManage: boolean, developersManage: boolean, draftInvoicesUpdate: boolean, invoicesCreate: boolean, invoicesSend: boolean, invoicesUpdate: boolean, invoicesView: boolean, invoicesVoid: boolean, organizationEmailsUpdate: boolean, organizationEmailsView: boolean, organizationIntegrationsCreate: boolean, organizationIntegrationsDelete: boolean, organizationIntegrationsUpdate: boolean, organizationIntegrationsView: boolean, organizationInvoicesUpdate: boolean, organizationInvoicesView: boolean, organizationMembersCreate: boolean, organizationMembersDelete: boolean, organizationMembersUpdate: boolean, organizationMembersView: boolean, organizationTaxesUpdate: boolean, organizationTaxesView: boolean, organizationUpdate: boolean, organizationView: boolean, plansCreate: boolean, plansDelete: boolean, plansUpdate: boolean, plansView: boolean, subscriptionsCreate: boolean, subscriptionsDelete: boolean, subscriptionsUpdate: boolean, subscriptionsView: boolean, walletsCreate: boolean, walletsTerminate: boolean, walletsTopUp: boolean, walletsUpdate: boolean } }> } };
 
 export type GetEmailSettingsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -5970,6 +5970,8 @@ export type GetOrganizationInfosQueryVariables = Exact<{ [key: string]: never; }
 
 
 export type GetOrganizationInfosQuery = { __typename?: 'Query', organization?: { __typename?: 'CurrentOrganization', id: string, name: string, logoUrl?: string | null, timezone?: TimezoneEnum | null, defaultCurrency: CurrencyEnum } | null };
+
+export type MembershipPermissionsFragment = { __typename?: 'Membership', id: string, permissions: { __typename?: 'Permissions', addonsCreate: boolean, addonsDelete: boolean, addonsUpdate: boolean, addonsView: boolean, analyticsView: boolean, billableMetricsCreate: boolean, billableMetricsDelete: boolean, billableMetricsUpdate: boolean, billableMetricsView: boolean, couponsAttach: boolean, couponsCreate: boolean, couponsDelete: boolean, couponsDetach: boolean, couponsUpdate: boolean, couponsView: boolean, creditNotesCreate: boolean, creditNotesUpdate: boolean, creditNotesView: boolean, creditNotesVoid: boolean, customerSettingsUpdateGracePeriod: boolean, customerSettingsUpdateLang: boolean, customerSettingsUpdatePaymentTerms: boolean, customerSettingsUpdateTaxRates: boolean, customerSettingsView: boolean, customersCreate: boolean, customersDelete: boolean, customersUpdate: boolean, customersView: boolean, developersKeysManage: boolean, developersManage: boolean, draftInvoicesUpdate: boolean, invoicesCreate: boolean, invoicesSend: boolean, invoicesUpdate: boolean, invoicesView: boolean, invoicesVoid: boolean, organizationEmailsUpdate: boolean, organizationEmailsView: boolean, organizationIntegrationsCreate: boolean, organizationIntegrationsDelete: boolean, organizationIntegrationsUpdate: boolean, organizationIntegrationsView: boolean, organizationInvoicesUpdate: boolean, organizationInvoicesView: boolean, organizationMembersCreate: boolean, organizationMembersDelete: boolean, organizationMembersUpdate: boolean, organizationMembersView: boolean, organizationTaxesUpdate: boolean, organizationTaxesView: boolean, organizationUpdate: boolean, organizationView: boolean, plansCreate: boolean, plansDelete: boolean, plansUpdate: boolean, plansView: boolean, subscriptionsCreate: boolean, subscriptionsDelete: boolean, subscriptionsUpdate: boolean, subscriptionsView: boolean, walletsCreate: boolean, walletsTerminate: boolean, walletsTopUp: boolean, walletsUpdate: boolean } };
 
 export type AllInvoiceDetailsForCustomerInvoiceDetailsFragment = { __typename?: 'Invoice', id: string, invoiceType: InvoiceTypeEnum, number: string, paymentStatus: InvoicePaymentStatusTypeEnum, status: InvoiceStatusTypeEnum, totalAmountCents: any, currency?: CurrencyEnum | null, refundableAmountCents: any, creditableAmountCents: any, voidable: boolean, paymentDisputeLostAt?: any | null, issuingDate: any, subTotalExcludingTaxesAmountCents: any, subTotalIncludingTaxesAmountCents: any, versionNumber: number, paymentDueDate: any, couponsAmountCents: any, creditNotesAmountCents: any, prepaidCreditAmountCents: any, customer: { __typename?: 'Customer', id: string, applicableTimezone: TimezoneEnum, currency?: CurrencyEnum | null, name?: string | null, legalNumber?: string | null, legalName?: string | null, taxIdentificationNumber?: string | null, email?: string | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, zipcode?: string | null, deletedAt?: any | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, displayInInvoice: boolean, key: string, value: string }> | null }, creditNotes?: Array<{ __typename?: 'CreditNote', id: string, couponsAdjustmentAmountCents: any, number: string, subTotalExcludingTaxesAmountCents: any, currency: CurrencyEnum, totalAmountCents: any, appliedTaxes?: Array<{ __typename?: 'CreditNoteAppliedTax', id: string, amountCents: any, baseAmountCents: any, taxRate: number, taxName: string }> | null, items: Array<{ __typename?: 'CreditNoteItem', amountCents: any, amountCurrency: CurrencyEnum, fee: { __typename?: 'Fee', id: string, amountCents: any, eventsCount?: any | null, units: number, feeType: FeeTypesEnum, groupedBy: any, itemName: string, invoiceName?: string | null, appliedTaxes?: Array<{ __typename?: 'FeeAppliedTax', id: string, tax: { __typename?: 'Tax', id: string, rate: number } }> | null, trueUpParentFee?: { __typename?: 'Fee', id: string } | null, charge?: { __typename?: 'Charge', id: string, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum } } | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, plan: { __typename?: 'Plan', id: string, name: string, invoiceDisplayName?: string | null } } | null, chargeFilter?: { __typename?: 'ChargeFilter', invoiceDisplayName?: string | null, values: any } | null } }> }> | null, fees?: Array<{ __typename?: 'Fee', id: string, amountCents: any, description?: string | null, feeType: FeeTypesEnum, invoiceDisplayName?: string | null, invoiceName?: string | null, itemName: string, units: number, preciseUnitAmount: number, eventsCount?: any | null, adjustedFee: boolean, adjustedFeeType?: AdjustedFeeTypeEnum | null, currency: CurrencyEnum, appliedTaxes?: Array<{ __typename?: 'FeeAppliedTax', id: string, taxRate: number }> | null, trueUpFee?: { __typename?: 'Fee', id: string } | null, trueUpParentFee?: { __typename?: 'Fee', id: string } | null, charge?: { __typename?: 'Charge', id: string, payInAdvance: boolean, invoiceDisplayName?: string | null, chargeModel: ChargeModelEnum, minAmountCents: any, prorated: boolean, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean } } | null, chargeFilter?: { __typename?: 'ChargeFilter', invoiceDisplayName?: string | null, values: any } | null, amountDetails?: { __typename?: 'FeeAmountDetails', freeUnits?: string | null, fixedFeeUnitAmount?: string | null, flatUnitAmount?: string | null, perUnitAmount?: string | null, perUnitTotalAmount?: string | null, paidUnits?: string | null, perPackageSize?: number | null, perPackageUnitAmount?: string | null, fixedFeeTotalAmount?: string | null, freeEvents?: number | null, minMaxAdjustmentTotalAmount?: string | null, paidEvents?: number | null, rate?: string | null, units?: string | null, graduatedRanges?: Array<{ __typename?: 'FeeAmountDetailsGraduatedRange', toValue?: any | null, flatUnitAmount?: string | null, fromValue?: any | null, perUnitAmount?: string | null, perUnitTotalAmount?: string | null, totalWithFlatAmount?: string | null, units?: string | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'FeeAmountDetailsGraduatedPercentageRange', toValue?: any | null, flatUnitAmount?: string | null, fromValue?: any | null, perUnitTotalAmount?: string | null, rate?: string | null, totalWithFlatAmount?: string | null, units?: string | null }> | null } | null }> | null, invoiceSubscriptions?: Array<{ __typename?: 'InvoiceSubscription', fromDatetime?: any | null, toDatetime?: any | null, chargesFromDatetime?: any | null, chargesToDatetime?: any | null, inAdvanceChargesFromDatetime?: any | null, inAdvanceChargesToDatetime?: any | null, subscription: { __typename?: 'Subscription', id: string, name?: string | null, plan: { __typename?: 'Plan', id: string, name: string, interval: PlanInterval, amountCents: any, amountCurrency: CurrencyEnum, invoiceDisplayName?: string | null } }, fees?: Array<{ __typename?: 'Fee', id: string, amountCents: any, invoiceName?: string | null, invoiceDisplayName?: string | null, units: number, groupedBy: any, description?: string | null, feeType: FeeTypesEnum, itemName: string, preciseUnitAmount: number, eventsCount?: any | null, adjustedFee: boolean, adjustedFeeType?: AdjustedFeeTypeEnum | null, currency: CurrencyEnum, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, plan: { __typename?: 'Plan', id: string, name: string, invoiceDisplayName?: string | null, interval: PlanInterval } } | null, charge?: { __typename?: 'Charge', id: string, payInAdvance: boolean, minAmountCents: any, invoiceDisplayName?: string | null, chargeModel: ChargeModelEnum, prorated: boolean, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean } } | null, chargeFilter?: { __typename?: 'ChargeFilter', invoiceDisplayName?: string | null, values: any } | null, appliedTaxes?: Array<{ __typename?: 'FeeAppliedTax', id: string, taxRate: number }> | null, trueUpFee?: { __typename?: 'Fee', id: string } | null, trueUpParentFee?: { __typename?: 'Fee', id: string } | null, amountDetails?: { __typename?: 'FeeAmountDetails', freeUnits?: string | null, fixedFeeUnitAmount?: string | null, flatUnitAmount?: string | null, perUnitAmount?: string | null, perUnitTotalAmount?: string | null, paidUnits?: string | null, perPackageSize?: number | null, perPackageUnitAmount?: string | null, fixedFeeTotalAmount?: string | null, freeEvents?: number | null, minMaxAdjustmentTotalAmount?: string | null, paidEvents?: number | null, rate?: string | null, units?: string | null, graduatedRanges?: Array<{ __typename?: 'FeeAmountDetailsGraduatedRange', toValue?: any | null, flatUnitAmount?: string | null, fromValue?: any | null, perUnitAmount?: string | null, perUnitTotalAmount?: string | null, totalWithFlatAmount?: string | null, units?: string | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'FeeAmountDetailsGraduatedPercentageRange', toValue?: any | null, flatUnitAmount?: string | null, fromValue?: any | null, perUnitTotalAmount?: string | null, rate?: string | null, totalWithFlatAmount?: string | null, units?: string | null }> | null } | null }> | null, invoice: { __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum } }> | null, metadata?: Array<{ __typename?: 'InvoiceMetadata', id: string, key: string, value: string }> | null, appliedTaxes?: Array<{ __typename?: 'InvoiceAppliedTax', id: string, amountCents: any, feesAmountCents: any, taxRate: number, taxName: string }> | null };
 
@@ -7452,12 +7454,85 @@ export const TaxFormQueryShapeFragmentDoc = gql`
   autoGenerated
 }
     ${TaxFormFragmentDoc}`;
+export const MembershipPermissionsFragmentDoc = gql`
+    fragment MembershipPermissions on Membership {
+  id
+  permissions {
+    addonsCreate
+    addonsDelete
+    addonsUpdate
+    addonsView
+    analyticsView
+    billableMetricsCreate
+    billableMetricsDelete
+    billableMetricsUpdate
+    billableMetricsView
+    couponsAttach
+    couponsCreate
+    couponsDelete
+    couponsDetach
+    couponsUpdate
+    couponsView
+    creditNotesCreate
+    creditNotesUpdate
+    creditNotesView
+    creditNotesVoid
+    customerSettingsUpdateGracePeriod
+    customerSettingsUpdateLang
+    customerSettingsUpdatePaymentTerms
+    customerSettingsUpdateTaxRates
+    customerSettingsView
+    customersCreate
+    customersDelete
+    customersUpdate
+    customersView
+    developersKeysManage
+    developersManage
+    draftInvoicesUpdate
+    invoicesCreate
+    invoicesSend
+    invoicesUpdate
+    invoicesView
+    invoicesVoid
+    organizationEmailsUpdate
+    organizationEmailsView
+    organizationIntegrationsCreate
+    organizationIntegrationsDelete
+    organizationIntegrationsUpdate
+    organizationIntegrationsView
+    organizationInvoicesUpdate
+    organizationInvoicesView
+    organizationMembersCreate
+    organizationMembersDelete
+    organizationMembersUpdate
+    organizationMembersView
+    organizationTaxesUpdate
+    organizationTaxesView
+    organizationUpdate
+    organizationView
+    plansCreate
+    plansDelete
+    plansUpdate
+    plansView
+    subscriptionsCreate
+    subscriptionsDelete
+    subscriptionsUpdate
+    subscriptionsView
+    walletsCreate
+    walletsTerminate
+    walletsTopUp
+    walletsUpdate
+  }
+}
+    `;
 export const CurrentUserInfosFragmentDoc = gql`
     fragment CurrentUserInfos on User {
   id
   email
   premium
   memberships {
+    id
+    ...MembershipPermissions
     organization {
       id
       name
@@ -7465,7 +7540,7 @@ export const CurrentUserInfosFragmentDoc = gql`
     }
   }
 }
-    `;
+    ${MembershipPermissionsFragmentDoc}`;
 export const OrganizationForDatePickerFragmentDoc = gql`
     fragment OrganizationForDatePicker on CurrentOrganization {
   id

--- a/src/hooks/__tests__/usePermissions.test.ts
+++ b/src/hooks/__tests__/usePermissions.test.ts
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react'
+
+import { GetCurrentUserInfosDocument } from '~/generated/graphql'
+import { AllTheProviders } from '~/test-utils'
+
+import { usePermissions } from '../usePermissions'
+
+const membershipWithPermissions = {
+  id: '2',
+  organization: {
+    id: '3',
+    name: 'Organization',
+    logoUrl: 'https://logo.com',
+  },
+  permissions: {
+    addonsCreate: true,
+    addonsDelete: false,
+    addonsEdit: true,
+    addonsRead: true,
+  },
+}
+
+jest.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    currentMembership: membershipWithPermissions,
+  }),
+}))
+
+async function prepare() {
+  const mocks = [
+    {
+      request: {
+        query: GetCurrentUserInfosDocument,
+      },
+      result: {
+        data: {
+          currentUser: {
+            id: '1',
+            email: 'gavin@hooli.com',
+            premium: true,
+            memberships: [membershipWithPermissions],
+            __typename: 'User',
+          },
+        },
+      },
+    },
+  ]
+
+  const customWrapper = ({ children }: { children: React.ReactNode }) =>
+    AllTheProviders({
+      children,
+      mocks,
+      forceTypenames: true,
+    })
+
+  const { result } = renderHook(() => usePermissions(), {
+    wrapper: customWrapper,
+  })
+
+  return { result: result }
+}
+
+describe('useCreateCreditNote()', () => {
+  it('returns default datas', async () => {
+    const { result } = await prepare()
+
+    expect(result.current.hasPermissions).toBeDefined()
+    expect(result.current.hasPermissions(['addonsCreate'])).toBeTruthy()
+    expect(result.current.hasPermissions(['addonsDelete'])).toBeFalsy()
+  })
+})

--- a/src/hooks/core/__tests__/useLocationHistory.test.ts
+++ b/src/hooks/core/__tests__/useLocationHistory.test.ts
@@ -46,6 +46,12 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }))
 
+jest.mock('~/hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    hasPermissions: () => true,
+  }),
+}))
+
 describe('useLocationHistory()', () => {
   beforeEach(() => {
     mockNavigate.mockClear()

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -1,7 +1,11 @@
 import { gql } from '@apollo/client'
 
 import { getItemFromLS, ORGANIZATION_LS_KEY_ID } from '~/core/apolloClient'
-import { CurrentUserInfosFragment, useGetCurrentUserInfosQuery } from '~/generated/graphql'
+import {
+  CurrentUserInfosFragment,
+  MembershipPermissionsFragmentDoc,
+  useGetCurrentUserInfosQuery,
+} from '~/generated/graphql'
 
 import { useIsAuthenticated } from './auth/useIsAuthenticated'
 
@@ -11,6 +15,8 @@ gql`
     email
     premium
     memberships {
+      id
+      ...MembershipPermissions
       organization {
         id
         name
@@ -18,11 +24,14 @@ gql`
       }
     }
   }
+
   query getCurrentUserInfos {
     currentUser {
       ...CurrentUserInfos
     }
   }
+
+  ${MembershipPermissionsFragmentDoc}
 `
 
 type UseCurrentUser = () => {

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -1,0 +1,99 @@
+import { gql } from '@apollo/client'
+
+import { Permissions } from '~/generated/graphql'
+
+import { useCurrentUser } from './useCurrentUser'
+
+gql`
+  fragment MembershipPermissions on Membership {
+    id
+    permissions {
+      addonsCreate
+      addonsDelete
+      addonsUpdate
+      addonsView
+      analyticsView
+      billableMetricsCreate
+      billableMetricsDelete
+      billableMetricsUpdate
+      billableMetricsView
+      couponsAttach
+      couponsCreate
+      couponsDelete
+      couponsDetach
+      couponsUpdate
+      couponsView
+      creditNotesCreate
+      creditNotesUpdate
+      creditNotesView
+      creditNotesVoid
+      customerSettingsUpdateGracePeriod
+      customerSettingsUpdateLang
+      customerSettingsUpdatePaymentTerms
+      customerSettingsUpdateTaxRates
+      customerSettingsView
+      customersCreate
+      customersDelete
+      customersUpdate
+      customersView
+      developersKeysManage
+      developersManage
+      draftInvoicesUpdate
+      invoicesCreate
+      invoicesSend
+      invoicesUpdate
+      invoicesView
+      invoicesVoid
+      organizationEmailsUpdate
+      organizationEmailsView
+      organizationIntegrationsCreate
+      organizationIntegrationsDelete
+      organizationIntegrationsUpdate
+      organizationIntegrationsView
+      organizationInvoicesUpdate
+      organizationInvoicesView
+      organizationMembersCreate
+      organizationMembersDelete
+      organizationMembersUpdate
+      organizationMembersView
+      organizationTaxesUpdate
+      organizationTaxesView
+      organizationUpdate
+      organizationView
+      plansCreate
+      plansDelete
+      plansUpdate
+      plansView
+      subscriptionsCreate
+      subscriptionsDelete
+      subscriptionsUpdate
+      subscriptionsView
+      walletsCreate
+      walletsTerminate
+      walletsTopUp
+      walletsUpdate
+    }
+  }
+`
+export type TMembershipPermissions = Omit<Permissions, '__typename'>
+
+type TUsePermissionsProps = () => {
+  hasPermissions: (permissionsToCheck: Array<keyof TMembershipPermissions>) => boolean
+}
+
+export const usePermissions: TUsePermissionsProps = () => {
+  const { currentMembership } = useCurrentUser()
+
+  const hasPermissions = (permissionsToCheck?: Array<keyof TMembershipPermissions>): boolean => {
+    const allPermissions = currentMembership?.permissions as TMembershipPermissions
+
+    const permissionsFound =
+      permissionsToCheck?.map((permission) => allPermissions[permission]) || []
+
+    return permissionsFound.every((permission) => !!permission && permission === true)
+  }
+
+  return {
+    hasPermissions,
+  }
+}

--- a/src/layouts/SideNavLayout.tsx
+++ b/src/layouts/SideNavLayout.tsx
@@ -225,7 +225,7 @@ const SideNav = () => {
                     title: translate('text_6553885df387fd0097fd7384'),
                     icon: 'chart-bar',
                     link: ANALYTIC_ROUTE,
-                    match: [ANALYTIC_ROUTE, HOME_ROUTE],
+                    match: [ANALYTIC_ROUTE],
                   },
                   {
                     title: translate('text_623b497ad05b960101be3448'),

--- a/src/pages/Forbidden.tsx
+++ b/src/pages/Forbidden.tsx
@@ -1,0 +1,38 @@
+import styled from 'styled-components'
+
+import { GenericPlaceholder } from '~/components/GenericPlaceholder'
+import { HOME_ROUTE } from '~/core/router'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useLocationHistory } from '~/hooks/core/useLocationHistory'
+import ErrorImage from '~/public/images/maneki/error.svg'
+import { theme } from '~/styles'
+
+const Forbidden = () => {
+  const { translate } = useInternationalization()
+  const { goBack } = useLocationHistory()
+
+  return (
+    <Container>
+      <GenericPlaceholder
+        image={<ErrorImage width="136" height="104" />}
+        title={translate('text_66474faf77c70900619567c7')}
+        subtitle={translate('text_66474fb55f1b6901c7ac7683')}
+        buttonTitle={translate('text_62bac37900192b773560e831')}
+        buttonAction={() => goBack(HOME_ROUTE, { previousCount: -2 })}
+      />
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  height: 100vh;
+  width: 100vw;
+  display: flex;
+
+  > * {
+    margin: auto;
+    padding: ${theme.spacing(4)};
+  }
+`
+
+export default Forbidden

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { ANALYTIC_ROUTE } from '~/core/router'
+
+const Home = () => {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    navigate(ANALYTIC_ROUTE, { replace: true })
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return null
+}
+
+export default Home


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/add-roles-for-members-rbac

## Context

We're about to implement roles in the app. Foundations relies on a Role Based Access Control, that shoud emit a list of permissions depending on multiple factors (role, licence, cloud user, ...)

All this logic is implemented on Backend side and the FE app needs to be prepared to handle those permissions in order to update accordingly the app and the user experience.

This PR is a first step into that direction, and implements the base logic for this project.

## Description

This PR is composed of 4 commits that have their own objectives
- https://github.com/getlago/lago-front/commit/ff24e6e6e818cc6ddc0cf39cef4e10021e50cd3a adds a new route that would be the fallback for any user that tries to access a route are are not permitted to access
- https://github.com/getlago/lago-front/commit/0bf82b977c14136dcd93835286b7831cbb64c460 makes the permissions of the connected membership available in the app. It also provide a way to check if the current membership holds a given list of permissions 
- https://github.com/getlago/lago-front/commit/64f90a99cd409e15c4903fa996fd10f29fbf811a relies on the previous' commit logic and adds a permission guard on the routes. Each route can now redirect to the forbidden route if the given permissions is not present
- https://github.com/getlago/lago-front/commit/e10cf3dd36c6514083694455bd774f8f254f7c85 add a new Home route the the app that uses `/` route. Today this route only redirects to `/analytics` and makes it's addition seamless. Later, depending on the membership role, we will be able to change this "default" home route to redirect user to the appropriate route depending on their role


Note all those logics are not "plugged" yet and this PR only makes them available for future guard implementation in the app.