### PR TITLE
misc(Skeleton): migrate to remove unnecessary attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "translations:add": "node scripts/translations/add",
     "translations:inspect": "node scripts/translations/inspect",
     "changelog:update": "auto-changelog --template=.changelog/regular.hbs",
+    "codemod": "node scripts/codemod.js",
     "postinstall": "npx yarn-deduplicate"
   },
   "devDependencies": {
@@ -85,6 +86,7 @@
     "html-webpack-plugin": "5.5.1",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
+    "jscodeshift": "^17.1.1",
     "postcss": "^8.4.38",
     "postcss-loader": "^8.1.1",
     "postcss-preset-env": "^9.5.13",

--- a/scripts/codemod.js
+++ b/scripts/codemod.js
@@ -1,0 +1,27 @@
+/* eslint no-console: ["error", { allow: ["info"] }] */
+
+const path = require('path')
+
+const { globSync } = require('glob')
+const { run: jscodeshift } = require('jscodeshift/src/Runner')
+
+const SRC_DIR = './src/'
+
+const transformPath = path.resolve('./scripts/transforms/skeleton-remove-unnecessary-height.js')
+const paths = globSync(path.join(SRC_DIR, '**/*.@(tsx)'))
+const options = {
+  // dry: true, // dry run (no changes are made to files)
+  verbose: 1,
+  parser: 'tsx',
+}
+
+async function main() {
+  try {
+    await jscodeshift(transformPath, paths, options)
+  } catch (e) {
+    console.info('\u001b[' + 31 + 'm' + 'Codemod transform failed' + '\u001b[0m', e)
+    process.exit(1)
+  }
+}
+
+main()

--- a/scripts/transforms/skeleton-remove-unnecessary-height.js
+++ b/scripts/transforms/skeleton-remove-unnecessary-height.js
@@ -1,0 +1,35 @@
+module.exports = function (file, api) {
+  // Alias the jscodeshift API for ease of use.
+  const j = api.jscodeshift
+
+  // Convert the entire file source into a collection of nodes paths.
+  const root = j(file.source)
+
+  root
+    // Find all JSX elements with the name FontAwesomeIcon...
+    .findJSXElements('Skeleton')
+    .filter((path) => {
+      // ...that have a variant text attribute...
+      const hasVariant = path.value.openingElement.attributes.some(
+        (attr) => attr.name.name === 'variant' && attr.value.value === 'text',
+      )
+      // ...and a height attribute with value 12
+      const hasHeight = path.value.openingElement.attributes.some(
+        (attr) => attr.name.name === 'height' && attr.value.expression.value === 12,
+      )
+
+      return hasVariant && hasHeight
+    })
+    // Get the height attribute node
+    .find(j.JSXAttribute, {
+      name: {
+        type: 'JSXIdentifier',
+        name: 'height',
+      },
+    })
+    // Remove it
+    .remove()
+
+  // Save changes to the file
+  return root.toSource()
+}

--- a/src/components/coupons/CouponItem.tsx
+++ b/src/components/coupons/CouponItem.tsx
@@ -121,7 +121,6 @@ export const CouponItem = ({
         </div>
         {shouldShowItemActions && <div className="w-10" />}
       </ConditionalWrapper>
-
       {shouldShowItemActions && (
         <Popper
           PopperProps={{ placement: 'bottom-end' }}

--- a/src/components/creditNote/CreditNoteFormCalculation.tsx
+++ b/src/components/creditNote/CreditNoteFormCalculation.tsx
@@ -243,7 +243,7 @@ export const CreditNoteFormCalculation = ({
             </InlineLabel>
             <Typography color="grey700" data-test="prorated-coupon-amount">
               {estiationLoading ? (
-                <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} height={12} />
+                <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} />
               ) : !proRatedCouponAmount || hasError ? (
                 '-'
               ) : (
@@ -258,7 +258,7 @@ export const CreditNoteFormCalculation = ({
           <Typography variant="bodyHl">{translate('text_636bedf292786b19d3398f02')}</Typography>
           <Typography color="grey700" data-test="total-excluded-tax">
             {estiationLoading ? (
-              <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} height={12} />
+              <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} />
             ) : !totalExcludedTax || hasError ? (
               '-'
             ) : (
@@ -273,7 +273,7 @@ export const CreditNoteFormCalculation = ({
             <Typography variant="bodyHl">{translate('text_636bedf292786b19d3398f06')}</Typography>
             <Typography color="grey700">
               {estiationLoading ? (
-                <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} height={12} />
+                <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} />
               ) : (
                 '-'
               )}
@@ -289,11 +289,7 @@ export const CreditNoteFormCalculation = ({
                 </Typography>
                 <Typography color="grey700" data-test={`tax-${tax.taxRate}-amount`}>
                   {estiationLoading ? (
-                    <ValueSkeleton
-                      variant="text"
-                      width={LOADING_VALUE_SKELETON_WIDTH}
-                      height={12}
-                    />
+                    <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} />
                   ) : !tax.amount || hasError ? (
                     '-'
                   ) : (
@@ -311,7 +307,7 @@ export const CreditNoteFormCalculation = ({
             )} (0%)`}</Typography>
             <Typography color="grey700">
               {estiationLoading ? (
-                <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} height={12} />
+                <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} />
               ) : hasError ? (
                 '-'
               ) : (
@@ -328,7 +324,7 @@ export const CreditNoteFormCalculation = ({
           </Typography>
           <Typography color="grey700" data-test="total-tax-included">
             {estiationLoading ? (
-              <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} height={12} />
+              <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} />
             ) : !totalTaxIncluded || hasError ? (
               '-'
             ) : (
@@ -345,7 +341,7 @@ export const CreditNoteFormCalculation = ({
             </Typography>
             <Typography color="grey700">
               {estiationLoading ? (
-                <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} height={12} />
+                <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} />
               ) : totalTaxIncluded === undefined || hasError ? (
                 '-'
               ) : (
@@ -453,7 +449,7 @@ export const CreditNoteFormCalculation = ({
             ) : (
               <Typography color="grey700">
                 {estiationLoading ? (
-                  <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} height={12} />
+                  <ValueSkeleton variant="text" width={LOADING_VALUE_SKELETON_WIDTH} />
                 ) : !payBack[0]?.value || hasError ? (
                   '-'
                 ) : (

--- a/src/components/creditNote/CreditNotesTable.tsx
+++ b/src/components/creditNote/CreditNotesTable.tsx
@@ -113,12 +113,12 @@ type TCreditNoteTableProps = {
 const CreditNoteTableItemSkeleton = () => {
   return (
     <SkeletonLine>
-      <Skeleton variant="text" width={180} height={12} />
-      <Skeleton variant="text" width={80} height={12} />
-      <Skeleton variant="text" width={160} height={12} />
-      <RightSkeleton variant="text" width={160} height={12} />
-      <Skeleton variant="text" width={112} height={12} />
-      <Skeleton variant="text" width={40} height={12} />
+      <Skeleton variant="text" width={180} />
+      <Skeleton variant="text" width={80} />
+      <Skeleton variant="text" width={160} />
+      <RightSkeleton variant="text" width={160} />
+      <Skeleton variant="text" width={112} />
+      <Skeleton variant="text" width={40} />
     </SkeletonLine>
   )
 }

--- a/src/components/customerPortal/common/SectionLoading.tsx
+++ b/src/components/customerPortal/common/SectionLoading.tsx
@@ -7,13 +7,13 @@ const group = (
 
     <div className="grid grid-cols-2">
       <div className="flex flex-col gap-3">
-        <Skeleton variant="text" height={12} width={72} />
-        <Skeleton variant="text" height={12} width={160} />
+        <Skeleton variant="text" width={72} />
+        <Skeleton variant="text" width={160} />
       </div>
 
       <div className="flex flex-col gap-3">
-        <Skeleton variant="text" height={12} width={72} />
-        <Skeleton variant="text" height={12} width={160} />
+        <Skeleton variant="text" width={72} />
+        <Skeleton variant="text" width={160} />
       </div>
     </div>
   </div>
@@ -22,27 +22,27 @@ const group = (
 export const LoaderUsageSection = () => (
   <div className="grid grid-cols-2">
     <div className="flex flex-col gap-3">
-      <Skeleton variant="text" height={12} width={72} />
-      <Skeleton variant="text" height={12} width={160} />
-      <Skeleton variant="text" height={12} width={240} />
-      <Skeleton variant="text" height={12} width={72} />
+      <Skeleton variant="text" width={72} />
+      <Skeleton variant="text" width={160} />
+      <Skeleton variant="text" width={240} />
+      <Skeleton variant="text" width={72} />
     </div>
 
     <div className="flex flex-col gap-3">
-      <Skeleton variant="text" height={12} width={72} />
-      <Skeleton variant="text" height={12} width={160} />
-      <Skeleton variant="text" height={12} width={240} />
-      <Skeleton variant="text" height={12} width={72} />
+      <Skeleton variant="text" width={72} />
+      <Skeleton variant="text" width={160} />
+      <Skeleton variant="text" width={240} />
+      <Skeleton variant="text" width={72} />
     </div>
   </div>
 )
 
 export const LoaderUsageSubscriptionItem = () => (
   <div className="flex flex-col gap-3">
-    <Skeleton variant="text" height={12} width={72} />
-    <Skeleton variant="text" height={12} width={160} />
-    <Skeleton variant="text" height={12} width={240} />
-    <Skeleton variant="text" height={12} width={72} />
+    <Skeleton variant="text" width={72} />
+    <Skeleton variant="text" width={160} />
+    <Skeleton variant="text" width={240} />
+    <Skeleton variant="text" width={72} />
   </div>
 )
 
@@ -57,13 +57,13 @@ export const LoaderWalletPage = () => (
 export const LoaderWalletSection = () => (
   <div className="grid grid-cols-2">
     <div className="flex flex-col gap-3">
-      <Skeleton variant="text" height={12} width={72} />
-      <Skeleton variant="text" height={12} width={160} />
+      <Skeleton variant="text" width={72} />
+      <Skeleton variant="text" width={160} />
     </div>
 
     <div className="flex flex-col gap-3">
-      <Skeleton variant="text" height={12} width={72} />
-      <Skeleton variant="text" height={12} width={160} />
+      <Skeleton variant="text" width={72} />
+      <Skeleton variant="text" width={160} />
     </div>
   </div>
 )
@@ -71,33 +71,33 @@ export const LoaderWalletSection = () => (
 export const LoaderCustomerInformationSection = () => (
   <div className="grid grid-cols-2 gap-6">
     <div className="flex flex-col gap-3">
-      <Skeleton variant="text" height={12} width={72} />
-      <Skeleton variant="text" height={12} width={240} />
+      <Skeleton variant="text" width={72} />
+      <Skeleton variant="text" width={240} />
     </div>
 
     <div className="flex flex-col gap-3">
-      <Skeleton variant="text" height={12} width={72} />
-      <Skeleton variant="text" height={12} width={240} />
+      <Skeleton variant="text" width={72} />
+      <Skeleton variant="text" width={240} />
     </div>
 
     <div className="flex flex-col gap-3">
-      <Skeleton variant="text" height={12} width={72} />
-      <Skeleton variant="text" height={12} width={240} />
+      <Skeleton variant="text" width={72} />
+      <Skeleton variant="text" width={240} />
     </div>
 
     <div className="flex flex-col gap-3">
-      <Skeleton variant="text" height={12} width={72} />
-      <Skeleton variant="text" height={12} width={240} />
+      <Skeleton variant="text" width={72} />
+      <Skeleton variant="text" width={240} />
     </div>
 
     <div className="flex flex-col gap-3">
-      <Skeleton variant="text" height={12} width={72} />
-      <Skeleton variant="text" height={12} width={240} />
+      <Skeleton variant="text" width={72} />
+      <Skeleton variant="text" width={240} />
     </div>
 
     <div className="flex flex-col gap-3">
-      <Skeleton variant="text" height={12} width={72} />
-      <Skeleton variant="text" height={12} width={240} />
+      <Skeleton variant="text" width={72} />
+      <Skeleton variant="text" width={240} />
     </div>
   </div>
 )
@@ -120,24 +120,24 @@ export const LoaderInvoicesListSection = () => (
 
 export const LoaderInvoicesListTotal = () => (
   <div className="flex flex-col gap-3">
-    <Skeleton variant="text" height={12} width={72} />
-    <Skeleton variant="text" height={12} width={240} />
+    <Skeleton variant="text" width={72} />
+    <Skeleton variant="text" width={240} />
   </div>
 )
 
 export const LoaderSidebarOrganization = () => (
   <div className="flex flex-col gap-8">
     <Skeleton className="!rounded-[8px] bg-grey-200" variant="text" height={32} width={32} />
-    <Skeleton className="bg-grey-200" variant="text" height={12} width={228} />
+    <Skeleton className="bg-grey-200" variant="text" width={228} />
   </div>
 )
 
 export const SectionLoading = () => {
   return (
     <div className="flex flex-col gap-2">
-      <Skeleton variant="text" height={12} width={120} />
-      <Skeleton variant="text" height={12} width={160} />
-      <Skeleton variant="text" height={12} width={200} />
+      <Skeleton variant="text" width={120} />
+      <Skeleton variant="text" width={160} />
+      <Skeleton variant="text" width={200} />
     </div>
   )
 }

--- a/src/components/customerPortal/common/SectionTitle.tsx
+++ b/src/components/customerPortal/common/SectionTitle.tsx
@@ -13,7 +13,7 @@ const SectionTitle = ({ className, title, action, loading }: SectionTitleProps) 
   <div className={tw('mb-6 flex items-center pb-4 shadow-b', className)}>
     {loading ? (
       <div className="flex h-7 w-full items-center">
-        <Skeleton variant="text" width={160} height={12} />
+        <Skeleton variant="text" width={160} />
       </div>
     ) : (
       <>

--- a/src/components/customers/CustomerInvoicesTab.tsx
+++ b/src/components/customers/CustomerInvoicesTab.tsx
@@ -93,7 +93,7 @@ export const CustomerInvoicesTab = ({ customerId, customerTimezone }: CustomerIn
     <div>
       {initialLoad ? (
         <LoadingState>
-          <Skeleton variant="text" width={224} height={12} marginBottom="30px" />
+          <Skeleton variant="text" width={224} marginBottom="30px" />
           <CustomerInvoicesList
             isLoading
             customerTimezone={customerTimezone}

--- a/src/components/customers/CustomerItem.tsx
+++ b/src/components/customers/CustomerItem.tsx
@@ -135,7 +135,6 @@ export const CustomerItem = memo(({ rowId, customer, editDialogRef }: CustomerIt
           )}
         </Popper>
       )}
-
       <DeleteCustomerDialog ref={deleteDialogRef} customer={customer} />
     </ItemContainer>
   )
@@ -147,8 +146,8 @@ export const CustomerItemSkeleton = () => {
   return (
     <BaseListItem>
       <Skeleton variant="connectorAvatar" size="big" marginRight={theme.spacing(3)} />
-      <Skeleton variant="text" height={12} width={240} marginRight="auto" />
-      <Skeleton variant="text" height={12} width={240} />
+      <Skeleton variant="text" width={240} marginRight="auto" />
+      <Skeleton variant="text" width={240} />
     </BaseListItem>
   )
 }

--- a/src/components/customers/CustomerMainInfos.tsx
+++ b/src/components/customers/CustomerMainInfos.tsx
@@ -243,15 +243,15 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
     return (
       <LoadingDetails>
         <SectionHeader>
-          <Skeleton variant="text" height={12} width={200} />
+          <Skeleton variant="text" width={200} />
         </SectionHeader>
         <div>
-          <Skeleton variant="text" height={12} width={80} marginBottom={theme.spacing(3)} />
-          <Skeleton variant="text" height={12} width={200} />
+          <Skeleton variant="text" width={80} marginBottom={theme.spacing(3)} />
+          <Skeleton variant="text" width={200} />
         </div>
         <div>
-          <Skeleton variant="text" height={12} width={80} marginBottom={theme.spacing(3)} />
-          <Skeleton variant="text" height={12} width={200} />
+          <Skeleton variant="text" width={80} marginBottom={theme.spacing(3)} />
+          <Skeleton variant="text" width={200} />
         </div>
       </LoadingDetails>
     )
@@ -292,7 +292,6 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
           {translate('text_626162c62f790600f850b75a')}
         </Button>
       </SectionHeader>
-
       <InfosBlock
         ref={(node) => {
           infosRef.current = node
@@ -461,8 +460,8 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
             <Typography variant="caption">{translate('text_66423cad72bbad009f2f568f')}</Typography>
             {integrationsLoading ? (
               <Stack flex={1} gap={3} marginTop={1}>
-                <Skeleton variant="text" height={12} width={200} />
-                <Skeleton variant="text" height={12} width={200} />
+                <Skeleton variant="text" width={200} />
+                <Skeleton variant="text" width={200} />
               </Stack>
             ) : !!connectedNetsuiteIntegration && customer?.netsuiteCustomer?.externalCustomerId ? (
               <Stack>
@@ -494,8 +493,8 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
             <Typography variant="caption">{translate('text_66423cad72bbad009f2f568f')}</Typography>
             {integrationsLoading ? (
               <Stack flex={1} gap={3} marginTop={1}>
-                <Skeleton variant="text" height={12} width={200} />
-                <Skeleton variant="text" height={12} width={200} />
+                <Skeleton variant="text" width={200} />
+                <Skeleton variant="text" width={200} />
               </Stack>
             ) : !!connectedXeroIntegration && customer?.xeroCustomer?.externalCustomerId ? (
               <Stack>
@@ -524,8 +523,8 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
             <Typography variant="caption">{translate('text_6668821d94e4da4dfd8b3840')}</Typography>
             {integrationsLoading ? (
               <Stack flex={1} gap={3} marginTop={1}>
-                <Skeleton variant="text" height={12} width={200} />
-                <Skeleton variant="text" height={12} width={200} />
+                <Skeleton variant="text" width={200} />
+                <Skeleton variant="text" width={200} />
               </Stack>
             ) : !!connectedAnrokIntegration && customer?.anrokCustomer?.integrationId ? (
               <Stack>
@@ -560,8 +559,8 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
             <Typography variant="caption">{translate('text_1728658962985xpfdvl5ru8a')}</Typography>
             {integrationsLoading ? (
               <Stack flex={1} gap={3} marginTop={1}>
-                <Skeleton variant="text" height={12} width={200} />
-                <Skeleton variant="text" height={12} width={200} />
+                <Skeleton variant="text" width={200} />
+                <Skeleton variant="text" width={200} />
               </Stack>
             ) : !!connectedHubspotIntegration &&
               customer?.hubspotCustomer?.integrationId &&
@@ -610,7 +609,6 @@ export const CustomerMainInfos = ({ loading, customer, onEdit }: CustomerMainInf
             </div>
           ))}
       </InfosBlock>
-
       {shouldSeeMoreButton && !showMore && (
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
         <ShowMoreButton

--- a/src/components/customers/subscriptions/SubscriptionItem.tsx
+++ b/src/components/customers/subscriptions/SubscriptionItem.tsx
@@ -134,8 +134,8 @@ export const SubscriptionItemSkeleton = () => {
     <SkeletonItem>
       <Skeleton variant="connectorAvatar" size="big" marginRight="12px" />
       <div>
-        <Skeleton variant="text" width={240} height={12} marginBottom="12px" />
-        <Skeleton variant="text" width={120} height={12} />
+        <Skeleton variant="text" width={240} marginBottom="12px" />
+        <Skeleton variant="text" width={120} />
       </div>
     </SkeletonItem>
   )

--- a/src/components/designSystem/graphs/ChartHeader.tsx
+++ b/src/components/designSystem/graphs/ChartHeader.tsx
@@ -22,8 +22,8 @@ const ChartHeader = ({
     <>
       {!!loading ? (
         <div className="flex h-14 flex-col justify-between pb-2 pt-1">
-          <Skeleton variant="text" width={72} height={12} marginBottom={4} />
-          <Skeleton variant="text" width={160} height={12} />
+          <Skeleton variant="text" width={72} marginBottom={4} />
+          <Skeleton variant="text" width={160} />
         </div>
       ) : (
         <ChartWrapper className="flex flex-col items-start justify-between gap-2" blur={blur}>

--- a/src/components/details/DetailsHeader.tsx
+++ b/src/components/details/DetailsHeader.tsx
@@ -37,8 +37,8 @@ export const DetailsHeaderSkeleton = () => {
 
       <HeaderDetailsWrapper>
         <LoadingWrapper>
-          <Skeleton variant="text" width={200} height={12} marginBottom={20} />
-          <Skeleton variant="text" width={200} height={12} />
+          <Skeleton variant="text" width={200} marginBottom={20} />
+          <Skeleton variant="text" width={200} />
         </LoadingWrapper>
       </HeaderDetailsWrapper>
     </HeaderWrapper>

--- a/src/components/developers/EventItem.tsx
+++ b/src/components/developers/EventItem.tsx
@@ -61,8 +61,8 @@ export const EventItemSkeleton = () => {
   return (
     <BaseListItem>
       <Skeleton className="mr-3" variant="connectorAvatar" size="big" />
-      <Skeleton className="mr-auto" variant="text" height={12} width={264} />
-      <Skeleton className="ml-3" variant="text" height={12} width={80} />
+      <Skeleton className="mr-auto" variant="text" width={264} />
+      <Skeleton className="ml-3" variant="text" width={80} />
     </BaseListItem>
   )
 }

--- a/src/components/developers/WebhookLogItem.tsx
+++ b/src/components/developers/WebhookLogItem.tsx
@@ -69,8 +69,8 @@ export const WebhookLogItemSkeleton = () => {
   return (
     <BaseListItem>
       <Skeleton className="mr-3" variant="connectorAvatar" size="big" />
-      <Skeleton className="mr-auto" variant="text" height={12} width={264} />
-      <Skeleton className="ml-3" variant="text" height={12} width={80} />
+      <Skeleton className="mr-auto" variant="text" width={264} />
+      <Skeleton className="ml-3" variant="text" width={80} />
     </BaseListItem>
   )
 }

--- a/src/components/emails/DunningEmail.tsx
+++ b/src/components/emails/DunningEmail.tsx
@@ -60,9 +60,9 @@ export interface DunningEmailProps {
 export const DunningEmailSkeleton = () => {
   return (
     <>
-      <Skeleton variant="text" width={104} height={12} color="dark" />
-      <Skeleton variant="text" width="100%" height={12} color="dark" />
-      <Skeleton variant="text" width={160} height={12} color="dark" />
+      <Skeleton variant="text" width={104} color="dark" />
+      <Skeleton variant="text" width="100%" color="dark" />
+      <Skeleton variant="text" width={160} color="dark" />
     </>
   )
 }

--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -136,7 +136,7 @@ export const ComboBox = ({
           {[1, 2, 3].map((i) => (
             <LoadingItem key={`combobox-loading-item-${i}`}>
               <Skeleton variant="circular" width={16} height={16} marginRight="16px" />
-              <Skeleton variant="text" width="100%" height={12} />
+              <Skeleton variant="text" width="100%" />
             </LoadingItem>
           ))}
         </LoadingIemsWrapper>

--- a/src/components/graphs/Invoices.tsx
+++ b/src/components/graphs/Invoices.tsx
@@ -302,14 +302,14 @@ const Invoices = ({
             <GraphWrapper>
               {!!isLoading ? (
                 <>
-                  <Skeleton variant="text" width="100%" height={12} />
+                  <Skeleton variant="text" width="100%" />
 
                   <div>
                     {[...Array(3)].map((_, index) => (
                       <SkeletonLine key={`invoices-skeleton-${index}`}>
                         <Skeleton variant="circular" width={8} height={8} />
-                        <Skeleton variant="text" width="32%" height={12} />
-                        <Skeleton variant="text" width="32%" height={12} />
+                        <Skeleton variant="text" width="32%" />
+                        <Skeleton variant="text" width="32%" />
                       </SkeletonLine>
                     ))}
                   </div>

--- a/src/components/graphs/Usage.tsx
+++ b/src/components/graphs/Usage.tsx
@@ -234,14 +234,14 @@ const Usage = ({
             <GraphWrapper>
               {!!isLoading ? (
                 <>
-                  <Skeleton variant="text" width="100%" height={12} />
+                  <Skeleton variant="text" width="100%" />
 
                   <div>
                     {[...Array(3)].map((_, index) => (
                       <SkeletonLine key={`usage-skeleton-${index}`}>
                         <Skeleton variant="circular" width={8} height={8} />
-                        <Skeleton variant="text" width="32%" height={12} />
-                        <Skeleton variant="text" width="32%" height={12} />
+                        <Skeleton variant="text" width="32%" />
+                        <Skeleton variant="text" width="32%" />
                       </SkeletonLine>
                     ))}
                   </div>

--- a/src/components/layouts/Settings.tsx
+++ b/src/components/layouts/Settings.tsx
@@ -36,9 +36,9 @@ export const SettingsListItemLoadingSkeleton = ({ count = 1 }: { count?: number 
       key={`settings-list-item-skeleton-${index}`}
       className="flex w-full flex-col justify-between pb-8 shadow-b last:pb-0 last:[box-shadow:none]"
     >
-      <Skeleton variant="text" width={160} height={12} marginBottom={24} />
-      <Skeleton variant="text" width={320} height={12} marginBottom={28} />
-      <Skeleton variant="text" width={240} height={12} marginBottom={8} />
+      <Skeleton variant="text" width={160} marginBottom={24} />
+      <Skeleton variant="text" width={320} marginBottom={28} />
+      <Skeleton variant="text" width={240} marginBottom={8} />
     </div>
   ))
 

--- a/src/components/plans/CommitmentsSection.tsx
+++ b/src/components/plans/CommitmentsSection.tsx
@@ -127,7 +127,6 @@ export const CommitmentsSection = ({
           })}
         </Typography>
       </SectionTitle>
-
       {displayMinimumCommitment ? (
         <StyledAccordion
           summary={

--- a/src/components/plans/PlanItem.tsx
+++ b/src/components/plans/PlanItem.tsx
@@ -165,8 +165,8 @@ export const PlanItemSkeleton = () => {
   return (
     <BaseListItem>
       <Skeleton variant="connectorAvatar" size="big" marginRight={theme.spacing(3)} />
-      <Skeleton variant="text" height={12} width={240} marginRight="auto" />
-      <Skeleton variant="text" height={12} width={240} />
+      <Skeleton variant="text" width={240} marginRight="auto" />
+      <Skeleton variant="text" width={240} />
     </BaseListItem>
   )
 }

--- a/src/components/plans/details/PlanSubscriptionListItem.tsx
+++ b/src/components/plans/details/PlanSubscriptionListItem.tsx
@@ -107,13 +107,13 @@ export const PlanSubscriptionListItemSkeleton = ({
       <CustomerNameWrapper>
         <Skeleton variant="circular" width={40} height={40} />
         <CustomerBlockInfos>
-          <Skeleton variant="text" height={12} width={160} marginBottom={14} />
-          <Skeleton variant="text" height={12} width={100} />
+          <Skeleton variant="text" width={160} marginBottom={14} />
+          <Skeleton variant="text" width={100} />
         </CustomerBlockInfos>
       </CustomerNameWrapper>
-      <Skeleton variant="text" height={12} width={80} />
-      <Skeleton variant="text" height={12} width={80} />
-      <Skeleton variant="text" height={12} width={80} />
+      <Skeleton variant="text" width={80} />
+      <Skeleton variant="text" width={80} />
+      <Skeleton variant="text" width={80} />
     </SkeletonWrapper>
   )
 }

--- a/src/components/settings/integrations/AnrokIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AnrokIntegrationSettings.tsx
@@ -155,7 +155,7 @@ const AnrokIntegrationSettings = () => {
                 {[0, 1, 2].map((i) => (
                   <Item key={`item-skeleton-item-${i}`}>
                     <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                    <Skeleton variant="text" width={240} height={12} />
+                    <Skeleton variant="text" width={240} />
                   </Item>
                 ))}
               </>
@@ -224,7 +224,7 @@ const AnrokIntegrationSettings = () => {
               {translate('text_66ba5a76e614f000a738c97a')}
             </Typography>
             {loading ? (
-              <CustomSkeleton variant="text" width="100%" height={12} />
+              <CustomSkeleton variant="text" width="100%" />
             ) : !!anrokIntegration?.failedInvoicesCount ? (
               <Stack display="inline" divider={<>{/* Space here is important */} </>}>
                 <Typography component="span" variant="caption" color="grey600">

--- a/src/components/settings/integrations/IntegrationItemLine.tsx
+++ b/src/components/settings/integrations/IntegrationItemLine.tsx
@@ -35,8 +35,8 @@ const IntegrationItemLine = ({
         <Stack direction="row" alignItems="center" gap={3} sx={{ flex: 1 }}>
           <Skeleton variant="connectorAvatar" size="big" />
           <Stack sx={{ flex: 1 }}>
-            <Skeleton variant="text" width={180} height={12} marginBottom={10} />
-            <Skeleton variant="text" width={80} height={12} />
+            <Skeleton variant="text" width={180} marginBottom={10} />
+            <Skeleton variant="text" width={80} />
           </Stack>
         </Stack>
 

--- a/src/components/settings/integrations/NetsuiteIntegrationSettings.tsx
+++ b/src/components/settings/integrations/NetsuiteIntegrationSettings.tsx
@@ -167,7 +167,7 @@ const NetsuiteIntegrationSettings = () => {
                 {[0, 1, 2].map((i) => (
                   <Item key={`item-skeleton-item-${i}`}>
                     <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                    <Skeleton variant="text" width={240} height={12} />
+                    <Skeleton variant="text" width={240} />
                   </Item>
                 ))}
               </>

--- a/src/components/settings/integrations/XeroIntegrationSettings.tsx
+++ b/src/components/settings/integrations/XeroIntegrationSettings.tsx
@@ -163,7 +163,7 @@ const XeroIntegrationSettings = () => {
                 {[0, 1, 2].map((i) => (
                   <Item key={`item-skeleton-item-${i}`}>
                     <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                    <Skeleton variant="text" width={240} height={12} />
+                    <Skeleton variant="text" width={240} />
                   </Item>
                 ))}
               </>

--- a/src/components/subscriptions/SubscriptionCurrentUsageTable.tsx
+++ b/src/components/subscriptions/SubscriptionCurrentUsageTable.tsx
@@ -189,7 +189,7 @@ export const SubscriptionCurrentUsageTableComponent = ({
         </Stack>
 
         {isLoading ? (
-          <Skeleton variant="text" height={12} width={144} marginTop={8} />
+          <Skeleton variant="text" width={144} marginTop={8} />
         ) : !hasError && !!usageData?.fromDatetime && !!usageData?.toDatetime ? (
           <Typography variant="caption" color="grey600" noWrap>
             {translate('text_633dae57ca9a923dd53c2097', {
@@ -260,7 +260,7 @@ export const SubscriptionCurrentUsageTableComponent = ({
             </Typography>
 
             {isLoading ? (
-              <Skeleton variant="text" height={12} width={144} marginTop={8} />
+              <Skeleton variant="text" width={144} marginTop={8} />
             ) : (
               <Typography variant="bodyHl" color="grey700" noWrap>
                 {intlFormatNumber(deserializeAmount(usageData?.amountCents, currency) || 0, {
@@ -460,8 +460,8 @@ export const SubscriptionCurrentUsageTableSkeleton = () => {
       <Button size="small" variant="quaternary" disabled icon="chevron-right" />
       <Skeleton variant="connectorAvatar" size="big" marginRight="12px" />
       <div>
-        <Skeleton variant="text" width={240} height={12} marginBottom="12px" />
-        <Skeleton variant="text" width={120} height={12} />
+        <Skeleton variant="text" width={240} marginBottom="12px" />
+        <Skeleton variant="text" width={120} />
       </div>
     </SkeletonItem>
   )

--- a/src/components/subscriptions/SubscriptionUsageLifetimeGraph.tsx
+++ b/src/components/subscriptions/SubscriptionUsageLifetimeGraph.tsx
@@ -131,7 +131,7 @@ export const SubscriptionUsageLifetimeGraphComponent = ({
         </div>
 
         {isLoading ? (
-          <Skeleton variant="text" height={12} width={144} marginTop={8} />
+          <Skeleton variant="text" width={144} marginTop={8} />
         ) : !subscriptionError && !!lifetimeUsage ? (
           <Typography
             variant="caption"
@@ -206,11 +206,11 @@ export const SubscriptionUsageLifetimeGraphComponent = ({
                   <div className="flex flex-col gap-3">
                     {!!isLoading ? (
                       <div className="flex flex-col gap-3">
-                        <Skeleton variant="text" width="100%" height={12} />
+                        <Skeleton variant="text" width="100%" />
 
                         <div className="flex h-6 items-center gap-2">
-                          <Skeleton variant="text" width="32%" height={12} />
-                          <Skeleton variant="text" width="32%" height={12} className="ml-auto" />
+                          <Skeleton variant="text" width="32%" />
+                          <Skeleton variant="text" width="32%" className="ml-auto" />
                         </div>
                       </div>
                     ) : (

--- a/src/components/wallets/WalletAccordion.tsx
+++ b/src/components/wallets/WalletAccordion.tsx
@@ -365,8 +365,8 @@ export const WalletAccordionSkeleton = () => {
         <Icon name="chevron-right" color="disabled" />
         <Skeleton variant="connectorAvatar" size="big" />
         <SummaryInfos $isLoading>
-          <Skeleton variant="text" height={12} width={240} marginBottom={theme.spacing(3)} />
-          <Skeleton variant="text" height={12} width={120} />
+          <Skeleton variant="text" width={240} marginBottom={theme.spacing(3)} />
+          <Skeleton variant="text" width={120} />
         </SummaryInfos>
       </SummaryLeft>
     </SkeletonContainer>

--- a/src/components/wallets/WalletTransactionList.tsx
+++ b/src/components/wallets/WalletTransactionList.tsx
@@ -81,7 +81,6 @@ export const WalletTransactionList = forwardRef<TopupWalletDialogRef, WalletTran
             </Typography>
           </TransactionListHeader>
         )}
-
         <TransactionListWrapper>
           {!!error && !loading ? (
             <GenericState
@@ -97,22 +96,12 @@ export const WalletTransactionList = forwardRef<TopupWalletDialogRef, WalletTran
               <Loader key={`wallet-transaction-skeleton-${i}`}>
                 <Skeleton variant="connectorAvatar" size="big" marginRight={theme.spacing(3)} />
                 <LeftLoader>
-                  <Skeleton
-                    variant="text"
-                    height={12}
-                    width={144}
-                    marginBottom={theme.spacing(3)}
-                  />
-                  <Skeleton variant="text" height={12} width={80} />
+                  <Skeleton variant="text" width={144} marginBottom={theme.spacing(3)} />
+                  <Skeleton variant="text" width={80} />
                 </LeftLoader>
                 <RightLoader>
-                  <Skeleton
-                    variant="text"
-                    height={12}
-                    width={144}
-                    marginBottom={theme.spacing(3)}
-                  />
-                  <Skeleton variant="text" height={12} width={80} />
+                  <Skeleton variant="text" width={144} marginBottom={theme.spacing(3)} />
+                  <Skeleton variant="text" width={80} />
                 </RightLoader>
               </Loader>
             ))

--- a/src/layouts/CustomerInvoiceDetails.tsx
+++ b/src/layouts/CustomerInvoiceDetails.tsx
@@ -557,7 +557,7 @@ const CustomerInvoiceDetails = () => {
         <HeaderLeft>
           <Button icon="arrow-left" variant="quaternary" onClick={() => goToPreviousRoute()} />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {number}
@@ -820,7 +820,6 @@ const CustomerInvoiceDetails = () => {
           </Popper>
         )}
       </PageHeader>
-
       {!!errorMessage && (
         <Alert fullWidth className="md:px-12" type="warning">
           <Stack>
@@ -832,7 +831,6 @@ const CustomerInvoiceDetails = () => {
           </Stack>
         </Alert>
       )}
-
       {hasError ? (
         <GenericPlaceholder
           title={translate('text_634812d6f16b31ce5cbf4111')}
@@ -848,8 +846,8 @@ const CustomerInvoiceDetails = () => {
             <MainInfos>
               <Skeleton variant="connectorAvatar" size="large" />
               <div>
-                <Skeleton variant="text" height={12} width={200} marginBottom={theme.spacing(5)} />
-                <Skeleton variant="text" height={12} width={128} />
+                <Skeleton variant="text" width={200} marginBottom={theme.spacing(5)} />
+                <Skeleton variant="text" width={128} />
               </div>
             </MainInfos>
           ) : (

--- a/src/layouts/SideNavLayout.tsx
+++ b/src/layouts/SideNavLayout.tsx
@@ -200,8 +200,8 @@ const SideNav = () => {
                     </Button>
                     {!!loading && !error ? (
                       <Version>
-                        <Skeleton variant="text" height={12} width={48} />
-                        <Skeleton variant="text" height={12} width={120} />
+                        <Skeleton variant="text" width={48} />
+                        <Skeleton variant="text" width={120} />
                       </Version>
                     ) : !!data && !error ? (
                       <Version>

--- a/src/pages/AddOnDetails.tsx
+++ b/src/pages/AddOnDetails.tsx
@@ -75,7 +75,7 @@ const AddOnDetails = () => {
           />
           {isAddOnLoading && !addOn ? (
             <AddOnTitleLoadingWrapper>
-              <Skeleton variant="text" width={200} height={12} />
+              <Skeleton variant="text" width={200} />
             </AddOnTitleLoadingWrapper>
           ) : (
             <Typography
@@ -134,7 +134,6 @@ const AddOnDetails = () => {
           </Popper>
         )}
       </PageHeader>
-
       {isAddOnLoading ? (
         <DetailsHeaderSkeleton />
       ) : (
@@ -144,7 +143,6 @@ const AddOnDetails = () => {
           description={translate('text_629728388c4d2300e2d3810b', { amountWithCurrency })}
         />
       )}
-
       <Container>
         <section>
           <DetailsSectionTitle variant="subhead" noWrap>
@@ -203,7 +201,6 @@ const AddOnDetails = () => {
           </DetailsCard>
         </section>
       </Container>
-
       <DeleteAddOnDialog ref={deleteDialogRef} />
     </>
   )

--- a/src/pages/CouponDetails.tsx
+++ b/src/pages/CouponDetails.tsx
@@ -102,7 +102,7 @@ const CouponDetails = () => {
           />
           {isCouponLoading && !coupon ? (
             <CouponTitleLoadingWrapper>
-              <Skeleton variant="text" width={200} height={12} />
+              <Skeleton variant="text" width={200} />
             </CouponTitleLoadingWrapper>
           ) : (
             <Typography
@@ -162,7 +162,6 @@ const CouponDetails = () => {
           </Popper>
         )}
       </PageHeader>
-
       {isCouponLoading ? (
         <DetailsHeaderSkeleton />
       ) : (
@@ -172,7 +171,6 @@ const CouponDetails = () => {
           description={`${couponValue} ${coupon?.frequency}`}
         />
       )}
-
       <Container>
         <section>
           <DetailsSectionTitle variant="subhead" noWrap>
@@ -330,7 +328,6 @@ const CouponDetails = () => {
           </section>
         )}
       </Container>
-
       <DeleteCouponDialog ref={deleteDialogRef} />
     </>
   )

--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -165,43 +165,22 @@ const CreateAddOn = () => {
           }
         />
       </PageHeader>
-
       <Content>
         <Main>
           <div>
             {loading ? (
               <>
                 <SkeletonHeader>
-                  <Skeleton
-                    variant="text"
-                    width={280}
-                    height={12}
-                    marginBottom={theme.spacing(5)}
-                  />
-                  <Skeleton
-                    variant="text"
-                    width="inherit"
-                    height={12}
-                    marginBottom={theme.spacing(4)}
-                  />
-                  <Skeleton variant="text" width={120} height={12} />
+                  <Skeleton variant="text" width={280} marginBottom={theme.spacing(5)} />
+                  <Skeleton variant="text" width="inherit" marginBottom={theme.spacing(4)} />
+                  <Skeleton variant="text" width={120} />
                 </SkeletonHeader>
 
                 {[0, 1, 2].map((skeletonCard) => (
                   <Card key={`skeleton-${skeletonCard}`}>
-                    <Skeleton
-                      variant="text"
-                      width={280}
-                      height={12}
-                      marginBottom={theme.spacing(9)}
-                    />
-                    <Skeleton
-                      variant="text"
-                      width="inherit"
-                      height={12}
-                      marginBottom={theme.spacing(4)}
-                    />
-                    <Skeleton variant="text" width={120} height={12} />
+                    <Skeleton variant="text" width={280} marginBottom={theme.spacing(9)} />
+                    <Skeleton variant="text" width="inherit" marginBottom={theme.spacing(4)} />
+                    <Skeleton variant="text" width={120} />
                   </Card>
                 ))}
               </>
@@ -414,7 +393,6 @@ const CreateAddOn = () => {
           <AddOnCodeSnippet loading={loading} addOn={formikProps.values} />
         </Side>
       </Content>
-
       <WarningDialog
         ref={warningDialogRef}
         title={translate('text_665deda4babaf700d603ea13')}

--- a/src/pages/CreateBillableMetric.tsx
+++ b/src/pages/CreateBillableMetric.tsx
@@ -266,43 +266,22 @@ const CreateBillableMetric = () => {
           }
         />
       </PageHeader>
-
       <Content>
         <Main>
           <div>
             {loading ? (
               <>
                 <SkeletonHeader>
-                  <Skeleton
-                    variant="text"
-                    width={280}
-                    height={12}
-                    marginBottom={theme.spacing(5)}
-                  />
-                  <Skeleton
-                    variant="text"
-                    width="inherit"
-                    height={12}
-                    marginBottom={theme.spacing(4)}
-                  />
-                  <Skeleton variant="text" width={120} height={12} />
+                  <Skeleton variant="text" width={280} marginBottom={theme.spacing(5)} />
+                  <Skeleton variant="text" width="inherit" marginBottom={theme.spacing(4)} />
+                  <Skeleton variant="text" width={120} />
                 </SkeletonHeader>
 
                 {[0, 1, 2].map((skeletonCard) => (
                   <Card key={`skeleton-${skeletonCard}`}>
-                    <Skeleton
-                      variant="text"
-                      width={280}
-                      height={12}
-                      marginBottom={theme.spacing(9)}
-                    />
-                    <Skeleton
-                      variant="text"
-                      width="inherit"
-                      height={12}
-                      marginBottom={theme.spacing(4)}
-                    />
-                    <Skeleton variant="text" width={120} height={12} />
+                    <Skeleton variant="text" width={280} marginBottom={theme.spacing(9)} />
+                    <Skeleton variant="text" width="inherit" marginBottom={theme.spacing(4)} />
+                    <Skeleton variant="text" width={120} />
                   </Card>
                 ))}
               </>
@@ -909,12 +888,10 @@ const CreateBillableMetric = () => {
           <BillableMetricCodeSnippet loading={loading} billableMetric={formikProps.values} />
         </Side>
       </Content>
-
       <CustomExpressionDrawer
         ref={customExpressionDrawerRef}
         onSave={(expression: string) => formikProps.setFieldValue('expression', expression)}
       />
-
       <WarningDialog
         ref={warningDirtyAttributesDialogRef}
         title={translate(

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -232,43 +232,22 @@ const CreateCoupon = () => {
           }
         />
       </PageHeader>
-
       <Content>
         <Main>
           <div>
             {loading ? (
               <>
                 <SkeletonHeader>
-                  <Skeleton
-                    variant="text"
-                    width={280}
-                    height={12}
-                    marginBottom={theme.spacing(5)}
-                  />
-                  <Skeleton
-                    variant="text"
-                    width="inherit"
-                    height={12}
-                    marginBottom={theme.spacing(4)}
-                  />
-                  <Skeleton variant="text" width={120} height={12} />
+                  <Skeleton variant="text" width={280} marginBottom={theme.spacing(5)} />
+                  <Skeleton variant="text" width="inherit" marginBottom={theme.spacing(4)} />
+                  <Skeleton variant="text" width={120} />
                 </SkeletonHeader>
 
                 {[0, 1].map((skeletonCard) => (
                   <Card key={`skeleton-${skeletonCard}`}>
-                    <Skeleton
-                      variant="text"
-                      width={280}
-                      height={12}
-                      marginBottom={theme.spacing(9)}
-                    />
-                    <Skeleton
-                      variant="text"
-                      width="inherit"
-                      height={12}
-                      marginBottom={theme.spacing(4)}
-                    />
-                    <Skeleton variant="text" width={120} height={12} />
+                    <Skeleton variant="text" width={280} marginBottom={theme.spacing(9)} />
+                    <Skeleton variant="text" width="inherit" marginBottom={theme.spacing(4)} />
+                    <Skeleton variant="text" width={120} />
                   </Card>
                 ))}
               </>
@@ -664,7 +643,6 @@ const CreateCoupon = () => {
           />
         </Side>
       </Content>
-
       <WarningDialog
         ref={warningDialogRef}
         title={translate('text_665deda4babaf700d603ea13')}
@@ -672,13 +650,11 @@ const CreateCoupon = () => {
         continueText={translate('text_645388d5bdbd7b00abffa033')}
         onContinue={() => couponCloseRedirection()}
       />
-
       <AddPlanToCouponDialog
         ref={addPlanToCouponDialogRef}
         onSubmit={attachPlanToCoupon}
         attachedPlansIds={limitPlansList.map((p) => p.id)}
       />
-
       <AddBillableMetricToCouponDialog
         ref={addBillableMetricToCouponDialogRef}
         onSubmit={attachBillableMetricToCoupon}

--- a/src/pages/CreateCreditNote.tsx
+++ b/src/pages/CreateCreditNote.tsx
@@ -245,7 +245,7 @@ const CreateCreditNote = () => {
       <PageHeader>
         {loading ? (
           <div>
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           </div>
         ) : (
           <Typography variant="bodyHl" color="textSecondary" noWrap>
@@ -270,22 +270,21 @@ const CreateCreditNote = () => {
           }
         />
       </PageHeader>
-
       <Content>
         <Main>
           <div>
             {loading ? (
               <>
-                <Skeleton variant="text" height={12} width={280} marginBottom="22px" />
-                <Skeleton variant="text" height={12} width={480} marginBottom="40px" />
+                <Skeleton variant="text" width={280} marginBottom="22px" />
+                <Skeleton variant="text" width={480} marginBottom="40px" />
                 <StyledCard $loading>
                   <Skeleton variant="connectorAvatar" size="medium" marginRight="12px" />
-                  <Skeleton variant="text" height={12} width={160} />
+                  <Skeleton variant="text" width={160} />
                 </StyledCard>
                 <Card>
-                  <Skeleton variant="text" height={12} width={416} marginBottom="36px" />
-                  <Skeleton variant="text" height={12} width={656} marginBottom="16px" />
-                  <Skeleton variant="text" height={12} width={256} />
+                  <Skeleton variant="text" width={416} marginBottom="36px" />
+                  <Skeleton variant="text" width={656} marginBottom="16px" />
+                  <Skeleton variant="text" width={256} />
                 </Card>
                 <ButtonContainer>
                   <Button size="large" disabled fullWidth>
@@ -620,7 +619,6 @@ const CreateCreditNote = () => {
           />
         </Side>
       </Content>
-
       <WarningDialog
         ref={warningDialogRef}
         title={translate('text_636bdf192a28e7cf28abf00d')}

--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -474,14 +474,13 @@ const CreateInvoice = () => {
           />
         )}
       </PageHeader>
-
       <PageWrapper>
         <CenteredWrapper>
           <BorderedCard $disableChildSpacing>
             {loading ? (
               <>
                 <InvoiceHeader>
-                  <Skeleton variant="text" width={120} height={12} />
+                  <Skeleton variant="text" width={120} />
                   <Skeleton
                     // eslint-disable-next-line tailwindcss/no-custom-classname
                     className="rounded-conector-skeleton"
@@ -491,26 +490,26 @@ const CreateInvoice = () => {
                 </InvoiceHeader>
                 <div>
                   <InlineSkeleton>
-                    <Skeleton variant="text" width={104} height={12} marginRight={52} />
-                    <Skeleton variant="text" width={96} height={12} />
+                    <Skeleton variant="text" width={104} marginRight={52} />
+                    <Skeleton variant="text" width={96} />
                   </InlineSkeleton>
                   <InlineSkeleton>
-                    <Skeleton variant="text" width={104} height={12} marginRight={52} />
-                    <Skeleton variant="text" width={96} height={12} />
+                    <Skeleton variant="text" width={104} marginRight={52} />
+                    <Skeleton variant="text" width={96} />
                   </InlineSkeleton>
                 </div>
                 <InlineSkeletonBlocks>
                   <div>
-                    <InfoSkeleton variant="text" width={104} height={12} />
-                    <InfoSkeleton variant="text" width={184} height={12} />
-                    <InfoSkeleton variant="text" width={184} height={12} />
-                    <InfoSkeleton variant="text" width={184} height={12} />
+                    <InfoSkeleton variant="text" width={104} />
+                    <InfoSkeleton variant="text" width={184} />
+                    <InfoSkeleton variant="text" width={184} />
+                    <InfoSkeleton variant="text" width={184} />
                   </div>
                   <div>
-                    <InfoSkeleton variant="text" width={104} height={12} />
-                    <InfoSkeleton variant="text" width={184} height={12} />
-                    <InfoSkeleton variant="text" width={184} height={12} />
-                    <InfoSkeleton variant="text" width={184} height={12} />
+                    <InfoSkeleton variant="text" width={104} />
+                    <InfoSkeleton variant="text" width={184} />
+                    <InfoSkeleton variant="text" width={184} />
+                    <InfoSkeleton variant="text" width={184} />
                   </div>
                 </InlineSkeletonBlocks>
               </>
@@ -1215,7 +1214,6 @@ const CreateInvoice = () => {
           </CustomStickySubmitBar>
         )}
       </PageWrapper>
-
       <WarningDialog
         ref={warningDialogRef}
         title={translate('text_645388d5bdbd7b00abffa030')}
@@ -1223,7 +1221,6 @@ const CreateInvoice = () => {
         continueText={translate('text_645388d5bdbd7b00abffa033')}
         onContinue={handleClosePage}
       />
-
       <EditInvoiceItemDescriptionDialog ref={editDescriptionDialogRef} />
       <EditInvoiceItemTaxDialog ref={editTaxDialogRef} />
       <EditInvoiceDisplayName ref={editInvoiceDisplayNameRef} />

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -182,43 +182,22 @@ const CreatePlan = () => {
           data-test="close-create-plan-button"
         />
       </PageHeader>
-
       <Content>
         <Main>
           <MainMinimumContent>
             {loading && !plan ? (
               <>
                 <SkeletonHeader>
-                  <Skeleton
-                    variant="text"
-                    width={280}
-                    height={12}
-                    marginBottom={theme.spacing(5)}
-                  />
-                  <Skeleton
-                    variant="text"
-                    width="inherit"
-                    height={12}
-                    marginBottom={theme.spacing(4)}
-                  />
-                  <Skeleton variant="text" width={120} height={12} />
+                  <Skeleton variant="text" width={280} marginBottom={theme.spacing(5)} />
+                  <Skeleton variant="text" width="inherit" marginBottom={theme.spacing(4)} />
+                  <Skeleton variant="text" width={120} />
                 </SkeletonHeader>
 
                 {[0, 1, 2].map((skeletonCard) => (
                   <Card key={`skeleton-${skeletonCard}`}>
-                    <Skeleton
-                      variant="text"
-                      width={280}
-                      height={12}
-                      marginBottom={theme.spacing(9)}
-                    />
-                    <Skeleton
-                      variant="text"
-                      width="inherit"
-                      height={12}
-                      marginBottom={theme.spacing(4)}
-                    />
-                    <Skeleton variant="text" width={120} height={12} />
+                    <Skeleton variant="text" width={280} marginBottom={theme.spacing(9)} />
+                    <Skeleton variant="text" width="inherit" marginBottom={theme.spacing(4)} />
+                    <Skeleton variant="text" width={120} />
                   </Card>
                 ))}
               </>
@@ -316,7 +295,6 @@ const CreatePlan = () => {
           <PlanCodeSnippet loading={loading} plan={formikProps.values} />
         </Side>
       </Content>
-
       <WarningDialog
         ref={warningDialogRef}
         title={translate('text_665deda4babaf700d603ea13')}
@@ -324,7 +302,6 @@ const CreatePlan = () => {
         continueText={translate('text_645388d5bdbd7b00abffa033')}
         onContinue={() => planCloseRedirection()}
       />
-
       <EditInvoiceDisplayName ref={editInvoiceDisplayNameRef} />
       <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </div>

--- a/src/pages/CreateSubscription.tsx
+++ b/src/pages/CreateSubscription.tsx
@@ -134,12 +134,11 @@ const LoadingSkeleton = () => {
         <Typography variant="headline">{translate('text_6335e8900c69f8ebdfef5312')}</Typography>
         <Card>
           <div>
-            <Skeleton variant="text" height={12} width={160} marginBottom={theme.spacing(3)} />
-            <Skeleton variant="text" height={12} width={384} />
+            <Skeleton variant="text" width={160} marginBottom={theme.spacing(3)} />
+            <Skeleton variant="text" width={384} />
           </div>
         </Card>
       </SectionWrapper>
-
       <SectionWrapper>
         <SectionTitle>
           <Typography variant="headline">{translate('text_642d5eb2783a2ad10d67031a')}</Typography>
@@ -148,7 +147,7 @@ const LoadingSkeleton = () => {
         <Card>
           <AccordionSkeleton>
             <Icon name="chevron-right" />
-            <Skeleton variant="text" height={12} width={160} />
+            <Skeleton variant="text" width={160} />
           </AccordionSkeleton>
         </Card>
       </SectionWrapper>
@@ -160,29 +159,29 @@ const LoadingSkeleton = () => {
         <Section>
           <Card>
             <div>
-              <Skeleton variant="text" height={12} width={160} marginBottom={theme.spacing(3)} />
-              <Skeleton variant="text" height={12} width={384} />
+              <Skeleton variant="text" width={160} marginBottom={theme.spacing(3)} />
+              <Skeleton variant="text" width={384} />
             </div>
             {Array(3)
               .fill('')
               .map((_, skeletonIndex) => (
                 <AccordionSkeleton key={`loading-skeleton-${skeletonIndex}`}>
                   <Icon name="chevron-right" />
-                  <Skeleton variant="text" height={12} width={160} />
+                  <Skeleton variant="text" width={160} />
                 </AccordionSkeleton>
               ))}
           </Card>
           <Card>
             <div>
-              <Skeleton variant="text" height={12} width={160} marginBottom={theme.spacing(3)} />
-              <Skeleton variant="text" height={12} width={384} />
+              <Skeleton variant="text" width={160} marginBottom={theme.spacing(3)} />
+              <Skeleton variant="text" width={384} />
             </div>
             {Array(2)
               .fill('')
               .map((_, skeletonIndex) => (
                 <AccordionSkeleton key={`loading-skeleton-${skeletonIndex}`}>
                   <Icon name="chevron-right" />
-                  <Skeleton variant="text" height={12} width={160} />
+                  <Skeleton variant="text" width={160} />
                 </AccordionSkeleton>
               ))}
           </Card>

--- a/src/pages/CreateTax.tsx
+++ b/src/pages/CreateTax.tsx
@@ -84,43 +84,22 @@ const CreateTaxRate = () => {
           }
         />
       </PageHeader>
-
       <Content>
         <Main>
           <div>
             {loading && !tax ? (
               <>
                 <SkeletonHeader>
-                  <Skeleton
-                    variant="text"
-                    width={280}
-                    height={12}
-                    marginBottom={theme.spacing(5)}
-                  />
-                  <Skeleton
-                    variant="text"
-                    width="inherit"
-                    height={12}
-                    marginBottom={theme.spacing(4)}
-                  />
-                  <Skeleton variant="text" width={120} height={12} />
+                  <Skeleton variant="text" width={280} marginBottom={theme.spacing(5)} />
+                  <Skeleton variant="text" width="inherit" marginBottom={theme.spacing(4)} />
+                  <Skeleton variant="text" width={120} />
                 </SkeletonHeader>
 
                 {[0, 1, 2].map((skeletonCard) => (
                   <Card key={`skeleton-${skeletonCard}`}>
-                    <Skeleton
-                      variant="text"
-                      width={280}
-                      height={12}
-                      marginBottom={theme.spacing(9)}
-                    />
-                    <Skeleton
-                      variant="text"
-                      width="inherit"
-                      height={12}
-                      marginBottom={theme.spacing(4)}
-                    />
-                    <Skeleton variant="text" width={120} height={12} />
+                    <Skeleton variant="text" width={280} marginBottom={theme.spacing(9)} />
+                    <Skeleton variant="text" width="inherit" marginBottom={theme.spacing(4)} />
+                    <Skeleton variant="text" width={120} />
                   </Card>
                 ))}
               </>
@@ -248,7 +227,6 @@ const CreateTaxRate = () => {
           />
         </Side>
       </Content>
-
       <WarningDialog
         ref={leavingNotSavedChagesWarningDialogRef}
         title={translate('text_645bb193927b375079d289cb')}

--- a/src/pages/CreditNoteDetails.tsx
+++ b/src/pages/CreditNoteDetails.tsx
@@ -350,7 +350,7 @@ const CreditNoteDetails = () => {
             }
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {creditNote?.number}
@@ -465,8 +465,8 @@ const CreditNoteDetails = () => {
             <MainInfos>
               <Skeleton variant="connectorAvatar" size="large" />
               <div>
-                <Skeleton variant="text" height={12} width={200} marginBottom={theme.spacing(5)} />
-                <Skeleton variant="text" height={12} width={128} />
+                <Skeleton variant="text" width={200} marginBottom={theme.spacing(5)} />
+                <Skeleton variant="text" width={128} />
               </div>
             </MainInfos>
           ) : (
@@ -527,10 +527,10 @@ const CreditNoteDetails = () => {
               <>
                 {[1, 2, 3, 4].map((i) => (
                   <SkeletonLine key={`key-skeleton-line-${i}`}>
-                    <Skeleton variant="text" width="12%" height={12} marginRight="6.4%" />
-                    <Skeleton variant="text" width="38%" height={12} marginRight="11.2%" />
-                    <Skeleton variant="text" width="12%" height={12} marginRight="6.4%" />
-                    <Skeleton variant="text" width="38%" height={12} marginRight="9.25%" />
+                    <Skeleton variant="text" width="12%" marginRight="6.4%" />
+                    <Skeleton variant="text" width="38%" marginRight="11.2%" />
+                    <Skeleton variant="text" width="12%" marginRight="6.4%" />
+                    <Skeleton variant="text" width="38%" marginRight="9.25%" />
                   </SkeletonLine>
                 ))}
               </>

--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -150,7 +150,7 @@ const CustomerDetails = () => {
             onClick={() => navigate(CUSTOMERS_LIST_ROUTE)}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography
               variant="bodyHl"
@@ -323,13 +323,8 @@ const CustomerDetails = () => {
               <MainInfos>
                 <Skeleton variant="userAvatar" size="large" />
                 <div>
-                  <Skeleton
-                    variant="text"
-                    height={12}
-                    width={200}
-                    marginBottom={theme.spacing(5)}
-                  />
-                  <Skeleton variant="text" height={12} width={128} />
+                  <Skeleton variant="text" width={200} marginBottom={theme.spacing(5)} />
+                  <Skeleton variant="text" width={128} />
                 </div>
               </MainInfos>
             ) : (
@@ -469,7 +464,6 @@ const CustomerDetails = () => {
           <AddCouponToCustomerDialog ref={addCouponDialogRef} customer={data?.customer} />
         </>
       )}
-
       <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </div>
   )

--- a/src/pages/CustomerDraftInvoicesList.tsx
+++ b/src/pages/CustomerDraftInvoicesList.tsx
@@ -97,14 +97,13 @@ const CustomerDraftInvoicesList = () => {
           </Typography>
         </HeaderLeft>
       </PageHeader>
-
       <Wrapper>
         {customerLoading ? (
           <MainInfos>
             <Skeleton variant="userAvatar" size="large" />
             <div>
-              <Skeleton variant="text" height={12} width={200} marginBottom={theme.spacing(5)} />
-              <Skeleton variant="text" height={12} width={128} />
+              <Skeleton variant="text" width={200} marginBottom={theme.spacing(5)} />
+              <Skeleton variant="text" width={128} />
             </div>
           </MainInfos>
         ) : (

--- a/src/pages/CustomerRequestOverduePayment/components/EmailPreview.tsx
+++ b/src/pages/CustomerRequestOverduePayment/components/EmailPreview.tsx
@@ -30,13 +30,13 @@ export const EmailPreview: FC<EmailPreviewProps> = ({
       <div className="mx-auto flex max-w-150 flex-col gap-8">
         <div className="flex flex-1 items-center justify-center gap-3">
           <Skeleton variant="connectorAvatar" size="medium" color="dark" />
-          <Skeleton variant="text" width={120} height={12} color="dark" />
+          <Skeleton variant="text" width={120} color="dark" />
         </div>
         <Card $childSpacing={4}>
           <DunningEmailSkeleton />
         </Card>
         <div className="flex justify-center">
-          <Skeleton variant="text" width={120} height={12} color="dark" />
+          <Skeleton variant="text" width={120} color="dark" />
         </div>
       </div>
     )

--- a/src/pages/Invitation.tsx
+++ b/src/pages/Invitation.tsx
@@ -299,9 +299,9 @@ const Invitation = () => {
           </>
         ) : !!loading ? (
           <>
-            <Skeleton variant="text" width={208} height={12} marginBottom={theme.spacing(8)} />
-            <Skeleton variant="text" width={440} height={12} marginBottom={theme.spacing(4)} />
-            <Skeleton variant="text" width={304} height={12} />
+            <Skeleton variant="text" width={208} marginBottom={theme.spacing(8)} />
+            <Skeleton variant="text" width={440} marginBottom={theme.spacing(4)} />
+            <Skeleton variant="text" width={304} />
           </>
         ) : (
           <Stack spacing={8}>

--- a/src/pages/InvoiceOverview.tsx
+++ b/src/pages/InvoiceOverview.tsx
@@ -230,7 +230,6 @@ const InvoiceOverview = memo(
             )}
           </NavigationRightActions>
         </SectionHeader>
-
         <>
           {loading ? (
             <>
@@ -272,10 +271,10 @@ const InvoiceOverview = memo(
                       <LoadingTR key={`invoice-details-table-footer-loading-${i}`}>
                         <td></td>
                         <td colSpan={3}>
-                          <Skeleton variant="text" height={12} width={160} />
+                          <Skeleton variant="text" width={160} />
                         </td>
                         <td>
-                          <RightSkeleton variant="text" height={12} width={120} />
+                          <RightSkeleton variant="text" width={120} />
                         </td>
                       </LoadingTR>
                     ))}

--- a/src/pages/PlanDetails.tsx
+++ b/src/pages/PlanDetails.tsx
@@ -98,7 +98,7 @@ const PlanDetails = () => {
           />
           {isPlanLoading && !plan ? (
             <PlanTitleLoadingWrapper>
-              <Skeleton variant="text" width={200} height={12} />
+              <Skeleton variant="text" width={200} />
             </PlanTitleLoadingWrapper>
           ) : (
             <Typography variant="bodyHl" color="textSecondary" noWrap>
@@ -167,8 +167,8 @@ const PlanDetails = () => {
         <PlanBlockInfos>
           {isPlanLoading && !plan ? (
             <PlanTitleLoadingWrapper>
-              <Skeleton variant="text" width={200} height={12} marginBottom={20} />
-              <Skeleton variant="text" width={200} height={12} />
+              <Skeleton variant="text" width={200} marginBottom={20} />
+              <Skeleton variant="text" width={200} />
             </PlanTitleLoadingWrapper>
           ) : (
             <>
@@ -232,7 +232,6 @@ const PlanDetails = () => {
           },
         ]}
       />
-
       <DeletePlanDialog ref={deletePlanDialogRef} />
     </>
   )

--- a/src/pages/SubscriptionDetails.tsx
+++ b/src/pages/SubscriptionDetails.tsx
@@ -100,7 +100,7 @@ const SubscriptionDetails = () => {
           />
           {isSubscriptionLoading ? (
             <TitleSkeletonWrapper>
-              <Skeleton variant="text" width={200} height={12} />
+              <Skeleton variant="text" width={200} />
             </TitleSkeletonWrapper>
           ) : (
             <Typography variant="bodyHl" color="textSecondary" noWrap>
@@ -207,7 +207,7 @@ const SubscriptionDetails = () => {
           {isSubscriptionLoading ? (
             <>
               <Skeleton variant="text" width={200} height={16} marginBottom={18} />
-              <Skeleton variant="text" width={200} height={12} />
+              <Skeleton variant="text" width={200} />
             </>
           ) : (
             <>
@@ -303,7 +303,6 @@ const SubscriptionDetails = () => {
           ]}
         />
       )}
-
       <TerminateCustomerSubscriptionDialog ref={terminateSubscriptionDialogRef} />
     </>
   )

--- a/src/pages/WalletForm/components/LoadingView.tsx
+++ b/src/pages/WalletForm/components/LoadingView.tsx
@@ -14,18 +14,17 @@ export const LoadingView: FC<LoadingViewProps> = ({ cardCount }) => {
   return (
     <>
       <SkeletonHeader>
-        <Skeleton variant="text" width={280} height={12} marginBottom={theme.spacing(5)} />
-        <Skeleton variant="text" width="inherit" height={12} marginBottom={theme.spacing(4)} />
-        <Skeleton variant="text" width={120} height={12} />
+        <Skeleton variant="text" width={280} marginBottom={theme.spacing(5)} />
+        <Skeleton variant="text" width="inherit" marginBottom={theme.spacing(4)} />
+        <Skeleton variant="text" width={120} />
       </SkeletonHeader>
-
       {skeletonCards.map((skeletonCard) => (
         <Card key={`skeleton-${skeletonCard}`}>
-          <Skeleton variant="text" width={280} height={12} marginBottom={theme.spacing(9)} />
-          <Skeleton variant="text" width={280} height={12} marginBottom={theme.spacing(9)} />
-          <Skeleton variant="text" width={280} height={12} marginBottom={theme.spacing(9)} />
-          <Skeleton variant="text" width="inherit" height={12} marginBottom={theme.spacing(4)} />
-          <Skeleton variant="text" width={120} height={12} />
+          <Skeleton variant="text" width={280} marginBottom={theme.spacing(9)} />
+          <Skeleton variant="text" width={280} marginBottom={theme.spacing(9)} />
+          <Skeleton variant="text" width={280} marginBottom={theme.spacing(9)} />
+          <Skeleton variant="text" width="inherit" marginBottom={theme.spacing(4)} />
+          <Skeleton variant="text" width={120} />
         </Card>
       ))}
     </>

--- a/src/pages/auth/ResetPassword.tsx
+++ b/src/pages/auth/ResetPassword.tsx
@@ -143,9 +143,9 @@ const ResetPassword = () => {
 
         {!!loading && !error ? (
           <>
-            <Skeleton variant="text" width={208} height={12} marginBottom={theme.spacing(8)} />
-            <Skeleton variant="text" width={440} height={12} marginBottom={theme.spacing(4)} />
-            <Skeleton variant="text" width={304} height={12} />
+            <Skeleton variant="text" width={208} marginBottom={theme.spacing(8)} />
+            <Skeleton variant="text" width={440} marginBottom={theme.spacing(4)} />
+            <Skeleton variant="text" width={304} />
           </>
         ) : !!error && !loading ? (
           <>

--- a/src/pages/developers/ApiKeys.tsx
+++ b/src/pages/developers/ApiKeys.tsx
@@ -28,7 +28,6 @@ const ApiKeys = () => {
       <Subtitle variant="body" color="grey600">
         {translate('text_637f813d31381b1ed90ab300')}
       </Subtitle>
-
       <InlineSectionTitle>
         <Typography variant="subhead" color="grey700">
           {translate('text_637f813d31381b1ed90ab313')}
@@ -50,11 +49,10 @@ const ApiKeys = () => {
           </Button>
         )}
       </InlineSectionTitle>
-
       {loading ? (
         <>
-          <Skeleton variant="text" height={12} width={240} marginBottom={theme.spacing(3)} />
-          <Skeleton variant="text" height={12} width={160} />
+          <Skeleton variant="text" width={240} marginBottom={theme.spacing(3)} />
+          <Skeleton variant="text" width={160} />
         </>
       ) : (
         <InfoBlock>
@@ -66,7 +64,6 @@ const ApiKeys = () => {
           </Typography>
         </InfoBlock>
       )}
-
       <InlineSectionTitle>
         <Typography variant="subhead" color="grey700">
           {translate('text_636df520279a9e1b3c68cc75')}
@@ -88,11 +85,10 @@ const ApiKeys = () => {
           </Button>
         )}
       </InlineSectionTitle>
-
       {loading ? (
         <>
-          <Skeleton variant="text" height={12} width={240} marginBottom={theme.spacing(3)} />
-          <Skeleton variant="text" height={12} width={160} />
+          <Skeleton variant="text" width={240} marginBottom={theme.spacing(3)} />
+          <Skeleton variant="text" width={160} />
         </>
       ) : (
         <InfoBlock>

--- a/src/pages/developers/Debugger.tsx
+++ b/src/pages/developers/Debugger.tsx
@@ -195,13 +195,13 @@ const Debugger = () => {
             {loading && (
               <>
                 <HeaderBillableMetric>
-                  <Skeleton variant="text" width={180} height={12} />
+                  <Skeleton variant="text" width={180} />
                 </HeaderBillableMetric>
                 <EventInfosSkeleton>
                   {[0, 1, 2, 3, 4, 5, 6].map((i) => (
                     <div key={`skeleton-event-${i}`}>
-                      <Skeleton variant="text" width={80} height={12} marginRight="72px" />
-                      <Skeleton variant="text" width={240} height={12} marginRight="auto" />
+                      <Skeleton variant="text" width={80} marginRight="72px" />
+                      <Skeleton variant="text" width={240} marginRight="auto" />
                     </div>
                   ))}
                 </EventInfosSkeleton>

--- a/src/pages/developers/WebhookLogs.tsx
+++ b/src/pages/developers/WebhookLogs.tsx
@@ -142,7 +142,7 @@ const WebhookLogs = () => {
             }
           />
           {webhookUrlLoading ? (
-            <Skeleton variant="text" width={240} height={12} />
+            <Skeleton variant="text" width={240} />
           ) : (
             <>
               <Title color="textSecondary" variant="bodyHl" noWrap>
@@ -307,13 +307,13 @@ const WebhookLogs = () => {
             {isLoading && (
               <>
                 <HeaderBlock $loading>
-                  <Skeleton variant="text" width={180} height={12} />
+                  <Skeleton variant="text" width={180} />
                 </HeaderBlock>
                 <LogPropertiesSkeleton>
                   {[0, 1, 2, 3, 4, 5, 6].map((i) => (
                     <div key={`skeleton-event-${i}`}>
-                      <Skeleton variant="text" width={80} height={12} marginRight="72px" />
-                      <Skeleton variant="text" width={240} height={12} marginRight="auto" />
+                      <Skeleton variant="text" width={80} marginRight="72px" />
+                      <Skeleton variant="text" width={240} marginRight="auto" />
                     </div>
                   ))}
                 </LogPropertiesSkeleton>

--- a/src/pages/developers/Webhooks.tsx
+++ b/src/pages/developers/Webhooks.tsx
@@ -78,7 +78,6 @@ const Webhooks = () => {
           {translate('text_6271200984178801ba8bdf1a')}
         </Button>
       </Head>
-
       {!webhooks.length && !loading ? (
         <EmptyText variant="caption" color="grey600">
           {translate('text_63e27c56dfe64b846474ef0c')}
@@ -86,7 +85,7 @@ const Webhooks = () => {
       ) : loading ? (
         <LoadingBlock>
           <Skeleton variant="connectorAvatar" size="big" marginRight={theme.spacing(3)} />
-          <Skeleton variant="text" width={160} height={12} />
+          <Skeleton variant="text" width={160} />
         </LoadingBlock>
       ) : (
         <>

--- a/src/pages/settings/AdyenIntegrationDetails.tsx
+++ b/src/pages/settings/AdyenIntegrationDetails.tsx
@@ -116,7 +116,7 @@ const AdyenIntegrationDetails = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {adyenPaymentProvider?.name}
@@ -170,14 +170,13 @@ const AdyenIntegrationDetails = () => {
           </Popper>
         )}
       </PageHeader>
-
       <MainInfos>
         {loading ? (
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -198,7 +197,6 @@ const AdyenIntegrationDetails = () => {
           </>
         )}
       </MainInfos>
-
       <Settings>
         <section>
           <InlineTitle>
@@ -227,7 +225,7 @@ const AdyenIntegrationDetails = () => {
                 {[0, 1, 2].map((i) => (
                   <ApiKeyItem key={`item-skeleton-item-${i}`}>
                     <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                    <Skeleton variant="text" width={240} height={12} />
+                    <Skeleton variant="text" width={240} />
                   </ApiKeyItem>
                 ))}
               </>
@@ -343,7 +341,7 @@ const AdyenIntegrationDetails = () => {
           {loading ? (
             <HeaderBlock>
               <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-              <Skeleton variant="text" width={240} height={12} />
+              <Skeleton variant="text" width={240} />
             </HeaderBlock>
           ) : (
             <>
@@ -432,7 +430,6 @@ const AdyenIntegrationDetails = () => {
           )}
         </section>
       </Settings>
-
       <AddAdyenDialog ref={addAdyenDialogRef} />
       <DeleteAdyenIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />

--- a/src/pages/settings/AdyenIntegrations.tsx
+++ b/src/pages/settings/AdyenIntegrations.tsx
@@ -102,7 +102,7 @@ const AdyenIntegrations = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {translate('text_645d071272418a14c1c76a6d')}
@@ -126,8 +126,8 @@ const AdyenIntegrations = () => {
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -147,7 +147,6 @@ const AdyenIntegrations = () => {
           </>
         )}
       </MainInfos>
-
       <ListWrapper>
         <section>
           <InlineTitle>
@@ -160,7 +159,7 @@ const AdyenIntegrations = () => {
                 {[1, 2].map((i) => (
                   <ListItem key={`item-skeleton-item-${i}`}>
                     <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                    <Skeleton variant="text" width={240} height={12} />
+                    <Skeleton variant="text" width={240} />
                   </ListItem>
                 ))}
               </>
@@ -257,7 +256,6 @@ const AdyenIntegrations = () => {
           </>
         </section>
       </ListWrapper>
-
       <AddAdyenDialog ref={addAdyenDialogRef} />
       <DeleteAdyenIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />

--- a/src/pages/settings/AnrokIntegrationDetails.tsx
+++ b/src/pages/settings/AnrokIntegrationDetails.tsx
@@ -120,7 +120,7 @@ const AnrokIntegrationDetails = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {anrokIntegration?.name}
@@ -168,14 +168,13 @@ const AnrokIntegrationDetails = () => {
           )}
         </Popper>
       </PageHeader>
-
       <MainInfos>
         {loading ? (
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -196,7 +195,6 @@ const AnrokIntegrationDetails = () => {
           </>
         )}
       </MainInfos>
-
       <NavigationTab
         className="px-4 md:px-12"
         loading={loading}
@@ -219,7 +217,6 @@ const AnrokIntegrationDetails = () => {
           },
         ]}
       />
-
       <AddAnrokDialog ref={addAnrokDialogRef} />
       <DeleteAnrokIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />

--- a/src/pages/settings/AnrokIntegrations.tsx
+++ b/src/pages/settings/AnrokIntegrations.tsx
@@ -92,7 +92,7 @@ const AnrokIntegrations = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {translate('text_6668821d94e4da4dfd8b3834')}
@@ -113,8 +113,8 @@ const AnrokIntegrations = () => {
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -134,7 +134,6 @@ const AnrokIntegrations = () => {
           </>
         )}
       </MainInfos>
-
       <ListWrapper>
         <section>
           <InlineTitle>
@@ -147,7 +146,7 @@ const AnrokIntegrations = () => {
                 {[1, 2].map((i) => (
                   <ListItem key={`item-skeleton-item-${i}`}>
                     <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                    <Skeleton variant="text" width={240} height={12} />
+                    <Skeleton variant="text" width={240} />
                   </ListItem>
                 ))}
               </>
@@ -238,7 +237,6 @@ const AnrokIntegrations = () => {
           </>
         </section>
       </ListWrapper>
-
       <AddAnrokDialog ref={addAnrokDialogRef} />
       <DeleteAnrokIntegrationDialog ref={deleteDialogRef} />
     </>

--- a/src/pages/settings/Authentication/OktaAuthenticationDetails.tsx
+++ b/src/pages/settings/Authentication/OktaAuthenticationDetails.tsx
@@ -94,7 +94,7 @@ const OktaAuthenticationDetails = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {translate('text_664c732c264d7eed1c74fda2')}
@@ -143,14 +143,13 @@ const OktaAuthenticationDetails = () => {
           )}
         </Popper>
       </PageHeader>
-
       <MainInfos>
         {loading ? (
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <SkeletonText>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </SkeletonText>
           </>
         ) : (
@@ -170,7 +169,6 @@ const OktaAuthenticationDetails = () => {
           </>
         )}
       </MainInfos>
-
       <Settings>
         <section>
           <InlineTitle>
@@ -221,7 +219,6 @@ const OktaAuthenticationDetails = () => {
           </>
         </section>
       </Settings>
-
       <AddOktaDialog ref={addOktaDialogRef} />
       <DeleteOktaIntegrationDialog ref={deleteOktaDialogRef} />
     </>

--- a/src/pages/settings/Authentication/components/PropertyListItem.tsx
+++ b/src/pages/settings/Authentication/components/PropertyListItem.tsx
@@ -33,8 +33,8 @@ export const SkeletonPropertyListItem: FC = () => {
     <Container>
       <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
       <SkeletonText>
-        <Skeleton variant="text" width={300} height={12} marginBottom="12px" />
-        <Skeleton variant="text" width={240} height={12} />
+        <Skeleton variant="text" width={300} marginBottom="12px" />
+        <Skeleton variant="text" width={240} />
       </SkeletonText>
     </Container>
   )

--- a/src/pages/settings/GocardlessIntegrationDetails.tsx
+++ b/src/pages/settings/GocardlessIntegrationDetails.tsx
@@ -117,7 +117,7 @@ const GocardlessIntegrationDetails = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {gocardlessPaymentProvider?.name}
@@ -207,8 +207,8 @@ const GocardlessIntegrationDetails = () => {
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -231,7 +231,6 @@ const GocardlessIntegrationDetails = () => {
           </>
         )}
       </MainInfos>
-
       <ContentWrapper>
         <section>
           <InlineTitle>
@@ -258,11 +257,11 @@ const GocardlessIntegrationDetails = () => {
               {[0, 1, 2].map((i) => (
                 <Item key={`item-skeleton-${i}`} direction="row" alignItems="center">
                   <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                  <Skeleton variant="text" width={240} height={12} />
+                  <Skeleton variant="text" width={240} />
                 </Item>
               ))}
               <div style={{ height: 20 }} />
-              <Skeleton variant="text" width={240} height={12} marginBottom={16} />
+              <Skeleton variant="text" width={240} marginBottom={16} />
             </>
           ) : (
             <>
@@ -356,7 +355,7 @@ const GocardlessIntegrationDetails = () => {
           {loading ? (
             <HeaderBlock>
               <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-              <Skeleton variant="text" width={240} height={12} />
+              <Skeleton variant="text" width={240} />
             </HeaderBlock>
           ) : (
             <>
@@ -445,7 +444,6 @@ const GocardlessIntegrationDetails = () => {
           )}
         </section>
       </ContentWrapper>
-
       <AddGocardlessDialog ref={addDialogRef} />
       <DeleteGocardlessIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />

--- a/src/pages/settings/GocardlessIntegrationOauthCallback.tsx
+++ b/src/pages/settings/GocardlessIntegrationOauthCallback.tsx
@@ -88,7 +88,7 @@ const GocardlessIntegrationOauthCallback = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {translate('text_634ea0ecc6147de10ddb6625')}
@@ -101,8 +101,8 @@ const GocardlessIntegrationOauthCallback = () => {
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -122,7 +122,6 @@ const GocardlessIntegrationOauthCallback = () => {
           </>
         )}
       </MainInfos>
-
       {loading || !error ? (
         <Loader>
           <Icon name="processing" color="info" size="large" animation="spin" />

--- a/src/pages/settings/GocardlessIntegrations.tsx
+++ b/src/pages/settings/GocardlessIntegrations.tsx
@@ -102,7 +102,7 @@ const GocardlessIntegrations = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {translate('text_634ea0ecc6147de10ddb6625')}
@@ -126,8 +126,8 @@ const GocardlessIntegrations = () => {
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -147,7 +147,6 @@ const GocardlessIntegrations = () => {
           </>
         )}
       </MainInfos>
-
       <ListWrapper>
         <section>
           <InlineTitle>
@@ -160,7 +159,7 @@ const GocardlessIntegrations = () => {
                 {[1, 2].map((i) => (
                   <ListItem key={`item-skeleton-item-${i}`}>
                     <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                    <Skeleton variant="text" width={240} height={12} />
+                    <Skeleton variant="text" width={240} />
                   </ListItem>
                 ))}
               </>
@@ -257,7 +256,6 @@ const GocardlessIntegrations = () => {
           </>
         </section>
       </ListWrapper>
-
       <AddGocardlessDialog ref={addGocardlessDialogRef} />
       <DeleteGocardlessIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />

--- a/src/pages/settings/HubspotIntegrationDetails.tsx
+++ b/src/pages/settings/HubspotIntegrationDetails.tsx
@@ -111,7 +111,7 @@ const HubspotIntegrationDetails = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {hubspotIntegration?.name}
@@ -161,15 +161,14 @@ const HubspotIntegrationDetails = () => {
           )}
         </Popper>
       </PageHeader>
-
       <div className="container">
         <section className="flex items-center py-8">
           {loading ? (
             <>
               <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
               <div className="flex-1">
-                <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-                <Skeleton variant="text" width={128} height={12} />
+                <Skeleton variant="text" width={200} marginBottom="22px" />
+                <Skeleton variant="text" width={128} />
               </div>
             </>
           ) : (
@@ -218,7 +217,7 @@ const HubspotIntegrationDetails = () => {
               {[1, 2].map((i) => (
                 <div className="flex h-18 items-center shadow-b" key={`item-skeleton-item-${i}`}>
                   <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                  <Skeleton variant="text" width={240} height={12} />
+                  <Skeleton variant="text" width={240} />
                 </div>
               ))}
             </>
@@ -256,7 +255,6 @@ const HubspotIntegrationDetails = () => {
           )}
         </>
       </div>
-
       <AddHubspotDialog ref={addHubspotDialogRef} />
       <DeleteHubspotIntegrationDialog ref={deleteHubspotDialogRef} />
     </>

--- a/src/pages/settings/HubspotIntegrations.tsx
+++ b/src/pages/settings/HubspotIntegrations.tsx
@@ -80,7 +80,7 @@ const HubspotIntegrations = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {translate('text_1727189568053s79ks5q07tr')}
@@ -91,15 +91,14 @@ const HubspotIntegrations = () => {
           {translate('text_65846763e6140b469140e235')}
         </Button>
       </PageHeader>
-
       <div className="container">
         <section className="flex items-center py-8">
           {loading ? (
             <>
               <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
               <div className="flex-1">
-                <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-                <Skeleton variant="text" width={128} height={12} />
+                <Skeleton variant="text" width={200} marginBottom="22px" />
+                <Skeleton variant="text" width={128} />
               </div>
             </>
           ) : (
@@ -138,7 +137,7 @@ const HubspotIntegrations = () => {
                       key={`item-skeleton-item-${i}`}
                     >
                       <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                      <Skeleton variant="text" width={240} height={12} />
+                      <Skeleton variant="text" width={240} />
                     </div>
                   ))}
                 </>
@@ -229,7 +228,6 @@ const HubspotIntegrations = () => {
           </section>
         </div>
       </div>
-
       <AddHubspotDialog ref={addHubspotDialogRef} />
       <DeleteHubspotIntegrationDialog ref={deleteDialogRef} />
     </>

--- a/src/pages/settings/LagoTaxManagementIntegration.tsx
+++ b/src/pages/settings/LagoTaxManagementIntegration.tsx
@@ -100,7 +100,7 @@ const LagoTaxManagementIntegration = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {translate('text_657078c28394d6b1ae1b9713')}
@@ -122,8 +122,8 @@ const LagoTaxManagementIntegration = () => {
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -145,7 +145,6 @@ const LagoTaxManagementIntegration = () => {
           </>
         )}
       </MainInfos>
-
       <ContentWrapper>
         <section>
           <Title variant="subhead">{translate('text_657078c28394d6b1ae1b9725')}</Title>
@@ -153,7 +152,7 @@ const LagoTaxManagementIntegration = () => {
             {loading ? (
               <>
                 <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                <Skeleton variant="text" width={240} height={12} />
+                <Skeleton variant="text" width={240} />
               </>
             ) : (
               <>
@@ -201,7 +200,7 @@ const LagoTaxManagementIntegration = () => {
           {loading ? (
             <HeaderBlock>
               <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-              <Skeleton variant="text" width={240} height={12} />
+              <Skeleton variant="text" width={240} />
             </HeaderBlock>
           ) : (
             <>
@@ -230,7 +229,6 @@ const LagoTaxManagementIntegration = () => {
           )}
         </section>
       </ContentWrapper>
-
       <WarningDialog
         ref={deleteConnectionRef}
         title={translate('text_657078c28394d6b1ae1b9707')}

--- a/src/pages/settings/NetsuiteIntegrationDetails.tsx
+++ b/src/pages/settings/NetsuiteIntegrationDetails.tsx
@@ -120,7 +120,7 @@ const NetsuiteIntegrationDetails = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {netsuiteIntegration?.name}
@@ -168,14 +168,13 @@ const NetsuiteIntegrationDetails = () => {
           )}
         </Popper>
       </PageHeader>
-
       <MainInfos>
         {loading ? (
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -196,7 +195,6 @@ const NetsuiteIntegrationDetails = () => {
           </>
         )}
       </MainInfos>
-
       <NavigationTab
         className="px-4 md:px-12"
         loading={loading}
@@ -219,7 +217,6 @@ const NetsuiteIntegrationDetails = () => {
           },
         ]}
       />
-
       <AddNetsuiteDialog ref={addNetsuiteDialogRef} />
       <DeleteNetsuiteIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />

--- a/src/pages/settings/NetsuiteIntegrations.tsx
+++ b/src/pages/settings/NetsuiteIntegrations.tsx
@@ -92,7 +92,7 @@ const NetsuiteIntegrations = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {translate('text_661ff6e56ef7e1b7c542b239')}
@@ -113,8 +113,8 @@ const NetsuiteIntegrations = () => {
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -134,7 +134,6 @@ const NetsuiteIntegrations = () => {
           </>
         )}
       </MainInfos>
-
       <ListWrapper>
         <section>
           <InlineTitle>
@@ -147,7 +146,7 @@ const NetsuiteIntegrations = () => {
                 {[1, 2].map((i) => (
                   <ListItem key={`item-skeleton-item-${i}`}>
                     <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                    <Skeleton variant="text" width={240} height={12} />
+                    <Skeleton variant="text" width={240} />
                   </ListItem>
                 ))}
               </>
@@ -238,7 +237,6 @@ const NetsuiteIntegrations = () => {
           </>
         </section>
       </ListWrapper>
-
       <AddNetsuiteDialog ref={addNetsuiteDialogRef} />
       <DeleteNetsuiteIntegrationDialog ref={deleteDialogRef} />
     </>

--- a/src/pages/settings/StripeIntegrationDetails.tsx
+++ b/src/pages/settings/StripeIntegrationDetails.tsx
@@ -115,7 +115,7 @@ const StripeIntegrationDetails = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {stripePaymentProvider?.name}
@@ -170,14 +170,13 @@ const StripeIntegrationDetails = () => {
           </Popper>
         )}
       </PageHeader>
-
       <MainInfos>
         {loading ? (
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -198,7 +197,6 @@ const StripeIntegrationDetails = () => {
           </>
         )}
       </MainInfos>
-
       <ContentWrapper>
         <section>
           <InlineTitle>
@@ -225,7 +223,7 @@ const StripeIntegrationDetails = () => {
             {loading ? (
               <>
                 <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                <Skeleton variant="text" width={240} height={12} />
+                <Skeleton variant="text" width={240} />
               </>
             ) : (
               <>
@@ -245,7 +243,7 @@ const StripeIntegrationDetails = () => {
             {loading ? (
               <>
                 <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                <Skeleton variant="text" width={240} height={12} />
+                <Skeleton variant="text" width={240} />
               </>
             ) : (
               <>
@@ -265,7 +263,7 @@ const StripeIntegrationDetails = () => {
             {loading ? (
               <>
                 <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                <Skeleton variant="text" width={240} height={12} />
+                <Skeleton variant="text" width={240} />
               </>
             ) : (
               <>
@@ -310,7 +308,7 @@ const StripeIntegrationDetails = () => {
           {loading ? (
             <LineItem>
               <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-              <Skeleton variant="text" width={240} height={12} />
+              <Skeleton variant="text" width={240} />
             </LineItem>
           ) : (
             <>
@@ -400,7 +398,6 @@ const StripeIntegrationDetails = () => {
           )}
         </section>
       </ContentWrapper>
-
       <AddStripeDialog ref={addDialogRef} />
       <DeleteStripeIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />

--- a/src/pages/settings/StripeIntegrations.tsx
+++ b/src/pages/settings/StripeIntegrations.tsx
@@ -102,7 +102,7 @@ const StripeIntegrations = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {translate('text_62b1edddbf5f461ab971277d')}
@@ -126,8 +126,8 @@ const StripeIntegrations = () => {
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -147,7 +147,6 @@ const StripeIntegrations = () => {
           </>
         )}
       </MainInfos>
-
       <ListWrapper>
         <section>
           <InlineTitle>
@@ -160,7 +159,7 @@ const StripeIntegrations = () => {
                 {[1, 2].map((i) => (
                   <ListItem key={`item-skeleton-item-${i}`}>
                     <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                    <Skeleton variant="text" width={240} height={12} />
+                    <Skeleton variant="text" width={240} />
                   </ListItem>
                 ))}
               </>
@@ -258,7 +257,6 @@ const StripeIntegrations = () => {
           </>
         </section>
       </ListWrapper>
-
       <AddStripeDialog ref={addStripeDialogRef} />
       <DeleteStripeIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />

--- a/src/pages/settings/XeroIntegrationDetails.tsx
+++ b/src/pages/settings/XeroIntegrationDetails.tsx
@@ -113,7 +113,7 @@ const XeroIntegrationDetails = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {xeroIntegration?.name}
@@ -161,14 +161,13 @@ const XeroIntegrationDetails = () => {
           )}
         </Popper>
       </PageHeader>
-
       <MainInfos>
         {loading ? (
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -189,7 +188,6 @@ const XeroIntegrationDetails = () => {
           </>
         )}
       </MainInfos>
-
       <NavigationTab
         className="px-4 md:px-12"
         loading={loading}
@@ -212,7 +210,6 @@ const XeroIntegrationDetails = () => {
           },
         ]}
       />
-
       <AddXeroDialog ref={addXeroDialogRef} />
       <DeleteXeroIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />

--- a/src/pages/settings/XeroIntegrations.tsx
+++ b/src/pages/settings/XeroIntegrations.tsx
@@ -89,7 +89,7 @@ const XeroIntegrations = () => {
             buttonProps={{ variant: 'quaternary', icon: 'arrow-left' }}
           />
           {loading ? (
-            <Skeleton variant="text" height={12} width={120} />
+            <Skeleton variant="text" width={120} />
           ) : (
             <Typography variant="bodyHl" color="textSecondary">
               {translate('text_6672ebb8b1b50be550eccaf8')}
@@ -110,8 +110,8 @@ const XeroIntegrations = () => {
           <>
             <Skeleton variant="connectorAvatar" size="large" marginRight="16px" />
             <div>
-              <Skeleton variant="text" width={200} height={12} marginBottom="22px" />
-              <Skeleton variant="text" width={128} height={12} />
+              <Skeleton variant="text" width={200} marginBottom="22px" />
+              <Skeleton variant="text" width={128} />
             </div>
           </>
         ) : (
@@ -131,7 +131,6 @@ const XeroIntegrations = () => {
           </>
         )}
       </MainInfos>
-
       <ListWrapper>
         <section>
           <InlineTitle>
@@ -144,7 +143,7 @@ const XeroIntegrations = () => {
                 {[1, 2].map((i) => (
                   <ListItem key={`item-skeleton-item-${i}`}>
                     <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                    <Skeleton variant="text" width={240} height={12} />
+                    <Skeleton variant="text" width={240} />
                   </ListItem>
                 ))}
               </>
@@ -235,7 +234,6 @@ const XeroIntegrations = () => {
           </>
         </section>
       </ListWrapper>
-
       <AddXeroDialog ref={addXeroDialogRef} />
       <DeleteXeroIntegrationDialog ref={deleteDialogRef} />
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,18 +90,19 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.24.7.tgz#882fd9e09e8ee324e496bd040401c6f046ef4465"
-  integrity sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0":
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
+  integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
   dependencies:
-    "@babel/highlight" "^7.24.7"
+    "@babel/helper-validator-identifier" "^7.25.9"
+    js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/compat-data@^7.20.5", "@babel/compat-data@^7.22.20", "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.25.2", "@babel/compat-data@^7.25.4":
-  version "7.25.4"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.25.4.tgz#7d2a80ce229890edcf4cc259d4d696cb4dae2fcb"
-  integrity sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==
+"@babel/compat-data@^7.20.5", "@babel/compat-data@^7.22.20", "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.25.4", "@babel/compat-data@^7.25.9":
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.2.tgz#278b6b13664557de95b8f35b90d96785850bb56e"
+  integrity sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==
 
 "@babel/core@7.23.0":
   version "7.23.0"
@@ -124,21 +125,21 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.14.0", "@babel/core@^7.21.3", "@babel/core@^7.22.9", "@babel/core@^7.23.9":
-  version "7.25.2"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.25.2.tgz#ed8eec275118d7613e77a352894cd12ded8eba77"
-  integrity sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==
+"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.14.0", "@babel/core@^7.21.3", "@babel/core@^7.22.9", "@babel/core@^7.23.9", "@babel/core@^7.24.7":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.26.0.tgz#d78b6023cc8f3114ccf049eb219613f74a747b40"
+  integrity sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==
   dependencies:
     "@ampproject/remapping" "^2.2.0"
-    "@babel/code-frame" "^7.24.7"
-    "@babel/generator" "^7.25.0"
-    "@babel/helper-compilation-targets" "^7.25.2"
-    "@babel/helper-module-transforms" "^7.25.2"
-    "@babel/helpers" "^7.25.0"
-    "@babel/parser" "^7.25.0"
-    "@babel/template" "^7.25.0"
-    "@babel/traverse" "^7.25.2"
-    "@babel/types" "^7.25.2"
+    "@babel/code-frame" "^7.26.0"
+    "@babel/generator" "^7.26.0"
+    "@babel/helper-compilation-targets" "^7.25.9"
+    "@babel/helper-module-transforms" "^7.26.0"
+    "@babel/helpers" "^7.26.0"
+    "@babel/parser" "^7.26.0"
+    "@babel/template" "^7.25.9"
+    "@babel/traverse" "^7.25.9"
+    "@babel/types" "^7.26.0"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -154,22 +155,23 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.14.0", "@babel/generator@^7.18.13", "@babel/generator@^7.23.0", "@babel/generator@^7.25.0", "@babel/generator@^7.25.6", "@babel/generator@^7.7.2":
-  version "7.25.6"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.25.6.tgz#0df1ad8cb32fe4d2b01d8bf437f153d19342a87c"
-  integrity sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==
+"@babel/generator@^7.14.0", "@babel/generator@^7.18.13", "@babel/generator@^7.23.0", "@babel/generator@^7.25.9", "@babel/generator@^7.26.0", "@babel/generator@^7.7.2":
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.2.tgz#87b75813bec87916210e5e01939a4c823d6bb74f"
+  integrity sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==
   dependencies:
-    "@babel/types" "^7.25.6"
+    "@babel/parser" "^7.26.2"
+    "@babel/types" "^7.26.0"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
-    jsesc "^2.5.1"
+    jsesc "^3.0.2"
 
-"@babel/helper-annotate-as-pure@^7.22.5", "@babel/helper-annotate-as-pure@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz#5373c7bc8366b12a033b4be1ac13a206c6656aab"
-  integrity sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==
+"@babel/helper-annotate-as-pure@^7.22.5", "@babel/helper-annotate-as-pure@^7.24.7", "@babel/helper-annotate-as-pure@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz#d8eac4d2dc0d7b6e11fa6e535332e0d3184f06b4"
+  integrity sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==
   dependencies:
-    "@babel/types" "^7.24.7"
+    "@babel/types" "^7.25.9"
 
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.24.7":
   version "7.24.7"
@@ -179,28 +181,28 @@
     "@babel/traverse" "^7.24.7"
     "@babel/types" "^7.24.7"
 
-"@babel/helper-compilation-targets@^7.20.7", "@babel/helper-compilation-targets@^7.22.15", "@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.24.7", "@babel/helper-compilation-targets@^7.24.8", "@babel/helper-compilation-targets@^7.25.2":
-  version "7.25.2"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz#e1d9410a90974a3a5a66e84ff55ef62e3c02d06c"
-  integrity sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==
+"@babel/helper-compilation-targets@^7.20.7", "@babel/helper-compilation-targets@^7.22.15", "@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.24.7", "@babel/helper-compilation-targets@^7.24.8", "@babel/helper-compilation-targets@^7.25.2", "@babel/helper-compilation-targets@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz#55af025ce365be3cdc0c1c1e56c6af617ce88875"
+  integrity sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==
   dependencies:
-    "@babel/compat-data" "^7.25.2"
-    "@babel/helper-validator-option" "^7.24.8"
-    browserslist "^4.23.1"
+    "@babel/compat-data" "^7.25.9"
+    "@babel/helper-validator-option" "^7.25.9"
+    browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
-"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.24.7", "@babel/helper-create-class-features-plugin@^7.25.0", "@babel/helper-create-class-features-plugin@^7.25.4":
-  version "7.25.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz#57eaf1af38be4224a9d9dd01ddde05b741f50e14"
-  integrity sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==
+"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.24.7", "@babel/helper-create-class-features-plugin@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz#7644147706bb90ff613297d49ed5266bde729f83"
+  integrity sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.24.7"
-    "@babel/helper-member-expression-to-functions" "^7.24.8"
-    "@babel/helper-optimise-call-expression" "^7.24.7"
-    "@babel/helper-replace-supers" "^7.25.0"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.24.7"
-    "@babel/traverse" "^7.25.4"
+    "@babel/helper-annotate-as-pure" "^7.25.9"
+    "@babel/helper-member-expression-to-functions" "^7.25.9"
+    "@babel/helper-optimise-call-expression" "^7.25.9"
+    "@babel/helper-replace-supers" "^7.25.9"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
+    "@babel/traverse" "^7.25.9"
     semver "^6.3.1"
 
 "@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.24.7", "@babel/helper-create-regexp-features-plugin@^7.25.0", "@babel/helper-create-regexp-features-plugin@^7.25.2":
@@ -267,43 +269,42 @@
   dependencies:
     "@babel/types" "^7.24.7"
 
-"@babel/helper-member-expression-to-functions@^7.24.8":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz#6155e079c913357d24a4c20480db7c712a5c3fb6"
-  integrity sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==
+"@babel/helper-member-expression-to-functions@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz#9dfffe46f727005a5ea29051ac835fb735e4c1a3"
+  integrity sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==
   dependencies:
-    "@babel/traverse" "^7.24.8"
-    "@babel/types" "^7.24.8"
+    "@babel/traverse" "^7.25.9"
+    "@babel/types" "^7.25.9"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.22.5", "@babel/helper-module-imports@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz#f2f980392de5b84c3328fc71d38bd81bbb83042b"
-  integrity sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.22.5", "@babel/helper-module-imports@^7.24.7", "@babel/helper-module-imports@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz#e7f8d20602ebdbf9ebbea0a0751fb0f2a4141715"
+  integrity sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==
   dependencies:
-    "@babel/traverse" "^7.24.7"
-    "@babel/types" "^7.24.7"
+    "@babel/traverse" "^7.25.9"
+    "@babel/types" "^7.25.9"
 
-"@babel/helper-module-transforms@^7.23.0", "@babel/helper-module-transforms@^7.24.7", "@babel/helper-module-transforms@^7.24.8", "@babel/helper-module-transforms@^7.25.0", "@babel/helper-module-transforms@^7.25.2":
-  version "7.25.2"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz#ee713c29768100f2776edf04d4eb23b8d27a66e6"
-  integrity sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==
+"@babel/helper-module-transforms@^7.23.0", "@babel/helper-module-transforms@^7.24.7", "@babel/helper-module-transforms@^7.25.0", "@babel/helper-module-transforms@^7.25.9", "@babel/helper-module-transforms@^7.26.0":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz#8ce54ec9d592695e58d84cd884b7b5c6a2fdeeae"
+  integrity sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==
   dependencies:
-    "@babel/helper-module-imports" "^7.24.7"
-    "@babel/helper-simple-access" "^7.24.7"
-    "@babel/helper-validator-identifier" "^7.24.7"
-    "@babel/traverse" "^7.25.2"
+    "@babel/helper-module-imports" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
+    "@babel/traverse" "^7.25.9"
 
-"@babel/helper-optimise-call-expression@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz#8b0a0456c92f6b323d27cfd00d1d664e76692a0f"
-  integrity sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==
+"@babel/helper-optimise-call-expression@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz#3324ae50bae7e2ab3c33f60c9a877b6a0146b54e"
+  integrity sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==
   dependencies:
-    "@babel/types" "^7.24.7"
+    "@babel/types" "^7.25.9"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.24.7", "@babel/helper-plugin-utils@^7.24.8", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz#94ee67e8ec0e5d44ea7baeb51e571bd26af07878"
-  integrity sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.24.7", "@babel/helper-plugin-utils@^7.24.8", "@babel/helper-plugin-utils@^7.25.9", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz#9cbdd63a9443a2c92a725cca7ebca12cc8dd9f46"
+  integrity sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==
 
 "@babel/helper-remap-async-to-generator@^7.24.7", "@babel/helper-remap-async-to-generator@^7.25.0":
   version "7.25.0"
@@ -314,30 +315,30 @@
     "@babel/helper-wrap-function" "^7.25.0"
     "@babel/traverse" "^7.25.0"
 
-"@babel/helper-replace-supers@^7.24.7", "@babel/helper-replace-supers@^7.25.0":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz#ff44deac1c9f619523fe2ca1fd650773792000a9"
-  integrity sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==
+"@babel/helper-replace-supers@^7.24.7", "@babel/helper-replace-supers@^7.25.0", "@babel/helper-replace-supers@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz#ba447224798c3da3f8713fc272b145e33da6a5c5"
+  integrity sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==
   dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.24.8"
-    "@babel/helper-optimise-call-expression" "^7.24.7"
-    "@babel/traverse" "^7.25.0"
+    "@babel/helper-member-expression-to-functions" "^7.25.9"
+    "@babel/helper-optimise-call-expression" "^7.25.9"
+    "@babel/traverse" "^7.25.9"
 
-"@babel/helper-simple-access@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz#bcade8da3aec8ed16b9c4953b74e506b51b5edb3"
-  integrity sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==
+"@babel/helper-simple-access@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.25.9.tgz#6d51783299884a2c74618d6ef0f86820ec2e7739"
+  integrity sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==
   dependencies:
-    "@babel/traverse" "^7.24.7"
-    "@babel/types" "^7.24.7"
+    "@babel/traverse" "^7.25.9"
+    "@babel/types" "^7.25.9"
 
-"@babel/helper-skip-transparent-expression-wrappers@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz#5f8fa83b69ed5c27adc56044f8be2b3ea96669d9"
-  integrity sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==
+"@babel/helper-skip-transparent-expression-wrappers@^7.24.7", "@babel/helper-skip-transparent-expression-wrappers@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz#0b2e1b62d560d6b1954893fd2b705dc17c91f0c9"
+  integrity sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==
   dependencies:
-    "@babel/traverse" "^7.24.7"
-    "@babel/types" "^7.24.7"
+    "@babel/traverse" "^7.25.9"
+    "@babel/types" "^7.25.9"
 
 "@babel/helper-split-export-declaration@^7.22.6":
   version "7.24.7"
@@ -346,20 +347,20 @@
   dependencies:
     "@babel/types" "^7.24.7"
 
-"@babel/helper-string-parser@^7.24.8":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz#5b3329c9a58803d5df425e5785865881a81ca48d"
-  integrity sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==
+"@babel/helper-string-parser@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
+  integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
 
-"@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz#75b889cfaf9e35c2aaf42cf0d72c8e91719251db"
-  integrity sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==
+"@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.24.7", "@babel/helper-validator-identifier@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
+  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
-"@babel/helper-validator-option@^7.22.15", "@babel/helper-validator-option@^7.24.7", "@babel/helper-validator-option@^7.24.8":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz#3725cdeea8b480e86d34df15304806a06975e33d"
-  integrity sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==
+"@babel/helper-validator-option@^7.22.15", "@babel/helper-validator-option@^7.24.7", "@babel/helper-validator-option@^7.24.8", "@babel/helper-validator-option@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz#86e45bd8a49ab7e03f276577f96179653d41da72"
+  integrity sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==
 
 "@babel/helper-wrap-function@^7.25.0":
   version "7.25.0"
@@ -370,30 +371,20 @@
     "@babel/traverse" "^7.25.0"
     "@babel/types" "^7.25.0"
 
-"@babel/helpers@^7.23.0", "@babel/helpers@^7.25.0":
-  version "7.25.6"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.25.6.tgz#57ee60141829ba2e102f30711ffe3afab357cc60"
-  integrity sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==
+"@babel/helpers@^7.23.0", "@babel/helpers@^7.26.0":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.26.0.tgz#30e621f1eba5aa45fe6f4868d2e9154d884119a4"
+  integrity sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==
   dependencies:
-    "@babel/template" "^7.25.0"
-    "@babel/types" "^7.25.6"
+    "@babel/template" "^7.25.9"
+    "@babel/types" "^7.26.0"
 
-"@babel/highlight@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.24.7.tgz#a05ab1df134b286558aae0ed41e6c5f731bf409d"
-  integrity sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.8", "@babel/parser@^7.20.5", "@babel/parser@^7.20.7", "@babel/parser@^7.23.0", "@babel/parser@^7.23.9", "@babel/parser@^7.24.7", "@babel/parser@^7.25.9", "@babel/parser@^7.26.0", "@babel/parser@^7.26.2":
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.2.tgz#fd7b6f487cfea09889557ef5d4eeb9ff9a5abd11"
+  integrity sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.24.7"
-    chalk "^2.4.2"
-    js-tokens "^4.0.0"
-    picocolors "^1.0.0"
-
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.8", "@babel/parser@^7.20.5", "@babel/parser@^7.20.7", "@babel/parser@^7.23.0", "@babel/parser@^7.23.9", "@babel/parser@^7.25.0", "@babel/parser@^7.25.6":
-  version "7.25.6"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.25.6.tgz#85660c5ef388cbbf6e3d2a694ee97a38f18afe2f"
-  integrity sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==
-  dependencies:
-    "@babel/types" "^7.25.6"
+    "@babel/types" "^7.26.0"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.25.3":
   version "7.25.3"
@@ -500,12 +491,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.7.tgz#d1759e84dd4b437cf9fae69b4c06c41d7625bfb7"
-  integrity sha512-9G8GYT/dxn/D1IIKOUBmGX0mnmj46mGH9NnZyJLwtCpgh5f7D2VbuKodb+2s9m1Yavh1s7ASQN8lf0eqrb1LTw==
+"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.25.9":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.26.0.tgz#96507595c21b45fccfc2bc758d5c45452e6164fa"
+  integrity sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.24.7"
+    "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/plugin-syntax-import-assertions@^7.20.0", "@babel/plugin-syntax-import-assertions@^7.22.5", "@babel/plugin-syntax-import-assertions@^7.24.7":
   version "7.25.6"
@@ -535,12 +526,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.0.0", "@babel/plugin-syntax-jsx@^7.22.5", "@babel/plugin-syntax-jsx@^7.24.7", "@babel/plugin-syntax-jsx@^7.7.2":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz#39a1fa4a7e3d3d7f34e2acc6be585b718d30e02d"
-  integrity sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==
+"@babel/plugin-syntax-jsx@^7.0.0", "@babel/plugin-syntax-jsx@^7.22.5", "@babel/plugin-syntax-jsx@^7.24.7", "@babel/plugin-syntax-jsx@^7.25.9", "@babel/plugin-syntax-jsx@^7.7.2":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz#a34313a178ea56f1951599b929c1ceacee719290"
+  integrity sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.24.7"
+    "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
   version "7.10.4"
@@ -598,12 +589,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-typescript@^7.24.7", "@babel/plugin-syntax-typescript@^7.7.2":
-  version "7.25.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz#04db9ce5a9043d9c635e75ae7969a2cd50ca97ff"
-  integrity sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==
+"@babel/plugin-syntax-typescript@^7.25.9", "@babel/plugin-syntax-typescript@^7.7.2":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz#67dda2b74da43727cf21d46cf9afef23f4365399"
+  integrity sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.24.8"
+    "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/plugin-syntax-unicode-sets-regex@^7.18.6":
   version "7.18.6"
@@ -653,13 +644,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.8"
 
-"@babel/plugin-transform-class-properties@^7.22.5", "@babel/plugin-transform-class-properties@^7.25.4":
-  version "7.25.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.4.tgz#bae7dbfcdcc2e8667355cd1fb5eda298f05189fd"
-  integrity sha512-nZeZHyCWPfjkdU5pA/uHiTaDAFUEqkpzf1YoQT2NeSynCGYq9rxfyI3XpQbfx/a0hSnFH6TGlEXvae5Vi7GD8g==
+"@babel/plugin-transform-class-properties@^7.22.5", "@babel/plugin-transform-class-properties@^7.24.7", "@babel/plugin-transform-class-properties@^7.25.4":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz#a8ce84fedb9ad512549984101fa84080a9f5f51f"
+  integrity sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.25.4"
-    "@babel/helper-plugin-utils" "^7.24.8"
+    "@babel/helper-create-class-features-plugin" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/plugin-transform-class-static-block@^7.22.11", "@babel/plugin-transform-class-static-block@^7.24.7":
   version "7.24.7"
@@ -744,13 +735,13 @@
     "@babel/helper-plugin-utils" "^7.24.7"
     "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
 
-"@babel/plugin-transform-flow-strip-types@^7.0.0":
-  version "7.25.2"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.25.2.tgz#b3aa251db44959b7a7c82abcd6b4225dec7d2258"
-  integrity sha512-InBZ0O8tew5V0K6cHcQ+wgxlrjOw1W4wDXLkOTjLRD8GYhTSkxTVBtdy3MMtvYBrbAWa1Qm3hNoTc1620Yj+Mg==
+"@babel/plugin-transform-flow-strip-types@^7.0.0", "@babel/plugin-transform-flow-strip-types@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.25.9.tgz#85879b42a8f5948fd6317069978e98f23ef8aec1"
+  integrity sha512-/VVukELzPDdci7UUsWQaSkhgnjIWXnIyRpM02ldxaVoFK96c41So8JcKT3m0gYjyv7j5FNPGS5vfELrWalkbDA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.24.8"
-    "@babel/plugin-syntax-flow" "^7.24.7"
+    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/plugin-syntax-flow" "^7.25.9"
 
 "@babel/plugin-transform-for-of@^7.0.0", "@babel/plugin-transform-for-of@^7.22.15", "@babel/plugin-transform-for-of@^7.24.7":
   version "7.24.7"
@@ -807,14 +798,14 @@
     "@babel/helper-module-transforms" "^7.24.7"
     "@babel/helper-plugin-utils" "^7.24.7"
 
-"@babel/plugin-transform-modules-commonjs@^7.0.0", "@babel/plugin-transform-modules-commonjs@^7.22.15", "@babel/plugin-transform-modules-commonjs@^7.24.7", "@babel/plugin-transform-modules-commonjs@^7.24.8":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz#ab6421e564b717cb475d6fff70ae7f103536ea3c"
-  integrity sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==
+"@babel/plugin-transform-modules-commonjs@^7.0.0", "@babel/plugin-transform-modules-commonjs@^7.22.15", "@babel/plugin-transform-modules-commonjs@^7.24.7", "@babel/plugin-transform-modules-commonjs@^7.24.8", "@babel/plugin-transform-modules-commonjs@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.9.tgz#d165c8c569a080baf5467bda88df6425fc060686"
+  integrity sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==
   dependencies:
-    "@babel/helper-module-transforms" "^7.24.8"
-    "@babel/helper-plugin-utils" "^7.24.8"
-    "@babel/helper-simple-access" "^7.24.7"
+    "@babel/helper-module-transforms" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-simple-access" "^7.25.9"
 
 "@babel/plugin-transform-modules-systemjs@^7.22.11", "@babel/plugin-transform-modules-systemjs@^7.25.0":
   version "7.25.0"
@@ -907,13 +898,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.7"
 
-"@babel/plugin-transform-private-methods@^7.22.5", "@babel/plugin-transform-private-methods@^7.25.4":
-  version "7.25.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.4.tgz#9bbefbe3649f470d681997e0b64a4b254d877242"
-  integrity sha512-ao8BG7E2b/URaUQGqN3Tlsg+M3KlHY6rJ1O1gXAEUnZoyNQnvKyH87Kfg+FoxSeyWUB8ISZZsC91C44ZuBFytw==
+"@babel/plugin-transform-private-methods@^7.22.5", "@babel/plugin-transform-private-methods@^7.24.7", "@babel/plugin-transform-private-methods@^7.25.4":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz#847f4139263577526455d7d3223cd8bda51e3b57"
+  integrity sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.25.4"
-    "@babel/helper-plugin-utils" "^7.24.8"
+    "@babel/helper-create-class-features-plugin" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/plugin-transform-private-property-in-object@^7.22.11", "@babel/plugin-transform-private-property-in-object@^7.24.7":
   version "7.24.7"
@@ -1023,16 +1014,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.8"
 
-"@babel/plugin-transform-typescript@^7.24.7":
-  version "7.25.2"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.2.tgz#237c5d10de6d493be31637c6b9fa30b6c5461add"
-  integrity sha512-lBwRvjSmqiMYe/pS0+1gggjJleUJi7NzjvQ1Fkqtt69hBa/0t1YuW/MLQMAPixfwaQOHUXsd6jeU3Z+vdGv3+A==
+"@babel/plugin-transform-typescript@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.9.tgz#69267905c2b33c2ac6d8fe765e9dc2ddc9df3849"
+  integrity sha512-7PbZQZP50tzv2KGGnhh82GSyMB01yKY9scIjf1a+GfZCtInOWqUH5+1EBU4t9fyR5Oykkkc9vFTs4OHrhHXljQ==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.24.7"
-    "@babel/helper-create-class-features-plugin" "^7.25.0"
-    "@babel/helper-plugin-utils" "^7.24.8"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.24.7"
-    "@babel/plugin-syntax-typescript" "^7.24.7"
+    "@babel/helper-annotate-as-pure" "^7.25.9"
+    "@babel/helper-create-class-features-plugin" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
+    "@babel/plugin-syntax-typescript" "^7.25.9"
 
 "@babel/plugin-transform-unicode-escapes@^7.22.10", "@babel/plugin-transform-unicode-escapes@^7.24.7":
   version "7.24.7"
@@ -1240,6 +1231,15 @@
     core-js-compat "^3.37.1"
     semver "^6.3.1"
 
+"@babel/preset-flow@^7.24.7":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.25.9.tgz#ef8b5e7e3f24a42b3711e77fb14919b87dffed0a"
+  integrity sha512-EASHsAhE+SSlEzJ4bzfusnXSHiU+JfAYzj+jbw2vgQKgq5HrUr8qs+vgtiEL5dOH6sEweI+PNt2D7AqrDSHyqQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-validator-option" "^7.25.9"
+    "@babel/plugin-transform-flow-strip-types" "^7.25.9"
+
 "@babel/preset-modules@0.1.6-no-external-plugins":
   version "0.1.6-no-external-plugins"
   resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz#ccb88a2c49c817236861fee7826080573b8a923a"
@@ -1273,16 +1273,27 @@
     "@babel/plugin-transform-react-jsx-development" "^7.24.7"
     "@babel/plugin-transform-react-pure-annotations" "^7.24.7"
 
-"@babel/preset-typescript@^7.21.0":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.24.7.tgz#66cd86ea8f8c014855671d5ea9a737139cbbfef1"
-  integrity sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==
+"@babel/preset-typescript@^7.21.0", "@babel/preset-typescript@^7.24.7":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.26.0.tgz#4a570f1b8d104a242d923957ffa1eaff142a106d"
+  integrity sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.24.7"
-    "@babel/helper-validator-option" "^7.24.7"
-    "@babel/plugin-syntax-jsx" "^7.24.7"
-    "@babel/plugin-transform-modules-commonjs" "^7.24.7"
-    "@babel/plugin-transform-typescript" "^7.24.7"
+    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-validator-option" "^7.25.9"
+    "@babel/plugin-syntax-jsx" "^7.25.9"
+    "@babel/plugin-transform-modules-commonjs" "^7.25.9"
+    "@babel/plugin-transform-typescript" "^7.25.9"
+
+"@babel/register@^7.24.6":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.25.9.tgz#1c465acf7dc983d70ccc318eb5b887ecb04f021b"
+  integrity sha512-8D43jXtGsYmEeDvm4MWHYUpWf8iiXgWYx3fW7E7Wb7Oe6FWqJPl5K6TuFW0dOwNZzEE5rjlaSJYH9JjrUKJszA==
+  dependencies:
+    clone-deep "^4.0.1"
+    find-cache-dir "^2.0.0"
+    make-dir "^2.1.0"
+    pirates "^4.0.6"
+    source-map-support "^0.5.16"
 
 "@babel/regjsgen@^0.8.0":
   version "0.8.0"
@@ -1296,14 +1307,14 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.22.15", "@babel/template@^7.24.7", "@babel/template@^7.25.0", "@babel/template@^7.3.3":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.0.tgz#e733dc3134b4fede528c15bc95e89cb98c52592a"
-  integrity sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==
+"@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.22.15", "@babel/template@^7.24.7", "@babel/template@^7.25.0", "@babel/template@^7.25.9", "@babel/template@^7.3.3":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.9.tgz#ecb62d81a8a6f5dc5fe8abfc3901fc52ddf15016"
+  integrity sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==
   dependencies:
-    "@babel/code-frame" "^7.24.7"
-    "@babel/parser" "^7.25.0"
-    "@babel/types" "^7.25.0"
+    "@babel/code-frame" "^7.25.9"
+    "@babel/parser" "^7.25.9"
+    "@babel/types" "^7.25.9"
 
 "@babel/traverse@7.23.2":
   version "7.23.2"
@@ -1321,16 +1332,16 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.14.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.23.0", "@babel/traverse@^7.24.7", "@babel/traverse@^7.24.8", "@babel/traverse@^7.25.0", "@babel/traverse@^7.25.1", "@babel/traverse@^7.25.2", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.4", "@babel/traverse@^7.4.5":
-  version "7.25.6"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.6.tgz#04fad980e444f182ecf1520504941940a90fea41"
-  integrity sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==
+"@babel/traverse@^7.14.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.23.0", "@babel/traverse@^7.24.7", "@babel/traverse@^7.25.0", "@babel/traverse@^7.25.1", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.4", "@babel/traverse@^7.25.9", "@babel/traverse@^7.4.5":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.9.tgz#a50f8fe49e7f69f53de5bea7e413cd35c5e13c84"
+  integrity sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==
   dependencies:
-    "@babel/code-frame" "^7.24.7"
-    "@babel/generator" "^7.25.6"
-    "@babel/parser" "^7.25.6"
-    "@babel/template" "^7.25.0"
-    "@babel/types" "^7.25.6"
+    "@babel/code-frame" "^7.25.9"
+    "@babel/generator" "^7.25.9"
+    "@babel/parser" "^7.25.9"
+    "@babel/template" "^7.25.9"
+    "@babel/types" "^7.25.9"
     debug "^4.3.1"
     globals "^11.1.0"
 
@@ -1342,14 +1353,13 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.18.13", "@babel/types@^7.20.7", "@babel/types@^7.21.3", "@babel/types@^7.22.19", "@babel/types@^7.23.0", "@babel/types@^7.24.7", "@babel/types@^7.24.8", "@babel/types@^7.25.0", "@babel/types@^7.25.2", "@babel/types@^7.25.6", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
-  version "7.25.6"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.25.6.tgz#893942ddb858f32ae7a004ec9d3a76b3463ef8e6"
-  integrity sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==
+"@babel/types@^7.0.0", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.18.13", "@babel/types@^7.20.7", "@babel/types@^7.21.3", "@babel/types@^7.22.19", "@babel/types@^7.23.0", "@babel/types@^7.24.7", "@babel/types@^7.25.0", "@babel/types@^7.25.2", "@babel/types@^7.25.9", "@babel/types@^7.26.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.0.tgz#deabd08d6b753bc8e0f198f8709fb575e31774ff"
+  integrity sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==
   dependencies:
-    "@babel/helper-string-parser" "^7.24.8"
-    "@babel/helper-validator-identifier" "^7.24.7"
-    to-fast-properties "^2.0.0"
+    "@babel/helper-string-parser" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -4436,6 +4446,13 @@ ast-types-flow@^0.0.8:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.8.tgz#0a85e1c92695769ac13a428bb653e7538bea27d6"
   integrity sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==
 
+ast-types@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.16.1.tgz#7a9da1617c9081bc121faafe91711b4c8bb81da2"
+  integrity sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==
+  dependencies:
+    tslib "^2.0.1"
+
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
@@ -4788,15 +4805,15 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.0.0, browserslist@^4.21.10, browserslist@^4.22.3, browserslist@^4.23.0, browserslist@^4.23.1, browserslist@^4.23.3:
-  version "4.23.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.3.tgz#debb029d3c93ebc97ffbc8d9cbb03403e227c800"
-  integrity sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==
+browserslist@^4.0.0, browserslist@^4.21.10, browserslist@^4.22.3, browserslist@^4.23.0, browserslist@^4.23.3, browserslist@^4.24.0:
+  version "4.24.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.2.tgz#f5845bc91069dbd55ee89faf9822e1d885d16580"
+  integrity sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==
   dependencies:
-    caniuse-lite "^1.0.30001646"
-    electron-to-chromium "^1.5.4"
+    caniuse-lite "^1.0.30001669"
+    electron-to-chromium "^1.5.41"
     node-releases "^2.0.18"
-    update-browserslist-db "^1.1.0"
+    update-browserslist-db "^1.1.1"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -4913,10 +4930,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001599, caniuse-lite@^1.0.30001646:
-  version "1.0.30001660"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz#31218de3463fabb44d0b7607b652e56edf2e2355"
-  integrity sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001599, caniuse-lite@^1.0.30001669:
+  version "1.0.30001677"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz#27c2e2c637e007cfa864a16f7dfe7cde66b38b5f"
+  integrity sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -4932,7 +4949,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
-chalk@^2.3.0, chalk@^2.4.2:
+chalk@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -5237,6 +5254,11 @@ common-tags@1.8.2, common-tags@^1.8.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
   integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
 compressible@~2.0.16:
   version "2.0.18"
@@ -6122,10 +6144,10 @@ ejs@^3.1.10:
   dependencies:
     jake "^10.8.5"
 
-electron-to-chromium@^1.5.4:
-  version "1.5.25"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.25.tgz#492ade1cde401332b9b75aa0c55fd5e1550ca66c"
-  integrity sha512-kMb204zvK3PsSlgvvwzI3wBIcAw15tRkYk+NQdsjdDtcQWTp2RABbMQ9rUBy8KNEOM+/E6ep+XC3AykiWZld4g==
+electron-to-chromium@^1.5.41:
+  version "1.5.52"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.52.tgz#2bed832c95a56a195504f918150e548474687da8"
+  integrity sha512-xtoijJTZ+qeucLBDNztDOuQBE1ksqjvNjvqFoST3nGC7fSpqJ+X6BdTBaY5BHG+IhWWmpc6b/KfpeuEDupEPOQ==
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -6335,7 +6357,7 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-escalade@^3.1.1, escalade@^3.1.2:
+escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
@@ -6546,7 +6568,7 @@ espree@^9.6.0, espree@^9.6.1:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
-esprima@^4.0.0, esprima@^4.0.1:
+esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -6885,6 +6907,15 @@ finalhandler@1.3.1:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
+find-cache-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
+  integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^2.0.0"
+    pkg-dir "^3.0.0"
+
 find-cache-dir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-4.0.0.tgz#a30ee0448f81a3990708f6453633c733e2f6eec2"
@@ -6897,6 +6928,13 @@ find-root@^1.0.0, find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
   integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
 
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -6940,6 +6978,11 @@ flatted@^3.2.9:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
+
+flow-parser@0.*:
+  version "0.251.1"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.251.1.tgz#b561c765baff1a93d85c510360d2d9c78f81ed86"
+  integrity sha512-8ZuLqJPlL/T9K3zFdr1m88Lx8JOoJluTTdyvN4uH5NT9zoIIFqbCDoXVhkHh022k2lhuAyFF27cu0BYKh5SmDA==
 
 follow-redirects@^1.0.0:
   version "1.15.9"
@@ -8550,6 +8593,30 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
 
+jscodeshift@^17.1.1:
+  version "17.1.1"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-17.1.1.tgz#03d81c8d32bd7100c2f092cf2a38bd9ae88379c6"
+  integrity sha512-4vq5B1sD37aa9qed3zWq2XQPun5XjxebIv+Folr57lt8B4HLGDHEz1UG7pfcxzSaelzPbcY7yZSs033/S0i6wQ==
+  dependencies:
+    "@babel/core" "^7.24.7"
+    "@babel/parser" "^7.24.7"
+    "@babel/plugin-transform-class-properties" "^7.24.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.24.7"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.24.7"
+    "@babel/plugin-transform-optional-chaining" "^7.24.7"
+    "@babel/plugin-transform-private-methods" "^7.24.7"
+    "@babel/preset-flow" "^7.24.7"
+    "@babel/preset-typescript" "^7.24.7"
+    "@babel/register" "^7.24.6"
+    flow-parser "0.*"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.7"
+    neo-async "^2.5.0"
+    picocolors "^1.0.1"
+    recast "^0.23.9"
+    tmp "^0.2.3"
+    write-file-atomic "^5.0.1"
+
 jsdom@^20.0.0:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-20.0.3.tgz#886a41ba1d4726f67a8858028c99489fed6ad4db"
@@ -8586,6 +8653,11 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+jsesc@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
+  integrity sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -8802,6 +8874,14 @@ localforage@1.10.0:
   dependencies:
     lie "3.1.1"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -8941,6 +9021,14 @@ lz-string@^1.5.0:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
+make-dir@^2.0.0, make-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
+
 make-dir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
@@ -9027,7 +9115,7 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
-micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.7:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -9155,7 +9243,7 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-neo-async@^2.6.2:
+neo-async@^2.5.0, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -9417,7 +9505,7 @@ p-limit@3.1.0, p-limit@^3.0.2, p-limit@^3.1.0:
   dependencies:
     yocto-queue "^0.1.0"
 
-p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -9430,6 +9518,13 @@ p-limit@^4.0.0:
   integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
   dependencies:
     yocto-queue "^1.0.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -9550,6 +9645,11 @@ path-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+  integrity sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -9630,10 +9730,22 @@ pify@^2.2.0, pify@^2.3.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
 
-pirates@^4.0.1, pirates@^4.0.4:
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+pirates@^4.0.1, pirates@^4.0.4, pirates@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
   integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+  dependencies:
+    find-up "^3.0.0"
 
 pkg-dir@^4.2.0:
   version "4.2.0"
@@ -10515,6 +10627,17 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+recast@^0.23.9:
+  version "0.23.9"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.23.9.tgz#587c5d3a77c2cfcb0c18ccce6da4361528c2587b"
+  integrity sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==
+  dependencies:
+    ast-types "^0.16.1"
+    esprima "~4.0.0"
+    source-map "~0.6.1"
+    tiny-invariant "^1.3.3"
+    tslib "^2.0.1"
+
 recharts-scale@^0.4.4:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/recharts-scale/-/recharts-scale-0.4.5.tgz#0969271f14e732e642fcc5bd4ab270d6e87dd1d9"
@@ -10885,7 +11008,7 @@ selfsigned@^2.4.1:
     "@types/node-forge" "^1.3.0"
     node-forge "^1"
 
-semver@^5.4.1:
+semver@^5.4.1, semver@^5.6.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
@@ -11123,7 +11246,7 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@~0.5.20:
+source-map-support@^0.5.16, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -11591,7 +11714,7 @@ tiny-case@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
   integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
 
-tiny-invariant@^1.3.1:
+tiny-invariant@^1.3.1, tiny-invariant@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
@@ -11615,7 +11738,7 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-tmp@~0.2.3:
+tmp@^0.2.3, tmp@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
   integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
@@ -11742,10 +11865,10 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.1, tslib@^2.6.2, tslib@^2.6.3:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
-  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.1, tslib@^2.6.2, tslib@^2.6.3:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@~2.4.0:
   version "2.4.1"
@@ -11938,13 +12061,13 @@ untildify@^4.0.0:
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
   integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
-update-browserslist-db@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz#7ca61c0d8650766090728046e416a8cde682859e"
-  integrity sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==
+update-browserslist-db@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz#80846fba1d79e82547fb661f8d141e0945755fe5"
+  integrity sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==
   dependencies:
-    escalade "^3.1.2"
-    picocolors "^1.0.1"
+    escalade "^3.2.0"
+    picocolors "^1.1.0"
 
 upper-case-first@^2.0.2:
   version "2.0.2"
@@ -12416,6 +12539,14 @@ write-file-atomic@^4.0.2:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
+
+write-file-atomic@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-5.0.1.tgz#68df4717c55c6fa4281a7860b4c2ba0a6d2b11e7"
+  integrity sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    signal-exit "^4.0.1"
 
 ws@^7.3.1:
   version "7.5.10"


### PR DESCRIPTION
## Context

Skeleton api has changed recently.
It has 2 versions
- The one with attributes to define width, height, margins
- The one using `className` to define those values

Also, by default all variant text has a height of 12px.

## Description

This PR is an enhancement to embrace the new API, and simply remove the `height={12}` on `variant="text"` invocations.
There will be other updated to fully migrate all API to use `className` tailwind notation but I prefer to go step by step and don't have time right now to finish.
I've let the codemod script in the codebase to help future usages and share knowledge.