### PR TITLE
misc: make sure redirection is not lost after outside navigation

### DIFF
--- a/src/core/apolloClient/cacheUtils.ts
+++ b/src/core/apolloClient/cacheUtils.ts
@@ -39,6 +39,10 @@ export const setItemFromLS = (key: string, value: unknown) => {
   return localStorage.setItem(key, stringify)
 }
 
+export const removeItemFromLS = (key: string) => {
+  return localStorage.removeItem(key)
+}
+
 // --------------------- Auth utils ---------------------
 export const logOut = async (client: ApolloClient<object>, resetLocationHistory?: boolean) => {
   await client.cache.reset()

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { getItemFromLS, removeItemFromLS } from '~/core/apolloClient'
 import { ANALYTIC_ROUTE, CUSTOMERS_LIST_ROUTE } from '~/core/router'
+import { LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY } from '~/hooks/core/useLocationHistory'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { usePermissions } from '~/hooks/usePermissions'
 
@@ -13,7 +15,15 @@ const Home = () => {
   useEffect(() => {
     // Make sure user permissions are loaded before performing redirection
     if (!isUserLoading) {
-      if (hasPermissions(['analyticsView'])) {
+      const lastPrivateVisitedRouteWhileNotConnected: Location = getItemFromLS(
+        LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY,
+      )
+
+      if (lastPrivateVisitedRouteWhileNotConnected) {
+        navigate(lastPrivateVisitedRouteWhileNotConnected, { replace: true })
+        // This is a temp value for redirection, should be removed after redirection have been performed
+        removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
+      } else if (hasPermissions(['analyticsView'])) {
         navigate(ANALYTIC_ROUTE, { replace: true })
       } else {
         navigate(CUSTOMERS_LIST_ROUTE, { replace: true })


### PR DESCRIPTION
Fixes ISSUE-422

## Context

If a user follows a link to Lago and is not redirected, they are asked to login.
Once logged in successfully, their reach their expected destination.

However, if a user logs in using a third party (like google SSO), this redirection logic breaks.
The reason is that during the thirdparty login process, they are redirected out the app and the "memory" of the destination page is lost.

## Description

This PR addresses this situation and bring a fix using the browser's local storage.

When ever a user is 
- kicked out the app after following a link (needs to login)
- Logs out the app (couldn't bypass this, this event looks just like a kick out)

they now "register" their last visited page (or destination in the first case) into their local storage.

This data is not lost when they use a thirdparty login (unless they use private navigation probably)

--

This is the best approach I found regarding those criteria
- Speed of implementation
- Number of files to change
- Complexity

It's not ideal, not the best, but probably the fastest approach regarding our current implemented logic.

I opened a ticket to refactor this approach, but mostly to change our route event and history system.