### PR TITLE
feat: new display table component

### DIFF
--- a/src/components/designSystem/Table/TableDisplay.tsx
+++ b/src/components/designSystem/Table/TableDisplay.tsx
@@ -7,16 +7,19 @@ import {
   TableRow as MUITableRow,
 } from '@mui/material'
 import { ReactNode } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { Button, ButtonProps, Popper, Skeleton } from '~/components/designSystem'
 import { ListClickableItemCss, MenuPopper, theme } from '~/styles'
+
+type Variant = 'outline' | 'borderless'
 
 type Column<T> = {
   key: keyof T
   title: string | ReactNode
   content: (item: T) => ReactNode
   size?: number
+  textAlign?: 'left' | 'center' | 'right'
 }
 
 interface TableDisplayProps<T> {
@@ -24,7 +27,7 @@ interface TableDisplayProps<T> {
   data: T[]
   columns: Column<T>[]
   isLoading?: boolean
-  variant?: 'outline'
+  variant?: Variant
   onRowAction?: (item: T) => void
   isFullWidth?: boolean
   actionColumn?: Array<{
@@ -40,13 +43,14 @@ export const TableDisplay = <T,>({
   name,
   data,
   columns,
+  variant = 'outline',
   isLoading,
   isFullWidth,
   onRowAction,
   actionColumn,
 }: TableDisplayProps<T>) => {
   return (
-    <TableContainer $isFullWidth={!!isFullWidth}>
+    <TableContainer $isFullWidth={!!isFullWidth} $variant={variant}>
       <MUITable>
         <TableHead>
           <TableRow>
@@ -57,7 +61,11 @@ export const TableDisplay = <T,>({
             ) : (
               <>
                 {columns.map((column, i) => (
-                  <TableCell $size={column.size} key={`table-display-${name}-head-${i}`}>
+                  <TableCell
+                    $size={column.size}
+                    key={`table-display-${name}-head-${i}`}
+                    align={column.textAlign || 'left'}
+                  >
                     {column.title}
                   </TableCell>
                 ))}
@@ -95,7 +103,11 @@ export const TableDisplay = <T,>({
                 }}
               >
                 {columns.map((column, j) => (
-                  <TableCell $size={column.size} key={`table-display-${name}-cell-${i}-${j}`}>
+                  <TableCell
+                    $size={column.size}
+                    key={`table-display-${name}-cell-${i}-${j}`}
+                    align={column.textAlign || 'left'}
+                  >
                     {column.content(item)}
                   </TableCell>
                 ))}
@@ -143,9 +155,29 @@ export const TableDisplay = <T,>({
   )
 }
 
-const TableContainer = styled(MUITableContainer)<{ $isFullWidth: boolean }>`
-  border: 1px solid ${theme.palette.grey[400]};
-  border-radius: ${theme.shape.borderRadius}px;
+const TableContainer = styled(MUITableContainer)<{
+  $isFullWidth: boolean
+  $variant: Variant
+}>`
+  ${({ $variant }) => {
+    if ($variant === 'outline') {
+      return css`
+        border: 1px solid ${theme.palette.grey[400]};
+        border-radius: ${theme.shape.borderRadius}px;
+      `
+    }
+
+    if ($variant === 'borderless') {
+      return css`
+        thead {
+          background-color: ${theme.palette.grey[100]};
+        }
+      `
+    }
+
+    return css``
+  }}
+
   width: ${({ $isFullWidth }) => ($isFullWidth ? '100%' : 'auto')};
 `
 

--- a/src/components/designSystem/Table/TableDisplay.tsx
+++ b/src/components/designSystem/Table/TableDisplay.tsx
@@ -1,0 +1,123 @@
+import {
+  Table as MUITable,
+  TableBody as MUITableBody,
+  TableCell as MUITableCell,
+  TableContainer as MUITableContainer,
+  TableHead as MUITableHead,
+  TableRow as MUITableRow,
+  Skeleton,
+} from '@mui/material'
+import { ReactNode } from 'react'
+import styled from 'styled-components'
+
+import { ListClickableItemCss, theme } from '~/styles'
+
+type Column<T> = {
+  key: keyof T
+  title: string | ReactNode
+  content: (item: T) => ReactNode
+  size?: number
+}
+
+interface TableDisplayProps<T> {
+  key: string
+  data: T[]
+  columns: Column<T>[]
+  isLoading?: boolean
+  variant?: 'outline'
+  onRowAction?: (item: T) => void
+}
+
+export const TableDisplay = <T,>({
+  key,
+  data,
+  columns,
+  isLoading,
+  onRowAction,
+}: TableDisplayProps<T>) => {
+  return (
+    <TableContainer>
+      <MUITable>
+        <TableHead>
+          <TableRow>
+            {isLoading ? (
+              <TableCell>
+                <Skeleton variant="text" width={300} />
+              </TableCell>
+            ) : (
+              columns.map((column, i) => (
+                <TableCell key={`table-display-${key}-head-${i}`}>{column.title}</TableCell>
+              ))
+            )}
+          </TableRow>
+        </TableHead>
+        <MUITableBody>
+          {isLoading ? (
+            <TableRow>
+              <TableCell>
+                <Skeleton variant="text" width={300} />
+              </TableCell>
+            </TableRow>
+          ) : (
+            data.map((item, i) => (
+              <TableRow
+                $isClickable={!!onRowAction}
+                key={`table-display-${key}-row-${i}`}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onRowAction?.(item)
+                }}
+              >
+                {columns.map((column, j) => (
+                  <TableCell key={`table-display-${key}-cell-${i}-${j}`}>
+                    {column.content(item)}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          )}
+        </MUITableBody>
+      </MUITable>
+    </TableContainer>
+  )
+}
+
+const TableContainer = styled(MUITableContainer)`
+  border: 1px solid ${theme.palette.grey[400]};
+  border-radius: ${theme.shape.borderRadius}px;
+`
+
+const TableHead = styled(MUITableHead)`
+  &:not(:last-child) {
+    > * {
+      box-shadow: ${theme.shadows[7]};
+    }
+  }
+
+  th {
+    padding: 10px ${theme.spacing(4)};
+    font-size: ${theme.typography.bodyHl.fontSize}px;
+    font-weight: ${theme.typography.bodyHl.fontWeight};
+    line-height: ${theme.typography.bodyHl.lineHeight};
+    color: ${theme.palette.text.disabled};
+  }
+`
+
+const TableCell = styled(MUITableCell)`
+  font-family: ${theme.typography.fontFamily};
+  color: ${theme.palette.text.secondary};
+  font-size: ${theme.typography.body.fontSize}px;
+  font-weight: ${theme.typography.body.fontWeight};
+  line-height: ${theme.typography.body.lineHeight};
+  border: 0;
+`
+
+const TableRow = styled(MUITableRow)<{ $isClickable?: boolean }>`
+  &:not(:last-child) {
+    > * {
+      box-shadow: ${theme.shadows[7]};
+    }
+  }
+
+  ${({ $isClickable }) => $isClickable && ListClickableItemCss}
+`

--- a/src/components/designSystem/Table/index.ts
+++ b/src/components/designSystem/Table/index.ts
@@ -1,1 +1,2 @@
 export * from './Table'
+export * from './TableDisplay'

--- a/src/pages/__devOnly/DesignSystem.tsx
+++ b/src/pages/__devOnly/DesignSystem.tsx
@@ -25,6 +25,7 @@ import {
   Status,
   StatusType,
   Table,
+  TableDisplay,
   Tooltip,
   Typography,
 } from '~/components/designSystem'
@@ -78,6 +79,34 @@ const POSSIBLE_TOAST: TToast[] = [
     id: 'toast5',
     severity: 'danger',
     message: '👿 Please stop doing that',
+  },
+]
+
+const tableData = [
+  {
+    name: 'Barney Stinson',
+    job: 'We will never know',
+    icon: 'plug',
+  },
+  {
+    name: 'Lily Aldrin',
+    job: 'Kindergarden teacher',
+    icon: 'book',
+  },
+  {
+    name: 'Marshal Eriksen',
+    job: 'Lawyer',
+    icon: 'bank',
+  },
+  {
+    name: 'Robin Scherbatzki',
+    job: 'News anchor',
+    icon: 'rocket',
+  },
+  {
+    name: 'Ted Mosby',
+    job: 'Architect',
+    icon: 'company',
   },
 ]
 
@@ -486,75 +515,98 @@ const DesignSystem = () => {
             component: (
               <Container>
                 <GroupTitle variant="headline">Table</GroupTitle>
-                <Table
-                  name="graduated-charge-table"
-                  data={[
-                    {
-                      name: 'Barney Stinson',
-                      job: 'We will never know',
-                      icon: 'plug',
-                    },
-                    {
-                      name: 'Lily Aldrin',
-                      job: 'Kindergarden teacher',
-                      icon: 'book',
-                    },
-                    {
-                      name: 'Marshal Eriksen',
-                      job: 'Lawyer',
-                      icon: 'bank',
-                    },
-                    {
-                      name: 'Robin Scherbatzki',
-                      job: 'News anchor',
-                      icon: 'rocket',
-                    },
-                    {
-                      name: 'Ted Mosby',
-                      job: 'Architect',
-                      icon: 'company',
-                    },
-                  ]}
-                  onDeleteRow={() => {}}
-                  columns={[
-                    {
-                      title: (
-                        <TableTitle variant="bodyHl" color="grey700">
-                          Name
-                        </TableTitle>
-                      ),
-                      size: 300,
-                      content: (row) => (
-                        <TableContent>
-                          <Avatar variant="user" identifier={row.name} size="small" />
-                          <Typography>{row.name}</Typography>
-                        </TableContent>
-                      ),
-                    },
-                    {
-                      title: (
-                        <TableTitle variant="bodyHl" color="grey700">
-                          Job
-                        </TableTitle>
-                      ),
-                      size: 124,
-                      mapKey: 'job',
-                    },
-                    {
-                      title: (
-                        <TableTitle variant="bodyHl" color="grey700">
-                          Icon
-                        </TableTitle>
-                      ),
-                      size: 124,
-                      content: (row) => (
-                        <TableContent>
-                          <Icon color="primary" name={row.icon as IconName} />
-                        </TableContent>
-                      ),
-                    },
-                  ]}
-                />
+                <Block $marginBottom={theme.spacing(6)}>
+                  <Table
+                    name="graduated-charge-table"
+                    data={tableData}
+                    onDeleteRow={() => {}}
+                    columns={[
+                      {
+                        title: (
+                          <TableTitle variant="bodyHl" color="grey700">
+                            Name
+                          </TableTitle>
+                        ),
+                        size: 300,
+                        content: (row) => (
+                          <TableContent>
+                            <Avatar variant="user" identifier={row.name} size="small" />
+                            <Typography>{row.name}</Typography>
+                          </TableContent>
+                        ),
+                      },
+                      {
+                        title: (
+                          <TableTitle variant="bodyHl" color="grey700">
+                            Job
+                          </TableTitle>
+                        ),
+                        size: 124,
+                        mapKey: 'job',
+                      },
+                      {
+                        title: (
+                          <TableTitle variant="bodyHl" color="grey700">
+                            Icon
+                          </TableTitle>
+                        ),
+                        size: 124,
+                        content: (row) => (
+                          <TableContent>
+                            <Icon color="primary" name={row.icon as IconName} />
+                          </TableContent>
+                        ),
+                      },
+                    ]}
+                  />
+                </Block>
+                <GroupTitle variant="headline">Display Table</GroupTitle>
+                <Block $marginBottom={theme.spacing(6)}>
+                  <TableDisplay
+                    key="display-table"
+                    data={tableData}
+                    isLoading={false}
+                    columns={[
+                      {
+                        key: 'name',
+                        title: 'Name',
+                        size: 300,
+                        content: (row) => (
+                          <TableContent>
+                            <Avatar variant="user" identifier={row.name} size="small" />
+                            <Typography>{row.name}</Typography>
+                          </TableContent>
+                        ),
+                      },
+                      {
+                        key: 'job',
+                        title: (
+                          <TableTitle variant="bodyHl" color="grey700">
+                            Job
+                          </TableTitle>
+                        ),
+                        content: (row) => row.job,
+                        size: 124,
+                      },
+                      {
+                        key: 'icon',
+                        title: (
+                          <TableTitle variant="captionCode" color="grey700">
+                            Icon
+                          </TableTitle>
+                        ),
+                        size: 124,
+                        content: (row) => (
+                          <TableContent>
+                            <Icon color="primary" name={row.icon as IconName} />
+                          </TableContent>
+                        ),
+                      },
+                    ]}
+                    // eslint-disable-next-line no-alert
+                    onRowAction={(item) => alert(`You clicked on ${item.name}`)}
+                  />
+                </Block>
               </Container>
             ),
           },

--- a/src/pages/__devOnly/DesignSystem.tsx
+++ b/src/pages/__devOnly/DesignSystem.tsx
@@ -563,7 +563,7 @@ const DesignSystem = () => {
                 <GroupTitle variant="headline">Display Table</GroupTitle>
                 <Block $marginBottom={theme.spacing(6)}>
                   <TableDisplay
-                    key="display-table"
+                    name="display-table"
                     data={tableData}
                     isLoading={false}
                     columns={[
@@ -590,21 +590,30 @@ const DesignSystem = () => {
                       },
                       {
                         key: 'icon',
-                        title: (
-                          <TableTitle variant="captionCode" color="grey700">
-                            Icon
-                          </TableTitle>
-                        ),
-                        size: 124,
-                        content: (row) => (
-                          <TableContent>
-                            <Icon color="primary" name={row.icon as IconName} />
-                          </TableContent>
-                        ),
+                        title: <Typography variant="captionCode">Icon</Typography>,
+                        content: (row) => <Icon color="primary" name={row.icon as IconName} />,
                       },
                     ]}
                     // eslint-disable-next-line no-alert
                     onRowAction={(item) => alert(`You clicked on ${item.name}`)}
+                    actionColumn={[
+                      {
+                        title: 'Edit',
+                        startIcon: 'pen',
+                        onAction: (item) => {
+                          // eslint-disable-next-line no-alert
+                          alert(`You edited ${item.name}`)
+                        },
+                      },
+                      {
+                        title: 'Delete',
+                        startIcon: 'trash',
+                        onAction: (item) => {
+                          // eslint-disable-next-line no-alert
+                          alert(`You deleted ${item.name}`)
+                        },
+                      },
+                    ]}
                   />
                 </Block>
               </Container>

--- a/src/pages/__devOnly/DesignSystem.tsx
+++ b/src/pages/__devOnly/DesignSystem.tsx
@@ -563,6 +563,7 @@ const DesignSystem = () => {
                 <GroupTitle variant="headline">Display Table</GroupTitle>
                 <Block $marginBottom={theme.spacing(6)}>
                   <TableDisplay
+                    variant="borderless"
                     name="display-table"
                     data={tableData}
                     isLoading={false}
@@ -580,13 +581,10 @@ const DesignSystem = () => {
                       },
                       {
                         key: 'job',
-                        title: (
-                          <TableTitle variant="bodyHl" color="grey700">
-                            Job
-                          </TableTitle>
-                        ),
+                        title: 'Job',
                         content: (row) => row.job,
                         size: 124,
+                        textAlign: 'center',
                       },
                       {
                         key: 'icon',


### PR DESCRIPTION
## Context

Hello! 
While working on `#ftr-overdue-balance`, i thought it would be a good idea to introduced a new table component to display our invoices instead of using `display: grid`. 

## Description

The component supports: 
- [x] Cell sizing
- [x] On row click
- [x] Action column with dots button

```typescript
<TableDisplay
  name="display-table"
  data={tableData}
  isLoading={false}
  columns={[
    {
      key: 'name',
      title: 'Name',
      size: 300,
      content: (row) => (
        <div>
          <Avatar variant="user" identifier={row.name} size="small" />
          <Typography>{row.name}</Typography>
        </div>
      ),
    },
    {
      key: 'job',
      title: 'Job',
      content: (row) => row.job,
      size: 124,
    },
    {
      key: 'icon',
      title: <Typography variant="captionCode">Icon</Typography>,
      content: (row) => <Icon color="primary" name={row.icon as IconName} />,
    },
  ]}
  onRowAction={(item) => alert(`You clicked on ${item.name}`)}
  actionColumn={[
    {
      title: 'Edit',
      startIcon: 'pen',
      onAction: (item) => {
        alert(`You edited ${item.name}`)
      },
    },
    {
      title: 'Delete',
      startIcon: 'trash',
      onAction: (item) => {
        alert(`You deleted ${item.name}`)
      },
    },
  ]}
/>

```

### Screenshots

**Default**
<img width="669" alt="Capture d’écran 2024-06-24 à 10 32 10" src="https://github.com/getlago/lago-front/assets/17253055/3c3aa54e-2f7f-4197-b030-d7b222cd849c">

**Action column**
<img width="669" alt="Capture d’écran 2024-06-24 à 10 32 21" src="https://github.com/getlago/lago-front/assets/17253055/fb8bf242-d77a-46b6-b28f-b944b2f8bfee">
<img width="669" alt="Capture d’écran 2024-06-24 à 10 32 25" src="https://github.com/getlago/lago-front/assets/17253055/39aff481-0e0a-4b6b-8fd2-e65da122a496">

**On row click**
<img width="669" alt="Capture d’écran 2024-06-24 à 10 32 39" src="https://github.com/getlago/lago-front/assets/17253055/fa79ce23-df0f-451a-bfde-a457968c21b0">

