### PR TITLE
chore: improve integration deletion object serialization

### DIFF
--- a/src/components/customers/addDrawer/AddCustomerDrawer.tsx
+++ b/src/components/customers/addDrawer/AddCustomerDrawer.tsx
@@ -149,16 +149,6 @@ export const AddCustomerDrawer = forwardRef<AddCustomerDrawerRef>((_, ref) => {
     validateOnMount: true,
     enableReinitialize: true,
     onSubmit: async ({ metadata, ...values }, formikBag) => {
-      const initialNetsuiteCustomer = customer?.netsuiteCustomer
-      const valuesDoesNotIncludeNetsuiteIntegration = !values.integrationCustomers?.some(
-        (integrationCustomer) =>
-          integrationCustomer.integrationType === IntegrationTypeEnum.Netsuite,
-      )
-
-      // On edition, if we remove the netsuite connection we need to return the data without the externalCustomerId
-      if (isEdition && !!initialNetsuiteCustomer && valuesDoesNotIncludeNetsuiteIntegration) {
-        values.integrationCustomers = [{ ...initialNetsuiteCustomer, externalCustomerId: null }]
-      }
       const answer = await onSave({
         ...values,
         metadata: ((metadata as LocalCustomerMetadata[]) || []).map(


### PR DESCRIPTION
## Context

We improved the way we remove integrations in the customer object on edit

## Description

On object deletion, we used to find back the original object, replace it in the customer payload and remove an attribute to "flag" it to be deleted in DB

Now, we can simply remove it in the customer payload and it's will be deleted.
As the UI is already deleting the object for display purpose, we can simply remove all this logic without addition