### PR TITLE
feat: preview email in dunning creation form

### DIFF
--- a/src/components/designSystem/Drawer.tsx
+++ b/src/components/designSystem/Drawer.tsx
@@ -27,6 +27,7 @@ interface DrawerProps extends Pick<MuiDrawerProps, 'anchor'> {
   fullContentHeight?: boolean
   children: (({ closeDrawer }: { closeDrawer: () => void }) => ReactNode) | ReactNode
   stickyBottomBar?: (({ closeDrawer }: { closeDrawer: () => void }) => ReactNode) | ReactNode
+  withPadding?: boolean
   onOpen?: () => void
   onClose?: () => void
 }
@@ -47,6 +48,7 @@ export const Drawer = forwardRef<DrawerRef, DrawerProps>(
       anchor = 'right',
       title,
       fullContentHeight,
+      withPadding = true,
       onOpen,
       onClose,
     }: DrawerProps,
@@ -119,7 +121,7 @@ export const Drawer = forwardRef<DrawerRef, DrawerProps>(
               }}
             />
           </Header>
-          <Content $fullContentHeight={fullContentHeight}>
+          <Content $fullContentHeight={fullContentHeight} $withPadding={withPadding}>
             {typeof children === 'function'
               ? children({ closeDrawer: () => setIsOpen(false) })
               : children}
@@ -182,12 +184,16 @@ const Header = styled.div`
   }
 `
 
-const Content = styled.div<{ $fullContentHeight?: boolean }>`
+const Content = styled.div<{ $fullContentHeight?: boolean; $withPadding?: boolean }>`
   height: ${({ $fullContentHeight }) => ($fullContentHeight ? '100%' : ' ')};
