### PR TITLE
fix: search by tax name when getting taxes for add-on

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -17440,8 +17440,8 @@ export type CouponsLazyQueryHookResult = ReturnType<typeof useCouponsLazyQuery>;
 export type CouponsSuspenseQueryHookResult = ReturnType<typeof useCouponsSuspenseQuery>;
 export type CouponsQueryResult = Apollo.QueryResult<CouponsQuery, CouponsQueryVariables>;
 export const GetTaxesForAddOnFormDocument = gql`
-    query getTaxesForAddOnForm($limit: Int, $page: Int) {
-  taxes(limit: $limit, page: $page) {
+    query getTaxesForAddOnForm($limit: Int, $page: Int, $searchTerm: String) {
+  taxes(limit: $limit, page: $page, searchTerm: $searchTerm) {
     metadata {
       currentPage
       totalPages
@@ -17470,6 +17470,7 @@ export const GetTaxesForAddOnFormDocument = gql`
  *   variables: {
  *      limit: // value for 'limit'
  *      page: // value for 'page'
+ *      searchTerm: // value for 'searchTerm'
  *   },
  * });
  */

--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -42,8 +42,8 @@ import {
 import { AddOnCodeSnippet } from '../components/addOns/AddOnCodeSnippet'
 
 gql`
-  query getTaxesForAddOnForm($limit: Int, $page: Int) {
-    taxes(limit: $limit, page: $page) {
+  query getTaxesForAddOnForm($limit: Int, $page: Int, $searchTerm: String) {
+    taxes(limit: $limit, page: $page, searchTerm: $searchTerm) {
       metadata {
         currentPage
         totalPages


### PR DESCRIPTION
## Context

When creating add-ons, we're getting paginated list of taxes and display only first page of 20 taxes. So to get 21st tax we should query it by it's name. we didn't send searchTerm before, now we do

