### PR TITLE
fix: compare numbers with same precision

### DIFF
--- a/src/components/creditNote/CreditNoteFormCalculation.tsx
+++ b/src/components/creditNote/CreditNoteFormCalculation.tsx
@@ -218,7 +218,11 @@ export const CreditNoteFormCalculation = ({
               const errors: ValidationError[] = []
 
               // Check if the sum of credit and refund is different than the total tax included
-              if (credit + refund !== totalTaxIncluded) {
+              const sum = credit + refund
+              const sumPrecision = Number(sum.toFixed(currencyPrecision))
+              const totalPrecision = Number(totalTaxIncluded.toFixed(currencyPrecision))
+
+              if (sumPrecision !== totalPrecision) {
                 errors.push(
                   createError({
                     message: PayBackErrorEnum.maxTotalInvoice,


### PR DESCRIPTION
## Context

Regarding the issue we got recently with one of our customer

## Description

Before
<img width="1508" alt="Capture d’écran 2025-02-20 à 15 06 53" src="https://github.com/user-attachments/assets/30f3c682-9116-4d17-a358-6655a92d0a5b" />

After
<img width="1513" alt="Capture d’écran 2025-02-20 à 15 07 34" src="https://github.com/user-attachments/assets/9fad0fb2-93ed-4506-8349-991d7cf024c3" />
