### PR TITLE
misc(revenue-streams) ensure reset filters restores default currency

### DIFF
--- a/src/components/analytics/RevenueStreamsOverviewSection.tsx
+++ b/src/components/analytics/RevenueStreamsOverviewSection.tsx
@@ -43,7 +43,8 @@ const RevenueStreamsOverviewSection = ({
 }: RevenueStreamsOverviewSectionProps) => {
   const { translate } = useInternationalization()
   const {
-    currency,
+    selectedCurrency,
+    defaultCurrency,
     data,
     hasError,
     isLoading,
@@ -61,7 +62,7 @@ const RevenueStreamsOverviewSection = ({
         <Filters.Provider
           filtersNamePrefix={REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX}
           staticFilters={{
-            currency,
+            currency: defaultCurrency,
             date: getDefaultStaticDateFilter(),
           }}
           staticQuickFilters={{
@@ -106,9 +107,9 @@ const RevenueStreamsOverviewSection = ({
 
       <div className="flex flex-col gap-1">
         <Typography variant="headline" color="grey700">
-          {intlFormatNumber(deserializeAmount(lastNetRevenueAmountCents || 0, currency), {
+          {intlFormatNumber(deserializeAmount(lastNetRevenueAmountCents || 0, selectedCurrency), {
             currencyDisplay: 'symbol',
-            currency: currency,
+            currency: selectedCurrency,
           })}
         </Typography>
         <div className="flex items-center gap-2">
@@ -150,7 +151,7 @@ const RevenueStreamsOverviewSection = ({
         <RevenueStreamsStateProvider>
           <MultipleLineChart
             xAxisDataKey="startOfPeriodDt"
-            currency={currency}
+            currency={selectedCurrency}
             data={data}
             loading={isLoading}
             timeGranularity={timeGranularity}
@@ -238,10 +239,10 @@ const RevenueStreamsOverviewSection = ({
                       })}
                     >
                       {intlFormatNumber(
-                        deserializeAmount(subscriptionFeeAmountCents || 0, currency),
+                        deserializeAmount(subscriptionFeeAmountCents || 0, selectedCurrency),
                         {
                           currencyDisplay: 'symbol',
-                          currency: currency,
+                          currency: selectedCurrency,
                         },
                       )}
                     </Typography>
@@ -276,10 +277,10 @@ const RevenueStreamsOverviewSection = ({
                       })}
                     >
                       {intlFormatNumber(
-                        deserializeAmount(usageBasedFeeAmountCents || 0, currency),
+                        deserializeAmount(usageBasedFeeAmountCents || 0, selectedCurrency),
                         {
                           currencyDisplay: 'symbol',
-                          currency: currency,
+                          currency: selectedCurrency,
                         },
                       )}
                     </Typography>
@@ -314,10 +315,10 @@ const RevenueStreamsOverviewSection = ({
                       })}
                     >
                       {intlFormatNumber(
-                        deserializeAmount(commitmentFeeAmountCents || 0, currency),
+                        deserializeAmount(commitmentFeeAmountCents || 0, selectedCurrency),
                         {
                           currencyDisplay: 'symbol',
-                          currency: currency,
+                          currency: selectedCurrency,
                         },
                       )}
                     </Typography>
@@ -351,10 +352,13 @@ const RevenueStreamsOverviewSection = ({
                         'text-grey-500': oneOffFeeAmountCents === 0,
                       })}
                     >
-                      {intlFormatNumber(deserializeAmount(oneOffFeeAmountCents || 0, currency), {
-                        currencyDisplay: 'symbol',
-                        currency: currency,
-                      })}
+                      {intlFormatNumber(
+                        deserializeAmount(oneOffFeeAmountCents || 0, selectedCurrency),
+                        {
+                          currencyDisplay: 'symbol',
+                          currency: selectedCurrency,
+                        },
+                      )}
                     </Typography>
                   )
                 },
@@ -378,10 +382,13 @@ const RevenueStreamsOverviewSection = ({
                         'text-grey-500': grossRevenueAmountCents === 0,
                       })}
                     >
-                      {intlFormatNumber(deserializeAmount(grossRevenueAmountCents || 0, currency), {
-                        currencyDisplay: 'symbol',
-                        currency: currency,
-                      })}
+                      {intlFormatNumber(
+                        deserializeAmount(grossRevenueAmountCents || 0, selectedCurrency),
+                        {
+                          currencyDisplay: 'symbol',
+                          currency: selectedCurrency,
+                        },
+                      )}
                     </Typography>
                   )
                 },
@@ -405,10 +412,13 @@ const RevenueStreamsOverviewSection = ({
                         'text-grey-500': couponsAmountCents === 0,
                       })}
                     >
-                      {intlFormatNumber(deserializeAmount(couponsAmountCents || 0, currency), {
-                        currencyDisplay: 'symbol',
-                        currency: currency,
-                      })}
+                      {intlFormatNumber(
+                        deserializeAmount(couponsAmountCents || 0, selectedCurrency),
+                        {
+                          currencyDisplay: 'symbol',
+                          currency: selectedCurrency,
+                        },
+                      )}
                     </Typography>
                   )
                 },
@@ -432,10 +442,13 @@ const RevenueStreamsOverviewSection = ({
                         'text-grey-500': netRevenueAmountCents === 0,
                       })}
                     >
