### PR TITLE
bug(Combobox): fix element height with description

### DIFF
--- a/src/components/form/ComboBox/ComboBoxVirtualizedList.tsx
+++ b/src/components/form/ComboBox/ComboBoxVirtualizedList.tsx
@@ -31,14 +31,21 @@ export const ComboBoxVirtualizedList = (props: ComboBoxVirtualizedListProps) => 
 
   const getHeight = () => {
     const hasAnyGroupHeader = elements.some((el) => (el.key as string).includes(GROUP_ITEM_KEY))
+    const hasDescription = elements.some(
+      (el) => (el.props?.children?.props?.option?.description as string)?.length > 0,
+    )
+
+    const itemheightDelta = hasDescription ? 8 : 4
 
     // recommended perf best practice
     if (itemCount > 5) {
-      return 5 * (ITEM_HEIGHT + 4) + 4 // Add 4px for margins
+      return 5 * (ITEM_HEIGHT + itemheightDelta) + 4 // Add 4px for margins
     } else if (itemCount <= 2 && hasAnyGroupHeader) {
       return itemCount * (ITEM_HEIGHT + 2) // Add 2px for margins
+    } else if (itemCount <= 2 && hasDescription) {
+      return itemCount * (ITEM_HEIGHT + itemheightDelta) + 4 // Add 4px for margins
     }
-    return itemCount * (ITEM_HEIGHT + 4) + 4 // Add 4px for margins
+    return itemCount * (ITEM_HEIGHT + itemheightDelta) + 4 // Add 4px for margins
   }
 
   // reset the `VariableSizeList` cache if data gets updated


### PR DESCRIPTION
Fixes the Combobox element height if it contains a description.

Note: I'm tired of those shenanigans and random calculation values there and in the multiple combobox. I think we should (i) upgrade MUI to v6, (ii) negociate to have a combobox looking like the MUI doc with design, (iii) remove all our custom implementation to get something simpler that works without all this magic and the world would be much safer place.

Fixes ISSUE-619