### PR TITLE
(fix): Fix custom expression crashing

### DIFF
--- a/src/components/billableMetrics/CustomExpressionDrawer.tsx
+++ b/src/components/billableMetrics/CustomExpressionDrawer.tsx
@@ -107,6 +107,7 @@ export const CustomExpressionDrawer = forwardRef<
     const result = wrappedEvaluateExpression(
       formikProps.values.expression,
       formikProps.values.eventPayload,
+      translate,
     )
 
     setValidationResult(result)

--- a/src/components/billableMetrics/utils.ts
+++ b/src/components/billableMetrics/utils.ts
@@ -1,10 +1,18 @@
 import { EventPayload, ValidationResult } from '~/components/billableMetrics/CustomExpressionDrawer'
+import { TranslateFunc } from '~/hooks/core/useInternationalization'
 
 import { evaluateExpression, parseExpression } from '../../lago-expression/expression_js'
+
+const REQUIRED_EVENT_FIELDS: Array<keyof EventPayload['event']> = [
+  'code',
+  'timestamp',
+  'properties',
+]
 
 export const wrappedEvaluateExpression = (
   expression: string,
   payload: EventPayload,
+  translate: TranslateFunc,
 ): ValidationResult => {
   try {
     let eventPayload = payload
@@ -12,6 +20,16 @@ export const wrappedEvaluateExpression = (
     if (typeof payload === 'string') {
       eventPayload = JSON.parse(payload)
     }
+
+    REQUIRED_EVENT_FIELDS.forEach((property) => {
+      if (!eventPayload?.event?.[property]) {
+        throw new Error(
+          translate('text_17326923760161haoak0v6km', {
+            property,
+          }),
+        )
+      }
+    })
 
     const res = evaluateExpression(
       parseExpression(expression),
@@ -25,7 +43,7 @@ export const wrappedEvaluateExpression = (
     }
   } catch (e) {
     return {
-      error: e as string,
+      error: String(e),
     }
   }
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -2667,5 +2667,7 @@
   "text_1731685304648t5kyi5j9fju": "Invoice not synced to Salesforce",
   "text_17316853046485zk7ibjnwbb": "Salesforce synchronization successfully triggered.",
   "text_17326262367759e7w9yfbeno": "{{amount}} (excl. tax)",
-  "text_17326286491076m81w5uy3el": "Total current usage (excl. tax)"
+  "text_17326286491076m81w5uy3el": "Total current usage (excl. tax)",
+  "text_17326923760161haoak0v6km": "Missing \"{{property}}\" from payload"
 }
+


### PR DESCRIPTION
## Context

Recently, it was found out that if the event payload doesn't contain a `timestamp`, the whole UI crashes.

## Description

It was happening because we were throwing an object Error & React couldn't render it.

Just converting it to a string wouldn't have worked, as the error would be cryptic. Instead, created a list of required properties which are checked before trying to evaluate an expression.