### PR TITLE
refactor: create credit note

### DIFF
--- a/src/components/creditNote/CreditNoteActions.tsx
+++ b/src/components/creditNote/CreditNoteActions.tsx
@@ -17,7 +17,7 @@ interface CreditNoteActionsProps {
   invoice?: InvoiceForCreditNoteFormCalculationFragment
   formikProps: FormikProps<Partial<CreditNoteForm>>
   hasCreditOrCoupon: boolean
-  maxRefundableAmountCents: number
+  maxRefundableAmount: number
   totalTaxIncluded: number
   currency: CurrencyEnum
   estimationLoading: boolean
@@ -28,7 +28,7 @@ export const CreditNoteActions: FC<CreditNoteActionsProps> = ({
   invoice,
   formikProps,
   hasCreditOrCoupon,
-  maxRefundableAmountCents,
+  maxRefundableAmount,
   totalTaxIncluded,
   currency,
   estimationLoading,
@@ -93,7 +93,7 @@ export const CreditNoteActions: FC<CreditNoteActionsProps> = ({
           <>
             <Tooltip
               title={translate('text_637e23e47a15bf0bd71e0d03', {
-                max: intlFormatNumber(deserializeAmount(maxRefundableAmountCents, currency), {
+                max: intlFormatNumber(maxRefundableAmount, {
                   currency,
                 }),
               })}

--- a/src/components/creditNote/CreditNoteActions.tsx
+++ b/src/components/creditNote/CreditNoteActions.tsx
@@ -1,0 +1,272 @@
+import { InputAdornment } from '@mui/material'
+import { FormikProps } from 'formik'
+import _get from 'lodash/get'
+import { FC } from 'react'
+import styled, { css } from 'styled-components'
+
+import { CreditNoteForm, CreditTypeEnum, PayBackErrorEnum } from '~/components/creditNote/types'
+import { Button, Skeleton, Tooltip, Typography } from '~/components/designSystem'
+import { AmountInputField, ComboBox, ComboBoxField } from '~/components/form'
+import { getCurrencySymbol, intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { CurrencyEnum, InvoiceForCreditNoteFormCalculationFragment } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { theme } from '~/styles'
+
+interface CreditNoteActionsProps {
+  invoice?: InvoiceForCreditNoteFormCalculationFragment
+  formikProps: FormikProps<Partial<CreditNoteForm>>
+  hasCreditOrCoupon: boolean
+  maxRefundableAmountCents: number
+  totalTaxIncluded: number
+  currency: CurrencyEnum
+  estimationLoading: boolean
+  hasError: boolean
+}
+
+export const CreditNoteActions: FC<CreditNoteActionsProps> = ({
+  invoice,
+  formikProps,
+  hasCreditOrCoupon,
+  maxRefundableAmountCents,
+  totalTaxIncluded,
+  currency,
+  estimationLoading,
+  hasError,
+}) => {
+  const { translate } = useInternationalization()
+
+  const payBack = formikProps.values.payBack || []
+
+  return (
+    <PayBackBlock>
+      <PayBackLine $multiline={payBack.length > 1}>
+        <ComboBox
+          name="payBack.0.type"
+          value={payBack[0]?.type}
+          onChange={(value) => {
+            if (value === CreditTypeEnum.refund && hasCreditOrCoupon) {
+              formikProps.setFieldValue('payBack', [
+                {
+                  type: value,
+                  value: Number(invoice?.refundableAmountCents || 0) / 100,
+                },
+                {
+                  type: CreditTypeEnum.credit,
+                  value:
+                    Math.round(
+                      (totalTaxIncluded || 0) * 100 - Number(invoice?.refundableAmountCents || 0),
+                    ) / 100,
+                },
+              ])
+            } else {
+              formikProps.setFieldValue('payBack.0.type', value)
+            }
+          }}
+          placeholder={translate('text_637d0e628762bd8fc95f045d')}
+          data={[
+            {
+              value: CreditTypeEnum?.credit,
+              label: translate('text_637d0e720ace4ea09aaf0630'),
+              disabled: payBack[1]?.type === CreditTypeEnum.credit,
+            },
+            {
+              value: CreditTypeEnum?.refund,
+              disabled: payBack[1]?.type === CreditTypeEnum.refund,
+              label: translate(
+                hasCreditOrCoupon
+                  ? 'text_637d10c83077eff6e8c79cd0'
+                  : 'text_637d0e6d94c87b04785fc6d2',
+                {
+                  max: intlFormatNumber(
+                    deserializeAmount(invoice?.refundableAmountCents || 0, currency),
+                    {
+                      currency,
+                    },
+                  ),
+                },
+              ),
+            },
+          ]}
+        />
+        {payBack.length > 1 ? (
+          <>
+            <Tooltip
+              title={translate('text_637e23e47a15bf0bd71e0d03', {
+                max: intlFormatNumber(deserializeAmount(maxRefundableAmountCents, currency), {
+                  currency,
+                }),
+              })}
+              placement="top-end"
+              disableHoverListener={
+                _get(formikProps.errors, 'payBack.0.value') !== PayBackErrorEnum.maxRefund
+              }
+            >
+              <AmountInputField
+                className="max-w-38 [&_input]:text-right"
+                name="payBack.0.value"
+                currency={currency}
+                formikProps={formikProps}
+                beforeChangeFormatter={['positiveNumber']}
+                displayErrorText={false}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">{getCurrencySymbol(currency)}</InputAdornment>
+                  ),
+                }}
+              />
+            </Tooltip>
+            <Tooltip title={translate('text_637d2e7e5af40c52246b1a12')} placement="top-end">
+              <Button
+                icon="trash"
+                variant="quaternary"
+                size="small"
+                onClick={() =>
+                  formikProps.setFieldValue('payBack', [
+                    { type: payBack[1].type, value: totalTaxIncluded },
+                  ])
+                }
+              />
+            </Tooltip>
+          </>
+        ) : (
+          <Typography color="grey700">
+            {estimationLoading ? (
+              <Skeleton variant="text" className="w-22" />
+            ) : !payBack[0]?.value || hasError ? (
+              '-'
+            ) : (
+              intlFormatNumber(payBack[0]?.value || 0, {
+                currency,
+              })
+            )}
+          </Typography>
+        )}
+      </PayBackLine>
+
+      {payBack.length < 2 ? (
+        <Button
+          variant="quaternary"
+          startIcon="plus"
+          onClick={() => {
+            formikProps.setFieldValue('payBack.1', {
+              type: payBack[0]?.type
+                ? payBack[0]?.type === CreditTypeEnum.credit
+                  ? CreditTypeEnum.refund
+                  : CreditTypeEnum.credit
+                : undefined,
+              value:
+                payBack[0]?.value && (totalTaxIncluded || 0) - payBack[0]?.value
+                  ? (totalTaxIncluded || 0) - payBack[0]?.value
+                  : undefined,
+            })
+          }}
+        >
+          {translate('text_637d0e9729bcc6bb0cb77141')}
+        </Button>
+      ) : (
+        <PayBackLine $multiline>
+          <ComboBoxField
+            name="payBack.1.type"
+            formikProps={formikProps}
+            placeholder={translate('text_637d0e628762bd8fc95f045d')}
+            data={[
+              {
+                value: CreditTypeEnum?.credit,
+                label: translate('text_637d0e720ace4ea09aaf0630'),
+                disabled: payBack[0]?.type === CreditTypeEnum.credit,
+              },
+              {
+                value: CreditTypeEnum?.refund,
+                disabled: payBack[0]?.type === CreditTypeEnum.refund,
+                label: translate(
+                  hasCreditOrCoupon
+                    ? 'text_637d10c83077eff6e8c79cd0'
+                    : 'text_637d0e6d94c87b04785fc6d2',
+                  {
+                    max: intlFormatNumber(
+                      deserializeAmount(invoice?.refundableAmountCents || 0, currency),
+                      {
+                        currency,
+                      },
+                    ),
+                  },
+                ),
+              },
+            ]}
+          />
+          <Tooltip
+            title={translate('text_637e23e47a15bf0bd71e0d03', {
+              max: intlFormatNumber(
+                deserializeAmount(invoice?.refundableAmountCents || 0, currency),
+                {
+                  currency,
+                },
+              ),
+            })}
+            placement="top-end"
+            disableHoverListener={
+              _get(formikProps.errors, 'payBack.1.value') !== PayBackErrorEnum.maxRefund
+            }
+          >
+            <AmountInputField
+              className="max-w-38 [&_input]:text-right"
+              name="payBack.1.value"
+              currency={currency}
+              formikProps={formikProps}
+              beforeChangeFormatter={['positiveNumber']}
+              displayErrorText={false}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">{getCurrencySymbol(currency)}</InputAdornment>
+                ),
+              }}
+            />
+          </Tooltip>
+          <Tooltip title={translate('text_637d2e7e5af40c52246b1a12')} placement="top-end">
+            <Button
+              icon="trash"
+              variant="quaternary"
+              size="small"
+              onClick={() => {
+                formikProps.setFieldValue('payBack', [
+                  { type: payBack[0].type, value: totalTaxIncluded },
+                ])
+              }}
+            />
+          </Tooltip>
+        </PayBackLine>
+      )}
+    </PayBackBlock>
+  )
+}
+
+const PayBackLine = styled.div<{ $multiline?: boolean }>`
+  display: flex;
+  align-items: center;
+
+  > *:not(:last-child) {
+    margin-right: ${theme.spacing(3)};
+  }
+
+  > *:first-child {
+    flex: 1;
+    max-width: 456px;
+  }
+
+  ${({ $multiline }) =>
+    !$multiline &&
+    css`
+      > *:last-child {
+        margin-left: auto;
+      }
+    `}
+`
+
+const PayBackBlock = styled.div`
+  margin-top: ${theme.spacing(6)};
+
+  > *:first-child {
+    margin-bottom: ${theme.spacing(6)};
+  }
+`

--- a/src/components/creditNote/CreditNoteActionsLine.tsx
+++ b/src/components/creditNote/CreditNoteActionsLine.tsx
@@ -1,0 +1,58 @@
+import { InputAdornment } from '@mui/material'
+import { FC } from 'react'
+
+import { Typography } from '~/components/designSystem'
+import { AmountInput } from '~/components/form'
+import { getCurrencySymbol } from '~/core/formats/intlFormatNumber'
+import { CurrencyEnum } from '~/generated/graphql'
+
+interface CreditNoteActionsLineProps {
+  label: string
+  currency: CurrencyEnum
+  inputName: string
+  error?: string
+}
+
+export const CreditNoteActionsLine: FC<CreditNoteActionsLineProps> = ({
+  label,
+  currency,
+  inputName,
+  error,
+}) => {
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <Typography variant="bodyHl" color="grey700">
+          {label}
+        </Typography>
+
+        <AmountInput
+          className="max-w-42"
+          error={!!error}
+          inputProps={{
+            style: {
+              textAlign: 'right',
+            },
+          }}
+          name={inputName}
+          currency={currency}
+          beforeChangeFormatter={['positiveNumber']}
+          InputProps={
+            currency
+              ? {
+                  startAdornment: (
+                    <InputAdornment position="start">{getCurrencySymbol(currency)}</InputAdornment>
+                  ),
+                }
+              : {}
+          }
+        />
+      </div>
+      {error && (
+        <Typography variant="caption" color="danger600" className="mt-1 text-right">
+          {error}
+        </Typography>
+      )}
+    </div>
+  )
+}

--- a/src/components/creditNote/CreditNoteEstimationLine.tsx
+++ b/src/components/creditNote/CreditNoteEstimationLine.tsx
@@ -1,0 +1,38 @@
+import { FC } from 'react'
+
+import { Icon, Skeleton, Tooltip, Typography, TypographyProps } from '~/components/designSystem'
+
+interface CreditNoteEstimationLineProps {
+  label: string
+  labelColor?: TypographyProps['color']
+  value: string
+  loading?: boolean
+  tooltipContent?: string
+}
+
+export const CreditNoteEstimationLine: FC<CreditNoteEstimationLineProps> = ({
+  label,
+  labelColor = 'grey700',
+  value,
+  loading,
+  tooltipContent,
+}) => {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <Typography variant="bodyHl" color={labelColor}>
+          {label}
+        </Typography>
+        {tooltipContent && (
+          <Tooltip className="flex h-5 items-end" placement="top-start" title={tooltipContent}>
+            <Icon name="info-circle" />
+          </Tooltip>
+        )}
+      </div>
+
+      {loading && <Skeleton variant="text" className="w-22" />}
+
+      <Typography color="grey700">{value}</Typography>
+    </div>
+  )
+}

