### PR TITLE
bug(NagivationTab): prevent min height if no children

### DIFF
--- a/src/components/designSystem/NavigationTab.tsx
+++ b/src/components/designSystem/NavigationTab.tsx
@@ -98,6 +98,7 @@ export const NavigationTab = ({
           onChange={handleChange}
           value={value}
           $leftPadding={leftPadding}
+          $nonHiddenTabsLength={nonHiddenTabs.length}
         >
           {nonHiddenTabs.length >= 2
             ? nonHiddenTabs.map((tab, tabIndex) => {
@@ -151,10 +152,10 @@ const TabsWrapper = styled.div`
   box-shadow: ${theme.shadows[7]};
 `
 
-const LocalTabs = styled(Tabs)<{ $leftPadding: boolean }>`
+const LocalTabs = styled(Tabs)<{ $leftPadding: boolean; $nonHiddenTabsLength: number }>`
   align-items: center;
   overflow: visible;
-  min-height: ${theme.spacing(13)};
+  min-height: ${({ $nonHiddenTabsLength }) => $nonHiddenTabsLength > 1 && theme.spacing(13)};
 
   ${({ $leftPadding }) =>
     !!$leftPadding &&


### PR DESCRIPTION
The component has a min height by default.

However, we don't display the children (tabs elements) if there is only one to display.
But then the min height was still there and the (invisible) parent then took space in the UI.


This PR makes sure ther min-height is applied only if some children are displayed (more than one to display)