### PR TITLE
bug: align min spending input and button

### DIFF
--- a/src/components/plans/ChargeAccordion.tsx
+++ b/src/components/plans/ChargeAccordion.tsx
@@ -1025,6 +1025,7 @@ const SummaryRight = styled.div`
 const SpendingMinimumWrapper = styled.div`
   display: flex;
   gap: ${theme.spacing(3)};
+  align-items: center;
 `
 
 const SpendingMinimumInput = styled(AmountInput)`


### PR DESCRIPTION
The Minimum spending does not have a label, so the input and the trash button next to it should be aligned horizontally 

