### PR TITLE
misc: improve analytics perf and handle premium filters

### DIFF
--- a/src/components/analytics/RevenueStreamsStateContext.tsx
+++ b/src/components/analytics/RevenueStreamsStateContext.tsx
@@ -1,0 +1,60 @@
+import { createContext, ReactNode, useCallback, useContext, useRef, useState } from 'react'
+
+interface RevenueStreamsStateContextValue {
+  hoverDataIndex: number | undefined
+  clickedDataIndex: number | undefined
+  setHoverDataIndex: (index: number | undefined) => void
+  setClickedDataIndex: (index: number | undefined) => void
+}
+
+const MIN_UPDATE_INTERVAL = 1000 / 60 // Cap at 60fps
+
+const RevenueStreamsStateContext = createContext<RevenueStreamsStateContextValue | undefined>(
+  undefined,
+)
+
+export const RevenueStreamsStateProvider = ({ children }: { children: ReactNode }) => {
+  const [hoverDataIndex, setHoverDataIndexState] = useState<number | undefined>(undefined)
+  const [clickedDataIndex, setClickedDataIndexState] = useState<number | undefined>(undefined)
+
+  const prevHoverIndex = useRef<number | undefined>(undefined)
+  const lastUpdateTime = useRef<number>(0)
+
+  // Optimized setter for hover state to prevent too many updates
+  const setHoverDataIndex = useCallback((index: number | undefined) => {
+    const now = performance.now()
+
+    if (index !== prevHoverIndex.current && now - lastUpdateTime.current >= MIN_UPDATE_INTERVAL) {
+      prevHoverIndex.current = index
+      lastUpdateTime.current = now
+      setHoverDataIndexState(index)
+    }
+  }, [])
+
+  const setClickedDataIndex = useCallback((index: number | undefined) => {
+    setClickedDataIndexState(index)
+  }, [])
+
+  const value = {
+    hoverDataIndex,
+    clickedDataIndex,
+    setHoverDataIndex,
+    setClickedDataIndex,
+  }
+
+  return (
+    <RevenueStreamsStateContext.Provider value={value}>
+      {children}
+    </RevenueStreamsStateContext.Provider>
+  )
+}
+
+export const useRevenueStreamsState = (): RevenueStreamsStateContextValue => {
+  const context = useContext(RevenueStreamsStateContext)
+
+  if (!context) {
+    throw new Error('useRevenueStreamsState must be used within a RevenueStreamsStateProvider')
+  }
+
+  return context
+}

