### PR TITLE
misc: improve charge handleUpdate method

### DIFF
--- a/src/components/plans/types.ts
+++ b/src/components/plans/types.ts
@@ -24,7 +24,7 @@ export type LocalChargeFilterInput = Omit<ChargeFilterInput, 'properties' | 'val
   values: string[] // This value should be defined using transformFilterObjectToString method
 }
 
-export type LocalChargeInput = Omit<ChargeInput, 'billableMetricId' | 'filters'> & {
+export type LocalChargeInput = Omit<ChargeInput, 'billableMetricId' | 'filters' | 'properties'> & {
   billableMetric: BillableMetricForPlanFragment
   id?: string
   properties?: LocalPropertiesInput


### PR DESCRIPTION
Currently investigating a misc related to inconsistent charge model setting between API and APP.

In the meantime, decided to refactor this callback and implement a new behaviour: on each charge model change, the charge will reset it's basic datas and inner properties.
So we make sure that there is no remaining data that should not be present on the new charge model.

This change should not implement any structural behaviour change, just make the charge model switch more deterministic