### PR TITLE
chore: prevent dependabot auto merge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
       "matchUpdateTypes": ["patch", "digest", "bump"],
       "commitMessagePrefix": "chore(deps)",
       "reviewers": ["renovate-approve"],
-      "automerge": true
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
A bit sad, but not everyone respect strict semver for their package tags. 

Prevent having issues after an automatic merge like this morning.