### PR TITLE
bug(revenueStreams): remove forgotten yet-unexisting metadata

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -6907,7 +6907,7 @@ export type GetRevenueStreamsPlanBreakdownQueryVariables = Exact<{
 }>;
 
 
-export type GetRevenueStreamsPlanBreakdownQuery = { __typename?: 'Query', dataApiRevenueStreamsPlans: { __typename?: 'RevenueStreamPlanCollection', collection: Array<{ __typename?: 'RevenueStreamPlan', amountCurrency: CurrencyEnum, customersCount: number, customersShare: number, netRevenueAmountCents: any, netRevenueShare: number, planCode: string, planId: string, planInterval: PlanInterval, planName: string }>, metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number } } };
+export type GetRevenueStreamsPlanBreakdownQuery = { __typename?: 'Query', dataApiRevenueStreamsPlans: { __typename?: 'RevenueStreamPlanCollection', collection: Array<{ __typename?: 'RevenueStreamPlan', amountCurrency: CurrencyEnum, customersCount: number, customersShare: number, netRevenueAmountCents: any, netRevenueShare: number, planCode: string, planId: string, planInterval: PlanInterval, planName: string }> } };
 
 export type GetRevenueStreamsQueryVariables = Exact<{
   currency?: InputMaybe<CurrencyEnum>;
@@ -13445,10 +13445,6 @@ export const GetRevenueStreamsPlanBreakdownDocument = gql`
       planId
       planInterval
       planName
-    }
-    metadata {
-      currentPage
-      totalPages
     }
   }
 }


### PR DESCRIPTION
Was doing some tests with pagination, and forgot to remove the not-yet-implemented metadata field in query result.

It should be ready soon on BE, but having it today makes the query fail, hence having a broken QA/dev env