### PR TITLE
misc: update selected tab when url changes

### DIFF
--- a/src/components/designSystem/NavigationTab.tsx
+++ b/src/components/designSystem/NavigationTab.tsx
@@ -80,8 +80,9 @@ export const NavigationTab = ({
       setValue(0)
     }
 
+    // NOTE: window.location.pathname has to be watched for programatic navigation (without clicking on tabs)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [nonHiddenTabs, window.location.pathname])
 
   // Prevent blink on first render
   if (value === null) return null


### PR DESCRIPTION
## Context

Tab component have recently been updated.

There is one place in the app where a button outside of the tab component make the url change, and it changes to another tab url (not the one currently selected)

## Description

This PR make sure every time the url changes, the tab component check about the selected tab and can update the tabs accordingly if needed.