### PR TITLE
fix: Fix filter title text overflow

### DIFF
--- a/src/components/plans/details/PlanDetailsChargesSectionAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsChargesSectionAccordion.tsx
@@ -59,9 +59,9 @@ const PlanDetailsChargesSectionAccordion = ({
               <Accordion
                 key={`plan-details-charges-section-accordion-${i}`}
                 summary={
-                  <Typography variant="bodyHl" color="grey700">
+                  <ChargeFilterTypography variant="bodyHl" color="grey700">
                     {filter.invoiceDisplayName || accordionMappedDisplayValues}
-                  </Typography>
+                  </ChargeFilterTypography>
                 }
               >
                 <PlanDetailsChargeWrapperSwitch
@@ -92,4 +92,10 @@ const PaddedChargesWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${theme.spacing(4)};
+`
+
+const ChargeFilterTypography = styled(Typography)`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `

--- a/src/components/plans/details/PlanDetailsChargesSectionAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsChargesSectionAccordion.tsx
@@ -59,9 +59,9 @@ const PlanDetailsChargesSectionAccordion = ({
               <Accordion
                 key={`plan-details-charges-section-accordion-${i}`}
                 summary={
-                  <ChargeFilterTypography variant="bodyHl" color="grey700">
+                  <Typography noWrap variant="bodyHl" color="grey700">
                     {filter.invoiceDisplayName || accordionMappedDisplayValues}
-                  </ChargeFilterTypography>
+                  </Typography>
                 }
               >
                 <PlanDetailsChargeWrapperSwitch
@@ -94,8 +94,3 @@ const PaddedChargesWrapper = styled.div`
   gap: ${theme.spacing(4)};
 `
 
-const ChargeFilterTypography = styled(Typography)`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`

--- a/src/components/plans/details/PlanDetailsChargesSectionAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsChargesSectionAccordion.tsx
@@ -93,4 +93,3 @@ const PaddedChargesWrapper = styled.div`
   flex-direction: column;
   gap: ${theme.spacing(4)};
 `
-


### PR DESCRIPTION
Before:

<img width="685" alt="image" src="https://github.com/user-attachments/assets/b74e4812-eb92-49a5-bcb5-39c3364b34fb">

After:
<img width="691" alt="image" src="https://github.com/user-attachments/assets/d9071023-4a61-4195-a60f-9e9d8807a6c4">