### PR TITLE
fix(alert): full width variation padding issue

### DIFF
--- a/src/components/designSystem/Alert.tsx
+++ b/src/components/designSystem/Alert.tsx
@@ -64,15 +64,23 @@ export const Alert = ({
       data-test={`alert-type-${type}`}
       {...props}
     >
-      <Stack direction="row" gap={4} alignItems="center">
-        <Icon name={iconConfig.name} color={iconConfig.color} />
-        <Content color="textSecondary">{children}</Content>
+      <Stack
+        direction="row"
+        gap={4}
+        alignItems="center"
+        justifyContent="space-between"
+        py={theme.spacing(4)}
+      >
+        <Stack direction="row" gap={4} alignItems="center">
+          <Icon name={iconConfig.name} color={iconConfig.color} />
+          <Content color="textSecondary">{children}</Content>
+        </Stack>
+        {!!ButtonProps.onClick && !!label && (
+          <Button variant="quaternary-dark" size="medium" {...ButtonProps}>
+            {label}
+          </Button>
+        )}
       </Stack>
-      {!!ButtonProps.onClick && !!label && (
-        <Button variant="quaternary-dark" size="medium" {...ButtonProps}>
-          {label}
-        </Button>
-      )}
     </Container>
   )
 }
@@ -81,13 +89,7 @@ const Container = styled.div<{
   $isFullWidth?: boolean
   $containerSize: ResponsiveStyleValue<ContainerSize>
 }>`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   border-radius: 12px;
-  gap: ${theme.spacing(4)};
-  padding-top: ${theme.spacing(4)};
-  padding-bottom: ${theme.spacing(4)};
 
   &.alert-type--${AlertType.info} {
     background-color: ${theme.palette.info[100]};
@@ -112,12 +114,14 @@ const Container = styled.div<{
       width: 100%;
     `}
 
-  ${({ $containerSize }) => {
-    return css`
-      ${setResponsiveProperty('paddingLeft', $containerSize)}
-      ${setResponsiveProperty('paddingRight', $containerSize)}
-    `
-  }}
+  > div {
+    ${({ $containerSize }) => {
+      return css`
+        ${setResponsiveProperty('paddingLeft', $containerSize)}
+        ${setResponsiveProperty('paddingRight', $containerSize)}
+      `
+    }}
+  }
 `
 
 const Content = styled(Typography)`


### PR DESCRIPTION
## Context

Left/Right Padding should not be applied to container itself while in full-width variation, otherwise it counts as `100% + PADDING_LEFT + PADDING_RIGHT` and causes overflow in the app

## Description

| |  Screenshots |
| ---- | ---- |
| **Before** | <img width="1237" alt="Capture d’écran 2024-08-16 à 17 00 43" src="https://github.com/user-attachments/assets/75d360dd-d346-4706-8f8c-1476cd599f86"> | 
| **After** | <img width="1237" alt="Capture d’écran 2024-08-16 à 17 01 33" src="https://github.com/user-attachments/assets/0a444425-fb7f-489f-aa95-03cd330a7921"> |
| **Design system** | <img width="1237" alt="Capture d’écran 2024-08-16 à 17 02 01" src="https://github.com/user-attachments/assets/a454ad86-0c38-409e-a7c5-2a8efee78d87"> |



