### PR TITLE
bug(Checkbox): align label with box

### DIFF
--- a/src/components/form/Checkbox/Checkbox.tsx
+++ b/src/components/form/Checkbox/Checkbox.tsx
@@ -143,7 +143,7 @@ const Main = styled.div`
   cursor: pointer;
 
   > *:first-child {
-    padding-top: 6px;
+    padding-top: 4px;
   }
 
   .MuiCheckbox-root {


### PR DESCRIPTION
It makes sure the box and the label's first line are always aligned.

Currently, if it was one line it was looking weirdly not aligned, it's not aligned with the grid