### PR TITLE
feat(eslint): enable no-nested-ternary and no-unneeded-ternary

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,6 +67,8 @@ export default [
       'no-unused-vars': 'off',
       'newline-after-var': ['warn'], // TOFIX: Deprecated rule
       'no-extra-boolean-cast': 'off',
+      'no-nested-ternary': 'warn',
+      'no-unneeded-ternary': 'warn',
 
       // Plugins
       'import/order': [


### PR DESCRIPTION
## Context

Enabled some extra eslint rules that will improve the readability and maintenance of our codebase.

## Description

Current count of nested ternaries: 285
Current count of unneeded ternaries: 1