-                      {intlFormatNumber(deserializeAmount(netRevenueAmountCents || 0, currency), {
-                        currencyDisplay: 'symbol',
-                        currency: currency,
-                      })}
+                      {intlFormatNumber(
+                        deserializeAmount(netRevenueAmountCents || 0, selectedCurrency),
+                        {
+                          currencyDisplay: 'symbol',
+                          currency: selectedCurrency,
+                        },
+                      )}
                     </Typography>
                   )
                 },

--- a/src/components/analytics/useRevenueAnalyticsOverview.ts
+++ b/src/components/analytics/useRevenueAnalyticsOverview.ts
@@ -54,7 +54,8 @@ gql`
 `
 
 type RevenueAnalyticsOverviewReturn = {
-  currency: CurrencyEnum
+  selectedCurrency: CurrencyEnum
+  defaultCurrency: CurrencyEnum
   data: RevenueStreamDataForOverviewSectionFragment[]
   hasAccessToRevenueAnalyticsFeature: boolean
   hasError: boolean
@@ -82,6 +83,8 @@ export const useRevenueAnalyticsOverview = (): RevenueAnalyticsOverviewReturn =>
     PremiumIntegrationTypeEnum.RevenueAnalytics,
   )
 
+  const defaultCurrency = organization?.defaultCurrency || CurrencyEnum.Usd
+
   const getDefaultStaticDateFilter = useCallback((): string => {
     const now = DateTime.now()
 
@@ -103,7 +106,7 @@ export const useRevenueAnalyticsOverview = (): RevenueAnalyticsOverviewReturn =>
   const filtersForRevenueStreamsQuery = useMemo(() => {
     if (!hasAccessToRevenueAnalyticsFeature) {
       return {
-        currency: organization?.defaultCurrency || CurrencyEnum.Usd,
+        currency: defaultCurrency,
         date: getDefaultStaticDateFilter(),
         timeGranularity: getDefaultStaticTimeGranularityFilter(),
       }
@@ -113,7 +116,7 @@ export const useRevenueAnalyticsOverview = (): RevenueAnalyticsOverviewReturn =>
   }, [
     hasAccessToRevenueAnalyticsFeature,
     searchParams,
-    organization?.defaultCurrency,
+    defaultCurrency,
     getDefaultStaticDateFilter,
     getDefaultStaticTimeGranularityFilter,
   ])
@@ -133,14 +136,14 @@ export const useRevenueAnalyticsOverview = (): RevenueAnalyticsOverviewReturn =>
     searchParams,
   ) as TimeGranularityEnum
 
-  const currency = useMemo(() => {
+  const selectedCurrency = useMemo(() => {
     const currencyFromFilter = getFilterByKey(AvailableFiltersEnum.currency, searchParams)
 
     if (!!currencyFromFilter) {
       return currencyFromFilter as CurrencyEnum
     }
-    return organization?.defaultCurrency || CurrencyEnum.Usd
-  }, [searchParams, organization])
+    return defaultCurrency
+  }, [searchParams, defaultCurrency])
 
   const formattedRevenueStreamsData = useMemo(() => {
     return formatRevenueStreamsData({
@@ -186,10 +189,11 @@ export const useRevenueAnalyticsOverview = (): RevenueAnalyticsOverviewReturn =>
   }, [formattedRevenueStreamsData])
 
   return {
-    currency,
+    defaultCurrency,
     hasAccessToRevenueAnalyticsFeature,
     lastNetRevenueAmountCents,
     netRevenueAmountCentsProgressionOnPeriod,
+    selectedCurrency,
     timeGranularity,
     data: formattedRevenueStreamsData,
     hasError: !!revenueStreamsError && !revenueStreamsLoading,


### PR DESCRIPTION
## Context

We're building the new version of analytics on a page non-accessible by customers. Pushing update as they are built as they are not user-facing yet.

## Description

This PR fixed the reset filter behaviour by reseting the currency to the default one.