### PR TITLE
fix(text): updating stripe connection button

### DIFF
--- a/translations/base.json
+++ b/translations/base.json
@@ -1822,7 +1822,7 @@
   "text_62b1edddbf5f461ab971270d": "Connected",
   "text_62b1edddbf5f461ab971271f": "Payment provider",
   "text_62b1edddbf5f461ab9712787": "Edit",
-  "text_62b1edddbf5f461ab9712769": "Edit API secret key",
+  "text_62b1edddbf5f461ab9712769": "Edit Stripe connection",
   "text_62b1edddbf5f461ab97126f6": "Stripe connection successfully edited",
   "text_62b1edddbf5f461ab9712758": "Stripe connection successfully deleted",
   "text_62b328ead9a4caef81cd9ca0": "Payment provider customer ID",


### PR DESCRIPTION
## Description

I was working on the stripe integration and found some dead code about updating stripe secret keys. I went to the frontend to confirm you couldn't update the key and I realized the button label was probably left from before.
the key is the only thing we can't update ^^

https://github.com/getlago/lago-api/pull/3300/files/f513ce745949c87fa7c31aaa2af185d2249ae42a#diff-0bfe4ac658f027888fa85c15375149c307d2ef0efa389f2527c9070be8970a48

![CleanShot 2025-03-06 at 09 54 48@2x](https://github.com/user-attachments/assets/1c5b7f76-7e5d-44da-ade9-e3b61c0cf31e)

![CleanShot 2025-03-06 at 10 29 48@2x](https://github.com/user-attachments/assets/2ae7ebd8-e666-43e8-9175-cad61750a220)
