### PR TITLE
chore(Sentry): record replay for 30% of errors

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,8 +25,8 @@ if (!!sentryDsn && appEnv !== AppEnvEnum.development) {
     environment: appEnv,
     // Prevent sending recorded session if no error occurs
     replaysSessionSampleRate: 0.0,
-    // Buffer (locally recorded) and send all errors if one occurs
-    replaysOnErrorSampleRate: 1.0,
+    // Buffer (locally recorded) and send 30% of errors if one occurs
+    replaysOnErrorSampleRate: 0.3,
     // Collect traces for 30% of sessions
     tracesSampleRate: 0.3,
   })


### PR DESCRIPTION
It costs a lot, better not get a record for all of them.

I've tested with "manual" error and I'm satisfied with the record, Sentry do not record sensitive data by default 