### PR TITLE
feat: add endIcon to status component

### DIFF
--- a/src/components/designSystem/Status.tsx
+++ b/src/components/designSystem/Status.tsx
@@ -5,6 +5,7 @@ import { Locale, TranslateData } from '~/core/translations'
 import { useContextualLocale } from '~/hooks/core/useContextualLocale'
 import { theme } from '~/styles'
 
+import { Icon, IconColor, IconName } from './Icon'
 import { Typography, TypographyColor } from './Typography'
 
 export enum StatusType {
@@ -65,6 +66,7 @@ const statusLabelMapping: Record<StatusLabel, string> = {
 export type StatusProps = {
   labelVariables?: TranslateData
   locale?: Locale
+  endIcon?: IconName
 } & (
   | {
       type: StatusType.success
@@ -96,6 +98,7 @@ type StatusConfig = Record<
   StatusType,
   {
     color: TypographyColor
+    iconColor: IconColor
     backgroundColor: string
     borderColor: string
   }
@@ -104,37 +107,49 @@ type StatusConfig = Record<
 const STATUS_CONFIG: StatusConfig = {
   success: {
     color: 'success600',
+    iconColor: 'success',
     backgroundColor: theme.palette.success[100],
     borderColor: theme.palette.success[200],
   },
   default: {
     color: 'grey700',
+    iconColor: 'dark',
     backgroundColor: theme.palette.grey[100],
     borderColor: theme.palette.grey[400],
   },
   outline: {
     color: 'grey600',
+    iconColor: 'dark',
     backgroundColor: theme.palette.background.default,
     borderColor: theme.palette.grey[400],
   },
   warning: {
     color: 'warning700',
+    iconColor: 'warning',
     backgroundColor: theme.palette.secondary[100],
     borderColor: theme.palette.secondary[300],
   },
   danger: {
     color: 'danger600',
+    iconColor: 'error',
     backgroundColor: theme.palette.error[100],
     borderColor: theme.palette.error[200],
   },
   disabled: {
     color: 'grey500',
+    iconColor: 'disabled',
     backgroundColor: theme.palette.grey[100],
     borderColor: theme.palette.grey[400],
   },
 }
 
-export const Status: FC<StatusProps> = ({ type, label, labelVariables, locale = 'en' }) => {
+export const Status: FC<StatusProps> = ({
+  type,
+  label,
+  labelVariables,
+  locale = 'en',
+  endIcon,
+}) => {
   const { translateWithContextualLocal: translate } = useContextualLocale(locale)
 
   const config = STATUS_CONFIG[type ?? 'default']
@@ -145,6 +160,7 @@ export const Status: FC<StatusProps> = ({ type, label, labelVariables, locale = 
       <Typography variant="captionHl" color={config.color} noWrap>
         {translate(statusLabel, labelVariables ?? {})}
       </Typography>
+      {endIcon && <Icon name={endIcon} size="medium" color={config.iconColor} />}
     </Container>
   )
 }

--- a/src/pages/__devOnly/DesignSystem.tsx
+++ b/src/pages/__devOnly/DesignSystem.tsx
@@ -384,7 +384,11 @@ const DesignSystem = () => {
                     <GroupTitle variant="bodyHl" color="textSecondary">
                       Success
                     </GroupTitle>
-                    <Status type={StatusType.success} label="succeeded" />
+                    <Status
+                      type={StatusType.success}
+                      label="succeeded"
+                      endIcon="warning-unfilled"
+                    />
                     <Status type={StatusType.success} label="finalized" />
                     <Status type={StatusType.success} label="active" />
                     <Status type={StatusType.success} label="pay" />
@@ -399,19 +403,19 @@ const DesignSystem = () => {
                     <GroupTitle variant="bodyHl" color="textSecondary">
                       Warning
                     </GroupTitle>
-                    <Status type={StatusType.warning} label="failed" />
+                    <Status type={StatusType.warning} label="failed" endIcon="warning-unfilled" />
                   </Block>
                   <Block>
                     <GroupTitle variant="bodyHl" color="textSecondary">
                       Outline
                     </GroupTitle>
-                    <Status type={StatusType.outline} label="draft" />
+                    <Status type={StatusType.outline} label="draft" endIcon="warning-unfilled" />
                   </Block>
                   <Block>
                     <GroupTitle variant="bodyHl" color="textSecondary">
                       Default
                     </GroupTitle>
-                    <Status type={StatusType.default} label="pending" />
+                    <Status type={StatusType.default} label="pending" endIcon="warning-unfilled" />
                     <Status type={StatusType.default} label="toPay" />
                     <Status type={StatusType.default} label="n/a" />
                   </Block>
@@ -419,7 +423,7 @@ const DesignSystem = () => {
                     <GroupTitle variant="bodyHl" color="textSecondary">
                       Danger
                     </GroupTitle>
-                    <Status type={StatusType.danger} label="disputed" />
+                    <Status type={StatusType.danger} label="disputed" endIcon="warning-unfilled" />
                     <Status type={StatusType.danger} label="disputeLost" />
                     <Status
                       type={StatusType.danger}
@@ -434,7 +438,7 @@ const DesignSystem = () => {
                     <GroupTitle variant="bodyHl" color="textSecondary">
                       Disabled
                     </GroupTitle>
-                    <Status type={StatusType.disabled} label="voided" />
+                    <Status type={StatusType.disabled} label="voided" endIcon="warning-unfilled" />
                   </Block>
                 </VerticalBlock>
 


### PR DESCRIPTION
## Roadmap Task

LAGO-212

## Context

To prepare next feature, I'm adding optional `endIcon` to status component

## Description

<img width="865" alt="Capture d’écran 2024-08-14 à 13 51 56" src="https://github.com/user-attachments/assets/b86a9f6a-2405-48ea-a876-3a267733f99a">