-  padding: ${theme.spacing(12)} ${theme.spacing(12)} ${theme.spacing(20)};
+  padding: ${({ $withPadding }) =>
+    $withPadding ? `${theme.spacing(12)} ${theme.spacing(12)} ${theme.spacing(20)}` : undefined};
 
   ${theme.breakpoints.down('md')} {
-    padding: ${theme.spacing(12)} ${theme.spacing(4)} ${theme.spacing(20)} ${theme.spacing(4)};
+    padding: ${({ $withPadding }) =>
+      $withPadding
+        ? `${theme.spacing(12)} ${theme.spacing(4)} ${theme.spacing(20)} ${theme.spacing(4)}`
+        : undefined};
   }
 `
 

--- a/src/components/settings/dunnings/PreviewCampaignEmailDrawer.tsx
+++ b/src/components/settings/dunnings/PreviewCampaignEmailDrawer.tsx
@@ -1,29 +1,62 @@
+import { gql } from '@apollo/client'
 import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
-import { Button, Drawer, DrawerRef, Skeleton, Typography } from '~/components/designSystem'
+import { Button, Drawer, DrawerRef, Typography } from '~/components/designSystem'
+import { DunningEmail, DunningEmailSkeleton } from '~/components/emails/DunningEmail'
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { LocaleEnum } from '~/core/translations'
+import {
+  CurrencyEnum,
+  useGetOrganizationInfoForPreviewDunningCampaignLazyQuery,
+} from '~/generated/graphql'
+import { useContextualLocale } from '~/hooks/core/useContextualLocale'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 import { LanguageSettingsButton } from '../LanguageSettingsButton'
 import { PreviewEmailLayout } from '../PreviewEmailLayout'
 
+gql`
+  fragment OrganizationInfoForPreviewDunningCampaign on CurrentOrganization {
+    name
+    email
+  }
+
+  query getOrganizationInfoForPreviewDunningCampaign {
+    organization {
+      ...OrganizationInfoForPreviewDunningCampaign
+    }
+  }
+`
+
 export interface PreviewCampaignEmailDrawerRef extends DrawerRef {
-  openDrawer: (data?: any) => unknown
+  openDrawer: () => void
   closeDrawer: () => void
 }
 
+const DUMMY_OVERDUE_AMOUNT_CENTS = 73000
+const DUMMY_INVOICES_COUNT = 5
+
 export const PreviewCampaignEmailDrawer = forwardRef<PreviewCampaignEmailDrawerRef>(
-  (props, ref) => {
+  (_props, ref) => {
     const { translate } = useInternationalization()
     const drawerRef = useRef<DrawerRef>(null)
     const [locale, setLocale] = useState<LocaleEnum>(LocaleEnum.en)
-    const [localData, setLocalData] = useState<any>()
+    const { translateWithContextualLocal } = useContextualLocale(locale)
 
-    const loading = false
+    const [getOrganizationInfo, { loading, data }] =
+      useGetOrganizationInfoForPreviewDunningCampaignLazyQuery()
+
+    const invoices = Array.from({ length: DUMMY_INVOICES_COUNT }).map((_, index) => ({
+      id: `${index}`,
+      number: `${data?.organization?.name.slice(0, 3).toUpperCase()}-1234-567-89${index + 1}`,
+      totalAmountCents:
+        index === 0 ? DUMMY_OVERDUE_AMOUNT_CENTS - 10000 * (DUMMY_INVOICES_COUNT - 1) : 10000,
+      currency: CurrencyEnum.Usd,
+    }))
 
     useImperativeHandle(ref, () => ({
-      openDrawer: (data) => {
-        setLocalData(data)
+      openDrawer: () => {
+        getOrganizationInfo()
         drawerRef.current?.openDrawer()
       },
       closeDrawer: () => drawerRef.current?.closeDrawer(),
@@ -35,13 +68,13 @@ export const PreviewCampaignEmailDrawer = forwardRef<PreviewCampaignEmailDrawerR
         withPadding={false}
         stickyBottomBar={({ closeDrawer }) => (
           <div className="flex justify-end">
-            <Button onClick={closeDrawer}>{translate('Close preview')}</Button>
+            <Button onClick={closeDrawer}>{translate('text_1729594310368kstqhifkf5p')}</Button>
           </div>
         )}
         title={
           <div className="flex flex-1 flex-row items-center justify-between gap-1">
             <Typography variant="bodyHl" color="textSecondary">
-              {translate('Preview email template')}
+              {translate('text_1728584028187udjepvgj8ra')}
             </Typography>
             <LanguageSettingsButton
               language={locale}
@@ -50,23 +83,40 @@ export const PreviewCampaignEmailDrawer = forwardRef<PreviewCampaignEmailDrawerR
           </div>
         }
       >
-        <div className="h-full bg-grey-100 p-12">
-          <PreviewEmailLayout
-            isLoading={loading}
-            language={locale}
-            emailObject={translate('Your overdue balance from Banco')}
-          >
-            {loading ? (
-              <div className="flex flex-col gap-7">
-                <Skeleton color="dark" variant="text" width={104} />
-                <Skeleton color="dark" variant="text" width="100%" />
-                <Skeleton color="dark" variant="text" width={160} />
-              </div>
-            ) : (
-              // TODO: Extract from manual dunning
-              <></>
-            )}
-          </PreviewEmailLayout>
+        <div className="h-full bg-grey-100 p-12 pb-0">
+          <div className="max-w-150 mx-auto">
+            <PreviewEmailLayout
+              isLoading={loading}
+              language={locale}
+              emailObject={translateWithContextualLocal('text_1729256593854oiy13slixjr', {
+                companyName: data?.organization?.name,
+              })}
+              emailFrom={`<${data?.organization?.email || '{{organization_email}}'}>`}
+            >
+              {loading ? (
+                <div className="flex flex-col gap-7">
+                  <DunningEmailSkeleton />
+                </div>
+              ) : (
+                <div className="flex flex-col gap-6">
+                  <DunningEmail
+                    locale={locale}
+                    invoices={invoices}
+                    currency={CurrencyEnum.Usd}
+                    overdueAmount={deserializeAmount(DUMMY_OVERDUE_AMOUNT_CENTS, CurrencyEnum.Usd)}
+                    organization={{
+                      name: data?.organization?.name ?? '{{organization_name}}',
+                      netPaymentTerm: '{{net_payment_term}}',
+                      email: data?.organization?.email || '{{organization_email}}',
+                    }}
+                    customer={{
+                      displayName: `{{customer_name}}`,
+                    }}
+                  />
+                </div>
+              )}
+            </PreviewEmailLayout>
+          </div>
         </div>
       </Drawer>
     )

--- a/src/components/settings/dunnings/PreviewCampaignEmailDrawer.tsx
+++ b/src/components/settings/dunnings/PreviewCampaignEmailDrawer.tsx
@@ -84,7 +84,7 @@ export const PreviewCampaignEmailDrawer = forwardRef<PreviewCampaignEmailDrawerR
         }
       >
         <div className="h-full bg-grey-100 p-12 pb-0">
-          <div className="max-w-150 mx-auto">
+          <div className="mx-auto max-w-150">
             <PreviewEmailLayout
               isLoading={loading}
               language={locale}

--- a/src/components/settings/dunnings/PreviewCampaignEmailDrawer.tsx
+++ b/src/components/settings/dunnings/PreviewCampaignEmailDrawer.tsx
@@ -1,0 +1,76 @@
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+
+import { Button, Drawer, DrawerRef, Skeleton, Typography } from '~/components/designSystem'
+import { LocaleEnum } from '~/core/translations'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+import { LanguageSettingsButton } from '../LanguageSettingsButton'
+import { PreviewEmailLayout } from '../PreviewEmailLayout'
+
+export interface PreviewCampaignEmailDrawerRef extends DrawerRef {
+  openDrawer: (data?: any) => unknown
+  closeDrawer: () => void
+}
+
+export const PreviewCampaignEmailDrawer = forwardRef<PreviewCampaignEmailDrawerRef>(
+  (props, ref) => {
+    const { translate } = useInternationalization()
+    const drawerRef = useRef<DrawerRef>(null)
+    const [locale, setLocale] = useState<LocaleEnum>(LocaleEnum.en)
+    const [localData, setLocalData] = useState<any>()
+
+    const loading = false
+
+    useImperativeHandle(ref, () => ({
+      openDrawer: (data) => {
+        setLocalData(data)
+        drawerRef.current?.openDrawer()
+      },
+      closeDrawer: () => drawerRef.current?.closeDrawer(),
+    }))
+
+    return (
+      <Drawer
+        ref={drawerRef}
+        withPadding={false}
+        stickyBottomBar={({ closeDrawer }) => (
+          <div className="flex justify-end">
+            <Button onClick={closeDrawer}>{translate('Close preview')}</Button>
+          </div>
+        )}
+        title={
+          <div className="flex flex-1 flex-row items-center justify-between gap-1">
+            <Typography variant="bodyHl" color="textSecondary">
+              {translate('Preview email template')}
+            </Typography>
+            <LanguageSettingsButton
+              language={locale}
+              onChange={(currentLocale) => setLocale(currentLocale)}
+            />
+          </div>
+        }
+      >
+        <div className="h-full bg-grey-100 p-12">
+          <PreviewEmailLayout
+            isLoading={loading}
+            language={locale}
+            emailObject={translate('Your overdue balance from Banco')}
+          >
+            {loading ? (
+              <div className="flex flex-col gap-7">
+                <Skeleton color="dark" variant="text" width={104} />
+                <Skeleton color="dark" variant="text" width="100%" />
+                <Skeleton color="dark" variant="text" width={160} />
+              </div>
+            ) : (
+              // TODO: Extract from manual dunning
+              <></>
+            )}
+          </PreviewEmailLayout>
+        </div>
+      </Drawer>
+    )
+  },
+)
+
+PreviewCampaignEmailDrawer.displayName = 'PreviewCampaignEmailDrawer'

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -6854,6 +6854,13 @@ export type UpdateOktaIntegrationMutationVariables = Exact<{
 
 export type UpdateOktaIntegrationMutation = { __typename?: 'Mutation', updateOktaIntegration?: { __typename?: 'OktaIntegration', id: string } | null };
 
+export type OrganizationInfoForPreviewDunningCampaignFragment = { __typename?: 'CurrentOrganization', name: string, email?: string | null };
+
+export type GetOrganizationInfoForPreviewDunningCampaignQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetOrganizationInfoForPreviewDunningCampaignQuery = { __typename?: 'Query', organization?: { __typename?: 'CurrentOrganization', name: string, email?: string | null } | null };
+
 export type UpdateOrganizationLogoMutationVariables = Exact<{
   input: UpdateOrganizationInput;
 }>;
@@ -9266,6 +9273,12 @@ export const AddOktaIntegrationDialogFragmentDoc = gql`
   ...DeleteOktaIntegrationDialog
 }
     ${DeleteOktaIntegrationDialogFragmentDoc}`;
+export const OrganizationInfoForPreviewDunningCampaignFragmentDoc = gql`
+    fragment OrganizationInfoForPreviewDunningCampaign on CurrentOrganization {
+  name
+  email
+}
+    `;
 export const AddAdyenProviderDialogFragmentDoc = gql`
     fragment AddAdyenProviderDialog on AdyenProvider {
   id
@@ -15480,6 +15493,45 @@ export function useUpdateOktaIntegrationMutation(baseOptions?: Apollo.MutationHo
 export type UpdateOktaIntegrationMutationHookResult = ReturnType<typeof useUpdateOktaIntegrationMutation>;
 export type UpdateOktaIntegrationMutationResult = Apollo.MutationResult<UpdateOktaIntegrationMutation>;
 export type UpdateOktaIntegrationMutationOptions = Apollo.BaseMutationOptions<UpdateOktaIntegrationMutation, UpdateOktaIntegrationMutationVariables>;
+export const GetOrganizationInfoForPreviewDunningCampaignDocument = gql`
+    query getOrganizationInfoForPreviewDunningCampaign {
+  organization {
+    ...OrganizationInfoForPreviewDunningCampaign
+  }
+}
+    ${OrganizationInfoForPreviewDunningCampaignFragmentDoc}`;
+
+/**
+ * __useGetOrganizationInfoForPreviewDunningCampaignQuery__
+ *
+ * To run a query within a React component, call `useGetOrganizationInfoForPreviewDunningCampaignQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetOrganizationInfoForPreviewDunningCampaignQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetOrganizationInfoForPreviewDunningCampaignQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetOrganizationInfoForPreviewDunningCampaignQuery(baseOptions?: Apollo.QueryHookOptions<GetOrganizationInfoForPreviewDunningCampaignQuery, GetOrganizationInfoForPreviewDunningCampaignQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetOrganizationInfoForPreviewDunningCampaignQuery, GetOrganizationInfoForPreviewDunningCampaignQueryVariables>(GetOrganizationInfoForPreviewDunningCampaignDocument, options);
+      }
+export function useGetOrganizationInfoForPreviewDunningCampaignLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetOrganizationInfoForPreviewDunningCampaignQuery, GetOrganizationInfoForPreviewDunningCampaignQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetOrganizationInfoForPreviewDunningCampaignQuery, GetOrganizationInfoForPreviewDunningCampaignQueryVariables>(GetOrganizationInfoForPreviewDunningCampaignDocument, options);
+        }
+export function useGetOrganizationInfoForPreviewDunningCampaignSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetOrganizationInfoForPreviewDunningCampaignQuery, GetOrganizationInfoForPreviewDunningCampaignQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetOrganizationInfoForPreviewDunningCampaignQuery, GetOrganizationInfoForPreviewDunningCampaignQueryVariables>(GetOrganizationInfoForPreviewDunningCampaignDocument, options);
+        }
+export type GetOrganizationInfoForPreviewDunningCampaignQueryHookResult = ReturnType<typeof useGetOrganizationInfoForPreviewDunningCampaignQuery>;
+export type GetOrganizationInfoForPreviewDunningCampaignLazyQueryHookResult = ReturnType<typeof useGetOrganizationInfoForPreviewDunningCampaignLazyQuery>;
+export type GetOrganizationInfoForPreviewDunningCampaignSuspenseQueryHookResult = ReturnType<typeof useGetOrganizationInfoForPreviewDunningCampaignSuspenseQuery>;
+export type GetOrganizationInfoForPreviewDunningCampaignQueryResult = Apollo.QueryResult<GetOrganizationInfoForPreviewDunningCampaignQuery, GetOrganizationInfoForPreviewDunningCampaignQueryVariables>;
 export const UpdateOrganizationLogoDocument = gql`
     mutation updateOrganizationLogo($input: UpdateOrganizationInput!) {
   updateOrganization(input: $input) {

--- a/src/pages/settings/Dunnings/CreateDunning.tsx
+++ b/src/pages/settings/Dunnings/CreateDunning.tsx
@@ -11,6 +11,10 @@ import {
   DefaultCampaignDialog,
   DefaultCampaignDialogRef,
 } from '~/components/settings/dunnings/DefaultCampaignDialog'
+import {
+  PreviewCampaignEmailDrawer,
+  PreviewCampaignEmailDrawerRef,
+} from '~/components/settings/dunnings/PreviewCampaignEmailDrawer'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { DUNNINGS_SETTINGS_ROUTE } from '~/core/router'
@@ -64,8 +68,9 @@ const CreateDunning = () => {
   const { translate } = useInternationalization()
   const navigate = useNavigate()
 
-  const defaultCampaignDialog = useRef<DefaultCampaignDialogRef>(null)
+  const defaultCampaignDialogRef = useRef<DefaultCampaignDialogRef>(null)
   const warningDirtyAttributesDialogRef = useRef<WarningDialogRef>(null)
+  const previewCampaignEmailDrawerRef = useRef<PreviewCampaignEmailDrawerRef>(null)
 
   const { organization: { defaultCurrency } = {} } = useOrganizationInfos()
 
@@ -359,6 +364,13 @@ const CreateDunning = () => {
                     {hasPaymentProviderExcludingGoCardless
                       ? translate('text_1728584028187l2wdjy4s5cs')
                       : translate('text_17291534666709ytr7mi4jjl')}
+
+                    <button
+                      className="ml-1 h-auto p-0 text-blue-600 hover:underline focus:underline"
+                      onClick={() => previewCampaignEmailDrawerRef.current?.openDrawer()}
+                    >
+                      {translate('text_1728584028187udjepvgj8ra')}
+                    </button>
                   </Typography>
                 </div>
 
@@ -406,7 +418,7 @@ const CreateDunning = () => {
                   checked={formikProps.values.appliedToOrganization}
                   onChange={() => {
                     if (!formikProps.values.appliedToOrganization) {
-                      defaultCampaignDialog.current?.openDialog({
+                      defaultCampaignDialogRef.current?.openDialog({
                         type: 'setDefault',
                         onConfirm: () => formikProps.setFieldValue('appliedToOrganization', true),
                       })
@@ -458,7 +470,8 @@ const CreateDunning = () => {
         onContinue={() => navigate(DUNNINGS_SETTINGS_ROUTE)}
       />
 
-      <DefaultCampaignDialog ref={defaultCampaignDialog} />
+      <DefaultCampaignDialog ref={defaultCampaignDialogRef} />
+      <PreviewCampaignEmailDrawer ref={previewCampaignEmailDrawerRef} />
     </>
   )
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -2555,5 +2555,8 @@
   "text_1728584028187qei3xba4i02": "Only one campaign can be applied to an organization. For more flexibility, override it at the customer level.",
   "text_1728584028187oqpu20oxuxq": "Add campaign",
   "text_17290016117598ws4m1j6wvy": "Dunning campaign successfully created",
-  "text_17291534666709ytr7mi4jjl": "Customers will receive an email reminder to pay their overdue balance based on the settings below."
+  "text_17291534666709ytr7mi4jjl": "Customers will receive an email reminder to pay their overdue balance based on the settings below.",
+  "text_1729256593854oiy13slixjr": "Your overdue balance from {{companyName}}",
+  "text_1728584028187udjepvgj8ra": "Preview email template",
+  "text_1729594310368kstqhifkf5p": "Close preview"
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -161,5 +161,6 @@
   "text_1728654170904707saidat0f": "Geben Sie einen Kundennamen ein",
   "text_62da6ec24a8e24e44f8128aa": "Mehr laden",
   "text_62da6ec24a8e24e44f81288c": "Kein Ablaufdatum",
-  "text_634687079be251fdb43833cb": "Kundenname"
+  "text_634687079be251fdb43833cb": "Kundenname",
+  "text_1729256593854oiy13slixjr": "Ihr überfälliger Saldo von {{companyName}}"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -161,5 +161,6 @@
   "text_1728654170904707saidat0f": "Escribe el nombre de un cliente",
   "text_62da6ec24a8e24e44f8128aa": "Cargar más",
   "text_62da6ec24a8e24e44f81288c": "Sin fecha de vencimiento",
-  "text_634687079be251fdb43833cb": "Nombre del cliente"
+  "text_634687079be251fdb43833cb": "Nombre del cliente",
+  "text_1729256593854oiy13slixjr": "Su saldo vencido de {{companyName}}"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -161,5 +161,6 @@
   "text_1728654170904707saidat0f": "Saisissez le nom d'un client",
   "text_62da6ec24a8e24e44f8128aa": "Charger plus",
   "text_62da6ec24a8e24e44f81288c": "Pas de date d'expiration",
-  "text_634687079be251fdb43833cb": "Nom du client"
+  "text_634687079be251fdb43833cb": "Nom du client",
+  "text_1729256593854oiy13slixjr": "Votre solde impayé pour {{companyName}}"
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -134,5 +134,6 @@
   "text_1728654170904707saidat0f": "Inserisci il nome di un cliente",
   "text_62da6ec24a8e24e44f8128aa": "Carica altro",
   "text_62da6ec24a8e24e44f81288c": "Nessuna data di scadenza",
-  "text_634687079be251fdb43833cb": "Nome del cliente"
+  "text_634687079be251fdb43833cb": "Nome del cliente",
+  "text_1729256593854oiy13slixjr": "Il tuo saldo in ritardo da {{companyName}}"
 }

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -160,5 +160,6 @@
   "text_1728654170904707saidat0f": "Skriv inn et kundenavn",
   "text_62da6ec24a8e24e44f8128aa": "Last inn mer",
   "text_62da6ec24a8e24e44f81288c": "Ingen utløpsdato",
-  "text_634687079be251fdb43833cb": "Kundenavn"
+  "text_634687079be251fdb43833cb": "Kundenavn",
+  "text_1729256593854oiy13slixjr": "Din forfalte saldo fra {{companyName}}"
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -161,5 +161,6 @@
   "text_1728654170904707saidat0f": "Skriv in ett kundnamn",
   "text_62da6ec24a8e24e44f8128aa": "Ladda mer",
   "text_62da6ec24a8e24e44f81288c": "Inget utgångsdatum",
-  "text_634687079be251fdb43833cb": "Kundnamn"
+  "text_634687079be251fdb43833cb": "Kundnamn",
+  "text_1729256593854oiy13slixjr": "Din förfallna saldo från {{companyName}}"
 }


### PR DESCRIPTION
## Context

This is related to automatic dunning initiative

## Description

It should implement the preview email in the create dunning page.
We use the same dunning email as for the manual payment feature but with fake data.

It can be safely merge as this is not visible in the app directly but only through `/settings/dunnings/create` URL


Fixes LAGO-403