### PR TITLE
misc: migrate combobox to Tailwind

### DIFF
--- a/src/components/coupons/AddBillableMetricToCouponDialog.tsx
+++ b/src/components/coupons/AddBillableMetricToCouponDialog.tsx
@@ -2,15 +2,13 @@ import { gql } from '@apollo/client'
 import { forwardRef, useMemo, useState } from 'react'
 
 import { Alert, Button, Dialog, DialogRef, Typography } from '~/components/designSystem'
-import { ComboBox } from '~/components/form'
+import { ComboBox, ComboboxItem } from '~/components/form'
 import {
   BillableMetricsForCouponsFragment,
   BillableMetricsForCouponsFragmentDoc,
   useGetBillableMetricsForCouponsLazyQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-
-import { Item } from '../form/ComboBox/ComboBoxItem'
 
 gql`
   fragment BillableMetricsForCoupons on BillableMetric {
@@ -57,7 +55,7 @@ export const AddBillableMetricToCouponDialog = forwardRef<
       return {
         label: `${name} - (${code})`,
         labelNode: (
-          <Item>
+          <ComboboxItem>
             <Typography color="grey700" noWrap>
               {name}
             </Typography>
@@ -65,7 +63,7 @@ export const AddBillableMetricToCouponDialog = forwardRef<
             <Typography color="textPrimary" noWrap>
               ({code})
             </Typography>
-          </Item>
+          </ComboboxItem>
         ),
         value: id,
         disabled: attachedBillableMetricsIds?.includes(id),

--- a/src/components/coupons/AddPlanToCouponDialog.tsx
+++ b/src/components/coupons/AddPlanToCouponDialog.tsx
@@ -2,15 +2,13 @@ import { gql } from '@apollo/client'
 import { forwardRef, useMemo, useState } from 'react'
 
 import { Button, Dialog, DialogRef, Typography } from '~/components/designSystem'
-import { ComboBox } from '~/components/form'
+import { ComboBox, ComboboxItem } from '~/components/form'
 import {
   PlansForCouponsFragment,
   PlansForCouponsFragmentDoc,
   useGetPlansForCouponsLazyQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-
-import { Item } from '../form/ComboBox/ComboBoxItem'
 
 gql`
   fragment PlansForCoupons on Plan {
@@ -53,7 +51,7 @@ export const AddPlanToCouponDialog = forwardRef<DialogRef, AddPlanToCouponDialog
         return {
           label: `${name} - (${code})`,
           labelNode: (
-            <Item>
+            <ComboboxItem>
               <Typography color="grey700" noWrap>
                 {name}
               </Typography>
@@ -61,7 +59,7 @@ export const AddPlanToCouponDialog = forwardRef<DialogRef, AddPlanToCouponDialog
               <Typography color="textPrimary" noWrap>
                 ({code})
               </Typography>
-            </Item>
+            </ComboboxItem>
           ),
           value: id,
           disabled: attachedPlansIds?.includes(id),

--- a/src/components/customers/EditCustomerVatRateDialog.tsx
+++ b/src/components/customers/EditCustomerVatRateDialog.tsx
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client'
 import { forwardRef, useMemo, useState } from 'react'
 
 import { Button, Dialog, DialogRef, Typography } from '~/components/designSystem'
-import { ComboBox } from '~/components/form'
+import { ComboBox, ComboboxItem } from '~/components/form'
 import { addToast } from '~/core/apolloClient'
 import { SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME } from '~/core/constants/form'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -15,8 +15,6 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { usePermissions } from '~/hooks/usePermissions'
-
-import { Item } from '../form/ComboBox/ComboBoxItem'
 
 gql`
   fragment EditCustomerVatRate on Customer {
@@ -97,7 +95,7 @@ export const EditCustomerVatRateDialog = forwardRef<DialogRef, EditCustomerVatRa
             style: 'percent',
           })})`,
           labelNode: (
-            <Item>
+            <ComboboxItem>
               {name}&nbsp;
               <Typography color="textPrimary">
                 (
@@ -106,7 +104,7 @@ export const EditCustomerVatRateDialog = forwardRef<DialogRef, EditCustomerVatRa
                 })}
                 )
               </Typography>
-            </Item>
+            </ComboboxItem>
           ),
           value: code,
           disabled: appliedTaxRatesTaxesIds?.includes(id),

--- a/src/components/customers/addDrawer/ExternalAppsAccordion.tsx
+++ b/src/components/customers/addDrawer/ExternalAppsAccordion.tsx
@@ -19,9 +19,9 @@ import {
   ComboBox,
   ComboboxDataGrouped,
   ComboBoxField,
+  ComboboxItem,
   TextInputField,
 } from '~/components/form'
