### PR TITLE
fix(JsonEditor): prevent user from changing the value of a disabled editor

### DIFF
--- a/src/components/form/JsonEditor/JsonEditor.tsx
+++ b/src/components/form/JsonEditor/JsonEditor.tsx
@@ -198,7 +198,7 @@ export const JsonEditor = ({
             showLineNumbers: true,
             tabSize: 2,
             showPrintMargin: false,
-            readOnly: readOnly || readOnlyWithoutStyles,
+            readOnly: readOnly || readOnlyWithoutStyles || disabled,
           }}
         />
       </div>


### PR DESCRIPTION
## Context

Users shouldn't be able to edit the value of a disabled editor

## Description

It seems like the only property that properly handles the disabled case is the `readonly` flag. Made that take into account the value of the `disabled` prop.

Fixes ISSUE-674