### PR TITLE
feat: add description props in form components

### DIFF
--- a/src/components/form/ButtonSelector/ButtonSelector.tsx
+++ b/src/components/form/ButtonSelector/ButtonSelector.tsx
@@ -1,8 +1,7 @@
 import styled, { css } from 'styled-components'
 
 import { Icon, Tooltip, Typography } from '~/components/designSystem'
-import { theme } from '~/styles'
-import { ButtonGroup } from '~/styles'
+import { ButtonGroup, theme } from '~/styles'
 
 import { TabButton } from './TabButton'
 
@@ -17,6 +16,7 @@ interface ButtonSelectorOption {
 export interface ButtonSelectorProps {
   className?: string
   label?: string
+  description?: string
   options: ButtonSelectorOption[]
   value?: ValueType
   error?: string
@@ -29,6 +29,7 @@ export interface ButtonSelectorProps {
 export const ButtonSelector = ({
   className,
   label,
+  description,
   options,
   value,
   error,
@@ -51,6 +52,11 @@ export const ButtonSelector = ({
             </Tooltip>
           )}
         </Label>
+      )}
+      {!!description && (
+        <Description>
+          <Typography variant="caption">{description}</Typography>
+        </Description>
       )}
       <ButtonGroup>
         {options.map(({ value: optionValue, label: optionLabel, disabled: optionDisabled }) => {
@@ -105,4 +111,8 @@ const Label = styled.div<{ $withInfo?: boolean }>`
         height: 16px;
       }
     `}
+`
+
+const Description = styled.div`
+  margin-bottom: ${theme.spacing(4)} !important;
 `

--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -23,6 +23,7 @@ export const ComboBox = ({
   addValueProps,
   sortValues = true,
   label,
+  description,
   infoText,
   placeholder,
   name,
@@ -105,6 +106,7 @@ export const ComboBox = ({
             searchQuery={debouncedSearch}
             helperText={helperText}
             label={label}
+            description={description}
             infoText={infoText}
             name={name}
             placeholder={placeholder}

--- a/src/components/form/ComboBox/ComboBoxInput.tsx
+++ b/src/components/form/ComboBox/ComboBoxInput.tsx
@@ -15,6 +15,7 @@ export const ComboBoxInput = ({
   error,
   helperText,
   label,
+  description,
   name,
   searchQuery,
   placeholder,
@@ -37,6 +38,7 @@ export const ComboBoxInput = ({
       name={name}
       placeholder={placeholder}
       label={label}
+      description={description}
       error={error}
       infoText={infoText}
       autoComplete="off"

--- a/src/components/form/ComboBox/types.ts
+++ b/src/components/form/ComboBox/types.ts
@@ -1,6 +1,5 @@
 import { LazyQueryExecFunction } from '@apollo/client'
-import { AutocompleteRenderInputParams } from '@mui/material'
-import { PopperProps as MuiPopperProps } from '@mui/material'
+import { AutocompleteRenderInputParams, PopperProps as MuiPopperProps } from '@mui/material'
 import { ReactNode } from 'react'
 
 import { Exact, InputMaybe } from '~/generated/graphql'
@@ -13,6 +12,7 @@ export interface BasicComboBoxData {
   selected?: boolean
   label?: string
   labelNode?: ReactNode
+  description?: string
   disabled?: boolean
   customValue?: boolean
   group?: never
@@ -71,6 +71,7 @@ export type ComboBoxInputProps = Pick<
   TextInputProps,
   | 'error'
   | 'label'
+  | 'description'
   | 'name'
   | 'placeholder'
   | 'helperText'

--- a/src/components/form/JsonEditor/JsonEditor.tsx
+++ b/src/components/form/JsonEditor/JsonEditor.tsx
@@ -21,6 +21,7 @@ enum JSON_EDITOR_ERROR_ENUM {
 }
 export interface JsonEditorProps {
   label: string
+  description?: string
   name?: string
   placeholder?: string
   value?: string | Record<string, unknown>
@@ -43,6 +44,7 @@ export const JsonEditor = ({
   value,
   placeholder,
   label,
+  description,
   infoText,
   helperText,
   error,
@@ -75,14 +77,21 @@ export const JsonEditor = ({
   return (
     <Container>
       {!hideLabel && (
-        <Label $withInfo={!!infoText}>
-          <Typography variant="captionHl" color="textSecondary">
-            {label}
-          </Typography>
-          {!!infoText && (
-            <Tooltip placement="bottom-start" title={infoText}>
-              <Icon name="info-circle" />
-            </Tooltip>
+        <Label>
+          <LabelContainer $withInfo={!!infoText}>
+            <Typography variant="captionHl" color="textSecondary">
+              {label}
+            </Typography>
+            {!!infoText && (
+              <Tooltip placement="bottom-start" title={infoText}>
+                <Icon name="info-circle" />
+              </Tooltip>
+            )}
+          </LabelContainer>
+          {description && (
+            <Description>
+              <Typography variant="caption">{description}</Typography>
+            </Description>
           )}
         </Label>
       )}
@@ -184,11 +193,14 @@ const Container = styled.div`
     'helper';
 `
 
-const Label = styled.div<{ $withInfo?: boolean }>`
+const Label = styled.div`
+  grid-area: label;
+`
+
+const LabelContainer = styled.div<{ $withInfo?: boolean }>`
   display: flex;
   align-items: center;
   margin-bottom: ${theme.spacing(1)};
-  grid-area: label;
 
   ${({ $withInfo }) =>
     $withInfo &&
@@ -405,4 +417,8 @@ const Editor = styled(AceEditor)`
 
 const Helper = styled(Typography)`
   grid-area: helper;
+`
+
+const Description = styled.div`
+  margin-bottom: ${theme.spacing(4)};
 `

--- a/src/components/form/TextInput/TextInput.tsx
+++ b/src/components/form/TextInput/TextInput.tsx
@@ -33,6 +33,7 @@ export interface TextInputProps
   error?: string | boolean
   name?: string
   label?: string | ReactNode
+  description?: string
   cleanable?: boolean
   password?: boolean
   value?: string | number
@@ -125,6 +126,7 @@ export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
       value = '',
       name,
       label,
+      description,
       helperText,
       infoText,
       maxRows,
@@ -197,6 +199,11 @@ export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
               </Label>
             )}
           </InlineLabelContainer>
+        )}
+        {!!description && (
+          <Description>
+            <Typography variant="caption">{description}</Typography>
+          </Description>
         )}
         <MuiTextField
           ref={ref}
@@ -293,4 +300,8 @@ const Label = styled.div<{ $withInfo?: boolean }>`
         height: 16px;
       }
     `}
