### PR TITLE
misc: add front-end feature flags logic using local storage

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,4 +1,7 @@
-interface Window { Cypress: any; }
+interface Window { 
+  Cypress: any;  
+  Lago: any;
+}
 
 declare type AppEnvEnum = import('./src/core/constants/globalTypes').AppEnvEnum
 

--- a/src/core/utils/featureFlags.ts
+++ b/src/core/utils/featureFlags.ts
@@ -1,0 +1,39 @@
+export enum FeatureFlags {
+  FTR_ENABLED = 'ftr_enabled',
+}
+
+const FF_KEY = 'featureFlags'
+
+export const getEnableFeatureFlags = (): FeatureFlags[] => {
+  const flags = localStorage.getItem(FF_KEY)
+
+  return flags ? JSON.parse(flags) : []
+}
+
+export const listFeatureFlags = (): FeatureFlags[] => {
+  return Object.values(FeatureFlags)
+}
+
+export const isFeatureFlagActive = (flag: FeatureFlags): boolean => {
+  const flags = getEnableFeatureFlags()
+
+  return flags.includes(flag)
+}
+
+export const setFeatureFlags = (flags: FeatureFlags[] | FeatureFlags | 'all') => {
+  if (!flags) {
+    flags = []
+  }
+
+  if (flags === 'all') {
+    flags = listFeatureFlags()
+  }
+
+  if (!Array.isArray(flags)) {
+    flags = [flags]
+  }
+
+  localStorage.setItem(FF_KEY, JSON.stringify(flags))
+
+  return getEnableFeatureFlags()
+}

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,21 @@ if (appEnv === AppEnvEnum.development) {
     setFeatureFlags: setFeatureFlags,
     listFeatureFlags: listFeatureFlags,
   }
+
+  const style = 'background: #eee; color: #fe3d3d'
+  const logs = [
+    'List available flags: %c window.Lago.listFeatureFlags() ',
+    "Set single flag: %c window.Lago.setFeatureFlags('ftr_xxx_enabled') ",
+    "Set multiple flags: %c window.Lago.setFeatureFlags(['ftr_xxx_enabled', 'ftr_yyy_enabled']) ",
+    "Set all flags: %c window.Lago.setFeatureFlags('all') ",
+    'Get enable flags: %c window.Lago.getEnableFeatureFlags() ',
+  ]
+
+  /* eslint-disable no-console */
+  console.groupCollapsed('%c window.Lago is available', style)
+  logs.forEach((log) => console.info(log, style))
+  console.groupEnd()
+  /* eslint-enable no-console */
 }
 
 const container = document.getElementById('root')

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client'
 import App from '~/App'
 import { envGlobalVar } from '~/core/apolloClient'
 import { AppEnvEnum } from '~/core/constants/globalTypes'
+import { getEnableFeatureFlags, listFeatureFlags, setFeatureFlags } from '~/core/utils/featureFlags'
 
 const { appEnv, sentryDsn } = envGlobalVar()
 
@@ -14,6 +15,14 @@ if (!!sentryDsn && appEnv !== AppEnvEnum.development) {
     integrations: [new BrowserTracing()],
     environment: appEnv,
   })
+}
+
+if (appEnv === AppEnvEnum.development) {
+  window.Lago = {
+    getEnableFeatureFlags: getEnableFeatureFlags,
+    setFeatureFlags: setFeatureFlags,
+    listFeatureFlags: listFeatureFlags,
+  }
 }
 
 const container = document.getElementById('root')


### PR DESCRIPTION
## Context

This PR should create functions to get/list/set object inside local storage with the key `featureFlags` to allow us to dev feature while hiding them to the customer

## Example

- How to use in codebase:
```ts
import { FeatureFlags, isFeatureFlagActive } from '~/core/utils/featureFlags'

const isFtrActive = isFeatureFlagActive(FeatureFlags.FTR_ENABLED);
// → true / false
```

- How to use inside browser console:
```ts
// List available flags
window.Lago.listFeatureFlags();

// Set flags (string or array)
window.Lago.setFeatureFlags('ftr_rbac_enabled');
window.Lago.setFeatureFlags(['ftr_rbac_enabled', 'ftr_okta_enabled']);

// Set all available flags
window.Lago.setFeatureFlags('all')

// Get enable flags
window.Lago.getEnableFeatureFlags()
```