-import { Item } from '~/components/form/ComboBox/ComboBoxItem'
 import {
   ADD_CUSTOMER_ACCOUNTING_PROVIDER_ACCORDION,
   ADD_CUSTOMER_CRM_PROVIDER_ACCORDION,
@@ -343,7 +343,7 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
       label: provider.name,
       group: provider.__typename.toLocaleLowerCase().replace('provider', ''),
       labelNode: (
-        <Item>
+        <ComboboxItem>
           <Typography color="grey700" noWrap>
             {provider.name}
           </Typography>
@@ -351,7 +351,7 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
           <Typography color="textPrimary" noWrap>
             ({provider.code})
           </Typography>
-        </Item>
+        </ComboboxItem>
       ),
     }))
   }, [paymentProvidersData?.paymentProviders?.collection])
@@ -364,7 +364,7 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
       label: integration.name,
       group: integration?.__typename?.replace('Integration', '') || '',
       labelNode: (
-        <Item>
+        <ComboboxItem>
           <Typography variant="body" color="grey700" noWrap>
             {integration.name}
           </Typography>
@@ -372,7 +372,7 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
           <Typography variant="body" color="grey600" noWrap>
             ({integration.code})
           </Typography>
-        </Item>
+        </ComboboxItem>
       ),
     }))
   }, [allAccountingIntegrationsData])
@@ -384,7 +384,7 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
       value: integrationSubsidiary.externalId,
       label: `${integrationSubsidiary.externalName} (${integrationSubsidiary.externalId})`,
       labelNode: (
-        <Item>
+        <ComboboxItem>
           <Typography variant="body" color="grey700" noWrap>
             {integrationSubsidiary.externalName}
           </Typography>
@@ -392,7 +392,7 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
           <Typography variant="body" color="grey600" noWrap>
             ({integrationSubsidiary.externalId})
           </Typography>
-        </Item>
+        </ComboboxItem>
       ),
     }))
   }, [subsidiariesData?.integrationSubsidiaries?.collection])
@@ -404,7 +404,7 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
       value: integration.code,
       label: integration.name,
       labelNode: (
-        <Item>
+        <ComboboxItem>
           <Typography variant="body" color="grey700" noWrap>
             {integration.name}
           </Typography>
@@ -412,7 +412,7 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
           <Typography variant="body" color="grey600" noWrap>
             ({integration.code})
           </Typography>
-        </Item>
+        </ComboboxItem>
       ),
     }))
   }, [allAnrokIntegrations])
@@ -425,7 +425,7 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
       label: integration.name,
       group: integration?.__typename?.replace('Integration', '') || '',
       labelNode: (
-        <Item>
+        <ComboboxItem>
           <Typography variant="body" color="grey700" noWrap>
             {integration.name}
           </Typography>
@@ -433,7 +433,7 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
           <Typography variant="body" color="grey600" noWrap>
             ({integration.code})
           </Typography>
-        </Item>
+        </ComboboxItem>
       ),
     }))
   }, [allCRMIntegrationsData])

--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -7,7 +7,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useDebouncedSearch } from '~/hooks/useDebouncedSearch'
 
 import { ComboBoxInput } from './ComboBoxInput'
-import { ComboBoxItem } from './ComboBoxItem'
+import { ComboBoxItemWrapper } from './ComboBoxItemWrapper'
 import { ComboboxList } from './ComboboxList'
 import { ComboBoxPopperFactory } from './ComboBoxPopperFactory'
 import { ComboBoxData, ComboBoxProps } from './types'
