### PR TITLE
misc: add error message if external id already exist

### DIFF
--- a/ditto/base.json
+++ b/ditto/base.json
@@ -2272,5 +2272,6 @@
   "text_66474faf77c70900619567c7": "Forbidden access",
   "text_66474fb55f1b6901c7ac7683": "It seems you don’t have the permission to access this page. If you think this is an error contact an admin of your organization.",
   "text_665deda4babaf700d603ea13": "Leaving without saving",
-  "text_665dedd557dc3c00c62eb83d": "By clicking 'Leave', any unsaved data will be lost. Are you sure you want to continue?"
+  "text_665dedd557dc3c00c62eb83d": "By clicking 'Leave', any unsaved data will be lost. Are you sure you want to continue?",
+  "text_668513bb1906740145e06abe": "Value already exist, please type a new one."
 }

--- a/src/pages/CreateSubscription.tsx
+++ b/src/pages/CreateSubscription.tsx
@@ -271,7 +271,7 @@ const CreateSubscription = () => {
     }),
     validateOnMount: true,
     enableReinitialize: true,
-    onSubmit: async (values) => {
+    onSubmit: async (values, formikBag) => {
       const localValues = {
         id: formType === FORM_TYPE_ENUM.edition ? subscription?.id : undefined,
         ...values,
@@ -287,6 +287,11 @@ const CreateSubscription = () => {
       if (errorsString === 'CurrenciesDoesNotMatch') {
         isResponsive && rootElement?.scrollTo({ top: 0, behavior: 'smooth' })
         return setShowCurrencyError(true)
+      } else if (errorsString === 'ValueAlreadyExist') {
+        rootElement?.scrollTo({ top: 0, behavior: 'smooth' })
+        formikBag.setErrors({
+          externalId: translate('text_668513bb1906740145e06abe'),
+        })
       }
     },
   })


### PR DESCRIPTION
When adding a subscription to a customer, you can define manually an external ID for this subscription.

This ID have to be unique, but defining an existing one stops the submission of the form but does not show any error visually.

This PR makes sure we display the error message under the corresponding input, and scrolls the screen if needed.