### PR TITLE
fix: set svg to inline-block

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -26,6 +26,10 @@ ul {
   @apply m-0 list-disc pl-6;
 }
 
+svg {
+  @apply inline-block;
+}
+
 span.line-break-anywhere {
   @apply break-all;
 }


### PR DESCRIPTION
## Context

Tailwind displays svg as `block` element and it breaks some of our components.

## Description

Set svgs to `inline-block` to fix the issue.


Fixes ISSUE-455