--- a/src/components/analytics/__tests__/utils.test.ts
+++ b/src/components/analytics/__tests__/utils.test.ts
@@ -1,0 +1,231 @@
+import { AvailableFiltersEnum } from '~/components/designSystem/Filters'
+import { REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX } from '~/core/constants/filters'
+import {
+  RevenueStreamDataForOverviewSectionFragment,
+  TimeGranularityEnum,
+} from '~/generated/graphql'
+
+import { formatRevenueStreamsData } from '../utils'
+
+jest.mock('~/components/designSystem/Filters', () => ({
+  AvailableFiltersEnum: {
+    date: 'date',
+    timeGranularity: 'timeGranularity',
+  },
+  getFilterValue: jest.fn().mockImplementation(({ key, searchParams, prefix }) => {
+    const paramKey = `${prefix}${key}`
+
+    return searchParams.get(paramKey)
+  }),
+}))
+
+describe('formatRevenueStreamsData', () => {
+  const defaultStaticDatePeriod = '2023-01-01,2023-12-31'
+  const defaultStaticTimeGranularity = TimeGranularityEnum.Daily
+  const mockData: RevenueStreamDataForOverviewSectionFragment[] = [
+    {
+      startOfPeriodDt: '2023-01-01',
+      endOfPeriodDt: '2023-01-01',
+      commitmentFeeAmountCents: 100,
+      couponsAmountCents: 50,
+      grossRevenueAmountCents: 1000,
+      netRevenueAmountCents: 950,
+      oneOffFeeAmountCents: 200,
+      subscriptionFeeAmountCents: 300,
+      usageBasedFeeAmountCents: 400,
+    },
+    {
+      startOfPeriodDt: '2023-01-15',
+      endOfPeriodDt: '2023-01-15',
+      commitmentFeeAmountCents: 150,
+      couponsAmountCents: 75,
+      grossRevenueAmountCents: 1500,
+      netRevenueAmountCents: 1425,
+      oneOffFeeAmountCents: 300,
+      subscriptionFeeAmountCents: 450,
+      usageBasedFeeAmountCents: 600,
+    },
+    {
+      startOfPeriodDt: '2023-12-31',
+      endOfPeriodDt: '2023-12-31',
+      commitmentFeeAmountCents: 500,
+      couponsAmountCents: 100,
+      grossRevenueAmountCents: 5000,
+      netRevenueAmountCents: 4900,
+      oneOffFeeAmountCents: 1000,
+      subscriptionFeeAmountCents: 2000,
+      usageBasedFeeAmountCents: 2000,
+    },
+  ]
+
+  it('should use values from search params when available', () => {
+    const searchParams = new URLSearchParams()
+
+    searchParams.set(
+      `${REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX}${AvailableFiltersEnum.date}`,
+      '2023-02-01,2023-02-28',
+    )
+    searchParams.set(
+      `${REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX}${AvailableFiltersEnum.timeGranularity}`,
+      TimeGranularityEnum.Weekly,
+    )
+
+    const result = formatRevenueStreamsData({
+      data: mockData,
+      searchParams,
+      defaultStaticDatePeriod,
+      defaultStaticTimeGranularity,
+    })
+
+    // Should generate 5 weeks for February (including partial weeks at month boundaries)
+    expect(result.length).toBe(5)
+    expect(result[0].startOfPeriodDt).toBe('2023-01-30')
+    expect(result[3].startOfPeriodDt).toBe('2023-02-20')
+  })
+
+  it('should use default values when search params are not available', () => {
+    const searchParams = new URLSearchParams()
+
+    const result = formatRevenueStreamsData({
+      data: mockData,
+      searchParams,
+      defaultStaticDatePeriod,
+      defaultStaticTimeGranularity,
+    })
+
+    // Should generate 365 days for the full year
+    expect(result.length).toBe(365)
+    expect(result[0].startOfPeriodDt).toBe('2023-01-01')
+    expect(result[364].startOfPeriodDt).toBe('2023-12-31')
+
+    // Check that the January 1st data matches the mock
+    expect(result[0].grossRevenueAmountCents).toBe(1000)
+    expect(result[0].netRevenueAmountCents).toBe(950)
+
+    // Check that January 15th data matches the mock
+    expect(result[14].grossRevenueAmountCents).toBe(1500)
+    expect(result[14].netRevenueAmountCents).toBe(1425)
+
+    // Check that some random days in the middle have zero values
+    expect(result[100].grossRevenueAmountCents).toBe(0)
+    expect(result[200].grossRevenueAmountCents).toBe(0)
+    expect(result[300].grossRevenueAmountCents).toBe(0)
+
+    // Check that December 31st data matches the mock
+    expect(result[364].grossRevenueAmountCents).toBe(5000)
+    expect(result[364].netRevenueAmountCents).toBe(4900)
+    expect(result[364].subscriptionFeeAmountCents).toBe(2000)
+    expect(result[364].usageBasedFeeAmountCents).toBe(2000)
+  })
+
+  it('should pad missing data points with zero values', () => {
+    const searchParams = new URLSearchParams()
+
+    searchParams.set(
+      `${REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX}${AvailableFiltersEnum.date}`,
+      '2023-01-01,2023-01-05',
+    )
+
+    const result = formatRevenueStreamsData({
+      data: mockData,
+      searchParams,
+      defaultStaticDatePeriod,
+      defaultStaticTimeGranularity,
+    })
+
+    // Should generate 5 days
+    expect(result.length).toBe(5)
+
+    // Day that has data should keep original values
+    expect(result[0].startOfPeriodDt).toBe('2023-01-01')
+    expect(result[0].grossRevenueAmountCents).toBe(1000)
+
+    // Day that has no data should have zero values
+    expect(result[1].startOfPeriodDt).toBe('2023-01-02')
+    expect(result[1].grossRevenueAmountCents).toBe(0)
+    expect(result[1].netRevenueAmountCents).toBe(0)
+    expect(result[1].subscriptionFeeAmountCents).toBe(0)
+  })
+
+  it('should correctly handle daily granularity', () => {
+    const searchParams = new URLSearchParams()
+
+    searchParams.set(
+      `${REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX}${AvailableFiltersEnum.date}`,
+      '2023-01-01,2023-01-03',
+    )
+    searchParams.set(
+      `${REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX}${AvailableFiltersEnum.timeGranularity}`,
+      TimeGranularityEnum.Daily,
+    )
+
+    const result = formatRevenueStreamsData({
+      data: mockData,
+      searchParams,
+      defaultStaticDatePeriod,
+      defaultStaticTimeGranularity,
+    })
+
+    expect(result.length).toBe(3)
+    expect(result[0].startOfPeriodDt).toBe('2023-01-01')
+    expect(result[1].startOfPeriodDt).toBe('2023-01-02')
+    expect(result[2].startOfPeriodDt).toBe('2023-01-03')
+  })
+
+  it('should correctly handle weekly granularity', () => {
+    const searchParams = new URLSearchParams()
+
+    searchParams.set(
+      `${REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX}${AvailableFiltersEnum.date}`,
+      '2023-01-01,2023-01-21',
+    )
+    searchParams.set(
+      `${REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX}${AvailableFiltersEnum.timeGranularity}`,
+      TimeGranularityEnum.Weekly,
+    )
+
+    const result = formatRevenueStreamsData({
+      data: mockData,
+      searchParams,
+      defaultStaticDatePeriod,
+      defaultStaticTimeGranularity,
+    })
+
+    // Should create 4 weeks (including partial week at end)
+    expect(result.length).toBe(4)
+    expect(result[0].startOfPeriodDt).toBe('2022-12-26')
+    expect(result[1].startOfPeriodDt).toBe('2023-01-02')
+    expect(result[2].startOfPeriodDt).toBe('2023-01-09')
+    expect(result[3].startOfPeriodDt).toBe('2023-01-16')
+
+    // Check end dates (note: exact end dates depend on implementation details of the utility)
+    expect(result[0].endOfPeriodDt).toBe('2023-01-01')
+    expect(result[1].endOfPeriodDt).toBe('2023-01-08')
+  })
+
+  it('should correctly handle monthly granularity', () => {
+    const searchParams = new URLSearchParams()
+
+    searchParams.set(
+      `${REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX}${AvailableFiltersEnum.date}`,
+      '2023-01-01,2023-03-31',
+    )
+    searchParams.set(
+      `${REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX}${AvailableFiltersEnum.timeGranularity}`,
+      TimeGranularityEnum.Monthly,
+    )
+
+    const result = formatRevenueStreamsData({
+      data: mockData,
+      searchParams,
+      defaultStaticDatePeriod,
+      defaultStaticTimeGranularity,
+    })
+
+    // Should create 3 months
+    expect(result.length).toBe(3)
+    expect(result[0].startOfPeriodDt).toBe('2023-01-01')
+    expect(result[1].startOfPeriodDt).toBe('2023-02-01')
+    expect(result[2].startOfPeriodDt).toBe('2023-03-01')
+  })
+})

