### PR TITLE
misc: typo

### DIFF
--- a/translations/fr.json
+++ b/translations/fr.json
@@ -10,7 +10,7 @@
   "text_64188b3d9735d5007d712270": "Date d'émission",
   "text_64188b3d9735d5007d712272": "1 Sep, 2023",
   "text_64188b3d9735d5007d712274": "Télécharger la facture pour plus de détails",
-  "text_64188b3d9735d5007d712276": "Questions? Contactez nous à",
+  "text_64188b3d9735d5007d712276": "Questions ? Contactez nous à",
   "text_64188b3d9735d5007d712278": "Généré par",
   "text_64188b3d9735d5007d712271": "Votre avoir nº LAG-1234-567-981-CN001 de {{organization}}",
   "text_64188b3d9735d5007d71227b": "Avoir de {{organization}}",


### PR DESCRIPTION
## Context

Added extra space in FR translation for email

## Description

There are spaces before double punctuations signs in FR (:;? etc)

Thanks!