### PR TITLE
feat: add lifetime usage graph to sub details

### DIFF
--- a/src/components/designSystem/graphs/fixtures.ts
+++ b/src/components/designSystem/graphs/fixtures.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import { TInvoiceCollectionsDataResult } from '~/components/graphs/Invoices'
 import { TGetInvoicedUsagesQuery } from '~/components/graphs/Usage'
 import { TAreaChartDataResult } from '~/components/graphs/utils'
+import { TSubscriptionUsageLifetimeGraphDataResult } from '~/components/subscriptions/SubscriptionUsageLifetimeGraph'
 import { CurrencyEnum, InvoicePaymentStatusTypeEnum } from '~/generated/graphql'
 
 export const AreaGrossRevenuesChartFakeData: TAreaChartDataResult = [
@@ -203,3 +204,11 @@ export const InvoicedUsageFakeData: TGetInvoicedUsagesQuery = [
     code: 'gb',
   },
 ]
+
+export const subscriptionLifetimeUsageFakeData: TSubscriptionUsageLifetimeGraphDataResult = {
+  lastThresholdAmountCents: '100000',
+  nextThresholdAmountCents: '200000',
+  totalUsageAmountCents: '125000',
+  totalUsageFromDatetime: DateTime.now().minus({ month: 12 }).toISO(),
+  totalUsageToDatetime: DateTime.now().toISO(),
+}

