### PR TITLE
bug: make search input's icon visible again

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -24,7 +24,7 @@ export const SearchInput = ({ onChange, placeholder }: SearchInputProps) => {
         setLocalValue(value)
       }}
       InputProps={{
-        startAdornment: <SearchIcon name="magnifying-glass" />,
+        startAdornment: <Icon className="ml-4" name="magnifying-glass" />,
       }}
       cleanable
     />
@@ -38,8 +38,4 @@ const TextInputForSearch = styled(TextInput)`
     height: 40px;
     padding-left: ${theme.spacing(3)};
   }
-`
-
-const SearchIcon = styled(Icon)`
-  padding-left: ${theme.spacing(4)};
 `


### PR DESCRIPTION
## Context

TW have been setup in our project recently.

Some default css rules have been added to the project.

## Description

We now have a `box-sizing: border-box` on all elements. In the search bar, the icon was places using padding, but it made it disappear from the UI, so using margin fixed it

<!-- Linear link -->
Fixes ISSUE-465