### PR TITLE
fix: fix typo for interface props in CustomCharge and StandardCharge

### DIFF
--- a/src/components/plans/CustomCharge.tsx
+++ b/src/components/plans/CustomCharge.tsx
@@ -20,7 +20,7 @@ gql`
   }
 `
 
-interface PackageChargeProps {
+interface CustomChargeProps {
   chargeIndex: number
   formikProps: FormikProps<PlanFormInput>
   propertyCursor: string
@@ -29,7 +29,7 @@ interface PackageChargeProps {
 }
 
 export const CustomCharge = memo(
-  ({ chargeIndex, disabled, formikProps, propertyCursor, valuePointer }: PackageChargeProps) => {
+  ({ chargeIndex, disabled, formikProps, propertyCursor, valuePointer }: CustomChargeProps) => {
     const { translate } = useInternationalization()
     const drawerRef = useRef<EditCustomChargeDrawerRef>(null)
 

--- a/src/components/plans/StandardCharge.tsx
+++ b/src/components/plans/StandardCharge.tsx
@@ -22,7 +22,7 @@ gql`
   }
 `
 
-interface PackageChargeProps {
+interface StandardChargeProps {
   chargeIndex: number
   currency: CurrencyEnum
   formikProps: FormikProps<PlanFormInput>
@@ -41,7 +41,7 @@ export const StandardCharge = memo(
     initialValuePointer,
     propertyCursor,
     valuePointer,
-  }: PackageChargeProps) => {
+  }: StandardChargeProps) => {
     const { translate } = useInternationalization()
 
     const [shouldDisplayGroupedBy, setShouldDisplayGroupedBy] = useState<boolean>(


### PR DESCRIPTION
Fix typo for interface props in CustomCharge and StandardCharge components


This PR re-opens [the original one](https://github.com/getlago/lago-front/pull/1732) created by [tnlong311](https://github.com/tnlong311) due to private CI token not shared.