### PR TITLE
refactor: migrate json editor component

### DIFF
--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/jest.config.js
+++ b/jest.config.js
@@ -49,6 +49,7 @@ module.exports = {
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/src/$1',
     'ace-builds': '<rootDir>/node_modules/ace-builds',
+    '\\.(css|less|sass|scss)$': '<rootDir>/__mocks__/styleMock.js',
   },
 
   // Module file extensions for importing

--- a/src/components/form/JsonEditor/JsonEditor.tsx
+++ b/src/components/form/JsonEditor/JsonEditor.tsx
@@ -1,20 +1,19 @@
-/* eslint-disable tailwindcss/no-custom-classname */
 import { Fade } from '@mui/material'
 import ace from 'ace-builds/src-noconflict/ace'
 import 'ace-builds/src-noconflict/ext-language_tools'
 import 'ace-builds/src-noconflict/mode-json'
 import 'ace-builds/src-noconflict/theme-github'
 import 'ace-builds/webpack-resolver'
-import { clsx } from 'clsx'
-// @ts-ignore
+// @ts-expect-error https://stackoverflow.com/questions/65616136/how-to-use-json-with-react-ace
 import jsonWorkerUrl from 'file-loader!ace-builds/src-noconflict/worker-json'
 import { ReactNode, useEffect, useRef, useState } from 'react'
 import AceEditor from 'react-ace'
-import styled, { css } from 'styled-components'
 
 import { Chip, Icon, Tooltip, Typography } from '~/components/designSystem'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { theme } from '~/styles'
+import { tw } from '~/styles/utils'
+
+import './jsonEditor.css'
 
 ace.config.setModuleUrl('ace/mode/json_worker', jsonWorkerUrl)
 
