### PR TITLE
Fix opening the customer portal link on Safari

### DIFF
--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -121,18 +121,20 @@ const CustomerDetails = () => {
         // We open a window, add url then focus on different lines, in order to prevent browsers to block page opening
         // It could be seen as unexpected popup as not immediatly done on user action
         // https://stackoverflow.com/questions/2587677/avoid-browser-popup-blockers
-        const myWindow = window.open('', '_blank')
+        setTimeout(() => {
+          const myWindow = window.open('', '_blank')
 
-        if (myWindow?.location?.href) {
-          myWindow.location.href = generateCustomerPortalUrl.url
-          return myWindow?.focus()
-        }
+          if (myWindow?.location?.href) {
+            myWindow.location.href = generateCustomerPortalUrl.url
+            return myWindow?.focus()
+          }
 
-        myWindow?.close()
-        addToast({
-          severity: 'danger',
-          translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-        })
+          myWindow?.close()
+          addToast({
+            severity: 'danger',
+            translateKey: 'text_62b31e1f6a5b8b1b745ece48',
+          })
+        }, 0)
       }
     },
   })


### PR DESCRIPTION
## Context

Clicking on the Customer portal link wouldn't work on Safari (it would generate a "Pop-up blocked" error).

<!-- Linear link -->
Fixes LAGO-434