### PR TITLE
fix(CustomExpressionDrawer): Fix broken example

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "apollo3-cache-persist": "0.15.0",
     "formik": "2.4.5",
     "graphql": "^16.6.0",
-    "lago-expression": "0.1.1",
+    "lago-expression": "0.1.2",
     "localforage": "1.10.0",
     "lodash": "4.17.21",
     "luxon": "3.4.4",

--- a/src/components/billableMetrics/CustomExpressionDrawer.tsx
+++ b/src/components/billableMetrics/CustomExpressionDrawer.tsx
@@ -51,7 +51,7 @@ export type ValidationResult = {
 
 const CUSTOM_EXPRESSION_EXAMPLES = [
   'event.properties.tokens * event.properties.replicas',
-  'concat(event.properties.user_id, ‘-‘ , event.properties.app_id)',
+  "concat(event.properties.user_id, '-' , event.properties.app_id)",
   '(event.properties.ended_at - event.timestamp) / 3600',
 ]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8848,10 +8848,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lago-expression@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/lago-expression/-/lago-expression-0.1.1.tgz#e185369401a324d2cd9202a2f29b40c142de4735"
-  integrity sha512-2P83bPbhbyzNVHhADIDc5jFMcKo4J8oJZuky+W3fMq+oYsEIo6cjgCfX9MNI+zXBAqDkIOnUgcgVqbmz6SJiDA==
+lago-expression@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/lago-expression/-/lago-expression-0.1.2.tgz#30a42f1d2b76e96e575298ec5275dde217371afc"
+  integrity sha512-qE+CsNFbs1fTrEGMlzOThkXsoMRPAUU/sA/uHsDhtpldMw0AfiI6MeHbxN+5hoylGuZNTMQQabe/qchAdUQ+ww==
 
 language-subtag-registry@^0.3.20:
   version "0.3.23"


### PR DESCRIPTION
## Context

An example was provided with the wrong kind of quotes which made the evaluating part fail.

## Description

Updated to normal single quotes.

Fixes LAGO-584