+`
+
+const Description = styled.div`
+  margin-bottom: ${theme.spacing(4)} !important;
 `

--- a/src/pages/__devOnly/DesignSystem.tsx
+++ b/src/pages/__devOnly/DesignSystem.tsx
@@ -898,6 +898,7 @@ const DesignSystem = () => {
                     <ButtonSelectorField
                       name="buttonSelector"
                       label="You'd rather..."
+                      description="Be careful with your choice"
                       infoText="You WILL be judge on the answer"
                       formikProps={formikProps}
                       options={[
@@ -961,6 +962,7 @@ const DesignSystem = () => {
                         group: Math.round(i / 5) + '',
                       }))}
                       label="Grouped by - virtualized"
+                      description="You can type anything to see the magic happen"
                       placeholder="Placeholder"
                       formikProps={formikProps}
                     />
@@ -1229,6 +1231,7 @@ const DesignSystem = () => {
                       formikProps={formikProps}
                       label="Amount"
                       name="amountCents"
+                      description='Amount in "cents" (1€ = 100 cents)'
                     />
                     <ComboBoxField
                       name="amountCurrency"
@@ -1236,6 +1239,7 @@ const DesignSystem = () => {
                         value: currencyType,
                       }))}
                       label="currency"
+                      description="Select your currency"
                       placeholder="Placeholder"
                       isEmptyNull={false}
                       disableClearable
@@ -1299,6 +1303,13 @@ const DesignSystem = () => {
                       formikProps={formikProps}
                       helperText="I'm here to help"
                     />
+                    <TextInputField
+                      label="With description"
+                      placeholder="Type something"
+                      name="input"
+                      formikProps={formikProps}
+                      description="I'm here to help"
+                    />
                   </Block>
 
                   <GroupTitle variant="subhead">JSON Editor</GroupTitle>
@@ -1306,6 +1317,8 @@ const DesignSystem = () => {
                     <JsonEditorField
                       name="json"
                       label="With small editor and overlay"
+                      description='Click on "expand" to remove the overlay'
+                      infoText="Some tips"
                       formikProps={formikProps}
                       onExpand={(deleteOverlay) => {
                         deleteOverlay()


### PR DESCRIPTION
## Context

To prepare the UI migration of plan form page, I'm adding optional `description` props to form components 