@@ -153,7 +153,7 @@ export const ComboBox = ({
       }}
       renderOption={(props, option, state) => {
         return (
-          <ComboBoxItem
+          <ComboBoxItemWrapper
             comboboxProps={props}
             id={`option-${option.value}`}
             key={`option-${option.value}`}

--- a/src/components/form/ComboBox/ComboBoxItem.tsx
+++ b/src/components/form/ComboBox/ComboBoxItem.tsx
@@ -1,105 +1,20 @@
-import { cx } from 'class-variance-authority'
-import { Link } from 'react-router-dom'
-import styled from 'styled-components'
+import { FC, PropsWithChildren } from 'react'
 
-import { ConditionalWrapper } from '~/components/ConditionalWrapper'
-import { Icon, Typography } from '~/components/designSystem'
-import { ITEM_HEIGHT } from '~/styles'
+import { tw } from '~/styles/utils'
 
-import { ComboBoxData } from './types'
-
-import { Radio } from '../Radio'
-
-interface ComboBoxItemProps {
-  id: string
-  option: ComboBoxData
-  selected?: boolean
-  comboboxProps: React.HTMLAttributes<HTMLLIElement>
-  virtualized?: boolean
-  addValueRedirectionUrl?: string
-}
-
-export const ComboBoxItem = ({
-  id,
-  option: { customValue, value, label, description, disabled, labelNode },
-  selected,
+export const ComboboxItem: FC<PropsWithChildren<{ virtualized?: boolean; className?: string }>> = ({
+  children,
+  className,
   virtualized,
-  comboboxProps,
-  addValueRedirectionUrl,
-}: ComboBoxItemProps) => {
-  const { className, ...allProps } = comboboxProps
-
-  return (
-    <ItemWrapper data-test={`combobox-item-${label}`}>
-      <ConditionalWrapper
-        condition={!!addValueRedirectionUrl}
-        invalidWrapper={(children) => <>{children}</>}
-        validWrapper={(children) => <Link to={addValueRedirectionUrl as string}>{children}</Link>}
-      >
-        {/* @ts-ignore */}
-        <Item
-          id={id}
-          $virtualized={virtualized}
-          className={cx(
-            {
-              'combo-box-item--disabled': disabled,
-            },
-            className,
-          )}
-          data-test={value}
-          key={value}
-          {...allProps}
-        >
-          {customValue ? (
-            <>
-              <Icon className="mr-4" color="dark" name="plus" />
-              <Typography variant="body" noWrap>
-                {labelNode ?? label}
-              </Typography>
-            </>
-          ) : (
-            <Radio
-              disabled={disabled}
-              name={value}
-              value={value}
-              checked={!!selected}
-              label={labelNode || label || value}
-              sublabel={description}
-              labelVariant="body"
-            />
-          )}
-        </Item>
-      </ConditionalWrapper>
-    </ItemWrapper>
-  )
-}
-
-const ItemWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  min-height: ${ITEM_HEIGHT}px;
-
-  a {
-    width: 100%;
-
-    &:focus,
-    &:active,
-    &:hover {
-      outline: none;
-      text-decoration: none;
-    }
-  }
-`
-
-export const Item = styled.div<{ $virtualized?: boolean }>`
-  display: flex;
-  align-items: center;
-  border-radius: 12px;
-  cursor: pointer;
-  width: ${({ $virtualized }) => ($virtualized ? 'initial' : 'inherit')};
-  box-sizing: border-box;
-
-  &.combo-box-item--disabled {
-    cursor: auto;
-  }
-`
+  ...props
+}) => (
+  <div
+    className={tw('flex cursor-pointer items-center rounded-xl', className)}
+    style={{
+      width: !!virtualized ? 'initial' : 'inherit',
+    }}
+    {...props}
+  >
+    {children}
+  </div>
+)

--- a/src/components/form/ComboBox/ComboBoxItem.tsx
+++ b/src/components/form/ComboBox/ComboBoxItem.tsx
@@ -4,13 +4,11 @@ import styled from 'styled-components'
 
 import { ConditionalWrapper } from '~/components/ConditionalWrapper'
 import { Icon, Typography } from '~/components/designSystem'
-import { theme } from '~/styles'
+import { ITEM_HEIGHT, theme } from '~/styles'
 
 import { ComboBoxData } from './types'
 
 import { Radio } from '../Radio'
-
-export const ITEM_HEIGHT = 56
 
 interface ComboBoxItemProps {
   id: string

--- a/src/components/form/ComboBox/ComboBoxItem.tsx
+++ b/src/components/form/ComboBox/ComboBoxItem.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 
 import { ConditionalWrapper } from '~/components/ConditionalWrapper'
 import { Icon, Typography } from '~/components/designSystem'
-import { ITEM_HEIGHT, theme } from '~/styles'
+import { ITEM_HEIGHT } from '~/styles'
 
 import { ComboBoxData } from './types'
 
@@ -88,12 +88,6 @@ const ItemWrapper = styled.div`
       outline: none;
       text-decoration: none;
     }
-  }
-
-  .MuiAutocomplete-option {
-    min-height: ${ITEM_HEIGHT}px;
-    width: calc(100% - 16px) !important;
-    margin: 0 ${theme.spacing(2)};
   }
 `
 

--- a/src/components/form/ComboBox/ComboBoxItemWrapper.tsx
+++ b/src/components/form/ComboBox/ComboBoxItemWrapper.tsx
@@ -1,43 +1,43 @@
 import { cx } from 'class-variance-authority'
 import { Link } from 'react-router-dom'
-import styled from 'styled-components'
 
 import { ConditionalWrapper } from '~/components/ConditionalWrapper'
 import { Icon, Typography } from '~/components/designSystem'
-import { ITEM_HEIGHT, theme } from '~/styles'
 
-import { MultipleComboBoxData } from './types'
+import { ComboboxItem } from './ComboBoxItem'
+import { ComboBoxData } from './types'
 
-import { Checkbox } from '../Checkbox'
-import { ComboboxItem } from '../ComboBox'
+import { Radio } from '../Radio'
 
-interface MultipleComboBoxItemProps {
+interface ComboBoxItemWrapperProps {
   id: string
-  option: MultipleComboBoxData
+  option: ComboBoxData
   selected?: boolean
-  multipleComboBoxProps: React.HTMLAttributes<HTMLLIElement>
+  comboboxProps: React.HTMLAttributes<HTMLLIElement>
   virtualized?: boolean
   addValueRedirectionUrl?: string
 }
 
-export const MultipleComboBoxItem = ({
+export const ComboBoxItemWrapper = ({
   id,
   option: { customValue, value, label, description, disabled, labelNode },
   selected,
   virtualized,
-  multipleComboBoxProps,
+  comboboxProps,
   addValueRedirectionUrl,
-}: MultipleComboBoxItemProps) => {
-  const { className, ...allProps } = multipleComboBoxProps
+}: ComboBoxItemWrapperProps) => {
+  const { className, ...allProps } = comboboxProps
 
   return (
-    <ItemWrapper data-test={`multipleComboBox-item-${label}`}>
+    <div
+      className="remove-child-link-style flex min-h-14 items-center"
+      data-test={`combobox-item-${label}`}
+    >
       <ConditionalWrapper
         condition={!!addValueRedirectionUrl}
         invalidWrapper={(children) => <>{children}</>}
         validWrapper={(children) => <Link to={addValueRedirectionUrl as string}>{children}</Link>}
       >
-        {/* @ts-ignore */}
         <ComboboxItem
           id={id}
           virtualized={virtualized}
@@ -53,41 +53,24 @@ export const MultipleComboBoxItem = ({
         >
           {customValue ? (
             <>
-              <AddCustomValueIcon color="dark" name="plus" />
+              <Icon className="mr-4" color="dark" name="plus" />
               <Typography variant="body" noWrap>
                 {labelNode ?? label}
               </Typography>
             </>
           ) : (
-            <Checkbox
+            <Radio
               disabled={disabled}
               name={value}
-              value={!!selected}
-              sublabel={description}
+              value={value}
+              checked={!!selected}
               label={labelNode || label || value}
+              sublabel={description}
+              labelVariant="body"
             />
           )}
         </ComboboxItem>
       </ConditionalWrapper>
-    </ItemWrapper>
+    </div>
   )
 }
-
-const ItemWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  min-height: ${ITEM_HEIGHT}px;
-
-  a {
-    &:focus,
-    &:active,
-    &:hover {
-      outline: none;
-      text-decoration: none;
-    }
-  }
-`
-
-const AddCustomValueIcon = styled(Icon)`
-  margin-right: ${theme.spacing(4)};
-`

--- a/src/components/form/ComboBox/ComboBoxPopperFactory.tsx
+++ b/src/components/form/ComboBox/ComboBoxPopperFactory.tsx
@@ -1,7 +1,6 @@
 import { Popper, PopperProps } from '@mui/material'
 import { cx } from 'class-variance-authority'
 import { ReactNode } from 'react'
-import styled from 'styled-components'
 
 import { theme } from '~/styles'
 
@@ -14,20 +13,16 @@ type ComboBoxPopperFactoryArgs = Required<Pick<ComboBoxProps, 'PopperProps'>>['P
 
 // return a configured <Popper> component with custom styles
 export const ComboBoxPopperFactory =
-  ({
-    maxWidth,
-    minWidth,
-    placement,
-    displayInDialog,
-    grouped,
-    virtualized,
-  }: ComboBoxPopperFactoryArgs = {}) =>
+  ({ placement, displayInDialog, grouped, virtualized }: ComboBoxPopperFactoryArgs = {}) =>
   // eslint-disable-next-line react/display-name
   (props: PopperProps) => (
-    <StyledPopper
-      $minWidth={minWidth || 0}
-      $maxWidth={maxWidth}
-      $displayInDialog={displayInDialog}
+    <Popper
+      className="min-w-0"
+      sx={{
+        zIndex: displayInDialog
+          ? `${theme.zIndex.dialog + 1} !important`
+          : `${theme.zIndex.popper} !important`,
+      }}
       placement={placement || 'bottom-start'}
       modifiers={[
         {
@@ -48,25 +43,5 @@ export const ComboBoxPopperFactory =
       >
         {props?.children as ReactNode}
       </div>
-    </StyledPopper>
+    </Popper>
   )
-
-const StyledPopper = styled(Popper)<{
-  $minWidth?: number
-  $maxWidth?: number
-  $displayInDialog?: boolean
-}>`
-  min-width: ${({ $minWidth }) => $minWidth}px;
-  max-width: ${({ $maxWidth }) => ($maxWidth ? `${$maxWidth}px` : 'initial')};
-  z-index: ${({ $displayInDialog }) =>
-    $displayInDialog ? theme.zIndex.dialog + 1 : theme.zIndex.popper};
-
-  ${theme.breakpoints.down('md')} {
-    max-width: ${({ $minWidth }) => ($minWidth ? `${$minWidth}px` : 'initial')};
-  }
-
-  .MuiAutocomplete-paper {
-    border: 1px solid ${theme.palette.grey[200]};
-    box-sizing: content-box;
-  }
-`

--- a/src/components/form/ComboBox/ComboBoxVirtualizedList.tsx
+++ b/src/components/form/ComboBox/ComboBoxVirtualizedList.tsx
@@ -1,9 +1,9 @@
 import { ReactElement, useEffect, useRef } from 'react'
 import { VariableSizeList } from 'react-window'
 
+import { ITEM_HEIGHT } from '~/styles'
 import { tw } from '~/styles/utils'
 
-import { ITEM_HEIGHT } from './ComboBoxItem'
 import { ComboBoxProps } from './types'
 
 export const GROUP_ITEM_KEY = 'combobox-group-by'

--- a/src/components/form/ComboBox/index.tsx
+++ b/src/components/form/ComboBox/index.tsx
@@ -1,3 +1,4 @@
 export * from './ComboBox'
 export * from './ComboBoxField'
+export * from './ComboBoxItem'
 export * from './types'

--- a/src/components/form/ComboBox/types.ts
+++ b/src/components/form/ComboBox/types.ts
@@ -37,8 +37,6 @@ interface BasicComboboxProps extends Omit<ComboBoxInputProps, 'params' | 'search
   disableClearable?: boolean
   renderGroupInputStartAdornment?: { [key: string]: string }
   PopperProps?: Pick<MuiPopperProps, 'placement'> & {
-    minWidth?: number
-    maxWidth?: number
     displayInDialog?: boolean
     offset?: string
   }

--- a/src/components/form/MultipleComboBox/MultipleComboBoxItem.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBoxItem.tsx
@@ -4,13 +4,11 @@ import styled from 'styled-components'
 
 import { ConditionalWrapper } from '~/components/ConditionalWrapper'
 import { Icon, Typography } from '~/components/designSystem'
-import { theme } from '~/styles'
+import { ITEM_HEIGHT, theme } from '~/styles'
 
 import { MultipleComboBoxData } from './types'
 
 import { Checkbox } from '../Checkbox'
-
-export const ITEM_HEIGHT = 56
 
 interface MultipleComboBoxItemProps {
   id: string

--- a/src/components/form/MultipleComboBox/MultipleComboBoxItem.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBoxItem.tsx
@@ -85,12 +85,6 @@ const ItemWrapper = styled.div`
       text-decoration: none;
     }
   }
-
-  .MuiAutocomplete-option {
-    min-height: ${ITEM_HEIGHT}px;
-    width: 100% !important;
-    margin: 0 ${theme.spacing(2)};
-  }
 `
 
 const AddCustomValueIcon = styled(Icon)`

--- a/src/components/form/MultipleComboBox/MultipleComboBoxPopperFactory.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBoxPopperFactory.tsx
@@ -67,8 +67,8 @@ const StyledPopper = styled(Popper)<{
     max-width: ${({ $minWidth }) => ($minWidth ? `${$minWidth}px` : 'initial')};
   }
 
+  /* During TW migration, the padding should be removed, following Combobox implementation */
   .MuiAutocomplete-paper {
-    border: 1px solid ${theme.palette.grey[200]};
     padding: ${theme.spacing(2)} 0;
   }
 

--- a/src/components/form/MultipleComboBox/MultipleComboBoxVirtualizedList.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBoxVirtualizedList.tsx
@@ -1,7 +1,8 @@
 import { ReactElement, useEffect, useRef } from 'react'
 import { VariableSizeList } from 'react-window'
 
-import { ITEM_HEIGHT } from './MultipleComboBoxItem'
+import { ITEM_HEIGHT } from '~/styles'
+
 import { MultipleComboBoxProps } from './types'
 
 export const GROUP_ITEM_KEY = 'multiple-comboBox-group-by'

--- a/src/components/invoices/EditInvoiceItemTaxDialog.tsx
+++ b/src/components/invoices/EditInvoiceItemTaxDialog.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { array, object, string } from 'yup'
 
 import { Button, Dialog, DialogRef, Tooltip, Typography } from '~/components/designSystem'
-import { ComboBox } from '~/components/form'
+import { ComboBox, ComboboxItem } from '~/components/form'
 import { SEARCH_TAX_INPUT_FOR_INVOICE_ADD_ON_CLASSNAME } from '~/core/constants/form'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { useGetTaxesForInvoiceEditTaxDialogQuery } from '~/generated/graphql'
@@ -13,8 +13,6 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { theme } from '~/styles'
 
 import { LocalFeeInput } from './types'
-
-import { Item } from '../form/ComboBox/ComboBoxItem'
 
 gql`
   fragment TaxForInvoiceEditTaxDialog on Tax {
@@ -149,7 +147,7 @@ export const EditInvoiceItemTaxDialog = forwardRef<EditInvoiceItemTaxDialogRef>(
                             style: 'percent',
                           })})`,
                           labelNode: (
-                            <Item>
+                            <ComboboxItem>
                               {name}&nbsp;
                               <Typography color="textPrimary">
                                 (
@@ -158,7 +156,7 @@ export const EditInvoiceItemTaxDialog = forwardRef<EditInvoiceItemTaxDialogRef>(
                                 })}
                                 )
                               </Typography>
-                            </Item>
+                            </ComboboxItem>
                           ),
                           value: localTaxId,
                           disabled:

--- a/src/components/plans/ChargeAccordion.tsx
+++ b/src/components/plans/ChargeAccordion.tsx
@@ -13,7 +13,7 @@ import {
   Tooltip,
   Typography,
 } from '~/components/designSystem'
-import { AmountInput, ComboBox, RadioGroupField, Switch } from '~/components/form'
+import { AmountInput, ComboBox, ComboboxItem, RadioGroupField, Switch } from '~/components/form'
 import { ChargeBillingRadioGroup } from '~/components/plans/ChargeBillingRadioGroup'
 import { useDuplicatePlanVar } from '~/core/apolloClient'
 import {
@@ -56,7 +56,6 @@ import { RemoveChargeWarningDialogRef } from './RemoveChargeWarningDialog'
 import { LocalChargeInput, PlanFormInput } from './types'
 
 import { ConditionalWrapper } from '../ConditionalWrapper'
-import { Item } from '../form/ComboBox/ComboBoxItem'
 import { EditInvoiceDisplayNameRef } from '../invoices/EditInvoiceDisplayName'
 import { PremiumWarningDialogRef } from '../PremiumWarningDialog'
 
@@ -324,7 +323,7 @@ export const ChargeAccordion = memo(
             style: 'percent',
           })})`,
           labelNode: (
-            <Item>
+            <ComboboxItem>
               {name}&nbsp;
               <Typography color="textPrimary">
                 (
@@ -333,7 +332,7 @@ export const ChargeAccordion = memo(
                 })}
                 )
               </Typography>
-            </Item>
+            </ComboboxItem>
           ),
           value: taxId,
           disabled: chargeTaxesIds.includes(taxId),

--- a/src/components/plans/ChargesSection.tsx
+++ b/src/components/plans/ChargesSection.tsx
@@ -5,8 +5,7 @@ import { memo, RefObject, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import { Button, Card, Popper, Tooltip, Typography } from '~/components/designSystem'
-import { ComboBox, SwitchField } from '~/components/form'
-import { Item } from '~/components/form/ComboBox/ComboBoxItem'
+import { ComboBox, ComboboxItem, SwitchField } from '~/components/form'
 import {
   FORM_TYPE_ENUM,
   MUI_INPUT_BASE_ROOT_CLASSNAME,
@@ -145,7 +144,7 @@ export const ChargesSection = memo(
         return {
           label: `${name} (${code})`,
           labelNode: (
-            <Item>
+            <ComboboxItem>
               <Typography color="grey700" noWrap>
                 {name}
               </Typography>
@@ -153,7 +152,7 @@ export const ChargesSection = memo(
               <Typography color="textPrimary" noWrap>
                 ({code})
               </Typography>
-            </Item>
+            </ComboboxItem>
           ),
           value: id,
         }
@@ -172,13 +171,13 @@ export const ChargesSection = memo(
         return {
           label: `${name} (${code})`,
           labelNode: (
-            <Item>
+            <ComboboxItem>
               <Typography color="grey700" noWrap>
                 {name}
               </Typography>
               &nbsp;
               <Typography color="textPrimary">({code})</Typography>
-            </Item>
+            </ComboboxItem>
           ),
           value: id,
         }

--- a/src/components/plans/CommitmentsSection.tsx
+++ b/src/components/plans/CommitmentsSection.tsx
@@ -22,8 +22,7 @@ import { NAV_HEIGHT, theme } from '~/styles'
 import { mapChargeIntervalCopy } from './ChargeAccordion'
 import { PlanFormInput } from './types'
 
-import { AmountInputField, ComboBox } from '../form'
-import { Item } from '../form/ComboBox/ComboBoxItem'
+import { AmountInputField, ComboBox, ComboboxItem } from '../form'
 import { EditInvoiceDisplayNameRef } from '../invoices/EditInvoiceDisplayName'
 import { PremiumWarningDialogRef } from '../PremiumWarningDialog'
 
@@ -82,7 +81,7 @@ export const CommitmentsSection = ({
           style: 'percent',
         })})`,
         labelNode: (
-          <Item>
+          <ComboboxItem>
             {name}&nbsp;
             <Typography color="textPrimary">
               (
@@ -91,7 +90,7 @@ export const CommitmentsSection = ({
               })}
               )
             </Typography>
-          </Item>
+          </ComboboxItem>
         ),
         value: taxId,
         disabled: minCommitmentsTaxesIds.includes(taxId),

--- a/src/components/plans/PlanSettingsSection.tsx
+++ b/src/components/plans/PlanSettingsSection.tsx
@@ -4,8 +4,13 @@ import { memo, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { Button, Card, Chip, Tooltip, Typography } from '~/components/designSystem'
-import { ButtonSelectorField, ComboBox, ComboBoxField, TextInputField } from '~/components/form'
-import { Item } from '~/components/form/ComboBox/ComboBoxItem'
+import {
+  ButtonSelectorField,
+  ComboBox,
+  ComboBoxField,
+  ComboboxItem,
+  TextInputField,
+} from '~/components/form'
 import {
   FORM_ERRORS_ENUM,
   FORM_TYPE_ENUM,
@@ -94,7 +99,7 @@ export const PlanSettingsSection = memo(
             style: 'percent',
           })})`,
           labelNode: (
-            <Item>
+            <ComboboxItem>
               {name}&nbsp;
               <Typography color="textPrimary">
                 (
@@ -103,7 +108,7 @@ export const PlanSettingsSection = memo(
                 })}
                 )
               </Typography>
-            </Item>
+            </ComboboxItem>
           ),
           value: id,
           disabled: planTaxesIds.includes(id),

--- a/src/components/settings/invoices/AddOrganizationVatRateDialog.tsx
+++ b/src/components/settings/invoices/AddOrganizationVatRateDialog.tsx
@@ -3,7 +3,7 @@ import { forwardRef, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { Button, Dialog, DialogRef, Typography } from '~/components/designSystem'
-import { ComboBox } from '~/components/form'
+import { ComboBox, ComboboxItem } from '~/components/form'
 import { addToast } from '~/core/apolloClient'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CREATE_TAX_ROUTE } from '~/core/router'
@@ -15,8 +15,6 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { usePermissions } from '~/hooks/usePermissions'
 import { theme } from '~/styles'
-
-import { Item } from '../../form/ComboBox/ComboBoxItem'
 
 gql`
   query getTaxRatesForEditOrga($limit: Int, $page: Int, $searchTerm: String) {
@@ -79,7 +77,7 @@ export const AddOrganizationVatRateDialog = forwardRef<
           style: 'percent',
         })})`,
         labelNode: (
-          <Item>
+          <ComboboxItem>
             {name}&nbsp;
             <Typography color="textPrimary">
               (
@@ -88,7 +86,7 @@ export const AddOrganizationVatRateDialog = forwardRef<
               })}
               )
             </Typography>
-          </Item>
+          </ComboboxItem>
         ),
         value: id,
         disabled: appliedTaxRatesTaxesIds?.includes(id),

--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -7,8 +7,13 @@ import { number, object, string } from 'yup'
 
 import { AddOnFormInput } from '~/components/addOns/types'
 import { Button, Card, Chip, Skeleton, Tooltip, Typography } from '~/components/designSystem'
-import { AmountInputField, ComboBox, ComboBoxField, TextInputField } from '~/components/form'
-import { Item } from '~/components/form/ComboBox/ComboBoxItem'
+import {
+  AmountInputField,
+  ComboBox,
+  ComboBoxField,
+  ComboboxItem,
+  TextInputField,
+} from '~/components/form'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import {
   FORM_ERRORS_ENUM,
@@ -108,7 +113,7 @@ const CreateAddOn = () => {
           style: 'percent',
         })})`,
         labelNode: (
-          <Item>
+          <ComboboxItem>
             {name}&nbsp;
             <Typography color="textPrimary">
               (
@@ -117,7 +122,7 @@ const CreateAddOn = () => {
               })}
               )
             </Typography>
-          </Item>
+          </ComboboxItem>
         ),
         value: id,
         disabled: addOnTaxesIds.includes(id),

--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -18,8 +18,7 @@ import {
   Tooltip,
   Typography,
 } from '~/components/designSystem'
-import { AmountInput, ComboBox, ComboBoxField, TextInput } from '~/components/form'
-import { Item } from '~/components/form/ComboBox/ComboBoxItem'
+import { AmountInput, ComboBox, ComboBoxField, ComboboxItem, TextInput } from '~/components/form'
 import { GenericPlaceholder } from '~/components/GenericPlaceholder'
 import {
   EditInvoiceDisplayName,
@@ -298,7 +297,7 @@ const CreateInvoice = () => {
       return {
         label: name,
         labelNode: (
-          <Item>
+          <ComboboxItem>
             <Typography color="grey700" noWrap>
               {name}
             </Typography>
@@ -311,7 +310,7 @@ const CreateInvoice = () => {
               })}
               )
             </Typography>
-          </Item>
+          </ComboboxItem>
         ),
         value: id,
       }

--- a/src/pages/CreateSubscription.tsx
+++ b/src/pages/CreateSubscription.tsx
@@ -30,10 +30,10 @@ import {
   BasicComboBoxData,
   ButtonSelectorField,
   ComboBoxField,
+  ComboboxItem,
   DatePickerField,
   TextInputField,
 } from '~/components/form'
-import { Item } from '~/components/form/ComboBox/ComboBoxItem'
 import {
   EditInvoiceDisplayName,
   EditInvoiceDisplayNameRef,
@@ -369,7 +369,7 @@ const CreateSubscription = () => {
         {
           label: `${name} - (${code})`,
           labelNode: (
-            <Item>
+            <ComboboxItem>
               <Typography color="grey700" noWrap>
                 {name}
               </Typography>
@@ -377,7 +377,7 @@ const CreateSubscription = () => {
               <Typography color="textPrimary" noWrap>
                 ({code})
               </Typography>
-            </Item>
+            </ComboboxItem>
           ),
           value: id,
           disabled:

--- a/src/styles/muiTheme.ts
+++ b/src/styles/muiTheme.ts
@@ -488,12 +488,11 @@ export const theme = createTheme({
           cursor: 'pointer',
         },
         option: {
-          paddingLeft: 0,
-          paddingRight: 0,
-          paddingTop: 0,
-          paddingBottom: 0,
           borderRadius: '12px',
           height: 'auto',
+          minHeight: `${ITEM_HEIGHT}px !important`,
+          width: '100% !important',
+          margin: '0 8px',
           '&.Mui-focused': {
             backgroundColor: `${palette.grey[100]} !important`,
           },

--- a/src/styles/muiTheme.ts
+++ b/src/styles/muiTheme.ts
@@ -3,6 +3,7 @@ import type {} from '@mui/x-date-pickers/themeAugmentation'
 
 import { palette } from './colorsPalette'
 
+export const ITEM_HEIGHT = 56
 export const NAV_HEIGHT = 72
 export const HEADER_TABLE_HEIGHT = 48
 export const INNER_CONTENT_WIDTH = 672

--- a/src/styles/muiTheme.ts
+++ b/src/styles/muiTheme.ts
@@ -478,6 +478,10 @@ export const theme = createTheme({
               },
             },
           },
+          '.MuiAutocomplete-paper': {
+            border: `1px solid ${palette.grey[200]}`,
+            boxSizing: 'content-box',
+          },
         },
         popupIndicator: {
           backgroundColor: 'transparent',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -286,6 +286,16 @@ const config = {
         '.height-minus-footer': {
           height: `calc(100vh - ${theme('spacing.footer')})`,
         },
+        '.remove-child-link-style': {
+          a: {
+            width: '100%',
+
+            '&:focus, &:active, &:hover': {
+              outline: 'none',
+              textDecoration: 'none',
+            },
+          },
+        },
       })
     }),
   ],

--- a/translations/base.json
+++ b/translations/base.json
@@ -1502,7 +1502,7 @@
   "text_636bedf292786b19d3398ed0": "Reason",
   "text_636bedf292786b19d3398ed2": "Select or search a reason",
   "text_636bedf292786b19d3398ed4": "Internal note (optional)",
-  "text_636bedf292786b19d3398ed6": "Explain the goal of this plan …",
+  "text_636bedf292786b19d3398ed6": "Add a description to your Credit Note",
   "text_636bedf292786b19d3398ed8": "Items to credit",
   "text_636bedf292786b19d3398eda": "Invoice",
   "text_636bedf292786b19d3398edc": "{{invoiceNumber}} for a remaining subtotal (incl. tax) of {{subtotal}}",


### PR DESCRIPTION
## Context

We migrate our components to Tailwind.

This PR is about combobox migration and a first part have already been done. Check it out for more details: https://github.com/getlago/lago-front/pull/1942

## Description

Migrate last Combobox inner components and rename ones.

Some impacts on the multiple combobox, that should be migrated very soon too.

<!-- Linear link -->
Fixes LAGO-433