### PR TITLE
misc: remove focus on click for inlined link

### DIFF
--- a/src/components/customers/CustomerMainInfos.tsx
+++ b/src/components/customers/CustomerMainInfos.tsx
@@ -742,7 +742,7 @@ const MetadataValue = styled(Typography)`
 const InlineLink = styled(Link)`
   width: fit-content;
   line-break: anywhere;
-  box-shadow: none;
+  box-shadow: none !important;
 
   &:hover {
     text-decoration: none;


### PR DESCRIPTION
A link is inlined with other infos, and the focus ring looks kinda broken on click and feels like a but.

I decided to break the internet and remove the focus ring on those link, but it has to be important 😬 