--- a/src/components/analytics/useRevenueAnalyticsOverview.ts
+++ b/src/components/analytics/useRevenueAnalyticsOverview.ts
@@ -103,6 +103,7 @@ export const useRevenueAnalyticsOverview = (): RevenueAnalyticsOverviewReturn =>
   const filtersForRevenueStreamsQuery = useMemo(() => {
     if (!hasAccessToRevenueAnalyticsFeature) {
       return {
+        currency: organization?.defaultCurrency || CurrencyEnum.Usd,
         date: getDefaultStaticDateFilter(),
         timeGranularity: getDefaultStaticTimeGranularityFilter(),
       }
@@ -111,9 +112,10 @@ export const useRevenueAnalyticsOverview = (): RevenueAnalyticsOverviewReturn =>
     return formatFiltersForRevenueStreamsQuery(searchParams)
   }, [
     hasAccessToRevenueAnalyticsFeature,
+    searchParams,
+    organization?.defaultCurrency,
     getDefaultStaticDateFilter,
     getDefaultStaticTimeGranularityFilter,
-    searchParams,
   ])
 
   const {

--- a/src/components/analytics/useRevenueAnalyticsOverview.ts
+++ b/src/components/analytics/useRevenueAnalyticsOverview.ts
@@ -56,6 +56,7 @@ gql`
 type RevenueAnalyticsOverviewReturn = {
   currency: CurrencyEnum
   data: RevenueStreamDataForOverviewSectionFragment[]
+  hasAccessToRevenueAnalyticsFeature: boolean
   hasError: boolean
   isLoading: boolean
   lastNetRevenueAmountCents: string
@@ -184,6 +185,7 @@ export const useRevenueAnalyticsOverview = (): RevenueAnalyticsOverviewReturn =>
 
   return {
     currency,
+    hasAccessToRevenueAnalyticsFeature,
     lastNetRevenueAmountCents,
     netRevenueAmountCentsProgressionOnPeriod,
     timeGranularity,

--- a/src/components/designSystem/Filters/FiltersPanelPopper.tsx
+++ b/src/components/designSystem/Filters/FiltersPanelPopper.tsx
@@ -14,8 +14,13 @@ import { useFilters } from './useFilters'
 
 export const FiltersPanelPopper = () => {
   const { translate } = useInternationalization()
-  const { availableFilters, initialFiltersFormValues, staticFiltersFormValues, applyFilters } =
-    useFilters()
+  const {
+    availableFilters,
+    initialFiltersFormValues,
+    staticFiltersFormValues,
+    applyFilters,
+    buttonOpener,
+  } = useFilters()
 
   const listContainerElementRef = useRef<HTMLDivElement>(null)
 
@@ -77,9 +82,11 @@ export const FiltersPanelPopper = () => {
     <Popper
       PopperProps={{ placement: 'bottom-start' }}
       opener={
-        <Button startIcon="filter" size="small" variant="quaternary">
-          {translate('text_66ab42d4ece7e6b7078993ad')}
-        </Button>
+        buttonOpener || (
+          <Button startIcon="filter" size="small" variant="quaternary">
+            {translate('text_66ab42d4ece7e6b7078993ad')}
+          </Button>
+        )
       }
     >
       {({ closePopper }) => (

--- a/src/components/designSystem/Filters/context.tsx
+++ b/src/components/designSystem/Filters/context.tsx
@@ -1,6 +1,8 @@
 import { createContext, FC, PropsWithChildren, useContext, useEffect } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
+import { PopperProps } from '~/components/designSystem'
+
 import { AvailableFiltersEnum, AvailableQuickFilters } from './types'
 
 interface FilterContextType {
@@ -9,6 +11,7 @@ interface FilterContextType {
   staticFilters?: Partial<Record<AvailableFiltersEnum, string>>
   staticQuickFilters?: Partial<Record<AvailableQuickFilters, string>>
   filtersNamePrefix: string
+  buttonOpener?: PopperProps['opener']
 }
 
 export const FilterContext = createContext<FilterContextType | undefined>(undefined)

--- a/src/components/designSystem/Popper.tsx
+++ b/src/components/designSystem/Popper.tsx
@@ -17,9 +17,11 @@ import {
 
 import { tw } from '~/styles/utils'
 
-interface PopperProps {
+export interface PopperProps {
   className?: string
-  opener?: ReactElement | (({ isOpen }: { isOpen: boolean }) => ReactElement)
+  opener?:
+    | ReactElement
+    | (({ isOpen, onClick }: { isOpen: boolean; onClick: () => void }) => ReactElement)
   maxHeight?: number | string
   minWidth?: number
   PopperProps?: Pick<MUIPopperProps, 'placement' | 'modifiers' | 'disablePortal'>
@@ -86,12 +88,15 @@ export const Popper = forwardRef<PopperRef, PopperProps>(
       <ClickAwayListener onClickAway={onClickAwayProxy}>
         <div className={tw(className)}>
           {typeof opener === 'function'
-            ? cloneElement(opener({ isOpen }), {
+            ? cloneElement(opener({ isOpen, onClick: toggle }), {
                 onClick: (e: MouseEvent<HTMLDivElement>) => {
-                  const element = opener({ isOpen })
+                  const element = opener({ isOpen, onClick: toggle })
 
                   element?.props?.onClick && element.props.onClick(e)
-                  toggle()
+                  // Only toggle if the event wasn't prevented
+                  if (!e.isPropagationStopped()) {
+                    toggle()
+                  }
                 },
                 ref: openerRef,
               })

--- a/src/pages/analytics/RevenueStreams.tsx
+++ b/src/pages/analytics/RevenueStreams.tsx
@@ -1,11 +1,15 @@
+import { useRef } from 'react'
+
 import RevenueStreamsBreakdownSection from '~/components/analytics/RevenueStreamsBreakdownSection'
 import RevenueStreamsOverviewSection from '~/components/analytics/RevenueStreamsOverviewSection'
 import { Icon, Tooltip, Typography } from '~/components/designSystem'
 import { FullscreenPage } from '~/components/layouts/FullscreenPage'
+import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 const RevenueStreams = () => {
   const { translate } = useInternationalization()
+  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
 
   return (
     <FullscreenPage.Wrapper>
@@ -16,9 +20,11 @@ const RevenueStreams = () => {
         </Tooltip>
       </Typography>
 
-      <RevenueStreamsOverviewSection />
+      <RevenueStreamsOverviewSection premiumWarningDialogRef={premiumWarningDialogRef} />
 
       <RevenueStreamsBreakdownSection />
+
+      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </FullscreenPage.Wrapper>
   )
 }


### PR DESCRIPTION
## Context

We're building the new version of analytics on a page non-accessible by customers. Pushing update as they are built as they are not user-facing yet.

## Description

This PR brings 2 changes
- Better performances on the graph hover. Allowing better experience on larger dataset
- Update the Popper to allow passing a custom opener

Also add some tests

Better review commit by commit