### PR TITLE
fix: shipping address in show more details

### DIFF
--- a/ditto/base.json
+++ b/ditto/base.json
@@ -1335,6 +1335,7 @@
   "text_666c5b12fea4aa1e1b26bf70": "There are no overdue invoices.",
   "text_666c5b12fea4aa1e1b26bf73": "An invoice is overdue when its due date is past, as per your <a href={{link}}>payment terms.</a> ",
   "text_666c5d227d073444e90be894": "Due date",
+  "text_6670a2a7ae3562006c4ee3ce": "Show more",
   "text_637f813d31381b1ed90ab315": "API Token",
   "text_637f813d31381b1ed90ab30e": "This API secret key is used to connect Stripe to Lago, edit it to make a new connection",
   "text_637f813d31381b1ed90ab2f6": "API keys & ID",

--- a/src/components/customers/CustomerMainInfos.tsx
+++ b/src/components/customers/CustomerMainInfos.tsx
@@ -350,19 +350,29 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
             {country && <Typography color="textSecondary">{CountryCodes[country]}</Typography>}
           </div>
         )}
-        {shippingAddress && (
-          <div>
-            <Typography variant="caption">{translate('text_667d708c1359b49f5a5a822a')}</Typography>
-            <Typography color="textSecondary">{shippingAddress.addressLine1}</Typography>
-            <Typography color="textSecondary">{shippingAddress.addressLine2}</Typography>
-            <Typography color="textSecondary">
-              {shippingAddress.zipcode} {shippingAddress.city} {shippingAddress.state}
-            </Typography>
-            {shippingAddress.country && (
-              <Typography color="textSecondary">{CountryCodes[shippingAddress.country]}</Typography>
-            )}
-          </div>
-        )}
+        {shippingAddress &&
+          (shippingAddress.addressLine1 ||
+            shippingAddress.addressLine2 ||
+            shippingAddress.state ||
+            shippingAddress.country ||
+            shippingAddress.city ||
+            shippingAddress.zipcode) && (
+            <div>
+              <Typography variant="caption">
+                {translate('text_667d708c1359b49f5a5a822a')}
+              </Typography>
+              <Typography color="textSecondary">{shippingAddress.addressLine1}</Typography>
+              <Typography color="textSecondary">{shippingAddress.addressLine2}</Typography>
+              <Typography color="textSecondary">
+                {shippingAddress.zipcode} {shippingAddress.city} {shippingAddress.state}
+              </Typography>
+              {shippingAddress.country && (
+                <Typography color="textSecondary">
+                  {CountryCodes[shippingAddress.country]}
+                </Typography>
+              )}
+            </div>
+          )}
         {!!paymentProvider && !!linkedProvider?.name && (
           <div>
             <Typography variant="caption">{translate('text_62b1edddbf5f461ab9712795')}</Typography>
@@ -522,7 +532,7 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
             setShowMore(true)
           }}
         >
-          Show more
+          {translate('text_6670a2a7ae3562006c4ee3ce')}
         </ShowMoreButton>
       )}
     </DetailsBlock>


### PR DESCRIPTION
## Roadmap Task

ISSUE-362

## Context

Shipping address object was sometimes defined but with empty values so we need to check single field before rendering it. It was causing issues with show more threshold counting.

