### PR TITLE
fix: convert date to ISO format by default

### DIFF
--- a/src/pages/CreatePayment.tsx
+++ b/src/pages/CreatePayment.tsx
@@ -63,7 +63,7 @@ gql`
   }
 `
 
-const today = DateTime.now()
+const today = DateTime.now().toISO()
 
 const CreatePayment = () => {
   const { translate } = useInternationalization()
@@ -98,7 +98,6 @@ const CreatePayment = () => {
           input: {
             ...values,
             amountCents: serializeAmount(values.amountCents, currency),
-            createdAt: values.createdAt.toISO(),
           },
         },
       })


### PR DESCRIPTION
## Context

Today date has a DateTime type whereas datepicker returns an iso format, which was causing an issue in the form

