### PR TITLE
misc: adapt fee copy for 1 tier graduated & percentage graduated

### DIFF
--- a/src/components/invoices/details/InvoiceDetailsTableBodyLineGraduated.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableBodyLineGraduated.tsx
@@ -46,18 +46,22 @@ export const InvoiceDetailsTableBodyLineGraduated = memo(
           <tr key={`fee-${fee.id}-graduated-range-fee-per-unit-${i}`} className="details-line">
             <td>
               <Typography variant="body" color="grey600">
-                {i === 0
-                  ? translate('text_659e67cd63512ef532843070', {
-                      toValue: Number(graduatedRange?.toValue),
+                {(fee?.amountDetails?.graduatedRanges?.length || 0) === 1
+                  ? translate('text_659e67cd63512ef5328430e6', {
+                      fromValue: Number(graduatedRange?.fromValue),
                     })
-                  : i === (fee?.amountDetails?.graduatedRanges?.length || 0) - 1
-                    ? translate('text_659e67cd63512ef5328430e6', {
-                        fromValue: Number(graduatedRange?.fromValue),
-                      })
-                    : translate('text_659e67cd63512ef5328430af', {
-                        fromValue: Number(graduatedRange?.fromValue),
+                  : i === 0
+                    ? translate('text_659e67cd63512ef532843070', {
                         toValue: Number(graduatedRange?.toValue),
-                      })}
+                      })
+                    : i === (fee?.amountDetails?.graduatedRanges?.length || 0) - 1
+                      ? translate('text_659e67cd63512ef5328430e6', {
+                          fromValue: Number(graduatedRange?.fromValue),
+                        })
+                      : translate('text_659e67cd63512ef5328430af', {
+                          fromValue: Number(graduatedRange?.fromValue),
+                          toValue: Number(graduatedRange?.toValue),
+                        })}
               </Typography>
             </td>
             <td>
@@ -113,18 +117,22 @@ export const InvoiceDetailsTableBodyLineGraduated = memo(
               <tr key={`fee-${fee.id}-graduated-range-flat-fee-${i}`} className="details-line">
                 <td>
                   <Typography variant="body" color="grey600">
-                    {i === 0
-                      ? translate('text_659e67cd63512ef53284310e', {
-                          toValue: Number(graduatedRange?.toValue),
+                    {(fee?.amountDetails?.graduatedRanges?.length || 0) === 1
+                      ? translate('text_659e67cd63512ef53284314a', {
+                          fromValue: Number(graduatedRange?.fromValue),
                         })
-                      : i === (fee?.amountDetails?.graduatedRanges?.length || 0) - 1
-                        ? translate('text_659e67cd63512ef53284314a', {
-                            fromValue: Number(graduatedRange?.fromValue),
-                          })
-                        : translate('text_659e67cd63512ef532843136', {
-                            fromValue: Number(graduatedRange?.fromValue),
+                      : i === 0
+                        ? translate('text_659e67cd63512ef53284310e', {
                             toValue: Number(graduatedRange?.toValue),
-                          })}
+                          })
+                        : i === (fee?.amountDetails?.graduatedRanges?.length || 0) - 1
+                          ? translate('text_659e67cd63512ef53284314a', {
+                              fromValue: Number(graduatedRange?.fromValue),
+                            })
+                          : translate('text_659e67cd63512ef532843136', {
+                              fromValue: Number(graduatedRange?.fromValue),
+                              toValue: Number(graduatedRange?.toValue),
+                            })}
                   </Typography>
                 </td>
                 <td>

--- a/src/components/invoices/details/InvoiceDetailsTableBodyLineGraduatedPercentage.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableBodyLineGraduatedPercentage.tsx
@@ -54,18 +54,22 @@ export const InvoiceDetailsTableBodyLineGraduatedPercentage = memo(
           >
             <td>
               <Typography variant="body" color="grey600">
-                {i === 0
-                  ? translate('text_659e67cd63512ef532843070', {
-                      toValue: Number(graduatedPercentageRange?.toValue),
+                {(fee?.amountDetails?.graduatedPercentageRanges?.length || 0) === 1
+                  ? translate('text_659e67cd63512ef5328430e6', {
+                      fromValue: Number(graduatedPercentageRange?.fromValue),
                     })
-                  : i === (fee?.amountDetails?.graduatedPercentageRanges?.length || 0) - 1
-                    ? translate('text_659e67cd63512ef5328430e6', {
-                        fromValue: Number(graduatedPercentageRange?.fromValue),
-                      })
-                    : translate('text_659e67cd63512ef5328430af', {
-                        fromValue: Number(graduatedPercentageRange?.fromValue),
+                  : i === 0
+                    ? translate('text_659e67cd63512ef532843070', {
                         toValue: Number(graduatedPercentageRange?.toValue),
-                      })}
+                      })
+                    : i === (fee?.amountDetails?.graduatedPercentageRanges?.length || 0) - 1
+                      ? translate('text_659e67cd63512ef5328430e6', {
+                          fromValue: Number(graduatedPercentageRange?.fromValue),
+                        })
+                      : translate('text_659e67cd63512ef5328430af', {
+                          fromValue: Number(graduatedPercentageRange?.fromValue),
+                          toValue: Number(graduatedPercentageRange?.toValue),
+                        })}
               </Typography>
             </td>
             <td>
@@ -120,18 +124,22 @@ export const InvoiceDetailsTableBodyLineGraduatedPercentage = memo(
               >
                 <td>
                   <Typography variant="body" color="grey600">
-                    {i === 0
-                      ? translate('text_659e67cd63512ef53284310e', {
-                          toValue: Number(graduatedPercentageRange?.toValue),
+                    {fee?.amountDetails?.graduatedPercentageRanges?.length || 0
+                      ? translate('text_659e67cd63512ef53284314a', {
+                          fromValue: Number(graduatedPercentageRange?.fromValue),
                         })
-                      : i === (fee?.amountDetails?.graduatedPercentageRanges?.length || 0) - 1
-                        ? translate('text_659e67cd63512ef53284314a', {
-                            fromValue: Number(graduatedPercentageRange?.fromValue),
-                          })
-                        : translate('text_659e67cd63512ef532843136', {
-                            fromValue: Number(graduatedPercentageRange?.fromValue),
+                      : i === 0
+                        ? translate('text_659e67cd63512ef53284310e', {
                             toValue: Number(graduatedPercentageRange?.toValue),
-                          })}
+                          })
+                        : i === (fee?.amountDetails?.graduatedPercentageRanges?.length || 0) - 1
+                          ? translate('text_659e67cd63512ef53284314a', {
+                              fromValue: Number(graduatedPercentageRange?.fromValue),
+                            })
+                          : translate('text_659e67cd63512ef532843136', {
+                              fromValue: Number(graduatedPercentageRange?.fromValue),
+                              toValue: Number(graduatedPercentageRange?.toValue),
+                            })}
                   </Typography>
                 </td>
                 <td>


### PR DESCRIPTION
## Context

Graduated and graduated percentage fee can have only one tier defined on plan level.

That mean any amount will be defined of 1 unit and above.

## Description

This PR does make sure we mention "above" in the copy, and also align with the BE copy on the PDF.

Note this translation already exist an just need to be used if the array length it 1.

<!-- Linear link -->
Fixes ISSUE-568