### PR TITLE
feat: Overdue column in invoices list

### DIFF
--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -3,7 +3,7 @@ import { FC, useRef } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
-import { InfiniteScroll, Status, Table, Tooltip, Typography } from '~/components/designSystem'
+import { Chip, InfiniteScroll, Status, Table, Tooltip, Typography } from '~/components/designSystem'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { invoiceStatusMapping, paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -260,6 +260,16 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
                       </Tooltip>
                     )
                   },
+                }
+              : null,
+            context === 'finalized'
+              ? {
+                  key: 'paymentOverdue',
+                  title: translate('text_666c5b12fea4aa1e1b26bf55'),
+                  content: ({ paymentOverdue }) =>
+                    paymentOverdue && (
+                      <Chip error={true} label={translate('text_666c5b12fea4aa1e1b26bf55')} />
+                    ),
                 }
               : null,
             {

--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -236,7 +236,7 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
                   key: 'paymentStatus',
                   minWidth: 120,
                   title: translate('text_63b5d225b075850e0fe489f4'),
-                  content: ({ status, paymentStatus, paymentOverdue, paymentDisputeLostAt }) => {
+                  content: ({ status, paymentStatus, paymentDisputeLostAt }) => {
                     if (status !== InvoiceStatusTypeEnum.Finalized) {
                       return null
                     }
@@ -254,7 +254,6 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
                           {...paymentStatusMapping({
                             status,
                             paymentStatus,
-                            paymentOverdue,
                           })}
                           endIcon={!!paymentDisputeLostAt ? 'warning-unfilled' : undefined}
                         />

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react'
 import { generatePath, useNavigate, useSearchParams } from 'react-router-dom'
 
 import {
+  Chip,
   InfiniteScroll,
   QuickFilters,
   Status,
@@ -329,6 +330,14 @@ const InvoicesList = ({
                     </Tooltip>
                   )
                 },
+              },
+              {
+                key: 'paymentOverdue',
+                title: translate('text_666c5b12fea4aa1e1b26bf55'),
+                content: ({ paymentOverdue }) =>
+                  paymentOverdue && (
+                    <Chip error={true} label={translate('text_666c5b12fea4aa1e1b26bf55')} />
+                  ),
               },
               {
                 key: 'customer.name',

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -305,7 +305,7 @@ const InvoicesList = ({
                 key: 'paymentStatus',
                 title: translate('text_6419c64eace749372fc72b40'),
                 minWidth: 80,
-                content: ({ status, paymentStatus, paymentOverdue, paymentDisputeLostAt }) => {
+                content: ({ status, paymentStatus, paymentDisputeLostAt }) => {
                   if (status !== InvoiceStatusTypeEnum.Finalized) {
                     return null
                   }
@@ -323,7 +323,6 @@ const InvoicesList = ({
                         {...paymentStatusMapping({
                           status,
                           paymentStatus,
-                          paymentOverdue,
                         })}
                         endIcon={!!paymentDisputeLostAt ? 'warning-unfilled' : undefined}
                       />

--- a/src/core/constants/statusInvoiceMapping.ts
+++ b/src/core/constants/statusInvoiceMapping.ts
@@ -23,16 +23,10 @@ export const invoiceStatusMapping = ({
 export const paymentStatusMapping = ({
   status,
   paymentStatus,
-  paymentOverdue,
 }: {
   status: InvoiceStatusTypeEnum
   paymentStatus: InvoicePaymentStatusTypeEnum
-  paymentOverdue?: boolean
 }): StatusProps => {
-  if (paymentOverdue) {
-    return { label: 'overdue', type: StatusType.danger }
-  }
-
   if (status === InvoiceStatusTypeEnum.Finalized) {
     switch (paymentStatus) {
       case InvoicePaymentStatusTypeEnum.Pending:


### PR DESCRIPTION
## Context

A customer has recently requested a new column in the invoices list: Overdue.

## Description

- Added the Overdue columns for the invoices page & customer invoices list (the ones that aren't draft)
- Removed a case from the `paymentStatusMapping` function, as it was returning `Overdue` for overdue invoices, and this would have overlapped with the new implementation

Fixes LAGO-575