### PR TITLE
refactor(avatar): migrate to tailwind

### DIFF
--- a/src/components/addOns/AddOnItem.tsx
+++ b/src/components/addOns/AddOnItem.tsx
@@ -71,9 +71,9 @@ export const AddOnItem = ({
         {...navigationProps}
       >
         <AddOnNameSection>
-          <ListAvatar size="big" variant="connector">
+          <Avatar className="mr-3" size="big" variant="connector">
             <Icon name="puzzle" color="dark" />
-          </ListAvatar>
+          </Avatar>
           <NameBlock>
             <Typography color="textSecondary" variant="bodyHl" noWrap>
               {name}
@@ -173,10 +173,6 @@ const AddOnNameSection = styled.div`
   display: flex;
   align-items: center;
   min-width: 0;
-`
-
-const ListAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(3)};
 `
 
 const NameBlock = styled.div`

--- a/src/components/coupons/CouponItem.tsx
+++ b/src/components/coupons/CouponItem.tsx
@@ -103,9 +103,9 @@ export const CouponItem = ({
         )}
       >
         <CouponNameSection>
-          <ListAvatar size="big" variant="connector">
+          <Avatar className="mr-3" size="big" variant="connector">
             <Icon name="coupon" color="dark" />
-          </ListAvatar>
+          </Avatar>
           <NameBlock>
             <Typography color="textSecondary" variant="bodyHl" noWrap>
               {name}
@@ -227,10 +227,6 @@ const CouponNameSection = styled.div`
   display: flex;
   align-items: center;
   min-width: 0;
-`
-
-const ListAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(3)};
 `
 
 const NameBlock = styled.div`

