### PR TITLE
feat: Invoice amount filter

### DIFF
--- a/src/components/designSystem/Filters/filtersElements/FiltersItemAmount.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemAmount.tsx
@@ -71,6 +71,7 @@ export const FiltersItemAmount = ({ value = '', setFilterValue }: FiltersItemAmo
         }))}
         placeholder={translate('text_66ab42d4ece7e6b7078993b1')}
         formikProps={formikProps}
+        disableClearable={true}
       />
 
       {showFrom && (

--- a/src/components/designSystem/Filters/types.ts
+++ b/src/components/designSystem/Filters/types.ts
@@ -49,6 +49,7 @@ export const InvoiceAvailableFilters = [
   AvailableFiltersEnum.paymentOverdue,
   AvailableFiltersEnum.paymentStatus,
   AvailableFiltersEnum.status,
+  AvailableFiltersEnum.amount,
 ]
 
 const translationMap: Record<AvailableFiltersEnum, string> = {

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -12,8 +12,8 @@ import {
 export const parseAmountValue = (value: string) => {
   const [interval, from, to] = value.split(',')
 
-  const fromAmount = from ? parseInt(from) : null
-  const toAmount = to ? parseInt(to) : null
+  const fromAmount = from ? Number(from) : null
+  const toAmount = to ? Number(to) : null
 
   switch (interval) {
     case AmountFilterInterval.isEqualTo:

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -118,6 +118,7 @@ const InvoicesList = ({
         <QuickFilters type={AvailableQuickFilters.InvoiceStatus} />
         <Filters
           filters={[
+            AvailableFiltersEnum.amount,
             AvailableFiltersEnum.status,
             AvailableFiltersEnum.invoiceType,
             AvailableFiltersEnum.paymentStatus,

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -2155,6 +2155,8 @@ export enum DataExportFormatTypeEnum {
 
 /** Export Invoices search query and filters input argument */
 export type DataExportInvoiceFiltersInput = {
+  amountFrom?: InputMaybe<Scalars['Int']['input']>;
+  amountTo?: InputMaybe<Scalars['Int']['input']>;
   currency?: InputMaybe<CurrencyEnum>;
   customerExternalId?: InputMaybe<Scalars['String']['input']>;
   invoiceType?: InputMaybe<Array<InvoiceTypeEnum>>;
@@ -4899,6 +4901,8 @@ export type QueryInvoicedUsagesArgs = {
 
 
 export type QueryInvoicesArgs = {
+  amountFrom?: InputMaybe<Scalars['Int']['input']>;
+  amountTo?: InputMaybe<Scalars['Int']['input']>;
   currency?: InputMaybe<CurrencyEnum>;
   customerExternalId?: InputMaybe<Scalars['String']['input']>;
   customerId?: InputMaybe<Scalars['ID']['input']>;
@@ -8695,6 +8699,8 @@ export type GetInvoicesListQueryVariables = Exact<{
   paymentStatus?: InputMaybe<Array<InvoicePaymentStatusTypeEnum> | InvoicePaymentStatusTypeEnum>;
   searchTerm?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<Array<InvoiceStatusTypeEnum> | InvoiceStatusTypeEnum>;
+  amountFrom?: InputMaybe<Scalars['Int']['input']>;
+  amountTo?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 
@@ -22961,7 +22967,7 @@ export type GetInvoiceCreditNotesLazyQueryHookResult = ReturnType<typeof useGetI
 export type GetInvoiceCreditNotesSuspenseQueryHookResult = ReturnType<typeof useGetInvoiceCreditNotesSuspenseQuery>;
 export type GetInvoiceCreditNotesQueryResult = Apollo.QueryResult<GetInvoiceCreditNotesQuery, GetInvoiceCreditNotesQueryVariables>;
 export const GetInvoicesListDocument = gql`
-    query getInvoicesList($currency: CurrencyEnum, $customerExternalId: String, $invoiceType: [InvoiceTypeEnum!], $issuingDateFrom: ISO8601Date, $issuingDateTo: ISO8601Date, $limit: Int, $page: Int, $paymentDisputeLost: Boolean, $paymentOverdue: Boolean, $paymentStatus: [InvoicePaymentStatusTypeEnum!], $searchTerm: String, $status: [InvoiceStatusTypeEnum!]) {
+    query getInvoicesList($currency: CurrencyEnum, $customerExternalId: String, $invoiceType: [InvoiceTypeEnum!], $issuingDateFrom: ISO8601Date, $issuingDateTo: ISO8601Date, $limit: Int, $page: Int, $paymentDisputeLost: Boolean, $paymentOverdue: Boolean, $paymentStatus: [InvoicePaymentStatusTypeEnum!], $searchTerm: String, $status: [InvoiceStatusTypeEnum!], $amountFrom: Int, $amountTo: Int) {
   invoices(
     currency: $currency
     customerExternalId: $customerExternalId
@@ -22975,6 +22981,8 @@ export const GetInvoicesListDocument = gql`
     paymentStatus: $paymentStatus
     searchTerm: $searchTerm
     status: $status
+    amountFrom: $amountFrom
+    amountTo: $amountTo
   ) {
     metadata {
       currentPage
@@ -23013,6 +23021,8 @@ export const GetInvoicesListDocument = gql`
  *      paymentStatus: // value for 'paymentStatus'
  *      searchTerm: // value for 'searchTerm'
  *      status: // value for 'status'
+ *      amountFrom: // value for 'amountFrom'
+ *      amountTo: // value for 'amountTo'
  *   },
  * });
  */

--- a/src/pages/InvoicesPage.tsx
+++ b/src/pages/InvoicesPage.tsx
@@ -216,7 +216,7 @@ const InvoicesPage = () => {
     nextFetchPolicy: 'network-only',
     variables: {
       limit: 20,
-      ...filtersForInvoiceQuery,
+      ...formatAmountCurrency(filtersForInvoiceQuery, amountCurrency),
     },
   })
 
@@ -258,7 +258,7 @@ const InvoicesPage = () => {
 
   const onInvoicesExport = async (values: ExportValues<InvoiceExportTypeEnum>) => {
     const filters = {
-      ...formatFiltersForInvoiceQuery(searchParams),
+      ...formatAmountCurrency(formatFiltersForInvoiceQuery(searchParams), amountCurrency),
       searchTerm: variableInvoices?.searchTerm,
     }
 

--- a/src/pages/InvoicesPage.tsx
+++ b/src/pages/InvoicesPage.tsx
@@ -59,6 +59,8 @@ gql`
     $paymentStatus: [InvoicePaymentStatusTypeEnum!]
     $searchTerm: String
     $status: [InvoiceStatusTypeEnum!]
+    $amountFrom: Int
+    $amountTo: Int
   ) {
     invoices(
       currency: $currency
@@ -73,6 +75,8 @@ gql`
       paymentStatus: $paymentStatus
       searchTerm: $searchTerm
       status: $status
+      amountFrom: $amountFrom
+      amountTo: $amountTo
     ) {
       metadata {
         currentPage


### PR DESCRIPTION
## Context

This PR enables filtering invoices by amount. A big chunk of the work was done previously for the Credit notes export feature.

## Description

Most of the change is just including the amount filter in invoice-related logic.

This change also includes an improvement to the query filtering logic, by making it consistent between credit notes and invoices. This should help us in the future if we want to also filter other entities.