### PR TITLE
feat(metadataSchema): increase max metadata length

### DIFF
--- a/src/formValidation/metadataSchema.ts
+++ b/src/formValidation/metadataSchema.ts
@@ -1,6 +1,6 @@
 import { array, object, string } from 'yup'
 
-export const METADATA_VALUE_MAX_LENGTH_DEFAULT = 40
+export const METADATA_VALUE_MAX_LENGTH_DEFAULT = 100
 export const METADATA_KEY_MAX_LENGTH = 20
 
 export enum MetadataErrorsEnum {


### PR DESCRIPTION
## Context

A customer wanted to add more than 40 characters to the metadata.

## Description

Increased the limit to the new one.

<!-- Linear link -->
Fixes LAGO-597