### PR TITLE
[LAGO-663] fix(CustomerSettings): include organization locale

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -324,7 +324,10 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                   {!!customer?.billingConfiguration?.documentLocale
                     ? DocumentLocales[customer?.billingConfiguration?.documentLocale]
                     : translate('text_1728374331992d2alok9y3kr', {
-                        value: DocumentLocales['en'],
+                        value:
+                          DocumentLocales[
+                            organization?.billingConfiguration?.documentLocale || 'en'
+                          ],
                       })}
                 </Typography>
               </SettingsListItem>


### PR DESCRIPTION
## Context

If a customer doesn't have a locale set, we defaulted to English.

## Description

Instead of defaulting directly to English, we now also take the organization locale into account.

<!-- Linear link -->
Fixes LAGO-663