### PR TITLE
fix: make take browser compatible

### DIFF
--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -214,7 +214,7 @@ export const Table = <T extends DataItem>({
       $rowSize={rowSize}
     >
       <TableHead>
-        <TableRow>
+          <tr>
           <>
             {columns.map((column, i) => (
               <TableCell
@@ -227,7 +227,7 @@ export const Table = <T extends DataItem>({
             ))}
             {shouldDisplayActionColumn && <TableActionCell />}
           </>
-        </TableRow>
+          </tr>
       </TableHead>
 
       <MUITableBody>
@@ -445,30 +445,32 @@ const TableActionCell = styled(TableCell)`
   position: sticky;
   right: 0;
   z-index: 1;
-  animation-name: shadow;
-  animation-duration: 1s;
-  animation-timing-function: ease-in-out;
-  animation-timeline: scroll(inline);
+  box-shadow: none;
+  background-color: ${theme.palette.background.paper};
 
   ${TableInnerCell} {
     justify-content: center;
     padding-left: ${theme.spacing(3)};
   }
 
+  @supports (animation-timeline: scroll(inline)) {
+    animation-name: shadow;
+    animation-duration: 1s;
+    animation-timing-function: ease-in-out;
+    animation-timeline: scroll(inline);
+  }
+
   @keyframes shadow {
     0% {
       box-shadow: ${theme.shadows[8]};
-      background-color: ${theme.palette.background.paper};
     }
 
     90% {
       box-shadow: ${theme.shadows[8]};
-      background-color: ${theme.palette.background.paper};
     }
 
     99% {
       box-shadow: none;
-      background-color: transparent;
     }
   }
 `

--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -207,7 +207,15 @@ export const Table = <T extends DataItem>({
   return (
     // Width is set to 0 and minWidth to 100% to prevent table from overflowing its container
     // cf. https://stackoverflow.com/a/73091777
-    <Box width={0} minWidth="100%" overflow="auto" height="100%">
+    <Box
+      width={0}
+      minWidth="100%"
+      overflow="auto"
+      height="100%"
+      sx={{
+        transform: 'translateZ(0)',
+      }}
+    >
       <StyledTable
         data-test={TABLE_ID}
         ref={tableRef}
@@ -478,7 +486,7 @@ const TableHead = styled(MUITableHead)`
     background-color: ${theme.palette.background.paper};
     position: sticky;
     top: 0;
-    transform: translateZ(1px);
+    z-index: 1;
     border-bottom: none;
     box-shadow: ${theme.shadows[7]};
   }

--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Table as MUITable,
   TableBody as MUITableBody,
   TableCell as MUITableCell,
@@ -62,7 +63,6 @@ interface TableProps<T> {
   name: string
   data: T[]
   columns: Column<T>[]
-  isFullWidth?: boolean
   isLoading?: boolean
   hasError?: boolean
   placeholder?: {
@@ -93,7 +93,6 @@ export const Table = <T extends DataItem>({
   columns,
   isLoading,
   hasError,
-  isFullWidth = true,
   containerSize = 48,
   rowSize = 56,
   placeholder,
@@ -206,96 +205,99 @@ export const Table = <T extends DataItem>({
   }
 
   return (
-    <StyledTable
-      data-test={TABLE_ID}
-      ref={tableRef}
-      $isFullWidth={!!isFullWidth}
-      $containerSize={containerSize}
-      $rowSize={rowSize}
-    >
-      <TableHead>
+    // Width is set to 0 and minWidth to 100% to prevent table from overflowing its container
+    // cf. https://stackoverflow.com/a/73091777
+    <Box width={0} minWidth="100%" overflow="auto">
+      <StyledTable
+        data-test={TABLE_ID}
+        ref={tableRef}
+        $containerSize={containerSize}
+        $rowSize={rowSize}
+      >
+        <TableHead>
           <tr>
-          <>
-            {columns.map((column, i) => (
-              <TableCell
-                key={`${TABLE_ID}-head-${i}`}
-                align={column.textAlign || 'left'}
-                $maxSpace={column.maxSpace ? 100 / maxSpaceColumns : undefined}
-              >
-                <TableInnerCell $align={column.textAlign}>{column.title}</TableInnerCell>
-              </TableCell>
-            ))}
-            {shouldDisplayActionColumn && <TableActionCell />}
-          </>
+            <>
+              {columns.map((column, i) => (
+                <TableCell
+                  key={`${TABLE_ID}-head-${i}`}
+                  align={column.textAlign || 'left'}
+                  $maxSpace={column.maxSpace ? 100 / maxSpaceColumns : undefined}
+                >
+                  <TableInnerCell $align={column.textAlign}>{column.title}</TableInnerCell>
+                </TableCell>
+              ))}
+              {shouldDisplayActionColumn && <TableActionCell />}
+            </>
           </tr>
-      </TableHead>
+        </TableHead>
 
-      <MUITableBody>
-        {renderPlaceholder() ??
-          (data.length > 0 &&
-            data.map((item, i) => (
-              <TableRow
-                key={`${TABLE_ID}-row-${i}`}
-                id={`${TABLE_ID}-row-${i}`}
-                data-id={item.id}
-                $isClickable={isClickable}
-                tabIndex={isClickable ? 0 : undefined}
-                onKeyDown={isClickable ? onKeyDown : undefined}
-                onClick={isClickable ? (e) => handleRowClick(e, item) : undefined}
-              >
-                {columns.map((column, j) => (
-                  <TableCell
-                    key={`${TABLE_ID}-cell-${i}-${j}`}
-                    align={column.textAlign || 'left'}
-                    $maxSpace={column.maxSpace ? 100 / maxSpaceColumns : undefined}
-                  >
-                    <TableInnerCell $minWidth={column.minWidth} $align={column.textAlign}>
+        <MUITableBody>
+          {renderPlaceholder() ??
+            (data.length > 0 &&
+              data.map((item, i) => (
+                <TableRow
+                  key={`${TABLE_ID}-row-${i}`}
+                  id={`${TABLE_ID}-row-${i}`}
+                  data-id={item.id}
+                  $isClickable={isClickable}
+                  tabIndex={isClickable ? 0 : undefined}
+                  onKeyDown={isClickable ? onKeyDown : undefined}
+                  onClick={isClickable ? (e) => handleRowClick(e, item) : undefined}
+                >
+                  {columns.map((column, j) => (
+                    <TableCell
+                      key={`${TABLE_ID}-cell-${i}-${j}`}
+                      align={column.textAlign || 'left'}
+                      $maxSpace={column.maxSpace ? 100 / maxSpaceColumns : undefined}
+                    >
+                      <TableInnerCell $minWidth={column.minWidth} $align={column.textAlign}>
                         <Typography noWrap>{column.content(item)}</Typography>
-                    </TableInnerCell>
-                  </TableCell>
-                ))}
-                {shouldDisplayActionColumn && (
-                  <TableActionCell>
-                    <TableInnerCell data-id={ACTION_COLUMN_ID}>
-                      {Array.isArray(actionColumn(item)) ? (
-                        <Popper
-                          popperGroupName={`${TABLE_ID}-action-cell`}
-                          PopperProps={{ placement: 'bottom-end' }}
-                          opener={<Button icon="dots-horizontal" variant="quaternary" />}
-                        >
-                          {({ closePopper }) => (
-                            <MenuPopper data-id={`${TABLE_ID}-popper`}>
-                              {(actionColumn(item) as Array<ActionItem<T> | null>)
-                                .filter((action) => !!action)
-                                .map((action, j) => {
-                                  if (!action) {
-                                    return
-                                  }
+                      </TableInnerCell>
+                    </TableCell>
+                  ))}
+                  {shouldDisplayActionColumn && (
+                    <TableActionCell>
+                      <TableInnerCell data-id={ACTION_COLUMN_ID}>
+                        {Array.isArray(actionColumn(item)) ? (
+                          <Popper
+                            popperGroupName={`${TABLE_ID}-action-cell`}
+                            PopperProps={{ placement: 'bottom-end' }}
+                            opener={<Button icon="dots-horizontal" variant="quaternary" />}
+                          >
+                            {({ closePopper }) => (
+                              <MenuPopper data-id={`${TABLE_ID}-popper`}>
+                                {(actionColumn(item) as Array<ActionItem<T> | null>)
+                                  .filter((action) => !!action)
+                                  .map((action, j) => {
+                                    if (!action) {
+                                      return
+                                    }
 
-                                  return (
-                                    <ActionItemButton
-                                      key={`${TABLE_ID}-popper-action-${i}-${j}`}
-                                      action={action}
-                                      item={item}
-                                      closePopper={closePopper}
-                                    />
-                                  )
-                                })}
-                            </MenuPopper>
-                          )}
-                        </Popper>
-                      ) : (
-                        (actionColumn(item) as ReactNode)
-                      )}
-                    </TableInnerCell>
-                  </TableActionCell>
-                )}
-              </TableRow>
-            )))}
-        {isLoading &&
-          LoadingRows({ columns, id: TABLE_ID, shouldDisplayActionColumn, actionColumn })}
-      </MUITableBody>
-    </StyledTable>
+                                    return (
+                                      <ActionItemButton
+                                        key={`${TABLE_ID}-popper-action-${i}-${j}`}
+                                        action={action}
+                                        item={item}
+                                        closePopper={closePopper}
+                                      />
+                                    )
+                                  })}
+                              </MenuPopper>
+                            )}
+                          </Popper>
+                        ) : (
+                          (actionColumn(item) as ReactNode)
+                        )}
+                      </TableInnerCell>
+                    </TableActionCell>
+                  )}
+                </TableRow>
+              )))}
+          {isLoading &&
+            LoadingRows({ columns, id: TABLE_ID, shouldDisplayActionColumn, actionColumn })}
+        </MUITableBody>
+      </StyledTable>
+    </Box>
   )
 }
 
@@ -418,12 +420,10 @@ const TableCell = styled(MUITableCell)<{
 `
 
 const StyledTable = styled(MUITable)<{
-  $isFullWidth: boolean
   $containerSize: ResponsiveStyleValue<ContainerSize>
   $rowSize: RowSize
 }>`
   border-collapse: collapse;
-  width: ${({ $isFullWidth }) => ($isFullWidth ? '100%' : 'auto')};
 
   ${TableCell}:first-of-type ${TableInnerCell} {
     ${({ $containerSize }) => setResponsiveProperty('paddingLeft', $containerSize)}

--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -250,9 +250,7 @@ export const Table = <T extends DataItem>({
                     $maxSpace={column.maxSpace ? 100 / maxSpaceColumns : undefined}
                   >
                     <TableInnerCell $minWidth={column.minWidth} $align={column.textAlign}>
-                      <Typography color="textSecondary" noWrap>
-                        {column.content(item)}
-                      </Typography>
+                        <Typography noWrap>{column.content(item)}</Typography>
                     </TableInnerCell>
                   </TableCell>
                 ))}

--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -207,7 +207,7 @@ export const Table = <T extends DataItem>({
   return (
     // Width is set to 0 and minWidth to 100% to prevent table from overflowing its container
     // cf. https://stackoverflow.com/a/73091777
-    <Box width={0} minWidth="100%" overflow="auto">
+    <Box width={0} minWidth="100%" overflow="auto" height="100%">
       <StyledTable
         data-test={TABLE_ID}
         ref={tableRef}
@@ -478,7 +478,7 @@ const TableHead = styled(MUITableHead)`
     background-color: ${theme.palette.background.paper};
     position: sticky;
     top: 0;
-    z-index: 1;
+    transform: translateZ(1px);
     border-bottom: none;
     box-shadow: ${theme.shadows[7]};
   }
@@ -513,13 +513,13 @@ const TableRow = styled(MUITableRow)<{ $isClickable?: boolean }>`
   &:focus:not(:active),
   &:hover:not(:active) ${TableActionCell}, &:focus:not(:active) ${TableActionCell} {
     background-color: ${({ $isClickable }) =>
-      $isClickable ? `${theme.palette.grey[100]} !important` : 'unset'};
+      $isClickable ? `${theme.palette.grey[100]}` : undefined};
   }
 
   &:active,
   &:active ${TableActionCell} {
     background-color: ${({ $isClickable }) =>
-      $isClickable ? `${theme.palette.grey[200]} !important` : 'unset'};
+      $isClickable ? `${theme.palette.grey[200]}` : undefined};
   }
 
   // Remove hover effect when action column is hovered
@@ -527,7 +527,7 @@ const TableRow = styled(MUITableRow)<{ $isClickable?: boolean }>`
     background-color: unset !important;
 
     ${TableActionCell} {
-      background-color: ${theme.palette.background.paper} !important;
+      background-color: ${theme.palette.background.paper};
     }
   }
 `


### PR DESCRIPTION
## Context

I've realized that we had some css issues when using Safari and Firefox. 
This PR aims to fix them.

## Description

- Remove unused `isFullWidth` props
- Add wrapping div with `width: 0` and `min-width: 100%` to fix to overflow scroll issue 

| **Before** | **After** |
| ---------- | ---------- |
| <img width="400" alt="Capture d’écran 2024-08-14 à 17 29 07" src="https://github.com/user-attachments/assets/65c8b5de-5c73-4d41-ab7a-875be94de1f9"> | <img width="400" alt="Capture d’écran 2024-08-14 à 17 25 17" src="https://github.com/user-attachments/assets/91767069-a4d4-4d2f-8aa8-35f87cb68f21"> | 


- Use `@supports (animation-timeline: scroll(inline))` when it's possible, otherwise don't render border-right on action column.

| **Before** | **After** |
| ---------- | ---------- |
| <img width="400" alt="Capture d’écran 2024-08-14 à 17 29 40" src="https://github.com/user-attachments/assets/7652a8f0-5b2a-428e-9aa8-8f52bae383de"> | <img width="400" alt="Capture d’écran 2024-08-14 à 17 25 14" src="https://github.com/user-attachments/assets/847140ca-2e1f-4561-8a25-cb11ccaa44b9"> | 


- Use `transform: 'translateZ(0)'` to fix Safari issue with the scrollbar when the action column is sticky

| **Before** | **After** |
| ---------- | ---------- |
| <img width="400" alt="Capture d’écran 2024-08-14 à 18 03 55" src="https://github.com/user-attachments/assets/e7333b96-bac7-4f1f-882d-14a3e461c0f2"> | <img width="300" alt="Capture d’écran 2024-08-14 à 18 11 57" src="https://github.com/user-attachments/assets/8e266e25-0585-497d-ae13-9ac7bcf186e1"> | 


- Use `undefined` instead of `unset` to remove issue when hovering rows

| **Before** | **After** |
| ---------- | ---------- |
| <img width="629" alt="Capture d’écran 2024-08-14 à 18 21 50" src="https://github.com/user-attachments/assets/49b03728-55e0-4df7-a3c4-30e6024444fc"> | <img width="629" alt="Capture d’écran 2024-08-14 à 18 22 09" src="https://github.com/user-attachments/assets/c481a354-cae9-4b7a-a890-fa5eb62a3a59"> | 
