### PR TITLE
misc: make sure we control filter values displayed

### DIFF
--- a/src/components/designSystem/Filters/filtersElements/FiltersItemInvoiceType.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemInvoiceType.tsx
@@ -17,9 +17,32 @@ export const FiltersItemInvoiceType = ({ value, setFilterValue }: FiltersItemInv
       disableClearable
       disableCloseOnSelect
       placeholder={translate('text_66ab42d4ece7e6b7078993b1')}
-      data={Object.values(InvoiceTypeEnum).map((invoiceType) => ({
-        value: invoiceType,
-      }))}
+      data={[
+        {
+          label: translate('text_1733136185960mb0c4wf2ekq'),
+          value: InvoiceTypeEnum.AddOn,
+        },
+        {
+          label: translate('text_1728472697691y39tdxgyrcg'),
+          value: InvoiceTypeEnum.AdvanceCharges,
+        },
+        {
+          label: translate('text_62d18855b22699e5cf55f879'),
+          value: InvoiceTypeEnum.Credit,
+        },
+        {
+          label: translate('text_17331361859605azhkvgofv3'),
+          value: InvoiceTypeEnum.OneOff,
+        },
+        {
+          label: translate('text_1724179887722baucvj7bvc1'),
+          value: InvoiceTypeEnum.ProgressiveBilling,
+        },
+        {
+          label: translate('text_1728472697691k6k2e9m5ibb'),
+          value: InvoiceTypeEnum.Subscription,
+        },
+      ]}
       onChange={(invoiceType) => {
         setFilterValue(String(invoiceType.map((v) => v.value).join(',')))
       }}

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemPaymentStatus.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemPaymentStatus.tsx
@@ -20,9 +20,20 @@ export const FiltersItemPaymentStatus = ({
       disableClearable
       disableCloseOnSelect
       placeholder={translate('text_66ab42d4ece7e6b7078993b1')}
-      data={Object.values(InvoicePaymentStatusTypeEnum).map((invoiceType) => ({
-        value: invoiceType,
-      }))}
+      data={[
+        {
+          label: translate('text_63e27c56dfe64b846474ef4e'),
+          value: InvoicePaymentStatusTypeEnum.Failed,
+        },
+        {
+          label: translate('text_62da6db136909f52c2704c30'),
+          value: InvoicePaymentStatusTypeEnum.Pending,
+        },
+        {
+          label: translate('text_63ac86d797f728a87b2f9fa1'),
+          value: InvoicePaymentStatusTypeEnum.Succeeded,
+        },
+      ]}
       onChange={(invoiceType) => {
         setFilterValue(String(invoiceType.map((v) => v.value).join(',')))
       }}

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemStatus.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemStatus.tsx
@@ -17,9 +17,24 @@ export const FiltersItemStatus = ({ value, setFilterValue }: FiltersItemStatusPr
       disableClearable
       disableCloseOnSelect
       placeholder={translate('text_66ab42d4ece7e6b7078993b1')}
-      data={Object.values(InvoiceStatusTypeEnum).map((status) => ({
-        value: status,
-      }))}
+      data={[
+        {
+          label: translate('text_63ac86d797f728a87b2f9f91'),
+          value: InvoiceStatusTypeEnum.Draft,
+        },
+        {
+          label: translate('text_63e27c56dfe64b846474ef4e'),
+          value: InvoiceStatusTypeEnum.Failed,
+        },
+        {
+          label: translate('text_65269c2e471133226211fd74'),
+          value: InvoiceStatusTypeEnum.Finalized,
+        },
+        {
+          label: translate('text_6376641a2a9c70fff5bddcd5'),
+          value: InvoiceStatusTypeEnum.Voided,
+        },
+      ]}
       onChange={(status) => {
         setFilterValue(String(status.map((v) => v.value).join(',')))
       }}

--- a/translations/base.json
+++ b/translations/base.json
@@ -2705,5 +2705,7 @@
   "text_1732286530467zstzwbegfiq": "Name (optional)",
   "text_17322865304681s5r90ntpdv": "Enter a name",
   "text_1732522865354i0r12i6z9mu": "Add API key",
-  "text_17325256621362d6ocmq1lhw": "API key successfully deleted"
+  "text_17325256621362d6ocmq1lhw": "API key successfully deleted",
+  "text_1733136185960mb0c4wf2ekq": "Add-on",
+  "text_17331361859605azhkvgofv3": "One off"
 }


### PR DESCRIPTION
## Context

We display some invoice status filter values that are internal states for Lago, hence not being relevant for customers

## Description

This PR make sure we only display what we want to, also passes on other filters to use proper translations for the filter's label

<!-- Linear link -->
Fixes ISSUE-572