### PR TITLE
misc: start migration of Combobox to Tailwind

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "react-ace": "^11.0.1",
     "react-dom": "18.2.0",
     "react-router-dom": "6.15.0",
-    "react-window": "1.8.9",
+    "react-window": "1.8.11",
     "recharts": "^2.9.0",
     "sanitize-html": "2.12.1",
     "styled-components": "^6.1.13",

--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -1,12 +1,10 @@
 import { Autocomplete, createFilterOptions } from '@mui/material'
 import _sortBy from 'lodash/sortBy'
 import { useEffect, useMemo, useRef } from 'react'
-import styled from 'styled-components'
 
 import { Skeleton } from '~/components/designSystem'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useDebouncedSearch } from '~/hooks/useDebouncedSearch'
-import { theme } from '~/styles'
 
 import { ComboBoxInput } from './ComboBoxInput'
 import { ComboBoxItem } from './ComboBoxItem'
@@ -132,14 +130,17 @@ export const ComboBox = ({
       value={value || null}
       loading={isLoading}
       loadingText={
-        <LoadingIemsWrapper>
+        <div className="my-4 flex flex-col gap-8">
           {[1, 2, 3].map((i) => (
-            <LoadingItem key={`combobox-loading-item-${i}`}>
+            <div
+              className="mx-2 flex items-center justify-between px-4"
+              key={`combobox-loading-item-${i}`}
+            >
               <Skeleton variant="circular" size="small" className="mr-4" />
               <Skeleton variant="text" />
-            </LoadingItem>
+            </div>
           ))}
-        </LoadingIemsWrapper>
+        </div>
       }
       noOptionsText={emptyText ?? translate('text_623b3acb8ee4e000ba87d082')}
       selectOnFocus={allowAddValue}
@@ -213,19 +214,3 @@ export const ComboBox = ({
     />
   )
 }
-
-const LoadingIemsWrapper = styled.div`
-  margin: ${theme.spacing(4)} 0;
-  display: flex;
-  flex-direction: column;
-  gap: ${theme.spacing(8)};
-`
-
-const LoadingItem = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  box-sizing: border-box;
-  margin: 0 ${theme.spacing(2)};
-  padding: 0 ${theme.spacing(4)};
-`

--- a/src/components/form/ComboBox/ComboBoxInput.tsx
+++ b/src/components/form/ComboBox/ComboBoxInput.tsx
@@ -1,9 +1,7 @@
 import { InputAdornment } from '@mui/material'
 import _omit from 'lodash/omit'
-import styled from 'styled-components'
 
 import { Button, Typography } from '~/components/designSystem'
-import { theme } from '~/styles'
 import { tw } from '~/styles/utils'
 
 import { ComboBoxInputProps } from './types'
@@ -84,10 +82,10 @@ export const ComboBoxInput = ({
         ),
         startAdornment: startAdornmentValue && (
           <InputAdornment position="start">
-            <StartAdornmentTypography noWrap variant="body" color="grey700">
-              <span>{startAdornmentValue}</span>
+            <Typography noWrap variant="body" color="grey700">
+              <span className="mr-2">{startAdornmentValue}</span>
               <span>•</span>
-            </StartAdornmentTypography>
+            </Typography>
           </InputAdornment>
         ),
       }}
@@ -96,9 +94,3 @@ export const ComboBoxInput = ({
     />
   )
 }
-
-const StartAdornmentTypography = styled(Typography)`
-  > span:first-child {
-    margin-right: ${theme.spacing(2)};
-  }
-`

--- a/src/components/form/ComboBox/ComboBoxItem.tsx
+++ b/src/components/form/ComboBox/ComboBoxItem.tsx
@@ -54,7 +54,7 @@ export const ComboBoxItem = ({
         >
           {customValue ? (
             <>
-              <AddCustomValueIcon color="dark" name="plus" />
+              <Icon className="mr-4" color="dark" name="plus" />
               <Typography variant="body" noWrap>
                 {labelNode ?? label}
               </Typography>
@@ -97,10 +97,6 @@ const ItemWrapper = styled.div`
     width: calc(100% - 16px) !important;
     margin: 0 ${theme.spacing(2)};
   }
-`
-
-const AddCustomValueIcon = styled(Icon)`
-  margin-right: ${theme.spacing(4)};
 `
 
 export const Item = styled.div<{ $virtualized?: boolean }>`

--- a/src/components/form/ComboBox/ComboBoxPopperFactory.tsx
+++ b/src/components/form/ComboBox/ComboBoxPopperFactory.tsx
@@ -67,11 +67,6 @@ const StyledPopper = styled(Popper)<{
 
   .MuiAutocomplete-paper {
     border: 1px solid ${theme.palette.grey[200]};
-    padding: ${theme.spacing(2)} 0;
     box-sizing: content-box;
-  }
-
-  > *.combobox-popper--grouped .MuiAutocomplete-paper {
-    padding: 0 0 ${theme.spacing(2)} 0;
   }
 `

--- a/src/components/form/ComboBox/ComboBoxVirtualizedList.tsx
+++ b/src/components/form/ComboBox/ComboBoxVirtualizedList.tsx
@@ -1,6 +1,8 @@
 import { ReactElement, useEffect, useRef } from 'react'
 import { VariableSizeList } from 'react-window'
 
+import { tw } from '~/styles/utils'
+
 import { ITEM_HEIGHT } from './ComboBoxItem'
 import { ComboBoxProps } from './types'
 
@@ -25,19 +27,18 @@ type ComboBoxVirtualizedListProps = {
 export const ComboBoxVirtualizedList = (props: ComboBoxVirtualizedListProps) => {
   const { elements, value } = props
 
-  const hasDescription = elements.some(
-    (el) => (el.props?.children?.props?.option?.description as string)?.length > 0,
-  )
-
   const itemCount = elements?.length
-  const elementHeight = hasDescription ? ITEM_HEIGHT + 4 : ITEM_HEIGHT
 
   const getHeight = () => {
+    const hasAnyGroupHeader = elements.some((el) => (el.key as string).includes(GROUP_ITEM_KEY))
+
     // recommended perf best practice
     if (itemCount > 5) {
-      return 5 * (elementHeight + 4) - 4 // Last item does not have 4px margin-bottom
+      return 5 * (ITEM_HEIGHT + 4) + 4 // Add 4px for margins
+    } else if (itemCount <= 2 && hasAnyGroupHeader) {
+      return itemCount * (ITEM_HEIGHT + 2) // Add 2px for margins
     }
-    return itemCount * (elementHeight + 4) - 4 // Last item does not have 4px margin-bottom
+    return itemCount * (ITEM_HEIGHT + 4) + 4 // Add 4px for margins
   }
 
   // reset the `VariableSizeList` cache if data gets updated
@@ -63,6 +64,9 @@ export const ComboBoxVirtualizedList = (props: ComboBoxVirtualizedListProps) => 
 
   return (
     <VariableSizeList
+      className={tw({
+        'mb-1': itemCount > 1,
+      })}
       itemData={elements}
       height={getHeight()}
       width="100%"
@@ -70,10 +74,10 @@ export const ComboBoxVirtualizedList = (props: ComboBoxVirtualizedListProps) => 
       innerElementType="div"
       itemSize={(index) => {
         return index === itemCount - 1
-          ? elementHeight
+          ? ITEM_HEIGHT
           : ((elements[index].key as string) || '').includes(GROUP_ITEM_KEY)
-            ? GROUP_HEADER_HEIGHT + (index === 0 ? 8 : 12)
-            : elementHeight + 4
+            ? GROUP_HEADER_HEIGHT + (index === 0 ? 2 : 6)
+            : ITEM_HEIGHT + 8
       }}
       overscanCount={5}
       itemCount={itemCount}

--- a/src/components/form/ComboBox/ComboboxList.tsx
+++ b/src/components/form/ComboBox/ComboboxList.tsx
@@ -1,15 +1,18 @@
 import _groupBy from 'lodash/groupBy'
-import { Children, ForwardedRef, forwardRef, ReactElement, ReactNode, useMemo } from 'react'
-import styled, { css } from 'styled-components'
+import {
+  Children,
+  ForwardedRef,
+  forwardRef,
+  PropsWithChildren,
+  ReactElement,
+  ReactNode,
+  useMemo,
+} from 'react'
 
 import { Typography } from '~/components/designSystem'
-import { theme } from '~/styles'
+import { tw } from '~/styles/utils'
 
-import {
-  ComboBoxVirtualizedList,
-  GROUP_HEADER_HEIGHT,
-  GROUP_ITEM_KEY,
-} from './ComboBoxVirtualizedList'
+import { ComboBoxVirtualizedList, GROUP_ITEM_KEY } from './ComboBoxVirtualizedList'
 import { ComboBoxData, ComboBoxProps } from './types'
 
 const randomKey = Math.round(Math.random() * 100000)
@@ -18,6 +21,27 @@ interface ComboBoxVirtualizedListProps
   extends Pick<ComboBoxProps, 'value' | 'renderGroupHeader' | 'virtualized'> {
   children: ReactNode
 }
+
+const ComboboxListItem = ({
+  children,
+  virtualized,
+  className,
+  ...propsToForward
+}: { className?: string } & PropsWithChildren & ComboBoxVirtualizedListProps) => (
+  <div
+    className={tw(
+      'my-1',
+      {
+        'not-last:mx-2': virtualized,
+        'not-last:mx-0': !virtualized,
+      },
+      className,
+    )}
+    {...propsToForward}
+  >
+    {children}
+  </div>
+)
 
 export const ComboboxList = forwardRef(
   (
@@ -36,9 +60,9 @@ export const ComboboxList = forwardRef(
       if (!isGrouped) {
         return Children.toArray(
           (children as ReactElement[]).map((item, i) => (
-            <Item key={`combobox-list-item-${randomKey}-${i}`} {...propsToForward}>
+            <ComboboxListItem key={`combobox-list-item-${randomKey}-${i}`} {...propsToForward}>
               {item}
-            </Item>
+            </ComboboxListItem>
           )),
         )
       }
@@ -60,22 +84,35 @@ export const ComboboxList = forwardRef(
               ...acc,
               isGrouped
                 ? [
-                    // If renderGroupHeader is provided, render the html, otherewise simply render the key
-                    <GroupHeader
+                    // If renderGroupHeader is provided, render the html, otherwise simply render the items
+                    <div
                       key={`${GROUP_ITEM_KEY}-${key}`}
-                      $isFirst={i === 0}
-                      $virtualized={virtualized}
+                      data-type={GROUP_ITEM_KEY}
+                      className={tw(
+                        'mx-0 my-1 flex h-11 w-[inherit] items-center bg-grey-100 px-6 py-0 shadow-[0px_-1px_0px_0px_#D9DEE7_inset,0px_-1px_0px_0px_#D9DEE7]',
+                        {
+                          '!mt-0': i === 0,
+                          'mb-1': virtualized,
+                          'sticky top-0 z-toast': !virtualized,
+                        },
+                      )}
                     >
                       {(!!renderGroupHeader && (renderGroupHeader[key] as ReactNode)) || (
                         <Typography noWrap>{key}</Typography>
                       )}
-                    </GroupHeader>,
+                    </div>,
                   ]
                 : [],
               ...(groupedBy[key] as ReactElement[]).map((item, j) => (
-                <Item key={`combobox-list-item-${randomKey}-${i}-${j}`} {...propsToForward}>
+                <ComboboxListItem
+                  key={`combobox-list-item-${randomKey}-${i}-${j}`}
+                  className={tw({
+                    'mt-1': i === 0 && !isGrouped,
+                  })}
+                  {...propsToForward}
+                >
                   {item}
-                </Item>
+                </ComboboxListItem>
               )),
             ]
           }, []),
@@ -83,59 +120,21 @@ export const ComboboxList = forwardRef(
     }, [isGrouped, renderGroupHeader, children, propsToForward, virtualized])
 
     return (
-      <Container ref={ref} role="listbox" $virtualized={virtualized}>
+      <div
+        className={tw('relative max-h-[inherit] overflow-auto pb-0', {
+          'overflow-hidden': virtualized,
+        })}
+        ref={ref}
+        role="listbox"
+      >
         {virtualized ? (
           <ComboBoxVirtualizedList value={value} elements={htmlItems as ReactElement[]} />
         ) : (
           htmlItems
         )}
-      </Container>
+      </div>
     )
   },
 )
 
 ComboboxList.displayName = 'ComboboxList'
-
-const Item = styled.div``
-
-const Container = styled.div<{ $virtualized?: boolean }>`
-  max-height: inherit;
-  position: relative;
-  padding-bottom: 0;
-  box-sizing: border-box;
-  overflow: ${({ $virtualized }) => ($virtualized ? 'hidden' : 'auto')};
-
-  .MuiAutocomplete-listbox {
-    max-height: inherit;
-  }
-
-  ${Item}:not(:last-child) {
-    margin: ${({ $virtualized }) =>
-      $virtualized ? `0 ${theme.spacing(2)}` : `0 0 ${theme.spacing(1)}`};
-  }
-`
-
-const GroupHeader = styled.div<{ $isFirst?: boolean; $virtualized?: boolean }>`
-  height: ${GROUP_HEADER_HEIGHT}px;
-  display: flex;
-  width: inherit;
-  align-items: center;
-  padding: 0 ${theme.spacing(6)};
-  background-color: ${theme.palette.grey[100]};
-  box-sizing: border-box;
-  box-shadow:
-    ${theme.shadows[7]},
-    0px -1px 0px 0px ${theme.palette.divider};
-
-  ${({ $virtualized, $isFirst }) =>
-    !$virtualized
-      ? css`
-          z-index: ${theme.zIndex.dialog + 2};
-          position: sticky;
-          top: 0;
-          margin: ${$isFirst ? 0 : theme.spacing(2)} 0 ${theme.spacing(2)};
-        `
-      : css`
-          margin: ${$isFirst ? 0 : theme.spacing(1)} 0 ${theme.spacing(2)};
-        `};
-`

--- a/src/components/form/MultipleComboBox/MultipleComboBoxList.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBoxList.tsx
@@ -106,10 +106,6 @@ const Container = styled.div<{ $virtualized?: boolean }>`
   box-sizing: border-box;
   overflow: ${({ $virtualized }) => ($virtualized ? 'hidden' : 'auto')};
 
-  .MuiAutocomplete-listbox {
-    max-height: inherit;
-  }
-
   ${Item}:not(:last-child) {
     margin: ${({ $virtualized }) =>
       $virtualized ? `0 ${theme.spacing(2)}` : `0 0 ${theme.spacing(1)}`};

--- a/src/styles/muiTheme.ts
+++ b/src/styles/muiTheme.ts
@@ -463,6 +463,7 @@ export const theme = createTheme({
           display: 'flex',
           flexDirection: 'column',
           gap: '4px',
+          maxHeight: 'inherit',
           padding: 0,
         },
         root: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10669,10 +10669,10 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-window@1.8.9:
-  version "1.8.9"
-  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.9.tgz#24bc346be73d0468cdf91998aac94e32bc7fa6a8"
-  integrity sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==
+react-window@1.8.11:
+  version "1.8.11"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.11.tgz#a857b48fa85bd77042d59cc460964ff2e0648525"
+  integrity sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"


### PR DESCRIPTION
## Context

We're migrating our app to use Tailwind. This PR is a kickoff for the Combobox one.

## Description

Many things happens here, from simple TW switch to some UI and logic change, to make sure the UI looks homogeneous

Please note:
- `MultipleComboBoxList` also have a change as I set the `maxHeight` rule in the MUI theme file.
- I updated `react-window` lib to get last bugfixes
- The `ComboBoxPopperFactory` lose some padding rules as they are now spread more "close" to the elements concerned (`ComboboxList` and `ComboBoxVirtualizedList.tsx`)

## Next steps
The Combobox TW migration is not done. 
I plan to then handle the more "noisy" part by renaming `ComboBoxItem` into `ComboBoxItemWrapper` and creating a new `ComboBoxItem` component that will return a TW wrapper for the exported const `Item` included in `ComboBoxItemWrapper`. 
This new component is widely used in the app and all imports will be updated

Some rules may need to be placed in the MUI theme file and once done, the same process will be reproduce for the multiple combobox (with some potential other problems in the road)

Let's be honest, this code is crap and should be fixed differently for the long term. We should probably (i) upgrade our MUI package to v6 to (ii) rely more on their new API and internal tools, rather than making everything custom as today.
That will for sure help us removing bunch of code and components we built.