### PR TITLE
misc: improve new analytics page skeleton

### DIFF
--- a/src/components/analytics/RevenueStreamsBreakdownSection.tsx
+++ b/src/components/analytics/RevenueStreamsBreakdownSection.tsx
@@ -1,0 +1,19 @@
+import { Typography } from '~/components/designSystem'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+const RevenueStreamsBreakdownSection = () => {
+  const { translate } = useInternationalization()
+
+  return (
+    <section>
+      <Typography className="mb-2" variant="subhead" color="grey700">
+        {translate('text_1739206045861dgu7ype5jyx')}
+      </Typography>
+      <Typography variant="caption" color="grey600">
+        {translate('text_17392060910488ax2d18o9u9')}
+      </Typography>
+    </section>
+  )
+}
+
+export default RevenueStreamsBreakdownSection

--- a/src/components/analytics/RevenueStreamsOverviewSection.tsx
+++ b/src/components/analytics/RevenueStreamsOverviewSection.tsx
@@ -1,0 +1,390 @@
+import { gql } from '@apollo/client'
+import { useState } from 'react'
+
+import { HorizontalDataTable, Typography } from '~/components/designSystem'
+import { REVENUE_STREAMS_GRAPH_COLORS } from '~/components/designSystem/graphs/const'
+import { multipleLineChartFakeData } from '~/components/designSystem/graphs/fixtures'
+import MultipleLineChart from '~/components/designSystem/graphs/MultipleLineChart'
+import { GenericPlaceholder } from '~/components/GenericPlaceholder'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { formatDateToTZ } from '~/core/timezone'
+import { CurrencyEnum, TimezoneEnum, useGetRevenueStreamsQuery } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import ErrorImage from '~/public/images/maneki/error.svg'
+import { tw } from '~/styles/utils'
+
+gql`
+  query getRevenueStreams(
+    $customerCountry: CountryCode
+    $customerCurrency: CurrencyEnum
+    $customerType: CustomerTypeEnum
+    $externalCustomerId: String
+    $externalSubscriptionId: String
+    $fromDate: ISO8601Date
+    $planCode: String
+    $timeGranularity: TimeGranularityEnum
+    $toDate: ISO8601Date
+  ) {
+    revenueStreams(
+      customerCountry: $customerCountry
+      customerCurrency: $customerCurrency
+      customerType: $customerType
+      externalCustomerId: $externalCustomerId
+      externalSubscriptionId: $externalSubscriptionId
+      fromDate: $fromDate
+      planCode: $planCode
+      timeGranularity: $timeGranularity
+      toDate: $toDate
+    ) {
+      collection {
+        commitmentFeeAmountCents
+        couponsAmountCents
+        amountCurrency
+        startOfPeriodDt
+        grossRevenueAmountCents
+        netRevenueAmountCents
+        oneOffFeeAmountCents
+        subscriptionFeeAmountCents
+        endOfPeriodDt
+        usageBasedFeeAmountCents
+      }
+    }
+  }
+`
+
+const RevenueStreamsOverviewSection = () => {
+  const { translate } = useInternationalization()
+  const [clickedDataIndex, setClickedDataIndex] = useState<number | undefined>(undefined)
+  const currency = CurrencyEnum.Usd
+  const blur = false
+
+  const {
+    data: revenueStreamsData,
+    loading: revenueStreamsLoading,
+    error: revenueStreamsError,
+  } = useGetRevenueStreamsQuery({
+    variables: {},
+    skip: blur,
+  })
+  const displayError = !!revenueStreamsError && !revenueStreamsLoading
+
+  return (
+    <section className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <Typography variant="subhead" color="grey700">
+            {translate('text_634687079be251fdb43833b7')}
+          </Typography>
+
+          {/* TODO: Period filters */}
+        </div>
+
+        {/* TODO: Filters */}
+      </div>
+
+      {displayError && (
+        <GenericPlaceholder
+          title={translate('text_636d023ce11a9d038819b579')}
+          subtitle={translate('text_636d023ce11a9d038819b57b')}
+          image={<ErrorImage width="136" height="104" />}
+        />
+      )}
+
+      <>
+        <MultipleLineChart
+          loading={revenueStreamsLoading}
+          // TODO: Add blur logic
+          blur={false}
+          currency={currency}
+          data={revenueStreamsData?.revenueStreams.collection}
+          xAxisDataKey="startOfPeriodDt"
+          setClickedDataIndex={setClickedDataIndex}
+          lines={[
+            {
+              dataKey: 'subscriptionFeeAmountCents',
+              colorHex: REVENUE_STREAMS_GRAPH_COLORS.subscriptionFeeAmountCents,
+              tooltipLabel: translate('text_1728472697691k6k2e9m5ibb'),
+            },
+            {
+              dataKey: 'usageBasedFeeAmountCents',
+              colorHex: REVENUE_STREAMS_GRAPH_COLORS.usageBasedFeeAmountCents,
+              tooltipLabel: translate('text_1725983967306cei92rkdtvb'),
+            },
+            {
+              dataKey: 'commitmentFeeAmountCents',
+              colorHex: REVENUE_STREAMS_GRAPH_COLORS.commitmentFeeAmountCents,
+              tooltipLabel: translate('text_1739270764222q8lrgvllulk'),
+            },
+            {
+              dataKey: 'oneOffFeeAmountCents',
+              colorHex: REVENUE_STREAMS_GRAPH_COLORS.oneOffFeeAmountCents,
+              tooltipLabel: translate('text_1728472697691t126b808cm9'),
+            },
+            {
+              hideOnGraph: true,
+              dataKey: 'grossRevenueAmountCents',
+              tooltipLabel: translate('text_1739869126030nbuobu5baxi'),
+            },
+            {
+              hideOnGraph: true,
+              dataKey: 'couponsAmountCents',
+              tooltipLabel: translate('text_637ccf8133d2c9a7d11ce705'),
+            },
+            {
+              hideOnGraph: true,
+              dataKey: 'netRevenueAmountCents',
+              tooltipLabel: translate('text_1739869126030kuxz0uvfj02'),
+            },
+          ]}
+        />
+
+        <HorizontalDataTable
+          leftColumnWidth={190}
+          data={blur ? multipleLineChartFakeData : revenueStreamsData?.revenueStreams.collection}
+          loading={revenueStreamsLoading}
+          clickedDataIndex={clickedDataIndex}
+          setClickedDataIndex={setClickedDataIndex}
+          rows={[
+            {
+              key: 'startOfPeriodDt',
+              type: 'header',
+              label: translate('text_1739268382272qnne2h7slna'),
+              content: (item) => (
+                <Typography variant="captionHl">
+                  {formatDateToTZ(item.startOfPeriodDt, TimezoneEnum.TzUtc, 'LLL yyyy')}
+                </Typography>
+              ),
+            },
+            {
+              key: 'subscriptionFeeAmountCents',
+              type: 'data',
+              label: (
+                <div className="flex items-center gap-2">
+                  <div
+                    className="size-3 rounded-full"
+                    style={{
+                      backgroundColor: REVENUE_STREAMS_GRAPH_COLORS.subscriptionFeeAmountCents,
+                    }}
+                  ></div>
+                  <Typography variant="bodyHl" color="grey700">
+                    {translate('text_1728472697691k6k2e9m5ibb')}
+                  </Typography>
+                </div>
+              ),
+              content: (item) => {
+                const subscriptionFeeAmountCents = Number(item.subscriptionFeeAmountCents) || 0
+
+                return (
+                  <Typography
+                    variant="body"
+                    className={tw({
+                      'text-green-600': subscriptionFeeAmountCents > 0,
+                      'text-grey-500': subscriptionFeeAmountCents === 0,
+                    })}
+                  >
+                    {intlFormatNumber(
+                      deserializeAmount(subscriptionFeeAmountCents || 0, currency),
+                      {
+                        currencyDisplay: 'symbol',
+                        currency: currency,
+                      },
+                    )}
+                  </Typography>
+                )
+              },
+            },
+            {
+              key: 'usageBasedFeeAmountCents',
+              type: 'data',
+              label: (
+                <div className="flex items-center gap-2">
+                  <div
+                    className="size-3 rounded-full"
+                    style={{
+                      backgroundColor: REVENUE_STREAMS_GRAPH_COLORS.usageBasedFeeAmountCents,
+                    }}
+                  ></div>
+                  <Typography variant="bodyHl" color="grey700">
+                    {translate('text_1725983967306cei92rkdtvb')}
+                  </Typography>
+                </div>
+              ),
+              content: (item) => {
+                const usageBasedFeeAmountCents = Number(item.usageBasedFeeAmountCents) || 0
+
+                return (
+                  <Typography
+                    variant="body"
+                    className={tw({
+                      'text-green-600': usageBasedFeeAmountCents > 0,
+                      'text-grey-500': usageBasedFeeAmountCents === 0,
+                    })}
+                  >
+                    {intlFormatNumber(deserializeAmount(usageBasedFeeAmountCents || 0, currency), {
+                      currencyDisplay: 'symbol',
+                      currency: currency,
+                    })}
+                  </Typography>
+                )
+              },
+            },
+            {
+              key: 'commitmentFeeAmountCents',
+              type: 'data',
+              label: (
+                <div className="flex items-center gap-2">
+                  <div
+                    className="size-3 rounded-full"
+                    style={{
+                      backgroundColor: REVENUE_STREAMS_GRAPH_COLORS.commitmentFeeAmountCents,
+                    }}
+                  ></div>
+                  <Typography variant="bodyHl" color="grey700">
+                    {translate('text_1739270764222q8lrgvllulk')}
+                  </Typography>
+                </div>
+              ),
+              content: (item) => {
+                const commitmentFeeAmountCents = Number(item.commitmentFeeAmountCents) || 0
+
+                return (
+                  <Typography
+                    variant="body"
+                    className={tw({
+                      'text-green-600': commitmentFeeAmountCents > 0,
+                      'text-grey-500': commitmentFeeAmountCents === 0,
+                    })}
+                  >
+                    {intlFormatNumber(deserializeAmount(commitmentFeeAmountCents || 0, currency), {
+                      currencyDisplay: 'symbol',
+                      currency: currency,
+                    })}
+                  </Typography>
+                )
+              },
+            },
+            {
+              key: 'oneOffFeeAmountCents',
+              type: 'data',
+              label: (
+                <div className="flex items-center gap-2">
+                  <div
+                    className="size-3 rounded-full"
+                    style={{
+                      backgroundColor: REVENUE_STREAMS_GRAPH_COLORS.oneOffFeeAmountCents,
+                    }}
+                  ></div>
+                  <Typography variant="bodyHl" color="grey700">
+                    {translate('text_1728472697691t126b808cm9')}
+                  </Typography>
+                </div>
+              ),
+              content: (item) => {
+                const oneOffFeeAmountCents = Number(item.oneOffFeeAmountCents) || 0
+
+                return (
+                  <Typography
+                    variant="body"
+                    className={tw({
+                      'text-green-600': oneOffFeeAmountCents > 0,
+                      'text-grey-500': oneOffFeeAmountCents === 0,
+                    })}
+                  >
+                    {intlFormatNumber(deserializeAmount(oneOffFeeAmountCents || 0, currency), {
+                      currencyDisplay: 'symbol',
+                      currency: currency,
+                    })}
+                  </Typography>
+                )
+              },
+            },
+            {
+              key: 'grossRevenueAmountCents',
+              type: 'data',
+              label: (
+                <Typography variant="bodyHl" color="grey700">
+                  {translate('text_1739869126030nbuobu5baxi')}
+                </Typography>
+              ),
+              content: (item) => {
+                const grossRevenueAmountCents = Number(item.grossRevenueAmountCents) || 0
+
+                return (
+                  <Typography
+                    variant="body"
+                    className={tw({
+                      'text-grey-700': grossRevenueAmountCents > 0,
+                      'text-grey-500': grossRevenueAmountCents === 0,
+                    })}
+                  >
+                    {intlFormatNumber(deserializeAmount(grossRevenueAmountCents || 0, currency), {
+                      currencyDisplay: 'symbol',
+                      currency: currency,
+                    })}
+                  </Typography>
+                )
+              },
+            },
+            {
+              key: 'couponsAmountCents',
+              type: 'data',
+              label: (
+                <Typography variant="bodyHl" color="grey700">
+                  {translate('text_637ccf8133d2c9a7d11ce705')}
+                </Typography>
+              ),
+              content: (item) => {
+                const couponsAmountCents = Number(item.couponsAmountCents) || 0
+
+                return (
+                  <Typography
+                    variant="body"
+                    className={tw({
+                      'text-red-600': couponsAmountCents > 0,
+                      'text-grey-500': couponsAmountCents === 0,
+                    })}
+                  >
+                    {intlFormatNumber(deserializeAmount(couponsAmountCents || 0, currency), {
+                      currencyDisplay: 'symbol',
+                      currency: currency,
+                    })}
+                  </Typography>
+                )
+              },
+            },
+            {
+              key: 'netRevenueAmountCents',
+              type: 'data',
+              label: (
+                <Typography variant="bodyHl" color="grey700">
+                  {translate('text_1739869126030kuxz0uvfj02')}
+                </Typography>
+              ),
+              content: (item) => {
+                const netRevenueAmountCents = Number(item.netRevenueAmountCents) || 0
+
+                return (
+                  <Typography
+                    variant="body"
+                    className={tw({
+                      'text-grey-700': netRevenueAmountCents > 0,
+                      'text-grey-500': netRevenueAmountCents === 0,
+                    })}
+                  >
+                    {intlFormatNumber(deserializeAmount(netRevenueAmountCents || 0, currency), {
+                      currencyDisplay: 'symbol',
+                      currency: currency,
+                    })}
+                  </Typography>
+                )
+              },
+            },
+          ]}
+        />
+      </>
+    </section>
+  )
+}
+
+export default RevenueStreamsOverviewSection

