### PR TITLE
misc: change Netsuite item mapping UX

### DIFF
--- a/src/components/settings/integrations/AddNetsuiteDialog.tsx
+++ b/src/components/settings/integrations/AddNetsuiteDialog.tsx
@@ -369,45 +369,7 @@ export const AddNetsuiteDialog = forwardRef<AddNetsuiteDialogRef>((_, ref) => {
                   </Typography>
                   <Chip
                     size="small"
-                    label={translate('text_661ff6e56ef7e1b7c542b2a6')}
-                    color="danger600"
-                  />
-                  <Typography variant="body" color="grey700">
-                    {translate('text_661ff6e56ef7e1b7c542b29e')}
-                  </Typography>
-                </Stack>
-              }
-              value={true}
-            />
-            <Checkbox
-              disabled
-              label={
-                <Stack spacing={1} direction="row" alignItems="center" flexWrap="wrap">
-                  <Typography variant="body" color="grey700">
-                    {translate('text_661ff6e56ef7e1b7c542b296')}
-                  </Typography>
-                  <Chip
-                    size="small"
                     label={translate('text_661ff6e56ef7e1b7c542b2c2')}
-                    color="danger600"
-                  />
-                  <Typography variant="body" color="grey700">
-                    {translate('text_661ff6e56ef7e1b7c542b29e')}
-                  </Typography>
-                </Stack>
-              }
-              value={true}
-            />
-            <Checkbox
-              disabled
-              label={
-                <Stack spacing={1} direction="row" alignItems="center" flexWrap="wrap">
-                  <Typography variant="body" color="grey700">
-                    {translate('text_661ff6e56ef7e1b7c542b296')}
-                  </Typography>
-                  <Chip
-                    size="small"
-                    label={translate('text_661ff6e56ef7e1b7c542b2d7')}
                     color="danger600"
                   />
                   <Typography variant="body" color="grey700">

--- a/src/components/settings/integrations/NetsuiteIntegrationSettings.tsx
+++ b/src/components/settings/integrations/NetsuiteIntegrationSettings.tsx
@@ -76,11 +76,7 @@ gql`
 `
 
 const buildEnabledSynchronizedLabelKeys = (integration?: NetsuiteIntegrationSettingsFragment) => {
-  const labels = [
-    'text_661ff6e56ef7e1b7c542b2a6',
-    'text_661ff6e56ef7e1b7c542b2c2',
-    'text_661ff6e56ef7e1b7c542b2d7',
-  ]
+  const labels = ['text_661ff6e56ef7e1b7c542b2c2']
 
   if (integration?.syncInvoices) {
     labels.push('text_661ff6e56ef7e1b7c542b2ff')

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -7313,29 +7313,9 @@ export type NetsuiteIntegrationItemsListBillableMetricsFragment = { __typename?:
 
 export type NetsuiteIntegrationItemsListDefaultFragment = { __typename?: 'CollectionMapping', id: string, mappingType: MappingTypeEnum, externalId: string, externalAccountCode?: string | null, externalName?: string | null, taxCode?: string | null, taxNexus?: string | null, taxType?: string | null };
 
-export type NetsuiteIntegrationMapItemDialogFragment = { __typename?: 'IntegrationItem', id: string, externalId: string, externalName?: string | null, externalAccountCode?: string | null, itemType: IntegrationItemTypeEnum };
-
 export type NetsuiteIntegrationMapItemDialogCollectionMappingItemFragment = { __typename?: 'CollectionMapping', id: string, externalId: string, externalName?: string | null, externalAccountCode?: string | null };
 
 export type NetsuiteIntegrationMapItemDialogCollectionItemFragment = { __typename?: 'Mapping', id: string, externalId: string, externalName?: string | null, externalAccountCode?: string | null };
-
-export type GetNetsuiteIntegrationItemsQueryVariables = Exact<{
-  integrationId: Scalars['ID']['input'];
-  itemType?: InputMaybe<IntegrationItemTypeEnum>;
-  page?: InputMaybe<Scalars['Int']['input']>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  searchTerm?: InputMaybe<Scalars['String']['input']>;
-}>;
-
-
-export type GetNetsuiteIntegrationItemsQuery = { __typename?: 'Query', integrationItems: { __typename?: 'IntegrationItemCollection', collection: Array<{ __typename?: 'IntegrationItem', id: string, externalId: string, externalName?: string | null, externalAccountCode?: string | null, itemType: IntegrationItemTypeEnum }>, metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number } } };
-
-export type TriggerNetsuiteIntegrationItemsRefetchMutationVariables = Exact<{
-  input: FetchIntegrationItemsInput;
-}>;
-
-
-export type TriggerNetsuiteIntegrationItemsRefetchMutation = { __typename?: 'Mutation', fetchIntegrationItems: { __typename?: 'IntegrationItemCollection', collection: Array<{ __typename?: 'IntegrationItem', id: string, externalId: string, externalName?: string | null, externalAccountCode?: string | null, itemType: IntegrationItemTypeEnum }> } };
 
 export type CreateNetsuiteIntegrationCollectionMappingMutationVariables = Exact<{
   input: CreateIntegrationCollectionMappingInput;
@@ -9568,15 +9548,6 @@ export const NetsuiteIntegrationItemsListDefaultFragmentDoc = gql`
   taxCode
   taxNexus
   taxType
-}
-    `;
-export const NetsuiteIntegrationMapItemDialogFragmentDoc = gql`
-    fragment NetsuiteIntegrationMapItemDialog on IntegrationItem {
-  id
-  externalId
-  externalName
-  externalAccountCode
-  itemType
 }
     `;
 export const NetsuiteIntegrationMapItemDialogCollectionMappingItemFragmentDoc = gql`
@@ -17141,98 +17112,6 @@ export type GetBillableMetricsForNetsuiteItemsListQueryHookResult = ReturnType<t
 export type GetBillableMetricsForNetsuiteItemsListLazyQueryHookResult = ReturnType<typeof useGetBillableMetricsForNetsuiteItemsListLazyQuery>;
 export type GetBillableMetricsForNetsuiteItemsListSuspenseQueryHookResult = ReturnType<typeof useGetBillableMetricsForNetsuiteItemsListSuspenseQuery>;
 export type GetBillableMetricsForNetsuiteItemsListQueryResult = Apollo.QueryResult<GetBillableMetricsForNetsuiteItemsListQuery, GetBillableMetricsForNetsuiteItemsListQueryVariables>;
-export const GetNetsuiteIntegrationItemsDocument = gql`
-    query getNetsuiteIntegrationItems($integrationId: ID!, $itemType: IntegrationItemTypeEnum, $page: Int, $limit: Int, $searchTerm: String) {
-  integrationItems(
-    integrationId: $integrationId
-    itemType: $itemType
-    page: $page
-    limit: $limit
-    searchTerm: $searchTerm
-  ) {
-    collection {
-      ...NetsuiteIntegrationMapItemDialog
-    }
-    metadata {
-      currentPage
-      totalPages
-      totalCount
-    }
-  }
-}
-    ${NetsuiteIntegrationMapItemDialogFragmentDoc}`;
-
-/**
- * __useGetNetsuiteIntegrationItemsQuery__
- *
- * To run a query within a React component, call `useGetNetsuiteIntegrationItemsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetNetsuiteIntegrationItemsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetNetsuiteIntegrationItemsQuery({
- *   variables: {
- *      integrationId: // value for 'integrationId'
- *      itemType: // value for 'itemType'
- *      page: // value for 'page'
- *      limit: // value for 'limit'
- *      searchTerm: // value for 'searchTerm'
- *   },
- * });
- */
-export function useGetNetsuiteIntegrationItemsQuery(baseOptions: Apollo.QueryHookOptions<GetNetsuiteIntegrationItemsQuery, GetNetsuiteIntegrationItemsQueryVariables> & ({ variables: GetNetsuiteIntegrationItemsQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetNetsuiteIntegrationItemsQuery, GetNetsuiteIntegrationItemsQueryVariables>(GetNetsuiteIntegrationItemsDocument, options);
-      }
-export function useGetNetsuiteIntegrationItemsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetNetsuiteIntegrationItemsQuery, GetNetsuiteIntegrationItemsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetNetsuiteIntegrationItemsQuery, GetNetsuiteIntegrationItemsQueryVariables>(GetNetsuiteIntegrationItemsDocument, options);
-        }
-export function useGetNetsuiteIntegrationItemsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetNetsuiteIntegrationItemsQuery, GetNetsuiteIntegrationItemsQueryVariables>) {
-          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<GetNetsuiteIntegrationItemsQuery, GetNetsuiteIntegrationItemsQueryVariables>(GetNetsuiteIntegrationItemsDocument, options);
-        }
-export type GetNetsuiteIntegrationItemsQueryHookResult = ReturnType<typeof useGetNetsuiteIntegrationItemsQuery>;
-export type GetNetsuiteIntegrationItemsLazyQueryHookResult = ReturnType<typeof useGetNetsuiteIntegrationItemsLazyQuery>;
-export type GetNetsuiteIntegrationItemsSuspenseQueryHookResult = ReturnType<typeof useGetNetsuiteIntegrationItemsSuspenseQuery>;
-export type GetNetsuiteIntegrationItemsQueryResult = Apollo.QueryResult<GetNetsuiteIntegrationItemsQuery, GetNetsuiteIntegrationItemsQueryVariables>;
-export const TriggerNetsuiteIntegrationItemsRefetchDocument = gql`
-    mutation triggerNetsuiteIntegrationItemsRefetch($input: FetchIntegrationItemsInput!) {
-  fetchIntegrationItems(input: $input) {
-    collection {
-      ...NetsuiteIntegrationMapItemDialog
-    }
-  }
-}
-    ${NetsuiteIntegrationMapItemDialogFragmentDoc}`;
-export type TriggerNetsuiteIntegrationItemsRefetchMutationFn = Apollo.MutationFunction<TriggerNetsuiteIntegrationItemsRefetchMutation, TriggerNetsuiteIntegrationItemsRefetchMutationVariables>;
-
-/**
- * __useTriggerNetsuiteIntegrationItemsRefetchMutation__
- *
- * To run a mutation, you first call `useTriggerNetsuiteIntegrationItemsRefetchMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useTriggerNetsuiteIntegrationItemsRefetchMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [triggerNetsuiteIntegrationItemsRefetchMutation, { data, loading, error }] = useTriggerNetsuiteIntegrationItemsRefetchMutation({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useTriggerNetsuiteIntegrationItemsRefetchMutation(baseOptions?: Apollo.MutationHookOptions<TriggerNetsuiteIntegrationItemsRefetchMutation, TriggerNetsuiteIntegrationItemsRefetchMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<TriggerNetsuiteIntegrationItemsRefetchMutation, TriggerNetsuiteIntegrationItemsRefetchMutationVariables>(TriggerNetsuiteIntegrationItemsRefetchDocument, options);
-      }
-export type TriggerNetsuiteIntegrationItemsRefetchMutationHookResult = ReturnType<typeof useTriggerNetsuiteIntegrationItemsRefetchMutation>;
-export type TriggerNetsuiteIntegrationItemsRefetchMutationResult = Apollo.MutationResult<TriggerNetsuiteIntegrationItemsRefetchMutation>;
-export type TriggerNetsuiteIntegrationItemsRefetchMutationOptions = Apollo.BaseMutationOptions<TriggerNetsuiteIntegrationItemsRefetchMutation, TriggerNetsuiteIntegrationItemsRefetchMutationVariables>;
 export const CreateNetsuiteIntegrationCollectionMappingDocument = gql`
     mutation createNetsuiteIntegrationCollectionMapping($input: CreateIntegrationCollectionMappingInput!) {
   createIntegrationCollectionMapping(input: $input) {

--- a/translations/base.json
+++ b/translations/base.json
@@ -428,7 +428,6 @@
   "text_6630e3210c13c500cd398eb0": "For all wallets",
   "text_6630e51df0a194013daea61f": "Define a fallback item",
   "text_6630e51df0a194013daea620": "This item serves as a fallback in case your mapping is incorrect, ensuring that your actions to NetSuite do not fail.",
-  "text_6630e51df0a194013daea621": "NetSuite item",
   "text_6630e51df0a194013daea622": "Search and select an item",
   "text_6630e51df0a194013daea624": "Map item",
   "text_6630e560a830417bd3b119fb": "Map your taxes with a {{integrationType}} tax item",
@@ -2604,5 +2603,11 @@
   "text_1730554642648p1mngqwys8n": "Round",
   "text_1730554642648qe9wjveh3fv": "Rounds a number based on the decimals value (e.g. 4.2 = 4 or 4.6 = 5)",
   "text_17305547268320wyhpbm8hh0": "Rounding rule",
-  "text_1730554726832vyn9bep4u0f": "Precision (optional)"
+  "text_1730554726832vyn9bep4u0f": "Precision (optional)",
+  "text_1730738987881evzsfqnn1tr": "NetSuite Item name",
+  "text_1730738987882hhl5gijws0m": "Type your NetSuite Item name",
+  "text_17307389878820u8ldpctozo": "NetSuite Item ID",
+  "text_173073898788226ev6fudddk": "Type your NetSuite Item Id",
+  "text_1730738987882c15jo2dyc9f": "NetSuite Item Account ID",
+  "text_1730738987882h2yy21a82k2": "Type the Account ID for this item"
 }


### PR DESCRIPTION
## Context

You can map a Lago item (collection or unique item) to an item in Netsuite.

The Process was the following
- open mapping modal on a Lago item
- Under the hood we fetch Netsuite items
- select a Netsuite mapping item
- save the mapping to attach the two items together (saved in Lago DB)

Main problem, the max amount of item you can fetch on Netsuite is 1000 and there is no pagination. It's a hard limit.

## Description

This PR changes the way we enter mapping informations.
Now, you have to fill in manually the informations we were pre-fetching and selecting when picking an item in the Netsuite item list.

We pass from 1 combobox to 3 fields.

Note it was already the case if the item was a tax type.
It almost make this component simpler.

<!-- Linear link -->
Fixes LAGO-504