### PR TITLE
bug: should manually build payload in mapping

### DIFF
--- a/src/components/settings/integrations/NetsuiteIntegrationMapItemDialog.tsx
+++ b/src/components/settings/integrations/NetsuiteIntegrationMapItemDialog.tsx
@@ -368,7 +368,6 @@ export const NetsuiteIntegrationMapItemDialog = forwardRef<NetsuiteIntegrationMa
                   externalName,
                   integrationId: localData?.integrationId as string,
                   mappingType: localData?.type as MappingTypeEnum,
-                  ...values,
                 },
               },
             })
@@ -382,7 +381,6 @@ export const NetsuiteIntegrationMapItemDialog = forwardRef<NetsuiteIntegrationMa
                   integrationId: localData?.integrationId as string,
                   mappableType: localData?.type as MappableTypeEnum,
                   mappableId: localData?.lagoMappableId as string,
-                  ...values,
                 },
               },
             })
@@ -406,7 +404,6 @@ export const NetsuiteIntegrationMapItemDialog = forwardRef<NetsuiteIntegrationMa
                   externalName,
                   integrationId: localData?.integrationId as string,
                   mappingType: localData?.type as unknown as MappingTypeEnum,
-                  ...values,
                 },
               },
             })
@@ -421,7 +418,6 @@ export const NetsuiteIntegrationMapItemDialog = forwardRef<NetsuiteIntegrationMa
                   integrationId: localData?.integrationId as string,
                   mappableType: localData?.type as unknown as MappableTypeEnum,
                   mappableId: localData?.lagoMappableId as string,
-                  ...values,
                 },
               },
             })


### PR DESCRIPTION
We have 2 system of mapping in the same component.

So there  2 payload shape, and spreading the whole values can make the other one having unexpected attribute.

We're already explicit in the payload data build, so there is no reason to spread the rest of the form's values here

Fixes ISSUE-506