### PR TITLE
bug: make sure className is passed to all Skeleton cases

### DIFF
--- a/src/components/designSystem/Skeleton.tsx
+++ b/src/components/designSystem/Skeleton.tsx
@@ -79,7 +79,7 @@ export const Skeleton = ({
     <ConditionalWrapper
       condition={!!textVariant && variant === 'text'}
       validWrapper={(children) => (
-        <div className={tw(textWrapperStyles({ textVariant }))}>{children}</div>
+        <div className={tw(textWrapperStyles({ textVariant }), className)}>{children}</div>
       )}
       invalidWrapper={(children) => <>{children}</>}
     >


### PR DESCRIPTION
## Context

We noticed the Navigation tab Skeleton was too wide

## Description

This PR fixes this bug, by making sure the classname defined during invocation is passed to every cases of the conditional wrapper

<!-- Linear link -->
Fixes ISSUE-609