### PR TITLE
bug: default combobox label variant should be body

### DIFF
--- a/src/components/form/ComboBox/ComboBoxItem.tsx
+++ b/src/components/form/ComboBox/ComboBoxItem.tsx
@@ -66,6 +66,7 @@ export const ComboBoxItem = ({
               value={value}
               checked={!!selected}
               label={labelNode || label || value}
+              labelVariant="body"
             />
           )}
         </Item>

--- a/src/components/form/Radio/Radio.tsx
+++ b/src/components/form/Radio/Radio.tsx
@@ -2,7 +2,7 @@ import clsns from 'classnames'
 import { forwardRef, ReactNode, useId, useRef, useState } from 'react'
 import styled from 'styled-components'
 
-import { Typography } from '~/components/designSystem'
+import { Typography, TypographyProps } from '~/components/designSystem'
 import RadioCheckedIcon from '~/public/icons/forms/radio-checked.svg'
 import RadioIcon from '~/public/icons/forms/radio.svg'
 import { theme } from '~/styles'
@@ -13,12 +13,16 @@ export interface RadioProps {
   checked: boolean
   disabled?: boolean
   label?: string | ReactNode
+  labelVariant?: TypographyProps['variant']
   sublabel?: string | ReactNode
   onChange?: (value: string | number) => void
 }
 
 export const Radio = forwardRef<HTMLDivElement, RadioProps>(
-  ({ name, checked, label, sublabel, disabled, value, onChange }: RadioProps, ref) => {
+  (
+    { name, checked, label, labelVariant, sublabel, disabled, value, onChange }: RadioProps,
+    ref,
+  ) => {
     const componentId = useId()
 
     const inputRef = useRef<HTMLInputElement>(null)
@@ -56,7 +60,7 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(
         </RadioContainer>
         <RadioLabelWrapper>
           <Typography
-            variant="bodyHl"
+            variant={labelVariant || 'bodyHl'}
             color={disabled ? 'disabled' : 'textSecondary'}
             component={(labelProps) => <label htmlFor={componentId} {...labelProps} />}
           >


### PR DESCRIPTION
## Context

The recent RBAC feature changed the default variant of the Radio component from `body` to `bodyHl`.

The issue is that this Radio component is used in the combobox item component, to render each options label.

## Description

This PR let the `bodyHl` as the default option, but allow to pass a param in order to change this value.

The `ComboboxItem` can now define the variant as `body`

Fixes ISSUE-348