### PR TITLE
misc(Table): migrate to Tailwind

### DIFF
--- a/src/core/utils/__tests__/responsiveProps.test.ts
+++ b/src/core/utils/__tests__/responsiveProps.test.ts
@@ -1,0 +1,41 @@
+import { setResponsiveProperty } from '../responsiveProps'
+
+describe('setResponsiveProperty', () => {
+  it('should return a responsive style object', () => {
+    expect(setResponsiveProperty('margin', 0)).toEqual({
+      margin: '0px',
+    })
+
+    expect(setResponsiveProperty('margin', { default: 4 })).toEqual({
+      margin: '4px',
+    })
+
+    expect(
+      setResponsiveProperty('margin', {
+        default: 4,
+        md: 48,
+      }),
+    ).toEqual({
+      margin: '4px',
+      '@media (min-width:776px)': {
+        margin: '48px',
+      },
+    })
+
+    expect(
+      setResponsiveProperty('margin', {
+        default: 20,
+        md: 30,
+        lg: 10,
+      }),
+    ).toEqual({
+      margin: '20px',
+      '@media (min-width:776px)': {
+        margin: '30px',
+      },
+      '@media (min-width:1024px)': {
+        margin: '10px',
+      },
+    })
+  })
+})

--- a/src/core/utils/responsiveProps.ts
+++ b/src/core/utils/responsiveProps.ts
@@ -1,5 +1,3 @@
-import { css } from 'styled-components'
-
 import { theme } from '~/styles'
 
 type Breakpoint = keyof typeof theme.breakpoints.values
@@ -24,18 +22,18 @@ export const setResponsiveProperty = <T extends string | number>(
         ...curr,
 
         [theme.breakpoints.up(breakpoint)]: {
-          [cssProperty]: value[breakpoint] ?? defaultValue,
+          [cssProperty]: !!value[breakpoint] ? `${value[breakpoint]}px` : `${defaultValue}px`,
         },
       }
     }, {})
 
-    return css({
-      [cssProperty]: defaultValue,
+    return {
       ...responsiveCssProperties,
-    })
+      [cssProperty]: `${defaultValue}px`,
+    }
   }
 
-  return css({
-    [cssProperty]: value,
-  })
+  return {
+    [cssProperty]: `${value}px`,
+  }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -216,6 +216,25 @@ const config = {
           boxShadow: `1px 0px 0px 0px ${theme('colors.grey.300')} inset`,
         },
       })
+
+      // Animation
+      addUtilities({
+        '.animate-shadow-left': {
+          '@supports (animation-timeline: scroll(inline))': {
+            animationName: 'shadowLeft',
+            animationDuration: '1s',
+            animationTimingFunction: 'ease-in-out',
+            animationTimeline: 'scroll(inline)',
+          },
+
+          '@keyframes shadowLeft': {
+            '0%': { boxShadow: `1px 0px 0px 0px ${theme('colors.grey.300')} inset` },
+            '90%': { boxShadow: `1px 0px 0px 0px ${theme('colors.grey.300')} inset` },
+            '99%': { boxShadow: 'none' },
+          },
+        },
+      })
+
       // Outline ring
       addUtilities({
         '.ring': {


### PR DESCRIPTION
## Context

As part of our ongoing journey to migrate from styled components to tailwind, the Table component also needed refactoring.

## Description

Few points to note about this migration:
- All styles components are now JSX components written on top of Table definition, in the same file
- Styles are defined in 3 separated manner
  - `className` for "default" and toggled styles
  - `styles` for "dynamic" styles mapped on variables
  - `sx` for "complex" selector (specific classes, pseudo elements, ...)
- Component class names `lago-*` are not in variables. Even tho they are used multiple times, I had to prevent using variables because we cannot use dynamic classe names in `sx` selector. Those are not interpreted during run time but build and "transformed" as static css on the flight. Even with unchanged const it don't work.
- Kept usage of `setResponsiveProperty` and added a test for it. Also even tho this util is only used in Table today I preferred to keep it in it's separated file. It now return an object and not a component css object anymore.
- rewrote the Box wrapper with a div & classNames. Note the transform was useless and removed.
- You can notice a custom `captionHl` defined in a style of `TableInnerCell`. I choose not to turn that into a TW className that could help, but rather keep it like this and maybe migrate later if sure reproduce too often.

There should be no change in UI and UX

<!-- Linear link -->
Fixes LAGO-422