### PR TITLE
bug: render nav children even if there is only one tab

### DIFF
--- a/src/components/designSystem/NavigationTab.tsx
+++ b/src/components/designSystem/NavigationTab.tsx
@@ -83,7 +83,8 @@ export const NavigationTab = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  if (nonHiddenTabs.length < 2 || value === null) return null
+  // Prevent blink on first render
+  if (value === null) return null
 
   return (
     <Box sx={{ width: '100%' }}>
@@ -97,38 +98,40 @@ export const NavigationTab = ({
           value={value}
           $leftPadding={leftPadding}
         >
-          {nonHiddenTabs.map((tab, tabIndex) => {
-            if (loading) {
-              return (
-                <Skeleton
-                  key={`loding-tab-${tabIndex}`}
-                  variant="text"
-                  width={80}
-                  height={12}
-                  marginRight={tabIndex !== nonHiddenTabs.length - 1 ? '16px' : 0}
-                />
-              )
-            }
+          {nonHiddenTabs.length >= 2
+            ? nonHiddenTabs.map((tab, tabIndex) => {
+                if (loading) {
+                  return (
+                    <Skeleton
+                      key={`loding-tab-${tabIndex}`}
+                      variant="text"
+                      width={80}
+                      height={12}
+                      marginRight={tabIndex !== nonHiddenTabs.length - 1 ? '16px' : 0}
+                    />
+                  )
+                }
 
-            return (
-              <Tab
-                key={`tab-${tabIndex}`}
-                disableFocusRipple
-                disableRipple
-                role="tab"
-                className="navigation-tab-item"
-                disabled={loading || tab.disabled}
-                icon={!!tab.icon ? <Icon name={tab.icon} /> : undefined}
-                iconPosition="start"
-                label={<Typography variant="captionHl">{tab.title}</Typography>}
-                value={tabIndex}
-                onClick={() => {
-                  !!tab.link && navigate(tab.link)
-                }}
-                {...a11yProps(tabIndex)}
-              />
-            )
-          })}
+                return (
+                  <Tab
+                    key={`tab-${tabIndex}`}
+                    disableFocusRipple
+                    disableRipple
+                    role="tab"
+                    className="navigation-tab-item"
+                    disabled={loading || tab.disabled}
+                    icon={!!tab.icon ? <Icon name={tab.icon} /> : undefined}
+                    iconPosition="start"
+                    label={<Typography variant="captionHl">{tab.title}</Typography>}
+                    value={tabIndex}
+                    onClick={() => {
+                      !!tab.link && navigate(tab.link)
+                    }}
+                    {...a11yProps(tabIndex)}
+                  />
+                )
+              })
+            : null}
         </LocalTabs>
       </TabsWrapper>
       {value !== null &&

--- a/src/layouts/CustomerInvoiceDetails.tsx
+++ b/src/layouts/CustomerInvoiceDetails.tsx
@@ -283,7 +283,6 @@ const CustomerInvoiceDetails = () => {
           invoiceId: invoiceId as string,
           tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
         }),
-        routerState: { disableScrollTop: true },
         match: [
           generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
             customerId: customerId as string,
@@ -314,7 +313,6 @@ const CustomerInvoiceDetails = () => {
           invoiceId: invoiceId as string,
           tab: CustomerInvoiceDetailsTabsOptionsEnum.creditNotes,
         }),
-        routerState: { disableScrollTop: true },
         match: [
           generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
             customerId: customerId as string,


### PR DESCRIPTION
## Context

We recently refactored the new tab component in the app

It was containing a condition to not render if there were less than 2 tabs.
But it also precented the children container to render in such case

## Description

This PR moves the condition to only hide the tab element in such case, but let the children render in any cases

Also fixes ISSUE-349