### PR TITLE
Handle missing TZ

### DIFF
--- a/ditto/base.json
+++ b/ditto/base.json
@@ -2039,6 +2039,7 @@
   "TZ_ATLANTIC_SOUTH_GEORGIA": "Atlantic/South Georgia",
   "TZ_AUSTRALIA_ADELAIDE": "Australia/Adelaide",
   "TZ_AUSTRALIA_BRISBANE": "Australia/Brisbane",
+  "TZ_AUSTRALIA_CANBERRA": "Australia/Canberra",
   "TZ_AUSTRALIA_DARWIN": "Australia/Darwin",
   "TZ_AUSTRALIA_HOBART": "Australia/Hobart",
   "TZ_AUSTRALIA_MELBOURNE": "Australia/Melbourne",

--- a/src/core/timezone/config.ts
+++ b/src/core/timezone/config.ts
@@ -412,6 +412,11 @@ export const TimeZonesConfig: Record<string, TimezoneConfigObject> = {
     offset: getOffset('Australia/Brisbane'),
     offsetInMinute: getOffsetInMinute('Australia/Brisbane'),
   },
+  TZ_AUSTRALIA_CANBERRA: {
+    name: 'Australia/Canberra',
+    offset: getOffset('Australia/Canberra'),
+    offsetInMinute: getOffsetInMinute('Australia/Canberra'),
+  },
   TZ_AUSTRALIA_DARWIN: {
     name: 'Australia/Darwin',
     offset: getOffset('Australia/Darwin'),

--- a/src/core/timezone/utils.ts
+++ b/src/core/timezone/utils.ts
@@ -1,11 +1,31 @@
+import * as Sentry from '@sentry/browser'
 import { DateTime } from 'luxon'
 
 import { TimezoneEnum } from '~/generated/graphql'
 
 import { TimeZonesConfig } from './config'
 
+import { envGlobalVar } from '../apolloClient'
+
+const { sentryDsn } = envGlobalVar()
+
 export const getTimezoneConfig = (timezone: TimezoneEnum | null | undefined) => {
-  return TimeZonesConfig[timezone || TimezoneEnum.TzUtc]
+  if (!timezone) return TimeZonesConfig[TimezoneEnum.TzUtc]
+
+  const doesTimezoneConfigExist = Object.keys(TimeZonesConfig).includes(timezone)
+
+  if (!doesTimezoneConfigExist) {
+    // If given timezone is not present in config, we should default to UTC config.
+    // However, it's pretty critical as UI and date calculation will be wrong.
+    // Calling sentry to make sure we notice and add missing timezone to the TimeZonesConfig enum then.
+    if (!!sentryDsn) {
+      Sentry.captureMessage(`Timezone ${timezone} is missing in TimeZonesConfig`)
+    }
+
+    return TimeZonesConfig[TimezoneEnum.TzUtc]
+  }
+
+  return TimeZonesConfig[timezone as TimezoneEnum]
 }
 
 export const formatDateToTZ = (

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3392,6 +3392,20 @@ export type OrganizationBillingConfigurationInput = {
   invoiceGracePeriod?: InputMaybe<Scalars['Int']['input']>;
 };
 
+export type OverdueBalance = {
+  __typename?: 'OverdueBalance';
+  amountCents: Scalars['BigInt']['output'];
+  currency: CurrencyEnum;
+  lagoInvoiceIds: Array<Scalars['String']['output']>;
+  month: Scalars['ISO8601DateTime']['output'];
+};
+
+export type OverdueBalanceCollection = {
+  __typename?: 'OverdueBalanceCollection';
+  collection: Array<OverdueBalance>;
+  metadata: CollectionMetadata;
+};
+
 export type PaymentProvider = AdyenProvider | GocardlessProvider | StripeProvider;
 
 export type PaymentProviderCollection = {
@@ -3666,6 +3680,8 @@ export type Query = {
   mrrs: MrrCollection;
   /** Query the current organization */
   organization?: Maybe<CurrentOrganization>;
+  /** Query overdue balances of an organization */
+  overdueBalances: OverdueBalanceCollection;
   /** Query a password reset by token */
   passwordReset: ResetPassword;
   /** Query a single payment provider */
@@ -3919,6 +3935,13 @@ export type QueryMembershipsArgs = {
 
 export type QueryMrrsArgs = {
   currency?: InputMaybe<CurrencyEnum>;
+};
+
+
+export type QueryOverdueBalancesArgs = {
+  currency?: InputMaybe<CurrencyEnum>;
+  externalCustomerId?: InputMaybe<Scalars['String']['input']>;
+  months?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -4456,6 +4479,8 @@ export enum TimezoneEnum {
   TzAustraliaAdelaide = 'TZ_AUSTRALIA_ADELAIDE',
   /** Australia/Brisbane */
   TzAustraliaBrisbane = 'TZ_AUSTRALIA_BRISBANE',
+  /** Australia/Canberra */
+  TzAustraliaCanberra = 'TZ_AUSTRALIA_CANBERRA',
   /** Australia/Darwin */
   TzAustraliaDarwin = 'TZ_AUSTRALIA_DARWIN',
   /** Australia/Hobart */


### PR DESCRIPTION
## Context

New TZ have been added following Rails upgrade, as the list comes from `ActiveSupport::TimeZone.all`

Our app was optimistically fetching TZ config, hence having an app broke when this new TZ appeared

## Description

This PR does 2 things
- Add the support for this new TZ
- Make sure if a TZ config is missing, app does not break (fallback to UTC) and we're warned about it (Sentry custom error)
