### PR TITLE
bug: remove extra space on navigation page invocation's page wrapper

### DIFF
--- a/src/components/designSystem/NavigationTab.tsx
+++ b/src/components/designSystem/NavigationTab.tsx
@@ -167,6 +167,7 @@ const LocalTabs = styled(Tabs)<{
   ${({ $leftSpacing }) => {
     return css`
       ${setResponsiveProperty('paddingLeft', $leftSpacing)}
+      ${setResponsiveProperty('paddingRight', $leftSpacing)}
     `
   }}
 


### PR DESCRIPTION
No TW migration yet, but will do it later.

A chain of spacing was making the container overflow with the new "box-sizing border-box everything" of tailwind.

This make sure the container is also adding the extra asked space on the right of it (as it was required by design since the begining BTW) so the calcualted width is reduced and prevent this extra overflow.