### PR TITLE
bug(new-analytics): make sure dates are correctly handled

### DIFF
--- a/src/components/analytics/mrr/useMrrAnalyticsOverview.ts
+++ b/src/components/analytics/mrr/useMrrAnalyticsOverview.ts
@@ -13,12 +13,14 @@ import { AvailableFiltersEnum } from '~/components/designSystem/Filters'
 import { formatFiltersForMrrQuery, getFilterValue } from '~/components/designSystem/Filters/utils'
 import { AreaChartDataType } from '~/components/designSystem/graphs/types'
 import { MRR_BREAKDOWN_OVERVIEW_FILTER_PREFIX } from '~/core/constants/filters'
+import { getTimezoneConfig } from '~/core/timezone'
 import {
   CurrencyEnum,
   MrrDataForOverviewSectionFragment,
   MrrDataForOverviewSectionFragmentDoc,
   PremiumIntegrationTypeEnum,
   TimeGranularityEnum,
+  TimezoneEnum,
   useGetMrrsQuery,
 } from '~/generated/graphql'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
@@ -87,7 +89,7 @@ export const useMrrAnalyticsOverview = (): MrrAnalyticsOverviewReturn => {
   const defaultCurrency = organization?.defaultCurrency || CurrencyEnum.Usd
 
   const getDefaultStaticDateFilter = useCallback((): string => {
-    const now = DateTime.now()
+    const now = DateTime.now().setZone(getTimezoneConfig(TimezoneEnum.TzUtc).name)
 
     if (!hasAccessToAnalyticsDashboardsFeature) {
       return `${now.minus({ month: 1 }).startOf('day').toISO()},${now.endOf('day').toISO()}`

--- a/src/components/analytics/revenueStreams/useRevenueAnalyticsOverview.ts
+++ b/src/components/analytics/revenueStreams/useRevenueAnalyticsOverview.ts
@@ -11,12 +11,14 @@ import {
   getFilterValue,
 } from '~/components/designSystem/Filters/utils'
 import { REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX } from '~/core/constants/filters'
+import { getTimezoneConfig } from '~/core/timezone'
 import {
   CurrencyEnum,
   PremiumIntegrationTypeEnum,
   RevenueStreamDataForOverviewSectionFragment,
   RevenueStreamDataForOverviewSectionFragmentDoc,
   TimeGranularityEnum,
+  TimezoneEnum,
   useGetRevenueStreamsQuery,
 } from '~/generated/graphql'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
@@ -86,7 +88,7 @@ export const useRevenueAnalyticsOverview = (): RevenueAnalyticsOverviewReturn =>
   const defaultCurrency = organization?.defaultCurrency || CurrencyEnum.Usd
 
   const getDefaultStaticDateFilter = useCallback((): string => {
-    const now = DateTime.now()
+    const now = DateTime.now().setZone(getTimezoneConfig(TimezoneEnum.TzUtc).name)
 
     if (!hasAccessToAnalyticsDashboardsFeature) {
       return `${now.minus({ month: 1 }).startOf('day').toISO()},${now.endOf('day').toISO()}`

--- a/src/components/designSystem/Filters/FiltersPanelPopper.tsx
+++ b/src/components/designSystem/Filters/FiltersPanelPopper.tsx
@@ -48,7 +48,9 @@ export const FiltersPanelPopper = () => {
             filterType: string().required(''),
             value: string().when('filterType', {
               is: (filterType: AvailableFiltersEnum) =>
-                !!filterType && filterType === AvailableFiltersEnum.issuingDate,
+                !!filterType &&
+                (filterType === AvailableFiltersEnum.issuingDate ||
+                  filterType === AvailableFiltersEnum.date),
               then: (schema) => schema.matches(/\w+,\w+/, '').required(''),
               otherwise: (schema) => schema.required(''),
             }),

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemDate.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemDate.tsx
@@ -1,6 +1,8 @@
 import { DateTime } from 'luxon'
 
 import { DatePicker } from '~/components/form'
+import { getTimezoneConfig } from '~/core/timezone'
+import { TimezoneEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 import { Typography } from '../../Typography'
@@ -20,6 +22,7 @@ export const FiltersItemDate = ({ value = ',', setFilterValue }: FiltersItemDate
       <DatePicker
         showErrorInTooltip
         className="flex-1"
+        defaultZone={getTimezoneConfig(TimezoneEnum.TzUtc).name}
         onChange={(dateFrom) => {
           setFilterValue(`${DateTime.fromISO(dateFrom as string).startOf('day')},${givenValueTo}`)
         }}
@@ -34,6 +37,7 @@ export const FiltersItemDate = ({ value = ',', setFilterValue }: FiltersItemDate
       <DatePicker
         showErrorInTooltip
         className="flex-1"
+        defaultZone={getTimezoneConfig(TimezoneEnum.TzUtc).name}
         onChange={(dateTo) => {
           setFilterValue(`${givenValueFrom},${DateTime.fromISO(dateTo as string).endOf('day')}`)
         }}

--- a/src/components/designSystem/Filters/useFilters.ts
+++ b/src/components/designSystem/Filters/useFilters.ts
@@ -126,12 +126,12 @@ export const useFilters = () => {
     return staticFilters ? `${staticFilters}&${newFiltersJoined}` : newFiltersJoined
   }
 
-  const selectTimeGranularity = (timeGranularity: TimeGranularityEnum) => {
-    return Object.entries(searchParamsObject)
-      .filter(([key]) => key !== keyWithPrefix(AvailableQuickFilters.timeGranularity))
-      .map(([key, value]) => `${key}=${value}`)
-      .concat(`${keyWithPrefix(AvailableQuickFilters.timeGranularity)}=${timeGranularity}`)
-      .join('&')
+  const selectTimeGranularity = (timeGranularity: TimeGranularityEnum): string => {
+    const newSearchParams = new URLSearchParams(searchParams)
+
+    newSearchParams.set(keyWithPrefix(AvailableQuickFilters.timeGranularity), timeGranularity)
+
+    return newSearchParams.toString()
   }
 
   const isQuickFilterActive = (filters: { [key: string]: unknown }) => {


### PR DESCRIPTION
## Context

New analytics graphs are in their late QA phase. We're performing more tests and discovered an inconsistency around dates

## Description

3 changes:
- All dates handled there should be handled as UTC dates. Data is interpreting them as utc anyway.
- Fix an issue with search params manipulation. Changing it as string didn't applied the encoded format. Using the `searchParams` directly fixes that as it's done under the hood 
- I also added a missing form validation for the date filter that have been recently added.

Better reviewed commit by commit