### PR TITLE
feat: Filters prefix

### DIFF
--- a/src/components/creditNote/CreditNotesTable.tsx
+++ b/src/components/creditNote/CreditNotesTable.tsx
@@ -158,6 +158,7 @@ const CreditNotesTable = ({
           )}
         >
           <Filters.Provider
+            filtersNamePrefix="cn"
             availableFilters={[
               AvailableFiltersEnum.amount,
               AvailableFiltersEnum.creditNoteCreditStatus,

--- a/src/components/creditNote/CreditNotesTable.tsx
+++ b/src/components/creditNote/CreditNotesTable.tsx
@@ -20,6 +20,7 @@ import {
 import { AvailableFiltersEnum, Filters } from '~/components/designSystem/Filters'
 import { GenericPlaceholder } from '~/components/GenericPlaceholder'
 import { addToast } from '~/core/apolloClient'
+import { CREDIT_NOTE_LIST_FILTER_PREFIX } from '~/core/constants/filters'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CUSTOMER_INVOICE_CREDIT_NOTE_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
@@ -158,7 +159,7 @@ const CreditNotesTable = ({
           )}
         >
           <Filters.Provider
-            filtersNamePrefix="cn"
+            filtersNamePrefix={CREDIT_NOTE_LIST_FILTER_PREFIX}
             availableFilters={[
               AvailableFiltersEnum.amount,
               AvailableFiltersEnum.creditNoteCreditStatus,

--- a/src/components/designSystem/Filters/__tests__/useFilters.test.tsx
+++ b/src/components/designSystem/Filters/__tests__/useFilters.test.tsx
@@ -16,6 +16,8 @@ import {
   isVoidedUrlParams,
 } from '../utils'
 
+const FILTER_PREFIX = 'f'
+
 const staticFilters = {
   currency: 'eur',
 }
@@ -32,7 +34,7 @@ const wrapper = ({
       <div>
         <FilterContext.Provider
           value={{
-            filtersNamePrefix: 'f',
+            filtersNamePrefix: FILTER_PREFIX,
             staticFilters: withStaticFilters ? staticFilters : undefined,
             availableFilters: [AvailableFiltersEnum.status, AvailableFiltersEnum.invoiceType],
           }}
@@ -62,7 +64,7 @@ describe('draft', () => {
       new URLSearchParams(`?${expectedSearchParams}`).entries(),
     ) as unknown as URLSearchParams
 
-    expect(isDraftUrlParams(draftSearchParams)).toBe(true)
+    expect(isDraftUrlParams({ prefix: FILTER_PREFIX, searchParams: draftSearchParams })).toBe(true)
   })
   it('should return search params with initial static filters', () => {
     const { result } = renderHook(() => useFilters(), {
@@ -80,7 +82,7 @@ describe('draft', () => {
         status: InvoiceStatusTypeEnum.Draft,
       }),
     ).toEqual(expectedSearchParams)
-    expect(isDraftUrlParams(draftSearchParams)).toBe(true)
+    expect(isDraftUrlParams({ prefix: FILTER_PREFIX, searchParams: draftSearchParams })).toBe(true)
   })
 })
 
@@ -103,7 +105,9 @@ describe('outstanding', () => {
       new URLSearchParams(`?${expectedSearchParams}`).entries(),
     ) as unknown as URLSearchParams
 
-    expect(isOutstandingUrlParams(outstandingSearchParams)).toBe(true)
+    expect(
+      isOutstandingUrlParams({ prefix: FILTER_PREFIX, searchParams: outstandingSearchParams }),
+    ).toBe(true)
   })
   it('should return search params with initial static filters', () => {
     const { result } = renderHook(() => useFilters(), {
@@ -123,7 +127,9 @@ describe('outstanding', () => {
       new URLSearchParams(`?${expectedSearchParams}`).entries(),
     ) as unknown as URLSearchParams
 
-    expect(isOutstandingUrlParams(outstandingSearchParams)).toBe(true)
+    expect(
+      isOutstandingUrlParams({ prefix: FILTER_PREFIX, searchParams: outstandingSearchParams }),
+    ).toBe(true)
   })
 })
 
@@ -145,7 +151,12 @@ describe('payment overdue', () => {
       new URLSearchParams(`?${expectedSearchParams}`).entries(),
     ) as unknown as URLSearchParams
 
-    expect(isPaymentOverdueUrlParams(paymentOverdueSearchParams)).toBe(true)
+    expect(
+      isPaymentOverdueUrlParams({
+        prefix: FILTER_PREFIX,
+        searchParams: paymentOverdueSearchParams,
+      }),
+    ).toBe(true)
   })
   it('should return search params with initial static filters', () => {
     const { result } = renderHook(() => useFilters(), {
@@ -164,7 +175,12 @@ describe('payment overdue', () => {
       new URLSearchParams(`?${expectedSearchParams}`).entries(),
     ) as unknown as URLSearchParams
 
-    expect(isPaymentOverdueUrlParams(paymentOverdueSearchParams)).toBe(true)
+    expect(
+      isPaymentOverdueUrlParams({
+        prefix: FILTER_PREFIX,
+        searchParams: paymentOverdueSearchParams,
+      }),
+    ).toBe(true)
   })
 })
 
@@ -187,7 +203,9 @@ describe('succeeded', () => {
       new URLSearchParams(`?${expectedSearchParams}`).entries(),
     ) as unknown as URLSearchParams
 
-    expect(isSucceededUrlParams(succeededSearchParams)).toBe(true)
+    expect(
+      isSucceededUrlParams({ prefix: FILTER_PREFIX, searchParams: succeededSearchParams }),
+    ).toBe(true)
   })
   it('should return search params with initial static filters', () => {
     const { result } = renderHook(() => useFilters(), {
@@ -207,7 +225,9 @@ describe('succeeded', () => {
       new URLSearchParams(`?${expectedSearchParams}`).entries(),
     ) as unknown as URLSearchParams
 
-    expect(isSucceededUrlParams(succeededSearchParams)).toBe(true)
+    expect(
+      isSucceededUrlParams({ prefix: FILTER_PREFIX, searchParams: succeededSearchParams }),
+    ).toBe(true)
   })
 })
 
@@ -229,7 +249,9 @@ describe('voided', () => {
       new URLSearchParams(`?${expectedSearchParams}`).entries(),
     ) as unknown as URLSearchParams
 
-    expect(isVoidedUrlParams(voidedSearchParams)).toBe(true)
+    expect(isVoidedUrlParams({ prefix: FILTER_PREFIX, searchParams: voidedSearchParams })).toBe(
+      true,
+    )
   })
   it('should return search params with initial static filters', () => {
     const { result } = renderHook(() => useFilters(), {
@@ -248,7 +270,9 @@ describe('voided', () => {
       new URLSearchParams(`?${expectedSearchParams}`).entries(),
     ) as unknown as URLSearchParams
 
-    expect(isVoidedUrlParams(voidedSearchParams)).toBe(true)
+    expect(isVoidedUrlParams({ prefix: FILTER_PREFIX, searchParams: voidedSearchParams })).toBe(
+      true,
+    )
   })
 })
 
@@ -270,7 +294,12 @@ describe('payment dispute lost', () => {
       new URLSearchParams(`?${expectedSearchParams}`).entries(),
     ) as unknown as URLSearchParams
 
-    expect(isPaymentDisputeLostUrlParams(paymentDisputeLostSearchParams)).toBe(true)
+    expect(
+      isPaymentDisputeLostUrlParams({
+        prefix: FILTER_PREFIX,
+        searchParams: paymentDisputeLostSearchParams,
+      }),
+    ).toBe(true)
   })
   it('should return search params with initial static filters', () => {
     const { result } = renderHook(() => useFilters(), {
@@ -289,6 +318,11 @@ describe('payment dispute lost', () => {
       new URLSearchParams(`?${expectedSearchParams}`).entries(),
     ) as unknown as URLSearchParams
 
-    expect(isPaymentDisputeLostUrlParams(paymentDisputeLostSearchParams)).toBe(true)
+    expect(
+      isPaymentDisputeLostUrlParams({
+        prefix: FILTER_PREFIX,
+        searchParams: paymentDisputeLostSearchParams,
+      }),
+    ).toBe(true)
   })
 })

--- a/src/components/designSystem/Filters/__tests__/useFilters.test.tsx
+++ b/src/components/designSystem/Filters/__tests__/useFilters.test.tsx
@@ -32,6 +32,7 @@ const wrapper = ({
       <div>
         <FilterContext.Provider
           value={{
+            filtersNamePrefix: 'f',
             staticFilters: withStaticFilters ? staticFilters : undefined,
             availableFilters: [AvailableFiltersEnum.status, AvailableFiltersEnum.invoiceType],
           }}
@@ -49,7 +50,7 @@ describe('draft', () => {
       wrapper: ({ children }) => wrapper({ children, withStaticFilters: false }),
     })
 
-    const expectedSearchParams = 'status=draft'
+    const expectedSearchParams = 'f_status=draft'
 
     expect(
       result.current.buildQuickFilterUrlParams({
@@ -68,7 +69,7 @@ describe('draft', () => {
       wrapper: ({ children }) => wrapper({ children, withStaticFilters: true }),
     })
 
-    const expectedSearchParams = 'currency=eur&status=draft'
+    const expectedSearchParams = 'f_currency=eur&f_status=draft'
 
     const draftSearchParams = new Map(
       new URLSearchParams(`?${expectedSearchParams}`).entries(),
@@ -89,7 +90,7 @@ describe('outstanding', () => {
       wrapper: ({ children }) => wrapper({ children, withStaticFilters: false }),
     })
 
-    const expectedSearchParams = 'paymentStatus=failed,pending&status=finalized'
+    const expectedSearchParams = 'f_paymentStatus=failed,pending&f_status=finalized'
 
     expect(
       result.current.buildQuickFilterUrlParams({
@@ -109,7 +110,7 @@ describe('outstanding', () => {
       wrapper: ({ children }) => wrapper({ children, withStaticFilters: true }),
     })
 
-    const expectedSearchParams = 'currency=eur&paymentStatus=failed,pending&status=finalized'
+    const expectedSearchParams = 'f_currency=eur&f_paymentStatus=failed,pending&f_status=finalized'
 
     expect(
       result.current.buildQuickFilterUrlParams({
@@ -132,7 +133,7 @@ describe('payment overdue', () => {
       wrapper: ({ children }) => wrapper({ children, withStaticFilters: false }),
     })
 
-    const expectedSearchParams = 'paymentOverdue=true'
+    const expectedSearchParams = 'f_paymentOverdue=true'
 
     expect(
       result.current.buildQuickFilterUrlParams({
@@ -151,7 +152,7 @@ describe('payment overdue', () => {
       wrapper: ({ children }) => wrapper({ children, withStaticFilters: true }),
     })
 
-    const expectedSearchParams = 'currency=eur&paymentOverdue=true'
+    const expectedSearchParams = 'f_currency=eur&f_paymentOverdue=true'
 
     expect(
       result.current.buildQuickFilterUrlParams({
@@ -173,7 +174,7 @@ describe('succeeded', () => {
       wrapper: ({ children }) => wrapper({ children, withStaticFilters: false }),
     })
 
-    const expectedSearchParams = 'paymentStatus=succeeded&status=finalized'
+    const expectedSearchParams = 'f_paymentStatus=succeeded&f_status=finalized'
 
     expect(
       result.current.buildQuickFilterUrlParams({
@@ -193,7 +194,7 @@ describe('succeeded', () => {
       wrapper: ({ children }) => wrapper({ children, withStaticFilters: true }),
     })
 
-    const expectedSearchParams = 'currency=eur&paymentStatus=succeeded&status=finalized'
+    const expectedSearchParams = 'f_currency=eur&f_paymentStatus=succeeded&f_status=finalized'
 
     expect(
       result.current.buildQuickFilterUrlParams({
@@ -216,7 +217,7 @@ describe('voided', () => {
       wrapper: ({ children }) => wrapper({ children, withStaticFilters: false }),
     })
 
-    const expectedSearchParams = 'status=voided'
+    const expectedSearchParams = 'f_status=voided'
 
     expect(
       result.current.buildQuickFilterUrlParams({
@@ -235,7 +236,7 @@ describe('voided', () => {
       wrapper: ({ children }) => wrapper({ children, withStaticFilters: true }),
     })
 
-    const expectedSearchParams = 'currency=eur&status=voided'
+    const expectedSearchParams = 'f_currency=eur&f_status=voided'
 
     expect(
       result.current.buildQuickFilterUrlParams({
@@ -257,7 +258,7 @@ describe('payment dispute lost', () => {
       wrapper: ({ children }) => wrapper({ children, withStaticFilters: false }),
     })
 
-    const expectedSearchParams = 'paymentDisputeLost=true'
+    const expectedSearchParams = 'f_paymentDisputeLost=true'
 
     expect(
       result.current.buildQuickFilterUrlParams({
@@ -276,7 +277,7 @@ describe('payment dispute lost', () => {
       wrapper: ({ children }) => wrapper({ children, withStaticFilters: true }),
     })
 
-    const expectedSearchParams = 'currency=eur&paymentDisputeLost=true'
+    const expectedSearchParams = 'f_currency=eur&f_paymentDisputeLost=true'
 
     expect(
       result.current.buildQuickFilterUrlParams({

--- a/src/components/designSystem/Filters/context.tsx
+++ b/src/components/designSystem/Filters/context.tsx
@@ -7,7 +7,7 @@ interface FilterContextType {
   availableFilters: AvailableFiltersEnum[]
   quickFiltersType?: AvailableQuickFilters
   staticFilters?: Partial<Record<AvailableFiltersEnum, unknown>>
-  filtersNamePrefix?: string
+  filtersNamePrefix: string
 }
 
 export const FilterContext = createContext<FilterContextType | undefined>(undefined)

--- a/src/components/designSystem/Filters/context.tsx
+++ b/src/components/designSystem/Filters/context.tsx
@@ -7,6 +7,7 @@ interface FilterContextType {
   availableFilters: AvailableFiltersEnum[]
   quickFiltersType?: AvailableQuickFilters
   staticFilters?: Partial<Record<AvailableFiltersEnum, unknown>>
+  filtersNamePrefix?: string
 }
 
 export const FilterContext = createContext<FilterContextType | undefined>(undefined)

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -77,17 +77,23 @@ const formatFiltersForQuery = ({
   searchParams,
   keyMap,
   availableFilters,
+  filtersNamePrefix,
 }: {
   searchParams: URLSearchParams
   keyMap?: Record<string, string>
   availableFilters: AvailableFiltersEnum[]
+  filtersNamePrefix?: string
 }) => {
   const filtersSetInUrl = Object.fromEntries(searchParams.entries())
 
   return Object.entries(filtersSetInUrl).reduce(
     (acc, cur) => {
       const current = cur as [AvailableFiltersEnum, string | string[] | boolean]
-      const key = current[0]
+      const _key = current[0]
+
+      const key = (
+        filtersNamePrefix ? _key.replace(`${filtersNamePrefix}_`, '') : _key
+      ) as AvailableFiltersEnum
 
       if (!availableFilters.includes(key)) {
         return acc

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -82,7 +82,7 @@ const formatFiltersForQuery = ({
   searchParams: URLSearchParams
   keyMap?: Record<string, string>
   availableFilters: AvailableFiltersEnum[]
-  filtersNamePrefix?: string
+  filtersNamePrefix: string
 }) => {
   const filtersSetInUrl = Object.fromEntries(searchParams.entries())
 
@@ -130,6 +130,7 @@ export const formatFiltersForCreditNotesQuery = (searchParams: URLSearchParams) 
     searchParams,
     keyMap,
     availableFilters: CreditNoteAvailableFilters,
+    filtersNamePrefix: 'cn',
   })
 }
 
@@ -137,6 +138,7 @@ export const formatFiltersForInvoiceQuery = (searchParams: URLSearchParams) => {
   return formatFiltersForQuery({
     searchParams,
     availableFilters: InvoiceAvailableFilters,
+    filtersNamePrefix: 'in',
   })
 }
 

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -1,5 +1,10 @@
 import { DateTime } from 'luxon'
 
+import {
+  CREDIT_NOTE_LIST_FILTER_PREFIX,
+  CUSTOMER_LIST_FILTER_PREFIX,
+  INVOICE_LIST_FILTER_PREFIX,
+} from '~/core/constants/filters'
 import { intlFormatDateTime } from '~/core/timezone'
 import { InvoicePaymentStatusTypeEnum, InvoiceStatusTypeEnum } from '~/generated/graphql'
 import { TranslateFunc } from '~/hooks/core/useInternationalization'
@@ -12,6 +17,8 @@ import {
   filterDataInlineSeparator,
   InvoiceAvailableFilters,
 } from './types'
+
+const keyWithPrefix = (key: string, prefix?: string) => (prefix ? `${prefix}_${key}` : key)
 
 export const parseAmountValue = (value: string) => {
   const [interval, from, to] = value.split(',')
@@ -130,7 +137,7 @@ export const formatFiltersForCreditNotesQuery = (searchParams: URLSearchParams) 
     searchParams,
     keyMap,
     availableFilters: CreditNoteAvailableFilters,
-    filtersNamePrefix: 'cn',
+    filtersNamePrefix: CREDIT_NOTE_LIST_FILTER_PREFIX,
   })
 }
 
@@ -138,7 +145,7 @@ export const formatFiltersForInvoiceQuery = (searchParams: URLSearchParams) => {
   return formatFiltersForQuery({
     searchParams,
     availableFilters: InvoiceAvailableFilters,
-    filtersNamePrefix: 'in',
+    filtersNamePrefix: INVOICE_LIST_FILTER_PREFIX,
   })
 }
 
@@ -146,7 +153,7 @@ export const formatFiltersForCustomerQuery = (searchParams: URLSearchParams) => 
   return formatFiltersForQuery({
     searchParams,
     availableFilters: CustomerAvailableFilters,
-    filtersNamePrefix: 'cu',
+    filtersNamePrefix: CUSTOMER_LIST_FILTER_PREFIX,
   })
 }
 
@@ -197,35 +204,83 @@ export const formatActiveFilterValueDisplay = (
   }
 }
 
-export const isOutstandingUrlParams = (searchParams: URLSearchParams): boolean => {
+export const isOutstandingUrlParams = ({
+  prefix,
+  searchParams,
+}: {
+  searchParams: URLSearchParams
+  prefix?: string
+}): boolean => {
   return (
     searchParams.size >= 2 &&
-    searchParams.get('paymentStatus') ===
+    searchParams.get(keyWithPrefix('paymentStatus', prefix)) ===
       `${InvoicePaymentStatusTypeEnum.Failed},${InvoicePaymentStatusTypeEnum.Pending}` &&
-    searchParams.get('status') === InvoiceStatusTypeEnum.Finalized
+    searchParams.get(keyWithPrefix('status', prefix)) === InvoiceStatusTypeEnum.Finalized
   )
 }
 
-export const isSucceededUrlParams = (searchParams: URLSearchParams): boolean => {
+export const isSucceededUrlParams = ({
+  prefix,
+  searchParams,
+}: {
+  searchParams: URLSearchParams
+  prefix?: string
+}): boolean => {
   return (
     searchParams.size >= 2 &&
-    searchParams.get('paymentStatus') === InvoicePaymentStatusTypeEnum.Succeeded &&
-    searchParams.get('status') === InvoiceStatusTypeEnum.Finalized
+    searchParams.get(keyWithPrefix('paymentStatus', prefix)) ===
+      InvoicePaymentStatusTypeEnum.Succeeded &&
+    searchParams.get(keyWithPrefix('status', prefix)) === InvoiceStatusTypeEnum.Finalized
   )
 }
 
-export const isDraftUrlParams = (searchParams: URLSearchParams): boolean => {
-  return searchParams.size >= 1 && searchParams.get('status') === InvoiceStatusTypeEnum.Draft
+export const isDraftUrlParams = ({
+  prefix,
+  searchParams,
+}: {
+  searchParams: URLSearchParams
+  prefix?: string
+}): boolean => {
+  return (
+    searchParams.size >= 1 &&
+    searchParams.get(keyWithPrefix('status', prefix)) === InvoiceStatusTypeEnum.Draft
+  )
 }
 
-export const isPaymentOverdueUrlParams = (searchParams: URLSearchParams): boolean => {
-  return searchParams.size >= 1 && searchParams.get('paymentOverdue') === 'true'
+export const isPaymentOverdueUrlParams = ({
+  prefix,
+  searchParams,
+}: {
+  searchParams: URLSearchParams
+  prefix?: string
+}): boolean => {
+  return (
+    searchParams.size >= 1 && searchParams.get(keyWithPrefix('paymentOverdue', prefix)) === 'true'
+  )
 }
 
-export const isVoidedUrlParams = (searchParams: URLSearchParams): boolean => {
-  return searchParams.size >= 1 && searchParams.get('status') === InvoiceStatusTypeEnum.Voided
+export const isVoidedUrlParams = ({
+  prefix,
+  searchParams,
+}: {
+  searchParams: URLSearchParams
+  prefix?: string
+}): boolean => {
+  return (
+    searchParams.size >= 1 &&
+    searchParams.get(keyWithPrefix('status', prefix)) === InvoiceStatusTypeEnum.Voided
+  )
 }
 
-export const isPaymentDisputeLostUrlParams = (searchParams: URLSearchParams): boolean => {
-  return searchParams.size >= 1 && searchParams.get('paymentDisputeLost') === 'true'
+export const isPaymentDisputeLostUrlParams = ({
+  prefix,
+  searchParams,
+}: {
+  searchParams: URLSearchParams
+  prefix?: string
+}): boolean => {
+  return (
+    searchParams.size >= 1 &&
+    searchParams.get(keyWithPrefix('paymentDisputeLost', prefix)) === 'true'
+  )
 }

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -146,6 +146,7 @@ export const formatFiltersForCustomerQuery = (searchParams: URLSearchParams) => 
   return formatFiltersForQuery({
     searchParams,
     availableFilters: CustomerAvailableFilters,
+    filtersNamePrefix: 'cu',
   })
 }
 

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -124,6 +124,7 @@ const InvoicesList = ({
     <>
       <div className="box-border flex w-full flex-col gap-3 p-4 shadow-b md:px-12 md:py-3">
         <Filters.Provider
+          filtersNamePrefix="in"
           quickFiltersType={AvailableQuickFilters.InvoiceStatus}
           availableFilters={[
             AvailableFiltersEnum.amount,

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -34,6 +34,7 @@ import {
 import { VoidInvoiceDialog, VoidInvoiceDialogRef } from '~/components/invoices/VoidInvoiceDialog'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
+import { INVOICE_LIST_FILTER_PREFIX } from '~/core/constants/filters'
 import { invoiceStatusMapping, paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
 import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -124,7 +125,7 @@ const InvoicesList = ({
     <>
       <div className="box-border flex w-full flex-col gap-3 p-4 shadow-b md:px-12 md:py-3">
         <Filters.Provider
-          filtersNamePrefix="in"
+          filtersNamePrefix={INVOICE_LIST_FILTER_PREFIX}
           quickFiltersType={AvailableQuickFilters.InvoiceStatus}
           availableFilters={[
             AvailableFiltersEnum.amount,
@@ -507,13 +508,19 @@ const InvoicesList = ({
               emptyState: variables?.searchTerm
                 ? {
                     title: translate(
-                      isSucceededUrlParams(searchParams)
+                      isSucceededUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX })
                         ? 'text_63c67d2913c20b8d7d05c44c'
-                        : isDraftUrlParams(searchParams)
+                        : isDraftUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX })
                           ? 'text_63c67d2913c20b8d7d05c442'
-                          : isOutstandingUrlParams(searchParams)
+                          : isOutstandingUrlParams({
+                                searchParams,
+                                prefix: INVOICE_LIST_FILTER_PREFIX,
+                              })
                             ? 'text_63c67d8796db41749ada51ca'
-                            : isVoidedUrlParams(searchParams)
+                            : isVoidedUrlParams({
+                                  searchParams,
+                                  prefix: INVOICE_LIST_FILTER_PREFIX,
+                                })
                               ? 'text_65269cd46e7ec037a6823fd8'
                               : 'text_63c67d2913c20b8d7d05c43e',
                     ),
@@ -521,35 +528,59 @@ const InvoicesList = ({
                   }
                 : {
                     title: translate(
-                      isSucceededUrlParams(searchParams)
+                      isSucceededUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX })
                         ? 'text_63b578e959c1366df5d14559'
-                        : isDraftUrlParams(searchParams)
+                        : isDraftUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX })
                           ? 'text_63b578e959c1366df5d1455b'
-                          : isOutstandingUrlParams(searchParams)
+                          : isOutstandingUrlParams({
+                                searchParams,
+                                prefix: INVOICE_LIST_FILTER_PREFIX,
+                              })
                             ? 'text_63b578e959c1366df5d1456e'
-                            : isVoidedUrlParams(searchParams)
+                            : isVoidedUrlParams({
+                                  searchParams,
+                                  prefix: INVOICE_LIST_FILTER_PREFIX,
+                                })
                               ? 'text_65269cd46e7ec037a6823fd6'
-                              : isPaymentDisputeLostUrlParams(searchParams)
+                              : isPaymentDisputeLostUrlParams({
+                                    searchParams,
+                                    prefix: INVOICE_LIST_FILTER_PREFIX,
+                                  })
                                 ? 'text_66141e30699a0631f0b2ec7f'
-                                : isPaymentOverdueUrlParams(searchParams)
+                                : isPaymentOverdueUrlParams({
+                                      searchParams,
+                                      prefix: INVOICE_LIST_FILTER_PREFIX,
+                                    })
                                   ? 'text_666c5b12fea4aa1e1b26bf70'
                                   : 'text_63b578e959c1366df5d14569',
                     ),
-                    subtitle: isSucceededUrlParams(searchParams) ? (
+                    subtitle: isSucceededUrlParams({
+                      searchParams,
+                      prefix: INVOICE_LIST_FILTER_PREFIX,
+                    }) ? (
                       translate('text_63b578e959c1366df5d1455f')
-                    ) : isDraftUrlParams(searchParams) ? (
+                    ) : isDraftUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX }) ? (
                       <Typography
                         html={translate('text_63b578e959c1366df5d14566', {
                           link: INVOICE_SETTINGS_ROUTE,
                         })}
                       />
-                    ) : isOutstandingUrlParams(searchParams) ? (
+                    ) : isOutstandingUrlParams({
+                        searchParams,
+                        prefix: INVOICE_LIST_FILTER_PREFIX,
+                      }) ? (
                       translate('text_63b578e959c1366df5d14570')
-                    ) : isVoidedUrlParams(searchParams) ? (
+                    ) : isVoidedUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX }) ? (
                       translate('text_65269cd46e7ec037a6823fda')
-                    ) : isPaymentDisputeLostUrlParams(searchParams) ? (
+                    ) : isPaymentDisputeLostUrlParams({
+                        searchParams,
+                        prefix: INVOICE_LIST_FILTER_PREFIX,
+                      }) ? (
                       translate('text_66141e30699a0631f0b2ec87')
-                    ) : isPaymentOverdueUrlParams(searchParams) ? (
+                    ) : isPaymentOverdueUrlParams({
+                        searchParams,
+                        prefix: INVOICE_LIST_FILTER_PREFIX,
+                      }) ? (
                       <Typography
                         html={translate('text_666c5b12fea4aa1e1b26bf73', {
                           link: INVOICE_SETTINGS_ROUTE,

--- a/src/core/constants/filters.ts
+++ b/src/core/constants/filters.ts
@@ -1,0 +1,3 @@
+export const INVOICE_LIST_FILTER_PREFIX = 'in'
+export const CREDIT_NOTE_LIST_FILTER_PREFIX = 'cn'
+export const CUSTOMER_LIST_FILTER_PREFIX = 'cu'

--- a/src/pages/CustomersList.tsx
+++ b/src/pages/CustomersList.tsx
@@ -16,6 +16,7 @@ import {
 } from '~/components/designSystem/Filters'
 import { PaymentProviderChip } from '~/components/PaymentProviderChip'
 import { SearchInput } from '~/components/SearchInput'
+import { CUSTOMER_LIST_FILTER_PREFIX } from '~/core/constants/filters'
 import { CREATE_CUSTOMER_ROUTE, CUSTOMER_DETAILS_ROUTE, UPDATE_CUSTOMER_ROUTE } from '~/core/router'
 import {
   AddCustomerDrawerFragmentDoc,
@@ -113,7 +114,7 @@ const CustomersList = () => {
 
       <div className="px-12 py-3 shadow-b">
         <Filters.Provider
-          filtersNamePrefix="cu"
+          filtersNamePrefix={CUSTOMER_LIST_FILTER_PREFIX}
           quickFiltersType={AvailableQuickFilters.CustomerAccountType}
           availableFilters={[AvailableFiltersEnum.customerAccountType]}
         >

--- a/src/pages/CustomersList.tsx
+++ b/src/pages/CustomersList.tsx
@@ -113,6 +113,7 @@ const CustomersList = () => {
 
       <div className="px-12 py-3 shadow-b">
         <Filters.Provider
+          filtersNamePrefix="cu"
           quickFiltersType={AvailableQuickFilters.CustomerAccountType}
           availableFilters={[AvailableFiltersEnum.customerAccountType]}
         >

--- a/src/pages/InvoicesPage.tsx
+++ b/src/pages/InvoicesPage.tsx
@@ -24,6 +24,7 @@ import { VoidInvoiceDialog, VoidInvoiceDialogRef } from '~/components/invoices/V
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { SearchInput } from '~/components/SearchInput'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
+import { INVOICE_LIST_FILTER_PREFIX } from '~/core/constants/filters'
 import { InvoiceListTabEnum } from '~/core/constants/tabsOptions'
 import { CREATE_PAYMENT_ROUTE, INVOICES_ROUTE, INVOICES_TAB_ROUTE } from '~/core/router'
 import { serializeAmount } from '~/core/serializers/serializeAmount'
@@ -426,23 +427,24 @@ const InvoicesPage = () => {
             </>
           )}
 
-          {isOutstandingUrlParams(searchParams) && hasPermissions(['invoicesSend']) && (
-            <Button
-              disabled={!dataInvoices?.invoices?.metadata?.totalCount}
-              onClick={async () => {
-                const { errors } = await retryAll({ variables: { input: {} } })
+          {isOutstandingUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX }) &&
+            hasPermissions(['invoicesSend']) && (
+              <Button
+                disabled={!dataInvoices?.invoices?.metadata?.totalCount}
+                onClick={async () => {
+                  const { errors } = await retryAll({ variables: { input: {} } })
 
-                if (hasDefinedGQLError('PaymentProcessorIsCurrentlyHandlingPayment', errors)) {
-                  addToast({
-                    severity: 'info',
-                    translateKey: 'text_63b6d06df1a53b7e2ad973ad',
-                  })
-                }
-              }}
-            >
-              {translate('text_63ac86d797f728a87b2f9fc4')}
-            </Button>
-          )}
+                  if (hasDefinedGQLError('PaymentProcessorIsCurrentlyHandlingPayment', errors)) {
+                    addToast({
+                      severity: 'info',
+                      translateKey: 'text_63b6d06df1a53b7e2ad973ad',
+                    })
+                  }
+                }}
+              >
+                {translate('text_63ac86d797f728a87b2f9fc4')}
+              </Button>
+            )}
         </PageHeader.Group>
       </PageHeader.Wrapper>
       <NavigationTab


### PR DESCRIPTION
## Context

The current Filters architecture makes it impossible to have 2 sets of filters on the same page, because of how the filters are stored in the URL params.

## Description

Added a new prop `filtersNamePrefix` which enables us to have multiple Filters on the same page by prefixing their name:

```
https://app.lago.dev/invoices/invoices?
  in_amount=isBetween%2C5%2C100
  &in_currency=USD
  &cn_amount=isBetween%2C5%2C6
  &cn_creditNoteCreditStatus=voided
```

To use this functionality, we need to pass the new prop in two places:
- The Filters.Provider
```
  <Filters.Provider
    quickFiltersType={AvailableQuickFilters.InvoiceStatus}
    filtersNamePrefix="in"
    ...
```

- When calling the `formatFiltersForQuery` function
```
  return formatFiltersForQuery({
    searchParams,
    availableFilters: InvoiceAvailableFilters,
    filtersNamePrefix: 'in',
  })
```

## Implementation

I've tried to keep the existing structure, without changing too many things. Most of the work was done inside `useFilters`, since it assumed a single set of filters in most cases (for example when setting a quick filter, or when resetting filters, it was deleting everything from the search params).

## Screenshot

<img width="2337" alt="image" src="https://github.com/user-attachments/assets/a8ceb0ff-3612-44cc-8e70-6324f8764db0" />