### PR TITLE
misc: regroup download file methods into one util

### DIFF
--- a/src/components/creditNote/CreditNotesTable.tsx
+++ b/src/components/creditNote/CreditNotesTable.tsx
@@ -13,6 +13,7 @@ import {
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { formatDateToTZ } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
+import { handleDownloadFile } from '~/core/utils/downloadFiles'
 import { ResponsiveStyleValue } from '~/core/utils/responsiveProps'
 import {
   CreditNoteForVoidCreditNoteDialogFragmentDoc,
@@ -144,26 +145,7 @@ const CreditNotesTable = ({
   const [downloadCreditNote, { loading: loadingCreditNoteDownload }] =
     useDownloadCreditNoteMutation({
       onCompleted({ downloadCreditNote: data }) {
-        const fileUrl = data?.fileUrl
-
-        if (fileUrl) {
-          // We open a window, add url then focus on different lines, in order to prevent browsers to block page opening
-          // It could be seen as unexpected popup as not immediatly done on user action
-          // https://stackoverflow.com/questions/2587677/avoid-browser-popup-blockers
-          const myWindow = window.open('', '_blank')
-
-          if (myWindow?.location?.href) {
-            myWindow.location.href = fileUrl
-            return myWindow?.focus()
-          }
-
-          myWindow?.close()
-        } else {
-          addToast({
-            severity: 'danger',
-            translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-          })
-        }
+        handleDownloadFile(data?.fileUrl)
       },
     })
 

--- a/src/components/customerPortal/PortalInvoicesList.tsx
+++ b/src/components/customerPortal/PortalInvoicesList.tsx
@@ -17,9 +17,9 @@ import {
   Typography,
 } from '~/components/designSystem'
 import { SearchInput } from '~/components/SearchInput'
-import { addToast } from '~/core/apolloClient'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { handleDownloadFile } from '~/core/utils/downloadFiles'
 import {
   CurrencyEnum,
   InvoiceForFinalizeInvoiceFragmentDoc,
@@ -203,26 +203,7 @@ const PortalInvoicesList = () => {
 
   const [downloadInvoice] = useDownloadCustomerPortalInvoiceMutation({
     onCompleted(localData) {
-      const fileUrl = localData?.downloadCustomerPortalInvoice?.fileUrl
-
-      if (fileUrl) {
-        // We open a window, add url then focus on different lines, in order to prevent browsers to block page opening
-        // It could be seen as unexpected popup as not immediatly done on user action
-        // https://stackoverflow.com/questions/2587677/avoid-browser-popup-blockers
-        const myWindow = window.open('', '_blank')
-
-        if (myWindow?.location?.href) {
-          myWindow.location.href = fileUrl
-          return myWindow?.focus()
-        }
-
-        myWindow?.close()
-      } else {
-        addToast({
-          severity: 'danger',
-          translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-        })
-      }
+      handleDownloadFile(localData?.downloadCustomerPortalInvoice?.fileUrl)
     },
   })
 

--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -11,6 +11,7 @@ import { CUSTOMER_INVOICE_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { formatDateToTZ, getTimezoneConfig } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
+import { handleDownloadFile } from '~/core/utils/downloadFiles'
 import {
   CurrencyEnum,
   InvoiceForFinalizeInvoiceFragmentDoc,
@@ -133,26 +134,7 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
   })
   const [downloadInvoice] = useDownloadInvoiceItemMutation({
     onCompleted({ downloadInvoice: data }) {
-      const fileUrl = data?.fileUrl
-
-      if (fileUrl) {
-        // We open a window, add url then focus on different lines, in order to prevent browsers to block page opening
-        // It could be seen as unexpected popup as not immediatly done on user action
-        // https://stackoverflow.com/questions/2587677/avoid-browser-popup-blockers
-        const myWindow = window.open('', '_blank')
-
-        if (myWindow?.location?.href) {
-          myWindow.location.href = fileUrl
-          return myWindow?.focus()
-        }
-
-        myWindow?.close()
-      } else {
-        addToast({
-          severity: 'danger',
-          translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-        })
-      }
+      handleDownloadFile(data?.fileUrl)
     },
   })
 

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -26,6 +26,7 @@ import { CUSTOMER_INVOICE_DETAILS_ROUTE, INVOICE_SETTINGS_ROUTE } from '~/core/r
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { formatDateToTZ } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
+import { handleDownloadFile } from '~/core/utils/downloadFiles'
 import {
   CurrencyEnum,
   GetInvoicesListQuery,
@@ -78,26 +79,7 @@ const InvoicesList = ({
 
   const [downloadInvoice] = useDownloadInvoiceItemMutation({
     onCompleted({ downloadInvoice: data }) {
-      const fileUrl = data?.fileUrl
-
-      if (fileUrl) {
-        // We open a window, add url then focus on different lines, in order to prevent browsers to block page opening
-        // It could be seen as unexpected popup as not immediatly done on user action
-        // https://stackoverflow.com/questions/2587677/avoid-browser-popup-blockers
-        const myWindow = window.open('', '_blank')
-
-        if (myWindow?.location?.href) {
-          myWindow.location.href = fileUrl
-          return myWindow?.focus()
-        }
-
-        myWindow?.close()
-      } else {
-        addToast({
-          severity: 'danger',
-          translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-        })
-      }
+      handleDownloadFile(data?.fileUrl)
     },
   })
 

--- a/src/core/utils/downloadFiles.ts
+++ b/src/core/utils/downloadFiles.ts
@@ -1,0 +1,28 @@
+import { addToast } from '../apolloClient'
+
+export const handleDownloadFile = (fileUrl?: string | null) => {
+  const showError = () => {
+    addToast({
+      severity: 'danger',
+      translateKey: 'text_62b31e1f6a5b8b1b745ece48',
+    })
+  }
+
+  if (!fileUrl) return showError()
+
+  // We open a window, add url then focus on different lines, in order to prevent browsers to block page opening
+  // It could be seen as unexpected popup as not immediatly done on user action
+  // https://stackoverflow.com/questions/2587677/avoid-browser-popup-blockers
+  // Also, we need to use setTimeout to avoid Safari blocking the popup
+  setTimeout(() => {
+    const myWindow = window.open('', '_blank')
+
+    if (myWindow?.location?.href) {
+      myWindow.location.href = fileUrl
+      return myWindow?.focus()
+    }
+
+    myWindow?.close()
+    showError()
+  }, 0)
+}

--- a/src/layouts/CustomerInvoiceDetails.tsx
+++ b/src/layouts/CustomerInvoiceDetails.tsx
@@ -44,6 +44,7 @@ import {
 } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
+import { handleDownloadFile } from '~/core/utils/downloadFiles'
 import {
   AllInvoiceDetailsForCustomerInvoiceDetailsFragment,
   AllInvoiceDetailsForCustomerInvoiceDetailsFragmentDoc,
@@ -314,25 +315,7 @@ const CustomerInvoiceDetails = () => {
 
   const [downloadInvoice, { loading: loadingInvoiceDownload }] = useDownloadInvoiceMutation({
     onCompleted({ downloadInvoice: downloadInvoiceData }) {
-      const fileUrl = downloadInvoiceData?.fileUrl
-
-      if (fileUrl) {
-        // We open a window, add url then focus on different lines, in order to prevent browsers to block page opening
-        // It could be seen as unexpected popup as not immediatly done on user action
-        // https://stackoverflow.com/questions/2587677/avoid-browser-popup-blockers
-        const myWindow = window.open('', '_blank')
-
-        if (myWindow?.location?.href) {
-          myWindow.location.href = fileUrl
-          return myWindow?.focus()
-        }
-
-        myWindow?.close()
-        addToast({
-          severity: 'danger',
-          translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-        })
-      }
+      handleDownloadFile(downloadInvoiceData?.fileUrl)
     },
   })
 

--- a/src/pages/CreditNoteDetails.tsx
+++ b/src/pages/CreditNoteDetails.tsx
@@ -44,6 +44,7 @@ import {
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { formatDateToTZ } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
+import { handleDownloadFile } from '~/core/utils/downloadFiles'
 import {
   CreditNote,
   CreditNoteCreditStatusEnum,
@@ -263,25 +264,7 @@ const CreditNoteDetails = () => {
   const [downloadCreditNote, { loading: loadingCreditNoteDownload }] =
     useDownloadCreditNoteMutation({
       onCompleted({ downloadCreditNote: downloadCreditNoteData }) {
-        const fileUrl = downloadCreditNoteData?.fileUrl
-
-        if (fileUrl) {
-          // We open a window, add url then focus on different lines, in order to prevent browsers to block page opening
-          // It could be seen as unexpected popup as not immediatly done on user action
-          // https://stackoverflow.com/questions/2587677/avoid-browser-popup-blockers
-          const myWindow = window.open('', '_blank')
-
-          if (myWindow?.location?.href) {
-            myWindow.location.href = fileUrl
-            return myWindow?.focus()
-          }
-
-          myWindow?.close()
-          addToast({
-            severity: 'danger',
-            translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-          })
-        }
+        handleDownloadFile(downloadCreditNoteData?.fileUrl)
       },
     })
 

--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -33,7 +33,6 @@ import {
 import { GenericPlaceholder } from '~/components/GenericPlaceholder'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { CustomerWalletsList } from '~/components/wallets/CustomerWalletList'
-import { addToast } from '~/core/apolloClient'
 import {
   CREATE_INVOICE_ROUTE,
   CREATE_SUBSCRIPTION,
@@ -43,6 +42,7 @@ import {
   CUSTOMER_REQUEST_OVERDUE_PAYMENT_ROUTE,
   CUSTOMERS_LIST_ROUTE,
 } from '~/core/router'
+import { handleDownloadFile } from '~/core/utils/downloadFiles'
 import {
   AddCustomerDrawerFragmentDoc,
   CustomerMainInfosFragmentDoc,
@@ -115,25 +115,7 @@ const CustomerDetails = () => {
   })
   const [generatePortalUrl] = useGenerateCustomerPortalUrlMutation({
     onCompleted({ generateCustomerPortalUrl }) {
-      if (generateCustomerPortalUrl?.url) {
-        // We open a window, add url then focus on different lines, in order to prevent browsers to block page opening
-        // It could be seen as unexpected popup as not immediatly done on user action
-        // https://stackoverflow.com/questions/2587677/avoid-browser-popup-blockers
-        setTimeout(() => {
-          const myWindow = window.open('', '_blank')
-
-          if (myWindow?.location?.href) {
-            myWindow.location.href = generateCustomerPortalUrl.url
-            return myWindow?.focus()
-          }
-
-          myWindow?.close()
-          addToast({
-            severity: 'danger',
-            translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-          })
-        }, 0)
-      }
+      handleDownloadFile(generateCustomerPortalUrl?.url)
     },
   })
   const {


### PR DESCRIPTION
As I was fixing some window open logic, decided to tackle this old issue.

This PR makes sure all file download uses the same logic and checks.
So
- Errors are handled the same way
- It works on all browsers

Fixes https://github.com/getlago/lago-front/issues/522