### PR TITLE
bug: remove unnecessary zindex rule

### DIFF
--- a/src/styles/muiTheme.ts
+++ b/src/styles/muiTheme.ts
@@ -57,7 +57,6 @@ export const theme = createTheme({
     MuiPopper: {
       styleOverrides: {
         root: {
-          zIndex: '1800 !important',
           '.MuiDateCalendar-viewTransitionContainer': {
             'min-height': '304px',
 


### PR DESCRIPTION
Was added during some tests for the filters feature, but it not needed and also it adds a bug in some places of the app