### PR TITLE
fix: add overdue column back in invoice list

### DIFF
--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -216,7 +216,6 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
                   title: translate('text_63b5d225b075850e0fe489f4'),
                   content: ({
                     status,
-                    paymentOverdue,
                     paymentStatus,
                     paymentDisputeLostAt,
                     totalAmountCents,
@@ -231,8 +230,6 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
                       statusEndIcon: undefined,
                     }
 
-                    const isOverdue =
-                      paymentOverdue && paymentStatus === InvoicePaymentStatusTypeEnum.Pending
                     const isPartiallyPaid =
                       Number(totalPaidAmountCents) > 0 &&
                       Number(totalAmountCents) - Number(totalPaidAmountCents) > 0
@@ -252,17 +249,12 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
                     return (
                       <Tooltip placement="top" title={content.tooltipTitle}>
                         <Status
-                          {...(isOverdue
-                            ? {
-                                type: StatusType.danger,
-                                label: 'overdue',
-                              }
-                            : paymentStatusMapping({
-                                status,
-                                paymentStatus,
-                                totalPaidAmountCents,
-                                totalAmountCents,
-                              }))}
+                          {...paymentStatusMapping({
+                            status,
+                            paymentStatus,
+                            totalPaidAmountCents,
+                            totalAmountCents,
+                          })}
                           endIcon={content.statusEndIcon}
                         />
                       </Tooltip>
@@ -297,6 +289,16 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
                     {intlFormatNumber(amount, { currency })}
                   </Typography>
                 )
+              },
+            },
+            {
+              key: 'paymentOverdue',
+              title: translate('text_666c5b12fea4aa1e1b26bf55'),
+              content: ({ paymentStatus, paymentOverdue }) => {
+                const isOverdue =
+                  paymentOverdue && paymentStatus === InvoicePaymentStatusTypeEnum.Pending
+
+                return isOverdue ? <Status type={StatusType.danger} label="overdue" /> : null
               },
             },
             {

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -418,7 +418,6 @@ const InvoicesList = ({
                   status,
                   paymentStatus,
                   paymentDisputeLostAt,
-                  paymentOverdue,
                   totalAmountCents,
                   totalPaidAmountCents,
                 }) => {
@@ -431,8 +430,6 @@ const InvoicesList = ({
                     statusEndIcon: undefined,
                   }
 
-                  const isOverdue =
-                    paymentOverdue && paymentStatus === InvoicePaymentStatusTypeEnum.Pending
                   const isPartiallyPaid =
                     Number(totalPaidAmountCents) > 0 &&
                     Number(totalAmountCents) - Number(totalPaidAmountCents) > 0
@@ -452,21 +449,26 @@ const InvoicesList = ({
                   return (
                     <Tooltip placement="top" title={content.tooltipTitle}>
                       <Status
-                        {...(isOverdue
-                          ? {
-                              type: StatusType.danger,
-                              label: 'overdue',
-                            }
-                          : paymentStatusMapping({
-                              status,
-                              paymentStatus,
-                              totalPaidAmountCents,
-                              totalAmountCents,
-                            }))}
+                        {...paymentStatusMapping({
+                          status,
+                          paymentStatus,
+                          totalPaidAmountCents,
+                          totalAmountCents,
+                        })}
                         endIcon={content.statusEndIcon}
                       />
                     </Tooltip>
                   )
+                },
+              },
+              {
+                key: 'paymentOverdue',
+                title: translate('text_666c5b12fea4aa1e1b26bf55'),
+                content: ({ paymentStatus, paymentOverdue }) => {
+                  const isOverdue =
+                    paymentOverdue && paymentStatus === InvoicePaymentStatusTypeEnum.Pending
+
+                  return isOverdue ? <Status type={StatusType.danger} label="overdue" /> : null
                 },
               },
               {


### PR DESCRIPTION
## Context

Add overdue column back in invoice list.
It was removed in the manual payment feature but product decided to rollback their decision.


Fixes ISSUE-724

https://issue-724-app.staging.getlago.com/ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated overdue payment column in invoice lists to clearly indicate invoices with an overdue status.
- **Refactor**
  - Separated the overdue status logic from standard payment status handling, streamlining the display and improving clarity in invoice state representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->