### PR TITLE
misc: fix badge alignment

### DIFF
--- a/src/pages/PaymentDetails.tsx
+++ b/src/pages/PaymentDetails.tsx
@@ -137,7 +137,7 @@ const InfoLine = ({
   value: string | ReactNode
   isBold?: boolean
 }) => (
-  <div className="flex gap-3 align-baseline [&>a>*]:text-inherit [&>a]:text-blue-600">
+  <div className="flex items-center gap-3 align-baseline [&>a>*]:text-inherit [&>a]:text-blue-600">
     <Typography variant={isBold ? 'captionHl' : 'caption'} noWrap className="min-w-35">
       {label}
     </Typography>


### PR DESCRIPTION
Fix badge alignment

BEFORE
![image](https://github.com/user-attachments/assets/ac9330ee-1a85-4b38-bc66-671db6ac646a)

AFTER
![image](https://github.com/user-attachments/assets/88d0faf1-0f3a-46e8-b1b0-040c4838da26)


I tested with a link displayed above, works well