### PR TITLE
bug: prevent current usage fetch for pending subscriptions

### DIFF
--- a/src/components/subscriptions/SubscriptionCurrentUsageTable.tsx
+++ b/src/components/subscriptions/SubscriptionCurrentUsageTable.tsx
@@ -18,8 +18,9 @@ import {
   CustomerForSubscriptionUsageQuery,
   CustomerUsageForUsageDetailsFragmentDoc,
   GetCustomerUsageForPortalQuery,
-  GetSubscriptionForSubscriptionUsageLifetimeGraphQuery,
   LagoApiError,
+  StatusTypeEnum,
+  SubscrptionForSubscriptionUsageQuery,
   TimezoneEnum,
   UsageForSubscriptionUsageQuery,
   useCustomerForSubscriptionUsageQuery,
@@ -48,6 +49,7 @@ gql`
     subscription(id: $subscription) {
       id
       name
+      status
       plan {
         id
         name
@@ -116,7 +118,7 @@ type SubscriptionCurrentUsageTableComponentProps = {
   usageLoading: boolean
   usageError?: ApolloError
 
-  subscription?: GetSubscriptionForSubscriptionUsageLifetimeGraphQuery['subscription']
+  subscription?: SubscrptionForSubscriptionUsageQuery['subscription']
   subscriptionLoading: boolean
 
   subscriptionError?: ApolloError
@@ -241,7 +243,11 @@ export const SubscriptionCurrentUsageTableComponent = ({
           ) : (
             <GenericPlaceholder
               title={translate('text_62c3f454e5d7f4ec8888c1d5')}
-              subtitle={translate('text_62c3f454e5d7f4ec8888c1d7')}
+              subtitle={
+                subscription?.status === StatusTypeEnum.Pending
+                  ? translate('text_173142196943714qsq737sre')
+                  : translate('text_62c3f454e5d7f4ec8888c1d7')
+              }
               image={<EmptyImage width="136" height="104" />}
             />
           )}
@@ -433,7 +439,7 @@ export const SubscriptionCurrentUsageTable = ({
       customerId: (customerId || subscription?.customer.id) as string,
       subscriptionId: subscription?.id || '',
     },
-    skip: !customerId || !subscription,
+    skip: !customerId || !subscription || subscription.status === StatusTypeEnum.Pending,
     fetchPolicy: 'no-cache',
   })
 

--- a/src/components/subscriptions/SubscriptionUsageLifetimeGraph.tsx
+++ b/src/components/subscriptions/SubscriptionUsageLifetimeGraph.tsx
@@ -12,6 +12,7 @@ import {
   CurrencyEnum,
   GetSubscriptionForSubscriptionUsageLifetimeGraphQuery,
   PremiumIntegrationTypeEnum,
+  StatusTypeEnum,
   SubscriptionUsageLifetimeGraphForLifetimeGraphFragment,
   useGetSubscriptionForSubscriptionUsageLifetimeGraphQuery,
 } from '~/generated/graphql'
@@ -35,6 +36,7 @@ export const REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE = 'subscriptionUsage'
 gql`
   fragment SubscriptionUsageLifetimeGraphForLifetimeGraph on Subscription {
     id
+    status
     lifetimeUsage {
       lastThresholdAmountCents
       nextThresholdAmountCents
@@ -172,7 +174,11 @@ export const SubscriptionUsageLifetimeGraphComponent = ({
           />
         ) : (
           <>
-            {!lifetimeUsage && !isLoading && hasProgressiveBillingPremiumIntegration ? (
+            {subscription?.status === StatusTypeEnum.Pending ? (
+              <Typography variant="body" color="grey600">
+                {translate('text_1731423623190elua4pl3ccr')}
+              </Typography>
+            ) : !lifetimeUsage && !isLoading && hasProgressiveBillingPremiumIntegration ? (
               <Typography
                 variant="body"
                 color="grey600"

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -7572,7 +7572,7 @@ export type SubscrptionForSubscriptionUsageQueryVariables = Exact<{
 }>;
 
 
-export type SubscrptionForSubscriptionUsageQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, name?: string | null, plan: { __typename?: 'Plan', id: string, name: string, code: string }, customer: { __typename?: 'Customer', id: string, applicableTimezone: TimezoneEnum } } | null };
+export type SubscrptionForSubscriptionUsageQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, name?: string | null, status?: StatusTypeEnum | null, plan: { __typename?: 'Plan', id: string, name: string, code: string }, customer: { __typename?: 'Customer', id: string, applicableTimezone: TimezoneEnum } } | null };
 
 export type SubscriptionCurrentUsageTableComponentCustomerUsageFragment = { __typename?: 'CustomerUsage', amountCents: any, currency: CurrencyEnum, fromDatetime: any, toDatetime: any, chargesUsage: Array<{ __typename?: 'ChargeUsage', id: string, units: number, amountCents: any, charge: { __typename?: 'Charge', id: string, invoiceDisplayName?: string | null }, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string }, filters?: Array<{ __typename?: 'ChargeFilterUsage', id?: string | null }> | null, groupedUsage: Array<{ __typename?: 'GroupedChargeUsage', amountCents: any, groupedBy?: any | null, eventsCount: number, units: number, filters?: Array<{ __typename?: 'ChargeFilterUsage', id?: string | null }> | null }> }> };
 
@@ -7593,14 +7593,14 @@ export type GetSubscriptionForDetailsOverviewQuery = { __typename?: 'Query', sub
 
 export type SubscriptionForSubscriptionInformationsFragment = { __typename?: 'Subscription', id: string, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, nextPendingStartDate?: any | null, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null } };
 
-export type SubscriptionUsageLifetimeGraphForLifetimeGraphFragment = { __typename?: 'Subscription', id: string, lifetimeUsage?: { __typename?: 'SubscriptionLifetimeUsage', lastThresholdAmountCents?: any | null, nextThresholdAmountCents?: any | null, totalUsageAmountCents: any, totalUsageFromDatetime: any, totalUsageToDatetime: any } | null, customer: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null, applicableTimezone: TimezoneEnum }, plan: { __typename?: 'Plan', id: string } };
+export type SubscriptionUsageLifetimeGraphForLifetimeGraphFragment = { __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, lifetimeUsage?: { __typename?: 'SubscriptionLifetimeUsage', lastThresholdAmountCents?: any | null, nextThresholdAmountCents?: any | null, totalUsageAmountCents: any, totalUsageFromDatetime: any, totalUsageToDatetime: any } | null, customer: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null, applicableTimezone: TimezoneEnum }, plan: { __typename?: 'Plan', id: string } };
 
 export type GetSubscriptionForSubscriptionUsageLifetimeGraphQueryVariables = Exact<{
   subscriptionId: Scalars['ID']['input'];
 }>;
 
 
-export type GetSubscriptionForSubscriptionUsageLifetimeGraphQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, lifetimeUsage?: { __typename?: 'SubscriptionLifetimeUsage', lastThresholdAmountCents?: any | null, nextThresholdAmountCents?: any | null, totalUsageAmountCents: any, totalUsageFromDatetime: any, totalUsageToDatetime: any } | null, customer: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null, applicableTimezone: TimezoneEnum }, plan: { __typename?: 'Plan', id: string } } | null };
+export type GetSubscriptionForSubscriptionUsageLifetimeGraphQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, lifetimeUsage?: { __typename?: 'SubscriptionLifetimeUsage', lastThresholdAmountCents?: any | null, nextThresholdAmountCents?: any | null, totalUsageAmountCents: any, totalUsageFromDatetime: any, totalUsageToDatetime: any } | null, customer: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null, applicableTimezone: TimezoneEnum }, plan: { __typename?: 'Plan', id: string } } | null };
 
 export type DeleteTaxFragment = { __typename?: 'Tax', id: string, name: string, customersCount: number };
 
