### PR TITLE
fix: handle falsy value for name

### DIFF
--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -235,7 +235,7 @@ export const useAddSubscription: UseAddSubscription = ({
                       ? DateTime.fromISO(subsDate).toUTC().toISO()
                       : undefined,
                   endingAt: !!subEndDate ? DateTime.fromISO(subEndDate).toUTC().toISO() : null,
-                  name: name || undefined,
+                  name: name ?? undefined,
                   planOverrides: hasPlanBeingChangedFromInitial
                     ? { ...cleanPlanValues(serializedPlanValues as PlanOverridesInput, formType) }
                     : undefined,


### PR DESCRIPTION
## Roadmap Task

ISSUE-366

## Context

Name wasn't updated to initial state when it was removed.

## Description

If we set `name: undefined` then it'll not be included in the updated object.
Using `??` instead of `||` should fix the issue as empty string won't longer be considered as false 

