### PR TITLE
fix: remove CVE currency from currencies with 0 decimals

### DIFF
--- a/src/core/serializers/serializeAmount.ts
+++ b/src/core/serializers/serializeAmount.ts
@@ -3,7 +3,6 @@ import { CurrencyEnum } from '~/generated/graphql'
 const CURRENCIES_WITH_4_DECIMALS = ['CLF']
 const CURRENCIES_WITH_3_DECIMALS = ['BHD', 'IQD', 'JOD', 'KWD', 'LYD', 'OMR', 'TND']
 const CURRENCIES_WITH_0_DECIMALS = [
-  'CVE',
   'DJF',
   'GNF',
   'ISK',


### PR DESCRIPTION
## Roadmap Task

Issue #1560 

## Context

It was reported that for CVE currency, the unit price amount was incorrect (compared to $)
![CleanShot 2024-06-23 at 00 35 54@2x](https://github.com/getlago/lago-front/assets/17253055/8cb3ee02-fefd-4025-9ab6-e9ca17c3f496)
![CleanShot 2024-06-23 at 00 36 36@2x](https://github.com/getlago/lago-front/assets/17253055/8a2acc99-7b59-47eb-bbab-9ef84091dcd8)


## Description


This PR should allow CVE currency to have 2 decimals (it was 0 initially) and should fix the issue.

**After**
<img width="863" alt="Capture d’écran 2024-06-24 à 10 16 25" src="https://github.com/getlago/lago-front/assets/17253055/e3bdc452-d7e1-41c8-904b-9bfb0e38d6e6">
