### PR TITLE
bug: fix redirection stuck on home white page

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -19,7 +19,10 @@ const Home = () => {
         LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY,
       )
 
-      if (!!lastPrivateVisitedRouteWhileNotConnected) {
+      if (
+        !!lastPrivateVisitedRouteWhileNotConnected &&
+        lastPrivateVisitedRouteWhileNotConnected.pathname !== '/'
+      ) {
         navigate(lastPrivateVisitedRouteWhileNotConnected, { replace: true })
         // This is a temp value for redirection, should be removed after redirection have been performed
         removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)


### PR DESCRIPTION
## Context

Recently added a logic to store the last visited page in LS, and this can be used to redirect the use back to the expected URL even is they are using an external auth like google SSO.

## Description

If you visit an url landing on `/`, the redirection will send you then again on Home and prevent the correct redirection to happen.

Here we simply prevent redirection on HOME `/` from HOME 😅 