### PR TITLE
misc(invoice-details): allow 6 max fractional digits on units

### DIFF
--- a/src/components/invoices/details/InvoiceDetailsTableBodyLine.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableBodyLine.tsx
@@ -231,7 +231,10 @@ export const InvoiceDetailsTableBodyLine = memo(
             <>
               <td>
                 <Typography variant="body" color="grey700">
-                  {fee?.units || 0}
+                  {intlFormatNumber(fee?.units || 0, {
+                    style: 'decimal',
+                    maximumFractionDigits: 6,
+                  })}
                 </Typography>
               </td>
               {canHaveUnitPrice && (


### PR DESCRIPTION
We changed this rule on the PDF hence reflecting it here.

The units sent on events can be huge, and we are making them more "digest" visually.


Fixes ISSUE-679