### PR TITLE
misc(Table): allow to open row link in new tab

### DIFF
--- a/src/components/creditNote/CreditNotesTable.tsx
+++ b/src/components/creditNote/CreditNotesTable.tsx
@@ -298,15 +298,13 @@ const CreditNotesTable = ({
 
                   return actions
                 }}
-                onRowAction={(creditNote) => {
-                  navigate(
-                    generatePath(CUSTOMER_INVOICE_CREDIT_NOTE_DETAILS_ROUTE, {
-                      customerId: creditNote?.invoice?.customer?.id as string,
-                      invoiceId: creditNote?.invoice?.id as string,
-                      creditNoteId: creditNote?.id as string,
-                    }),
-                  )
-                }}
+                onRowActionLink={(creditNote) =>
+                  generatePath(CUSTOMER_INVOICE_CREDIT_NOTE_DETAILS_ROUTE, {
+                    customerId: creditNote?.invoice?.customer?.id as string,
+                    invoiceId: creditNote?.invoice?.id as string,
+                    creditNoteId: creditNote?.id as string,
+                  })
+                }
                 columns={[
                   {
                     key: 'totalAmountCents',

--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -173,14 +173,12 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
           isLoading={isLoading}
           hasError={hasError}
           data={invoiceData?.collection ?? []}
-          onRowAction={({ id }) =>
-            navigate(
-              generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
-                customerId,
-                invoiceId: id,
-                tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
-              }),
-            )
+          onRowActionLink={({ id }) =>
+            generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
+              customerId,
+              invoiceId: id,
+              tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
+            })
           }
           placeholder={{
             errorState: {

--- a/src/components/designSystem/__tests__/Table.test.tsx
+++ b/src/components/designSystem/__tests__/Table.test.tsx
@@ -82,7 +82,7 @@ describe('Table', () => {
 
     await prepare({
       props: {
-        onRowAction: (row: any) => onRow(row),
+        onRowActionLink: (row: any) => onRow(row),
         actionColumn: () => [
           {
             title: 'Edit',
@@ -136,7 +136,7 @@ describe('Table', () => {
     await prepare({
       props: {
         actionColumn: (row: any) => <Button onClick={onClick(row)}>Click me</Button>,
-        onRowAction: (row: any) => onRow(row),
+        onRowActionLink: (row: any) => onRow(row),
       },
     })
 

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -416,15 +416,13 @@ const InvoicesList = ({
                 ),
               },
             ]}
-            onRowAction={(invoice) => {
-              navigate(
-                generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
-                  customerId: invoice?.customer?.id,
-                  invoiceId: invoice.id,
-                  tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
-                }),
-              )
-            }}
+            onRowActionLink={(invoice) =>
+              generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
+                customerId: invoice?.customer?.id,
+                invoiceId: invoice.id,
+                tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
+              })
+            }
             placeholder={{
               errorState: variables?.searchTerm
                 ? {

--- a/src/pages/AddOnsList.tsx
+++ b/src/pages/AddOnsList.tsx
@@ -109,7 +109,7 @@ const AddOnsList = () => {
           rowSize={72}
           isLoading={isLoading}
           hasError={!!error}
-          onRowAction={({ id }) => navigate(generatePath(ADD_ON_DETAILS_ROUTE, { addOnId: id }))}
+          onRowActionLink={({ id }) => generatePath(ADD_ON_DETAILS_ROUTE, { addOnId: id })}
           rowDataTestId={(addOn) => `${addOn.name}`}
           columns={[
             {

--- a/src/pages/BillableMetricsList.tsx
+++ b/src/pages/BillableMetricsList.tsx
@@ -101,8 +101,8 @@ const BillableMetricsList = () => {
           rowSize={72}
           isLoading={isLoading}
           hasError={!!error}
-          onRowAction={({ id }) =>
-            navigate(generatePath(UPDATE_BILLABLE_METRIC_ROUTE, { billableMetricId: id }))
+          onRowActionLink={({ id }) =>
+            generatePath(UPDATE_BILLABLE_METRIC_ROUTE, { billableMetricId: id })
           }
           columns={[
             {

--- a/src/pages/CouponsList.tsx
+++ b/src/pages/CouponsList.tsx
@@ -138,7 +138,7 @@ const CouponsList = () => {
           rowSize={72}
           isLoading={isLoading}
           hasError={!!error}
-          onRowAction={({ id }) => navigate(generatePath(COUPON_DETAILS_ROUTE, { couponId: id }))}
+          onRowActionLink={({ id }) => generatePath(COUPON_DETAILS_ROUTE, { couponId: id })}
           rowDataTestId={(addOn) => `${addOn.name}`}
           columns={[
             {

--- a/src/pages/CustomersList.tsx
+++ b/src/pages/CustomersList.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { useRef } from 'react'
-import { generatePath, useNavigate } from 'react-router-dom'
+import { generatePath } from 'react-router-dom'
 
 import {
   AddCustomerDrawer,
@@ -56,7 +56,6 @@ gql`
 `
 
 const CustomersList = () => {
-  const navigate = useNavigate()
   const { translate } = useInternationalization()
   const { hasPermissions } = usePermissions()
   const { formatTimeOrgaTZ } = useOrganizationInfos()
@@ -115,9 +114,7 @@ const CustomersList = () => {
             default: 16,
             md: 48,
           }}
-          onRowAction={({ id }) =>
-            navigate(generatePath(CUSTOMER_DETAILS_ROUTE, { customerId: id }))
-          }
+          onRowActionLink={({ id }) => generatePath(CUSTOMER_DETAILS_ROUTE, { customerId: id })}
           columns={[
             {
               key: 'displayName',

--- a/src/pages/PlansList.tsx
+++ b/src/pages/PlansList.tsx
@@ -107,13 +107,11 @@ const PlansList = () => {
           isLoading={isLoading}
           hasError={!!error}
           rowDataTestId={(plan) => `${plan.name}`}
-          onRowAction={({ id }) =>
-            navigate(
-              generatePath(PLAN_DETAILS_ROUTE, {
-                planId: id,
-                tab: PlanDetailsTabsOptionsEnum.overview,
-              }),
-            )
+          onRowActionLink={({ id }) =>
+            generatePath(PLAN_DETAILS_ROUTE, {
+              planId: id,
+              tab: PlanDetailsTabsOptionsEnum.overview,
+            })
           }
           columns={[
             {

--- a/src/pages/__devOnly/DesignSystem.tsx
+++ b/src/pages/__devOnly/DesignSystem.tsx
@@ -643,7 +643,7 @@ const DesignSystem = () => {
                         content: (row) => row.date,
                       },
                     ]}
-                    onRowAction={(item) => alert(`You clicked on ${item.id}`)}
+                    onRowActionLink={(item) => `you clicked on ${item.id}`}
                     actionColumn={(currentItem) => [
                       currentItem.amount > 1000
                         ? {
@@ -706,7 +706,7 @@ const DesignSystem = () => {
                         ),
                       },
                     ]}
-                    onRowAction={(item) => alert(`You clicked on ${item.id}`)}
+                    onRowActionLink={(item) => `you clicked on ${item.id}`}
                   />
                 </Block>
               </Container>

--- a/src/pages/developers/Webhooks.tsx
+++ b/src/pages/developers/Webhooks.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { useRef, useState } from 'react'
-import { generatePath, useNavigate } from 'react-router-dom'
+import { generatePath } from 'react-router-dom'
 
 import { Button, Table, Tooltip, Typography } from '~/components/designSystem'
 import {
@@ -55,7 +55,6 @@ gql`
 `
 
 const Webhooks = () => {
-  const navigate = useNavigate()
   const { translate } = useInternationalization()
   const [showOrganizationHmac, setShowOrganizationHmac] = useState<boolean>(false)
   const createDialogRef = useRef<CreateWebhookDialogRef>(null)
@@ -208,9 +207,7 @@ const Webhooks = () => {
                       ),
                     },
                   ]}
-                  onRowAction={({ id }) => {
-                    navigate(generatePath(WEBHOOK_LOGS_ROUTE, { webhookId: id }))
-                  }}
+                  onRowActionLink={({ id }) => generatePath(WEBHOOK_LOGS_ROUTE, { webhookId: id })}
                   actionColumnTooltip={() => translate('text_6256de3bba111e00b3bfa51b')}
                   actionColumn={(webhook) => {
                     return [

--- a/src/pages/settings/EmailSettings.tsx
+++ b/src/pages/settings/EmailSettings.tsx
@@ -88,13 +88,11 @@ const EmailSettings = () => {
                   containerSize={{ default: 0 }}
                   rowSize={72}
                   data={EMAIL_SCENARIOS}
-                  onRowAction={({ setting }) => {
-                    navigate(
-                      generatePath(EMAILS_SCENARIO_CONFIG_ROUTE, {
-                        type: setting,
-                      }),
-                    )
-                  }}
+                  onRowActionLink={({ setting }) =>
+                    generatePath(EMAILS_SCENARIO_CONFIG_ROUTE, {
+                      type: setting,
+                    })
+                  }
                   columns={[
                     {
                       key: 'id',


### PR DESCRIPTION
## Context

A customer asked to be able to open row link redirection in a new tab.

## Description

We're not the best in term of accessibility and it's kinda hard to have a native `a` link into a table structure without increasing the complexity of the Table component.

I noticed we only use the `onRowAction` to execute a navigate all over the app, so decided to rename it and for it to return a string.
So we can check if meta or ctrl key are pressed to open in new tab, otherwise use the navigate from `rect-router-dom` as usual.
Put that into the same commit as pretty tied

<!-- Linear link -->
Fixes ISSUE-615