### PR TITLE
bug: fix error assertion for graduated error display

### DIFF
--- a/src/components/plans/GraduatedChargeTable.tsx
+++ b/src/components/plans/GraduatedChargeTable.tsx
@@ -120,7 +120,10 @@ export const GraduatedChargeTable = memo(
                         value={row.toValue as number | undefined}
                         beforeChangeFormatter={['int', 'positiveNumber']}
                         onBlur={() => {
-                          if (typeof row.toValue === 'number' && row.toValue < row.fromValue) {
+                          if (
+                            typeof row.toValue === 'string' &&
+                            Number(row.toValue) < Number(row.fromValue)
+                          ) {
                             setErrorIndex(i)
                           }
                         }}


### PR DESCRIPTION
Range error was not properly displayed for graduated range.

Issue was due to wrong value assertion.

This PR makes sure the error is displayed if a range is not correctly set