### PR TITLE
fix: manual dunning email preview

### DIFF
--- a/src/pages/CustomerRequestOverduePayment/components/EmailPreview.tsx
+++ b/src/pages/CustomerRequestOverduePayment/components/EmailPreview.tsx
@@ -108,8 +108,8 @@ export const EmailPreview: FC<EmailPreviewProps> = ({
           <Text color="textSecondary">
             {translate(
               'text_66b378e748cda1004ff00db3',
-              { netPaymentTerm: customer?.netPaymentTerm || organization?.netPaymentTerm },
-              customer?.netPaymentTerm || organization?.netPaymentTerm,
+              { netPaymentTerm: customer?.netPaymentTerm ?? organization?.netPaymentTerm },
+              customer?.netPaymentTerm ?? organization?.netPaymentTerm,
             )}
           </Text>
           <Text color="textSecondary">{translate('text_66b378e748cda1004ff00db4')}</Text>


### PR DESCRIPTION
## Context

If customer net payment term was set to 0 days, it was not taken into account in the email preview and we used the organization settings.

## Description

Using `??` fixes the issue instead of `||`

