### PR TITLE
bug: no text should be wrapped in table rows

### DIFF
--- a/src/components/analytics/mrr/MrrBreakdownSection.tsx
+++ b/src/components/analytics/mrr/MrrBreakdownSection.tsx
@@ -168,16 +168,16 @@ export const MrrBreakdownSection = ({ premiumWarningDialogRef }: MrrBreakdownSec
                 return (
                   <>
                     <div className="flex items-baseline gap-1">
-                      <Typography color="grey700" variant="bodyHl" noWrap>
+                      <Typography color="grey700" variant="bodyHl">
                         {planName || '-'}
                       </Typography>
                       {!!planDeletedAt && (
-                        <Typography variant="caption" color="grey600" noWrap>
+                        <Typography variant="caption" color="grey600">
                           ({translate('text_1743158702704o1juwxmr4ab')})
                         </Typography>
                       )}
                     </div>
-                    <Typography variant="caption" color="grey600" noWrap>
+                    <Typography variant="caption" color="grey600">
                       {planCode}
                     </Typography>
                   </>
@@ -190,7 +190,7 @@ export const MrrBreakdownSection = ({ premiumWarningDialogRef }: MrrBreakdownSec
               minWidth: 120,
               content({ planInterval }) {
                 return (
-                  <Typography variant="body" noWrap>
+                  <Typography variant="body">
                     {translate(getIntervalTranslationKey[planInterval])}
                   </Typography>
                 )
@@ -204,10 +204,10 @@ export const MrrBreakdownSection = ({ premiumWarningDialogRef }: MrrBreakdownSec
               content({ activeCustomersShare, activeCustomersCount }) {
                 return (
                   <div className="flex items-center gap-2">
-                    <Typography variant="body" color="grey700" noWrap>
+                    <Typography variant="body" color="grey700">
                       {activeCustomersCount}
                     </Typography>
-                    <Typography className="w-16" variant="body" color="grey600" noWrap>
+                    <Typography className="w-16" variant="body" color="grey600">
                       {intlFormatNumber(activeCustomersShare, { style: 'percent' })}
                     </Typography>
                   </div>
@@ -222,13 +222,13 @@ export const MrrBreakdownSection = ({ premiumWarningDialogRef }: MrrBreakdownSec
               content({ mrrShare, mrr, amountCurrency }) {
                 return (
                   <div className="flex items-center gap-2">
-                    <Typography variant="body" color="grey700" noWrap>
+                    <Typography variant="body" color="grey700">
                       {intlFormatNumber(deserializeAmount(mrr || 0, amountCurrency), {
                         style: 'currency',
                         currency: amountCurrency,
                       })}
                     </Typography>
-                    <Typography className="w-16 text-right" variant="body" color="grey600" noWrap>
+                    <Typography className="w-16 text-right" variant="body" color="grey600">
                       {intlFormatNumber(mrrShare, { style: 'percent' })}
                     </Typography>
                   </div>

--- a/src/components/analytics/revenueStreams/RevenueStreamsCustomerBreakdownSection.tsx
+++ b/src/components/analytics/revenueStreams/RevenueStreamsCustomerBreakdownSection.tsx
@@ -158,16 +158,16 @@ export const RevenueStreamsCustomerBreakdownSection = ({
                 return (
                   <>
                     <div className="flex items-baseline gap-1">
-                      <Typography color="grey700" variant="bodyHl" noWrap>
+                      <Typography color="grey700" variant="bodyHl">
                         {customerName || '-'}
                       </Typography>
                       {!!customerDeletedAt && (
-                        <Typography variant="caption" color="grey600" noWrap>
+                        <Typography variant="caption" color="grey600">
                           ({translate('text_1743158702704o1juwxmr4ab')})
                         </Typography>
                       )}
                     </div>
-                    <Typography variant="caption" color="grey600" noWrap>
+                    <Typography variant="caption" color="grey600">
                       {externalCustomerId}
                     </Typography>
                   </>
@@ -182,7 +182,7 @@ export const RevenueStreamsCustomerBreakdownSection = ({
               content({ netRevenueShare, netRevenueAmountCents, amountCurrency }) {
                 return (
                   <div className="flex items-center gap-2">
-                    <Typography variant="body" color="grey700" noWrap>
+                    <Typography variant="body" color="grey700">
                       {intlFormatNumber(
                         deserializeAmount(netRevenueAmountCents || 0, amountCurrency),
                         {
@@ -191,7 +191,7 @@ export const RevenueStreamsCustomerBreakdownSection = ({
                         },
                       )}
                     </Typography>
-                    <Typography className="w-16 text-right" variant="body" color="grey600" noWrap>
+                    <Typography className="w-16 text-right" variant="body" color="grey600">
                       {intlFormatNumber(netRevenueShare, { style: 'percent' })}
                     </Typography>
                   </div>

--- a/src/components/analytics/revenueStreams/RevenueStreamsPlanBreakdownSection.tsx
+++ b/src/components/analytics/revenueStreams/RevenueStreamsPlanBreakdownSection.tsx
@@ -161,16 +161,16 @@ export const RevenueStreamsPlanBreakdownSection = ({
                 return (
                   <>
                     <div className="flex items-baseline gap-1">
-                      <Typography color="grey700" variant="bodyHl" noWrap>
+                      <Typography color="grey700" variant="bodyHl">
                         {planName || '-'}
                       </Typography>
                       {!!planDeletedAt && (
-                        <Typography variant="caption" color="grey600" noWrap>
+                        <Typography variant="caption" color="grey600">
                           ({translate('text_1743158702704o1juwxmr4ab')})
                         </Typography>
                       )}
                     </div>
-                    <Typography variant="caption" color="grey600" noWrap>
+                    <Typography variant="caption" color="grey600">
                       {planCode}
                     </Typography>
                   </>
@@ -197,10 +197,10 @@ export const RevenueStreamsPlanBreakdownSection = ({
               content({ customersShare, customersCount }) {
                 return (
                   <div className="flex items-center gap-2">
-                    <Typography variant="body" color="grey700" noWrap>
+                    <Typography variant="body" color="grey700">
                       {customersCount}
                     </Typography>
-                    <Typography className="w-16" variant="body" color="grey600" noWrap>
+                    <Typography className="w-16" variant="body" color="grey600">
                       {intlFormatNumber(customersShare, { style: 'percent' })}
                     </Typography>
                   </div>
@@ -215,7 +215,7 @@ export const RevenueStreamsPlanBreakdownSection = ({
               content({ netRevenueShare, netRevenueAmountCents, amountCurrency }) {
                 return (
                   <div className="flex items-center gap-2">
-                    <Typography variant="body" color="grey700" noWrap>
+                    <Typography variant="body" color="grey700">
                       {intlFormatNumber(
                         deserializeAmount(netRevenueAmountCents || 0, amountCurrency),
                         {
@@ -224,7 +224,7 @@ export const RevenueStreamsPlanBreakdownSection = ({
                         },
                       )}
                     </Typography>
-                    <Typography className="w-16 text-right" variant="body" color="grey600" noWrap>
+                    <Typography className="w-16 text-right" variant="body" color="grey600">
                       {intlFormatNumber(netRevenueShare, { style: 'percent' })}
                     </Typography>
                   </div>


### PR DESCRIPTION
No typography noWrap attributes should be used inside rows of a Table component.

The Table grows depending on the children content's width, so we don't want to crop it!