### PR TITLE
misc: revenue streams UX improvements

### DIFF
--- a/src/components/analytics/RevenueStreamsOverviewSection.tsx
+++ b/src/components/analytics/RevenueStreamsOverviewSection.tsx
@@ -72,6 +72,7 @@ const RevenueStreamsOverviewSection = () => {
   const { translate } = useInternationalization()
   const { organization } = useOrganizationInfos()
   const [clickedDataIndex, setClickedDataIndex] = useState<number | undefined>(undefined)
+  const [hoverDataIndex, setHoverDataIndex] = useState<number | undefined>(undefined)
 
   const currency = organization?.defaultCurrency || CurrencyEnum.Usd
 
@@ -202,6 +203,8 @@ const RevenueStreamsOverviewSection = () => {
             data={revenueStreamsData?.dataApiRevenueStreams.collection}
             xAxisDataKey="startOfPeriodDt"
             setClickedDataIndex={setClickedDataIndex}
+            hoveredDataIndex={hoverDataIndex}
+            setHoverDataIndex={setHoverDataIndex}
             lines={[
               {
                 dataKey: 'subscriptionFeeAmountCents',
@@ -247,6 +250,7 @@ const RevenueStreamsOverviewSection = () => {
             loading={revenueStreamsLoading}
             clickedDataIndex={clickedDataIndex}
             setClickedDataIndex={setClickedDataIndex}
+            setHoveredDataIndex={setHoverDataIndex}
             rows={[
               {
                 key: 'startOfPeriodDt',

--- a/src/components/designSystem/Table/HorizontalDataTable.tsx
+++ b/src/components/designSystem/Table/HorizontalDataTable.tsx
@@ -42,6 +42,7 @@ type HorizontalDataTableProps<T> = {
   leftColumnWidth?: number
   loading?: boolean
   setClickedDataIndex?: Dispatch<SetStateAction<number | undefined>>
+  setHoveredDataIndex?: Dispatch<SetStateAction<number | undefined>>
 }
 
 const getRowHeight = (rowType: RowType) => {
@@ -59,6 +60,7 @@ export const HorizontalDataTable = <T extends DataItem>({
   loading,
   rows,
   setClickedDataIndex,
+  setHoveredDataIndex,
 }: HorizontalDataTableProps<T>) => {
   const parentRef = useRef(null)
 
@@ -164,6 +166,20 @@ export const HorizontalDataTable = <T extends DataItem>({
                 width: `${virtualColumn.size}px`,
                 left: `${virtualColumn.start}px`,
               }}
+              onMouseEnter={
+                !loading && !!setHoveredDataIndex
+                  ? () => {
+                      setHoveredDataIndex(virtualColumn.index)
+                    }
+                  : undefined
+              }
+              onMouseLeave={
+                !loading && !!setHoveredDataIndex
+                  ? () => {
+                      setHoveredDataIndex(undefined)
+                    }
+                  : undefined
+              }
             >
               {rows.map((row, index) => {
                 return (

--- a/src/components/designSystem/graphs/MultipleLineChart.tsx
+++ b/src/components/designSystem/graphs/MultipleLineChart.tsx
@@ -367,11 +367,11 @@ const MultipleLineChart = <T extends DataItem>({
               defaultIndex={localHoverDataIndex}
               active={typeof localHoverDataIndex === 'number'}
               includeHidden={true}
-              isAnimationActive={false}
               cursor={{
                 stroke: `${theme.palette.grey[500]}`,
                 strokeDasharray: '2 2',
               }}
+              offset={0}
               position={{ y: yTooltipPosition }}
               content={({ active, payload, includeHidden }) => (
                 <div className="min-w-90 rounded-xl bg-grey-700 px-4 py-3">


### PR DESCRIPTION
## Context

We're building the new version of analytics on a page non-accessible by customers. Pushing update as they are built as they are not user-facing yet.

## Description

This PR improves look and feel for the revenue streams graph.
1. You can now see the tooltip when hovering an element in the table bellow.
2. The tooltip animation is restored and it's position now stick with the bar cursor