### PR TITLE
bug: handle special case when tax breakdown not present

### DIFF
--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -759,19 +759,23 @@ const CreateInvoice = () => {
                             <TaxCell variant="body" color="grey700">
                               {hasTaxProvider
                                 ? !!taxProviderTaxesResult?.collection.length
-                                  ? taxProviderTaxesResult?.collection
-                                      ?.find((t) => t.itemId === fee.addOnId)
-                                      ?.taxBreakdown?.map((tax) => (
-                                        <Typography
-                                          key={`fee-${i}-applied-taxe-${tax.name}`}
-                                          variant="body"
-                                          color="grey700"
-                                        >
-                                          {intlFormatNumber(tax?.rate || 0, {
-                                            style: 'percent',
-                                          })}
-                                        </Typography>
-                                      ))
+                                  ? taxProviderTaxesResult?.collection?.find(
+                                      (t) => t.itemId === fee.addOnId,
+                                    )?.taxBreakdown?.length
+                                    ? taxProviderTaxesResult?.collection
+                                        ?.find((t) => t.itemId === fee.addOnId)
+                                        ?.taxBreakdown?.map((tax) => (
+                                          <Typography
+                                            key={`fee-${i}-applied-taxe-${tax.name}`}
+                                            variant="body"
+                                            color="grey700"
+                                          >
+                                            {intlFormatNumber(tax?.rate || 0, {
+                                              style: 'percent',
+                                            })}
+                                          </Typography>
+                                        ))
+                                    : '0%'
                                   : '-'
                                 : fee.taxes?.length
                                   ? fee.taxes.map((tax) => (


### PR DESCRIPTION
## Context

We display some third party taxes in the one-off invoice creation.

## Description

We now make sure if the data is not present to display tax 0%, instead of a blank space

<!-- Linear link -->
Fixes ISSUE-533