### PR TITLE
bug: charge min amount should default to undefined if not set

### DIFF
--- a/src/components/plans/ChargeAccordion.tsx
+++ b/src/components/plans/ChargeAccordion.tsx
@@ -952,7 +952,7 @@ export const ChargeAccordion = memo(
                         variant="quaternary"
                         disabled={disabled}
                         onClick={() => {
-                          formikProps.setFieldValue(`charges.${index}.minAmountCents`, null)
+                          formikProps.setFieldValue(`charges.${index}.minAmountCents`, undefined)
                           setShowSpendingMinimum(false)
                         }}
                       />

--- a/src/core/serializers/__tests__/serializePlanInput.test.ts
+++ b/src/core/serializers/__tests__/serializePlanInput.test.ts
@@ -296,7 +296,7 @@ describe('serializePlanInput()', () => {
             billableMetricId: '1234',
             chargeModel: 'package',
             filters: [],
-            minAmountCents: 0,
+            minAmountCents: undefined,
             properties: {
               amount: '1',
               fixedAmount: '2',
@@ -363,7 +363,7 @@ describe('serializePlanInput()', () => {
           {
             billableMetricId: '1234',
             chargeModel: 'percentage',
-            minAmountCents: 0,
+            minAmountCents: undefined,
             filters: [],
             properties: {
               amount: undefined,
@@ -431,7 +431,7 @@ describe('serializePlanInput()', () => {
           {
             billableMetricId: '1234',
             chargeModel: 'standard',
-            minAmountCents: 0,
+            minAmountCents: undefined,
             filters: [],
             properties: {
               amount: '1',
@@ -498,7 +498,7 @@ describe('serializePlanInput()', () => {
           {
             billableMetricId: '1234',
             chargeModel: 'standard',
-            minAmountCents: 0,
+            minAmountCents: undefined,
             filters: [],
             properties: {
               amount: undefined,
@@ -588,7 +588,7 @@ describe('serializePlanInput()', () => {
           {
             billableMetricId: '1234',
             chargeModel: 'standard',
-            minAmountCents: 0,
+            minAmountCents: undefined,
             properties: {
               amount: undefined,
               freeUnits: undefined,
@@ -691,7 +691,7 @@ describe('serializePlanInput()', () => {
           {
             billableMetricId: '1234',
             chargeModel: 'volume',
-            minAmountCents: 0,
+            minAmountCents: undefined,
             filters: [],
             properties: {
               amount: '1',
@@ -770,7 +770,7 @@ describe('serializePlanInput()', () => {
           {
             billableMetricId: '1234',
             chargeModel: 'custom',
-            minAmountCents: 0,
+            minAmountCents: undefined,
             filters: [],
             properties: {
               amount: '1',

--- a/src/core/serializers/serializePlanInput.ts
+++ b/src/core/serializers/serializePlanInput.ts
@@ -157,7 +157,9 @@ export const serializePlanInput = (values: PlanFormInput) => {
         return {
           chargeModel,
           billableMetricId: billableMetric.id,
-          minAmountCents: Number(serializeAmount(minAmountCents, values.amountCurrency) || 0),
+          minAmountCents: !!minAmountCents
+            ? Number(serializeAmount(minAmountCents, values.amountCurrency) || 0)
+            : undefined,
           taxCodes: chargeTaxes?.map(({ code }) => code) || [],
           filters: serializeFilters(filters, chargeModel),
           properties: properties

--- a/src/hooks/plans/usePlanForm.tsx
+++ b/src/hooks/plans/usePlanForm.tsx
@@ -164,11 +164,17 @@ export const usePlanForm: ({
               // Used to not enable submit button on invoiceDisplayName reset
               invoiceDisplayName: invoiceDisplayName || '',
               taxes: taxes || [],
-              minAmountCents: isNaN(minAmountCents)
-                ? undefined
-                : String(
-                    deserializeAmount(minAmountCents || 0, plan.amountCurrency || CurrencyEnum.Usd),
-                  ),
+              minAmountCents:
+                // Some plan have been saved with minAmountCents as 0 string but it makes the sub form send an override plan each time
+                // This || minAmountCents === '0' serves to prevent this to happen
+                isNaN(minAmountCents) || minAmountCents === '0'
+                  ? undefined
+                  : String(
+                      deserializeAmount(
+                        minAmountCents || 0,
+                        plan.amountCurrency || CurrencyEnum.Usd,
+                      ),
+                    ),
               payInAdvance: payInAdvance || false,
               properties: properties ? getPropertyShape(properties) : undefined,
               filters: (filters || []).map((filter) => {


### PR DESCRIPTION
## Context

We have a bug in the subscription form.

Each plan with a charge in advance makes the creatge subscription to create a plan override.

The reason is that FE sent `0` as a value when the field is set to undefined.

## Description

This PR does
- Make sure this does not happen anymore, and all '0' values are handled as undefined -> no plan override
- Make sure if the user save a plan with an charge min amount, we dont populate the attribute with `'0'`