### PR TITLE
refactor: split add customer drawer

### DIFF
--- a/src/components/customers/addDrawer/AddCustomerDrawer.tsx
+++ b/src/components/customers/addDrawer/AddCustomerDrawer.tsx
@@ -1,14 +1,12 @@
 import { Grid } from '@mui/material'
 import { useFormik } from 'formik'
-import { forwardRef, RefObject, useEffect, useImperativeHandle, useRef, useState } from 'react'
-import styled from 'styled-components'
+import { forwardRef, RefObject, useImperativeHandle, useRef, useState } from 'react'
 import { array, object, string } from 'yup'
 
 import { TRANSLATIONS_MAP_CUSTOMER_TYPE } from '~/components/customers/utils'
-import { Accordion, Button, Card, Drawer, DrawerRef, Typography } from '~/components/designSystem'
-import { Checkbox, ComboBoxField, TextInputField } from '~/components/form'
+import { Button, Card, Drawer, DrawerRef, Typography } from '~/components/designSystem'
+import { ComboBoxField, TextInputField } from '~/components/form'
 import { hasDefinedGQLError } from '~/core/apolloClient'
-import { countryDataForCombobox } from '~/core/formats/countryDataForCombobox'
 import { ORGANIZATION_INFORMATIONS_ROUTE } from '~/core/router'
 import { getTimezoneConfig } from '~/core/timezone'
 import { metadataSchema } from '~/formValidation/metadataSchema'
@@ -32,8 +30,9 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCreateEditCustomer } from '~/hooks/useCreateEditCustomer'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
-import { DrawerContent, DrawerSubmitButton, DrawerTitle, theme } from '~/styles'
+import { DrawerContent, DrawerSubmitButton, DrawerTitle } from '~/styles'
 
+import { BillingAccordion } from './BillingAccordion'
 import { ExternalAppsAccordion } from './ExternalAppsAccordion'
 import { LocalCustomerMetadata, MetadataAccordion } from './MetadataAccordion'
 
