### PR TITLE
fix: add content-box sizing to combobox popper

### DIFF
--- a/src/components/form/ComboBox/ComboBoxPopperFactory.tsx
+++ b/src/components/form/ComboBox/ComboBoxPopperFactory.tsx
@@ -68,6 +68,7 @@ const StyledPopper = styled(Popper)<{
   .MuiAutocomplete-paper {
     border: 1px solid ${theme.palette.grey[200]};
     padding: ${theme.spacing(2)} 0;
+    box-sizing: content-box;
   }
 
   > *.combobox-popper--grouped .MuiAutocomplete-paper {


### PR DESCRIPTION
## Context

Applying content-box to combobox component. It should not impact popper with buttons with this solution.

Fixes ISSUE-464