### PR TITLE
feat: add analytics route role guard

### DIFF
--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -71,6 +71,7 @@ export const routes: CustomRouteObject[] = [
         path: [ANALYTIC_ROUTE],
         private: true,
         element: <Analytic />,
+        permissions: ['analyticsView'],
       },
       ...customerRoutes,
       ...developperRoutes,

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -47,7 +47,7 @@ export const useCurrentUser: UseCurrentUser = () => {
 
   const { data, loading } = useGetCurrentUserInfosQuery({
     canonizeResults: true,
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only', // Requires to be network only - properly handles membership role guard on app boot
     skip: !isAuthenticated,
   })
 

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -84,11 +84,13 @@ type TUsePermissionsProps = () => {
 export const usePermissions: TUsePermissionsProps = () => {
   const { currentMembership } = useCurrentUser()
 
-  const hasPermissions = (permissionsToCheck?: Array<keyof TMembershipPermissions>): boolean => {
-    const allPermissions = currentMembership?.permissions as TMembershipPermissions
+  const hasPermissions = (permissionsToCheck: Array<keyof TMembershipPermissions>): boolean => {
+    if (!currentMembership) return false
+
+    const allPermissions = currentMembership.permissions as TMembershipPermissions
 
     const permissionsFound =
-      permissionsToCheck?.map((permission) => allPermissions[permission]) || []
+      permissionsToCheck.map((permission) => allPermissions[permission]) || []
 
     return permissionsFound.every((permission) => !!permission && permission === true)
   }

--- a/src/layouts/SideNavLayout.tsx
+++ b/src/layouts/SideNavLayout.tsx
@@ -56,6 +56,7 @@ import { useSideNavInfosQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
+import { usePermissions } from '~/hooks/usePermissions'
 import { theme } from '~/styles'
 import { MenuPopper } from '~/styles/designSystem'
 
@@ -80,16 +81,17 @@ interface TabProps {
 }
 
 const SideNav = () => {
-  const client = useApolloClient()
-  const navigate = useNavigate()
-  const { translate } = useInternationalization()
-  const [open, setOpen] = useState(false)
   const location = useLocation()
+  const navigate = useNavigate()
+  const client = useApolloClient()
+  const [open, setOpen] = useState(false)
+  const { currentUser } = useCurrentUser()
+  const { hasPermissions } = usePermissions()
+  const { organization } = useOrganizationInfos()
+  const { translate } = useInternationalization()
   const { data, loading, error } = useSideNavInfosQuery()
   const { pathname, state } = location as Location & { state: { disableScrollTop?: boolean } }
   const contentRef = useRef<HTMLDivElement>(null)
-  const { organization } = useOrganizationInfos()
-  const { currentUser } = useCurrentUser()
   const organizationList = currentUser?.memberships.map((membership) => membership.organization)
 
   useEffect(() => {
@@ -221,12 +223,17 @@ const SideNav = () => {
               <NavigationTab
                 onClick={() => setOpen(false)}
                 tabs={[
-                  {
-                    title: translate('text_6553885df387fd0097fd7384'),
-                    icon: 'chart-bar',
-                    link: ANALYTIC_ROUTE,
-                    match: [ANALYTIC_ROUTE],
-                  },
+                  ...(hasPermissions(['analyticsView'])
+                    ? [
+                        {
+                          title: translate('text_6553885df387fd0097fd7384'),
+                          icon: 'chart-bar',
+                          link: ANALYTIC_ROUTE,
+                          match: [ANALYTIC_ROUTE],
+                        } as TabProps,
+                      ]
+                    : []),
+
                   {
                     title: translate('text_623b497ad05b960101be3448'),
                     icon: 'pulse',

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,13 +1,19 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { ANALYTIC_ROUTE } from '~/core/router'
+import { ANALYTIC_ROUTE, CUSTOMERS_LIST_ROUTE } from '~/core/router'
+import { usePermissions } from '~/hooks/usePermissions'
 
 const Home = () => {
   const navigate = useNavigate()
+  const { hasPermissions } = usePermissions()
 
   useEffect(() => {
-    navigate(ANALYTIC_ROUTE, { replace: true })
+    if (hasPermissions(['analyticsView'])) {
+      navigate(ANALYTIC_ROUTE, { replace: true })
+    } else {
+      navigate(CUSTOMERS_LIST_ROUTE, { replace: true })
+    }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/add-roles-for-members-rbac

## Context

This PR is part of the RBAC feature. 

## Description

Add route and permission logic for the analytics view of the app.

Note it's usually the default view of the app, so some extra changes needed to be performed to be properly working