### PR TITLE
misc(multipleLineChart): Remove over optimisations that led to slow performances

### DIFF
--- a/src/components/designSystem/graphs/MultipleLineChart.tsx
+++ b/src/components/designSystem/graphs/MultipleLineChart.tsx
@@ -250,11 +250,6 @@ const MultipleLineChart = <T extends DataItem>({
                 Math.max(1, Math.round(Math.pow((localData?.length || 0) / 300, 1.5) * 8)),
                 {
                   leading: true,
-                  trailing: true,
-                  maxWait: Math.max(
-                    2,
-                    Math.round(Math.pow((localData?.length || 0) / 300, 1.5) * 16),
-                  ),
                 },
               ),
             [handleHoverUpdate, localData?.length],


### PR DESCRIPTION
## Context

We're building the new version of analytics on a page non-accessible by customers. Pushing update as they are built as they are not user-facing yet.

## Description

While building the multiple line chart, I ended up pre-optimising some perf for the graph hover debounce function.
While they provide good directions, the `maxWait` was too flaky and let to slower rendering in the end. I may have to adapt the math here bure realised just removing it improved drastically perfs here.
We still have some fps drop when dataset is above 1k elements but it's mostly renders well.
Also `trailing` default value is `true` so no need to have it here.