### PR TITLE
misc: fix back navigation on integration deletion

### DIFF
--- a/src/components/settings/integrations/NetsuiteIntegrationSettings.tsx
+++ b/src/components/settings/integrations/NetsuiteIntegrationSettings.tsx
@@ -11,6 +11,7 @@ import {
 } from '~/core/router'
 import {
   DeleteNetsuiteIntegrationDialogFragmentDoc,
+  IntegrationTypeEnum,
   NetsuiteForCreateDialogDialogFragmentDoc,
   NetsuiteIntegrationSettingsFragment,
   useGetNetsuiteIntegrationsSettingsQuery,
@@ -47,7 +48,11 @@ gql`
     syncSalesOrders
   }
 
-  query getNetsuiteIntegrationsSettings($id: ID!, $limit: Int) {
+  query getNetsuiteIntegrationsSettings(
+    $id: ID!
+    $limit: Int
+    $integrationsType: IntegrationTypeEnum!
+  ) {
     integration(id: $id) {
       ... on NetsuiteIntegration {
         id
@@ -57,7 +62,7 @@ gql`
       }
     }
 
-    integrations(limit: $limit) {
+    integrations(limit: $limit, type: $integrationsType) {
       collection {
         ... on NetsuiteIntegration {
           id
@@ -107,12 +112,13 @@ const NetsuiteIntegrationSettings = () => {
     variables: {
       id: integrationId as string,
       limit: PROVIDER_CONNECTION_LIMIT,
+      integrationsType: IntegrationTypeEnum.Netsuite,
     },
     skip: !integrationId,
   })
   const netsuiteIntegration = data?.integration as NetsuiteIntegrationSettingsFragment | undefined
   const deleteDialogCallback = () => {
-    if (data?.integrations?.collection.length === PROVIDER_CONNECTION_LIMIT) {
+    if ((data?.integrations?.collection.length || 0) >= PROVIDER_CONNECTION_LIMIT) {
       navigate(NETSUITE_INTEGRATION_ROUTE)
     } else {
       navigate(INTEGRATIONS_ROUTE)

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -127,6 +127,16 @@ export enum AggregationTypeEnum {
   WeightedSumAgg = 'weighted_sum_agg'
 }
 
+export type AnrokCustomer = {
+  __typename?: 'AnrokCustomer';
+  externalCustomerId?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  integrationCode?: Maybe<Scalars['String']['output']>;
+  integrationId?: Maybe<Scalars['ID']['output']>;
+  integrationType?: Maybe<IntegrationTypeEnum>;
+  syncWithProvider?: Maybe<Scalars['Boolean']['output']>;
+};
+
 export type AnrokIntegration = {
   __typename?: 'AnrokIntegration';
   apiKey: Scalars['String']['output'];
@@ -1094,7 +1104,7 @@ export type CreateIntegrationCollectionMappingInput = {
 export type CreateIntegrationMappingInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
-  externalAccountCode: Scalars['String']['input'];
+  externalAccountCode?: InputMaybe<Scalars['String']['input']>;
   externalId: Scalars['String']['input'];
   externalName?: InputMaybe<Scalars['String']['input']>;
   integrationId: Scalars['ID']['input'];
@@ -1661,6 +1671,7 @@ export type Customer = {
   activeSubscriptionsCount: Scalars['Int']['output'];
   addressLine1?: Maybe<Scalars['String']['output']>;
   addressLine2?: Maybe<Scalars['String']['output']>;
+  anrokCustomer?: Maybe<AnrokCustomer>;
   applicableTimezone: TimezoneEnum;
   appliedAddOns?: Maybe<Array<AppliedAddOn>>;
   appliedCoupons?: Maybe<Array<AppliedCoupon>>;
@@ -2295,6 +2306,7 @@ export enum IntegrationItemTypeEnum {
 }
 
 export enum IntegrationTypeEnum {
+  Anrok = 'anrok',
   Netsuite = 'netsuite',
   Okta = 'okta'
 }
@@ -2531,7 +2543,7 @@ export enum MappableTypeEnum {
 
 export type Mapping = {
   __typename?: 'Mapping';
-  externalAccountCode: Scalars['String']['output'];
+  externalAccountCode?: Maybe<Scalars['String']['output']>;
   externalId: Scalars['String']['output'];
   externalName?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
@@ -5954,7 +5966,7 @@ export type GetAddOnsForNetsuiteItemsListQueryVariables = Exact<{
 }>;
 
 
-export type GetAddOnsForNetsuiteItemsListQuery = { __typename?: 'Query', addOns: { __typename?: 'AddOnCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'AddOn', id: string, name: string, code: string, integrationMappings?: Array<{ __typename?: 'Mapping', id: string, externalId: string, externalAccountCode: string, externalName?: string | null, mappableType: MappableTypeEnum }> | null }> } };
+export type GetAddOnsForNetsuiteItemsListQuery = { __typename?: 'Query', addOns: { __typename?: 'AddOnCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'AddOn', id: string, name: string, code: string, integrationMappings?: Array<{ __typename?: 'Mapping', id: string, externalId: string, externalAccountCode?: string | null, externalName?: string | null, mappableType: MappableTypeEnum }> | null }> } };
 
 export type GetBillableMetricsForNetsuiteItemsListQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -5964,11 +5976,11 @@ export type GetBillableMetricsForNetsuiteItemsListQueryVariables = Exact<{
 }>;
 
 
-export type GetBillableMetricsForNetsuiteItemsListQuery = { __typename?: 'Query', billableMetrics: { __typename?: 'BillableMetricCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'BillableMetric', id: string, name: string, code: string, integrationMappings?: Array<{ __typename?: 'Mapping', id: string, externalId: string, externalAccountCode: string, externalName?: string | null, mappableType: MappableTypeEnum }> | null }> } };
+export type GetBillableMetricsForNetsuiteItemsListQuery = { __typename?: 'Query', billableMetrics: { __typename?: 'BillableMetricCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'BillableMetric', id: string, name: string, code: string, integrationMappings?: Array<{ __typename?: 'Mapping', id: string, externalId: string, externalAccountCode?: string | null, externalName?: string | null, mappableType: MappableTypeEnum }> | null }> } };
 
-export type NetsuiteIntegrationItemsListAddonsFragment = { __typename?: 'AddOn', id: string, name: string, code: string, integrationMappings?: Array<{ __typename?: 'Mapping', id: string, externalId: string, externalAccountCode: string, externalName?: string | null, mappableType: MappableTypeEnum }> | null };
+export type NetsuiteIntegrationItemsListAddonsFragment = { __typename?: 'AddOn', id: string, name: string, code: string, integrationMappings?: Array<{ __typename?: 'Mapping', id: string, externalId: string, externalAccountCode?: string | null, externalName?: string | null, mappableType: MappableTypeEnum }> | null };
 
-export type NetsuiteIntegrationItemsListBillableMetricsFragment = { __typename?: 'BillableMetric', id: string, name: string, code: string, integrationMappings?: Array<{ __typename?: 'Mapping', id: string, externalId: string, externalAccountCode: string, externalName?: string | null, mappableType: MappableTypeEnum }> | null };
+export type NetsuiteIntegrationItemsListBillableMetricsFragment = { __typename?: 'BillableMetric', id: string, name: string, code: string, integrationMappings?: Array<{ __typename?: 'Mapping', id: string, externalId: string, externalAccountCode?: string | null, externalName?: string | null, mappableType: MappableTypeEnum }> | null };
 
 export type NetsuiteIntegrationItemsListDefaultFragment = { __typename?: 'CollectionMapping', id: string, mappingType: MappingTypeEnum, externalId: string, externalAccountCode?: string | null, externalName?: string | null };
 
@@ -5977,6 +5989,7 @@ export type NetsuiteIntegrationSettingsFragment = { __typename?: 'NetsuiteIntegr
 export type GetNetsuiteIntegrationsSettingsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
+  integrationsType: IntegrationTypeEnum;
 }>;
 
 
@@ -5986,7 +5999,7 @@ export type NetsuiteMapItemDialogItemFragment = { __typename?: 'IntegrationItem'
 
 export type NetsuiteMapItemDialogCollectionMappingItemFragment = { __typename?: 'CollectionMapping', id: string, externalId: string, externalName?: string | null, externalAccountCode?: string | null };
 
-export type NetsuiteMapItemDialogCollectionItemFragment = { __typename?: 'Mapping', id: string, externalId: string, externalName?: string | null, externalAccountCode: string };
+export type NetsuiteMapItemDialogCollectionItemFragment = { __typename?: 'Mapping', id: string, externalId: string, externalName?: string | null, externalAccountCode?: string | null };
 
 export type GetIntegrationItemsQueryVariables = Exact<{
   integrationId: Scalars['ID']['input'];
@@ -6025,7 +6038,7 @@ export type CreateIntegrationMappingMutationVariables = Exact<{
 }>;
 
 
-export type CreateIntegrationMappingMutation = { __typename?: 'Mutation', createIntegrationMapping?: { __typename?: 'Mapping', id: string, externalId: string, externalName?: string | null, externalAccountCode: string } | null };
+export type CreateIntegrationMappingMutation = { __typename?: 'Mutation', createIntegrationMapping?: { __typename?: 'Mapping', id: string, externalId: string, externalName?: string | null, externalAccountCode?: string | null } | null };
 
 export type UpdateIntegrationCollectionMappingMutationVariables = Exact<{
   input: UpdateIntegrationCollectionMappingInput;
@@ -6931,6 +6944,7 @@ export type NetsuiteIntegrationDetailsFragment = { __typename?: 'NetsuiteIntegra
 export type GetNetsuiteIntegrationsDetailsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
+  integrationsType: IntegrationTypeEnum;
 }>;
 
 
@@ -13430,7 +13444,7 @@ export type GetBillableMetricsForNetsuiteItemsListLazyQueryHookResult = ReturnTy
 export type GetBillableMetricsForNetsuiteItemsListSuspenseQueryHookResult = ReturnType<typeof useGetBillableMetricsForNetsuiteItemsListSuspenseQuery>;
 export type GetBillableMetricsForNetsuiteItemsListQueryResult = Apollo.QueryResult<GetBillableMetricsForNetsuiteItemsListQuery, GetBillableMetricsForNetsuiteItemsListQueryVariables>;
 export const GetNetsuiteIntegrationsSettingsDocument = gql`
-    query getNetsuiteIntegrationsSettings($id: ID!, $limit: Int) {
+    query getNetsuiteIntegrationsSettings($id: ID!, $limit: Int, $integrationsType: IntegrationTypeEnum!) {
   integration(id: $id) {
     ... on NetsuiteIntegration {
       id
@@ -13439,7 +13453,7 @@ export const GetNetsuiteIntegrationsSettingsDocument = gql`
       ...NetsuiteForCreateDialogDialog
     }
   }
-  integrations(limit: $limit) {
+  integrations(limit: $limit, type: $integrationsType) {
     collection {
       ... on NetsuiteIntegration {
         id
@@ -13465,6 +13479,7 @@ ${NetsuiteForCreateDialogDialogFragmentDoc}`;
  *   variables: {
  *      id: // value for 'id'
  *      limit: // value for 'limit'
+ *      integrationsType: // value for 'integrationsType'
  *   },
  * });
  */
@@ -18407,14 +18422,14 @@ export type GetMembersLazyQueryHookResult = ReturnType<typeof useGetMembersLazyQ
 export type GetMembersSuspenseQueryHookResult = ReturnType<typeof useGetMembersSuspenseQuery>;
 export type GetMembersQueryResult = Apollo.QueryResult<GetMembersQuery, GetMembersQueryVariables>;
 export const GetNetsuiteIntegrationsDetailsDocument = gql`
-    query getNetsuiteIntegrationsDetails($id: ID!, $limit: Int) {
+    query getNetsuiteIntegrationsDetails($id: ID!, $limit: Int, $integrationsType: IntegrationTypeEnum!) {
   integration(id: $id) {
     ... on NetsuiteIntegration {
       id
       ...NetsuiteIntegrationDetails
     }
   }
-  integrations(limit: $limit) {
+  integrations(limit: $limit, type: $integrationsType) {
     collection {
       ... on NetsuiteIntegration {
         id
@@ -18438,6 +18453,7 @@ export const GetNetsuiteIntegrationsDetailsDocument = gql`
  *   variables: {
  *      id: // value for 'id'
  *      limit: // value for 'limit'
+ *      integrationsType: // value for 'integrationsType'
  *   },
  * });
  */

--- a/src/pages/settings/AdyenIntegrationDetails.tsx
+++ b/src/pages/settings/AdyenIntegrationDetails.tsx
@@ -97,7 +97,7 @@ const AdyenIntegrationDetails = () => {
   })
   const adyenPaymentProvider = data?.paymentProvider as AdyenIntegrationDetailsFragment
   const deleteDialogCallback = () => {
-    if (data?.paymentProviders?.collection.length === PROVIDER_CONNECTION_LIMIT) {
+    if ((data?.paymentProviders?.collection.length || 0) >= PROVIDER_CONNECTION_LIMIT) {
       navigate(ADYEN_INTEGRATION_ROUTE)
     } else {
       navigate(INTEGRATIONS_ROUTE)

--- a/src/pages/settings/GocardlessIntegrationDetails.tsx
+++ b/src/pages/settings/GocardlessIntegrationDetails.tsx
@@ -97,7 +97,7 @@ const GocardlessIntegrationDetails = () => {
   const gocardlessPaymentProvider = data?.paymentProvider as GocardlessIntegrationDetailsFragment
   const isConnectionEstablished = !!gocardlessPaymentProvider?.webhookSecret
   const deleteDialogCallback = () => {
-    if (data?.paymentProviders?.collection.length === PROVIDER_CONNECTION_LIMIT) {
+    if ((data?.paymentProviders?.collection.length || 0) >= PROVIDER_CONNECTION_LIMIT) {
       navigate(GOCARDLESS_INTEGRATION_ROUTE)
     } else {
       navigate(INTEGRATIONS_ROUTE)

--- a/src/pages/settings/NetsuiteIntegrationDetails.tsx
+++ b/src/pages/settings/NetsuiteIntegrationDetails.tsx
@@ -34,6 +34,7 @@ import {
 } from '~/core/router'
 import {
   DeleteNetsuiteIntegrationDialogFragmentDoc,
+  IntegrationTypeEnum,
   NetsuiteForCreateDialogDialogFragmentDoc,
   NetsuiteIntegrationDetailsFragment,
   NetsuiteIntegrationItemsFragmentDoc,
@@ -59,7 +60,11 @@ gql`
     ...NetsuiteIntegrationItems
   }
 
-  query getNetsuiteIntegrationsDetails($id: ID!, $limit: Int) {
+  query getNetsuiteIntegrationsDetails(
+    $id: ID!
+    $limit: Int
+    $integrationsType: IntegrationTypeEnum!
+  ) {
     integration(id: $id) {
       ... on NetsuiteIntegration {
         id
@@ -67,7 +72,7 @@ gql`
       }
     }
 
-    integrations(limit: $limit) {
+    integrations(limit: $limit, type: $integrationsType) {
       collection {
         ... on NetsuiteIntegration {
           id
@@ -92,12 +97,13 @@ const NetsuiteIntegrationDetails = () => {
     variables: {
       id: integrationId as string,
       limit: PROVIDER_CONNECTION_LIMIT,
+      integrationsType: IntegrationTypeEnum.Netsuite,
     },
     skip: !integrationId,
   })
   const netsuiteIntegration = data?.integration as NetsuiteIntegrationDetailsFragment
   const deleteDialogCallback = () => {
-    if (data?.integrations?.collection.length === PROVIDER_CONNECTION_LIMIT) {
+    if ((data?.integrations?.collection.length || 0) >= PROVIDER_CONNECTION_LIMIT) {
       navigate(NETSUITE_INTEGRATION_ROUTE)
     } else {
       navigate(INTEGRATIONS_ROUTE)

--- a/src/pages/settings/StripeIntegrationDetails.tsx
+++ b/src/pages/settings/StripeIntegrationDetails.tsx
@@ -95,7 +95,7 @@ const StripeIntegrationDetails = () => {
   })
   const stripePaymentProvider = data?.paymentProvider as StripeIntegrationDetailsFragment
   const deleteDialogCallback = () => {
-    if (data?.paymentProviders?.collection.length === PROVIDER_CONNECTION_LIMIT) {
+    if ((data?.paymentProviders?.collection.length || 0) >= PROVIDER_CONNECTION_LIMIT) {
       navigate(STRIPE_INTEGRATION_ROUTE)
     } else {
       navigate(INTEGRATIONS_ROUTE)


### PR DESCRIPTION
## Context

While working on the addition of a new integration, I noticed the back redirection logic was clumsy and could fail in some cases

## Description

This PR does 2 thing
- fix the condition for all integration back button
- Make sure the integrations fetched to perform this condition only fetch related integration type