@@ -9782,6 +9782,7 @@ export const SubscriptionForSubscriptionInformationsFragmentDoc = gql`
 export const SubscriptionUsageLifetimeGraphForLifetimeGraphFragmentDoc = gql`
     fragment SubscriptionUsageLifetimeGraphForLifetimeGraph on Subscription {
   id
+  status
   lifetimeUsage {
     lastThresholdAmountCents
     nextThresholdAmountCents
@@ -18259,6 +18260,7 @@ export const SubscrptionForSubscriptionUsageDocument = gql`
   subscription(id: $subscription) {
     id
     name
+    status
     plan {
       id
       name

--- a/translations/base.json
+++ b/translations/base.json
@@ -1839,7 +1839,7 @@
   "text_62c3f3fca8a1625624e83379": "Something went wrong",
   "text_62c3f3fca8a1625624e8337e": "Please refresh the page or contact us if the error persists.",
   "text_62c3f3fca8a1625624e83382": "Refresh the page",
-  "text_62c3f454e5d7f4ec8888c1d5": "No usage reported",
+  "text_62c3f454e5d7f4ec8888c1d5": "No usage has been reported",
   "text_62c3f454e5d7f4ec8888c1d7": "Add a plan with charges to this customer to start reporting the current usage",
   "text_62b1edddbf5f461ab9712733": "Integrations",
   "text_62b1edddbf5f461ab9712750": "Integrations",
@@ -2623,5 +2623,7 @@
   "text_17295436903260tlyb1gp1i7": "Save edits",
   "text_1729543690326d4dmmcw7n89": "Search and select a dunning campaign",
   "text_17295437652543pf2j5lqe67": "Dunning campaign behavior successfully applied",
-  "text_1731078338811aok1u8oopxl": "No dunning campaign available for this customer"
+  "text_1731078338811aok1u8oopxl": "No dunning campaign available for this customer",
+  "text_173142196943714qsq737sre": "This subscription is not yet active. Current usage is displayed only for active subscriptions.",
+  "text_1731423623190elua4pl3ccr": "This subscription is not yet active. Lifetime usage is displayed only for active subscriptions."
 }


### PR DESCRIPTION
## Context

If a subscription is pending, the current usage endpoint throw an error if fetched.

## Description

This PR make sure the endpoint is not fetched in such situation and adapts the empty state copy.

Also adapt the copy for lifetime usage that kinda have the same problem (without the error) but it still have to fetch the data before, as it's used in 2 placed and have an internal fetch logic.

<!-- Linear link -->
Fixes ISSUE-536