### PR TITLE
bug: slight improvement for home redirection

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,17 +9,17 @@ import { usePermissions } from '~/hooks/usePermissions'
 
 const Home = () => {
   const navigate = useNavigate()
-  const { loading: isUserLoading } = useCurrentUser()
+  const { loading: isUserLoading, currentMembership } = useCurrentUser()
   const { hasPermissions } = usePermissions()
 
   useEffect(() => {
     // Make sure user permissions are loaded before performing redirection
-    if (!isUserLoading) {
-      const lastPrivateVisitedRouteWhileNotConnected: Location = getItemFromLS(
+    if (!isUserLoading && !!currentMembership) {
+      const lastPrivateVisitedRouteWhileNotConnected: Location | undefined = getItemFromLS(
         LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY,
       )
 
-      if (lastPrivateVisitedRouteWhileNotConnected) {
+      if (!!lastPrivateVisitedRouteWhileNotConnected) {
         navigate(lastPrivateVisitedRouteWhileNotConnected, { replace: true })
         // This is a temp value for redirection, should be removed after redirection have been performed
         removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
@@ -29,8 +29,9 @@ const Home = () => {
         navigate(CUSTOMERS_LIST_ROUTE, { replace: true })
       }
     }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isUserLoading])
+  }, [isUserLoading, currentMembership])
 
   return null
 }


### PR DESCRIPTION
## Context

I felt into a random situation multiple time.
After log in, I fall in the home `/` route, and never been redirected to the correct destination (depending on LS or permissions).
Ending in only having the side nav displayed, but a blank screen elsewhere.
I can never reproducing afterward, cleaning LS or using private nav did not help.

I was considering that we had some kind of race condition at app boot (I mean, we probably do), where the expected data was not there, even tho the loading of the data was done.

We have an issue with the app boot but landing a big refactor is not something I wanna start right now 😕 

## Description

To try making it more efficient, I make sure the membership is present and the hook is called if so, before triggering the redirection.

This does not solve the deeper issue but might patch this situation.

Let me know if you see a better approach and if you had the same situation in the past.