--- a/src/components/subscriptions/SubscriptionUsageLifetimeGraph.tsx
+++ b/src/components/subscriptions/SubscriptionUsageLifetimeGraph.tsx
@@ -1,0 +1,361 @@
+import { gql } from '@apollo/client'
+import { Stack } from '@mui/material'
+import { useMemo } from 'react'
+import { generatePath } from 'react-router-dom'
+import styled, { css } from 'styled-components'
+
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { UPDATE_PLAN_ROUTE, UPDATE_SUBSCRIPTION } from '~/core/router'
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { formatDateToTZ } from '~/core/timezone'
+import {
+  CurrencyEnum,
+  PremiumIntegrationTypeEnum,
+  SubscriptionUsageLifetimeGraphForLifetimeGraphFragment,
+  useGetSubscriptionForSubscriptionUsageLifetimeGraphQuery,
+} from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
+import ErrorImage from '~/public/images/maneki/error.svg'
+import { theme } from '~/styles'
+
+import { getLifetimeGraphPercentages } from './utils'
+
+import { ButtonLink, Icon, Skeleton, Tooltip, Typography } from '../designSystem'
+import ChartHeader from '../designSystem/graphs/ChartHeader'
+import { subscriptionLifetimeUsageFakeData } from '../designSystem/graphs/fixtures'
+import InlineBarsChart from '../designSystem/graphs/InlineBarsChart'
+import { GenericPlaceholder } from '../GenericPlaceholder'
+
+export const LAST_USAGE_GRAPH_LINE_KEY_NAME = 'Others'
+export const REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE = 'subscriptionUsage'
+
+gql`
+  fragment SubscriptionUsageLifetimeGraphForLifetimeGraph on Subscription {
+    id
+    lifetimeUsage {
+      lastThresholdAmountCents
+      nextThresholdAmountCents
+      totalUsageAmountCents
+      totalUsageFromDatetime
+      totalUsageToDatetime
+    }
+    customer {
+      id
+      currency
+      applicableTimezone
+    }
+    plan {
+      id
+    }
+  }
+
+  query getSubscriptionForSubscriptionUsageLifetimeGraph($subscriptionId: ID!) {
+    subscription(id: $subscriptionId) {
+      id
+      ...SubscriptionUsageLifetimeGraphForLifetimeGraph
+    }
+  }
+`
+
+const GRAPH_COLORS = [theme.palette.primary[700], theme.palette.grey[300]]
+
+export type TSubscriptionUsageLifetimeGraphDataResult =
+  SubscriptionUsageLifetimeGraphForLifetimeGraphFragment['lifetimeUsage']
+
+type SubscriptionUsageLifetimeGraphProps = {
+  subscriptionId: string
+  customerId: string
+}
+
+const SubscriptionUsageLifetimeGraph = ({
+  customerId,
+  subscriptionId,
+}: SubscriptionUsageLifetimeGraphProps) => {
+  const { translate } = useInternationalization()
+  const { organization, loading: currentOrganizationDataLoading } = useOrganizationInfos()
+
+  const hasProgressiveBillingPremiumIntegration = !!organization?.premiumIntegrations?.includes(
+    PremiumIntegrationTypeEnum.ProgressiveBilling,
+  )
+
+  const {
+    data: lifetimeUsageData,
+    loading: lifetimeUsageLoading,
+    error: lifetimeUsageError,
+    refetch: refetchLifetimeData,
+  } = useGetSubscriptionForSubscriptionUsageLifetimeGraphQuery({
+    variables: {
+      subscriptionId,
+    },
+    fetchPolicy: 'no-cache',
+  })
+  const lifetimeUsage = hasProgressiveBillingPremiumIntegration
+    ? lifetimeUsageData?.subscription?.lifetimeUsage
+    : subscriptionLifetimeUsageFakeData
+  const isLoading = lifetimeUsageLoading || currentOrganizationDataLoading
+  const currency = lifetimeUsageData?.subscription?.customer?.currency || CurrencyEnum.Usd
+  const isBlurred = !hasProgressiveBillingPremiumIntegration || !organization
+  const customerTimezone = lifetimeUsageData?.subscription?.customer?.applicableTimezone
+
+  const { nextThresholdPercentage, lastThresholdPercentage } = useMemo(() => {
+    return getLifetimeGraphPercentages(lifetimeUsage)
+  }, [lifetimeUsage])
+
+  return (
+    <section>
+      <Stack
+        direction={'row'}
+        height={40}
+        boxShadow={theme.shadows[7]}
+        alignItems={'flex-start'}
+        justifyContent={'space-between'}
+      >
+        <Stack direction={'row'} gap={2} alignItems={'flex-end'}>
+          <Typography variant="subhead" color="grey700" noWrap>
+            {translate('text_1726481163322ntor50xdm8k')}
+          </Typography>
+          <Tooltip placement="top-start" title={translate('text_1726481163322vbcsvivii5k')}>
+            <Icon name="info-circle" />
+          </Tooltip>
+        </Stack>
+
+        {isLoading ? (
+          <Skeleton variant="text" height={12} width={144} marginTop={8} />
+        ) : !lifetimeUsageError && !!lifetimeUsage ? (
+          <Typography
+            variant="caption"
+            color="grey600"
+            blur={!hasProgressiveBillingPremiumIntegration}
+            noWrap
+          >
+            {translate('text_633dae57ca9a923dd53c2097', {
+              fromDate: formatDateToTZ(lifetimeUsage.totalUsageFromDatetime, customerTimezone),
+              toDate: formatDateToTZ(lifetimeUsage.totalUsageToDatetime, customerTimezone),
+            })}
+          </Typography>
+        ) : null}
+      </Stack>
+
+      <Wrapper>
+        {!!lifetimeUsageError ? (
+          <Error
+            title={translate('text_636d023ce11a9d038819b579')}
+            subtitle={translate('text_636d023ce11a9d038819b57b')}
+            buttonTitle={translate('text_1725983967306qz0npfuhlo1')}
+            buttonVariant="primary"
+            buttonAction={() => refetchLifetimeData()}
+            image={<ErrorImage width="136" height="104" />}
+          />
+        ) : (
+          <>
+            {!lifetimeUsage && !isLoading && hasProgressiveBillingPremiumIntegration ? (
+              <Typography
+                variant="body"
+                color="grey600"
+                html={translate('text_17264811633225nhatoh524y', {
+                  planLink: `${generatePath(UPDATE_PLAN_ROUTE, {
+                    planId: lifetimeUsageData?.subscription?.plan?.id || '',
+                  })}?origin=${REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE}&subscriptionId=${subscriptionId}&customerId=${customerId}`,
+                  subscriptionLink: `${generatePath(UPDATE_SUBSCRIPTION, {
+                    subscriptionId,
+                    customerId: lifetimeUsageData?.subscription?.customer?.id || '',
+                  })}?origin=${REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE}&subscriptionId=${subscriptionId}&customerId=${customerId}`,
+                })}
+              />
+            ) : (
+              <>
+                <ChartHeader
+                  name={translate('text_1726481163322wngkv4nqfh9')}
+                  amount={intlFormatNumber(
+                    deserializeAmount(lifetimeUsage?.totalUsageAmountCents, currency),
+                    {
+                      currency,
+                    },
+                  )}
+                  blur={isBlurred}
+                  loading={isLoading}
+                />
+
+                <GraphContainer $blur={isBlurred}>
+                  <GraphWrapper>
+                    {!!isLoading ? (
+                      <>
+                        <Skeleton variant="text" width="100%" height={12} />
+
+                        <div>
+                          {[...Array(3)].map((_, index) => (
+                            <SkeletonLine key={`usage-skeleton-${index}`}>
+                              <Skeleton variant="circular" width={8} height={8} />
+                              <Skeleton variant="text" width="32%" height={12} />
+                              <Skeleton variant="text" width="32%" height={12} />
+                            </SkeletonLine>
+                          ))}
+                        </div>
+                      </>
+                    ) : (
+                      <>
+                        <InlineBarsChart
+                          data={[
+                            {
+                              lastThresholdPercentage,
+                              nextThresholdPercentage,
+                            },
+                          ]}
+                          tooltipsData={
+                            !!nextThresholdPercentage && nextThresholdPercentage !== 0
+                              ? [
+                                  {
+                                    lastThresholdPercentage: translate(
+                                      'text_1726576554903s2dddtq5qz4',
+                                      {
+                                        rate: intlFormatNumber(lastThresholdPercentage / 100 || 0, {
+                                          style: 'percent',
+                                          // This is a ratio so we will only allow 2 decimal
+                                          maximumFractionDigits: 2,
+                                        }),
+                                      },
+                                    ),
+                                    nextThresholdPercentage: translate(
+                                      'text_1726576554903930hsa8vg23',
+                                      {
+                                        rate: intlFormatNumber(nextThresholdPercentage / 100 || 0, {
+                                          style: 'percent',
+                                          // This is a ratio so we will only allow 2 decimal
+                                          maximumFractionDigits: 2,
+                                        }),
+                                      },
+                                    ),
+                                  },
+                                ]
+                              : undefined
+                          }
+                          colors={GRAPH_COLORS}
+                        />
+                        <Stack direction={'row'} justifyContent={'space-between'}>
+                          <Typography variant="caption" color="grey600">
+                            {translate('text_17265631916994iccuwziryu', {
+                              amount: intlFormatNumber(
+                                deserializeAmount(
+                                  lifetimeUsage?.lastThresholdAmountCents || 0,
+                                  currency,
+                                ),
+                                {
+                                  currency,
+                                },
+                              ),
+                            })}
+                          </Typography>
+                          <Typography variant="caption" color="grey600">
+                            {!lifetimeUsage?.nextThresholdAmountCents
+                              ? translate('text_17265631917004vcwz8zc0gy')
+                              : translate('text_172656319170006dm5ta4sd8', {
+                                  amount: intlFormatNumber(
+                                    deserializeAmount(
+                                      lifetimeUsage?.nextThresholdAmountCents || 0,
+                                      currency,
+                                    ),
+                                    {
+                                      currency,
+                                    },
+                                  ),
+                                })}
+                          </Typography>
+                        </Stack>
+                      </>
+                    )}
+                  </GraphWrapper>
+                </GraphContainer>
+
+                {/* Non premium block */}
+                {!isLoading && !hasProgressiveBillingPremiumIntegration && (
+                  <Stack
+                    direction={'row'}
+                    gap={4}
+                    alignItems={'center'}
+                    justifyContent={'space-between'}
+                    padding={`${theme.spacing(4)} ${theme.spacing(6)}`}
+                    sx={{
+                      borderRadius: theme.spacing(2),
+                      backgroundColor: theme.palette.grey[100],
+                    }}
+                  >
+                    <Stack>
+                      <Stack direction={'row'} alignItems={'center'} gap={1}>
+                        <Typography variant="bodyHl" color="grey700">
+                          {translate('text_1724345142892pcnx5m2k3r2')}
+                        </Typography>
+                        <Icon name="sparkles" />
+                      </Stack>
+                      <Typography variant="caption" color="grey600">
+                        {translate('text_1724345142892ljzi79afhmc')}
+                      </Typography>
+                    </Stack>
+                    <ButtonLink
+                      buttonProps={{
+                        variant: 'tertiary',
+                        size: 'medium',
+                        endIcon: 'sparkles',
+                      }}
+                      type="button"
+                      external
+                      to={`mailto:hello@getlago.com?subject=${translate('text_172434514289283gmf8bdhh3')}&body=${translate('text_1724346450317iqs2rtvx1tp')}`}
+                    >
+                      {translate('text_65ae73ebe3a66bec2b91d72d')}
+                    </ButtonLink>
+                  </Stack>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </Wrapper>
+    </section>
+  )
+}
+
+export default SubscriptionUsageLifetimeGraph
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(6)};
+  padding: ${theme.spacing(6)} 0;
+  box-sizing: border-box;
+  background-color: ${theme.palette.common.white};
+`
+
+const GraphContainer = styled.div<{ $blur: boolean }>`
+  ${({ $blur }) =>
+    $blur &&
+    css`
+      filter: blur(4px);
+      pointer-events: none;
+    `}
+`
+
+const GraphWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(3)};
+`
+
+const SkeletonLine = styled.div`
+  display: flex;
+  align-items: center;
+  height: 40px;
+  gap: ${theme.spacing(2)};
+
+  &:not(:last-child) {
+    box-shadow: ${theme.shadows[7]};
+  }
+
+  > *:last-child {
+    margin-left: auto;
+  }
+`
+
+const Error = styled(GenericPlaceholder)`
+  margin: 0;
+  padding: 0;
+`

--- a/src/components/subscriptions/SubscriptionUsageTabContent.tsx
+++ b/src/components/subscriptions/SubscriptionUsageTabContent.tsx
@@ -4,13 +4,14 @@ import styled from 'styled-components'
 import { theme } from '~/styles'
 
 import { SubscriptionCurrentUsageTable } from './SubscriptionCurrentUsageTable'
+import SubscriptionUsageLifetimeGraph from './SubscriptionUsageLifetimeGraph'
 
 const SubscriptionUsageTabContent = () => {
   const { subscriptionId = '', customerId = '' } = useParams()
 
   return (
     <Container>
-      {/* TODO: <SubscriptionUsageLifetimeGraph subscriptionId={subscriptionId} /> */}
+      <SubscriptionUsageLifetimeGraph customerId={customerId} subscriptionId={subscriptionId} />
       <SubscriptionCurrentUsageTable customerId={customerId} subscriptionId={subscriptionId} />
     </Container>
   )

--- a/src/components/subscriptions/__tests__/utils.test.ts
+++ b/src/components/subscriptions/__tests__/utils.test.ts
@@ -1,0 +1,73 @@
+import { SubscriptionLifetimeUsage } from '~/generated/graphql'
+
+import { getLifetimeGraphPercentages } from '../utils'
+
+describe('subscriptions utils tests', () => {
+  it('should return the appropriate calculated percentages', () => {
+    expect(
+      getLifetimeGraphPercentages({
+        totalUsageAmountCents: '100',
+        lastThresholdAmountCents: '100',
+        nextThresholdAmountCents: '200',
+      } as SubscriptionLifetimeUsage),
+    ).toEqual({
+      nextThresholdPercentage: 100,
+      lastThresholdPercentage: 0,
+    })
+
+    expect(
+      getLifetimeGraphPercentages({
+        totalUsageAmountCents: '200',
+        lastThresholdAmountCents: '100',
+        nextThresholdAmountCents: '200',
+      } as SubscriptionLifetimeUsage),
+    ).toEqual({
+      nextThresholdPercentage: 0,
+      lastThresholdPercentage: 100,
+    })
+
+    expect(
+      getLifetimeGraphPercentages({
+        totalUsageAmountCents: '150000',
+        lastThresholdAmountCents: '100000',
+        nextThresholdAmountCents: '300000',
+      } as SubscriptionLifetimeUsage),
+    ).toEqual({
+      lastThresholdPercentage: 25,
+      nextThresholdPercentage: 75,
+    })
+
+    expect(
+      getLifetimeGraphPercentages({
+        totalUsageAmountCents: '150000',
+        lastThresholdAmountCents: '100000',
+        nextThresholdAmountCents: '450000',
+      } as SubscriptionLifetimeUsage),
+    ).toEqual({
+      lastThresholdPercentage: 14.285714285714286,
+      nextThresholdPercentage: 85.71428571428571,
+    })
+
+    expect(
+      getLifetimeGraphPercentages({
+        totalUsageAmountCents: '150000',
+        lastThresholdAmountCents: '100000',
+        nextThresholdAmountCents: null,
+      } as SubscriptionLifetimeUsage),
+    ).toEqual({
+      lastThresholdPercentage: 100,
+      nextThresholdPercentage: 0,
+    })
+
+    expect(
+      getLifetimeGraphPercentages({
+        totalUsageAmountCents: '150000',
+        lastThresholdAmountCents: '100000',
+        nextThresholdAmountCents: '0',
+      } as SubscriptionLifetimeUsage),
+    ).toEqual({
+      lastThresholdPercentage: 100,
+      nextThresholdPercentage: 0,
+    })
+  })
+})

--- a/src/components/subscriptions/utils.ts
+++ b/src/components/subscriptions/utils.ts
@@ -1,0 +1,35 @@
+import { TSubscriptionUsageLifetimeGraphDataResult } from './SubscriptionUsageLifetimeGraph'
+
+export const getLifetimeGraphPercentages = (
+  lifetimeUsage?: TSubscriptionUsageLifetimeGraphDataResult,
+): {
+  nextThresholdPercentage: number
+  lastThresholdPercentage: number
+} => {
+  if (!lifetimeUsage) {
+    return {
+      nextThresholdPercentage: 0,
+      lastThresholdPercentage: 0,
+    }
+  }
+
+  const localTotalUsageAmountCents = Number(lifetimeUsage.totalUsageAmountCents || 0)
+  const localLastThresholdAmountCents = Number(lifetimeUsage.lastThresholdAmountCents || 0)
+  const localNextThresholdAmountCents = Number(lifetimeUsage.nextThresholdAmountCents || 0)
+  let localLastThresholdPercentage = 0
+  let localNextThresholdPercentage = 0
+
+  if (!localNextThresholdAmountCents) {
+    localLastThresholdPercentage = 100
+  } else {
+    localLastThresholdPercentage =
+      ((localTotalUsageAmountCents - localLastThresholdAmountCents) * 100) /
+      (localNextThresholdAmountCents - localLastThresholdAmountCents)
+    localNextThresholdPercentage = 100 - localLastThresholdPercentage
+  }
+
+  return {
+    nextThresholdPercentage: localNextThresholdPercentage,
+    lastThresholdPercentage: localLastThresholdPercentage,
+  }
+}

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -7077,6 +7077,15 @@ export type GetSubscriptionForDetailsOverviewQuery = { __typename?: 'Query', sub
 
 export type SubscriptionForSubscriptionInformationsFragment = { __typename?: 'Subscription', id: string, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, nextPendingStartDate?: any | null, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null } };
 
+export type SubscriptionUsageLifetimeGraphForLifetimeGraphFragment = { __typename?: 'Subscription', id: string, lifetimeUsage?: { __typename?: 'SubscriptionLifetimeUsage', lastThresholdAmountCents?: any | null, nextThresholdAmountCents?: any | null, totalUsageAmountCents: any, totalUsageFromDatetime: any, totalUsageToDatetime: any } | null, customer: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null, applicableTimezone: TimezoneEnum }, plan: { __typename?: 'Plan', id: string } };
+
+export type GetSubscriptionForSubscriptionUsageLifetimeGraphQueryVariables = Exact<{
+  subscriptionId: Scalars['ID']['input'];
+}>;
+
+
+export type GetSubscriptionForSubscriptionUsageLifetimeGraphQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, lifetimeUsage?: { __typename?: 'SubscriptionLifetimeUsage', lastThresholdAmountCents?: any | null, nextThresholdAmountCents?: any | null, totalUsageAmountCents: any, totalUsageFromDatetime: any, totalUsageToDatetime: any } | null, customer: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null, applicableTimezone: TimezoneEnum }, plan: { __typename?: 'Plan', id: string } } | null };
+
 export type DeleteTaxFragment = { __typename?: 'Tax', id: string, name: string, customersCount: number };
 
 export type DeleteTaxMutationVariables = Exact<{
@@ -7148,7 +7157,7 @@ export type UpdateSubscriptionMutationVariables = Exact<{
 }>;
 
 
-export type UpdateSubscriptionMutation = { __typename?: 'Mutation', updateSubscription?: { __typename?: 'Subscription', id: string, customer: { __typename?: 'Customer', id: string, activeSubscriptionsCount: number, customerType?: CustomerTypeEnum | null, name?: string | null, displayName: string, firstname?: string | null, lastname?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, hasOverdueInvoices: boolean, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, externalSalesforceId?: string | null, legalName?: string | null, legalNumber?: string | null, taxIdentificationNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, url?: string | null, paymentProviderCode?: string | null, shippingAddress?: { __typename?: 'CustomerAddress', addressLine1?: string | null, addressLine2?: string | null, city?: string | null, country?: CountryCode | null, state?: string | null, zipcode?: string | null } | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null, providerPaymentMethods?: Array<ProviderPaymentMethodsEnum> | null } | null, netsuiteCustomer?: { __typename: 'NetsuiteCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, integrationCode?: string | null, integrationType?: IntegrationTypeEnum | null, subsidiaryId?: string | null, syncWithProvider?: boolean | null } | null, anrokCustomer?: { __typename: 'AnrokCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, integrationCode?: string | null, integrationType?: IntegrationTypeEnum | null, syncWithProvider?: boolean | null } | null, xeroCustomer?: { __typename: 'XeroCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, integrationCode?: string | null, integrationType?: IntegrationTypeEnum | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null } } | null };
+export type UpdateSubscriptionMutation = { __typename?: 'Mutation', updateSubscription?: { __typename?: 'Subscription', id: string, customer: { __typename?: 'Customer', id: string, activeSubscriptionsCount: number, customerType?: CustomerTypeEnum | null, name?: string | null, displayName: string, firstname?: string | null, lastname?: string | null, externalId: string, hasActiveWallet: boolean, currency?: CurrencyEnum | null, hasCreditNotes: boolean, creditNotesCreditsAvailableCount: number, creditNotesBalanceAmountCents: any, applicableTimezone: TimezoneEnum, hasOverdueInvoices: boolean, addressLine1?: string | null, addressLine2?: string | null, canEditAttributes: boolean, city?: string | null, country?: CountryCode | null, email?: string | null, externalSalesforceId?: string | null, legalName?: string | null, legalNumber?: string | null, taxIdentificationNumber?: string | null, paymentProvider?: ProviderTypeEnum | null, phone?: string | null, state?: string | null, timezone?: TimezoneEnum | null, zipcode?: string | null, url?: string | null, paymentProviderCode?: string | null, shippingAddress?: { __typename?: 'CustomerAddress', addressLine1?: string | null, addressLine2?: string | null, city?: string | null, country?: CountryCode | null, state?: string | null, zipcode?: string | null } | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null, providerPaymentMethods?: Array<ProviderPaymentMethodsEnum> | null } | null, netsuiteCustomer?: { __typename: 'NetsuiteCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, integrationCode?: string | null, integrationType?: IntegrationTypeEnum | null, subsidiaryId?: string | null, syncWithProvider?: boolean | null } | null, anrokCustomer?: { __typename: 'AnrokCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, integrationCode?: string | null, integrationType?: IntegrationTypeEnum | null, syncWithProvider?: boolean | null } | null, xeroCustomer?: { __typename: 'XeroCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, integrationCode?: string | null, integrationType?: IntegrationTypeEnum | null, syncWithProvider?: boolean | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string, displayInInvoice: boolean }> | null }, plan: { __typename?: 'Plan', id: string } } | null };
 
 export type GetSinglePlanQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -9169,6 +9178,26 @@ export const SubscriptionForSubscriptionInformationsFragmentDoc = gql`
       id
       name
     }
+  }
+}
+    `;
+export const SubscriptionUsageLifetimeGraphForLifetimeGraphFragmentDoc = gql`
+    fragment SubscriptionUsageLifetimeGraphForLifetimeGraph on Subscription {
+  id
+  lifetimeUsage {
+    lastThresholdAmountCents
+    nextThresholdAmountCents
+    totalUsageAmountCents
+    totalUsageFromDatetime
+    totalUsageToDatetime
+  }
+  customer {
+    id
+    currency
+    applicableTimezone
+  }
+  plan {
+    id
   }
 }
     `;
@@ -17232,6 +17261,47 @@ export type GetSubscriptionForDetailsOverviewQueryHookResult = ReturnType<typeof
 export type GetSubscriptionForDetailsOverviewLazyQueryHookResult = ReturnType<typeof useGetSubscriptionForDetailsOverviewLazyQuery>;
 export type GetSubscriptionForDetailsOverviewSuspenseQueryHookResult = ReturnType<typeof useGetSubscriptionForDetailsOverviewSuspenseQuery>;
 export type GetSubscriptionForDetailsOverviewQueryResult = Apollo.QueryResult<GetSubscriptionForDetailsOverviewQuery, GetSubscriptionForDetailsOverviewQueryVariables>;
+export const GetSubscriptionForSubscriptionUsageLifetimeGraphDocument = gql`
+    query getSubscriptionForSubscriptionUsageLifetimeGraph($subscriptionId: ID!) {
+  subscription(id: $subscriptionId) {
+    id
+    ...SubscriptionUsageLifetimeGraphForLifetimeGraph
+  }
+}
+    ${SubscriptionUsageLifetimeGraphForLifetimeGraphFragmentDoc}`;
+
+/**
+ * __useGetSubscriptionForSubscriptionUsageLifetimeGraphQuery__
+ *
+ * To run a query within a React component, call `useGetSubscriptionForSubscriptionUsageLifetimeGraphQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetSubscriptionForSubscriptionUsageLifetimeGraphQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetSubscriptionForSubscriptionUsageLifetimeGraphQuery({
+ *   variables: {
+ *      subscriptionId: // value for 'subscriptionId'
+ *   },
+ * });
+ */
+export function useGetSubscriptionForSubscriptionUsageLifetimeGraphQuery(baseOptions: Apollo.QueryHookOptions<GetSubscriptionForSubscriptionUsageLifetimeGraphQuery, GetSubscriptionForSubscriptionUsageLifetimeGraphQueryVariables> & ({ variables: GetSubscriptionForSubscriptionUsageLifetimeGraphQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetSubscriptionForSubscriptionUsageLifetimeGraphQuery, GetSubscriptionForSubscriptionUsageLifetimeGraphQueryVariables>(GetSubscriptionForSubscriptionUsageLifetimeGraphDocument, options);
+      }
+export function useGetSubscriptionForSubscriptionUsageLifetimeGraphLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetSubscriptionForSubscriptionUsageLifetimeGraphQuery, GetSubscriptionForSubscriptionUsageLifetimeGraphQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetSubscriptionForSubscriptionUsageLifetimeGraphQuery, GetSubscriptionForSubscriptionUsageLifetimeGraphQueryVariables>(GetSubscriptionForSubscriptionUsageLifetimeGraphDocument, options);
+        }
+export function useGetSubscriptionForSubscriptionUsageLifetimeGraphSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetSubscriptionForSubscriptionUsageLifetimeGraphQuery, GetSubscriptionForSubscriptionUsageLifetimeGraphQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetSubscriptionForSubscriptionUsageLifetimeGraphQuery, GetSubscriptionForSubscriptionUsageLifetimeGraphQueryVariables>(GetSubscriptionForSubscriptionUsageLifetimeGraphDocument, options);
+        }
+export type GetSubscriptionForSubscriptionUsageLifetimeGraphQueryHookResult = ReturnType<typeof useGetSubscriptionForSubscriptionUsageLifetimeGraphQuery>;
+export type GetSubscriptionForSubscriptionUsageLifetimeGraphLazyQueryHookResult = ReturnType<typeof useGetSubscriptionForSubscriptionUsageLifetimeGraphLazyQuery>;
+export type GetSubscriptionForSubscriptionUsageLifetimeGraphSuspenseQueryHookResult = ReturnType<typeof useGetSubscriptionForSubscriptionUsageLifetimeGraphSuspenseQuery>;
+export type GetSubscriptionForSubscriptionUsageLifetimeGraphQueryResult = Apollo.QueryResult<GetSubscriptionForSubscriptionUsageLifetimeGraphQuery, GetSubscriptionForSubscriptionUsageLifetimeGraphQueryVariables>;
 export const DeleteTaxDocument = gql`
     mutation deleteTax($input: DestroyTaxInput!) {
   destroyTax(input: $input) {
@@ -17483,6 +17553,9 @@ export const UpdateSubscriptionDocument = gql`
       id
       activeSubscriptionsCount
       ...CustomerDetails
+    }
+    plan {
+      id
     }
   }
 }

--- a/src/pages/SubscriptionDetails.tsx
+++ b/src/pages/SubscriptionDetails.tsx
@@ -236,14 +236,20 @@ const SubscriptionDetails = () => {
           tabs={[
             {
               title: translate('text_628cf761cbe6820138b8f2e4'),
-              link: generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
-                customerId: subscription?.customer?.id as string,
-                subscriptionId: subscriptionId as string,
-                tab: CustomerSubscriptionDetailsTabsOptionsEnum.overview,
-              }),
+              link: !!customerId
+                ? generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
+                    customerId,
+                    subscriptionId: subscriptionId as string,
+                    tab: CustomerSubscriptionDetailsTabsOptionsEnum.overview,
+                  })
+                : generatePath(PLAN_SUBSCRIPTION_DETAILS_ROUTE, {
+                    planId: planId || '',
+                    subscriptionId: subscriptionId as string,
+                    tab: CustomerSubscriptionDetailsTabsOptionsEnum.overview,
+                  }),
               match: [
                 generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
-                  customerId: subscription?.customer?.id as string,
+                  customerId: customerId || '',
                   subscriptionId: subscriptionId as string,
                   tab: CustomerSubscriptionDetailsTabsOptionsEnum.overview,
                 }),
@@ -263,11 +269,29 @@ const SubscriptionDetails = () => {
             },
             {
               title: translate('text_1725983967306cei92rkdtvb'),
-              link: generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
-                customerId: subscription?.customer?.id as string,
-                subscriptionId: subscriptionId as string,
-                tab: CustomerSubscriptionDetailsTabsOptionsEnum.usage,
-              }),
+              link: !!customerId
+                ? generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
+                    customerId,
+                    subscriptionId: subscriptionId as string,
+                    tab: CustomerSubscriptionDetailsTabsOptionsEnum.usage,
+                  })
+                : generatePath(PLAN_SUBSCRIPTION_DETAILS_ROUTE, {
+                    planId: planId || '',
+                    subscriptionId: subscriptionId as string,
+                    tab: CustomerSubscriptionDetailsTabsOptionsEnum.usage,
+                  }),
+              match: [
+                generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
+                  customerId: customerId || '',
+                  subscriptionId: subscriptionId as string,
+                  tab: CustomerSubscriptionDetailsTabsOptionsEnum.usage,
+                }),
+                generatePath(PLAN_SUBSCRIPTION_DETAILS_ROUTE, {
+                  planId: planId || '',
+                  subscriptionId: subscriptionId as string,
+                  tab: CustomerSubscriptionDetailsTabsOptionsEnum.usage,
+                }),
+              ],
               component: (
                 <ContentContainer>
                   <TabContentWrapper>

--- a/translations/base.json
+++ b/translations/base.json
@@ -2429,5 +2429,14 @@
   "text_1725983967306cei92rkdtvb": "Usage",
   "text_1726044816685r61awuydvji": "Close details",
   "text_1726158292600r2xetfumq5t": "Item name",
-  "text_1726498444629i1fpjyvh0kg": "Please refresh this section or contact us if the error persists."
+  "text_1726481163322ntor50xdm8k": "Lifetime usage",
+  "text_1726481163322vbcsvivii5k": "Total usage since the subscription start date, excluding paid in advance charges.",
+  "text_17264811633225nhatoh524y": "There is no defined lifetime usage for this subscription. Feel free to <a href=\"{{planLink}}\">edit the plan details</a> or <a href=\"{{subscriptionLink}}\">update this subscription</a> as needed.",
+  "text_1726481163322wngkv4nqfh9": "Total lifetime usage",
+  "text_1726498444629i1fpjyvh0kg": "Please refresh this section or contact us if the error persists.",
+  "text_17265631916994iccuwziryu": "Last threshold: {{amount}}",
+  "text_172656319170006dm5ta4sd8": "Next threshold: {{amount}}",
+  "text_17265631917004vcwz8zc0gy": "Next threshold not set",
+  "text_1726576554903s2dddtq5qz4": "{{rate}} consumed",
+  "text_1726576554903930hsa8vg23": "{{rate}} remaining"
 }


### PR DESCRIPTION
## Context

We've recently moved the current usage to the subscription details > usage tab

## Description

This PR adds an additional graph representing the progressive billing evolution.
Some redirections needed to be fixed and have been added in a separate commit.

This it the last part of the progressive billing - Current usage initiative

<!-- Linear link -->
Fixes LAGO-302