### PR TITLE
refactor(WalletForm) - split file into separate components

### DIFF
--- a/src/core/router/ObjectsRoutes.tsx
+++ b/src/core/router/ObjectsRoutes.tsx
@@ -38,7 +38,7 @@ const CreateSubscription = lazyLoad(
   () => import(/* webpackChunkName: 'create-subscription' */ '~/pages/CreateSubscription'),
 )
 const WalletForm = lazyLoad(
-  () => import(/* webpackChunkName: 'wallet-form' */ '~/pages/WalletForm'),
+  () => import(/* webpackChunkName: 'wallet-form' */ '~/pages/WalletForm/WalletForm'),
 )
 
 // Details

--- a/src/pages/WalletForm/WalletForm.tsx
+++ b/src/pages/WalletForm/WalletForm.tsx
@@ -7,7 +7,7 @@ import { generatePath, useNavigate, useParams } from 'react-router-dom'
 import styled, { css } from 'styled-components'
 import { array, object, string } from 'yup'
 
-import { Alert, Button, Icon, Skeleton, Tooltip, Typography } from '~/components/designSystem'
+import { Alert, Button, Icon, Tooltip, Typography } from '~/components/designSystem'
 import {
   AmountInputField,
   ComboBoxField,
@@ -44,8 +44,9 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
+import { LoadingView } from '~/pages/WalletForm/components/LoadingView'
 import { Card, NAV_HEIGHT, PageHeader, theme } from '~/styles'
-import { ButtonContainer, Side, SkeletonHeader } from '~/styles/mainObjectsForm'
+import { ButtonContainer, Side } from '~/styles/mainObjectsForm'
 
 import { TWalletDataForm } from './types'
 
@@ -420,48 +421,7 @@ const WalletForm = () => {
       <Content>
         <Main>
           {isLoading && !wallet ? (
-            <>
-              <SkeletonHeader>
-                <Skeleton variant="text" width={280} height={12} marginBottom={theme.spacing(5)} />
-                <Skeleton
-                  variant="text"
-                  width="inherit"
-                  height={12}
-                  marginBottom={theme.spacing(4)}
-                />
-                <Skeleton variant="text" width={120} height={12} />
-              </SkeletonHeader>
-
-              {[0, 1, 2].map((skeletonCard) => (
-                <Card key={`skeleton-${skeletonCard}`}>
-                  <Skeleton
-                    variant="text"
-                    width={280}
-                    height={12}
-                    marginBottom={theme.spacing(9)}
-                  />
-                  <Skeleton
-                    variant="text"
-                    width={280}
-                    height={12}
-                    marginBottom={theme.spacing(9)}
-                  />
-                  <Skeleton
-                    variant="text"
-                    width={280}
-                    height={12}
-                    marginBottom={theme.spacing(9)}
-                  />
-                  <Skeleton
-                    variant="text"
-                    width="inherit"
-                    height={12}
-                    marginBottom={theme.spacing(4)}
-                  />
-                  <Skeleton variant="text" width={120} height={12} />
-                </Card>
-              ))}
-            </>
+            <LoadingView cardCount={2} />
           ) : (
             <>
               <div>

--- a/src/pages/WalletForm/WalletForm.tsx
+++ b/src/pages/WalletForm/WalletForm.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { InputAdornment } from '@mui/material'
 import { useFormik } from 'formik'
 import { DateTime } from 'luxon'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -7,25 +6,18 @@ import { generatePath, useNavigate, useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { array, object, string } from 'yup'
 
-import { Alert, Button, Icon, Typography } from '~/components/designSystem'
-import { AmountInputField, ComboBoxField, Switch } from '~/components/form'
+import { Button, Typography } from '~/components/designSystem'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
-import {
-  getWordingForWalletCreationAlert,
-  getWordingForWalletEditionAlert,
-} from '~/components/wallets/utils'
 import { WalletCodeSnippet } from '~/components/wallets/WalletCodeSnippet'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import { addToast } from '~/core/apolloClient'
 import { dateErrorCodes, FORM_TYPE_ENUM } from '~/core/constants/form'
-import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CUSTOMER_DETAILS_TAB_ROUTE } from '~/core/router'
 import { getCurrencyPrecision } from '~/core/serializers/serializeAmount'
 import {
   CurrencyEnum,
   GetWalletInfosForWalletFormQuery,
   LagoApiError,
-  RecurringTransactionIntervalEnum,
   RecurringTransactionTriggerEnum,
   UpdateRecurringTransactionRuleInput,
   useCreateCustomerWalletMutation,
@@ -35,25 +27,16 @@ import {
   WalletForUpdateFragmentDoc,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { LoadingView } from '~/pages/WalletForm/components/LoadingView'
 import { SettingsCard } from '~/pages/WalletForm/components/SettingsCard'
-import { Card, NAV_HEIGHT, PageHeader, theme } from '~/styles'
+import { TopUpCard } from '~/pages/WalletForm/components/TopUpCard'
+import { NAV_HEIGHT, PageHeader, theme } from '~/styles'
 import { ButtonContainer, Side } from '~/styles/mainObjectsForm'
 
 import { TWalletDataForm } from './types'
 
 import { CustomerDetailsTabsOptions } from '../CustomerDetails'
-
-const DEFAULT_RULES = {
-  grantedCredits: undefined,
-  interval: undefined,
-  lagoId: undefined,
-  paidCredits: undefined,
-  trigger: RecurringTransactionTriggerEnum.Threshold,
-  thresholdCredits: undefined,
-}
 
 gql`
   fragment WalletForUpdate on Wallet {
@@ -113,7 +96,7 @@ function hasWalletRecurringTopUpEnabled(
 
 const WalletForm = () => {
   const navigate = useNavigate()
-  const { isPremium } = useCurrentUser()
+
   const { customerId = '', walletId = '' } = useParams()
   const { translate } = useInternationalization()
   const { organization } = useOrganizationInfos()
@@ -382,14 +365,6 @@ const WalletForm = () => {
     },
   })
 
-  const recurringTransactionRules = formikProps.values?.recurringTransactionRules?.[0]
-
-  const canDisplayEditionAlert =
-    (!!recurringTransactionRules?.paidCredits || !!recurringTransactionRules?.grantedCredits) &&
-    ((recurringTransactionRules?.trigger === RecurringTransactionTriggerEnum.Interval &&
-      !!recurringTransactionRules?.interval) ||
-      recurringTransactionRules?.trigger === RecurringTransactionTriggerEnum.Threshold)
-
   return (
     <>
       <PageHeader>
@@ -439,246 +414,15 @@ const WalletForm = () => {
                 setShowExpirationDate={setShowExpirationDate}
               />
 
-              <Card>
-                <Typography variant="subhead">
-                  {translate('text_6560809c38fb9de88d8a5198')}
-                </Typography>
+              <TopUpCard
+                formikProps={formikProps}
+                formType={formType}
+                customerData={customerData}
+                isRecurringTopUpEnabled={isRecurringTopUpEnabled}
+                setIsRecurringTopUpEnabled={setIsRecurringTopUpEnabled}
+                premiumWarningDialogRef={premiumWarningDialogRef}
+              />
 
-                {formType === FORM_TYPE_ENUM.creation && (
-                  <>
-                    <AmountInputField
-                      name="paidCredits"
-                      currency={formikProps.values.currency}
-                      beforeChangeFormatter={['positiveNumber']}
-                      label={translate('text_62d18855b22699e5cf55f885')}
-                      formikProps={formikProps}
-                      silentError={true}
-                      helperText={translate('text_62d18855b22699e5cf55f88b', {
-                        paidCredits: intlFormatNumber(
-                          isNaN(Number(formikProps.values.paidCredits))
-                            ? 0
-                            : Number(formikProps.values.paidCredits) *
-                                Number(formikProps.values.rateAmount),
-                          {
-                            currencyDisplay: 'symbol',
-                            currency: formikProps?.values?.currency || CurrencyEnum.Usd,
-                          },
-                        ),
-                      })}
-                      InputProps={{
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            {translate('text_62d18855b22699e5cf55f889')}
-                          </InputAdornment>
-                        ),
-                      }}
-                    />
-
-                    <AmountInputField
-                      name="grantedCredits"
-                      currency={formikProps.values.currency}
-                      beforeChangeFormatter={['positiveNumber']}
-                      label={translate('text_62d18855b22699e5cf55f88d')}
-                      formikProps={formikProps}
-                      silentError={true}
-                      helperText={translate('text_62d18855b22699e5cf55f893', {
-                        grantedCredits: intlFormatNumber(
-                          isNaN(Number(formikProps.values.grantedCredits))
-                            ? 0
-                            : Number(formikProps.values.grantedCredits) *
-                                Number(formikProps.values.rateAmount),
-                          {
-                            currencyDisplay: 'symbol',
-                            currency: formikProps?.values?.currency || CurrencyEnum.Usd,
-                          },
-                        ),
-                      })}
-                      InputProps={{
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            {translate('text_62d18855b22699e5cf55f891')}
-                          </InputAdornment>
-                        ),
-                      }}
-                    />
-                  </>
-                )}
-
-                <InlineElements>
-                  <Switch
-                    name="isRecurringTopUpEnabled"
-                    checked={isRecurringTopUpEnabled}
-                    label={translate('text_6560809c38fb9de88d8a52ad')}
-                    subLabel={translate('text_6560809c38fb9de88d8a52c7')}
-                    onChange={(value) => {
-                      if (isPremium) {
-                        if (value) {
-                          formikProps.setFieldValue('recurringTransactionRules.0', DEFAULT_RULES)
-                        } else {
-                          formikProps.setFieldValue('recurringTransactionRules', [])
-                        }
-
-                        setIsRecurringTopUpEnabled(value)
-                      } else {
-                        premiumWarningDialogRef.current?.openDialog()
-                      }
-                    }}
-                  />
-                  {!isPremium && <Icon name="sparkles" />}
-                </InlineElements>
-
-                {formType === FORM_TYPE_ENUM.edition && isRecurringTopUpEnabled && (
-                  <>
-                    <AmountInputField
-                      name="recurringTransactionRules.0.paidCredits"
-                      currency={formikProps.values.currency}
-                      beforeChangeFormatter={['positiveNumber']}
-                      label={translate('text_62d18855b22699e5cf55f885')}
-                      formikProps={formikProps}
-                      silentError={true}
-                      helperText={translate('text_62d18855b22699e5cf55f88b', {
-                        paidCredits: intlFormatNumber(
-                          isNaN(Number(recurringTransactionRules?.paidCredits))
-                            ? 0
-                            : Number(recurringTransactionRules?.paidCredits) *
-                                Number(formikProps.values.rateAmount),
-                          {
-                            currencyDisplay: 'symbol',
-                            currency: formikProps?.values?.currency || CurrencyEnum.Usd,
-                          },
-                        ),
-                      })}
-                      InputProps={{
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            {translate('text_62d18855b22699e5cf55f889')}
-                          </InputAdornment>
-                        ),
-                      }}
-                    />
-
-                    <AmountInputField
-                      name="recurringTransactionRules.0.grantedCredits"
-                      currency={formikProps.values.currency}
-                      beforeChangeFormatter={['positiveNumber']}
-                      label={translate('text_62d18855b22699e5cf55f88d')}
-                      formikProps={formikProps}
-                      silentError={true}
-                      helperText={translate('text_62d18855b22699e5cf55f893', {
-                        grantedCredits: intlFormatNumber(
-                          isNaN(Number(recurringTransactionRules?.grantedCredits))
-                            ? 0
-                            : Number(recurringTransactionRules?.grantedCredits) *
-                                Number(formikProps.values.rateAmount),
-                          {
-                            currencyDisplay: 'symbol',
-                            currency: formikProps?.values?.currency || CurrencyEnum.Usd,
-                          },
-                        ),
-                      })}
-                      InputProps={{
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            {translate('text_62d18855b22699e5cf55f891')}
-                          </InputAdornment>
-                        ),
-                      }}
-                    />
-                  </>
-                )}
-
-                {isRecurringTopUpEnabled && (
-                  <InlineTopUpElements>
-                    <ComboBoxField
-                      disableClearable
-                      label={translate('text_6560809c38fb9de88d8a52fb')}
-                      name="recurringTransactionRules.0.trigger"
-                      data={[
-                        {
-                          label: translate('text_65201b8216455901fe273dc1'),
-                          value: RecurringTransactionTriggerEnum.Interval,
-                        },
-                        {
-                          label: translate('text_6560809c38fb9de88d8a5315'),
-                          value: RecurringTransactionTriggerEnum.Threshold,
-                        },
-                      ]}
-                      formikProps={formikProps}
-                    />
-
-                    {recurringTransactionRules?.trigger ===
-                      RecurringTransactionTriggerEnum.Interval && (
-                      <ComboBoxField
-                        disableClearable
-                        sortValues={false}
-                        label={translate('text_65201b8216455901fe273dc1')}
-                        placeholder={translate('text_6560c252c4f33631aff1ab27')}
-                        name="recurringTransactionRules.0.interval"
-                        data={[
-                          {
-                            label: translate('text_62b32ec6b0434070791c2d4c'),
-                            value: RecurringTransactionIntervalEnum.Weekly,
-                          },
-                          {
-                            label: translate('text_624453d52e945301380e49aa'),
-                            value: RecurringTransactionIntervalEnum.Monthly,
-                          },
-                          {
-                            label: translate('text_64d6357b00dea100ad1cb9e9'),
-                            value: RecurringTransactionIntervalEnum.Quarterly,
-                          },
-                          {
-                            label: translate('text_624453d52e945301380e49ac'),
-                            value: RecurringTransactionIntervalEnum.Yearly,
-                          },
-                        ]}
-                        formikProps={formikProps}
-                      />
-                    )}
-                    {recurringTransactionRules?.trigger ===
-                      RecurringTransactionTriggerEnum.Threshold && (
-                      <AmountInputField
-                        name="recurringTransactionRules.0.thresholdCredits"
-                        currency={formikProps.values.currency}
-                        label={translate('text_6560809c38fb9de88d8a5315')}
-                        formikProps={formikProps}
-                        silentError={true}
-                        InputProps={{
-                          endAdornment: (
-                            <InputAdornment position="end">
-                              {translate('text_62d18855b22699e5cf55f891')}
-                            </InputAdornment>
-                          ),
-                        }}
-                      />
-                    )}
-                  </InlineTopUpElements>
-                )}
-
-                {formType === FORM_TYPE_ENUM.creation && (
-                  <Alert type="info">
-                    {getWordingForWalletCreationAlert({
-                      translate,
-                      currency: formikProps.values?.currency,
-                      customerTimezone: customerData?.customer?.timezone,
-                      rulesValues: recurringTransactionRules,
-                      walletValues: formikProps.values,
-                    })}
-                  </Alert>
-                )}
-                {isRecurringTopUpEnabled &&
-                  canDisplayEditionAlert &&
-                  formType === FORM_TYPE_ENUM.edition && (
-                    <Alert type="info">
-                      {getWordingForWalletEditionAlert({
-                        translate,
-                        currency: formikProps.values?.currency,
-                        customerTimezone: customerData?.customer?.timezone,
-                        rulesValues: recurringTransactionRules,
-                      })}
-                    </Alert>
-                  )}
-              </Card>
               <CustomButtonContainer>
                 <Button
                   disabled={
@@ -757,18 +501,6 @@ const Main = styled.div`
 
 const Title = styled(Typography)`
   margin-bottom: ${theme.spacing(1)};
-`
-
-const InlineElements = styled.div`
-  display: flex;
-  align-items: center;
-  gap: ${theme.spacing(3)};
-`
-
-const InlineTopUpElements = styled.div`
-  display: grid;
-  grid-template-columns: 160px 1fr;
-  gap: ${theme.spacing(3)};
 `
 
 const CustomButtonContainer = styled(ButtonContainer)`

--- a/src/pages/WalletForm/WalletForm.tsx
+++ b/src/pages/WalletForm/WalletForm.tsx
@@ -4,18 +4,11 @@ import { useFormik } from 'formik'
 import { DateTime } from 'luxon'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { generatePath, useNavigate, useParams } from 'react-router-dom'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { array, object, string } from 'yup'
 
-import { Alert, Button, Icon, Tooltip, Typography } from '~/components/designSystem'
-import {
-  AmountInputField,
-  ComboBoxField,
-  DatePickerField,
-  Switch,
-  TextInput,
-  TextInputField,
-} from '~/components/form'
+import { Alert, Button, Icon, Typography } from '~/components/designSystem'
+import { AmountInputField, ComboBoxField, Switch } from '~/components/form'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import {
   getWordingForWalletCreationAlert,
@@ -25,7 +18,7 @@ import { WalletCodeSnippet } from '~/components/wallets/WalletCodeSnippet'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import { addToast } from '~/core/apolloClient'
 import { dateErrorCodes, FORM_TYPE_ENUM } from '~/core/constants/form'
-import { getCurrencySymbol, intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CUSTOMER_DETAILS_TAB_ROUTE } from '~/core/router'
 import { getCurrencyPrecision } from '~/core/serializers/serializeAmount'
 import {
@@ -45,6 +38,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { LoadingView } from '~/pages/WalletForm/components/LoadingView'
+import { SettingsCard } from '~/pages/WalletForm/components/SettingsCard'
 import { Card, NAV_HEIGHT, PageHeader, theme } from '~/styles'
 import { ButtonContainer, Side } from '~/styles/mainObjectsForm'
 
@@ -436,93 +430,14 @@ const WalletForm = () => {
                   {translate('text_62d18855b22699e5cf55f873')}
                 </Typography>
               </div>
-              <Card>
-                <Typography variant="subhead">
-                  {translate('text_6560809c38fb9de88d8a5090')}
-                </Typography>
-                <TextInputField
-                  name="name"
-                  label={translate('text_62d18855b22699e5cf55f875')}
-                  placeholder={translate('text_62d18855b22699e5cf55f877')}
-                  formikProps={formikProps}
-                />
-                <Inlineinputs $hasOnlyThreeColumn={!!customerData?.customer?.currency}>
-                  <TextInput
-                    value="1"
-                    label={translate('text_62d18855b22699e5cf55f879')}
-                    disabled={true}
-                  />
-                  <TextInput value="=" disabled={true} />
-                  <AmountInputField
-                    name="rateAmount"
-                    disabled={formType === FORM_TYPE_ENUM.edition}
-                    currency={formikProps.values.currency}
-                    beforeChangeFormatter={['positiveNumber']}
-                    label={translate('text_62d18855b22699e5cf55f87d')}
-                    formikProps={formikProps}
-                    InputProps={{
-                      endAdornment: !!customerData?.customer?.currency && (
-                        <InputAdornment position="end">
-                          {getCurrencySymbol(customerData?.customer?.currency)}
-                        </InputAdornment>
-                      ),
-                    }}
-                  />
-                  {!customerData?.customer?.currency && (
-                    <ComboBoxField
-                      disableClearable
-                      name="currency"
-                      data={Object.values(CurrencyEnum).map((currencyType) => ({
-                        value: currencyType,
-                      }))}
-                      formikProps={formikProps}
-                      PopperProps={{ displayInDialog: true }}
-                    />
-                  )}
-                </Inlineinputs>
 
-                {showExpirationDate ? (
-                  <InlineExpirationInput>
-                    <DatePickerField
-                      disablePast
-                      name="expirationAt"
-                      placement="top-end"
-                      label={translate('text_62d18855b22699e5cf55f897')}
-                      placeholder={translate('text_62d18855b22699e5cf55f899')}
-                      formikProps={formikProps}
-                      error={
-                        formikProps.errors.expirationAt === dateErrorCodes.shouldBeInFuture
-                          ? translate('text_630ccd87b251590eaa5f9831', {
-                              date: DateTime.now().toFormat('LLL. dd, yyyy'),
-                            })
-                          : undefined
-                      }
-                    />
-                    <CloseExpirationTooltip
-                      placement="top-end"
-                      title={translate('text_63aa085d28b8510cd46443ff')}
-                    >
-                      <Button
-                        icon="trash"
-                        variant="quaternary"
-                        onClick={() => {
-                          formikProps.setFieldValue('expirationAt', null)
-                          setShowExpirationDate(false)
-                        }}
-                      />
-                    </CloseExpirationTooltip>
-                  </InlineExpirationInput>
-                ) : (
-                  <Button
-                    startIcon="plus"
-                    variant="quaternary"
-                    onClick={() => setShowExpirationDate(true)}
-                    data-test="show-expiration-at"
-                  >
-                    {translate('text_6560809c38fb9de88d8a517e')}
-                  </Button>
-                )}
-              </Card>
+              <SettingsCard
+                formikProps={formikProps}
+                formType={formType}
+                customerData={customerData}
+                showExpirationDate={showExpirationDate}
+                setShowExpirationDate={setShowExpirationDate}
+              />
 
               <Card>
                 <Typography variant="subhead">
@@ -842,33 +757,6 @@ const Main = styled.div`
 
 const Title = styled(Typography)`
   margin-bottom: ${theme.spacing(1)};
-`
-
-const Inlineinputs = styled.div<{ $hasOnlyThreeColumn?: boolean }>`
-  display: grid;
-  grid-template-columns: 48px 48px 1fr 120px;
-  gap: ${theme.spacing(3)};
-  align-items: flex-end;
-
-  ${({ $hasOnlyThreeColumn }) =>
-    $hasOnlyThreeColumn &&
-    css`
-      grid-template-columns: minmax(48px, 120px) 48px minmax(160px, 1fr);
-    `}
-`
-
-const InlineExpirationInput = styled.div`
-  display: flex;
-  gap: ${theme.spacing(4)};
-  align-items: center;
-
-  > *:first-child {
-    flex-grow: 1;
-  }
-`
-
-const CloseExpirationTooltip = styled(Tooltip)`
-  margin-top: ${theme.spacing(6)};
 `
 
 const InlineElements = styled.div`

--- a/src/pages/WalletForm/WalletForm.tsx
+++ b/src/pages/WalletForm/WalletForm.tsx
@@ -29,13 +29,11 @@ import { getCurrencySymbol, intlFormatNumber } from '~/core/formats/intlFormatNu
 import { CUSTOMER_DETAILS_TAB_ROUTE } from '~/core/router'
 import { getCurrencyPrecision } from '~/core/serializers/serializeAmount'
 import {
-  CreateCustomerWalletInput,
   CurrencyEnum,
   GetWalletInfosForWalletFormQuery,
   LagoApiError,
   RecurringTransactionIntervalEnum,
   RecurringTransactionTriggerEnum,
-  UpdateCustomerWalletInput,
   UpdateRecurringTransactionRuleInput,
   useCreateCustomerWalletMutation,
   useGetCustomerInfosForWalletFormQuery,
@@ -49,10 +47,9 @@ import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { Card, NAV_HEIGHT, PageHeader, theme } from '~/styles'
 import { ButtonContainer, Side, SkeletonHeader } from '~/styles/mainObjectsForm'
 
-import { CustomerDetailsTabsOptions } from './CustomerDetails'
+import { TWalletDataForm } from './types'
 
-export type TWalletDataForm = Omit<CreateCustomerWalletInput, 'customerId'> &
-  Omit<UpdateCustomerWalletInput, 'id'>
+import { CustomerDetailsTabsOptions } from '../CustomerDetails'
 
 const DEFAULT_RULES = {
   grantedCredits: undefined,

--- a/src/pages/WalletForm/components/LoadingView.tsx
+++ b/src/pages/WalletForm/components/LoadingView.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react'
+
+import { Skeleton } from '~/components/designSystem'
+import { Card, theme } from '~/styles'
+import { SkeletonHeader } from '~/styles/mainObjectsForm'
+
+interface LoadingViewProps {
+  cardCount: number
+}
+
+export const LoadingView: FC<LoadingViewProps> = ({ cardCount }) => {
+  const skeletonCards = Array.from({ length: cardCount }, (_, i) => i)
+
+  return (
+    <>
+      <SkeletonHeader>
+        <Skeleton variant="text" width={280} height={12} marginBottom={theme.spacing(5)} />
+        <Skeleton variant="text" width="inherit" height={12} marginBottom={theme.spacing(4)} />
+        <Skeleton variant="text" width={120} height={12} />
+      </SkeletonHeader>
+
+      {skeletonCards.map((skeletonCard) => (
+        <Card key={`skeleton-${skeletonCard}`}>
+          <Skeleton variant="text" width={280} height={12} marginBottom={theme.spacing(9)} />
+          <Skeleton variant="text" width={280} height={12} marginBottom={theme.spacing(9)} />
+          <Skeleton variant="text" width={280} height={12} marginBottom={theme.spacing(9)} />
+          <Skeleton variant="text" width="inherit" height={12} marginBottom={theme.spacing(4)} />
+          <Skeleton variant="text" width={120} height={12} />
+        </Card>
+      ))}
+    </>
+  )
+}

--- a/src/pages/WalletForm/components/SettingsCard.tsx
+++ b/src/pages/WalletForm/components/SettingsCard.tsx
@@ -1,0 +1,151 @@
+import { InputAdornment } from '@mui/material'
+import { FormikProps } from 'formik'
+import { DateTime } from 'luxon'
+import { FC } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Button, Tooltip, Typography } from '~/components/designSystem'
+import {
+  AmountInputField,
+  ComboBoxField,
+  DatePickerField,
+  TextInput,
+  TextInputField,
+} from '~/components/form'
+import { dateErrorCodes, FORM_TYPE_ENUM } from '~/core/constants/form'
+import { getCurrencySymbol } from '~/core/formats/intlFormatNumber'
+import { CurrencyEnum, GetCustomerInfosForWalletFormQuery } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { Card, theme } from '~/styles'
+
+import { TWalletDataForm } from '../types'
+
+interface SettingsCardProps {
+  formikProps: FormikProps<TWalletDataForm>
+  customerData?: GetCustomerInfosForWalletFormQuery
+  showExpirationDate: boolean
+  setShowExpirationDate: (value: boolean) => void
+  formType: (typeof FORM_TYPE_ENUM)[keyof typeof FORM_TYPE_ENUM]
+}
+
+export const SettingsCard: FC<SettingsCardProps> = ({
+  formikProps,
+  formType,
+  customerData,
+  showExpirationDate,
+  setShowExpirationDate,
+}) => {
+  const { translate } = useInternationalization()
+
+  return (
+    <Card>
+      <Typography variant="subhead">{translate('text_6560809c38fb9de88d8a5090')}</Typography>
+
+      <TextInputField
+        name="name"
+        label={translate('text_62d18855b22699e5cf55f875')}
+        placeholder={translate('text_62d18855b22699e5cf55f877')}
+        formikProps={formikProps}
+      />
+      <InlineInputs $hasOnlyThreeColumn={!!customerData?.customer?.currency}>
+        <TextInput value="1" label={translate('text_62d18855b22699e5cf55f879')} disabled={true} />
+        <TextInput value="=" disabled={true} />
+        <AmountInputField
+          name="rateAmount"
+          disabled={formType === FORM_TYPE_ENUM.edition}
+          currency={formikProps.values.currency}
+          beforeChangeFormatter={['positiveNumber']}
+          label={translate('text_62d18855b22699e5cf55f87d')}
+          formikProps={formikProps}
+          InputProps={{
+            endAdornment: !!customerData?.customer?.currency && (
+              <InputAdornment position="end">
+                {getCurrencySymbol(customerData?.customer?.currency)}
+              </InputAdornment>
+            ),
+          }}
+        />
+        {!customerData?.customer?.currency && (
+          <ComboBoxField
+            disableClearable
+            name="currency"
+            data={Object.values(CurrencyEnum).map((currencyType) => ({
+              value: currencyType,
+            }))}
+            formikProps={formikProps}
+            PopperProps={{ displayInDialog: true }}
+          />
+        )}
+      </InlineInputs>
+
+      {showExpirationDate ? (
+        <InlineExpirationInput>
+          <DatePickerField
+            disablePast
+            name="expirationAt"
+            placement="top-end"
+            label={translate('text_62d18855b22699e5cf55f897')}
+            placeholder={translate('text_62d18855b22699e5cf55f899')}
+            formikProps={formikProps}
+            error={
+              formikProps.errors.expirationAt === dateErrorCodes.shouldBeInFuture
+                ? translate('text_630ccd87b251590eaa5f9831', {
+                    date: DateTime.now().toFormat('LLL. dd, yyyy'),
+                  })
+                : undefined
+            }
+          />
+          <CloseExpirationTooltip
+            placement="top-end"
+            title={translate('text_63aa085d28b8510cd46443ff')}
+          >
+            <Button
+              icon="trash"
+              variant="quaternary"
+              onClick={() => {
+                formikProps.setFieldValue('expirationAt', null)
+                setShowExpirationDate(false)
+              }}
+            />
+          </CloseExpirationTooltip>
+        </InlineExpirationInput>
+      ) : (
+        <Button
+          startIcon="plus"
+          variant="quaternary"
+          onClick={() => setShowExpirationDate(true)}
+          data-test="show-expiration-at"
+        >
+          {translate('text_6560809c38fb9de88d8a517e')}
+        </Button>
+      )}
+    </Card>
+  )
+}
+
+const InlineInputs = styled.div<{ $hasOnlyThreeColumn?: boolean }>`
+  display: grid;
+  grid-template-columns: 48px 48px 1fr 120px;
+  gap: ${theme.spacing(3)};
+  align-items: flex-end;
+
+  ${({ $hasOnlyThreeColumn }) =>
+    $hasOnlyThreeColumn &&
+    css`
+      grid-template-columns: minmax(48px, 120px) 48px minmax(160px, 1fr);
+    `}
+`
+
+const InlineExpirationInput = styled.div`
+  display: flex;
+  gap: ${theme.spacing(4)};
+  align-items: center;
+
+  > *:first-child {
+    flex-grow: 1;
+  }
+`
+
+const CloseExpirationTooltip = styled(Tooltip)`
+  margin-top: ${theme.spacing(6)};
+`

--- a/src/pages/WalletForm/components/TopUpCard.tsx
+++ b/src/pages/WalletForm/components/TopUpCard.tsx
@@ -1,0 +1,311 @@
+import { InputAdornment } from '@mui/material'
+import { FormikProps } from 'formik'
+import { FC, RefObject } from 'react'
+import styled from 'styled-components'
+
+import { Alert, Icon, Typography } from '~/components/designSystem'
+import { AmountInputField, ComboBoxField, Switch } from '~/components/form'
+import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import {
+  getWordingForWalletCreationAlert,
+  getWordingForWalletEditionAlert,
+} from '~/components/wallets/utils'
+import { FORM_TYPE_ENUM } from '~/core/constants/form'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import {
+  CurrencyEnum,
+  GetCustomerInfosForWalletFormQuery,
+  RecurringTransactionIntervalEnum,
+  RecurringTransactionTriggerEnum,
+} from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { Card, theme } from '~/styles'
+
+import { TWalletDataForm } from '../types'
+
+const DEFAULT_RULES = {
+  grantedCredits: undefined,
+  interval: undefined,
+  lagoId: undefined,
+  paidCredits: undefined,
+  trigger: RecurringTransactionTriggerEnum.Threshold,
+  thresholdCredits: undefined,
+}
+
+interface TopUpCardProps {
+  formikProps: FormikProps<TWalletDataForm>
+  formType: (typeof FORM_TYPE_ENUM)[keyof typeof FORM_TYPE_ENUM]
+  customerData?: GetCustomerInfosForWalletFormQuery
+  isRecurringTopUpEnabled: boolean
+  setIsRecurringTopUpEnabled: (value: boolean) => void
+  premiumWarningDialogRef: RefObject<PremiumWarningDialogRef>
+}
+
+export const TopUpCard: FC<TopUpCardProps> = ({
+  formikProps,
+  formType,
+  customerData,
+  isRecurringTopUpEnabled,
+  setIsRecurringTopUpEnabled,
+  premiumWarningDialogRef,
+}) => {
+  const { isPremium } = useCurrentUser()
+  const { translate } = useInternationalization()
+
+  const recurringTransactionRules = formikProps.values?.recurringTransactionRules?.[0]
+
+  const canDisplayEditionAlert =
+    (!!recurringTransactionRules?.paidCredits || !!recurringTransactionRules?.grantedCredits) &&
+    ((recurringTransactionRules?.trigger === RecurringTransactionTriggerEnum.Interval &&
+      !!recurringTransactionRules?.interval) ||
+      recurringTransactionRules?.trigger === RecurringTransactionTriggerEnum.Threshold)
+
+  return (
+    <Card>
+      <Typography variant="subhead">{translate('text_6560809c38fb9de88d8a5198')}</Typography>
+
+      {formType === FORM_TYPE_ENUM.creation && (
+        <>
+          <AmountInputField
+            name="paidCredits"
+            currency={formikProps.values.currency}
+            beforeChangeFormatter={['positiveNumber']}
+            label={translate('text_62d18855b22699e5cf55f885')}
+            formikProps={formikProps}
+            silentError={true}
+            helperText={translate('text_62d18855b22699e5cf55f88b', {
+              paidCredits: intlFormatNumber(
+                isNaN(Number(formikProps.values.paidCredits))
+                  ? 0
+                  : Number(formikProps.values.paidCredits) * Number(formikProps.values.rateAmount),
+                {
+                  currencyDisplay: 'symbol',
+                  currency: formikProps?.values?.currency || CurrencyEnum.Usd,
+                },
+              ),
+            })}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  {translate('text_62d18855b22699e5cf55f889')}
+                </InputAdornment>
+              ),
+            }}
+          />
+
+          <AmountInputField
+            name="grantedCredits"
+            currency={formikProps.values.currency}
+            beforeChangeFormatter={['positiveNumber']}
+            label={translate('text_62d18855b22699e5cf55f88d')}
+            formikProps={formikProps}
+            silentError={true}
+            helperText={translate('text_62d18855b22699e5cf55f893', {
+              grantedCredits: intlFormatNumber(
+                isNaN(Number(formikProps.values.grantedCredits))
+                  ? 0
+                  : Number(formikProps.values.grantedCredits) *
+                      Number(formikProps.values.rateAmount),
+                {
+                  currencyDisplay: 'symbol',
+                  currency: formikProps?.values?.currency || CurrencyEnum.Usd,
+                },
+              ),
+            })}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  {translate('text_62d18855b22699e5cf55f891')}
+                </InputAdornment>
+              ),
+            }}
+          />
+        </>
+      )}
+
+      <InlineElements>
+        <Switch
+          name="isRecurringTopUpEnabled"
+          checked={isRecurringTopUpEnabled}
+          label={translate('text_6560809c38fb9de88d8a52ad')}
+          subLabel={translate('text_6560809c38fb9de88d8a52c7')}
+          onChange={(value) => {
+            if (isPremium) {
+              if (value) {
+                formikProps.setFieldValue('recurringTransactionRules.0', DEFAULT_RULES)
+              } else {
+                formikProps.setFieldValue('recurringTransactionRules', [])
+              }
+
+              setIsRecurringTopUpEnabled(value)
+            } else {
+              premiumWarningDialogRef.current?.openDialog()
+            }
+          }}
+        />
+        {!isPremium && <Icon name="sparkles" />}
+      </InlineElements>
+
+      {formType === FORM_TYPE_ENUM.edition && isRecurringTopUpEnabled && (
+        <>
+          <AmountInputField
+            name="recurringTransactionRules.0.paidCredits"
+            currency={formikProps.values.currency}
+            beforeChangeFormatter={['positiveNumber']}
+            label={translate('text_62d18855b22699e5cf55f885')}
+            formikProps={formikProps}
+            silentError={true}
+            helperText={translate('text_62d18855b22699e5cf55f88b', {
+              paidCredits: intlFormatNumber(
+                isNaN(Number(recurringTransactionRules?.paidCredits))
+                  ? 0
+                  : Number(recurringTransactionRules?.paidCredits) *
+                      Number(formikProps.values.rateAmount),
+                {
+                  currencyDisplay: 'symbol',
+                  currency: formikProps?.values?.currency || CurrencyEnum.Usd,
+                },
+              ),
+            })}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  {translate('text_62d18855b22699e5cf55f889')}
+                </InputAdornment>
+              ),
+            }}
+          />
+
+          <AmountInputField
+            name="recurringTransactionRules.0.grantedCredits"
+            currency={formikProps.values.currency}
+            beforeChangeFormatter={['positiveNumber']}
+            label={translate('text_62d18855b22699e5cf55f88d')}
+            formikProps={formikProps}
+            silentError={true}
+            helperText={translate('text_62d18855b22699e5cf55f893', {
+              grantedCredits: intlFormatNumber(
+                isNaN(Number(recurringTransactionRules?.grantedCredits))
+                  ? 0
+                  : Number(recurringTransactionRules?.grantedCredits) *
+                      Number(formikProps.values.rateAmount),
+                {
+                  currencyDisplay: 'symbol',
+                  currency: formikProps?.values?.currency || CurrencyEnum.Usd,
+                },
+              ),
+            })}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  {translate('text_62d18855b22699e5cf55f891')}
+                </InputAdornment>
+              ),
+            }}
+          />
+        </>
+      )}
+
+      {isRecurringTopUpEnabled && (
+        <InlineTopUpElements>
+          <ComboBoxField
+            disableClearable
+            label={translate('text_6560809c38fb9de88d8a52fb')}
+            name="recurringTransactionRules.0.trigger"
+            data={[
+              {
+                label: translate('text_65201b8216455901fe273dc1'),
+                value: RecurringTransactionTriggerEnum.Interval,
+              },
+              {
+                label: translate('text_6560809c38fb9de88d8a5315'),
+                value: RecurringTransactionTriggerEnum.Threshold,
+              },
+            ]}
+            formikProps={formikProps}
+          />
+
+          {recurringTransactionRules?.trigger === RecurringTransactionTriggerEnum.Interval && (
+            <ComboBoxField
+              disableClearable
+              sortValues={false}
+              label={translate('text_65201b8216455901fe273dc1')}
+              placeholder={translate('text_6560c252c4f33631aff1ab27')}
+              name="recurringTransactionRules.0.interval"
+              data={[
+                {
+                  label: translate('text_62b32ec6b0434070791c2d4c'),
+                  value: RecurringTransactionIntervalEnum.Weekly,
+                },
+                {
+                  label: translate('text_624453d52e945301380e49aa'),
+                  value: RecurringTransactionIntervalEnum.Monthly,
+                },
+                {
+                  label: translate('text_64d6357b00dea100ad1cb9e9'),
+                  value: RecurringTransactionIntervalEnum.Quarterly,
+                },
+                {
+                  label: translate('text_624453d52e945301380e49ac'),
+                  value: RecurringTransactionIntervalEnum.Yearly,
+                },
+              ]}
+              formikProps={formikProps}
+            />
+          )}
+          {recurringTransactionRules?.trigger === RecurringTransactionTriggerEnum.Threshold && (
+            <AmountInputField
+              name="recurringTransactionRules.0.thresholdCredits"
+              currency={formikProps.values.currency}
+              label={translate('text_6560809c38fb9de88d8a5315')}
+              formikProps={formikProps}
+              silentError={true}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    {translate('text_62d18855b22699e5cf55f891')}
+                  </InputAdornment>
+                ),
+              }}
+            />
+          )}
+        </InlineTopUpElements>
+      )}
+
+      {formType === FORM_TYPE_ENUM.creation && (
+        <Alert type="info">
+          {getWordingForWalletCreationAlert({
+            translate,
+            currency: formikProps.values?.currency,
+            customerTimezone: customerData?.customer?.timezone,
+            rulesValues: recurringTransactionRules,
+            walletValues: formikProps.values,
+          })}
+        </Alert>
+      )}
+      {isRecurringTopUpEnabled && canDisplayEditionAlert && formType === FORM_TYPE_ENUM.edition && (
+        <Alert type="info">
+          {getWordingForWalletEditionAlert({
+            translate,
+            currency: formikProps.values?.currency,
+            customerTimezone: customerData?.customer?.timezone,
+            rulesValues: recurringTransactionRules,
+          })}
+        </Alert>
+      )}
+    </Card>
+  )
+}
+
+const InlineElements = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing(3)};
+`
+
+const InlineTopUpElements = styled.div`
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: ${theme.spacing(3)};
+`

--- a/src/pages/WalletForm/index.ts
+++ b/src/pages/WalletForm/index.ts
@@ -1,0 +1,2 @@
+export { type TWalletDataForm } from './types'
+export { default as WalletForm } from './WalletForm'

--- a/src/pages/WalletForm/types.ts
+++ b/src/pages/WalletForm/types.ts
@@ -1,0 +1,4 @@
+import { CreateCustomerWalletInput, UpdateCustomerWalletInput } from '~/generated/graphql'
+
+export type TWalletDataForm = Omit<CreateCustomerWalletInput, 'customerId'> &
+  Omit<UpdateCustomerWalletInput, 'id'>


### PR DESCRIPTION
## Context

This is a refactor and it should not change any current behaviours.

## Description

While working on the wallet top-up improvement feature, I was editing `WalletForm` file and it became so large that it was exceeding 1000 lines. 

I thought that as pre-requisites to this PR, I would split the file into multiple components so it would be easier to code and review. 

Let me know what you think!