### PR TITLE
feat: add Boleto as Stripe payment method

### DIFF
--- a/src/components/customers/CustomerMainInfos.tsx
+++ b/src/components/customers/CustomerMainInfos.tsx
@@ -47,6 +47,7 @@ const PaymentProviderMethodTranslationsLookup = {
   [ProviderPaymentMethodsEnum.Link]: 'text_6686b316b672a6e75a29eea0',
   [ProviderPaymentMethodsEnum.SepaDebit]: 'text_64aeb7b998c4322918c8420c',
   [ProviderPaymentMethodsEnum.UsBankAccount]: 'text_65e1f90471bc198c0c934d8e',
+  [ProviderPaymentMethodsEnum.Boleto]: 'text_1738234109827diqh4eswleu',
 }
 
 gql`

--- a/src/components/customers/createCustomer/ExternalAppsAccordion/PaymentProvidersAccordion.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/PaymentProvidersAccordion.tsx
@@ -5,6 +5,7 @@ import { Dispatch, FC, ReactNode, SetStateAction, useMemo } from 'react'
 import { Accordion, Alert, Avatar, Typography } from '~/components/designSystem'
 import { Checkbox, ComboBox, ComboboxDataGrouped, TextInputField } from '~/components/form'
 import { ADD_CUSTOMER_PAYMENT_PROVIDER_ACCORDION } from '~/core/constants/form'
+import { FeatureFlags, isFeatureFlagActive } from '~/core/utils/featureFlags'
 import {
   CreateCustomerInput,
   CurrencyEnum,
@@ -78,6 +79,7 @@ export const PaymentProvidersAccordion: FC<PaymentProvidersAccordionProps> = ({
     usePaymentProvidersListForCustomerCreateEditExternalAppsAccordionQuery({
       variables: { limit: 1000 },
     })
+  const hasAccessToBoletoOption = isFeatureFlagActive(FeatureFlags.FTR_STRIPE_BOLETO)
 
   const selectedPaymentProvider = paymentProviders?.collection.find(
     (p) => p.code === formikProps.values.paymentProviderCode,
@@ -246,16 +248,19 @@ export const PaymentProvidersAccordion: FC<PaymentProvidersAccordionProps> = ({
                         ))
                     }
                     onChange={(e, checked) => {
-                      const newValue = [
+                      let newValue = [
                         ...(formikProps.values.providerCustomer?.providerPaymentMethods || []),
                       ]
 
                       if (checked) {
                         newValue.push(ProviderPaymentMethodsEnum.Card)
                       } else {
-                        newValue.splice(newValue.indexOf(ProviderPaymentMethodsEnum.Card), 1)
-                        // Link cannot be selected without card
-                        newValue.splice(newValue.indexOf(ProviderPaymentMethodsEnum.Link), 1)
+                        // Note: Link option cannot be selected without card
+                        newValue = newValue.filter(
+                          (method) =>
+                            method !== ProviderPaymentMethodsEnum.Card &&
+                            method !== ProviderPaymentMethodsEnum.Link,
+                        )
                       }
 
                       formikProps.setFieldValue('providerCustomer.providerPaymentMethods', newValue)
@@ -277,14 +282,16 @@ export const PaymentProvidersAccordion: FC<PaymentProvidersAccordionProps> = ({
                       )
                     }
                     onChange={(e, checked) => {
-                      const newValue = [
+                      let newValue = [
                         ...(formikProps.values.providerCustomer?.providerPaymentMethods || []),
                       ]
 
                       if (checked) {
                         newValue.push(ProviderPaymentMethodsEnum.Link)
                       } else {
-                        newValue.splice(newValue.indexOf(ProviderPaymentMethodsEnum.Link), 1)
+                        newValue = newValue.filter(
+                          (method) => method !== ProviderPaymentMethodsEnum.Link,
+                        )
                       }
 
                       formikProps.setFieldValue('providerCustomer.providerPaymentMethods', newValue)
@@ -314,14 +321,16 @@ export const PaymentProvidersAccordion: FC<PaymentProvidersAccordionProps> = ({
                       )
                     }
                     onChange={(e, checked) => {
-                      const newValue = [
+                      let newValue = [
                         ...(formikProps.values.providerCustomer?.providerPaymentMethods || []),
                       ]
 
                       if (checked) {
                         newValue.push(ProviderPaymentMethodsEnum.SepaDebit)
                       } else {
-                        newValue.splice(newValue.indexOf(ProviderPaymentMethodsEnum.SepaDebit), 1)
+                        newValue = newValue.filter(
+                          (method) => method !== ProviderPaymentMethodsEnum.SepaDebit,
+                        )
                       }
 
                       formikProps.setFieldValue('providerCustomer.providerPaymentMethods', newValue)
@@ -344,16 +353,15 @@ export const PaymentProvidersAccordion: FC<PaymentProvidersAccordionProps> = ({
                       )
                     }
                     onChange={(e, checked) => {
-                      const newValue = [
+                      let newValue = [
                         ...(formikProps.values.providerCustomer?.providerPaymentMethods || []),
                       ]
 
                       if (checked) {
                         newValue.push(ProviderPaymentMethodsEnum.UsBankAccount)
                       } else {
-                        newValue.splice(
-                          newValue.indexOf(ProviderPaymentMethodsEnum.UsBankAccount),
-                          1,
+                        newValue = newValue.filter(
+                          (method) => method !== ProviderPaymentMethodsEnum.UsBankAccount,
                         )
                       }
 
@@ -376,49 +384,58 @@ export const PaymentProvidersAccordion: FC<PaymentProvidersAccordionProps> = ({
                       )
                     }
                     onChange={(e, checked) => {
-                      const newValue = [
+                      let newValue = [
                         ...(formikProps.values.providerCustomer?.providerPaymentMethods || []),
                       ]
 
                       if (checked) {
                         newValue.push(ProviderPaymentMethodsEnum.BacsDebit)
                       } else {
-                        newValue.splice(newValue.indexOf(ProviderPaymentMethodsEnum.BacsDebit), 1)
+                        newValue = newValue.filter(
+                          (method) => method !== ProviderPaymentMethodsEnum.BacsDebit,
+                        )
                       }
 
                       formikProps.setFieldValue('providerCustomer.providerPaymentMethods', newValue)
                     }}
                   />
 
-                  <Checkbox
-                    name="providerCustomer.providerPaymentMethods.boleto"
-                    value={
-                      !!formikProps.values.providerCustomer?.providerPaymentMethods?.includes(
-                        ProviderPaymentMethodsEnum.Boleto,
-                      )
-                    }
-                    label={translate('text_1738234109827diqh4eswleu')}
-                    sublabel={translate('text_1738234109827hev75h17loy')}
-                    disabled={
-                      formikProps.values.providerCustomer?.providerPaymentMethods?.length === 1 &&
-                      formikProps.values.providerCustomer?.providerPaymentMethods.includes(
-                        ProviderPaymentMethodsEnum.Boleto,
-                      )
-                    }
-                    onChange={(e, checked) => {
-                      const newValue = [
-                        ...(formikProps.values.providerCustomer?.providerPaymentMethods || []),
-                      ]
-
-                      if (checked) {
-                        newValue.push(ProviderPaymentMethodsEnum.Boleto)
-                      } else {
-                        newValue.splice(newValue.indexOf(ProviderPaymentMethodsEnum.Boleto), 1)
+                  {hasAccessToBoletoOption && (
+                    <Checkbox
+                      name="providerCustomer.providerPaymentMethods.boleto"
+                      value={
+                        !!formikProps.values.providerCustomer?.providerPaymentMethods?.includes(
+                          ProviderPaymentMethodsEnum.Boleto,
+                        )
                       }
+                      label={translate('text_1738234109827diqh4eswleu')}
+                      sublabel={translate('text_1738234109827hev75h17loy')}
+                      disabled={
+                        formikProps.values.providerCustomer?.providerPaymentMethods?.length === 1 &&
+                        formikProps.values.providerCustomer?.providerPaymentMethods.includes(
+                          ProviderPaymentMethodsEnum.Boleto,
+                        )
+                      }
+                      onChange={(e, checked) => {
+                        let newValue = [
+                          ...(formikProps.values.providerCustomer?.providerPaymentMethods || []),
+                        ]
 
-                      formikProps.setFieldValue('providerCustomer.providerPaymentMethods', newValue)
-                    }}
-                  />
+                        if (checked) {
+                          newValue.push(ProviderPaymentMethodsEnum.Boleto)
+                        } else {
+                          newValue = newValue.filter(
+                            (method) => method !== ProviderPaymentMethodsEnum.Boleto,
+                          )
+                        }
+
+                        formikProps.setFieldValue(
+                          'providerCustomer.providerPaymentMethods',
+                          newValue,
+                        )
+                      }}
+                    />
+                  )}
                 </div>
               </div>
 

--- a/src/components/customers/createCustomer/ExternalAppsAccordion/PaymentProvidersAccordion.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/PaymentProvidersAccordion.tsx
@@ -389,6 +389,36 @@ export const PaymentProvidersAccordion: FC<PaymentProvidersAccordionProps> = ({
                       formikProps.setFieldValue('providerCustomer.providerPaymentMethods', newValue)
                     }}
                   />
+
+                  <Checkbox
+                    name="providerCustomer.providerPaymentMethods.boleto"
+                    value={
+                      !!formikProps.values.providerCustomer?.providerPaymentMethods?.includes(
+                        ProviderPaymentMethodsEnum.Boleto,
+                      )
+                    }
+                    label={translate('text_1738234109827diqh4eswleu')}
+                    sublabel={translate('text_1738234109827hev75h17loy')}
+                    disabled={
+                      formikProps.values.providerCustomer?.providerPaymentMethods?.length === 1 &&
+                      formikProps.values.providerCustomer?.providerPaymentMethods.includes(
+                        ProviderPaymentMethodsEnum.Boleto,
+                      )
+                    }
+                    onChange={(e, checked) => {
+                      const newValue = [
+                        ...(formikProps.values.providerCustomer?.providerPaymentMethods || []),
+                      ]
+
+                      if (checked) {
+                        newValue.push(ProviderPaymentMethodsEnum.Boleto)
+                      } else {
+                        newValue.splice(newValue.indexOf(ProviderPaymentMethodsEnum.Boleto), 1)
+                      }
+
+                      formikProps.setFieldValue('providerCustomer.providerPaymentMethods', newValue)
+                    }}
+                  />
                 </div>
               </div>
 

--- a/src/core/utils/featureFlags.ts
+++ b/src/core/utils/featureFlags.ts
@@ -1,7 +1,7 @@
 // You can list your features such as FTR_ENABLED = 'ftr_enabled'
 export enum FeatureFlags {
   FTR_ENABLED = 'ftr_enabled',
-  FTR_SALESFORCE_ENABLED = 'ftr_salesforce_enabled',
+  FTR_STRIPE_BOLETO = 'ftr_stripe_boleto',
 }
 
 const FF_KEY = 'featureFlags'

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -4526,6 +4526,7 @@ export type ProviderCustomerInput = {
 
 export enum ProviderPaymentMethodsEnum {
   BacsDebit = 'bacs_debit',
+  Boleto = 'boleto',
   Card = 'card',
   Link = 'link',
   SepaDebit = 'sepa_debit',

--- a/translations/base.json
+++ b/translations/base.json
@@ -2811,5 +2811,7 @@
   "text_1737731953885tbem8s4xo8t": "Charge",
   "text_1737733582553rmmlatfbk1r": "Search or select a specific charge",
   "text_1737733582553dm4huzkoee6": "Search or select a specific filters",
-  "text_1738084927595tzdnuy6oxyu": "Fee successfully reset"
+  "text_1738084927595tzdnuy6oxyu": "Fee successfully reset",
+  "text_1738234109827diqh4eswleu": "Boleto Payments",
+  "text_1738234109827hev75h17loy": "For customers invoiced in BRL"
 }


### PR DESCRIPTION
## Context

Boleto is an important payment method in Brasil. Some of our customers needs this to be enabled in their Stripe setup to bill over there.

## Description

FE changes is is only about adding this new option in the list.

I also fixed an unexpected behaviour when unchecking Card option, that was caused by having 2 slice on the same array next to each other.
I used the filter approach on other options too.

<!-- Linear link -->
Fixes LAGO-714