### PR TITLE
hotfix: Remove filters from credit notes

### DIFF
--- a/src/components/creditNote/CreditNotesTable.tsx
+++ b/src/components/creditNote/CreditNotesTable.tsx
@@ -109,6 +109,7 @@ type TCreditNoteTableProps = {
   variables: LazyQueryHookOptions['variables'] | undefined
   customerTimezone?: TimezoneEnum
   tableContainerSize?: ResponsiveStyleValue<TableContainerSize>
+  showFilters?: boolean
 }
 
 const CreditNoteTableItemSkeleton = () => {
@@ -133,6 +134,7 @@ const CreditNotesTable = ({
   customerTimezone,
   error,
   tableContainerSize,
+  showFilters = true,
 }: TCreditNoteTableProps) => {
   const { translate } = useInternationalization()
   const navigate = useNavigate()
@@ -174,22 +176,24 @@ const CreditNotesTable = ({
 
   return (
     <>
-      <div className="box-border flex w-full flex-col gap-3 p-4 shadow-b md:px-12 md:py-3">
-        <Filters.Provider
-          availableFilters={[
-            AvailableFiltersEnum.amount,
-            AvailableFiltersEnum.creditNoteCreditStatus,
-            AvailableFiltersEnum.currency,
-            AvailableFiltersEnum.customerExternalId,
-            AvailableFiltersEnum.invoiceNumber,
-            AvailableFiltersEnum.issuingDate,
-            AvailableFiltersEnum.creditNoteReason,
-            AvailableFiltersEnum.creditNoteRefundStatus,
-          ]}
-        >
-          <Filters.Component />
-        </Filters.Provider>
-      </div>
+      {showFilters && (
+        <div className="box-border flex w-full flex-col gap-3 p-4 shadow-b md:px-12 md:py-3">
+          <Filters.Provider
+            availableFilters={[
+              AvailableFiltersEnum.amount,
+              AvailableFiltersEnum.creditNoteCreditStatus,
+              AvailableFiltersEnum.currency,
+              AvailableFiltersEnum.customerExternalId,
+              AvailableFiltersEnum.invoiceNumber,
+              AvailableFiltersEnum.issuingDate,
+              AvailableFiltersEnum.creditNoteReason,
+              AvailableFiltersEnum.creditNoteRefundStatus,
+            ]}
+          >
+            <Filters.Component />
+          </Filters.Provider>
+        </div>
+      )}
 
       <ScrollContainer
         ref={listContainerElementRef}

--- a/src/components/customers/CustomerCreditNotesList.tsx
+++ b/src/components/customers/CustomerCreditNotesList.tsx
@@ -113,6 +113,7 @@ export const CustomerCreditNotesList = ({
           customerTimezone={customerTimezone}
           error={error}
           variables={variables}
+          showFilters={false}
         />
       )}
     </div>

--- a/src/pages/InvoiceCreditNoteList.tsx
+++ b/src/pages/InvoiceCreditNoteList.tsx
@@ -139,6 +139,7 @@ const InvoiceCreditNoteList = () => {
             customerTimezone={data?.invoice?.customer.applicableTimezone || TimezoneEnum.TzUtc}
             error={error}
             variables={variables}
+            showFilters={false}
           />
         )}
       </>


### PR DESCRIPTION
Removes the filters from customer/invoice credit notes. We will introduce them at a later point, together with invoice filtering.




<!-- Linear link -->
Fixes LAGO-660