### PR TITLE
misc: improve multiple combobox behaviour

### DIFF
--- a/src/components/designSystem/Filters/filtersElements/FiltersItemPaymentStatus.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemPaymentStatus.tsx
@@ -37,7 +37,7 @@ export const FiltersItemPaymentStatus = ({
       onChange={(invoiceType) => {
         setFilterValue(String(invoiceType.map((v) => v.value).join(',')))
       }}
-      value={value
+      value={(value || '')
         ?.split(',')
         .filter((v) => !!v)
         .map((v) => ({ value: v }))}

--- a/src/components/form/MultipleComboBox/MultipleComboBox.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBox.tsx
@@ -138,7 +138,7 @@ export const MultipleComboBox = ({
                 {...tagOptions}
                 className="my-2 ml-2 mr-0"
                 key={tagOptions.key}
-                label={option.value}
+                label={option.label ?? option.value}
               />
             )
           })


### PR DESCRIPTION
This PR fixes 2 aspects of the Multiple combobox
- Make sure that once selected, we display the item label first THEN the value, in the input's badge
- Fix the uncontrolled state warning, as it was initialised with undefined. Defaulting to empty string fixes this 