@@ -50,7 +49,6 @@ export const AddCustomerDrawer = forwardRef<AddCustomerDrawerRef>((_, ref) => {
   const { isEdition, onSave } = useCreateEditCustomer({
     customer,
   })
-  const [isShippingEqualBillingAddress, setIsShippingEqualBillingAddress] = useState(false)
 
   const formikProps = useFormik<CreateCustomerInput | UpdateCustomerInput>({
     initialValues: {
@@ -242,29 +240,6 @@ export const AddCustomerDrawer = forwardRef<AddCustomerDrawerRef>((_, ref) => {
     closeDrawer: () => drawerRef.current?.closeDrawer(),
   }))
 
-  useEffect(() => {
-    if (isShippingEqualBillingAddress) {
-      formikProps.setFieldValue('shippingAddress', {
-        addressLine1: formikProps.values.addressLine1,
-        addressLine2: formikProps.values.addressLine2,
-        city: formikProps.values.city,
-        country: formikProps.values.country,
-        state: formikProps.values.state,
-        zipcode: formikProps.values.zipcode,
-      })
-    }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    formikProps.values.addressLine1,
-    formikProps.values.addressLine2,
-    formikProps.values.city,
-    formikProps.values.country,
-    formikProps.values.state,
-    formikProps.values.zipcode,
-    isShippingEqualBillingAddress,
-  ])
-
   return (
     <Drawer
       ref={drawerRef}
@@ -383,162 +358,9 @@ export const AddCustomerDrawer = forwardRef<AddCustomerDrawerRef>((_, ref) => {
             formikProps={formikProps}
           />
         </Card>
-        <Accordion
-          size="large"
-          summary={
-            <Typography variant="subhead">{translate('text_632b49e2620ea4c6d96c9662')}</Typography>
-          }
-        >
-          <AccordionContentWrapper $largeSpacing>
-            <Typography variant="bodyHl" color="textSecondary">
-              {translate('text_626c0c09812bbc00e4c59dff')}
-            </Typography>
-            <ComboBoxField
-              disabled={!!customer && !customer?.canEditAttributes}
-              label={translate('text_632c6e59b73f9a54d4c72247')}
-              placeholder={translate('text_632c6e59b73f9a54d4c7224b')}
-              infoText={translate(
-                !customer?.canEditAttributes && isEdition
-                  ? 'text_632c6e59b73f9a54d4c7223d'
-                  : 'text_632c6e59b73f9a54d4c7223f',
-              )}
-              name="currency"
-              data={Object.values(CurrencyEnum).map((currencyType) => ({
-                value: currencyType,
-              }))}
-              disableClearable
-              formikProps={formikProps}
-            />
-            <TextInputField
-              name="legalName"
-              label={translate('text_626c0c09812bbc00e4c59e01')}
-              placeholder={translate('text_626c0c09812bbc00e4c59e03')}
-              formikProps={formikProps}
-            />
-            <TextInputField
-              name="legalNumber"
-              label={translate('text_626c0c09812bbc00e4c59e05')}
-              placeholder={translate('text_626c0c09812bbc00e4c59e07')}
-              formikProps={formikProps}
-            />
-            <TextInputField
-              name="taxIdentificationNumber"
-              label={translate('text_648053ee819b60364c675d05')}
-              placeholder={translate('text_648053ee819b60364c675d0b')}
-              formikProps={formikProps}
-            />
-            <TextInputField
-              name="email"
-              beforeChangeFormatter={['lowercase']}
-              label={translate('text_626c0c09812bbc00e4c59e09')}
-              placeholder={translate('text_626c0c09812bbc00e4c59e0b')}
-              formikProps={formikProps}
-              helperText={translate('text_641394c4c936000079c5639a')}
-            />
 
-            <TextInputField
-              name="url"
-              label={translate('text_641b15b0df87eb00848944ea')}
-              placeholder={translate('text_641b15e7ac746900b68377f9')}
-              formikProps={formikProps}
-            />
-            <TextInputField
-              name="phone"
-              label={translate('text_626c0c09812bbc00e4c59e0d')}
-              placeholder={translate('text_626c0c09812bbc00e4c59e0f')}
-              formikProps={formikProps}
-            />
-          </AccordionContentWrapper>
-          <AccordionContentWrapper>
-            <Typography variant="bodyHl" color="textSecondary">
-              {translate('text_626c0c09812bbc00e4c59e19')}
-            </Typography>
-            <TextInputField
-              name="addressLine1"
-              label={translate('text_626c0c09812bbc00e4c59e1b')}
-              placeholder={translate('text_626c0c09812bbc00e4c59e1d')}
-              formikProps={formikProps}
-            />
-            <TextInputField
-              name="addressLine2"
-              placeholder={translate('text_626c0c09812bbc00e4c59e1f')}
-              formikProps={formikProps}
-            />
-            <TextInputField
-              name="zipcode"
-              placeholder={translate('text_626c0c09812bbc00e4c59e21')}
-              formikProps={formikProps}
-            />
-            <TextInputField
-              name="city"
-              placeholder={translate('text_626c0c09812bbc00e4c59e23')}
-              formikProps={formikProps}
-            />
-            <TextInputField
-              name="state"
-              placeholder={translate('text_626c0c09812bbc00e4c59e25')}
-              formikProps={formikProps}
-            />
-            <ComboBoxField
-              data={countryDataForCombobox}
-              name="country"
-              placeholder={translate('text_626c0c09812bbc00e4c59e27')}
-              formikProps={formikProps}
-              PopperProps={{ displayInDialog: true }}
-            />
-          </AccordionContentWrapper>
-          <AccordionContentWrapper>
-            <Typography variant="bodyHl" color="textSecondary">
-              {translate('text_667d708c1359b49f5a5a8230')}
-            </Typography>
-            <Checkbox
-              label={translate('text_667d708c1359b49f5a5a8234')}
-              value={isShippingEqualBillingAddress}
-              onChange={() => setIsShippingEqualBillingAddress((prev) => !prev)}
-            />
-            <TextInputField
-              name="shippingAddress.addressLine1"
-              label={translate('text_626c0c09812bbc00e4c59e1b')}
-              placeholder={translate('text_626c0c09812bbc00e4c59e1d')}
-              formikProps={formikProps}
-              disabled={isShippingEqualBillingAddress}
-            />
-            <TextInputField
-              name="shippingAddress.addressLine2"
-              placeholder={translate('text_626c0c09812bbc00e4c59e1f')}
-              formikProps={formikProps}
-              disabled={isShippingEqualBillingAddress}
-            />
-            <TextInputField
-              name="shippingAddress.zipcode"
-              placeholder={translate('text_626c0c09812bbc00e4c59e21')}
-              formikProps={formikProps}
-              disabled={isShippingEqualBillingAddress}
-            />
-            <TextInputField
-              name="shippingAddress.city"
-              placeholder={translate('text_626c0c09812bbc00e4c59e23')}
-              formikProps={formikProps}
-              disabled={isShippingEqualBillingAddress}
-            />
-            <TextInputField
-              name="shippingAddress.state"
-              placeholder={translate('text_626c0c09812bbc00e4c59e25')}
-              formikProps={formikProps}
-              disabled={isShippingEqualBillingAddress}
-            />
-            <ComboBoxField
-              data={countryDataForCombobox}
-              name="shippingAddress.country"
-              placeholder={translate('text_626c0c09812bbc00e4c59e27')}
-              formikProps={formikProps}
-              disabled={isShippingEqualBillingAddress}
-              PopperProps={{ displayInDialog: true }}
-            />
-          </AccordionContentWrapper>
-        </Accordion>
+        <BillingAccordion formikProps={formikProps} isEdition={isEdition} customer={customer} />
 
-        {/* External apps */}
         <ExternalAppsAccordion formikProps={formikProps} isEdition={isEdition} />
 
         <MetadataAccordion formikProps={formikProps} />
@@ -561,15 +383,5 @@ export const AddCustomerDrawer = forwardRef<AddCustomerDrawerRef>((_, ref) => {
     </Drawer>
   )
 })
-
-const AccordionContentWrapper = styled.div<{ $largeSpacing?: boolean }>`
-  &:not(:last-child) {
-    margin-bottom: ${theme.spacing(8)};
-  }
-
-  > *:not(:last-child) {
-    margin-bottom: ${({ $largeSpacing }) => ($largeSpacing ? theme.spacing(6) : theme.spacing(4))};
-  }
-`
 
 AddCustomerDrawer.displayName = 'AddCustomerDrawer'

--- a/src/components/customers/addDrawer/AddCustomerDrawer.tsx
+++ b/src/components/customers/addDrawer/AddCustomerDrawer.tsx
@@ -1,43 +1,22 @@
 import { Grid } from '@mui/material'
 import { useFormik } from 'formik'
-import _get from 'lodash/get'
-import React, {
-  forwardRef,
-  RefObject,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from 'react'
-import styled, { css } from 'styled-components'
+import { forwardRef, RefObject, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import styled from 'styled-components'
 import { array, object, string } from 'yup'
 
 import { TRANSLATIONS_MAP_CUSTOMER_TYPE } from '~/components/customers/utils'
-import {
-  Accordion,
-  Button,
-  Card,
-  Drawer,
-  DrawerRef,
-  Tooltip,
-  Typography,
-} from '~/components/designSystem'
-import { Checkbox, ComboBoxField, Switch, TextInputField } from '~/components/form'
+import { Accordion, Button, Card, Drawer, DrawerRef, Typography } from '~/components/designSystem'
+import { Checkbox, ComboBoxField, TextInputField } from '~/components/form'
 import { hasDefinedGQLError } from '~/core/apolloClient'
 import { countryDataForCombobox } from '~/core/formats/countryDataForCombobox'
 import { ORGANIZATION_INFORMATIONS_ROUTE } from '~/core/router'
 import { getTimezoneConfig } from '~/core/timezone'
-import {
-  METADATA_VALUE_MAX_LENGTH_DEFAULT,
-  MetadataErrorsEnum,
-  metadataSchema,
-} from '~/formValidation/metadataSchema'
+import { metadataSchema } from '~/formValidation/metadataSchema'
 import {
   AddCustomerDrawerFragment,
   AnrokCustomer,
   CreateCustomerInput,
   CurrencyEnum,
-  CustomerMetadataInput,
   CustomerTypeEnum,
   HubspotCustomer,
   IntegrationTypeEnum,
@@ -56,16 +35,11 @@ import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { DrawerContent, DrawerSubmitButton, DrawerTitle, theme } from '~/styles'
 
 import { ExternalAppsAccordion } from './ExternalAppsAccordion'
-
-const MAX_METADATA_COUNT = 5
+import { LocalCustomerMetadata, MetadataAccordion } from './MetadataAccordion'
 
 export interface AddCustomerDrawerRef {
   openDrawer: (customer?: AddCustomerDrawerFragment | null) => unknown
   closeDrawer: () => unknown
-}
-
-interface LocalCustomerMetadata extends CustomerMetadataInput {
-  localId?: string
 }
 
 export const AddCustomerDrawer = forwardRef<AddCustomerDrawerRef>((_, ref) => {
@@ -567,134 +541,7 @@ export const AddCustomerDrawer = forwardRef<AddCustomerDrawerRef>((_, ref) => {
         {/* External apps */}
         <ExternalAppsAccordion formikProps={formikProps} isEdition={isEdition} />
 
-        <Accordion
-          size="large"
-          summary={
-            <Typography variant="subhead">{translate('text_63fcc3218d35b9377840f59b')}</Typography>
-          }
-        >
-          <AccordionContentWrapper>
-            <Typography variant="body" color="grey600">
-              {translate('text_63fcc3218d35b9377840f59f')}
-            </Typography>
-            {!!formikProps?.values?.metadata?.length && (
-              <div>
-                <MetadataGrid $isHeader>
-                  <Typography variant="captionHl" color="grey700">
-                    {translate('text_63fcc3218d35b9377840f5a3')}
-                  </Typography>
-                  <Typography variant="captionHl" color="grey700">
-                    {translate('text_63fcc3218d35b9377840f5ab')}
-                  </Typography>
-                  <Typography variant="captionHl" color="grey700">
-                    {translate('text_63fcc3218d35b9377840f5b3')}
-                  </Typography>
-                </MetadataGrid>
-                <MetadataGrid>
-                  {formikProps?.values?.metadata?.map((m: LocalCustomerMetadata, i) => {
-                    const metadataItemKeyError: string =
-                      _get(formikProps.errors, `metadata.${i}.key`) || ''
-                    const metadataItemValueError: string =
-                      _get(formikProps.errors, `metadata.${i}.value`) || ''
-                    const hasCustomKeyError =
-                      Object.keys(MetadataErrorsEnum).includes(metadataItemKeyError)
-                    const hasCustomValueError =
-                      Object.keys(MetadataErrorsEnum).includes(metadataItemValueError)
-
-                    return (
-                      <React.Fragment key={`metadata-item-${m.id || m.localId || i}`}>
-                        <Tooltip
-                          placement="top-end"
-                          title={
-                            metadataItemKeyError === MetadataErrorsEnum.uniqueness
-                              ? translate('text_63fcc3218d35b9377840f5dd')
-                              : metadataItemKeyError === MetadataErrorsEnum.maxLength
-                                ? translate('text_63fcc3218d35b9377840f5d9')
-                                : undefined
-                          }
-                          disableHoverListener={!hasCustomKeyError}
-                        >
-                          <TextInputField
-                            name={`metadata.${i}.key`}
-                            silentError={!hasCustomKeyError}
-                            placeholder={translate('text_63fcc3218d35b9377840f5a7')}
-                            formikProps={formikProps}
-                            displayErrorText={false}
-                          />
-                        </Tooltip>
-                        <Tooltip
-                          placement="top-end"
-                          title={
-                            metadataItemValueError === MetadataErrorsEnum.maxLength
-                              ? translate('text_63fcc3218d35b9377840f5e5', {
-                                  max: METADATA_VALUE_MAX_LENGTH_DEFAULT,
-                                })
-                              : undefined
-                          }
-                          disableHoverListener={!hasCustomValueError}
-                        >
-                          <TextInputField
-                            name={`metadata.${i}.value`}
-                            silentError={!hasCustomValueError}
-                            placeholder={translate('text_63fcc3218d35b9377840f5af')}
-                            formikProps={formikProps}
-                            displayErrorText={false}
-                          />
-                        </Tooltip>
-                        <Switch
-                          name={`metadata.${i}.displayInInvoice`}
-                          checked={
-                            !!formikProps.values.metadata?.length &&
-                            !!formikProps.values.metadata[i].displayInInvoice
-                          }
-                          onChange={(newValue) => {
-                            formikProps.setFieldValue(`metadata.${i}.displayInInvoice`, newValue)
-                          }}
-                        />
-                        <StyledTooltip
-                          placement="top-end"
-                          title={translate('text_63fcc3218d35b9377840f5e1')}
-                        >
-                          <Button
-                            variant="quaternary"
-                            size="small"
-                            icon="trash"
-                            onClick={() => {
-                              formikProps.setFieldValue('metadata', [
-                                ...(formikProps.values.metadata || []).filter((metadata, j) => {
-                                  return j !== i
-                                }),
-                              ])
-                            }}
-                          />
-                        </StyledTooltip>
-                      </React.Fragment>
-                    )
-                  })}
-                </MetadataGrid>
-              </div>
-            )}
-            <Button
-              startIcon="plus"
-              variant="quaternary"
-              disabled={(formikProps?.values?.metadata?.length || 0) >= MAX_METADATA_COUNT}
-              onClick={() =>
-                formikProps.setFieldValue('metadata', [
-                  ...(formikProps.values.metadata || []),
-                  {
-                    key: '',
-                    value: '',
-                    displayInInvoice: false,
-                    localId: Date.now(),
-                  },
-                ])
-              }
-              data-test="add-fixed-fee"
-            >
-              {translate('text_63fcc3218d35b9377840f5bb')}
-            </Button>
-          </AccordionContentWrapper>
-        </Accordion>
+        <MetadataAccordion formikProps={formikProps} />
 
         <DrawerSubmitButton>
           <Button
@@ -723,27 +570,6 @@ const AccordionContentWrapper = styled.div<{ $largeSpacing?: boolean }>`
   > *:not(:last-child) {
     margin-bottom: ${({ $largeSpacing }) => ($largeSpacing ? theme.spacing(6) : theme.spacing(4))};
   }
-`
-
-const MetadataGrid = styled.div<{ $isHeader?: boolean }>`
-  display: grid;
-  grid-template-columns: 200px 1fr 60px 24px;
-  gap: ${theme.spacing(6)} ${theme.spacing(3)};
-
-  ${({ $isHeader }) =>
-    $isHeader &&
-    css`
-      margin-bottom: ${theme.spacing(1)};
-
-      > div:nth-child(3) {
-        grid-column: span 2;
-      }
-    `};
-`
-
-const StyledTooltip = styled(Tooltip)`
-  display: flex;
-  align-items: center;
 `
 
 AddCustomerDrawer.displayName = 'AddCustomerDrawer'

--- a/src/components/customers/addDrawer/BillingAccordion.tsx
+++ b/src/components/customers/addDrawer/BillingAccordion.tsx
@@ -1,6 +1,5 @@
 import { FormikProps } from 'formik'
 import { FC, useEffect, useState } from 'react'
-import styled from 'styled-components'
 
 import { Accordion, Typography } from '~/components/designSystem'
 import { Checkbox, ComboBoxField, TextInputField } from '~/components/form'
@@ -12,7 +11,6 @@ import {
   UpdateCustomerInput,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { theme } from '~/styles'
 
 interface BillingAccordionProps {
   formikProps: FormikProps<CreateCustomerInput | UpdateCustomerInput>
@@ -58,163 +56,155 @@ export const BillingAccordion: FC<BillingAccordionProps> = ({
         <Typography variant="subhead">{translate('text_632b49e2620ea4c6d96c9662')}</Typography>
       }
     >
-      <AccordionContentWrapper $largeSpacing>
-        <Typography variant="bodyHl" color="textSecondary">
-          {translate('text_626c0c09812bbc00e4c59dff')}
-        </Typography>
-        <ComboBoxField
-          disabled={!!customer && !customer?.canEditAttributes}
-          label={translate('text_632c6e59b73f9a54d4c72247')}
-          placeholder={translate('text_632c6e59b73f9a54d4c7224b')}
-          infoText={translate(
-            !customer?.canEditAttributes && isEdition
-              ? 'text_632c6e59b73f9a54d4c7223d'
-              : 'text_632c6e59b73f9a54d4c7223f',
-          )}
-          name="currency"
-          data={Object.values(CurrencyEnum).map((currencyType) => ({
-            value: currencyType,
-          }))}
-          disableClearable
-          formikProps={formikProps}
-        />
-        <TextInputField
-          name="legalName"
-          label={translate('text_626c0c09812bbc00e4c59e01')}
-          placeholder={translate('text_626c0c09812bbc00e4c59e03')}
-          formikProps={formikProps}
-        />
-        <TextInputField
-          name="legalNumber"
-          label={translate('text_626c0c09812bbc00e4c59e05')}
-          placeholder={translate('text_626c0c09812bbc00e4c59e07')}
-          formikProps={formikProps}
-        />
-        <TextInputField
-          name="taxIdentificationNumber"
-          label={translate('text_648053ee819b60364c675d05')}
-          placeholder={translate('text_648053ee819b60364c675d0b')}
-          formikProps={formikProps}
-        />
-        <TextInputField
-          name="email"
-          beforeChangeFormatter={['lowercase']}
-          label={translate('text_626c0c09812bbc00e4c59e09')}
-          placeholder={translate('text_626c0c09812bbc00e4c59e0b')}
-          formikProps={formikProps}
-          helperText={translate('text_641394c4c936000079c5639a')}
-        />
+      <div className="not-last-child:mb-8">
+        <div className="not-last-child:mb-6">
+          <Typography variant="bodyHl" color="textSecondary">
+            {translate('text_626c0c09812bbc00e4c59dff')}
+          </Typography>
+          <ComboBoxField
+            disabled={!!customer && !customer?.canEditAttributes}
+            label={translate('text_632c6e59b73f9a54d4c72247')}
+            placeholder={translate('text_632c6e59b73f9a54d4c7224b')}
+            infoText={translate(
+              !customer?.canEditAttributes && isEdition
+                ? 'text_632c6e59b73f9a54d4c7223d'
+                : 'text_632c6e59b73f9a54d4c7223f',
+            )}
+            name="currency"
+            data={Object.values(CurrencyEnum).map((currencyType) => ({
+              value: currencyType,
+            }))}
+            disableClearable
+            formikProps={formikProps}
+          />
+          <TextInputField
+            name="legalName"
+            label={translate('text_626c0c09812bbc00e4c59e01')}
+            placeholder={translate('text_626c0c09812bbc00e4c59e03')}
+            formikProps={formikProps}
+          />
+          <TextInputField
+            name="legalNumber"
+            label={translate('text_626c0c09812bbc00e4c59e05')}
+            placeholder={translate('text_626c0c09812bbc00e4c59e07')}
+            formikProps={formikProps}
+          />
+          <TextInputField
+            name="taxIdentificationNumber"
+            label={translate('text_648053ee819b60364c675d05')}
+            placeholder={translate('text_648053ee819b60364c675d0b')}
+            formikProps={formikProps}
+          />
+          <TextInputField
+            name="email"
+            beforeChangeFormatter={['lowercase']}
+            label={translate('text_626c0c09812bbc00e4c59e09')}
+            placeholder={translate('text_626c0c09812bbc00e4c59e0b')}
+            formikProps={formikProps}
+            helperText={translate('text_641394c4c936000079c5639a')}
+          />
 
-        <TextInputField
-          name="url"
-          label={translate('text_641b15b0df87eb00848944ea')}
-          placeholder={translate('text_641b15e7ac746900b68377f9')}
-          formikProps={formikProps}
-        />
-        <TextInputField
-          name="phone"
-          label={translate('text_626c0c09812bbc00e4c59e0d')}
-          placeholder={translate('text_626c0c09812bbc00e4c59e0f')}
-          formikProps={formikProps}
-        />
-      </AccordionContentWrapper>
-      <AccordionContentWrapper>
-        <Typography variant="bodyHl" color="textSecondary">
-          {translate('text_626c0c09812bbc00e4c59e19')}
-        </Typography>
-        <TextInputField
-          name="addressLine1"
-          label={translate('text_626c0c09812bbc00e4c59e1b')}
-          placeholder={translate('text_626c0c09812bbc00e4c59e1d')}
-          formikProps={formikProps}
-        />
-        <TextInputField
-          name="addressLine2"
-          placeholder={translate('text_626c0c09812bbc00e4c59e1f')}
-          formikProps={formikProps}
-        />
-        <TextInputField
-          name="zipcode"
-          placeholder={translate('text_626c0c09812bbc00e4c59e21')}
-          formikProps={formikProps}
-        />
-        <TextInputField
-          name="city"
-          placeholder={translate('text_626c0c09812bbc00e4c59e23')}
-          formikProps={formikProps}
-        />
-        <TextInputField
-          name="state"
-          placeholder={translate('text_626c0c09812bbc00e4c59e25')}
-          formikProps={formikProps}
-        />
-        <ComboBoxField
-          data={countryDataForCombobox}
-          name="country"
-          placeholder={translate('text_626c0c09812bbc00e4c59e27')}
-          formikProps={formikProps}
-          PopperProps={{ displayInDialog: true }}
-        />
-      </AccordionContentWrapper>
-      <AccordionContentWrapper>
-        <Typography variant="bodyHl" color="textSecondary">
-          {translate('text_667d708c1359b49f5a5a8230')}
-        </Typography>
-        <Checkbox
-          label={translate('text_667d708c1359b49f5a5a8234')}
-          value={isShippingEqualBillingAddress}
-          onChange={() => setIsShippingEqualBillingAddress((prev) => !prev)}
-        />
-        <TextInputField
-          name="shippingAddress.addressLine1"
-          label={translate('text_626c0c09812bbc00e4c59e1b')}
-          placeholder={translate('text_626c0c09812bbc00e4c59e1d')}
-          formikProps={formikProps}
-          disabled={isShippingEqualBillingAddress}
-        />
-        <TextInputField
-          name="shippingAddress.addressLine2"
-          placeholder={translate('text_626c0c09812bbc00e4c59e1f')}
-          formikProps={formikProps}
-          disabled={isShippingEqualBillingAddress}
-        />
-        <TextInputField
-          name="shippingAddress.zipcode"
-          placeholder={translate('text_626c0c09812bbc00e4c59e21')}
-          formikProps={formikProps}
-          disabled={isShippingEqualBillingAddress}
-        />
-        <TextInputField
-          name="shippingAddress.city"
-          placeholder={translate('text_626c0c09812bbc00e4c59e23')}
-          formikProps={formikProps}
-          disabled={isShippingEqualBillingAddress}
-        />
-        <TextInputField
-          name="shippingAddress.state"
-          placeholder={translate('text_626c0c09812bbc00e4c59e25')}
-          formikProps={formikProps}
-          disabled={isShippingEqualBillingAddress}
-        />
-        <ComboBoxField
-          data={countryDataForCombobox}
-          name="shippingAddress.country"
-          placeholder={translate('text_626c0c09812bbc00e4c59e27')}
-          formikProps={formikProps}
-          disabled={isShippingEqualBillingAddress}
-          PopperProps={{ displayInDialog: true }}
-        />
-      </AccordionContentWrapper>
+          <TextInputField
+            name="url"
+            label={translate('text_641b15b0df87eb00848944ea')}
+            placeholder={translate('text_641b15e7ac746900b68377f9')}
+            formikProps={formikProps}
+          />
+          <TextInputField
+            name="phone"
+            label={translate('text_626c0c09812bbc00e4c59e0d')}
+            placeholder={translate('text_626c0c09812bbc00e4c59e0f')}
+            formikProps={formikProps}
+          />
+        </div>
+        <div className="not-last-child:mb-4">
+          <Typography variant="bodyHl" color="textSecondary">
+            {translate('text_626c0c09812bbc00e4c59e19')}
+          </Typography>
+          <TextInputField
+            name="addressLine1"
+            label={translate('text_626c0c09812bbc00e4c59e1b')}
+            placeholder={translate('text_626c0c09812bbc00e4c59e1d')}
+            formikProps={formikProps}
+          />
+          <TextInputField
+            name="addressLine2"
+            placeholder={translate('text_626c0c09812bbc00e4c59e1f')}
+            formikProps={formikProps}
+          />
+          <TextInputField
+            name="zipcode"
+            placeholder={translate('text_626c0c09812bbc00e4c59e21')}
+            formikProps={formikProps}
+          />
+          <TextInputField
+            name="city"
+            placeholder={translate('text_626c0c09812bbc00e4c59e23')}
+            formikProps={formikProps}
+          />
+          <TextInputField
+            name="state"
+            placeholder={translate('text_626c0c09812bbc00e4c59e25')}
+            formikProps={formikProps}
+          />
+          <ComboBoxField
+            data={countryDataForCombobox}
+            name="country"
+            placeholder={translate('text_626c0c09812bbc00e4c59e27')}
+            formikProps={formikProps}
+            PopperProps={{ displayInDialog: true }}
+          />
+        </div>
+        <div className="not-last-child:mb-4">
+          <Typography variant="bodyHl" color="textSecondary">
+            {translate('text_667d708c1359b49f5a5a8230')}
+          </Typography>
+          <Checkbox
+            label={translate('text_667d708c1359b49f5a5a8234')}
+            value={isShippingEqualBillingAddress}
+            onChange={() => setIsShippingEqualBillingAddress((prev) => !prev)}
+          />
+          <TextInputField
+            name="shippingAddress.addressLine1"
+            label={translate('text_626c0c09812bbc00e4c59e1b')}
+            placeholder={translate('text_626c0c09812bbc00e4c59e1d')}
+            formikProps={formikProps}
+            disabled={isShippingEqualBillingAddress}
+          />
+          <TextInputField
+            name="shippingAddress.addressLine2"
+            placeholder={translate('text_626c0c09812bbc00e4c59e1f')}
+            formikProps={formikProps}
+            disabled={isShippingEqualBillingAddress}
+          />
+          <TextInputField
+            name="shippingAddress.zipcode"
+            placeholder={translate('text_626c0c09812bbc00e4c59e21')}
+            formikProps={formikProps}
+            disabled={isShippingEqualBillingAddress}
+          />
+          <TextInputField
+            name="shippingAddress.city"
+            placeholder={translate('text_626c0c09812bbc00e4c59e23')}
+            formikProps={formikProps}
+            disabled={isShippingEqualBillingAddress}
+          />
+          <TextInputField
+            name="shippingAddress.state"
+            placeholder={translate('text_626c0c09812bbc00e4c59e25')}
+            formikProps={formikProps}
+            disabled={isShippingEqualBillingAddress}
+          />
+          <ComboBoxField
+            data={countryDataForCombobox}
+            name="shippingAddress.country"
+            placeholder={translate('text_626c0c09812bbc00e4c59e27')}
+            formikProps={formikProps}
+            disabled={isShippingEqualBillingAddress}
+            PopperProps={{ displayInDialog: true }}
+          />
+        </div>
+      </div>
     </Accordion>
   )
 }
-
-const AccordionContentWrapper = styled.div<{ $largeSpacing?: boolean }>`
-  &:not(:last-child) {
-    margin-bottom: ${theme.spacing(8)};
-  }
-
-  > *:not(:last-child) {
-    margin-bottom: ${({ $largeSpacing }) => ($largeSpacing ? theme.spacing(6) : theme.spacing(4))};
-  }
-`

--- a/src/components/customers/addDrawer/BillingAccordion.tsx
+++ b/src/components/customers/addDrawer/BillingAccordion.tsx
@@ -2,15 +2,61 @@ import { FormikProps } from 'formik'
 import { FC, useEffect, useState } from 'react'
 
 import { Accordion, Typography } from '~/components/designSystem'
-import { Checkbox, ComboBoxField, TextInputField } from '~/components/form'
+import { Checkbox, ComboBoxField, ComboBoxProps, TextInputField } from '~/components/form'
 import { countryDataForCombobox } from '~/core/formats/countryDataForCombobox'
 import {
   AddCustomerDrawerFragment,
   CreateCustomerInput,
   CurrencyEnum,
+  CustomerAddress,
   UpdateCustomerInput,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+const billingFields: Array<
+  { name: keyof CustomerAddress; label?: string; placeholder?: string } & (
+    | {
+        type: 'text'
+      }
+    | {
+        type: 'combobox'
+        data: ComboBoxProps['data']
+      }
+  )
+> = [
+  {
+    name: 'addressLine1',
+    type: 'text',
+    label: 'text_626c0c09812bbc00e4c59e1b',
+    placeholder: 'text_626c0c09812bbc00e4c59e1d',
+  },
+  {
+    name: 'addressLine2',
+    type: 'text',
+    placeholder: 'text_626c0c09812bbc00e4c59e1f',
+  },
+  {
+    name: 'zipcode',
+    type: 'text',
+    placeholder: 'text_626c0c09812bbc00e4c59e21',
+  },
+  {
+    name: 'city',
+    type: 'text',
+    placeholder: 'text_626c0c09812bbc00e4c59e23',
+  },
+  {
+    name: 'state',
+    type: 'text',
+    placeholder: 'text_626c0c09812bbc00e4c59e25',
+  },
+  {
+    name: 'country',
+    type: 'combobox',
+    placeholder: 'text_626c0c09812bbc00e4c59e27',
+    data: countryDataForCombobox,
+  },
+]
 
 interface BillingAccordionProps {
   formikProps: FormikProps<CreateCustomerInput | UpdateCustomerInput>
@@ -103,7 +149,6 @@ export const BillingAccordion: FC<BillingAccordionProps> = ({
             formikProps={formikProps}
             helperText={translate('text_641394c4c936000079c5639a')}
           />
-
           <TextInputField
             name="url"
             label={translate('text_641b15b0df87eb00848944ea')}
@@ -121,39 +166,31 @@ export const BillingAccordion: FC<BillingAccordionProps> = ({
           <Typography variant="bodyHl" color="textSecondary">
             {translate('text_626c0c09812bbc00e4c59e19')}
           </Typography>
-          <TextInputField
-            name="addressLine1"
-            label={translate('text_626c0c09812bbc00e4c59e1b')}
-            placeholder={translate('text_626c0c09812bbc00e4c59e1d')}
-            formikProps={formikProps}
-          />
-          <TextInputField
-            name="addressLine2"
-            placeholder={translate('text_626c0c09812bbc00e4c59e1f')}
-            formikProps={formikProps}
-          />
-          <TextInputField
-            name="zipcode"
-            placeholder={translate('text_626c0c09812bbc00e4c59e21')}
-            formikProps={formikProps}
-          />
-          <TextInputField
-            name="city"
-            placeholder={translate('text_626c0c09812bbc00e4c59e23')}
-            formikProps={formikProps}
-          />
-          <TextInputField
-            name="state"
-            placeholder={translate('text_626c0c09812bbc00e4c59e25')}
-            formikProps={formikProps}
-          />
-          <ComboBoxField
-            data={countryDataForCombobox}
-            name="country"
-            placeholder={translate('text_626c0c09812bbc00e4c59e27')}
-            formikProps={formikProps}
-            PopperProps={{ displayInDialog: true }}
-          />
+
+          {billingFields.map((field) => {
+            if (field.type === 'text') {
+              return (
+                <TextInputField
+                  key={field.name}
+                  name={field.name}
+                  label={field.label && translate(field.label)}
+                  placeholder={field.placeholder && translate(field.placeholder)}
+                  formikProps={formikProps}
+                />
+              )
+            }
+
+            return (
+              <ComboBoxField
+                key={field.name}
+                data={field.data}
+                name={field.name}
+                placeholder={field.placeholder && translate(field.placeholder)}
+                formikProps={formikProps}
+                PopperProps={{ displayInDialog: true }}
+              />
+            )
+          })}
         </div>
         <div className="not-last-child:mb-4">
           <Typography variant="bodyHl" color="textSecondary">
@@ -164,45 +201,32 @@ export const BillingAccordion: FC<BillingAccordionProps> = ({
             value={isShippingEqualBillingAddress}
             onChange={() => setIsShippingEqualBillingAddress((prev) => !prev)}
           />
-          <TextInputField
-            name="shippingAddress.addressLine1"
-            label={translate('text_626c0c09812bbc00e4c59e1b')}
-            placeholder={translate('text_626c0c09812bbc00e4c59e1d')}
-            formikProps={formikProps}
-            disabled={isShippingEqualBillingAddress}
-          />
-          <TextInputField
-            name="shippingAddress.addressLine2"
-            placeholder={translate('text_626c0c09812bbc00e4c59e1f')}
-            formikProps={formikProps}
-            disabled={isShippingEqualBillingAddress}
-          />
-          <TextInputField
-            name="shippingAddress.zipcode"
-            placeholder={translate('text_626c0c09812bbc00e4c59e21')}
-            formikProps={formikProps}
-            disabled={isShippingEqualBillingAddress}
-          />
-          <TextInputField
-            name="shippingAddress.city"
-            placeholder={translate('text_626c0c09812bbc00e4c59e23')}
-            formikProps={formikProps}
-            disabled={isShippingEqualBillingAddress}
-          />
-          <TextInputField
-            name="shippingAddress.state"
-            placeholder={translate('text_626c0c09812bbc00e4c59e25')}
-            formikProps={formikProps}
-            disabled={isShippingEqualBillingAddress}
-          />
-          <ComboBoxField
-            data={countryDataForCombobox}
-            name="shippingAddress.country"
-            placeholder={translate('text_626c0c09812bbc00e4c59e27')}
-            formikProps={formikProps}
-            disabled={isShippingEqualBillingAddress}
-            PopperProps={{ displayInDialog: true }}
-          />
+          {billingFields.map((field) => {
+            if (field.type === 'text') {
+              return (
+                <TextInputField
+                  key={`shippingAddress.${field.name}`}
+                  name={`shippingAddress.${field.name}`}
+                  label={field.label && translate(field.label)}
+                  placeholder={field.placeholder && translate(field.placeholder)}
+                  formikProps={formikProps}
+                  disabled={isShippingEqualBillingAddress}
+                />
+              )
+            }
+
+            return (
+              <ComboBoxField
+                key={`shippingAddress.${field.name}`}
+                name={`shippingAddress.${field.name}`}
+                placeholder={field.placeholder && translate(field.placeholder)}
+                formikProps={formikProps}
+                disabled={isShippingEqualBillingAddress}
+                PopperProps={{ displayInDialog: true }}
+                data={field.data}
+              />
+            )
+          })}
         </div>
       </div>
     </Accordion>

--- a/src/components/customers/addDrawer/BillingAccordion.tsx
+++ b/src/components/customers/addDrawer/BillingAccordion.tsx
@@ -1,0 +1,220 @@
+import { FormikProps } from 'formik'
+import { FC, useEffect, useState } from 'react'
+import styled from 'styled-components'
+
+import { Accordion, Typography } from '~/components/designSystem'
+import { Checkbox, ComboBoxField, TextInputField } from '~/components/form'
+import { countryDataForCombobox } from '~/core/formats/countryDataForCombobox'
+import {
+  AddCustomerDrawerFragment,
+  CreateCustomerInput,
+  CurrencyEnum,
+  UpdateCustomerInput,
+} from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { theme } from '~/styles'
+
+interface BillingAccordionProps {
+  formikProps: FormikProps<CreateCustomerInput | UpdateCustomerInput>
+  isEdition?: boolean
+  customer?: AddCustomerDrawerFragment | null
+}
+
+export const BillingAccordion: FC<BillingAccordionProps> = ({
+  formikProps,
+  isEdition,
+  customer,
+}) => {
+  const { translate } = useInternationalization()
+  const [isShippingEqualBillingAddress, setIsShippingEqualBillingAddress] = useState(false)
+
+  useEffect(() => {
+    if (isShippingEqualBillingAddress) {
+      formikProps.setFieldValue('shippingAddress', {
+        addressLine1: formikProps.values.addressLine1,
+        addressLine2: formikProps.values.addressLine2,
+        city: formikProps.values.city,
+        country: formikProps.values.country,
+        state: formikProps.values.state,
+        zipcode: formikProps.values.zipcode,
+      })
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    formikProps.values.addressLine1,
+    formikProps.values.addressLine2,
+    formikProps.values.city,
+    formikProps.values.country,
+    formikProps.values.state,
+    formikProps.values.zipcode,
+    isShippingEqualBillingAddress,
+  ])
+
+  return (
+    <Accordion
+      size="large"
+      summary={
+        <Typography variant="subhead">{translate('text_632b49e2620ea4c6d96c9662')}</Typography>
+      }
+    >
+      <AccordionContentWrapper $largeSpacing>
+        <Typography variant="bodyHl" color="textSecondary">
+          {translate('text_626c0c09812bbc00e4c59dff')}
+        </Typography>
+        <ComboBoxField
+          disabled={!!customer && !customer?.canEditAttributes}
+          label={translate('text_632c6e59b73f9a54d4c72247')}
+          placeholder={translate('text_632c6e59b73f9a54d4c7224b')}
+          infoText={translate(
+            !customer?.canEditAttributes && isEdition
+              ? 'text_632c6e59b73f9a54d4c7223d'
+              : 'text_632c6e59b73f9a54d4c7223f',
+          )}
+          name="currency"
+          data={Object.values(CurrencyEnum).map((currencyType) => ({
+            value: currencyType,
+          }))}
+          disableClearable
+          formikProps={formikProps}
+        />
+        <TextInputField
+          name="legalName"
+          label={translate('text_626c0c09812bbc00e4c59e01')}
+          placeholder={translate('text_626c0c09812bbc00e4c59e03')}
+          formikProps={formikProps}
+        />
+        <TextInputField
+          name="legalNumber"
+          label={translate('text_626c0c09812bbc00e4c59e05')}
+          placeholder={translate('text_626c0c09812bbc00e4c59e07')}
+          formikProps={formikProps}
+        />
+        <TextInputField
+          name="taxIdentificationNumber"
+          label={translate('text_648053ee819b60364c675d05')}
+          placeholder={translate('text_648053ee819b60364c675d0b')}
+          formikProps={formikProps}
+        />
+        <TextInputField
+          name="email"
+          beforeChangeFormatter={['lowercase']}
+          label={translate('text_626c0c09812bbc00e4c59e09')}
+          placeholder={translate('text_626c0c09812bbc00e4c59e0b')}
+          formikProps={formikProps}
+          helperText={translate('text_641394c4c936000079c5639a')}
+        />
+
+        <TextInputField
+          name="url"
+          label={translate('text_641b15b0df87eb00848944ea')}
+          placeholder={translate('text_641b15e7ac746900b68377f9')}
+          formikProps={formikProps}
+        />
+        <TextInputField
+          name="phone"
+          label={translate('text_626c0c09812bbc00e4c59e0d')}
+          placeholder={translate('text_626c0c09812bbc00e4c59e0f')}
+          formikProps={formikProps}
+        />
+      </AccordionContentWrapper>
+      <AccordionContentWrapper>
+        <Typography variant="bodyHl" color="textSecondary">
+          {translate('text_626c0c09812bbc00e4c59e19')}
+        </Typography>
+        <TextInputField
+          name="addressLine1"
+          label={translate('text_626c0c09812bbc00e4c59e1b')}
+          placeholder={translate('text_626c0c09812bbc00e4c59e1d')}
+          formikProps={formikProps}
+        />
+        <TextInputField
+          name="addressLine2"
+          placeholder={translate('text_626c0c09812bbc00e4c59e1f')}
+          formikProps={formikProps}
+        />
+        <TextInputField
+          name="zipcode"
+          placeholder={translate('text_626c0c09812bbc00e4c59e21')}
+          formikProps={formikProps}
+        />
+        <TextInputField
+          name="city"
+          placeholder={translate('text_626c0c09812bbc00e4c59e23')}
+          formikProps={formikProps}
+        />
+        <TextInputField
+          name="state"
+          placeholder={translate('text_626c0c09812bbc00e4c59e25')}
+          formikProps={formikProps}
+        />
+        <ComboBoxField
+          data={countryDataForCombobox}
+          name="country"
+          placeholder={translate('text_626c0c09812bbc00e4c59e27')}
+          formikProps={formikProps}
+          PopperProps={{ displayInDialog: true }}
+        />
+      </AccordionContentWrapper>
+      <AccordionContentWrapper>
+        <Typography variant="bodyHl" color="textSecondary">
+          {translate('text_667d708c1359b49f5a5a8230')}
+        </Typography>
+        <Checkbox
+          label={translate('text_667d708c1359b49f5a5a8234')}
+          value={isShippingEqualBillingAddress}
+          onChange={() => setIsShippingEqualBillingAddress((prev) => !prev)}
+        />
+        <TextInputField
+          name="shippingAddress.addressLine1"
+          label={translate('text_626c0c09812bbc00e4c59e1b')}
+          placeholder={translate('text_626c0c09812bbc00e4c59e1d')}
+          formikProps={formikProps}
+          disabled={isShippingEqualBillingAddress}
+        />
+        <TextInputField
+          name="shippingAddress.addressLine2"
+          placeholder={translate('text_626c0c09812bbc00e4c59e1f')}
+          formikProps={formikProps}
+          disabled={isShippingEqualBillingAddress}
+        />
+        <TextInputField
+          name="shippingAddress.zipcode"
+          placeholder={translate('text_626c0c09812bbc00e4c59e21')}
+          formikProps={formikProps}
+          disabled={isShippingEqualBillingAddress}
+        />
+        <TextInputField
+          name="shippingAddress.city"
+          placeholder={translate('text_626c0c09812bbc00e4c59e23')}
+          formikProps={formikProps}
+          disabled={isShippingEqualBillingAddress}
+        />
+        <TextInputField
+          name="shippingAddress.state"
+          placeholder={translate('text_626c0c09812bbc00e4c59e25')}
+          formikProps={formikProps}
+          disabled={isShippingEqualBillingAddress}
+        />
+        <ComboBoxField
+          data={countryDataForCombobox}
+          name="shippingAddress.country"
+          placeholder={translate('text_626c0c09812bbc00e4c59e27')}
+          formikProps={formikProps}
+          disabled={isShippingEqualBillingAddress}
+          PopperProps={{ displayInDialog: true }}
+        />
+      </AccordionContentWrapper>
+    </Accordion>
+  )
+}
+
+const AccordionContentWrapper = styled.div<{ $largeSpacing?: boolean }>`
+  &:not(:last-child) {
+    margin-bottom: ${theme.spacing(8)};
+  }
+
+  > *:not(:last-child) {
+    margin-bottom: ${({ $largeSpacing }) => ($largeSpacing ? theme.spacing(6) : theme.spacing(4))};
+  }
+`

--- a/src/components/customers/addDrawer/MetadataAccordion.tsx
+++ b/src/components/customers/addDrawer/MetadataAccordion.tsx
@@ -1,0 +1,194 @@
+import { FormikProps } from 'formik'
+import _get from 'lodash/get'
+import React, { FC } from 'react'
+import { css, styled } from 'styled-components'
+
+import { Accordion, Button, Tooltip, Typography } from '~/components/designSystem'
+import { Switch, TextInputField } from '~/components/form'
+import {
+  METADATA_VALUE_MAX_LENGTH_DEFAULT,
+  MetadataErrorsEnum,
+} from '~/formValidation/metadataSchema'
+import {
+  CreateCustomerInput,
+  CustomerMetadataInput,
+  UpdateCustomerInput,
+} from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { theme } from '~/styles'
+
+const MAX_METADATA_COUNT = 5
+
+interface MetadataAccordionProps {
+  formikProps: FormikProps<CreateCustomerInput | UpdateCustomerInput>
+}
+
+export interface LocalCustomerMetadata extends CustomerMetadataInput {
+  localId?: string
+}
+
+export const MetadataAccordion: FC<MetadataAccordionProps> = ({ formikProps }) => {
+  const { translate } = useInternationalization()
+
+  return (
+    <Accordion
+      size="large"
+      summary={
+        <Typography variant="subhead">{translate('text_63fcc3218d35b9377840f59b')}</Typography>
+      }
+    >
+      <AccordionContentWrapper>
+        <Typography variant="body" color="grey600">
+          {translate('text_63fcc3218d35b9377840f59f')}
+        </Typography>
+        {!!formikProps?.values?.metadata?.length && (
+          <div>
+            <MetadataGrid $isHeader>
+              <Typography variant="captionHl" color="grey700">
+                {translate('text_63fcc3218d35b9377840f5a3')}
+              </Typography>
+              <Typography variant="captionHl" color="grey700">
+                {translate('text_63fcc3218d35b9377840f5ab')}
+              </Typography>
+              <Typography variant="captionHl" color="grey700">
+                {translate('text_63fcc3218d35b9377840f5b3')}
+              </Typography>
+            </MetadataGrid>
+            <MetadataGrid>
+              {formikProps?.values?.metadata?.map((m: LocalCustomerMetadata, i) => {
+                const metadataItemKeyError: string =
+                  _get(formikProps.errors, `metadata.${i}.key`) || ''
+                const metadataItemValueError: string =
+                  _get(formikProps.errors, `metadata.${i}.value`) || ''
+                const hasCustomKeyError =
+                  Object.keys(MetadataErrorsEnum).includes(metadataItemKeyError)
+                const hasCustomValueError =
+                  Object.keys(MetadataErrorsEnum).includes(metadataItemValueError)
+
+                return (
+                  <React.Fragment key={`metadata-item-${m.id || m.localId || i}`}>
+                    <Tooltip
+                      placement="top-end"
+                      title={
+                        metadataItemKeyError === MetadataErrorsEnum.uniqueness
+                          ? translate('text_63fcc3218d35b9377840f5dd')
+                          : metadataItemKeyError === MetadataErrorsEnum.maxLength
+                            ? translate('text_63fcc3218d35b9377840f5d9')
+                            : undefined
+                      }
+                      disableHoverListener={!hasCustomKeyError}
+                    >
+                      <TextInputField
+                        name={`metadata.${i}.key`}
+                        silentError={!hasCustomKeyError}
+                        placeholder={translate('text_63fcc3218d35b9377840f5a7')}
+                        formikProps={formikProps}
+                        displayErrorText={false}
+                      />
+                    </Tooltip>
+                    <Tooltip
+                      placement="top-end"
+                      title={
+                        metadataItemValueError === MetadataErrorsEnum.maxLength
+                          ? translate('text_63fcc3218d35b9377840f5e5', {
+                              max: METADATA_VALUE_MAX_LENGTH_DEFAULT,
+                            })
+                          : undefined
+                      }
+                      disableHoverListener={!hasCustomValueError}
+                    >
+                      <TextInputField
+                        name={`metadata.${i}.value`}
+                        silentError={!hasCustomValueError}
+                        placeholder={translate('text_63fcc3218d35b9377840f5af')}
+                        formikProps={formikProps}
+                        displayErrorText={false}
+                      />
+                    </Tooltip>
+                    <Switch
+                      name={`metadata.${i}.displayInInvoice`}
+                      checked={
+                        !!formikProps.values.metadata?.length &&
+                        !!formikProps.values.metadata[i].displayInInvoice
+                      }
+                      onChange={(newValue) => {
+                        formikProps.setFieldValue(`metadata.${i}.displayInInvoice`, newValue)
+                      }}
+                    />
+                    <StyledTooltip
+                      placement="top-end"
+                      title={translate('text_63fcc3218d35b9377840f5e1')}
+                    >
+                      <Button
+                        variant="quaternary"
+                        size="small"
+                        icon="trash"
+                        onClick={() => {
+                          formikProps.setFieldValue('metadata', [
+                            ...(formikProps.values.metadata || []).filter((_metadata, j) => {
+                              return j !== i
+                            }),
+                          ])
+                        }}
+                      />
+                    </StyledTooltip>
+                  </React.Fragment>
+                )
+              })}
+            </MetadataGrid>
+          </div>
+        )}
+        <Button
+          startIcon="plus"
+          variant="quaternary"
+          disabled={(formikProps?.values?.metadata?.length || 0) >= MAX_METADATA_COUNT}
+          onClick={() =>
+            formikProps.setFieldValue('metadata', [
+              ...(formikProps.values.metadata || []),
+              {
+                key: '',
+                value: '',
+                displayInInvoice: false,
+                localId: Date.now(),
+              },
+            ])
+          }
+          data-test="add-fixed-fee"
+        >
+          {translate('text_63fcc3218d35b9377840f5bb')}
+        </Button>
+      </AccordionContentWrapper>
+    </Accordion>
+  )
+}
+
+const AccordionContentWrapper = styled.div<{ $largeSpacing?: boolean }>`
+  &:not(:last-child) {
+    margin-bottom: ${theme.spacing(8)};
+  }
+
+  > *:not(:last-child) {
+    margin-bottom: ${({ $largeSpacing }) => ($largeSpacing ? theme.spacing(6) : theme.spacing(4))};
+  }
+`
+
+const MetadataGrid = styled.div<{ $isHeader?: boolean }>`
+  display: grid;
+  grid-template-columns: 200px 1fr 60px 24px;
+  gap: ${theme.spacing(6)} ${theme.spacing(3)};
+
+  ${({ $isHeader }) =>
+    $isHeader &&
+    css`
+      margin-bottom: ${theme.spacing(1)};
+
+      > div:nth-child(3) {
+        grid-column: span 2;
+      }
+    `};
+`
+
+const StyledTooltip = styled(Tooltip)`
+  display: flex;
+  align-items: center;
+`

--- a/src/components/customers/addDrawer/MetadataAccordion.tsx
+++ b/src/components/customers/addDrawer/MetadataAccordion.tsx
@@ -1,7 +1,6 @@
 import { FormikProps } from 'formik'
 import _get from 'lodash/get'
 import React, { FC } from 'react'
-import { css, styled } from 'styled-components'
 
 import { Accordion, Button, Tooltip, Typography } from '~/components/designSystem'
 import { Switch, TextInputField } from '~/components/form'
@@ -15,7 +14,7 @@ import {
   UpdateCustomerInput,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { theme } from '~/styles'
+import { tw } from '~/styles/utils'
 
 const MAX_METADATA_COUNT = 5
 
@@ -30,6 +29,8 @@ export interface LocalCustomerMetadata extends CustomerMetadataInput {
 export const MetadataAccordion: FC<MetadataAccordionProps> = ({ formikProps }) => {
   const { translate } = useInternationalization()
 
+  const gridClassName = 'grid grid-cols-[200px_1fr_60px_24px] gap-x-3 gap-y-6'
+
   return (
     <Accordion
       size="large"
@@ -37,13 +38,13 @@ export const MetadataAccordion: FC<MetadataAccordionProps> = ({ formikProps }) =
         <Typography variant="subhead">{translate('text_63fcc3218d35b9377840f59b')}</Typography>
       }
     >
-      <AccordionContentWrapper>
+      <div className="not-last-child:mb-4">
         <Typography variant="body" color="grey600">
           {translate('text_63fcc3218d35b9377840f59f')}
         </Typography>
         {!!formikProps?.values?.metadata?.length && (
           <div>
-            <MetadataGrid $isHeader>
+            <div className={tw(gridClassName, 'mb-1 [&>*:nth-child(3)]:col-span-2')}>
               <Typography variant="captionHl" color="grey700">
                 {translate('text_63fcc3218d35b9377840f5a3')}
               </Typography>
@@ -53,8 +54,9 @@ export const MetadataAccordion: FC<MetadataAccordionProps> = ({ formikProps }) =
               <Typography variant="captionHl" color="grey700">
                 {translate('text_63fcc3218d35b9377840f5b3')}
               </Typography>
-            </MetadataGrid>
-            <MetadataGrid>
+            </div>
+
+            <div className={gridClassName}>
               {formikProps?.values?.metadata?.map((m: LocalCustomerMetadata, i) => {
                 const metadataItemKeyError: string =
                   _get(formikProps.errors, `metadata.${i}.key`) || ''
@@ -115,7 +117,8 @@ export const MetadataAccordion: FC<MetadataAccordionProps> = ({ formikProps }) =
                         formikProps.setFieldValue(`metadata.${i}.displayInInvoice`, newValue)
                       }}
                     />
-                    <StyledTooltip
+                    <Tooltip
+                      className="flex items-center"
                       placement="top-end"
                       title={translate('text_63fcc3218d35b9377840f5e1')}
                     >
@@ -131,11 +134,11 @@ export const MetadataAccordion: FC<MetadataAccordionProps> = ({ formikProps }) =
                           ])
                         }}
                       />
-                    </StyledTooltip>
+                    </Tooltip>
                   </React.Fragment>
                 )
               })}
-            </MetadataGrid>
+            </div>
           </div>
         )}
         <Button
@@ -157,38 +160,7 @@ export const MetadataAccordion: FC<MetadataAccordionProps> = ({ formikProps }) =
         >
           {translate('text_63fcc3218d35b9377840f5bb')}
         </Button>
-      </AccordionContentWrapper>
+      </div>
     </Accordion>
   )
 }
-
-const AccordionContentWrapper = styled.div<{ $largeSpacing?: boolean }>`
-  &:not(:last-child) {
-    margin-bottom: ${theme.spacing(8)};
-  }
-
-  > *:not(:last-child) {
-    margin-bottom: ${({ $largeSpacing }) => ($largeSpacing ? theme.spacing(6) : theme.spacing(4))};
-  }
-`
-
-const MetadataGrid = styled.div<{ $isHeader?: boolean }>`
-  display: grid;
-  grid-template-columns: 200px 1fr 60px 24px;
-  gap: ${theme.spacing(6)} ${theme.spacing(3)};
-
-  ${({ $isHeader }) =>
-    $isHeader &&
-    css`
-      margin-bottom: ${theme.spacing(1)};
-
-      > div:nth-child(3) {
-        grid-column: span 2;
-      }
-    `};
-`
-
-const StyledTooltip = styled(Tooltip)`
-  display: flex;
-  align-items: center;
-`


### PR DESCRIPTION
## Context

`AddCustomerDrawer` component started to be very long (around 750 lines). 

## Description

This PR should split it into multiple ones and migrate them to Tailwind 
