### PR TITLE
misc(OneOffInvoice): allow 3 decimal value for units

### DIFF
--- a/cypress/e2e/t30-create-one-off-invoice.cy.ts
+++ b/cypress/e2e/t30-create-one-off-invoice.cy.ts
@@ -119,21 +119,21 @@ describe('Create one-off', () => {
       cy.get('[data-test="edit-invoice-item-tax-dialog-submit-button"]').click({ force: true })
 
       // Update it's units
-      cy.get('input[name="fees.0.units"]').clear().type('3')
+      cy.get('input[name="fees.0.units"]').clear().type('3.333')
 
       // Check displayed amounts
-      cy.get('[data-test="one-off-invoice-subtotal-value"]').should('have.text', '$9,060.00')
+      cy.get('[data-test="one-off-invoice-subtotal-value"]').should('have.text', '$10,065.66')
       cy.get('[data-test="one-off-invoice-tax-item-0-label"]').should('have.text', 'twenty (20%)')
-      cy.get('[data-test="one-off-invoice-tax-item-0-value"]').should('have.text', '$1,812.00')
+      cy.get('[data-test="one-off-invoice-tax-item-0-value"]').should('have.text', '$2,013.13')
       cy.get('[data-test="one-off-invoice-tax-item-1-label"]').should('have.text', 'ten (10%)')
-      cy.get('[data-test="one-off-invoice-tax-item-1-value"]').should('have.text', '$906.00')
+      cy.get('[data-test="one-off-invoice-tax-item-1-value"]').should('have.text', '$1,006.57')
       cy.get('[data-test="one-off-invoice-subtotal-amount-due-value"]').should(
         'have.text',
-        '$11,778.00',
+        '$13,085.36',
       )
       cy.get('[data-test="one-off-invoice-total-amount-due-value"]').should(
         'have.text',
-        '$11,778.00',
+        '$13,085.36',
       )
     })
   })

--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -732,12 +732,12 @@ const CreateInvoice = () => {
                               <TextInput
                                 name={`fees.${i}.units`}
                                 type="number"
-                                beforeChangeFormatter={['int', 'positiveNumber']}
+                                beforeChangeFormatter={['triDecimal', 'positiveNumber']}
                                 error={false}
                                 placeholder={translate('text_62824f0e5d93bc008d268d00')}
                                 value={formikProps.values.fees[i].units || undefined}
                                 onChange={(value) => {
-                                  formikProps.setFieldValue(`fees.${i}.units`, value)
+                                  formikProps.setFieldValue(`fees.${i}.units`, Number(value))
                                   !!hasTaxProvider && setTaxProviderTaxesResult(null)
                                 }}
                               />


### PR DESCRIPTION
The API allows multiple decimal for units in one-off creation.

This allows to do the same from the UI