--- a/src/components/customers/CustomerItem.tsx
+++ b/src/components/customers/CustomerItem.tsx
@@ -65,7 +65,8 @@ export const CustomerItem = memo(({ rowId, customer, editDialogRef }: CustomerIt
         data-test={customerName}
       >
         <CustomerNameSection>
-          <ListAvatar
+          <Avatar
+            className="mr-3"
             variant="user"
             size="big"
             identifier={customerName as string}
@@ -160,10 +161,6 @@ const Item = styled(ListItemLink)`
 
 const SmallCell = styled(Typography)<{ $alignLeft?: boolean }>`
   width: 112px;
-`
-
-const ListAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(3)};
 `
 
 const CustomerNameSection = styled.div`

--- a/src/components/customers/overview/CustomerCoupons.tsx
+++ b/src/components/customers/overview/CustomerCoupons.tsx
@@ -105,9 +105,9 @@ export const CustomerCoupons = memo(() => {
           </ListHeader>
           {(coupons || []).map((appliedCoupon) => (
             <CouponNameSection key={appliedCoupon.id} data-test={appliedCoupon.coupon?.name}>
-              <ListAvatar variant="connector">
+              <Avatar className="mr-3" variant="connector">
                 <Icon name="coupon" color="dark" />
-              </ListAvatar>
+              </Avatar>
               <NameBlock>
                 <Typography color="textSecondary" variant="bodyHl" noWrap>
                   {appliedCoupon.coupon?.name}
@@ -178,10 +178,6 @@ const CouponNameSection = styled.div`
   height: ${NAV_HEIGHT}px;
   box-shadow: ${theme.shadows[7]};
   width: 100%;
-`
-
-const ListAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(3)};
 `
 
 const NameBlock = styled.div`

--- a/src/components/designSystem/Avatar.tsx
+++ b/src/components/designSystem/Avatar.tsx
@@ -1,7 +1,7 @@
-import { cva } from 'class-variance-authority'
+import { cva, cx } from 'class-variance-authority'
 import { ReactNode } from 'react'
 
-import { cn } from '~/styles/utils'
+import { tw } from '~/styles/utils'
 
 import { Typography } from './Typography'
 
@@ -78,15 +78,15 @@ const getBackgroundColorKey = (identifier?: string): keyof typeof colors.avatar 
 }
 
 const avatarSizeStyles: Record<AvatarSize, string> = {
-  small: 'w-4 min-w-4 h-4 rounded',
-  intermediate: 'w-6 min-w-6 h-6 rounded-lg',
-  medium: 'w-8 min-w-8 h-8 rounded-xl',
-  big: 'w-10 min-w-10 h-10 rounded-xl',
-  large: 'w-16 min-w-16 h-16 rounded-xl',
+  small: cx('w-4 min-w-4 h-4 rounded'),
+  intermediate: cx('w-6 min-w-6 h-6 rounded-lg'),
+  medium: cx('w-8 min-w-8 h-8 rounded-xl'),
+  big: cx('w-10 min-w-10 h-10 rounded-xl'),
+  large: cx('w-16 min-w-16 h-16 rounded-xl'),
 }
 
 const avatarStyles = cva(
-  'flex items-center justify-center [&>img]:object-cover [&>img]:h-full [&>img]:w-full [&>img]:rounded-[inherit]',
+  'flex items-center justify-center [&>img]:h-full [&>img]:w-full [&>img]:rounded-[inherit] [&>img]:object-cover',
   {
     variants: {
       size: avatarSizeStyles,
@@ -128,7 +128,7 @@ export const Avatar = ({
   if (variant === 'connector') {
     return (
       <div
-        className={cn(avatarStyles({ size, rounded: true }), className)}
+        className={tw(avatarStyles({ size, rounded: true }), className)}
         data-test={`${variant}/${size}`}
       >
         {children}
@@ -148,7 +148,7 @@ export const Avatar = ({
 
   return (
     <div
-      className={cn(
+      className={tw(
         avatarStyles({
           size,
           backgroundColor: getBackgroundColorKey(identifier) ?? 'default',

--- a/src/components/developers/EventItem.tsx
+++ b/src/components/developers/EventItem.tsx
@@ -6,6 +6,7 @@ import { EventItemFragment } from '~/generated/graphql'
 import { ListKeyNavigationItemProps } from '~/hooks/ui/useListKeyNavigation'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { BaseListItem, ItemContainer, ListItem, theme } from '~/styles'
+import { cn } from '~/styles/utils'
 
 gql`
   fragment EventItem on Event {
@@ -34,12 +35,17 @@ export const EventItem = ({ event, navigationProps, selected, onClick }: EventIt
     <ItemContainer>
       <Item tabIndex={0} onClick={onClick} {...navigationProps} $active={selected}>
         <NameSection>
-          <ListAvatar variant="connector" $hasWarning={hasWarning}>
+          <Avatar
+            className={cn('mr-3', {
+              'bg-yellow-100': hasWarning,
+            })}
+            variant="connector"
+          >
             <Icon
               name={hasWarning ? 'warning-unfilled' : 'checkmark'}
               color={hasWarning ? 'warning' : 'dark'}
             />
-          </ListAvatar>
+          </Avatar>
           <NameBlock>
             <Typography color="textSecondary" variant="bodyHl" noWrap>
               {code}
@@ -76,15 +82,6 @@ const NameSection = styled.div`
   display: flex;
   align-items: center;
   min-width: 0;
-`
-
-const ListAvatar = styled(Avatar)<{ $hasWarning?: boolean }>`
-  margin-right: ${theme.spacing(3)};
-  ${({ $hasWarning }) =>
-    $hasWarning &&
-    css`
-      background-color: ${theme.palette.secondary[100]};
-    `}
 `
 
 const NameBlock = styled.div`

--- a/src/components/developers/EventItem.tsx
+++ b/src/components/developers/EventItem.tsx
@@ -6,7 +6,7 @@ import { EventItemFragment } from '~/generated/graphql'
 import { ListKeyNavigationItemProps } from '~/hooks/ui/useListKeyNavigation'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { BaseListItem, ItemContainer, ListItem, theme } from '~/styles'
-import { cn } from '~/styles/utils'
+import { tw } from '~/styles/utils'
 
 gql`
   fragment EventItem on Event {
@@ -36,7 +36,7 @@ export const EventItem = ({ event, navigationProps, selected, onClick }: EventIt
       <Item tabIndex={0} onClick={onClick} {...navigationProps} $active={selected}>
         <NameSection>
           <Avatar
-            className={cn('mr-3', {
+            className={tw('mr-3', {
               'bg-yellow-100': hasWarning,
             })}
             variant="connector"

--- a/src/components/developers/WebhookLogItem.tsx
+++ b/src/components/developers/WebhookLogItem.tsx
@@ -6,7 +6,7 @@ import { WebhookLogItemFragment, WebhookStatusEnum } from '~/generated/graphql'
 import { ListKeyNavigationItemProps } from '~/hooks/ui/useListKeyNavigation'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { BaseListItem, ItemContainer, ListItem, theme } from '~/styles'
-import { cn } from '~/styles/utils'
+import { tw } from '~/styles/utils'
 
 gql`
   fragment WebhookLogItem on Webhook {
@@ -38,12 +38,7 @@ export const WebhookLogItem = ({
     <ItemContainer>
       <Item tabIndex={0} onClick={onClick} {...navigationProps} $active={selected}>
         <NameSection>
-          <Avatar
-            size="big"
-            variant="connector"
-            className={cn('mr-3', { 'bg-red-100': hasError })}
-            // $isFailed={status === WebhookStatusEnum.Failed}
-          >
+          <Avatar size="big" variant="connector" className={tw('mr-3', { 'bg-red-100': hasError })}>
             <Icon
               name={hasError ? 'close-circle-unfilled' : 'checkmark'}
               color={hasError ? 'error' : 'dark'}

--- a/src/components/developers/WebhookLogItem.tsx
+++ b/src/components/developers/WebhookLogItem.tsx
@@ -6,6 +6,7 @@ import { WebhookLogItemFragment, WebhookStatusEnum } from '~/generated/graphql'
 import { ListKeyNavigationItemProps } from '~/hooks/ui/useListKeyNavigation'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { BaseListItem, ItemContainer, ListItem, theme } from '~/styles'
+import { cn } from '~/styles/utils'
 
 gql`
   fragment WebhookLogItem on Webhook {
@@ -37,16 +38,17 @@ export const WebhookLogItem = ({
     <ItemContainer>
       <Item tabIndex={0} onClick={onClick} {...navigationProps} $active={selected}>
         <NameSection>
-          <ListAvatar
+          <Avatar
             size="big"
             variant="connector"
-            $isFailed={status === WebhookStatusEnum.Failed}
+            className={cn('mr-3', { 'bg-red-100': hasError })}
+            // $isFailed={status === WebhookStatusEnum.Failed}
           >
             <Icon
               name={hasError ? 'close-circle-unfilled' : 'checkmark'}
               color={hasError ? 'error' : 'dark'}
             />
-          </ListAvatar>
+          </Avatar>
           <NameBlock>
             <Typography color="textSecondary" variant="bodyHl" noWrap>
               {webhookType}
@@ -83,15 +85,6 @@ const NameSection = styled.div`
   display: flex;
   align-items: center;
   min-width: 0;
-`
-
-const ListAvatar = styled(Avatar)<{ $isFailed?: boolean }>`
-  margin-right: ${theme.spacing(3)};
-  ${({ $isFailed }) =>
-    $isFailed &&
-    css`
-      background-color: ${theme.palette.error[100]};
-    `}
 `
 
 const NameBlock = styled.div`

--- a/src/components/plans/PlanItem.tsx
+++ b/src/components/plans/PlanItem.tsx
@@ -71,9 +71,9 @@ export const PlanItem = memo(
           {...navigationProps}
         >
           <PlanNameSection>
-            <ListAvatar size="big" variant="connector">
+            <Avatar className="mr-3" size="big" variant="connector">
               <Icon name="board" color="dark" />
-            </ListAvatar>
+            </Avatar>
             <NameBlock>
               <Typography color="textSecondary" variant="bodyHl" noWrap>
                 {name}
@@ -170,10 +170,6 @@ export const PlanItemSkeleton = () => {
     </BaseListItem>
   )
 }
-
-const ListAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(3)};
-`
 
 const NameBlock = styled.div`
   min-width: 0;

--- a/src/components/wallets/WalletTransactionListItem/ListItem.tsx
+++ b/src/components/wallets/WalletTransactionListItem/ListItem.tsx
@@ -37,9 +37,9 @@ export const ListItem: FC<ListItemProps> = ({
   return (
     <ListItemWrapper {...props}>
       <ListLeftWrapper>
-        <ItemIcon size="big" variant="connector">
+        <Avatar className="mr-3" size="big" variant="connector">
           <Icon name={isPending ? 'sync' : iconName} color="dark" />
-        </ItemIcon>
+        </Avatar>
         <ColumnWrapper>
           <Typography variant="bodyHl" color={isPending ? 'grey600' : labelColor}>
             {label}
@@ -91,10 +91,6 @@ const ListLeftWrapper = styled.div`
   &:last-child {
     align-items: flex-end;
   }
-`
-
-const ItemIcon = styled(Avatar)`
-  margin-right: ${theme.spacing(3)};
 `
 
 const ListRightWrapper = styled.div`

--- a/src/layouts/CustomerInvoiceDetails.tsx
+++ b/src/layouts/CustomerInvoiceDetails.tsx
@@ -753,9 +753,9 @@ const CustomerInvoiceDetails = () => {
             </MainInfos>
           ) : (
             <MainInfos>
-              <ConnectorAvatar size="big" variant="connector">
+              <Avatar size="large" variant="connector">
                 <Icon name="document" color="dark" size="large" />
-              </ConnectorAvatar>
+              </Avatar>
               <div>
                 <MainInfoLine>
                   <Typography variant="headline" color="grey700">
@@ -841,10 +841,6 @@ const MainInfos = styled.div`
   > *:first-child {
     margin-right: ${theme.spacing(4)};
   }
-`
-
-const ConnectorAvatar = styled(Avatar)`
-  padding: ${theme.spacing(3)};
 `
 
 const MainInfoLine = styled.div`

--- a/src/layouts/SideNavLayout.tsx
+++ b/src/layouts/SideNavLayout.tsx
@@ -1,9 +1,7 @@
-import { gql } from '@apollo/client'
-import { useApolloClient } from '@apollo/client'
+import { gql, useApolloClient } from '@apollo/client'
 import { ClickAwayListener, Stack } from '@mui/material'
 import { useEffect, useRef, useState } from 'react'
-import { Outlet, useNavigate } from 'react-router-dom'
-import { Location, useLocation } from 'react-router-dom'
+import { Location, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
 import {
@@ -171,11 +169,12 @@ const SideNav = () => {
                             }}
                           >
                             {!!logoUrl ? (
-                              <OrganizationAvatar size="small" variant="connector">
+                              <Avatar className="mr-2" size="small" variant="connector">
                                 <img src={logoUrl} alt={`${name}'s logo`} />
-                              </OrganizationAvatar>
+                              </Avatar>
                             ) : (
-                              <OrganizationAvatar
+                              <Avatar
+                                className="mr-2"
                                 variant="company"
                                 identifier={name || ''}
                                 size="small"
@@ -516,10 +515,6 @@ const OrganizationList = styled.div`
   > *:not(:last-child) {
     margin-bottom: ${theme.spacing(1)};
   }
-`
-
-const OrganizationAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(2)};
 `
 
 const Logout = styled.div`

--- a/src/pages/CreditNoteDetails.tsx
+++ b/src/pages/CreditNoteDetails.tsx
@@ -426,9 +426,9 @@ const CreditNoteDetails = () => {
             </MainInfos>
           ) : (
             <MainInfos>
-              <ConnectorAvatar size="big" variant="connector">
+              <Avatar size="large" variant="connector">
                 <Icon name="document" color="dark" size="large" />
-              </ConnectorAvatar>
+              </Avatar>
               <div>
                 <MainInfoLine>
                   <Typography variant="headline" color="grey700">
@@ -980,10 +980,6 @@ const MainInfos = styled.div`
   > *:first-child {
     margin-right: ${theme.spacing(4)};
   }
-`
-
-const ConnectorAvatar = styled(Avatar)`
-  padding: ${theme.spacing(3)};
 `
 
 const MainInfoLine = styled.div`

--- a/src/pages/settings/AdyenIntegrationDetails.tsx
+++ b/src/pages/settings/AdyenIntegrationDetails.tsx
@@ -182,9 +182,9 @@ const AdyenIntegrationDetails = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Adyen />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">{adyenPaymentProvider?.name}</Typography>
@@ -513,10 +513,6 @@ const ApiKeyItem = styled.div`
   > *:first-child {
     margin-right: ${theme.spacing(3)};
   }
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/AdyenIntegrations.tsx
+++ b/src/pages/settings/AdyenIntegrations.tsx
@@ -132,9 +132,9 @@ const AdyenIntegrations = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Adyen />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">
@@ -319,10 +319,6 @@ const ListItem = styled.div`
   > *:first-child {
     margin-right: ${theme.spacing(3)};
   }
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/AnrokIntegrationDetails.tsx
+++ b/src/pages/settings/AnrokIntegrationDetails.tsx
@@ -180,9 +180,9 @@ const AnrokIntegrationDetails = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Anrok />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">{anrokIntegration?.name}</Typography>
@@ -247,10 +247,6 @@ const MainInfos = styled.div`
   ${theme.breakpoints.down('md')} {
     padding: ${theme.spacing(8)} ${theme.spacing(4)};
   }
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/AnrokIntegrations.tsx
+++ b/src/pages/settings/AnrokIntegrations.tsx
@@ -119,9 +119,9 @@ const AnrokIntegrations = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Anrok />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">
@@ -298,10 +298,6 @@ const ListItem = styled.div`
   > *:first-child {
     margin-right: ${theme.spacing(3)};
   }
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/Authentication/OktaAuthenticationDetails.tsx
+++ b/src/pages/settings/Authentication/OktaAuthenticationDetails.tsx
@@ -155,9 +155,9 @@ const OktaAuthenticationDetails = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Okta />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">
@@ -271,10 +271,6 @@ const InlineTitle = styled.div`
 
 const SkeletonText = styled.div`
   width: 100%;
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/GocardlessIntegrationDetails.tsx
+++ b/src/pages/settings/GocardlessIntegrationDetails.tsx
@@ -27,8 +27,7 @@ import {
   DeleteGocardlessIntegrationDialog,
   DeleteGocardlessIntegrationDialogRef,
 } from '~/components/settings/integrations/DeleteGocardlessIntegrationDialog'
-import { envGlobalVar } from '~/core/apolloClient'
-import { addToast } from '~/core/apolloClient'
+import { addToast, envGlobalVar } from '~/core/apolloClient'
 import { GOCARDLESS_INTEGRATION_ROUTE, INTEGRATIONS_ROUTE } from '~/core/router'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import {
@@ -198,9 +197,9 @@ const GocardlessIntegrationDetails = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <GoCardless />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">{gocardlessPaymentProvider?.name}</Typography>
@@ -484,10 +483,6 @@ const Item = styled(Stack)`
 
 const Info = styled(Typography)`
   margin-top: ${theme.spacing(3)};
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/GocardlessIntegrationOauthCallback.tsx
+++ b/src/pages/settings/GocardlessIntegrationOauthCallback.tsx
@@ -107,9 +107,9 @@ const GocardlessIntegrationOauthCallback = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Gocardless />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">
@@ -157,10 +157,6 @@ const MainInfos = styled.div`
   ${theme.breakpoints.down('md')} {
     padding: ${theme.spacing(8)} ${theme.spacing(4)};
   }
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/GocardlessIntegrations.tsx
+++ b/src/pages/settings/GocardlessIntegrations.tsx
@@ -132,9 +132,9 @@ const GocardlessIntegrations = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Gocardless />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">
@@ -319,10 +319,6 @@ const ListItem = styled.div`
   > *:first-child {
     margin-right: ${theme.spacing(3)};
   }
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/LagoTaxManagementIntegration.tsx
+++ b/src/pages/settings/LagoTaxManagementIntegration.tsx
@@ -128,9 +128,9 @@ const LagoTaxManagementIntegration = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <LagoTaxManagement />
-            </StyledAvatar>
+            </Avatar>
             <Stack spacing={1}>
               <Line>
                 <Typography variant="headline">
@@ -307,10 +307,6 @@ const Info = styled(Typography)`
   display: flex;
   justify-content: flex-start;
   align-items: center;
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/NetsuiteIntegrationDetails.tsx
+++ b/src/pages/settings/NetsuiteIntegrationDetails.tsx
@@ -180,9 +180,9 @@ const NetsuiteIntegrationDetails = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Netsuite />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">{netsuiteIntegration?.name}</Typography>
@@ -247,10 +247,6 @@ const MainInfos = styled.div`
   ${theme.breakpoints.down('md')} {
     padding: ${theme.spacing(8)} ${theme.spacing(4)};
   }
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/NetsuiteIntegrations.tsx
+++ b/src/pages/settings/NetsuiteIntegrations.tsx
@@ -119,9 +119,9 @@ const NetsuiteIntegrations = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Netsuite />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">
@@ -298,10 +298,6 @@ const ListItem = styled.div`
   > *:first-child {
     margin-right: ${theme.spacing(3)};
   }
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/OrganizationInformations.tsx
+++ b/src/pages/settings/OrganizationInformations.tsx
@@ -166,11 +166,12 @@ const OrganizationInformations = () => {
         ) : (
           <Grid>
             {logoUrl ? (
-              <CompanyAvatar size="big" variant="connector">
+              <Avatar className="col-span-2 mb-3" size="big" variant="connector">
                 <img src={logoUrl} alt={`${name}'s logo`} />
-              </CompanyAvatar>
+              </Avatar>
             ) : (
-              <CompanyAvatar
+              <Avatar
+                className="col-span-2 mb-3"
                 size="big"
                 variant="company"
                 identifier={name || ''}
@@ -268,11 +269,6 @@ const SkeletonLine = styled.div`
   &:first-child {
     margin-right: ${theme.spacing(18)};
   }
-`
-
-const CompanyAvatar = styled(Avatar)`
-  grid-column: 1 / span 2;
-  margin-bottom: ${theme.spacing(3)};
 `
 
 const Grid = styled.div`

--- a/src/pages/settings/StripeIntegrationDetails.tsx
+++ b/src/pages/settings/StripeIntegrationDetails.tsx
@@ -182,9 +182,9 @@ const StripeIntegrationDetails = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Stripe />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">{stripePaymentProvider?.name}</Typography>
@@ -461,10 +461,6 @@ const LineItem = styled.div`
 
 const LineItemCaption = styled(Typography)`
   margin-top: ${theme.spacing(3)};
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/StripeIntegrations.tsx
+++ b/src/pages/settings/StripeIntegrations.tsx
@@ -132,9 +132,9 @@ const StripeIntegrations = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Stripe />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">
@@ -320,10 +320,6 @@ const ListItem = styled.div`
   > *:first-child {
     margin-right: ${theme.spacing(3)};
   }
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/XeroIntegrationDetails.tsx
+++ b/src/pages/settings/XeroIntegrationDetails.tsx
@@ -173,9 +173,9 @@ const XeroIntegrationDetails = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Xero />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">{xeroIntegration?.name}</Typography>
@@ -240,10 +240,6 @@ const MainInfos = styled.div`
   ${theme.breakpoints.down('md')} {
     padding: ${theme.spacing(8)} ${theme.spacing(4)};
   }
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/src/pages/settings/XeroIntegrations.tsx
+++ b/src/pages/settings/XeroIntegrations.tsx
@@ -116,9 +116,9 @@ const XeroIntegrations = () => {
           </>
         ) : (
           <>
-            <StyledAvatar variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector" size="large">
               <Xero />
-            </StyledAvatar>
+            </Avatar>
             <div>
               <Line>
                 <Typography variant="headline">
@@ -295,10 +295,6 @@ const ListItem = styled.div`
   > *:first-child {
     margin-right: ${theme.spacing(3)};
   }
-`
-
-const StyledAvatar = styled(Avatar)`
-  margin-right: ${theme.spacing(4)};
 `
 
 const Line = styled.div`

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -60,6 +60,16 @@ export const colors = {
     700: '#BA2B08',
     800: '#9D2507',
   },
+  avatar: {
+    orange: '#FF9351',
+    brown: '#D59993',
+    green: '#66DD93',
+    turquoise: '#6FD8C1',
+    blue: '#2FC1FE',
+    indigo: '#5195FF',
+    grey: '#889ABF',
+    pink: '#FF9BE0',
+  },
 }
 
 const config = {
@@ -90,6 +100,7 @@ const config = {
         ...colors.red,
         DEFAULT: colors.red[600],
       },
+      avatar: colors.avatar,
       black: '#000000',
       white: '#FFFFFF',
     },


### PR DESCRIPTION
## Context

Tailwind migration

## Description

Migrate avatar component and remove usage of `styled(Avatar)` in favor of dedicated classnames

Related to LAGO-329

QA: https://feat-tailwind-app.staging.getlago.com/ 