### PR TITLE
bug: orga switch should reset cache and invalidate all active queries

### DIFF
--- a/src/core/apolloClient/cacheUtils.ts
+++ b/src/core/apolloClient/cacheUtils.ts
@@ -75,7 +75,7 @@ export const switchCurrentOrganization = async (
 ) => {
   setItemFromLS(ORGANIZATION_LS_KEY_ID, organizationId)
 
-  await client.clearStore()
+  await client.cache.reset()
 }
 
 export const onAccessCustomerPortal = (token?: string) => {

--- a/src/hooks/useOrganizationInfos.ts
+++ b/src/hooks/useOrganizationInfos.ts
@@ -40,7 +40,9 @@ type UseOrganizationInfos = () => {
 export const useOrganizationInfos: UseOrganizationInfos = () => {
   const { data, loading } = useGetOrganizationInfosQuery({
     fetchPolicy: 'cache-first',
+    nextFetchPolicy: 'cache-first',
     canonizeResults: true,
+    notifyOnNetworkStatusChange: true,
   })
   const orgaTimezone = data?.organization?.timezone || TimezoneEnum.TzUtc
   const timezoneConfig = TimeZonesConfig[orgaTimezone]

--- a/src/layouts/SideNavLayout.tsx
+++ b/src/layouts/SideNavLayout.tsx
@@ -88,7 +88,7 @@ const SideNav = () => {
   const [open, setOpen] = useState(false)
   const { currentUser, loading: currentUserLoading } = useCurrentUser()
   const { hasPermissions } = usePermissions()
-  const { organization } = useOrganizationInfos()
+  const { organization, loading: currentOrganizationLoading } = useOrganizationInfos()
   const { translate } = useInternationalization()
   const { data, loading, error } = useSideNavInfosQuery()
   const { pathname, state } = location as Location & { state: { disableScrollTop?: boolean } }
@@ -124,25 +124,38 @@ const SideNav = () => {
               maxHeight={`calc(100vh - 64px - 16px)`}
               enableFlip={false}
               opener={
-                <HeaderButton data-test="side-nav-name" variant="quaternary">
-                  {organization?.logoUrl ? (
-                    <Avatar size="small" variant="connector">
-                      <img
-                        src={organization?.logoUrl as string}
-                        alt={`${organization?.name}'s logo`}
-                      />
-                    </Avatar>
+                <HeaderButton
+                  data-test="side-nav-name"
+                  variant="quaternary"
+                  disabled={currentOrganizationLoading}
+                >
+                  {currentOrganizationLoading ? (
+                    <div className="flex flex-row items-center gap-2">
+                      <Skeleton variant="circular" size="small" />
+                      <Skeleton variant="text" className="w-30" />
+                    </div>
                   ) : (
-                    <Avatar
-                      variant="company"
-                      identifier={organization?.name || ''}
-                      size="small"
-                      initials={(organization?.name ?? 'Lago')[0]}
-                    />
+                    <>
+                      {organization?.logoUrl ? (
+                        <Avatar size="small" variant="connector">
+                          <img
+                            src={organization?.logoUrl as string}
+                            alt={`${organization?.name}'s logo`}
+                          />
+                        </Avatar>
+                      ) : (
+                        <Avatar
+                          variant="company"
+                          identifier={organization?.name || ''}
+                          size="small"
+                          initials={(organization?.name ?? 'Lago')[0]}
+                        />
+                      )}
+                      <Typography color="textSecondary" noWrap>
+                        {organization?.name}
+                      </Typography>
+                    </>
                   )}
-                  <Typography color="textSecondary" noWrap>
-                    {organization?.name}
-                  </Typography>
                 </HeaderButton>
               }
             >


### PR DESCRIPTION
## Context

When switching orga, some "core" data are not renewed. That lead for example to have the orga name not being updated in the sidebar.

## Description

This PR make sure the cache is totally reset during an orga switch, just like we do for a log out. 
But keeping the auth token allows to re-trigger all usefull queries.
Note that as the cache is reset, all active queries are still triggered but canceled by apollo (haven't found a better way).
Also added a loading state on the orga name in the sidebar

Fixes ISSUE-565