### PR TITLE
fix: no wrapping in status badge

### DIFF
--- a/src/components/designSystem/Status.tsx
+++ b/src/components/designSystem/Status.tsx
@@ -142,7 +142,7 @@ export const Status: FC<StatusProps> = ({ type, label, labelVariables, locale = 
 
   return (
     <Container $backgroundColor={config.backgroundColor} $borderColor={config.borderColor}>
-      <Typography variant="captionHl" color={config.color}>
+      <Typography variant="captionHl" color={config.color} noWrap>
         {translate(statusLabel, labelVariables ?? {})}
       </Typography>
     </Container>


### PR DESCRIPTION
## Description

Before
<img width="801" alt="Capture d’écran 2024-08-12 à 10 51 49" src="https://github.com/user-attachments/assets/fe598431-d895-4f91-97dd-8d0cef8121c8">


After
<img width="801" alt="Capture d’écran 2024-08-12 à 10 52 02" src="https://github.com/user-attachments/assets/0495e136-d908-47c5-8ff8-a0a5ff8ab18e">