### PR TITLE
fix: svg not being rendered on safari due to missing width attribute

### DIFF
--- a/src/components/designSystem/Avatar.tsx
+++ b/src/components/designSystem/Avatar.tsx
@@ -1,5 +1,5 @@
 import { cva, cx } from 'class-variance-authority'
-import { ReactNode } from 'react'
+import { isValidElement, ReactNode } from 'react'
 
 import { tw } from '~/styles/utils'
 
@@ -126,9 +126,17 @@ export const Avatar = ({
   className,
 }: AvatarGenericProps | AvatarConnectorProps) => {
   if (variant === 'connector') {
+    // If children is a valid element, check if it's an SVG directly rendered (not wrapped in an Icon component)
+    // If it is, apply the full size to it
+    const isSvg = isValidElement(children) ? children.type?.toString().includes('Svg') : null
+
     return (
       <div
-        className={tw(avatarStyles({ size, rounded: true }), className)}
+        className={tw(
+          avatarStyles({ size, rounded: true }),
+          isSvg && '[&>svg]:size-full',
+          className,
+        )}
         data-test={`${variant}/${size}`}
       >
         {children}

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -56,7 +56,17 @@ module.exports = (env) =>
               loader: '@svgr/webpack',
               options: {
                 svgoConfig: {
-                  pluggins: [{ prefixIds: false, prefixClassNames: false }],
+                  plugins: [
+                    {
+                      name: 'prefixIds',
+                      params: {
+                        overrides: {
+                          prefixIds: false,
+                          prefixClassNames: false,
+                        },
+                      },
+                    },
+                  ],
                 },
               },
             },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -54,7 +54,17 @@ const config = {
             loader: '@svgr/webpack',
             options: {
               svgoConfig: {
-                pluggins: [{ prefixIds: false, prefixClassNames: false }],
+                plugins: [
+                  {
+                    name: 'prefixIds',
+                    params: {
+                      overrides: {
+                        prefixIds: false,
+                        prefixClassNames: false,
+                      },
+                    },
+                  },
+                ],
               },
             },
           },


### PR DESCRIPTION
## Context

When width/height is not defined on svg, there are not visible on safari.

## Description

Fixes ISSUE-435