### PR TITLE
bug: better min commitment accordion display

### DIFF
--- a/src/components/plans/details/PlanDetailsCommitmentsSection.tsx
+++ b/src/components/plans/details/PlanDetailsCommitmentsSection.tsx
@@ -21,7 +21,7 @@ const PlanDetailsCommitmentsSection = ({
   const { translate } = useInternationalization()
 
   return (
-    <Stack direction="column" spacing={6}>
+    <Stack direction="column" gap={4}>
       <div>
         <Typography variant="bodyHl" color="grey700">
           {translate('text_65d601bffb11e0f9d1d9f569')}


### PR DESCRIPTION
This PR fixes 2 things
- uses gap instead of spacing. Spacing adds margin top to elements and makes the accordion break when open. Gap fixes that
- use 16px instead of 24, as in other sections of this page