### PR TITLE
feat: deprecate margin props

### DIFF
--- a/src/components/designSystem/Skeleton.tsx
+++ b/src/components/designSystem/Skeleton.tsx
@@ -25,8 +25,17 @@ interface SkeletonConnectorProps {
   width?: never
   height?: never
   className?: string
+  /**
+   * @deprecated Use `className` and TailwindCSS instead
+   */
   marginRight?: number | string
+  /**
+   * @deprecated Use `className` and TailwindCSS instead
+   */
   marginBottom?: number | string
+  /**
+   * @deprecated Use `className` and TailwindCSS instead
+   */
   marginTop?: number | string
   color?: keyof typeof SkeletonColorEnum
 }
@@ -37,8 +46,17 @@ interface SkeletonGenericProps {
   height?: number | string
   size?: never
   className?: string
+  /**
+   * @deprecated Use `className` and TailwindCSS instead
+   */
   marginRight?: number | string
+  /**
+   * @deprecated Use `className` and TailwindCSS instead
+   */
   marginBottom?: number | string
+  /**
+   * @deprecated Use `className` and TailwindCSS instead
+   */
   marginTop?: number | string
   color?: keyof typeof SkeletonColorEnum
 }


### PR DESCRIPTION
## Context

Tailwind migration

## Description

Deprecate margin props in favour of tailwind classnames

<img width="1302" alt="Capture d’écran 2024-10-30 à 16 18 01" src="https://github.com/user-attachments/assets/eb204cfe-0805-4b1b-82ff-e38039d0124f">