--- a/src/components/layouts/FullscreenPage.tsx
+++ b/src/components/layouts/FullscreenPage.tsx
@@ -1,0 +1,9 @@
+import { FC, PropsWithChildren } from 'react'
+
+const Wrapper: FC<PropsWithChildren> = ({ children }) => {
+  return <div className="flex w-full flex-col gap-12 px-4 py-12 md:p-12">{children}</div>
+}
+
+export const FullscreenPage = {
+  Wrapper,
+}

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -6601,6 +6601,21 @@ export type DeleteAddOnMutationVariables = Exact<{
 
 export type DeleteAddOnMutation = { __typename?: 'Mutation', destroyAddOn?: { __typename?: 'DestroyAddOnPayload', id?: string | null } | null };
 
+export type GetRevenueStreamsQueryVariables = Exact<{
+  customerCountry?: InputMaybe<CountryCode>;
+  customerCurrency?: InputMaybe<CurrencyEnum>;
+  customerType?: InputMaybe<CustomerTypeEnum>;
+  externalCustomerId?: InputMaybe<Scalars['String']['input']>;
+  externalSubscriptionId?: InputMaybe<Scalars['String']['input']>;
+  fromDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
+  planCode?: InputMaybe<Scalars['String']['input']>;
+  timeGranularity?: InputMaybe<TimeGranularityEnum>;
+  toDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
+}>;
+
+
+export type GetRevenueStreamsQuery = { __typename?: 'Query', revenueStreams: { __typename?: 'RevenueStreamsCollection', collection: Array<{ __typename?: 'RevenueStreams', commitmentFeeAmountCents: any, couponsAmountCents: any, amountCurrency: CurrencyEnum, startOfPeriodDt: any, grossRevenueAmountCents: any, netRevenueAmountCents: any, oneOffFeeAmountCents: any, subscriptionFeeAmountCents: any, endOfPeriodDt: any, usageBasedFeeAmountCents: any }> } };
+
 export type GetGoogleAuthUrlQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -12859,6 +12874,75 @@ export function useDeleteAddOnMutation(baseOptions?: Apollo.MutationHookOptions<
 export type DeleteAddOnMutationHookResult = ReturnType<typeof useDeleteAddOnMutation>;
 export type DeleteAddOnMutationResult = Apollo.MutationResult<DeleteAddOnMutation>;
 export type DeleteAddOnMutationOptions = Apollo.BaseMutationOptions<DeleteAddOnMutation, DeleteAddOnMutationVariables>;
+export const GetRevenueStreamsDocument = gql`
+    query getRevenueStreams($customerCountry: CountryCode, $customerCurrency: CurrencyEnum, $customerType: CustomerTypeEnum, $externalCustomerId: String, $externalSubscriptionId: String, $fromDate: ISO8601Date, $planCode: String, $timeGranularity: TimeGranularityEnum, $toDate: ISO8601Date) {
+  revenueStreams(
+    customerCountry: $customerCountry
+    customerCurrency: $customerCurrency
+    customerType: $customerType
+    externalCustomerId: $externalCustomerId
+    externalSubscriptionId: $externalSubscriptionId
+    fromDate: $fromDate
+    planCode: $planCode
+    timeGranularity: $timeGranularity
+    toDate: $toDate
+  ) {
+    collection {
+      commitmentFeeAmountCents
+      couponsAmountCents
+      amountCurrency
+      startOfPeriodDt
+      grossRevenueAmountCents
+      netRevenueAmountCents
+      oneOffFeeAmountCents
+      subscriptionFeeAmountCents
+      endOfPeriodDt
+      usageBasedFeeAmountCents
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetRevenueStreamsQuery__
+ *
+ * To run a query within a React component, call `useGetRevenueStreamsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetRevenueStreamsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetRevenueStreamsQuery({
+ *   variables: {
+ *      customerCountry: // value for 'customerCountry'
+ *      customerCurrency: // value for 'customerCurrency'
+ *      customerType: // value for 'customerType'
+ *      externalCustomerId: // value for 'externalCustomerId'
+ *      externalSubscriptionId: // value for 'externalSubscriptionId'
+ *      fromDate: // value for 'fromDate'
+ *      planCode: // value for 'planCode'
+ *      timeGranularity: // value for 'timeGranularity'
+ *      toDate: // value for 'toDate'
+ *   },
+ * });
+ */
+export function useGetRevenueStreamsQuery(baseOptions?: Apollo.QueryHookOptions<GetRevenueStreamsQuery, GetRevenueStreamsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetRevenueStreamsQuery, GetRevenueStreamsQueryVariables>(GetRevenueStreamsDocument, options);
+      }
+export function useGetRevenueStreamsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetRevenueStreamsQuery, GetRevenueStreamsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetRevenueStreamsQuery, GetRevenueStreamsQueryVariables>(GetRevenueStreamsDocument, options);
+        }
+export function useGetRevenueStreamsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetRevenueStreamsQuery, GetRevenueStreamsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetRevenueStreamsQuery, GetRevenueStreamsQueryVariables>(GetRevenueStreamsDocument, options);
+        }
+export type GetRevenueStreamsQueryHookResult = ReturnType<typeof useGetRevenueStreamsQuery>;
+export type GetRevenueStreamsLazyQueryHookResult = ReturnType<typeof useGetRevenueStreamsLazyQuery>;
+export type GetRevenueStreamsSuspenseQueryHookResult = ReturnType<typeof useGetRevenueStreamsSuspenseQuery>;
+export type GetRevenueStreamsQueryResult = Apollo.QueryResult<GetRevenueStreamsQuery, GetRevenueStreamsQueryVariables>;
 export const GetGoogleAuthUrlDocument = gql`
     query getGoogleAuthUrl {
   googleAuthUrl {

--- a/src/pages/analytics/NewAnalytics.tsx
+++ b/src/pages/analytics/NewAnalytics.tsx
@@ -1,4 +1,4 @@
-import { generatePath, Outlet } from 'react-router-dom'
+import { generatePath } from 'react-router-dom'
 
 import { NavigationTab, Typography } from '~/components/designSystem'
 import { NewAnalyticsTabsOptionsEnum } from '~/core/constants/tabsOptions'

--- a/src/pages/analytics/NewAnalytics.tsx
+++ b/src/pages/analytics/NewAnalytics.tsx
@@ -23,9 +23,10 @@ const NewAnalytics = () => {
       </PageHeader.Wrapper>
 
       <NavigationTab
+        className="px-4 md:px-12"
         tabs={[
           {
-            title: translate('text_62d175066d2dbf1d50bc937c'),
+            title: translate('text_1739203651003n5f5qzxnhin'),
             link: generatePath(NEW_ANALYTIC_TABS_ROUTE, {
               tab: NewAnalyticsTabsOptionsEnum.revenueStreams,
             }),
@@ -67,8 +68,6 @@ const NewAnalytics = () => {
           },
         ]}
       />
-
-      <Outlet />
     </>
   )
 }

--- a/src/pages/analytics/RevenueStreams.tsx
+++ b/src/pages/analytics/RevenueStreams.tsx
@@ -1,5 +1,26 @@
+import RevenueStreamsBreakdownSection from '~/components/analytics/RevenueStreamsBreakdownSection'
+import RevenueStreamsOverviewSection from '~/components/analytics/RevenueStreamsOverviewSection'
+import { Icon, Tooltip, Typography } from '~/components/designSystem'
+import { FullscreenPage } from '~/components/layouts/FullscreenPage'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
 const RevenueStreams = () => {
-  return <>Revenue Streams content</>
+  const { translate } = useInternationalization()
+
+  return (
+    <FullscreenPage.Wrapper>
+      <Typography className="flex items-center gap-2" variant="headline" color="grey700">
+        {translate('text_1739203651003n5f5qzxnhin')}
+        <Tooltip placement="top-start" title={translate('text_1739204265494pq9zoax7hb0')}>
+          <Icon name="info-circle" />
+        </Tooltip>
+      </Typography>
+
+      <RevenueStreamsOverviewSection />
+
+      <RevenueStreamsBreakdownSection />
+    </FullscreenPage.Wrapper>
+  )
 }
 
 export default RevenueStreams

--- a/translations/base.json
+++ b/translations/base.json
@@ -2860,5 +2860,13 @@
   "text_1739289860782ljvy21lcake": "Set metadata",
   "text_1739870196554qh3i1j3twdo": "Create your first customer and mark them as a partner.",
   "text_1739870196554eghdpihly57": "A partner is an entity that sells your products or services. Lago will issue invoices to you on their behalf—an ideal setup for revenue sharing.",
-  "text_17394287699017cunbdlhnhf": "Crypto (Stablecoins)"
+  "text_17394287699017cunbdlhnhf": "Crypto (Stablecoins)",
+  "text_1739203651003n5f5qzxnhin": "Revenue streams",
+  "text_1739204265494pq9zoax7hb0": "Total monthly income, covering all financial aspects including taxes. Coupons are added to the gross revenue but removed from the net.",
+  "text_1739206045861dgu7ype5jyx": "Breakdown by plan or customer",
+  "text_17392060910488ax2d18o9u9": "Plans or customers with no relevant results are hidden",
+  "text_1739268382272qnne2h7slna": "Breakout",
+  "text_1739270764222q8lrgvllulk": "Commitment",
+  "text_1739869126030nbuobu5baxi": "Total (Gross)",
+  "text_1739869126030kuxz0uvfj02": "Total (Net)"
 }


### PR DESCRIPTION
## Context

We're building a new analytics page.
Goal is to slowly implement those pages without letting users access it.
Those will be part of the build and available on prod if you modify url tho. We decided not to worry about that during development phase.

## Description

This PR implements the revenue streams overview part, without the filters.
Later I will add a PR to add filters and the breakdown part of the page

I prefer to merge this before going further into complexity. I think it contain a good chunk of functionality and code that work well together.