### PR TITLE
fix: use string instead of number to avoid scientific notation

### DIFF
--- a/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
@@ -195,7 +195,7 @@ describe('useGraduatedRange()', () => {
           {
             fromValue: '0',
             toValue: '1',
-            flatAmount: 4,
+            flatAmount: '4',
             perUnitAmount: undefined,
             disabledDelete: true,
           },
@@ -203,7 +203,7 @@ describe('useGraduatedRange()', () => {
             fromValue: '2',
             toValue: null,
             flatAmount: undefined,
-            perUnitAmount: 5,
+            perUnitAmount: '5',
             disabledDelete: false,
           },
         ])
@@ -506,7 +506,7 @@ describe('useGraduatedRange()', () => {
           {
             fromValue: '0',
             toValue: '1',
-            flatAmount: 4,
+            flatAmount: '4',
             perUnitAmount: undefined,
             disabledDelete: true,
           },
@@ -514,7 +514,7 @@ describe('useGraduatedRange()', () => {
             fromValue: '2',
             toValue: null,
             flatAmount: undefined,
-            perUnitAmount: 5,
+            perUnitAmount: '5',
             disabledDelete: false,
           },
         ])

--- a/src/hooks/plans/__tests__/useVolumeChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useVolumeChargeForm.test.tsx
@@ -309,7 +309,7 @@ describe('useVolumeChargeForm()', () => {
         await act(async () => await result.current.handleUpdate(1, 'flatAmount', '10'))
         expect(result.current.tableDatas).toStrictEqual([
           { ...volumeRanges[0], disabledDelete: true },
-          { ...{ ...volumeRanges[1], flatAmount: 10 }, disabledDelete: false },
+          { ...{ ...volumeRanges[1], flatAmount: '10' }, disabledDelete: false },
           { ...volumeRanges[2], disabledDelete: false },
         ])
         await act(async () => await result.current.handleUpdate(1, 'flatAmount', '1'))
@@ -317,7 +317,7 @@ describe('useVolumeChargeForm()', () => {
         await act(async () => await result.current.handleUpdate(1, 'fromValue', 5))
         expect(result.current.tableDatas).toStrictEqual([
           { ...volumeRanges[0], disabledDelete: true },
-          { ...{ ...volumeRanges[1], flatAmount: 1, fromValue: 5 }, disabledDelete: false },
+          { ...{ ...volumeRanges[1], flatAmount: '1', fromValue: 5 }, disabledDelete: false },
           { ...volumeRanges[2], disabledDelete: false },
         ])
       })
@@ -584,7 +584,7 @@ describe('useVolumeChargeForm()', () => {
         await act(async () => await result.current.handleUpdate(1, 'flatAmount', '10'))
         expect(result.current.tableDatas).toStrictEqual([
           { ...volumeRanges[0], disabledDelete: true },
-          { ...{ ...volumeRanges[1], flatAmount: 10 }, disabledDelete: false },
+          { ...{ ...volumeRanges[1], flatAmount: '10' }, disabledDelete: false },
           { ...volumeRanges[2], disabledDelete: false },
         ])
         await act(async () => await result.current.handleUpdate(1, 'flatAmount', '1'))
@@ -592,7 +592,7 @@ describe('useVolumeChargeForm()', () => {
         await act(async () => await result.current.handleUpdate(1, 'fromValue', 5))
         expect(result.current.tableDatas).toStrictEqual([
           { ...volumeRanges[0], disabledDelete: true },
-          { ...{ ...volumeRanges[1], flatAmount: 1, fromValue: 5 }, disabledDelete: false },
+          { ...{ ...volumeRanges[1], flatAmount: '1', fromValue: 5 }, disabledDelete: false },
           { ...volumeRanges[2], disabledDelete: false },
         ])
       })

--- a/src/hooks/plans/useGraduatedChargeForm.ts
+++ b/src/hooks/plans/useGraduatedChargeForm.ts
@@ -165,10 +165,7 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
     },
     handleUpdate: (rangeIndex, fieldName, value) => {
       if (fieldName !== 'toValue') {
-        formikProps.setFieldValue(
-          `${formikIdentifier}.${rangeIndex}.${fieldName}`,
-          value !== '' ? Number(value) : value,
-        )
+        formikProps.setFieldValue(`${formikIdentifier}.${rangeIndex}.${fieldName}`, value)
       } else {
         const newGraduatedRanges = graduatedRanges.reduce<GraduatedRangeInput[]>(
           (acc, range, i) => {

--- a/src/hooks/plans/useVolumeChargeForm.ts
+++ b/src/hooks/plans/useVolumeChargeForm.ts
@@ -127,10 +127,7 @@ export const useVolumeChargeForm: UseVolumeChargeForm = ({
     },
     handleUpdate: (rangeIndex, fieldName, value) => {
       if (fieldName !== 'toValue') {
-        formikProps.setFieldValue(
-          `${formikIdentifier}.${rangeIndex}.${fieldName}`,
-          value !== '' ? Number(value) : value,
-        )
+        formikProps.setFieldValue(`${formikIdentifier}.${rangeIndex}.${fieldName}`, value)
       } else {
         const newVolumeRanges = volumeRanges.reduce<VolumeRangeInput[]>((acc, range, i) => {
           if (rangeIndex === i) {


### PR DESCRIPTION
## Context

We had a decimal limitation on the volume and graduated table
![image](https://github.com/user-attachments/assets/908413ba-a22e-4a08-8cc8-a302d016042b)


## Description

Turn the value into a number breaks the input as it turns the value into a scientific notation and after 1e-7 we were not able to add more decimals. Turning into a string should fix the issue.