--- a/src/components/creditNote/CreditNoteFormCalculation.tsx
+++ b/src/components/creditNote/CreditNoteFormCalculation.tsx
@@ -1,16 +1,14 @@
 import { gql } from '@apollo/client'
-import { InputAdornment } from '@mui/material'
 import { FormikProps } from 'formik'
 import { debounce } from 'lodash'
 import _get from 'lodash/get'
 import { useCallback, useEffect, useMemo } from 'react'
-import styled, { css } from 'styled-components'
 import { array, number, object, string } from 'yup'
 
+import { CreditNoteActions } from '~/components/creditNote/CreditNoteActions'
 import { CreditNoteEstimationLine } from '~/components/creditNote/CreditNoteEstimationLine'
-import { Alert, Button, Skeleton, Tooltip, Typography } from '~/components/designSystem'
-import { AmountInputField, ComboBox, ComboBoxField } from '~/components/form'
-import { getCurrencySymbol, intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { Alert } from '~/components/designSystem'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount, getCurrencyPrecision } from '~/core/serializers/serializeAmount'
 import {
   CreditNoteItemInput,
@@ -22,7 +20,6 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { DEBOUNCE_SEARCH_MS } from '~/hooks/useDebouncedSearch'
-import { theme } from '~/styles'
 
 import { CreditNoteForm, CreditTypeEnum, PayBackErrorEnum } from './types'
 
@@ -91,6 +88,8 @@ export const CreditNoteFormCalculation = ({
   const canOnlyCredit =
     invoice?.paymentStatus !== InvoicePaymentStatusTypeEnum.Succeeded ||
     !!invoice.paymentDisputeLostAt
+  const canRefund = !canOnlyCredit
+
   const currency = invoice?.currency || CurrencyEnum.Usd
   const currencyPrecision = getCurrencyPrecision(currency)
   const isLegacyInvoice = (invoice?.versionNumber || 0) < 3
@@ -229,7 +228,7 @@ export const CreditNoteFormCalculation = ({
 
   return (
     <div>
-      <CalculationContainer>
+      <div className="ml-auto flex w-full max-w-100 flex-col gap-3">
         {hasCouponLine && (
           <CreditNoteEstimationLine
             label={translate('text_644b9f17623605a945cafdbb')}
@@ -327,212 +326,19 @@ export const CreditNoteFormCalculation = ({
             }
           />
         )}
-      </CalculationContainer>
-      {!canOnlyCredit && (
-        <PayBackBlock>
-          <PayBackLine $multiline={payBack.length > 1}>
-            <ComboBox
-              name="payBack.0.type"
-              value={payBack[0]?.type}
-              onChange={(value) => {
-                if (value === CreditTypeEnum.refund && hasCreditOrCoupon) {
-                  formikProps.setFieldValue('payBack', [
-                    {
-                      type: value,
-                      value: Number(invoice?.refundableAmountCents || 0) / 100,
-                    },
-                    {
-                      type: CreditTypeEnum.credit,
-                      value:
-                        Math.round(
-                          (totalTaxIncluded || 0) * 100 -
-                            Number(invoice?.refundableAmountCents || 0),
-                        ) / 100,
-                    },
-                  ])
-                } else {
-                  formikProps.setFieldValue('payBack.0.type', value)
-                }
-              }}
-              placeholder={translate('text_637d0e628762bd8fc95f045d')}
-              data={[
-                {
-                  value: CreditTypeEnum?.credit,
-                  label: translate('text_637d0e720ace4ea09aaf0630'),
-                  disabled: payBack[1]?.type === CreditTypeEnum.credit,
-                },
-                {
-                  value: CreditTypeEnum?.refund,
-                  disabled: payBack[1]?.type === CreditTypeEnum.refund,
-                  label: translate(
-                    hasCreditOrCoupon
-                      ? 'text_637d10c83077eff6e8c79cd0'
-                      : 'text_637d0e6d94c87b04785fc6d2',
-                    {
-                      max: intlFormatNumber(
-                        deserializeAmount(invoice?.refundableAmountCents || 0, currency),
-                        {
-                          currency,
-                        },
-                      ),
-                    },
-                  ),
-                },
-              ]}
-            />
-            {payBack.length > 1 ? (
-              <>
-                <Tooltip
-                  title={translate('text_637e23e47a15bf0bd71e0d03', {
-                    max: intlFormatNumber(deserializeAmount(maxRefundableAmountCents, currency), {
-                      currency,
-                    }),
-                  })}
-                  placement="top-end"
-                  disableHoverListener={
-                    _get(formikProps.errors, 'payBack.0.value') !== PayBackErrorEnum.maxRefund
-                  }
-                >
-                  <AmountInputField
-                    className="max-w-38 [&_input]:text-right"
-                    name="payBack.0.value"
-                    currency={currency}
-                    formikProps={formikProps}
-                    beforeChangeFormatter={['positiveNumber']}
-                    displayErrorText={false}
-                    InputProps={{
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          {getCurrencySymbol(currency)}
-                        </InputAdornment>
-                      ),
-                    }}
-                  />
-                </Tooltip>
-                <Tooltip title={translate('text_637d2e7e5af40c52246b1a12')} placement="top-end">
-                  <Button
-                    icon="trash"
-                    variant="quaternary"
-                    size="small"
-                    onClick={() =>
-                      formikProps.setFieldValue('payBack', [
-                        { type: payBack[1].type, value: totalTaxIncluded },
-                      ])
-                    }
-                  />
-                </Tooltip>
-              </>
-            ) : (
-              <Typography color="grey700">
-                {estimationLoading ? (
-                  <Skeleton variant="text" className="w-22" />
-                ) : !payBack[0]?.value || hasError ? (
-                  '-'
-                ) : (
-                  intlFormatNumber(payBack[0]?.value || 0, {
-                    currency,
-                  })
-                )}
-              </Typography>
-            )}
-          </PayBackLine>
+      </div>
 
-          {payBack.length < 2 ? (
-            <Button
-              variant="quaternary"
-              startIcon="plus"
-              onClick={() => {
-                formikProps.setFieldValue('payBack.1', {
-                  type: payBack[0]?.type
-                    ? payBack[0]?.type === CreditTypeEnum.credit
-                      ? CreditTypeEnum.refund
-                      : CreditTypeEnum.credit
-                    : undefined,
-                  value:
-                    payBack[0]?.value && (totalTaxIncluded || 0) - payBack[0]?.value
-                      ? (totalTaxIncluded || 0) - payBack[0]?.value
-                      : undefined,
-                })
-              }}
-            >
-              {translate('text_637d0e9729bcc6bb0cb77141')}
-            </Button>
-          ) : (
-            <PayBackLine $multiline>
-              <ComboBoxField
-                name="payBack.1.type"
-                formikProps={formikProps}
-                placeholder={translate('text_637d0e628762bd8fc95f045d')}
-                data={[
-                  {
-                    value: CreditTypeEnum?.credit,
-                    label: translate('text_637d0e720ace4ea09aaf0630'),
-                    disabled: payBack[0]?.type === CreditTypeEnum.credit,
-                  },
-                  {
-                    value: CreditTypeEnum?.refund,
-                    disabled: payBack[0]?.type === CreditTypeEnum.refund,
-                    label: translate(
-                      hasCreditOrCoupon
-                        ? 'text_637d10c83077eff6e8c79cd0'
-                        : 'text_637d0e6d94c87b04785fc6d2',
-                      {
-                        max: intlFormatNumber(
-                          deserializeAmount(invoice?.refundableAmountCents || 0, currency),
-                          {
-                            currency,
-                          },
-                        ),
-                      },
-                    ),
-                  },
-                ]}
-              />
-              <Tooltip
-                title={translate('text_637e23e47a15bf0bd71e0d03', {
-                  max: intlFormatNumber(
-                    deserializeAmount(invoice?.refundableAmountCents || 0, currency),
-                    {
-                      currency,
-                    },
-                  ),
-                })}
-                placement="top-end"
-                disableHoverListener={
-                  _get(formikProps.errors, 'payBack.1.value') !== PayBackErrorEnum.maxRefund
-                }
-              >
-                <AmountInputField
-                  className="max-w-38 [&_input]:text-right"
-                  name="payBack.1.value"
-                  currency={currency}
-                  formikProps={formikProps}
-                  beforeChangeFormatter={['positiveNumber']}
-                  displayErrorText={false}
-                  InputProps={{
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        {getCurrencySymbol(currency)}
-                      </InputAdornment>
-                    ),
-                  }}
-                />
-              </Tooltip>
-              <Tooltip title={translate('text_637d2e7e5af40c52246b1a12')} placement="top-end">
-                <Button
-                  icon="trash"
-                  variant="quaternary"
-                  size="small"
-                  onClick={() => {
-                    formikProps.setFieldValue('payBack', [
-                      { type: payBack[0].type, value: totalTaxIncluded },
-                    ])
-                  }}
-                />
-              </Tooltip>
-            </PayBackLine>
-          )}
-        </PayBackBlock>
+      {canRefund && (
+        <CreditNoteActions
+          invoice={invoice}
+          formikProps={formikProps}
+          hasCreditOrCoupon={hasCreditOrCoupon}
+          maxRefundableAmountCents={maxRefundableAmountCents}
+          totalTaxIncluded={totalTaxIncluded}
+          currency={currency}
+          estimationLoading={estimationLoading}
+          hasError={hasError}
+        />
       )}
 
       {_get(formikProps.errors, 'payBack.0.value') === LagoApiError.DoesNotMatchItemAmounts && (
@@ -547,42 +353,3 @@ export const CreditNoteFormCalculation = ({
     </div>
   )
 }
-
-const CalculationContainer = styled.div`
-  max-width: 400px;
-  margin-left: auto;
-
-  > *:not(:last-child) {
-    margin-bottom: ${theme.spacing(3)};
-  }
-`
-
-const PayBackLine = styled.div<{ $multiline?: boolean }>`
-  display: flex;
-  align-items: center;
-
-  > *:not(:last-child) {
-    margin-right: ${theme.spacing(3)};
-  }
-
-  > *:first-child {
-    flex: 1;
-    max-width: 456px;
-  }
-
-  ${({ $multiline }) =>
-    !$multiline &&
-    css`
-      > *:last-child {
-        margin-left: auto;
-      }
-    `}
-`
-
-const PayBackBlock = styled.div`
-  margin-top: ${theme.spacing(6)};
-
-  > *:first-child {
-    margin-bottom: ${theme.spacing(6)};
-  }
-`

--- a/src/components/creditNote/CreditNoteFormCalculation.tsx
+++ b/src/components/creditNote/CreditNoteFormCalculation.tsx
@@ -95,8 +95,10 @@ export const CreditNoteFormCalculation = ({
   const currencyPrecision = getCurrencyPrecision(currency)
   const isLegacyInvoice = (invoice?.versionNumber || 0) < 3
 
-  const [getEstimate, { data: estimationData, error: estimationError, loading: estiationLoading }] =
-    useCreditNoteEstimateLazyQuery()
+  const [
+    getEstimate,
+    { data: estimationData, error: estimationError, loading: estimationLoading },
+  ] = useCreditNoteEstimateLazyQuery()
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedQuery = useCallback(
@@ -238,7 +240,7 @@ export const CreditNoteFormCalculation = ({
                     currency,
                   })}`
             }
-            loading={estiationLoading}
+            loading={estimationLoading}
             labelColor="grey600"
             tooltipContent={translate('text_644b9f17623605a945cafdb9')}
           />
@@ -247,7 +249,7 @@ export const CreditNoteFormCalculation = ({
         <CreditNoteEstimationLine
           label={translate('text_636bedf292786b19d3398f02')}
           labelColor="grey600"
-          loading={estiationLoading}
+          loading={estimationLoading}
           value={
             !totalExcludedTax || hasError
               ? '-'
@@ -262,7 +264,7 @@ export const CreditNoteFormCalculation = ({
             label={translate('text_636bedf292786b19d3398f06')}
             labelColor="grey600"
             value={'-'}
-            loading={estiationLoading}
+            loading={estimationLoading}
           />
         )}
 
@@ -281,7 +283,7 @@ export const CreditNoteFormCalculation = ({
                         currency,
                       })
                 }
-                loading={estiationLoading}
+                loading={estimationLoading}
                 data-test={`tax-${tax.taxRate}-amount`}
               />
             ))
@@ -296,13 +298,13 @@ export const CreditNoteFormCalculation = ({
                     currency,
                   })
             }
-            loading={estiationLoading}
+            loading={estimationLoading}
           />
         )}
 
         <CreditNoteEstimationLine
           label={translate('text_636bedf292786b19d3398f0a')}
-          loading={estiationLoading}
+          loading={estimationLoading}
           value={
             !totalTaxIncluded || hasError
               ? '-'
@@ -315,7 +317,7 @@ export const CreditNoteFormCalculation = ({
         {canOnlyCredit && (
           <CreditNoteEstimationLine
             label={translate('text_636bedf292786b19d3398f0e')}
-            loading={estiationLoading}
+            loading={estimationLoading}
             value={
               totalTaxIncluded === undefined || hasError
                 ? '-'
@@ -422,7 +424,7 @@ export const CreditNoteFormCalculation = ({
               </>
             ) : (
               <Typography color="grey700">
-                {estiationLoading ? (
+                {estimationLoading ? (
                   <Skeleton variant="text" className="w-22" />
                 ) : !payBack[0]?.value || hasError ? (
                   '-'

--- a/src/components/creditNote/CreditNoteItemsForm.tsx
+++ b/src/components/creditNote/CreditNoteItemsForm.tsx
@@ -1,0 +1,259 @@
+import { FormikProps } from 'formik'
+import _get from 'lodash/get'
+import { DateTime } from 'luxon'
+import { FC, useMemo } from 'react'
+import styled from 'styled-components'
+
+import { CreditNoteFormItem } from '~/components/creditNote/CreditNoteFormItem'
+import { CreditNoteForm, FeesPerInvoice, FromFee, GroupedFee } from '~/components/creditNote/types'
+import { Typography } from '~/components/designSystem'
+import { Checkbox } from '~/components/form/Checkbox'
+import { CurrencyEnum } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { HEADER_TABLE_HEIGHT, theme } from '~/styles'
+
+const determineCheckboxValue = (
+  initialValue: boolean | undefined | null,
+  additionalValue: boolean | undefined,
+) => {
+  if (initialValue === undefined || additionalValue === undefined) return undefined
+  if (initialValue === null) {
+    return additionalValue
+  }
+  if (initialValue !== additionalValue) {
+    return undefined
+  }
+  return additionalValue
+}
+
+interface CreditNoteItemsFormProps {
+  isPrepaidCreditsInvoice: boolean
+  formikProps: FormikProps<Partial<CreditNoteForm>>
+  feeForCredit?: FromFee[]
+  feeForAddOn?: FromFee[]
+  feesPerInvoice?: FeesPerInvoice
+  currency: CurrencyEnum
+}
+
+export const CreditNoteItemsForm: FC<CreditNoteItemsFormProps> = ({
+  isPrepaidCreditsInvoice,
+  formikProps,
+  feeForCredit,
+  feeForAddOn,
+  feesPerInvoice,
+  currency,
+}) => {
+  const { translate } = useInternationalization()
+
+  const checkboxGroupValue = useMemo(() => {
+    const fees = formikProps.values.fees || {}
+
+    return (
+      Object.keys(fees).reduce((acc, subscriptionKey) => {
+        const subscriptionValues = fees[subscriptionKey]
+
+        let subscriptionGroupValues: {
+          value: undefined | boolean | null
+          [key: string]: undefined | boolean | null
+        } = {
+          value: null,
+        }
+
+        Object.keys(subscriptionValues.fees).forEach((childKey) => {
+          const child = subscriptionValues.fees[childKey] as FromFee
+
+          if (typeof child?.checked === 'boolean') {
+            subscriptionGroupValues = {
+              ...subscriptionGroupValues,
+              value: determineCheckboxValue(subscriptionGroupValues.value, child?.checked),
+            }
+          } else {
+            let groupValue: boolean | undefined | null = null
+
+            const grouped = (child as unknown as GroupedFee)?.grouped
+
+            Object.keys(grouped || {}).forEach((groupedKey) => {
+              const feeValues = grouped[groupedKey]
+
+              groupValue = determineCheckboxValue(groupValue, feeValues.checked)
+            })
+
+            subscriptionGroupValues = {
+              ...subscriptionGroupValues,
+              [childKey]: groupValue,
+              value: determineCheckboxValue(
+                subscriptionGroupValues.value,
+                groupValue as unknown as boolean | undefined,
+              ),
+            }
+          }
+        })
+
+        return { ...acc, [subscriptionKey]: subscriptionGroupValues }
+      }, {}) || {}
+    )
+  }, [formikProps.values.fees])
+
+  return (
+    <div>
+      {isPrepaidCreditsInvoice && (
+        <HeaderLine className="!mb-0">
+          <Checkbox
+            label={
+              <Typography variant="bodyHl" color="grey500">
+                {translate('text_661ff6e56ef7e1b7c542b200')}
+              </Typography>
+            }
+            value={formikProps.values.creditFee?.[0]?.checked}
+            onChange={(_, value) => {
+              formikProps.setFieldValue(`creditFee.0.checked`, value)
+            }}
+          />
+
+          <Typography variant="bodyHl" color="grey500">
+            {translate('text_636bedf292786b19d3398ee0')}
+          </Typography>
+        </HeaderLine>
+      )}
+
+      {feeForCredit &&
+        feeForCredit.map((fee, i) => (
+          <CreditNoteFormItem
+            key={fee?.id}
+            formikProps={formikProps}
+            currency={currency}
+            feeName={translate('text_1729262241097k3cnpci6p5j')}
+            formikKey={`creditFee.${i}`}
+            maxValue={fee?.maxAmount}
+          />
+        ))}
+
+      {feeForAddOn &&
+        feeForAddOn.map((fee, i) => (
+          <CreditNoteFormItem
+            key={fee?.id}
+            formikProps={formikProps}
+            currency={currency}
+            feeName={fee?.name}
+            formikKey={`addOnFee.${i}`}
+            maxValue={fee?.maxAmount}
+          />
+        ))}
+
+      {feesPerInvoice &&
+        Object.keys(feesPerInvoice).map((subKey) => {
+          const subscription = feesPerInvoice[subKey]
+
+          return (
+            <div key={subKey}>
+              <HeaderLine>
+                <Checkbox
+                  value={_get(checkboxGroupValue, `${subKey}.value`)}
+                  canBeIndeterminate
+                  label={
+                    <Typography variant="bodyHl" color="grey500">
+                      {subscription?.subscriptionName}
+                    </Typography>
+                  }
+                  onChange={(_, value) => {
+                    const childValues = _get(
+                      formikProps.values.fees,
+                      `${subKey}.fees`,
+                    ) as unknown as { [feeGroupId: string]: FromFee | GroupedFee }
+
+                    formikProps.setFieldValue(
+                      `fees.${subKey}.fees`,
+                      Object.keys(childValues).reduce((acc, childKey) => {
+                        const child = childValues[childKey] as FromFee
+
+                        if (typeof child.checked === 'boolean') {
+                          acc = { ...acc, [childKey]: { ...child, checked: value } }
+                        } else {
+                          const grouped = (child as unknown as GroupedFee)?.grouped
+
+                          acc = {
+                            ...acc,
+                            [childKey]: {
+                              ...child,
+                              grouped: Object.keys(grouped || {}).reduce((accGroup, groupKey) => {
+                                const fee = grouped[groupKey]
+
+                                return {
+                                  ...accGroup,
+                                  [groupKey]: { ...fee, checked: value },
+                                }
+                              }, {}),
+                            },
+                          }
+                        }
+                        return acc
+                      }, {}),
+                    )
+                  }}
+                />
+                <Typography variant="bodyHl" color="grey500">
+                  {translate('text_636bedf292786b19d3398ee0')}
+                </Typography>
+              </HeaderLine>
+              {Object.keys(subscription?.fees)?.map((groupFeeKey) => {
+                const child = subscription?.fees[groupFeeKey] as FromFee
+
+                if (typeof child?.checked === 'boolean') {
+                  return (
+                    <CreditNoteFormItem
+                      key={child?.id}
+                      formikProps={formikProps}
+                      currency={currency}
+                      feeName={`${child?.name}${
+                        child.isTrueUpFee ? ` - ${translate('text_64463aaa34904c00a23be4f7')}` : ''
+                      }`}
+                      formikKey={`fees.${subKey}.fees.${groupFeeKey}`}
+                      maxValue={child?.maxAmount || 0}
+                      feeSucceededAt={
+                        !!child?.succeededAt
+                          ? DateTime.fromISO(child?.succeededAt).toFormat('LLL. dd, yyyy')
+                          : undefined
+                      }
+                    />
+                  )
+                }
+
+                const grouped = (child as unknown as GroupedFee)?.grouped
+
+                return (
+                  <div key={groupFeeKey}>
+                    {Object.keys(grouped).map((groupedFeeKey) => {
+                      const fee = grouped[groupedFeeKey]
+
+                      return (
+                        <CreditNoteFormItem
+                          key={fee?.id}
+                          formikProps={formikProps}
+                          currency={currency}
+                          feeName={`${child.name} • ${fee?.name}${
+                            fee.isTrueUpFee
+                              ? ` - ${translate('text_64463aaa34904c00a23be4f7')}`
+                              : ''
+                          }`}
+                          formikKey={`fees.${subKey}.fees.${groupFeeKey}.grouped.${fee?.id}`}
+                          maxValue={fee?.maxAmount || 0}
+                        />
+                      )
+                    })}
+                  </div>
+                )
+              })}
+            </div>
+          )
+        })}
+    </div>
+  )
+}
+
+const HeaderLine = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: ${theme.shadows[7]};
+  height: ${HEADER_TABLE_HEIGHT}px;
+`

--- a/src/components/creditNote/CreditNoteItemsForm.tsx
+++ b/src/components/creditNote/CreditNoteItemsForm.tsx
@@ -2,7 +2,6 @@ import { FormikProps } from 'formik'
 import _get from 'lodash/get'
 import { DateTime } from 'luxon'
 import { FC, useMemo } from 'react'
-import styled from 'styled-components'
 
 import { CreditNoteFormItem } from '~/components/creditNote/CreditNoteFormItem'
 import { CreditNoteForm, FeesPerInvoice, FromFee, GroupedFee } from '~/components/creditNote/types'
@@ -10,7 +9,6 @@ import { Typography } from '~/components/designSystem'
 import { Checkbox } from '~/components/form/Checkbox'
 import { CurrencyEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { HEADER_TABLE_HEIGHT, theme } from '~/styles'
 
 const determineCheckboxValue = (
   initialValue: boolean | undefined | null,
@@ -97,7 +95,7 @@ export const CreditNoteItemsForm: FC<CreditNoteItemsFormProps> = ({
   return (
     <div>
       {isPrepaidCreditsInvoice && (
-        <HeaderLine className="!mb-0">
+        <div className="flex h-12 flex-row items-center justify-between shadow-b">
           <Checkbox
             label={
               <Typography variant="bodyHl" color="grey500">
@@ -113,7 +111,7 @@ export const CreditNoteItemsForm: FC<CreditNoteItemsFormProps> = ({
           <Typography variant="bodyHl" color="grey500">
             {translate('text_636bedf292786b19d3398ee0')}
           </Typography>
-        </HeaderLine>
+        </div>
       )}
 
       {feeForCredit &&
@@ -146,7 +144,7 @@ export const CreditNoteItemsForm: FC<CreditNoteItemsFormProps> = ({
 
           return (
             <div key={subKey}>
-              <HeaderLine>
+              <div className="flex h-12 flex-row items-center justify-between shadow-b">
                 <Checkbox
                   value={_get(checkboxGroupValue, `${subKey}.value`)}
                   canBeIndeterminate
@@ -194,7 +192,7 @@ export const CreditNoteItemsForm: FC<CreditNoteItemsFormProps> = ({
                 <Typography variant="bodyHl" color="grey500">
                   {translate('text_636bedf292786b19d3398ee0')}
                 </Typography>
-              </HeaderLine>
+              </div>
               {Object.keys(subscription?.fees)?.map((groupFeeKey) => {
                 const child = subscription?.fees[groupFeeKey] as FromFee
 
@@ -249,11 +247,3 @@ export const CreditNoteItemsForm: FC<CreditNoteItemsFormProps> = ({
     </div>
   )
 }
-
-const HeaderLine = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  box-shadow: ${theme.shadows[7]};
-  height: ${HEADER_TABLE_HEIGHT}px;
-`

--- a/src/components/form/TextInput/TextInput.tsx
+++ b/src/components/form/TextInput/TextInput.tsx
@@ -278,7 +278,7 @@ export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
           }
           {...props}
         />
-        {(helperText || error) && (
+        {(typeof helperText === 'string' || typeof error === 'string') && (
           <Typography
             variant="caption"
             data-test={error ? 'text-field-error' : 'text-field-helpertext'}

--- a/src/pages/CreateCreditNote.tsx
+++ b/src/pages/CreateCreditNote.tsx
@@ -6,9 +6,7 @@ import styled from 'styled-components'
 import { array, object, string } from 'yup'
 
 import { CreditNoteCodeSnippet } from '~/components/creditNote/CreditNoteCodeSnippet'
-import {
-  CreditNoteEstimationLine
-} from '~/components/creditNote/CreditNoteEstimationLine'
+import { CreditNoteEstimationLine } from '~/components/creditNote/CreditNoteEstimationLine'
 import { CreditNoteFormCalculation } from '~/components/creditNote/CreditNoteFormCalculation'
 import { CreditNoteItemsForm } from '~/components/creditNote/CreditNoteItemsForm'
 import { CreditNoteForm, CreditTypeEnum } from '~/components/creditNote/types'

--- a/src/pages/CreateCreditNote.tsx
+++ b/src/pages/CreateCreditNote.tsx
@@ -6,6 +6,9 @@ import styled from 'styled-components'
 import { array, object, string } from 'yup'
 
 import { CreditNoteCodeSnippet } from '~/components/creditNote/CreditNoteCodeSnippet'
+import {
+  CreditNoteEstimationLine
+} from '~/components/creditNote/CreditNoteEstimationLine'
 import { CreditNoteFormCalculation } from '~/components/creditNote/CreditNoteFormCalculation'
 import { CreditNoteItemsForm } from '~/components/creditNote/CreditNoteItemsForm'
 import { CreditNoteForm, CreditTypeEnum } from '~/components/creditNote/types'
@@ -358,21 +361,16 @@ const CreateCreditNote = () => {
 
                   {isPrepaidCreditsInvoice ? (
                     <>
-                      <div className="ml-auto max-w-[400px]">
-                        <div className="flex justify-between">
-                          <Typography className="text-base font-medium text-grey-700">
-                            {translate('text_1729262339446mk289ygp31g')}
-                          </Typography>
-
-                          <Typography className="text-base font-normal text-grey-700">
-                            {intlFormatNumber(
-                              Number(formikProps.values.creditFee?.[0]?.value || 0),
-                              {
-                                currency,
-                              },
-                            )}
-                          </Typography>
-                        </div>
+                      <div className="ml-auto w-full max-w-100">
+                        <CreditNoteEstimationLine
+                          label={translate('text_1729262339446mk289ygp31g')}
+                          value={intlFormatNumber(
+                            Number(formikProps.values.creditFee?.[0]?.value || 0),
+                            {
+                              currency,
+                            },
+                          )}
+                        />
                       </div>
 
                       <Alert className="mt-6" type="info">

--- a/src/pages/CreateCreditNote.tsx
+++ b/src/pages/CreateCreditNote.tsx
@@ -2,7 +2,6 @@ import { gql } from '@apollo/client'
 import { useFormik } from 'formik'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { generatePath, useNavigate, useParams } from 'react-router-dom'
-import styled from 'styled-components'
 import { array, object, string } from 'yup'
 
 import { CreditNoteCodeSnippet } from '~/components/creditNote/CreditNoteCodeSnippet'
@@ -45,7 +44,7 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCreateCreditNote } from '~/hooks/useCreateCreditNote'
-import { PageHeader, theme } from '~/styles'
+import { PageHeader } from '~/styles'
 import { Content, Main, Side, Subtitle, Title } from '~/styles/mainObjectsForm'
 
 gql`
@@ -241,20 +240,20 @@ const CreateCreditNote = () => {
               <>
                 <Skeleton variant="text" className="mb-5 w-70" />
                 <Skeleton variant="text" className="mb-10 w-120" />
-                <StyledCard $loading>
-                  <Skeleton variant="connectorAvatar" size="medium" className="mr-3" />
+                <Card className="flex flex-row items-center gap-3 p-4">
+                  <Skeleton variant="connectorAvatar" size="medium" />
                   <Skeleton variant="text" className="w-40" />
-                </StyledCard>
+                </Card>
                 <Card>
                   <Skeleton variant="text" className="w-104" />
                   <Skeleton variant="text" className="w-164" />
                   <Skeleton variant="text" className="w-64" />
                 </Card>
-                <ButtonContainer>
+                <div className="mb-20 px-8">
                   <Button size="large" disabled fullWidth>
                     {translate('text_636bedf292786b19d3398ec4')}
                   </Button>
-                </ButtonContainer>
+                </div>
               </>
             ) : (
               <>
@@ -262,36 +261,39 @@ const CreateCreditNote = () => {
                   <Title variant="headline">{translate('text_636bedf292786b19d3398ec4')}</Title>
                   <Subtitle>{translate('text_636bedf292786b19d3398ec6')}</Subtitle>
                 </div>
-                <StyledCard>
-                  <Avatar size="big" variant="connector">
-                    <Icon name="document" />
-                  </Avatar>
 
-                  <div>
-                    <Typography variant="caption">
-                      {translate('text_636bedf292786b19d3398ec8')}
-                    </Typography>
-                    <Typography variant="bodyHl" color="grey700">
-                      {translate('text_636bedf292786b19d3398eca', {
-                        invoiceNumber: invoice?.number,
-                        subtotal: intlFormatNumber(
-                          deserializeAmount(
-                            invoice?.subTotalIncludingTaxesAmountCents || 0,
-                            currency,
+                <Card className="flex flex-row items-center justify-between p-4">
+                  <div className="flex flex-row items-center gap-3">
+                    <Avatar size="big" variant="connector">
+                      <Icon name="document" />
+                    </Avatar>
+
+                    <div>
+                      <Typography variant="caption">
+                        {translate('text_636bedf292786b19d3398ec8')}
+                      </Typography>
+                      <Typography variant="bodyHl" color="grey700">
+                        {translate('text_636bedf292786b19d3398eca', {
+                          invoiceNumber: invoice?.number,
+                          subtotal: intlFormatNumber(
+                            deserializeAmount(
+                              invoice?.subTotalIncludingTaxesAmountCents || 0,
+                              currency,
+                            ),
+                            {
+                              currency,
+                            },
                           ),
-                          {
-                            currency,
-                          },
-                        ),
-                      })}
-                    </Typography>
+                        })}
+                      </Typography>
+                    </div>
                   </div>
                   {!!invoice?.paymentDisputeLostAt ? (
                     <Status type={StatusType.danger} label="disputeLost" />
                   ) : (
                     <Status {...statusMap} />
                   )}
-                </StyledCard>
+                </Card>
 
                 <Card>
                   <Typography variant="subhead">
@@ -385,7 +387,7 @@ const CreateCreditNote = () => {
                     />
                   )}
                 </Card>
-                <ButtonContainer>
+                <div className="mb-20 px-8">
                   <Button
                     disabled={!formikProps.isValid}
                     fullWidth
@@ -394,7 +396,7 @@ const CreateCreditNote = () => {
                   >
                     {translate('text_636bedf292786b19d3398f12')}
                   </Button>
-                </ButtonContainer>
+                </div>
               </>
             )}
           </div>
@@ -428,26 +430,3 @@ const CreateCreditNote = () => {
 }
 
 export default CreateCreditNote
-
-const StyledCard = styled.div<{ $loading?: boolean }>`
-  border: 1px solid ${theme.palette.grey[300]};
-  border-radius: 12px;
-  box-sizing: border-box;
-  padding: ${theme.spacing(4)};
-  display: flex;
-  align-items: center;
-
-  > *:first-child {
-    display: flex;
-    margin-right: ${theme.spacing(3)};
-  }
-
-  > *:last-child {
-    margin-left: auto;
-  }
-`
-
-const ButtonContainer = styled.div`
-  padding: 0 ${theme.spacing(8)};
-  margin-bottom: ${theme.spacing(20)};
-`


### PR DESCRIPTION
## Context

To prepare Partial Payment feature, I refactored this component that was very hard to read (and to maintain)

## Description

This PR essentially separate the `CreateCreditNote` page into specific components :

- `<CreditNoteItemsForm/>` :
<img width="679" alt="Capture d’écran 2025-02-07 à 12 44 13" src="https://github.com/user-attachments/assets/8ceb9ad6-6e06-4ce6-ba9a-cc01d8a32235" />


- `<CreditNoteFormCalculation/>` uses now a `<CreditNoteEstimationLine/>` component to avoid repeating ourselves :
<img width="679" alt="Capture d’écran 2025-02-07 à 12 44 38" src="https://github.com/user-attachments/assets/ae4236cb-cf6b-4e6c-9e48-be94842f4a9e" />


- `<CreditNoteActions/>` 
<img width="692" alt="Capture d’écran 2025-02-07 à 12 46 32" src="https://github.com/user-attachments/assets/8ac3d860-4464-41ba-b69d-62af76d367a2" />



It also introduces a new component called `<CreditNoteActionsLine/>` that is not used for the moment but will be in the next feature.

**Note: I didn't migrate CreditNoteActions to tailwind as the UI will change in the next feature.**