### PR TITLE
fix: add location when search params changes to history

### DIFF
--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -1,7 +1,6 @@
 import { ReactNode, Suspense, useEffect } from 'react'
-import { useRoutes } from 'react-router-dom'
-import { useLocation } from 'react-router-dom'
 import type { RouteObject } from 'react-router-dom'
+import { useLocation, useRoutes } from 'react-router-dom'
 
 import { Icon } from '~/components/designSystem'
 import { CustomRouteObject, routes } from '~/core/router'

--- a/src/core/apolloClient/reactiveVars/locationHistoryVar.ts
+++ b/src/core/apolloClient/reactiveVars/locationHistoryVar.ts
@@ -12,8 +12,10 @@ export const locationHistoryVar = makeVar<Location[]>([])
 
 export const addLocationToHistory = (location: Location) => {
   const current = locationHistoryVar()
+  const currentPathname = (current || [])[0]?.pathname
+  const currentSearchParams = (current || [])[0]?.search
 
-  if (location.pathname !== (current || [])[0]?.pathname) {
+  if (location.pathname !== currentPathname || location.search !== currentSearchParams) {
     locationHistoryVar([location, ...current].slice(0, MAX_HISTORY_KEPT))
   }
 }


### PR DESCRIPTION
## Context

Route wasn't added to the history when using quick filters because de pathname was the same and we didn't check for search params changes.


## Description


Fixes ISSUE-683