### PR TITLE
misc: remove classnames and use cx feature from cva

### DIFF
--- a/.vscode/lago.code-snippets
+++ b/.vscode/lago.code-snippets
@@ -19,62 +19,57 @@
   "Import from generated graphql file": {
     "scope": "typescript, typescriptreact",
     "prefix": "igenerated",
-    "body": "import { $1 } from '~/generated/graphql'"
+    "body": "import { $1 } from '~/generated/graphql'",
   },
   "Import MuiTheme": {
     "scope": "typescript, typescriptreact",
     "prefix": "itheme",
-    "body": "import { theme } from '~/styles'"
+    "body": "import { theme } from '~/styles'",
   },
   "Import from MaterialUI/core": {
     "scope": "typescript, typescriptreact",
     "prefix": "imui",
-    "body": "import { $1 } from '@mui/material'"
+    "body": "import { $1 } from '@mui/material'",
   },
   "Import styled from styled-components": {
     "scope": "typescript, typescriptreact",
     "prefix": "istyled",
-    "body": "import styled from 'styled-components'"
+    "body": "import styled from 'styled-components'",
   },
   "Import from components generics": {
     "scope": "typescript, typescriptreact",
     "prefix": "ids",
-    "body": "import { $1 } from '~/components/designSystem'"
+    "body": "import { $1 } from '~/components/designSystem'",
   },
   "Import from form components": {
     "scope": "typescript, typescriptreact",
     "prefix": "iforms",
-    "body": "import { $1 } from '~/components/form'"
-  },
-  "Import from classnames": {
-    "scope": "typescript, typescriptreact",
-    "prefix": "iclsns",
-    "body": "import clsns from 'classnames'"
+    "body": "import { $1 } from '~/components/form'",
   },
   "Import permissions hook with method hasPermissions": {
     "scope": "typescript, typescriptreact",
     "prefix": "uhp",
-    "body": "const { hasPermissions } = usePermissions()"
+    "body": "const { hasPermissions } = usePermissions()",
   },
 
   // Translations
   "Add translate with TODO: key": {
     "scope": "typescript, typescriptreact",
     "prefix": "trl",
-    "body": "translate('TODO: $1')"
+    "body": "translate('TODO: $1')",
   },
 
   // Linter ignore
   "Ignore exhaustive deps if needed": {
     "scope": "typescript, typescriptreact",
     "prefix": "exhaustive-deps",
-    "body": "// eslint-disable-next-line react-hooks/exhaustive-deps"
+    "body": "// eslint-disable-next-line react-hooks/exhaustive-deps",
   },
 
   // In styles
   "Add theme spacing in px": {
     "scope": "css, styled, typescript, typescriptreact",
     "prefix": "tspx",
-    "body": "${theme.spacing(${1:4})}"
-  }
+    "body": "${theme.spacing(${1:4})}",
+  },
 }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "apollo-link-timeout": "4.0.0",
     "apollo-upload-client": "17.0.0",
     "apollo3-cache-persist": "0.15.0",
-    "classnames": "2.3.2",
     "formik": "2.4.5",
     "graphql": "^16.6.0",
     "localforage": "1.10.0",

