### PR TITLE
misc(CustomerPortal): display some excluding tax label when needed

### DIFF
--- a/src/components/customerPortal/usage/UsagePage.tsx
+++ b/src/components/customerPortal/usage/UsagePage.tsx
@@ -136,6 +136,7 @@ const UsagePage = () => {
       {customerId && subscriptionId && (
         <div className="mt-12">
           <SubscriptionCurrentUsageTableComponent
+            showExcludingTaxLabel
             usageData={usageData?.customerPortalCustomerUsage}
             usageLoading={usageLoading}
             usageError={usageError}

--- a/src/components/customerPortal/usage/UsageSubscriptionItem.tsx
+++ b/src/components/customerPortal/usage/UsageSubscriptionItem.tsx
@@ -64,17 +64,19 @@ const UsageSubscriptionItem = ({
       {typeof subscription.plan?.amountCurrency !== 'undefined' && (
         <div className="flex gap-1">
           <Typography className="text-base font-normal text-grey-700">
-            {intlFormatNumber(
-              deserializeAmount(
-                subscription.plan?.amountCents || 0,
-                subscription.plan?.amountCurrency,
+            {translate('text_17326262367759e7w9yfbeno', {
+              amount: intlFormatNumber(
+                deserializeAmount(
+                  subscription.plan?.amountCents || 0,
+                  subscription.plan?.amountCurrency,
+                ),
+                {
+                  currencyDisplay: 'narrowSymbol',
+                  currency: subscription.plan?.amountCurrency,
+                  locale: documentLocale,
+                },
               ),
-              {
-                currencyDisplay: 'narrowSymbol',
-                currency: subscription.plan?.amountCurrency,
-                locale: documentLocale,
-              },
-            )}
+            })}
           </Typography>
 
           {subscription?.plan?.interval && (

--- a/src/components/subscriptions/SubscriptionCurrentUsageTable.tsx
+++ b/src/components/subscriptions/SubscriptionCurrentUsageTable.tsx
@@ -126,6 +126,7 @@ type SubscriptionCurrentUsageTableComponentProps = {
   customerData?: CustomerForSubscriptionUsageQuery['customer']
   customerLoading: boolean
   customerError?: ApolloError
+  showExcludingTaxLabel?: boolean
 
   refetchUsage: () => void
 
@@ -147,6 +148,7 @@ export const SubscriptionCurrentUsageTableComponent = ({
   customerData,
   customerLoading,
   customerError,
+  showExcludingTaxLabel = false,
 
   refetchUsage,
 
@@ -261,7 +263,9 @@ export const SubscriptionCurrentUsageTableComponent = ({
             justifyContent={'space-between'}
           >
             <Typography variant="bodyHl" color="grey700" noWrap>
-              {translate('text_62c3f3fca8a1625624e83380')}
+              {showExcludingTaxLabel
+                ? translate('text_17326286491076m81w5uy3el')
+                : translate('text_62c3f3fca8a1625624e83380')}
             </Typography>
 
             {isLoading ? (

--- a/translations/base.json
+++ b/translations/base.json
@@ -2665,5 +2665,7 @@
   "text_17316852355256pb6ga10vb4": "Salesforce invoice url",
   "text_1731685235525jazy82715wh": "Sync invoice to Salesforce",
   "text_1731685304648t5kyi5j9fju": "Invoice not synced to Salesforce",
-  "text_17316853046485zk7ibjnwbb": "Salesforce synchronization successfully triggered."
+  "text_17316853046485zk7ibjnwbb": "Salesforce synchronization successfully triggered.",
+  "text_17326262367759e7w9yfbeno": "{{amount}} (excl. tax)",
+  "text_17326286491076m81w5uy3el": "Total current usage (excl. tax)"
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -162,5 +162,7 @@
   "text_62da6ec24a8e24e44f8128aa": "Mehr laden",
   "text_62da6ec24a8e24e44f81288c": "Kein Ablaufdatum",
   "text_634687079be251fdb43833cb": "Kundenname",
-  "text_1729256593854oiy13slixjr": "Ihr überfälliger Saldo von {{companyName}}"
+  "text_1729256593854oiy13slixjr": "Ihr überfälliger Saldo von {{companyName}}",
+  "text_17326262367759e7w9yfbeno": "{{amount}} (zzgl. MwSt.)",
+  "text_17326286491076m81w5uy3el": "Gesamte aktuelle Nutzung (zzgl. MwSt.)"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -162,5 +162,7 @@
   "text_62da6ec24a8e24e44f8128aa": "Cargar más",
   "text_62da6ec24a8e24e44f81288c": "Sin fecha de vencimiento",
   "text_634687079be251fdb43833cb": "Nombre del cliente",
-  "text_1729256593854oiy13slixjr": "Su saldo vencido de {{companyName}}"
+  "text_1729256593854oiy13slixjr": "Su saldo vencido de {{companyName}}",
+  "text_17326262367759e7w9yfbeno": "{{amount}} (sin impuestos)",
+  "text_17326286491076m81w5uy3el": "Uso total actual (sin impuestos)"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -162,5 +162,7 @@
   "text_62da6ec24a8e24e44f8128aa": "Charger plus",
   "text_62da6ec24a8e24e44f81288c": "Pas de date d'expiration",
   "text_634687079be251fdb43833cb": "Nom du client",
-  "text_1729256593854oiy13slixjr": "Votre solde impayé pour {{companyName}}"
+  "text_1729256593854oiy13slixjr": "Votre solde impayé pour {{companyName}}",
+  "text_17326262367759e7w9yfbeno": "{{amount}} (HT)",
+  "text_17326286491076m81w5uy3el": "Utilisation totale actuelle (HT)"
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -135,5 +135,7 @@
   "text_62da6ec24a8e24e44f8128aa": "Carica altro",
   "text_62da6ec24a8e24e44f81288c": "Nessuna data di scadenza",
   "text_634687079be251fdb43833cb": "Nome del cliente",
-  "text_1729256593854oiy13slixjr": "Il tuo saldo in ritardo da {{companyName}}"
+  "text_1729256593854oiy13slixjr": "Il tuo saldo in ritardo da {{companyName}}",
+  "text_17326262367759e7w9yfbeno": "{{amount}} (escl. tasse)",
+  "text_17326286491076m81w5uy3el": "Utilizzo totale corrente (escl. tasse)"
 }

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -161,5 +161,7 @@
   "text_62da6ec24a8e24e44f8128aa": "Last inn mer",
   "text_62da6ec24a8e24e44f81288c": "Ingen utløpsdato",
   "text_634687079be251fdb43833cb": "Kundenavn",
-  "text_1729256593854oiy13slixjr": "Din forfalte saldo fra {{companyName}}"
+  "text_1729256593854oiy13slixjr": "Din forfalte saldo fra {{companyName}}",
+  "text_17326262367759e7w9yfbeno": "{{amount}} (eks. mva)",
+  "text_17326286491076m81w5uy3el": "Total nåværende bruk (eks. mva)"
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -162,5 +162,7 @@
   "text_62da6ec24a8e24e44f8128aa": "Ladda mer",
   "text_62da6ec24a8e24e44f81288c": "Inget utgångsdatum",
   "text_634687079be251fdb43833cb": "Kundnamn",
-  "text_1729256593854oiy13slixjr": "Din förfallna saldo från {{companyName}}"
+  "text_1729256593854oiy13slixjr": "Din förfallna saldo från {{companyName}}",
+  "text_17326262367759e7w9yfbeno": "{{amount}} (exkl. moms)",
+  "text_17326286491076m81w5uy3el": "Total aktuell användning (exkl. moms)"
 }


### PR DESCRIPTION
## Context

Some customer found it not clear whereas if a price is display including or excluding taxes

## Description

We now display this information when it make sense

<!-- Linear link -->
Fixes ISSUE-567