### PR TITLE
misc(RevenueStreams): improve XAxis tick display logic

### DIFF
--- a/src/components/analytics/revenueStreams/RevenueStreamsOverviewSection.tsx
+++ b/src/components/analytics/revenueStreams/RevenueStreamsOverviewSection.tsx
@@ -152,6 +152,7 @@ export const RevenueStreamsOverviewSection = ({
         <AnalyticsStateProvider>
           <MultipleLineChart
             xAxisDataKey="startOfPeriodDt"
+            xAxisTickAttributes={['startOfPeriodDt', 'endOfPeriodDt']}
             currency={selectedCurrency}
             data={data}
             loading={isLoading}


### PR DESCRIPTION
## Context

We're testing ths revenue streams and performing some adjustments before it's official release.

## Description

The multiple line chart x axis ticks displays dates. Those were initially showing the `xAxisDataKey` attribute of the data, here set to the start period value of each object.
What we want in the end is to display the first items' start date, and the last item's end date in this graph's ticks

To do so, we passes an array of size 2 describing what attributes to show based on the data attributes.


I'll create another PR for the area chart component with similar intent. But the change is different and implies more QA on my side.