### PR TITLE
fix: class into classname

### DIFF
--- a/src/public/icons/forms/radio-checked.svg
+++ b/src/public/icons/forms/radio-checked.svg
@@ -1,5 +1,5 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <circle class="radio-checked-coloured" cx="8" cy="8" r="8" fill="currentColor" />
-  <circle class="radio-inner" cx="8" cy="8" r="7" fill="white" />
-  <circle class="radio-checked-coloured" cx="8" cy="8" r="4" fill="currentColor" />
+  <circle className="radio-checked-coloured" cx="8" cy="8" r="8" fill="currentColor" />
+  <circle className="radio-inner" cx="8" cy="8" r="7" fill="white" />
+  <circle className="radio-checked-coloured" cx="8" cy="8" r="4" fill="currentColor" />
 </svg>

--- a/src/public/icons/forms/radio.svg
+++ b/src/public/icons/forms/radio.svg
@@ -1,4 +1,4 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <circle class="radio-coloured" cx="8" cy="8" r="8" fill="#8C95A6" />
-  <circle class="radio-inner" cx="8" cy="8" r="7" fill="white" />
+  <circle className="radio-coloured" cx="8" cy="8" r="8" fill="#8C95A6" />
+  <circle className="radio-inner" cx="8" cy="8" r="7" fill="white" />
 </svg>


### PR DESCRIPTION
## Context

Classname wasn't applied to component due to class attributes instead of className in react