### PR TITLE
secu: add nginx header config for CSP frame-ancestors

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,12 +1,13 @@
 server {
   listen 80;
   listen [::]:80;
-  
+
   location / {
+    add_header Content-Security-Policy "frame-ancestors *.force.com;" always;
     root /usr/share/nginx/html;
     index index.html index.htm;
     try_files $uri $uri/ /index.html =404;
   }
-  
+
   include /etc/nginx/extra-conf.d/*.conf;
 }


### PR DESCRIPTION
Adding CSP `frame-ancestors` rule to prevent rendering Lago into an unexpected iFrame context.