--- a/src/components/designSystem/Alert.tsx
+++ b/src/components/designSystem/Alert.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '@mui/material'
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import { ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -60,7 +60,7 @@ export const Alert = ({
     <Container
       $isFullWidth={fullWidth}
       $containerSize={containerSize}
-      className={clsns(className, [`alert-type--${type}`])}
+      className={cx(className, [`alert-type--${type}`])}
       data-test={`alert-type-${type}`}
       {...props}
     >

--- a/src/components/designSystem/Button.tsx
+++ b/src/components/designSystem/Button.tsx
@@ -2,7 +2,7 @@
 
 /* eslint-disable react/prop-types */
 import { Button as MuiButton, ButtonProps as MuiButtonProps } from '@mui/material'
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import { forwardRef, MouseEvent, useEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -149,7 +149,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <StyledButton
-        className={clsns(className, {
+        className={cx(className, {
           'button-danger': danger,
           'button-icon-only': icon && !children,
           'button-quaternary-light': variant === 'quaternary-light',

--- a/src/components/designSystem/ButtonLink.tsx
+++ b/src/components/designSystem/ButtonLink.tsx
@@ -1,4 +1,4 @@
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import { forwardRef, MouseEvent, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import styled, { css } from 'styled-components'
@@ -74,7 +74,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
           }
         : buttonProps || {}
 
-    const classNames = clsns(className, {
+    const classNames = cx(className, {
       'button-link-disabled': (active && !canBeClickedOnActive) || disabled,
     })
 

--- a/src/components/designSystem/Icon/Icon.tsx
+++ b/src/components/designSystem/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import { cloneElement } from 'react'
 import styled from 'styled-components'
 
@@ -84,7 +84,7 @@ export const Icon = ({
       data-test={`${name}/${size}`}
       $size={size}
       $canClick={!!onClick}
-      className={clsns('svg-icon', className, { [`icon-animation--${animation}`]: animation })}
+      className={cx('svg-icon', className, { [`icon-animation--${animation}`]: animation })}
       $color={mapColor(color)}
       component={<SVGIcon />}
       onClick={onClick}

--- a/src/components/designSystem/Skeleton.tsx
+++ b/src/components/designSystem/Skeleton.tsx
@@ -1,4 +1,4 @@
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import styled from 'styled-components'
 
 import { theme } from '~/styles'
@@ -61,7 +61,7 @@ export const Skeleton = ({
       $marginTop={marginTop}
       $height={(size ? mapAvatarSize(size) : height) || 12}
       $width={(size ? mapAvatarSize(size) : width) || 90}
-      className={clsns(className, {
+      className={cx(className, {
         'skeleton-variant--circular': [
           SkeletonVariantEnum.circular,
           SkeletonVariantEnum.userAvatar,

--- a/src/components/designSystem/Toasts/Toast.tsx
+++ b/src/components/designSystem/Toasts/Toast.tsx
@@ -1,4 +1,4 @@
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -66,7 +66,7 @@ export const Toast = forwardRef<ToastRef, ToastProps>(({ toast }: ToastProps, re
           removeToast(id)
         }
       }}
-      className={clsns({ 'toast-closing': closing })}
+      className={cx({ 'toast-closing': closing })}
       key={id}
       $severity={severity}
       onMouseEnter={stopTimeout}

--- a/src/components/form/Checkbox/Checkbox.tsx
+++ b/src/components/form/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import { ChangeEvent, useRef, useState } from 'react'
 import styled from 'styled-components'
 
@@ -41,7 +41,7 @@ export const Checkbox = ({
       onClick={() => inputRef.current?.click()}
     >
       <Main
-        className={clsns({
+        className={cx({
           'checkbox--disabled': disabled,
           'checkbox--focused': focused,
         })}

--- a/src/components/form/ComboBox/ComboBoxInput.tsx
+++ b/src/components/form/ComboBox/ComboBoxInput.tsx
@@ -1,5 +1,5 @@
 import { InputAdornment } from '@mui/material'
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import _omit from 'lodash/omit'
 import styled from 'styled-components'
 
@@ -56,7 +56,7 @@ export const ComboBoxInput = ({
             {!disableClearable && (
               <StyledButton
                 // To make sure the "clear button" is displayed only on hover or focus
-                className={clsns('MuiAutocomplete-clearIndicator', {
+                className={cx('MuiAutocomplete-clearIndicator', {
                   'MuiAutocomplete-clearIndicatorDirty': inputProps?.value,
                 })}
                 disabled={restParams.disabled}

--- a/src/components/form/ComboBox/ComboBoxItem.tsx
+++ b/src/components/form/ComboBox/ComboBoxItem.tsx
@@ -1,4 +1,4 @@
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -42,7 +42,7 @@ export const ComboBoxItem = ({
         <Item
           id={id}
           $virtualized={virtualized}
-          className={clsns(
+          className={cx(
             {
               'combo-box-item--disabled': disabled,
             },

--- a/src/components/form/ComboBox/ComboBoxPopperFactory.tsx
+++ b/src/components/form/ComboBox/ComboBoxPopperFactory.tsx
@@ -1,5 +1,5 @@
 import { Popper, PopperProps } from '@mui/material'
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import { ReactNode } from 'react'
 import styled from 'styled-components'
 
@@ -41,7 +41,7 @@ export const ComboBoxPopperFactory =
       {...props}
     >
       <div
-        className={clsns({
+        className={cx({
           'combobox-popper--virtualized': virtualized,
           'combobox-popper--grouped': grouped,
         })}

--- a/src/components/form/MultipleComboBox/MultipleComboBoxItem.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBoxItem.tsx
@@ -1,4 +1,4 @@
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -42,7 +42,7 @@ export const MultipleComboBoxItem = ({
         <Item
           id={id}
           $virtualized={virtualized}
-          className={clsns(
+          className={cx(
             {
               'combo-box-item--disabled': disabled,
             },

--- a/src/components/form/MultipleComboBox/MultipleComboBoxPopperFactory.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBoxPopperFactory.tsx
@@ -1,5 +1,5 @@
 import { Popper, PopperProps } from '@mui/material'
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import { ReactNode } from 'react'
 import styled from 'styled-components'
 
@@ -43,7 +43,7 @@ export const MultipleComboBoxPopperFactory =
       {...props}
     >
       <div
-        className={clsns({
+        className={cx({
           'multipleComboBox-popper--virtualized': virtualized,
           'multipleComboBox-popper--grouped': grouped,
         })}

--- a/src/components/form/Radio/Radio.tsx
+++ b/src/components/form/Radio/Radio.tsx
@@ -1,4 +1,4 @@
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import { isBoolean } from 'lodash'
 import { forwardRef, ReactNode, useId, useRef, useState } from 'react'
 import styled from 'styled-components'
@@ -33,7 +33,7 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(
       <Container
         ref={ref}
         onClick={() => inputRef.current?.click()}
-        className={clsns({
+        className={cx({
           'radio--disabled': disabled,
           'radio--focused': focused,
           'radio--checked': checked,

--- a/src/components/form/Switch/Switch.tsx
+++ b/src/components/form/Switch/Switch.tsx
@@ -1,4 +1,4 @@
-import clsns from 'classnames'
+import { cx } from 'class-variance-authority'
 import { MouseEvent, useEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -77,7 +77,7 @@ export const Switch = ({
     >
       <SwitchContainer
         $checked={!!checked}
-        className={clsns('switchField', {
+        className={cx('switchField', {
           'switchField--disabled': disabled,
           'switchField--focused': focused,
           'switchField--loading': loading,

--- a/src/styles/utils.ts
+++ b/src/styles/utils.ts
@@ -1,6 +1,6 @@
-import clsx from 'classnames'
+import { cx, CxOptions } from 'class-variance-authority'
 import { twMerge } from 'tailwind-merge'
 
-export const tw = (...inputs: clsx.ArgumentArray) => {
-  return twMerge(clsx(inputs))
+export const tw = (...inputs: CxOptions) => {
+  return twMerge(cx(inputs))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5068,11 +5068,6 @@ class-variance-authority@^0.7.0:
   dependencies:
     clsx "2.0.0"
 
-classnames@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
-  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
-
 clean-css@^5.2.2:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.3.tgz#b330653cd3bd6b75009cc25c714cae7b93351ccd"


### PR DESCRIPTION
## Context

With the introduction of tailwind, and especially **Class Variance Authority** package to handle classes, we no longer need `classnames` lib as cva exports `clsx` already.

Doc : https://cva.style/docs/api-reference#cx
Ref: [Understanding the Differences Between clsx, classnames, and twMerge in React and Tailwind CSS](https://www.linkedin.com/pulse/understanding-differences-between-clsx-classnames-react-terranova-l5dxf/)


## Description

This PR removes `classnames` and replace with `cx`