### PR TITLE
misc(Analytics): show deleted plans and customer with correct label

### DIFF
--- a/src/components/analytics/mrr/MrrBreakdownSection.tsx
+++ b/src/components/analytics/mrr/MrrBreakdownSection.tsx
@@ -31,6 +31,7 @@ gql`
         mrr
         mrrShare
         planCode
+        planDeletedAt
         planId
         planInterval
         planName
@@ -163,12 +164,19 @@ export const MrrBreakdownSection = ({ premiumWarningDialogRef }: MrrBreakdownSec
               title: translate('text_63d3a658c6d84a5843032145'),
               maxSpace: true,
               minWidth: 200,
-              content({ planName, planCode }) {
+              content({ planName, planCode, planDeletedAt }) {
                 return (
                   <>
-                    <Typography color="grey700" variant="bodyHl" noWrap>
-                      {planName || '-'}
-                    </Typography>
+                    <div className="flex items-baseline gap-1">
+                      <Typography color="grey700" variant="bodyHl" noWrap>
+                        {planName || '-'}
+                      </Typography>
+                      {!!planDeletedAt && (
+                        <Typography variant="caption" color="grey600" noWrap>
+                          ({translate('text_1743158702704o1juwxmr4ab')})
+                        </Typography>
+                      )}
+                    </div>
                     <Typography variant="caption" color="grey600" noWrap>
                       {planCode}
                     </Typography>

--- a/src/components/analytics/revenueStreams/RevenueStreamsCustomerBreakdownSection.tsx
+++ b/src/components/analytics/revenueStreams/RevenueStreamsCustomerBreakdownSection.tsx
@@ -25,6 +25,7 @@ gql`
     dataApiRevenueStreamsCustomers(currency: $currency, limit: $limit, page: $page) {
       collection {
         amountCurrency
+        customerDeletedAt
         customerName
         externalCustomerId
         netRevenueAmountCents
@@ -153,12 +154,19 @@ export const RevenueStreamsCustomerBreakdownSection = ({
               title: translate('text_63d3a658c6d84a5843032145'),
               maxSpace: true,
               minWidth: 200,
-              content({ customerName, externalCustomerId }) {
+              content({ customerName, externalCustomerId, customerDeletedAt }) {
                 return (
                   <>
-                    <Typography color="grey700" variant="bodyHl" noWrap>
-                      {customerName || '-'}
-                    </Typography>
+                    <div className="flex items-baseline gap-1">
+                      <Typography color="grey700" variant="bodyHl" noWrap>
+                        {customerName || '-'}
+                      </Typography>
+                      {!!customerDeletedAt && (
+                        <Typography variant="caption" color="grey600" noWrap>
+                          ({translate('text_1743158702704o1juwxmr4ab')})
+                        </Typography>
+                      )}
+                    </div>
                     <Typography variant="caption" color="grey600" noWrap>
                       {externalCustomerId}
                     </Typography>

--- a/src/components/analytics/revenueStreams/RevenueStreamsPlanBreakdownSection.tsx
+++ b/src/components/analytics/revenueStreams/RevenueStreamsPlanBreakdownSection.tsx
@@ -31,6 +31,7 @@ gql`
         netRevenueAmountCents
         netRevenueShare
         planCode
+        planDeletedAt
         planId
         planInterval
         planName
@@ -156,12 +157,19 @@ export const RevenueStreamsPlanBreakdownSection = ({
               title: translate('text_63d3a658c6d84a5843032145'),
               maxSpace: true,
               minWidth: 200,
-              content({ planName, planCode }) {
+              content({ planName, planCode, planDeletedAt }) {
                 return (
                   <>
-                    <Typography color="grey700" variant="bodyHl" noWrap>
-                      {planName || '-'}
-                    </Typography>
+                    <div className="flex items-baseline gap-1">
+                      <Typography color="grey700" variant="bodyHl" noWrap>
+                        {planName || '-'}
+                      </Typography>
+                      {!!planDeletedAt && (
+                        <Typography variant="caption" color="grey600" noWrap>
+                          ({translate('text_1743158702704o1juwxmr4ab')})
+                        </Typography>
+                      )}
+                    </div>
                     <Typography variant="caption" color="grey600" noWrap>
                       {planCode}
                     </Typography>

--- a/src/components/designSystem/Filters/__tests__/utils.test.ts
+++ b/src/components/designSystem/Filters/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import { AvailableFiltersEnum, filterDataInlineSeparator } from '../types'
 import {
   formatActiveFilterValueDisplay,
   formatFiltersForInvoiceQuery,
+  formatFiltersForMrrQuery,
   formatFiltersForRevenueStreamsQuery,
   getFilterValue,
 } from '../utils'
@@ -70,14 +71,48 @@ describe('Filters utils', () => {
       const result = formatFiltersForRevenueStreamsQuery(searchParams)
 
       expect(result).toEqual({
-        accountType: 'company',
+        customerType: 'company',
         fromDate: '2022-01-01',
         planCode: 'planCodeValue',
         timeGranularity: 'day',
         toDate: '2022-01-31',
         currency: 'USD',
         customerCountry: 'US',
-        customerExternalId: 'externalCustomerIdValue',
+        externalCustomerId: 'externalCustomerIdValue',
+      })
+    })
+  })
+
+  describe('formatFiltersForMrrQuery', () => {
+    it('should format filters for MRR query', () => {
+      const searchParams = new URLSearchParams()
+
+      searchParams.set('timeGranularity', 'month')
+      searchParams.set('accountType', 'individual')
+      searchParams.set('invoiceType', 'advance_charges,credit,one_off,subscription')
+      searchParams.set('status', 'finalized')
+      searchParams.set('currency', 'EUR')
+      searchParams.set('paymentOverdue', 'true')
+      searchParams.set('date', '2023-01-01,2023-01-31')
+      searchParams.set('country', 'FR')
+      searchParams.set(
+        'customerExternalId',
+        `customer123${filterDataInlineSeparator}Customer Display Name`,
+      )
+      searchParams.set('planCode', 'premium')
+      searchParams.set('partiallyPaid', 'true')
+      searchParams.set('selfBilled', 'true')
+
+      const result = formatFiltersForMrrQuery(searchParams)
+
+      expect(result).toEqual({
+        customerType: 'individual',
+        fromDate: '2023-01-01',
+        timeGranularity: 'month',
+        toDate: '2023-01-31',
+        currency: 'EUR',
+        customerCountry: 'FR',
+        externalCustomerId: 'customer123',
       })
     })
   })

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemCustomer.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemCustomer.tsx
@@ -9,7 +9,7 @@ import { filterDataInlineSeparator, FiltersFormValues } from '../types'
 
 gql`
   query getCustomersForFilterItemCustomer($page: Int, $limit: Int, $searchTerm: String) {
-    customers(page: $page, limit: $limit, searchTerm: $searchTerm) {
+    customers(page: $page, limit: $limit, searchTerm: $searchTerm, withDeleted: true) {
       metadata {
         currentPage
         totalPages
@@ -18,6 +18,7 @@ gql`
         id
         displayName
         externalId
+        deletedAt
       }
     }
   }
@@ -43,11 +44,11 @@ export const FiltersItemCustomer = ({ value, setFilterValue }: FiltersItemCustom
       const customerName = customer?.displayName
 
       return {
-        label: customerName || '',
+        label: `${customerName || externalId || ''}${customer.deletedAt ? ` (${translate('text_1743158702704o1juwxmr4ab')})` : ''}`,
         value: `${externalId}${filterDataInlineSeparator}${customerName}`,
       }
     })
-  }, [data])
+  }, [data?.customers?.collection, translate])
 
   return (
     <ComboBox

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemPlanCode.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemPlanCode.tsx
@@ -9,7 +9,7 @@ import { FiltersFormValues } from '../types'
 
 gql`
   query getPlansForFiltersItemPlanCode($page: Int, $limit: Int, $searchTerm: String) {
-    plans(page: $page, limit: $limit, searchTerm: $searchTerm) {
+    plans(page: $page, limit: $limit, searchTerm: $searchTerm, withDeleted: true) {
       metadata {
         currentPage
         totalPages
@@ -17,6 +17,7 @@ gql`
       collection {
         id
         code
+        deletedAt
       }
     }
   }
@@ -37,9 +38,10 @@ export const FiltersItemPlanCode = ({ value, setFilterValue }: FiltersItemPlanCo
     if (!data?.plans?.collection) return []
 
     return data.plans.collection.map((plan) => ({
+      label: `${plan.code}${plan.deletedAt ? ` (${translate('text_1743158702704o1juwxmr4ab')})` : ''}`,
       value: plan.code,
     }))
-  }, [data])
+  }, [data?.plans?.collection, translate])
 
   return (
     <ComboBox

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -266,7 +266,7 @@ export const formatActiveFilterValueDisplay = (
 
   switch (key) {
     case AvailableFiltersEnum.customerExternalId:
-      return value.split(filterDataInlineSeparator)[1]
+      return value.split(filterDataInlineSeparator)[1] || value.split(filterDataInlineSeparator)[0]
     case AvailableFiltersEnum.date:
     case AvailableFiltersEnum.issuingDate:
       return value

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -179,6 +179,9 @@ export const formatFiltersForCustomerQuery = (searchParams: URLSearchParams) => 
 export const formatFiltersForRevenueStreamsQuery = (searchParams: URLSearchParams) => {
   const keyMap: Partial<Record<AvailableFiltersEnum, string>> = {
     [AvailableFiltersEnum.country]: 'customerCountry',
+    [AvailableFiltersEnum.customerAccountType]: 'customerType',
+    [AvailableFiltersEnum.customerExternalId]: 'externalCustomerId',
+    [AvailableFiltersEnum.subscriptionExternalId]: 'externalSubscriptionId',
   }
 
   return formatFiltersForQuery({
@@ -203,6 +206,9 @@ export const formatFiltersForRevenueStreamsPlansQuery = (searchParams: URLSearch
 export const formatFiltersForMrrQuery = (searchParams: URLSearchParams) => {
   const keyMap: Partial<Record<AvailableFiltersEnum, string>> = {
     [AvailableFiltersEnum.country]: 'customerCountry',
+    [AvailableFiltersEnum.customerAccountType]: 'customerType',
+    [AvailableFiltersEnum.customerExternalId]: 'externalCustomerId',
+    [AvailableFiltersEnum.subscriptionExternalId]: 'externalSubscriptionId',
   }
 
   return formatFiltersForQuery({

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -4673,6 +4673,7 @@ export type Plan = {
   createdAt: Scalars['ISO8601DateTime']['output'];
   /** Number of customers attached to a plan */
   customersCount: Scalars['Int']['output'];
+  deletedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   draftInvoicesCount: Scalars['Int']['output'];
   hasActiveSubscriptions: Scalars['Boolean']['output'];
@@ -5124,6 +5125,7 @@ export type QueryCustomersArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   page?: InputMaybe<Scalars['Int']['input']>;
   searchTerm?: InputMaybe<Scalars['String']['input']>;
+  withDeleted?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 
@@ -5214,6 +5216,7 @@ export type QueryEventsArgs = {
 
 
 export type QueryGrossRevenuesArgs = {
+  billingEntityId?: InputMaybe<Scalars['ID']['input']>;
   currency?: InputMaybe<CurrencyEnum>;
   expireCache?: InputMaybe<Scalars['Boolean']['input']>;
   externalCustomerId?: InputMaybe<Scalars['String']['input']>;
@@ -5290,6 +5293,7 @@ export type QueryInvoiceArgs = {
 
 
 export type QueryInvoiceCollectionsArgs = {
+  billingEntityId?: InputMaybe<Scalars['ID']['input']>;
   currency?: InputMaybe<CurrencyEnum>;
 };
 
@@ -5313,6 +5317,7 @@ export type QueryInvoiceCustomSectionsArgs = {
 
 
 export type QueryInvoicedUsagesArgs = {
+  billingEntityId?: InputMaybe<Scalars['ID']['input']>;
   currency?: InputMaybe<CurrencyEnum>;
 };
 
@@ -5346,11 +5351,13 @@ export type QueryMembershipsArgs = {
 
 
 export type QueryMrrsArgs = {
+  billingEntityId?: InputMaybe<Scalars['ID']['input']>;
   currency?: InputMaybe<CurrencyEnum>;
 };
 
 
 export type QueryOverdueBalancesArgs = {
+  billingEntityId?: InputMaybe<Scalars['ID']['input']>;
   currency?: InputMaybe<CurrencyEnum>;
   expireCache?: InputMaybe<Scalars['Boolean']['input']>;
   externalCustomerId?: InputMaybe<Scalars['String']['input']>;
@@ -5405,6 +5412,7 @@ export type QueryPlansArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   page?: InputMaybe<Scalars['Int']['input']>;
   searchTerm?: InputMaybe<Scalars['String']['input']>;
+  withDeleted?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 
@@ -6888,7 +6896,7 @@ export type GetMrrPlanBreakdownQueryVariables = Exact<{
 }>;
 
 
-export type GetMrrPlanBreakdownQuery = { __typename?: 'Query', dataApiMrrsPlans: { __typename?: 'DataApiMrrsPlans', collection: Array<{ __typename?: 'DataApiMrrPlan', activeCustomersCount: any, activeCustomersShare: number, amountCurrency: CurrencyEnum, mrr: number, mrrShare: number, planCode: string, planId: string, planInterval: PlanInterval, planName: string }>, metadata: { __typename?: 'DataApiMetadata', currentPage: number, totalPages: number } } };
+export type GetMrrPlanBreakdownQuery = { __typename?: 'Query', dataApiMrrsPlans: { __typename?: 'DataApiMrrsPlans', collection: Array<{ __typename?: 'DataApiMrrPlan', activeCustomersCount: any, activeCustomersShare: number, amountCurrency: CurrencyEnum, mrr: number, mrrShare: number, planCode: string, planDeletedAt?: any | null, planId: string, planInterval: PlanInterval, planName: string }>, metadata: { __typename?: 'DataApiMetadata', currentPage: number, totalPages: number } } };
 
 export type MrrDataForOverviewSectionFragment = { __typename?: 'DataApiMrr', endOfPeriodDt: any, endingMrr: any, mrrChange: any, mrrChurn: any, mrrContraction: any, mrrExpansion: any, mrrNew: any, startOfPeriodDt: any, startingMrr: any };
 
@@ -6913,7 +6921,7 @@ export type GetRevenueStreamsCustomerBreakdownQueryVariables = Exact<{
 }>;
 
 
-export type GetRevenueStreamsCustomerBreakdownQuery = { __typename?: 'Query', dataApiRevenueStreamsCustomers: { __typename?: 'DataApiRevenueStreamsCustomers', collection: Array<{ __typename?: 'DataApiRevenueStreamCustomer', amountCurrency: CurrencyEnum, customerName: string, externalCustomerId: string, netRevenueAmountCents: any, netRevenueShare: number }>, metadata: { __typename?: 'DataApiMetadata', currentPage: number, totalPages: number } } };
+export type GetRevenueStreamsCustomerBreakdownQuery = { __typename?: 'Query', dataApiRevenueStreamsCustomers: { __typename?: 'DataApiRevenueStreamsCustomers', collection: Array<{ __typename?: 'DataApiRevenueStreamCustomer', amountCurrency: CurrencyEnum, customerDeletedAt?: any | null, customerName: string, externalCustomerId: string, netRevenueAmountCents: any, netRevenueShare: number }>, metadata: { __typename?: 'DataApiMetadata', currentPage: number, totalPages: number } } };
 
 export type RevenueStreamDataForOverviewSectionFragment = { __typename?: 'DataApiRevenueStream', commitmentFeeAmountCents: any, couponsAmountCents: any, endOfPeriodDt: any, grossRevenueAmountCents: any, netRevenueAmountCents: any, oneOffFeeAmountCents: any, startOfPeriodDt: any, subscriptionFeeAmountCents: any, usageBasedFeeAmountCents: any };
 
@@ -6924,7 +6932,7 @@ export type GetRevenueStreamsPlanBreakdownQueryVariables = Exact<{
 }>;
 
 
-export type GetRevenueStreamsPlanBreakdownQuery = { __typename?: 'Query', dataApiRevenueStreamsPlans: { __typename?: 'DataApiRevenueStreamsPlans', collection: Array<{ __typename?: 'DataApiRevenueStreamPlan', amountCurrency: CurrencyEnum, customersCount: number, customersShare: number, netRevenueAmountCents: any, netRevenueShare: number, planCode: string, planId: string, planInterval: PlanInterval, planName: string }>, metadata: { __typename?: 'DataApiMetadata', currentPage: number, totalPages: number } } };
+export type GetRevenueStreamsPlanBreakdownQuery = { __typename?: 'Query', dataApiRevenueStreamsPlans: { __typename?: 'DataApiRevenueStreamsPlans', collection: Array<{ __typename?: 'DataApiRevenueStreamPlan', amountCurrency: CurrencyEnum, customersCount: number, customersShare: number, netRevenueAmountCents: any, netRevenueShare: number, planCode: string, planDeletedAt?: any | null, planId: string, planInterval: PlanInterval, planName: string }>, metadata: { __typename?: 'DataApiMetadata', currentPage: number, totalPages: number } } };
 
 export type GetRevenueStreamsQueryVariables = Exact<{
   currency?: InputMaybe<CurrencyEnum>;
@@ -7453,7 +7461,7 @@ export type GetCustomersForFilterItemCustomerQueryVariables = Exact<{
 }>;
 
 
-export type GetCustomersForFilterItemCustomerQuery = { __typename?: 'Query', customers: { __typename?: 'CustomerCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Customer', id: string, displayName: string, externalId: string }> } };
+export type GetCustomersForFilterItemCustomerQuery = { __typename?: 'Query', customers: { __typename?: 'CustomerCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Customer', id: string, displayName: string, externalId: string, deletedAt?: any | null }> } };
 
 export type GetInvoiceNumbersForFilterItemInvoiceNumbersQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -7471,7 +7479,7 @@ export type GetPlansForFiltersItemPlanCodeQueryVariables = Exact<{
 }>;
 
 
-export type GetPlansForFiltersItemPlanCodeQuery = { __typename?: 'Query', plans: { __typename?: 'PlanCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Plan', id: string, code: string }> } };
+export type GetPlansForFiltersItemPlanCodeQuery = { __typename?: 'Query', plans: { __typename?: 'PlanCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Plan', id: string, code: string, deletedAt?: any | null }> } };
 
 export type WebhookForCreateAndEditFragment = { __typename?: 'WebhookEndpoint', id: string, webhookUrl: string, signatureAlgo?: WebhookEndpointSignatureAlgoEnum | null };
 
@@ -13303,6 +13311,7 @@ export const GetMrrPlanBreakdownDocument = gql`
       mrr
       mrrShare
       planCode
+      planDeletedAt
       planId
       planInterval
       planName
@@ -13412,6 +13421,7 @@ export const GetRevenueStreamsCustomerBreakdownDocument = gql`
   dataApiRevenueStreamsCustomers(currency: $currency, limit: $limit, page: $page) {
     collection {
       amountCurrency
+      customerDeletedAt
       customerName
       externalCustomerId
       netRevenueAmountCents
@@ -13469,6 +13479,7 @@ export const GetRevenueStreamsPlanBreakdownDocument = gql`
       netRevenueAmountCents
       netRevenueShare
       planCode
+      planDeletedAt
       planId
       planInterval
       planName
@@ -16215,7 +16226,12 @@ export type GetCustomerSubscriptionForUsageSuspenseQueryHookResult = ReturnType<
 export type GetCustomerSubscriptionForUsageQueryResult = Apollo.QueryResult<GetCustomerSubscriptionForUsageQuery, GetCustomerSubscriptionForUsageQueryVariables>;
 export const GetCustomersForFilterItemCustomerDocument = gql`
     query getCustomersForFilterItemCustomer($page: Int, $limit: Int, $searchTerm: String) {
-  customers(page: $page, limit: $limit, searchTerm: $searchTerm) {
+  customers(
+    page: $page
+    limit: $limit
+    searchTerm: $searchTerm
+    withDeleted: true
+  ) {
     metadata {
       currentPage
       totalPages
@@ -16224,6 +16240,7 @@ export const GetCustomersForFilterItemCustomerDocument = gql`
       id
       displayName
       externalId
+      deletedAt
     }
   }
 }
@@ -16314,7 +16331,7 @@ export type GetInvoiceNumbersForFilterItemInvoiceNumbersSuspenseQueryHookResult 
 export type GetInvoiceNumbersForFilterItemInvoiceNumbersQueryResult = Apollo.QueryResult<GetInvoiceNumbersForFilterItemInvoiceNumbersQuery, GetInvoiceNumbersForFilterItemInvoiceNumbersQueryVariables>;
 export const GetPlansForFiltersItemPlanCodeDocument = gql`
     query getPlansForFiltersItemPlanCode($page: Int, $limit: Int, $searchTerm: String) {
-  plans(page: $page, limit: $limit, searchTerm: $searchTerm) {
+  plans(page: $page, limit: $limit, searchTerm: $searchTerm, withDeleted: true) {
     metadata {
       currentPage
       totalPages
@@ -16322,6 +16339,7 @@ export const GetPlansForFiltersItemPlanCodeDocument = gql`
     collection {
       id
       code
+      deletedAt
     }
   }
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -2923,5 +2923,6 @@
   "text_1742996757451ng6z8o2xif2": "Starting MRR",
   "text_1742996757451700705sjtf8": "Change",
   "text_17429967574517l2yykxqmau": "Ending MRR",
-  "text_174299767573783t24sdrsp1": "Summary"
+  "text_174299767573783t24sdrsp1": "Summary",
+  "text_1743158702704o1juwxmr4ab": "deleted"
 }


### PR DESCRIPTION
## Context

This PR performs the last adjustments for the revenue streams so we can QA it again

## Description

It does
- Handle deleted customers dans plans, and displays them correctly in the lists and filters
- Makes sure the filters attributes are correctly renamed before usign them in the queries
- Makes sure if a customer has no name, we fallback the active filter badge display to show the customer external id

Better reviewed commit by commit

<!-- Linear link -->
Fixes LAGO-796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Analytics views now display clear indicators for plans and customers marked as deleted.
  - Filters for customers and plans have been enhanced to show deletion status via updated labels.
  - Translations have been updated to support the new deletion status messages in the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->