@@ -88,33 +87,40 @@ export const JsonEditor = ({
   }, [value])
 
   return (
-    <Container>
+    <div className="grid w-full grid-rows-[auto-1fr-auto]">
       {!hideLabel && (
-        <Label>
-          <LabelContainer $withInfo={!!infoText}>
+        <div>
+          <div className="mb-1 flex items-center">
             <Typography variant="captionHl" color="textSecondary">
               {label}
             </Typography>
             {!!infoText && (
-              <Tooltip className="flex h-5 items-end" placement="bottom-start" title={infoText}>
+              <Tooltip
+                className="ml-1 flex h-5 items-end"
+                placement="bottom-start"
+                title={infoText}
+              >
                 <Icon name="info-circle" />
               </Tooltip>
             )}
-          </LabelContainer>
+          </div>
           {description && (
-            <Description>
+            <div className="mb-4">
               <Typography variant="caption">{description}</Typography>
-            </Description>
+            </div>
           )}
-        </Label>
+        </div>
       )}
 
-      <EditorContainer
+      <div
+        style={{ height: height ?? undefined }}
+        className={tw(
+          'relative h-full overflow-hidden',
+          !readOnly && 'rounded-xl border border-grey-500',
+          !!error && 'border-red-600',
+          (!!helperText || !!error) && 'mb-1',
+        )}
         aria-label={name}
-        $hasErrorOrHelper={!!helperText || !!error}
-        $hasError={!!error}
-        $height={height}
-        $readOnly={readOnly}
         onMouseEnter={() => {
           if (!isHover) {
             setHover(true)
@@ -128,20 +134,24 @@ export const JsonEditor = ({
       >
         {onExpand && (
           <Fade in={showOverlay}>
-            <Overlay>
+            <div className="absolute inset-0 z-10 rounded-xl bg-gradient-to-t from-white from-20%">
               <Fade in={isHover}>
-                <Button onClick={() => onExpand(() => setShowOverlay(false))}>
+                <button
+                  className="flex size-full cursor-pointer items-center justify-center rounded-none border-none bg-none"
+                  onClick={() => onExpand(() => setShowOverlay(false))}
+                >
                   <Chip icon="plus" label={translate('text_663dea5702b60301d8d0650a')} />
-                </Button>
+                </button>
               </Fade>
-            </Overlay>
+            </div>
           </Fade>
         )}
 
-        <LineNumbersBackground />
-        <Editor
+        <div className="absolute left-0 top-0 h-full w-[42px] bg-grey-100" />
+        <AceEditor
           ref={editorRef}
-          className={clsx(
+          className={tw(
+            'ace-editor',
             disabled && 'json-editor--disabled',
             readOnly && 'json-editor--readonly',
             readOnlyWithoutStyles && 'json-editor--readonlywithoutstyles',
@@ -189,16 +199,16 @@ export const JsonEditor = ({
             readOnly: readOnly || readOnlyWithoutStyles,
           }}
         />
-      </EditorContainer>
+      </div>
 
       {helperText && !error && (
-        <Helper variant="caption" color="textPrimary">
+        <Typography variant="caption" color="textPrimary">
           {helperText}
-        </Helper>
+        </Typography>
       )}
 
       {error && (
-        <Helper variant="caption" color="danger600">
+        <Typography variant="caption" color="danger600">
           {customInvalidError}
 
           {!customInvalidError &&
@@ -208,258 +218,14 @@ export const JsonEditor = ({
           {!customInvalidError &&
             error === JSON_EDITOR_ERROR_ENUM.invalidCustomValidate &&
             translate('text_1729864971171gfdioq71rvt')}
-        </Helper>
+        </Typography>
       )}
 
       {helperText && showHelperOnError && error && (
-        <Helper className="mt-5" variant="caption" color="textPrimary">
+        <Typography variant="caption" color="textPrimary">
           {helperText}
-        </Helper>
+        </Typography>
       )}
-    </Container>
+    </div>
   )
 }
-
-const Container = styled.div`
-  width: 100%;
-  height: calc(100% - 32px - 20px);
-  display: grid;
-  grid-auto-rows: auto 1fr auto;
-  grid-template-areas:
-    'label'
-    'editor'
-    'helper';
-`
-
-const Label = styled.div`
-  grid-area: label;
-`
-
-const LabelContainer = styled.div<{ $withInfo?: boolean }>`
-  display: flex;
-  align-items: center;
-  margin-bottom: ${theme.spacing(1)};
-
-  ${({ $withInfo }) =>
-    $withInfo &&
-    css`
-      > *:first-child {
-        margin-right: ${theme.spacing(1)};
-      }
-    `}
-`
-
-const EditorContainer = styled.div<{
-  $hasErrorOrHelper?: boolean
-  $hasError?: boolean
-  $height?: string
-  $readOnly?: boolean
-}>`
-  border: ${({ $readOnly, $hasError }) =>
-    $readOnly
-      ? undefined
-      : `1px solid ${$hasError ? theme.palette.error[600] : theme.palette.grey[500]}`};
-  border-radius: ${({ $readOnly }) => ($readOnly ? undefined : '12px')};
-  position: relative;
-  overflow: hidden;
-  margin-bottom: ${({ $hasErrorOrHelper }) => ($hasErrorOrHelper ? theme.spacing(1) : '0px')};
-  height: ${({ $height }) => ($height ? $height : '100%')};
-  box-sizing: border-box;
-  grid-area: editor;
-`
-
-const LineNumbersBackground = styled.div`
-  position: absolute;
-  left: 0;
-  top: 0;
-  background-color: ${theme.palette.grey[100]};
-  width: 42px;
-  height: 100%;
-`
-
-const Overlay = styled.div`
-  position: absolute;
-  inset: 0px;
-  z-index: 10;
-  border-radius: 12px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, ${theme.palette.common.white} 80%);
-`
-
-const Button = styled.button`
-  width: 100%;
-  height: 100%;
-  background: none;
-  border: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`
-
-const Editor = styled(AceEditor)`
-  && {
-    width: 100%;
-    min-height: 136px;
-    font-family:
-      IBM Plex Mono,
-      Consolas,
-      Monaco,
-      Andale Mono,
-      Ubuntu Mono,
-      monospace;
-    font-size: 14px;
-
-    .ace_active-line {
-      background-color: ${theme.palette.grey[100]};
-    }
-
-    .ace_cursor {
-      display: none !important;
-    }
-
-    &.ace_focus {
-      .ace_active-line {
-        background-color: ${theme.palette.primary[100]};
-      }
-
-      .ace_cursor {
-        display: block !important;
-        border-left: 1px solid;
-        color: ${theme.palette.grey[600]};
-      }
-    }
-
-    .ace_editor.ace_autocomplete {
-      width: inherit;
-      max-width: 500 !important;
-    }
-
-    .ace_content {
-      color: ${theme.palette.grey[700]};
-    }
-
-    .ace_fold-widget.ace_invalid {
-      background-color: ${theme.palette.error[100]};
-      border-color: ${theme.palette.error[600]};
-    }
-
-    .ace_variable {
-      color: ${theme.palette.grey[700]};
-    }
-
-    .ace_string {
-      color: ${theme.palette.success[600]};
-    }
-
-    .ace_numeric {
-      color: ${theme.palette.secondary[500]};
-    }
-
-    .ace_scroller {
-      left: 42px !important;
-    }
-
-    .ace_gutter {
-      background-color: ${theme.palette.grey[100]};
-      color: ${theme.palette.grey[500]};
-      width: 42px !important;
-
-      > * {
-        width: 42px !important;
-      }
-    }
-
-    .ace_gutter-active-line.ace_gutter-cell {
-      background-color: ${theme.palette.grey[200]};
-      padding-right: ${theme.spacing(3)};
-    }
-
-    .ace_gutter-cell {
-      padding-right: ${theme.spacing(3)};
-
-      &.ace_error {
-        background-image: none;
-        background-color: ${theme.palette.error[100]};
-
-        &:before {
-          content: '•';
-          color: ${theme.palette.error[600]};
-          font-size: 30px;
-          position: absolute;
-          left: 1px;
-          top: -11px;
-        }
-      }
-    }
-
-    .ace_scroller.ace_scroll-left {
-      box-shadow: none;
-    }
-
-    .ace_tooltip.ace_error {
-      background-color: ${theme.palette.common.black};
-      border: none;
-      border-radius: 12px;
-      color: ${theme.palette.common.white};
-      padding: ${theme.spacing(3)} ${theme.spacing(4)};
-      font-family: Inter, Arial, Verdana, Helvetica, sans-serif;
-    }
-
-    .ace_placeholder {
-      color: ${theme.palette.grey[500]};
-      font-family:
-        IBM Plex Mono,
-        Consolas,
-        Monaco,
-        Andale Mono,
-        Ubuntu Mono,
-        monospace;
-      font-size: 14px;
-      top: 10px;
-      padding: 0 !important;
-      margin: 0;
-      left: ${theme.spacing(1)};
-    }
-
-    &.json-editor--disabled {
-      background-color: ${theme.palette.grey[100]};
-      .ace_cursor,
-      .ace_active-line {
-        display: none !important;
-      }
-      .ace_content,
-      .ace_numeric,
-      .ace_string,
-      .ace_variable {
-        color: ${theme.palette.grey[600]};
-      }
-
-      .ace_gutter,
-      .ace_gutter-active-line.ace_gutter-cell {
-        background-color: ${theme.palette.grey[200]};
-      }
-    }
-
-    &.json-editor--readonly {
-      .ace_cursor,
-      .ace_active-line {
-        display: none !important;
-      }
-    }
-
-    &.json-editor--readonlywithoutstyles {
-      .ace_cursor,
-      .ace_active-line {
-        display: none !important;
-      }
-    }
-  }
-`
-
-const Helper = styled(Typography)`
-  grid-area: helper;
-`
-
-const Description = styled.div`
-  margin-bottom: ${theme.spacing(4)};
-`

--- a/src/components/form/JsonEditor/JsonEditor.tsx
+++ b/src/components/form/JsonEditor/JsonEditor.tsx
@@ -1,4 +1,3 @@
-import { Fade } from '@mui/material'
 import ace from 'ace-builds/src-noconflict/ace'
 import 'ace-builds/src-noconflict/ext-language_tools'
 import 'ace-builds/src-noconflict/mode-json'
@@ -133,18 +132,22 @@ export const JsonEditor = ({
         }}
       >
         {onExpand && (
-          <Fade in={showOverlay}>
-            <div className="absolute inset-0 z-10 rounded-xl bg-gradient-to-t from-white from-20%">
-              <Fade in={isHover}>
-                <button
-                  className="flex size-full cursor-pointer items-center justify-center rounded-none border-none bg-none"
-                  onClick={() => onExpand(() => setShowOverlay(false))}
-                >
-                  <Chip icon="plus" label={translate('text_663dea5702b60301d8d0650a')} />
-                </button>
-              </Fade>
-            </div>
-          </Fade>
+          <div
+            className={tw(
+              'absolute inset-0 z-10 rounded-xl bg-gradient-to-t from-white from-20% transition-opacity',
+              showOverlay ? 'opacity-100' : 'opacity-0',
+            )}
+          >
+            <button
+              className={tw(
+                'flex size-full cursor-pointer items-center justify-center rounded-none border-none bg-none transition-opacity',
+                isHover ? 'opacity-100' : 'opacity-0',
+              )}
+              onClick={() => onExpand(() => setShowOverlay(false))}
+            >
+              <Chip icon="plus" label={translate('text_663dea5702b60301d8d0650a')} />
+            </button>
+          </div>
         )}
 
         <div className="absolute left-0 top-0 h-full w-[42px] bg-grey-100" />

--- a/src/components/form/JsonEditor/jsonEditor.css
+++ b/src/components/form/JsonEditor/jsonEditor.css
@@ -1,0 +1,153 @@
+.ace-editor {
+  width: 100%;
+  min-height: 136px;
+  font-family:
+    IBM Plex Mono,
+    Consolas,
+    Monaco,
+    Andale Mono,
+    Ubuntu Mono,
+    monospace;
+  font-size: 14px;
+}
+
+.ace-tm .ace_active-line {
+  background-color: theme(colors.grey.100);
+}
+
+.ace-tm .ace_cursor {
+  display: none !important;
+}
+
+.ace-tm.ace_focus .ace_active-line {
+  background-color: theme(colors.blue.100);
+}
+
+.ace-tm.ace_focus .ace_cursor {
+  display: block !important;
+  border-left: 1px solid;
+  color: theme(colors.grey.600);
+}
+
+.ace-tm .ace_autocomplete {
+  width: inherit;
+  max-width: 500 !important;
+}
+
+.ace-tm .ace_content {
+  color: theme(colors.grey.700);
+}
+
+.ace-tm .ace_fold-widget.ace_invalid {
+  background-color: theme(colors.red.100);
+  border-color: theme(colors.red.600);
+}
+
+.ace-tm .ace_variable {
+  color: theme(colors.grey.700);
+}
+
+.ace-tm .ace_string {
+  color: theme(colors.green.600);
+}
+
+.ace-tm .ace_constant.ace_numeric {
+  color: theme(colors.yellow.500);
+}
+
+.ace-tm .ace_scroller {
+  left: 42px !important;
+}
+
+.ace-tm .ace_gutter {
+  background-color: theme(colors.grey.100);
+  color: theme(colors.grey.500);
+  width: 42px !important;
+}
+
+.ace-tm .ace_gutter > * {
+  width: 42px !important;
+}
+
+.ace-tm .ace_gutter-active-line.ace_gutter-cell {
+  background-color: theme(colors.grey.200);
+  padding-right: theme(space.3);
+}
+
+.ace-tm .ace_gutter-cell {
+  padding-right: theme(space.3);
+}
+
+.ace-tm .ace_gutter-cell.ace_error {
+  background-image: none;
+  background-color: theme(colors.red.100);
+}
+
+.ace-tm .ace_gutter-cell.ace_error:before {
+  content: '•';
+  color: theme(colors.red.600);
+  font-size: 30px;
+  position: absolute;
+  left: 1px;
+  top: -11px;
+}
+
+.ace-tm .ace_scroller.ace_scroll-left {
+  box-shadow: none;
+}
+
+.ace-tm .ace_tooltip.ace_error {
+  background-color: theme(colors.black);
+  border: none;
+  border-radius: 12px;
+  color: theme(colors.white);
+  padding: theme(space.3) theme(space.4);
+  font-family: Inter, Arial, Verdana, Helvetica, sans-serif;
+}
+
+.ace-tm .ace_placeholder {
+  color: theme(colors.grey.500);
+  font-family:
+    IBM Plex Mono,
+    Consolas,
+    Monaco,
+    Andale Mono,
+    Ubuntu Mono,
+    monospace;
+  font-size: 14px;
+  top: 10px;
+  padding: 0 !important;
+  margin: 0;
+  left: theme(space.1);
+}
+
+.ace-editor.json-editor--disabled {
+  background-color: theme(colors.grey.100);
+}
+
+.ace-editor.json-editor--disabled .ace_cursor,
+.ace-editor.json-editor--disabled .ace_active-line {
+  display: none !important;
+}
+
+.ace-editor.json-editor--disabled .ace_content,
+.ace-editor.json-editor--disabled .ace_numeric,
+.ace-editor.json-editor--disabled .ace_string,
+.ace-editor.json-editor--disabled .ace_variable {
+  color: theme(colors.grey.600);
+}
+
+.ace-editor.json-editor--disabled .ace_gutter,
+.ace-editor.json-editor--disabled .ace_gutter-active-line.ace_gutter-cell {
+  background-color: theme(colors.grey.200);
+}
+
+.ace-editor.json-editor--readonly .ace_cursor,
+.ace-editor.json-editor--readonly .ace_active-line {
+  display: none !important;
+}
+
+.ace-editor.json-editor--readonlywithoutstyles .ace_cursor,
+.ace-editor.json-editor--readonlywithoutstyles .ace_active-line {
+  display: none !important;
+}


### PR DESCRIPTION
## Context

Related to Tailwind Migration

## Description

- Extract custom `react-ace` style into a specific file
- Remove usage of `<Fade>` from MUI in favour of Tailwind
- Remove usage of styled-component

Fixes LAGO-431