### PR TITLE
bug: display svg images on safari

### DIFF
--- a/src/components/customers/CustomerMainInfos.tsx
+++ b/src/components/customers/CustomerMainInfos.tsx
@@ -401,7 +401,7 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
           <div>
             <Typography variant="caption">{translate('text_62b1edddbf5f461ab9712795')}</Typography>
             <Stack direction="row" spacing={2} alignItems="center">
-              <Avatar variant="connector" size="small">
+              <Avatar variant="connector-full" size="small">
                 {paymentProvider === ProviderTypeEnum?.Stripe ? (
                   <Stripe />
                 ) : paymentProvider === ProviderTypeEnum?.Gocardless ? (
@@ -439,7 +439,7 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
             ) : !!connectedNetsuiteIntegration && customer?.netsuiteCustomer?.externalCustomerId ? (
               <Stack>
                 <Stack direction="row" spacing={2} alignItems="center">
-                  <Avatar variant="connector" size="small">
+                  <Avatar variant="connector-full" size="small">
                     <Netsuite />
                   </Avatar>
                   <Typography color="grey700">{connectedNetsuiteIntegration?.name}</Typography>
@@ -472,7 +472,7 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
             ) : !!connectedXeroIntegration && customer?.xeroCustomer?.externalCustomerId ? (
               <Stack>
                 <Stack direction="row" spacing={2} alignItems="center">
-                  <Avatar variant="connector" size="small">
+                  <Avatar variant="connector-full" size="small">
                     <Xero />
                   </Avatar>
                   <Typography color="grey700">{connectedXeroIntegration?.name}</Typography>
@@ -502,7 +502,7 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
             ) : !!connectedAnrokIntegration && customer?.anrokCustomer?.integrationId ? (
               <Stack>
                 <Stack direction="row" spacing={2} alignItems="center">
-                  <Avatar variant="connector" size="small">
+                  <Avatar variant="connector-full" size="small">
                     <Anrok />
                   </Avatar>
                   <Typography color="grey700">{connectedAnrokIntegration?.name}</Typography>

--- a/src/components/customers/addDrawer/ExternalAppsAccordion.tsx
+++ b/src/components/customers/addDrawer/ExternalAppsAccordion.tsx
@@ -377,7 +377,7 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
               summary={
                 <Stack gap={3} flex={1} direction="row" alignItems="center">
                   <Stack gap={3} flex={1} direction="row" alignItems="center">
-                    <Avatar size="big" variant="connector">
+                    <Avatar size="big" variant="connector-full">
                       {!!formikProps.values.paymentProvider ? (
                         <>
                           {formikProps.values.paymentProvider === ProviderTypeEnum?.Stripe ? (
@@ -731,15 +731,19 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
               summary={
                 <Stack gap={3} flex={1} direction="row" alignItems="center">
                   <Stack gap={3} flex={1} direction="row" alignItems="center">
-                    <Avatar size="big" variant="connector">
-                      {!!selectedNetsuiteIntegrationSettings ? (
+                    {!!selectedNetsuiteIntegrationSettings ? (
+                      <Avatar size="big" variant="connector-full">
                         <Netsuite />
-                      ) : !!selectedXeroIntegrationSettings ? (
+                      </Avatar>
+                    ) : !!selectedXeroIntegrationSettings ? (
+                      <Avatar size="big" variant="connector-full">
                         <Xero />
-                      ) : (
+                      </Avatar>
+                    ) : (
+                      <Avatar size="big" variant="connector">
                         <Icon name="plug" color="dark" />
-                      )}
-                    </Avatar>
+                      </Avatar>
+                    )}
                     <Stack>
                       <Typography variant="bodyHl" color="grey700">
                         {!selectedNetsuiteIntegrationSettings
@@ -942,13 +946,15 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
               summary={
                 <Stack gap={3} flex={1} direction="row" alignItems="center">
                   <Stack gap={3} flex={1} direction="row" alignItems="center">
-                    <Avatar size="big" variant="connector">
-                      {showTaxIntegrationSection && !!selectedAnrokIntegrationSettings ? (
+                    {showTaxIntegrationSection && !!selectedAnrokIntegrationSettings ? (
+                      <Avatar size="big" variant="connector-full">
                         <Anrok />
-                      ) : (
+                      </Avatar>
+                    ) : (
+                      <Avatar size="big" variant="connector">
                         <Icon name="plug" color="dark" />
-                      )}
-                    </Avatar>
+                      </Avatar>
+                    )}
                     <Stack>
                       <Typography variant="bodyHl" color="grey700">
                         {!selectedAnrokIntegrationSettings

--- a/src/components/designSystem/Avatar.tsx
+++ b/src/components/designSystem/Avatar.tsx
@@ -1,5 +1,5 @@
 import { cva, cx } from 'class-variance-authority'
-import { isValidElement, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { tw } from '~/styles/utils'
 
@@ -8,10 +8,10 @@ import { Typography } from './Typography'
 import { colors } from '../../../tailwind.config'
 
 export type AvatarSize = 'small' | 'intermediate' | 'medium' | 'big' | 'large'
-type AvatarVariant = 'connector' | 'user' | 'company'
+type AvatarVariant = 'connector' | 'user' | 'company' | 'connector-full'
 
 interface AvatarConnectorProps {
-  variant: Extract<AvatarVariant, 'connector'>
+  variant: Extract<AvatarVariant, 'connector' | 'connector-full'>
   children: ReactNode | string
   size?: AvatarSize
   initials?: never
@@ -125,16 +125,12 @@ export const Avatar = ({
   children,
   className,
 }: AvatarGenericProps | AvatarConnectorProps) => {
-  if (variant === 'connector') {
-    // If children is a valid element, check if it's an SVG directly rendered (not wrapped in an Icon component)
-    // If it is, apply the full size to it
-    const isSvg = isValidElement(children) ? children.type?.toString().includes('Svg') : null
-
+  if (variant === 'connector' || variant === 'connector-full') {
     return (
       <div
         className={tw(
           avatarStyles({ size, rounded: true }),
-          isSvg && '[&>svg]:size-full',
+          variant === 'connector-full' && '[&>svg]:size-full',
           className,
         )}
         data-test={`${variant}/${size}`}

--- a/src/pages/__devOnly/DesignSystem.tsx
+++ b/src/pages/__devOnly/DesignSystem.tsx
@@ -342,7 +342,7 @@ const DesignSystem = () => {
                     title="A simple selector"
                     subtitle="with more info"
                     icon={
-                      <Avatar variant="connector">
+                      <Avatar variant="connector-full">
                         <Stripe />
                       </Avatar>
                     }
@@ -677,7 +677,7 @@ const DesignSystem = () => {
                     </Avatar>
                   </Tooltip>
                   <Tooltip title="Connector with image">
-                    <Avatar variant="connector">
+                    <Avatar variant="connector-full">
                       <Stripe />
                     </Avatar>
                   </Tooltip>

--- a/src/pages/settings/AdyenIntegrationDetails.tsx
+++ b/src/pages/settings/AdyenIntegrationDetails.tsx
@@ -182,7 +182,7 @@ const AdyenIntegrationDetails = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Adyen />
             </Avatar>
             <div>

--- a/src/pages/settings/AdyenIntegrations.tsx
+++ b/src/pages/settings/AdyenIntegrations.tsx
@@ -132,7 +132,7 @@ const AdyenIntegrations = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Adyen />
             </Avatar>
             <div>

--- a/src/pages/settings/AnrokIntegrationDetails.tsx
+++ b/src/pages/settings/AnrokIntegrationDetails.tsx
@@ -180,7 +180,7 @@ const AnrokIntegrationDetails = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Anrok />
             </Avatar>
             <div>

--- a/src/pages/settings/AnrokIntegrations.tsx
+++ b/src/pages/settings/AnrokIntegrations.tsx
@@ -119,7 +119,7 @@ const AnrokIntegrations = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Anrok />
             </Avatar>
             <div>

--- a/src/pages/settings/Authentication/Authentication.tsx
+++ b/src/pages/settings/Authentication/Authentication.tsx
@@ -92,7 +92,7 @@ const Authentication = () => {
                 title={translate('text_664c732c264d7eed1c74fda2')}
                 subtitle={translate('text_664c732c264d7eed1c74fda8')}
                 icon={
-                  <Avatar size="big" variant="connector">
+                  <Avatar size="big" variant="connector-full">
                     <Okta />
                   </Avatar>
                 }

--- a/src/pages/settings/Authentication/OktaAuthenticationDetails.tsx
+++ b/src/pages/settings/Authentication/OktaAuthenticationDetails.tsx
@@ -155,7 +155,7 @@ const OktaAuthenticationDetails = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Okta />
             </Avatar>
             <div>

--- a/src/pages/settings/GocardlessIntegrationDetails.tsx
+++ b/src/pages/settings/GocardlessIntegrationDetails.tsx
@@ -197,7 +197,7 @@ const GocardlessIntegrationDetails = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <GoCardless />
             </Avatar>
             <div>

--- a/src/pages/settings/GocardlessIntegrationOauthCallback.tsx
+++ b/src/pages/settings/GocardlessIntegrationOauthCallback.tsx
@@ -107,7 +107,7 @@ const GocardlessIntegrationOauthCallback = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Gocardless />
             </Avatar>
             <div>

--- a/src/pages/settings/GocardlessIntegrations.tsx
+++ b/src/pages/settings/GocardlessIntegrations.tsx
@@ -132,7 +132,7 @@ const GocardlessIntegrations = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Gocardless />
             </Avatar>
             <div>

--- a/src/pages/settings/HubspotIntegrationDetails.tsx
+++ b/src/pages/settings/HubspotIntegrationDetails.tsx
@@ -175,7 +175,7 @@ const HubspotIntegrationDetails = () => {
             </>
           ) : (
             <>
-              <Avatar className="mr-4" variant="connector" size="large">
+              <Avatar className="mr-4" variant="connector-full" size="large">
                 <Hubspot />
               </Avatar>
               <div className="flex flex-col gap-1">

--- a/src/pages/settings/HubspotIntegrations.tsx
+++ b/src/pages/settings/HubspotIntegrations.tsx
@@ -104,7 +104,7 @@ const HubspotIntegrations = () => {
             </>
           ) : (
             <>
-              <Avatar className="mr-4" variant="connector" size="large">
+              <Avatar className="mr-4" variant="connector-full" size="large">
                 <Hubspot />
               </Avatar>
               <div className="flex flex-col gap-1">

--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -203,7 +203,7 @@ const Integrations = () => {
                   ) : undefined
                 }
                 icon={
-                  <Avatar size="big" variant="connector">
+                  <Avatar size="big" variant="connector-full">
                     {<Anrok />}
                   </Avatar>
                 }
@@ -226,7 +226,7 @@ const Integrations = () => {
                 title={translate('text_645d071272418a14c1c76a6d')}
                 subtitle={translate('text_634ea0ecc6147de10ddb6631')}
                 icon={
-                  <Avatar size="big" variant="connector">
+                  <Avatar size="big" variant="connector-full">
                     <Adyen />
                   </Avatar>
                 }
@@ -251,7 +251,7 @@ const Integrations = () => {
                 title={translate('text_639c334c3fa0e9c6ca3512b2')}
                 subtitle={translate('text_639c334c3fa0e9c6ca3512b4')}
                 icon={
-                  <Avatar size="big" variant="connector">
+                  <Avatar size="big" variant="connector-full">
                     {<Airbyte />}
                   </Avatar>
                 }
@@ -264,7 +264,7 @@ const Integrations = () => {
                 title={translate('text_63e26d8308d03687188221a5')}
                 subtitle={translate('text_63e26d8308d03687188221a6')}
                 icon={
-                  <Avatar size="big" variant="connector">
+                  <Avatar size="big" variant="connector-full">
                     {<Oso />}
                   </Avatar>
                 }
@@ -277,7 +277,7 @@ const Integrations = () => {
                 title={translate('text_634ea0ecc6147de10ddb6625')}
                 subtitle={translate('text_634ea0ecc6147de10ddb6631')}
                 icon={
-                  <Avatar size="big" variant="connector">
+                  <Avatar size="big" variant="connector-full">
                     <GoCardless />
                   </Avatar>
                 }
@@ -299,7 +299,7 @@ const Integrations = () => {
                 title={translate('text_641b41f3cec373009a265e9e')}
                 subtitle={translate('text_641b41fa604ef10070cab5ea')}
                 icon={
-                  <Avatar size="big" variant="connector">
+                  <Avatar size="big" variant="connector-full">
                     {<HightTouch />}
                   </Avatar>
                 }
@@ -313,7 +313,7 @@ const Integrations = () => {
                   title={translate('text_1727189568053s79ks5q07tr')}
                   subtitle={translate('text_1727189568053q2gpkjzpmxr')}
                   icon={
-                    <Avatar size="big" variant="connector">
+                    <Avatar size="big" variant="connector-full">
                       {<Hubspot />}
                     </Avatar>
                   }
@@ -346,7 +346,7 @@ const Integrations = () => {
                 title={translate('text_657078c28394d6b1ae1b9713')}
                 subtitle={translate('text_657078c28394d6b1ae1b971f')}
                 icon={
-                  <Avatar size="big" variant="connector">
+                  <Avatar size="big" variant="connector-full">
                     {<LagoTaxManagement />}
                   </Avatar>
                 }
@@ -375,7 +375,7 @@ const Integrations = () => {
                   ) : undefined
                 }
                 icon={
-                  <Avatar size="big" variant="connector">
+                  <Avatar size="big" variant="connector-full">
                     {<Netsuite />}
                   </Avatar>
                 }
@@ -398,7 +398,7 @@ const Integrations = () => {
                 title={translate('text_641b42035d62fd004e07cdde')}
                 subtitle={translate('text_641b420ccd75240062f2386e')}
                 icon={
-                  <Avatar size="big" variant="connector">
+                  <Avatar size="big" variant="connector-full">
                     {<Segment />}
                   </Avatar>
                 }
@@ -411,7 +411,7 @@ const Integrations = () => {
                 title={translate('text_62b1edddbf5f461ab971277d')}
                 subtitle={translate('text_62b1edddbf5f461ab9712795')}
                 icon={
-                  <Avatar size="big" variant="connector">
+                  <Avatar size="big" variant="connector-full">
                     <Stripe />
                   </Avatar>
                 }
@@ -445,7 +445,7 @@ const Integrations = () => {
                   ) : undefined
                 }
                 icon={
-                  <Avatar size="big" variant="connector">
+                  <Avatar size="big" variant="connector-full">
                     {<Xero />}
                   </Avatar>
                 }

--- a/src/pages/settings/LagoTaxManagementIntegration.tsx
+++ b/src/pages/settings/LagoTaxManagementIntegration.tsx
@@ -128,7 +128,7 @@ const LagoTaxManagementIntegration = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <LagoTaxManagement />
             </Avatar>
             <Stack spacing={1}>

--- a/src/pages/settings/NetsuiteIntegrationDetails.tsx
+++ b/src/pages/settings/NetsuiteIntegrationDetails.tsx
@@ -180,7 +180,7 @@ const NetsuiteIntegrationDetails = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Netsuite />
             </Avatar>
             <div>

--- a/src/pages/settings/NetsuiteIntegrations.tsx
+++ b/src/pages/settings/NetsuiteIntegrations.tsx
@@ -119,7 +119,7 @@ const NetsuiteIntegrations = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Netsuite />
             </Avatar>
             <div>

--- a/src/pages/settings/StripeIntegrationDetails.tsx
+++ b/src/pages/settings/StripeIntegrationDetails.tsx
@@ -182,7 +182,7 @@ const StripeIntegrationDetails = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Stripe />
             </Avatar>
             <div>

--- a/src/pages/settings/StripeIntegrations.tsx
+++ b/src/pages/settings/StripeIntegrations.tsx
@@ -132,7 +132,7 @@ const StripeIntegrations = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Stripe />
             </Avatar>
             <div>

--- a/src/pages/settings/XeroIntegrationDetails.tsx
+++ b/src/pages/settings/XeroIntegrationDetails.tsx
@@ -173,7 +173,7 @@ const XeroIntegrationDetails = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Xero />
             </Avatar>
             <div>

--- a/src/pages/settings/XeroIntegrations.tsx
+++ b/src/pages/settings/XeroIntegrations.tsx
@@ -116,7 +116,7 @@ const XeroIntegrations = () => {
           </>
         ) : (
           <>
-            <Avatar className="mr-4" variant="connector" size="large">
+            <Avatar className="mr-4" variant="connector-full" size="large">
               <Xero />
             </Avatar>
             <div>


### PR DESCRIPTION
## Context

Some images are not loading on Safari as they need to have a set width and height to appear.

## Description

The issue comes from a check we perform to check if the children is an SVG or not, not working on the built app on safari browsers.
To fix that without impacting too much our app, we decided to implement a new variant that will explicitly set the wrapper svg size.

<!-- Linear link -->
Fixes ISSUE-489