### PR TITLE
bug: define allowedHosts in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -81,6 +81,7 @@ export default defineConfig(({ mode }) => {
       port,
       host: true,
       strictPort: true,
+      allowedHosts: ['app.lago.dev'],
     },
     preview: {
       port,


### PR DESCRIPTION
A recent [update of vite](https://github.com/getlago/lago-front/pull/1998) package requires us to configure the allowed hosts for local dev, in order to whitelist the proxy.