### PR TITLE
feat: improve table component action column

### DIFF
--- a/src/components/designSystem/__tests__/Table.test.tsx
+++ b/src/components/designSystem/__tests__/Table.test.tsx
@@ -1,0 +1,200 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { act, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { Button } from '~/components/designSystem'
+import { render } from '~/test-utils'
+
+import { Table } from '../Table/Table'
+
+const data = [
+  {
+    id: '1',
+    name: 'John Doe',
+    age: 30,
+  },
+  {
+    id: '2',
+    name: 'Jane Doe',
+    age: 25,
+  },
+  {
+    id: '3',
+    name: 'James Smith',
+    age: 40,
+  },
+  {
+    id: '4',
+    name: 'Jane Smith',
+    age: 35,
+  },
+]
+
+async function prepare({ props }: { props?: Record<string, any> } = {}) {
+  await act(() =>
+    render(
+      <Table
+        name="test"
+        data={data}
+        columns={
+          props?.columns || [
+            {
+              key: 'name' as const,
+              title: 'Name',
+              content: (row: any) => row.name,
+            },
+            {
+              key: 'age' as const,
+              title: 'Age',
+              content: (row: any) => row.age,
+            },
+          ]
+        }
+        {...props}
+      />,
+    ),
+  )
+}
+
+describe('Table', () => {
+  it('renders some basic table', async () => {
+    await prepare()
+
+    // Header
+    expect(screen.queryAllByRole('columnheader')).toHaveLength(2)
+    expect(screen.queryAllByRole('columnheader')[0]).toHaveTextContent('Name')
+    expect(screen.queryAllByRole('columnheader')[1]).toHaveTextContent('Age')
+
+    // Body
+    expect(screen.queryAllByRole('rowgroup')).toHaveLength(2)
+    const bodyRows = within(screen.queryAllByRole('rowgroup')[1]).queryAllByRole('row')
+
+    expect(bodyRows).toHaveLength(4)
+    expect(within(bodyRows[0]).queryAllByRole('cell')).toHaveLength(2)
+    expect(within(bodyRows[0]).queryAllByRole('cell')[0]).toHaveTextContent('John Doe')
+    expect(within(bodyRows[0]).queryAllByRole('cell')[1]).toHaveTextContent('30')
+  })
+
+  it('renders with interaction', async () => {
+    const onEdit = jest.fn()
+    const onDelete = jest.fn()
+    const onRow = jest.fn()
+
+    await prepare({
+      props: {
+        onRowAction: (row: any) => onRow(row),
+        actionColumn: () => [
+          {
+            title: 'Edit',
+            onAction: (row: any) => onEdit(row),
+          },
+          {
+            title: 'Delete',
+            onAction: (row: any) => onDelete(row),
+          },
+        ],
+      },
+    })
+
+    // Header
+    expect(screen.queryAllByRole('columnheader')).toHaveLength(3)
+    expect(screen.queryAllByRole('columnheader')[2]).not.toHaveValue()
+
+    // Body
+    expect(screen.queryAllByRole('rowgroup')).toHaveLength(2)
+    const bodyRows = within(screen.queryAllByRole('rowgroup')[1]).queryAllByRole('row')
+
+    expect(bodyRows).toHaveLength(4)
+    expect(within(bodyRows[0]).queryAllByRole('cell')).toHaveLength(3)
+    expect(within(bodyRows[0]).queryByTestId('button')).toBeInTheDocument()
+
+    // Click on action menu
+    await waitFor(() =>
+      userEvent.click(within(bodyRows[0]).queryByTestId('button') as HTMLButtonElement),
+    )
+
+    // Check if action menu is visible
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+    expect(within(screen.getByRole('tooltip')).queryAllByRole('button')).toHaveLength(2)
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+
+    // Click on Edit
+    await waitFor(() => userEvent.click(screen.getByRole('button', { name: 'Edit' })))
+    expect(onEdit).toHaveBeenNthCalledWith(1, data[0])
+
+    // Click on row
+    await waitFor(() => userEvent.click(bodyRows[0]))
+    expect(onRow).toHaveBeenNthCalledWith(1, data[0])
+    expect(onEdit).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders with custom action element', async () => {
+    const onClick = jest.fn()
+    const onRow = jest.fn()
+
+    await prepare({
+      props: {
+        actionColumn: (row: any) => <Button onClick={onClick(row)}>Click me</Button>,
+        onRowAction: (row: any) => onRow(row),
+      },
+    })
+
+    // Header
+    expect(screen.queryAllByRole('columnheader')).toHaveLength(3)
+    expect(screen.queryAllByRole('columnheader')[2]).not.toHaveValue()
+
+    // On row action
+    const bodyRows = within(screen.queryAllByRole('rowgroup')[1]).queryAllByRole('row')
+
+    await waitFor(() => userEvent.click(bodyRows[0]))
+    expect(onRow).toHaveBeenNthCalledWith(1, data[0])
+
+    // On click action
+    await waitFor(() => userEvent.click(within(bodyRows[0]).getByText('Click me')))
+    expect(onClick).toHaveBeenNthCalledWith(1, data[0])
+    expect(onRow).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders with loading state', async () => {
+    await prepare({
+      props: {
+        isLoading: true,
+        data: [],
+      },
+    })
+
+    // Header
+    expect(screen.queryAllByRole('columnheader')).toHaveLength(2)
+    expect(screen.queryAllByRole('columnheader')[0]).toHaveTextContent('Name')
+    expect(screen.queryAllByRole('columnheader')[1]).toHaveTextContent('Age')
+
+    // Body
+    expect(screen.queryAllByRole('rowgroup')).toHaveLength(2)
+    const bodyRows = within(screen.queryAllByRole('rowgroup')[1]).queryAllByRole('row')
+
+    expect(bodyRows).toHaveLength(3)
+    expect(within(bodyRows[0]).queryAllByRole('cell')).toHaveLength(2)
+  })
+
+  it('renders with empty state', async () => {
+    await prepare({
+      props: {
+        isLoading: false,
+        data: [],
+      },
+    })
+
+    expect(screen.getByText('empty.svg')).toBeInTheDocument()
+  })
+
+  it('renders with empty state', async () => {
+    await prepare({
+      props: {
+        hasError: true,
+      },
+    })
+
+    expect(screen.getByText('error.svg')).toBeInTheDocument()
+  })
+})

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -295,6 +295,7 @@ const InvoicesList = ({
               {
                 key: 'status',
                 title: translate('text_63ac86d797f728a87b2f9fa7'),
+                minWidth: 80,
                 content: ({ status, paymentStatus, paymentOverdue, paymentDisputeLostAt }) => {
                   if (!!paymentDisputeLostAt) {
                     return <Status type={StatusType.danger} label="disputed" />
@@ -306,6 +307,7 @@ const InvoicesList = ({
               {
                 key: 'number',
                 title: translate('text_63ac86d797f728a87b2f9fad'),
+                minWidth: 160,
                 content: ({ number }) => (
                   <Typography variant="body" noWrap>
                     {number}
@@ -316,6 +318,7 @@ const InvoicesList = ({
                 key: 'customer.name',
                 title: translate('text_65201c5a175a4b0238abf29a'),
                 maxSpace: true,
+                minWidth: 160,
                 content: ({ customer }) => (
                   <Typography variant="body" noWrap>
                     {customer.name || '-'}
@@ -326,6 +329,7 @@ const InvoicesList = ({
                 key: 'totalAmountCents',
                 title: translate('text_63ac86d797f728a87b2f9fb9'),
                 textAlign: 'right',
+                minWidth: 160,
                 content: ({ totalAmountCents, currency }) => (
                   <Typography variant="bodyHl" color="textSecondary" noWrap>
                     {intlFormatNumber(
@@ -340,6 +344,7 @@ const InvoicesList = ({
               {
                 key: 'issuingDate',
                 title: translate('text_63ac86d797f728a87b2f9fbf'),
+                minWidth: 104,
                 content: ({ issuingDate, customer }) => (
                   <Typography variant="body" noWrap>
                     {formatDateToTZ(issuingDate, customer.applicableTimezone)}


### PR DESCRIPTION
## Roadmap Task

LAGO-182

## Context

![image](https://github.com/user-attachments/assets/36a0b4ef-211c-4eb8-823a-3885512cd9d5)

Currently, our table component can only renders button with popper menu, but we want to be more flexible **and render any kind of button.**

This PR should allow that.

**Dive-in: https://www.notion.so/getlago/Dive-in-Request-payment-for-overdue-balance-d19d73c71c794acfb5dbb22e8415e17b?d=f84c0f8220704d86b873fbb5f73b6be3#6cba8087abe8417591b77ef1d211789d**

## Description

Action column can now support custom ReactNode instead of array of `ActionItem`

```typescript
actionColumn={(currentItem) => (
  <Button onClick={() => console.log(currentItem)}>Click</Button>
)}
```

