### PR TITLE
feat: allow to search anywhere in the combobox value

### DIFF
--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -79,6 +79,7 @@ export const ComboBox = ({
   const filter = createFilterOptions<ComboBoxData>({
     matchFrom: allowAddValue ? 'start' : 'any',
     stringify: (option) => option.label || option.value,
+    trim: true,
   })
   const startAdornmentValue = useMemo(() => {
     if (!renderGroupInputStartAdornment || !value) return undefined

--- a/src/components/form/MultipleComboBox/MultipleComboBox.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBox.tsx
@@ -56,9 +56,10 @@ export const MultipleComboBox = ({
         : rawData
     ) as MultipleComboBoxData[]
   }, [rawData, sortValues])
+
   const filter = createFilterOptions<MultipleComboBoxData>({
-    matchFrom: 'start',
     stringify: (option) => option.label || option.value,
+    trim: true,
   })
 
   return (


### PR DESCRIPTION
## Description

Remove match from `start` and set it to default (`any` position).
Doc: https://mui.com/material-ui/react-autocomplete/#createfilteroptions-config-filteroptions

Also trim the searched value.

Fixes ISSUE-403

<img width="696" alt="Capture d’écran 2024-10-30 à 16 12 58" src="https://github.com/user-attachments/assets/73884b27-0b55-4159-abb7-ea5cb8fb642f">
<img width="714" alt="Capture d’écran 2024-10-30 à 16 12 52" src="https://github.com/user-attachments/assets/b239a781-65af-4734-858b-9f413b7390e1">
