### PR TITLE
misc: recast type to remove ts expected error comment

### DIFF
--- a/src/core/apolloClient/init.ts
+++ b/src/core/apolloClient/init.ts
@@ -65,8 +65,9 @@ export const initializeApolloClient = async () => {
       silentErrorCodes.push(...AUTH_ERRORS, LagoApiError.Forbidden)
 
       if (graphQLErrors) {
-        // @ts-expect-error
-        graphQLErrors.forEach(({ message, locations, path, extensions }: LagoGQLError) => {
+        graphQLErrors.forEach((value) => {
+          const { message, path, locations, extensions } = value as LagoGQLError
+
           const isUnauthorized = extensions && AUTH_ERRORS.includes(extensions?.code)
 
           if (isUnauthorized && globalApolloClient) {
@@ -100,11 +101,10 @@ export const initializeApolloClient = async () => {
         console.warn(`[Network error]: ${JSON.stringify(networkError)}`)
       }
     }),
-    // afterwareLink.concat(
+
     createUploadLink({
       uri: `${apiUrl}/graphql`,
     }) as unknown as ApolloLink,
-    // ),
   ]
 
   await persistCache({


### PR DESCRIPTION
Just saw this `@ts-expected-error` we could get rid of.

FYI this is what `LagoGQLError` looks like 

```
export interface LagoGQLError extends GraphQLFormattedError {
  extensions: {
    code: LagoApiError
    details: Record<string, string[]>
  }
}
```

and the value is of type `GraphQLFormattedError` 