### PR TITLE
bug: only show override modal on edit mode

### DIFF
--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -285,7 +285,7 @@ const CreatePlan = () => {
                   disabled={!formikProps.isValid || (isEdition && !formikProps.dirty)}
                   size="large"
                   onClick={() => {
-                    if (plan?.hasOverriddenPlans) {
+                    if (plan?.hasOverriddenPlans && isEdition) {
                       return impactOverridenSubscriptionsDialogRef.current?.openDialog({
                         onSave: async (cascadeUpdates) => {
                           await formikProps.setFieldValue('cascadeUpdates', cascadeUpdates)


### PR DESCRIPTION
## Context

We recently added a feature to display a warning modal when it impacts a subscription with overrides.

This modal should only be displayed during an edit flow tho

## Description

This PR make sure the display condition is respected.

<!-- Linear link -->
Fixes ISSUE-548