### PR TITLE
fix(MultipleComboBox): Fix chip spacing

### DIFF
--- a/src/components/form/MultipleComboBox/MultipleComboBox.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBox.tsx
@@ -135,11 +135,9 @@ export const MultipleComboBox = ({
             return (
               <Chip
                 {...tagOptions}
+                className="my-2 ml-2 mr-0"
                 key={tagOptions.key}
                 label={option.value}
-                sx={{
-                  margin: '8px 0px 8px 8px',
-                }}
               />
             )
           })


### PR DESCRIPTION
## Context

The chip spacing inside an Autocomplete wasn't right.

## Description

It seemed like the `sx` we were passing were getting overridden by some default theme styles. Changed it to a `className` and now it works properly.

Before & after:

<img width="828" alt="image" src="https://github.com/user-attachments/assets/fa5bf4c0-11d8-4148-a191-539a02d813cc">

Fixes LAGO-573