### PR TITLE
misc: make sure initial render does not raise a warning

### DIFF
--- a/src/components/designSystem/NavigationTab.tsx
+++ b/src/components/designSystem/NavigationTab.tsx
@@ -61,6 +61,7 @@ export const NavigationTab = ({
   const navigate = useNavigate()
   const nonHiddenTabs = tabs.filter((t) => !t.hidden)
 
+  // Default value is not 0 to prevent useEffect value udpate to flash first component
   const [value, setValue] = useState<number | null>(null)
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
@@ -82,7 +83,7 @@ export const NavigationTab = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  if (nonHiddenTabs.length < 2) return null
+  if (nonHiddenTabs.length < 2 || value === null) return null
 
   return (
     <Box sx={{ width: '100%' }}>


### PR DESCRIPTION
## Context

On some pages, when a component was not given in the tabs array, the MUI tabs component was raison an error. 

This PR fixes this initial state.

## Description

The NavigationTab component does init with a state value being null.

This is because the initial state is given by the internal useEffect of this component.

This useEffect does check the url, and decide whether or not the value should be 0 or a different value.

During this moment, the MUI tabs list is rendered but with a value being `null`.

The component is then rendering properly, but the MUI does logs a warning mentioning this unexpected state.

In this PR we make sure the MUI component is not rendered if the value is null, so only once we have the useEffect being triggered it can properly render.