### PR TITLE
chore: unify imports and remove unused NavigationEnum

### DIFF
--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -15,8 +15,8 @@ import {
 import { VoidInvoiceDialog, VoidInvoiceDialogRef } from '~/components/invoices/VoidInvoiceDialog'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
-import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/NavigationEnum'
 import { invoiceStatusMapping, paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
+import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import {
   CUSTOMER_INVOICE_CREATE_CREDIT_NOTE_ROUTE,

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -26,8 +26,8 @@ import {
 import { VoidInvoiceDialog, VoidInvoiceDialogRef } from '~/components/invoices/VoidInvoiceDialog'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
-import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/NavigationEnum'
 import { invoiceStatusMapping, paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
+import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import {
   CUSTOMER_INVOICE_CREATE_CREDIT_NOTE_ROUTE,

--- a/src/core/constants/NavigationEnum.ts
+++ b/src/core/constants/NavigationEnum.ts
@@ -1,4 +1,0 @@
-export enum CustomerInvoiceDetailsTabsOptionsEnum {
-  overview = 'overview',
-  creditNotes = 'credit-notes',
-}

--- a/src/pages/CreateCreditNote.tsx
+++ b/src/pages/CreateCreditNote.tsx
@@ -25,7 +25,7 @@ import {
 import { ComboBoxField, TextInputField } from '~/components/form'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import { hasDefinedGQLError } from '~/core/apolloClient'
-import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/NavigationEnum'
+import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CUSTOMER_INVOICE_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'

--- a/src/pages/CreditNoteDetails.tsx
+++ b/src/pages/CreditNoteDetails.tsx
@@ -28,7 +28,7 @@ import {
   buildNetsuiteCreditNoteUrl,
   buildXeroCreditNoteUrl,
 } from '~/core/constants/externalUrls'
-import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/NavigationEnum'
+import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import formatCreditNotesItems from '~/core/formats/formatCreditNotesItems'
 import {
   composeChargeFilterDisplayName,

--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -34,8 +34,8 @@ import {
 import { VoidInvoiceDialog, VoidInvoiceDialogRef } from '~/components/invoices/VoidInvoiceDialog'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { addToast, LagoGQLError } from '~/core/apolloClient'
-import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/NavigationEnum'
 import { invoiceStatusMapping, paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
+import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import {
   CUSTOMER_CREDIT_NOTE_DETAILS_ROUTE,


### PR DESCRIPTION
Noticed `NavigationEnum` exported the exact same enum as in `tabsOptions` file.

Also `tabsOptions` contains more exported constants so it's the winner that deserved to stay in the app ⚔️ 