### PR TITLE
fix: dates util function

### DIFF
--- a/src/core/timezone/__tests__/utils.test.ts
+++ b/src/core/timezone/__tests__/utils.test.ts
@@ -115,26 +115,26 @@ describe('intlFormatDateTime', () => {
   })
 
   describe('it should format timezones correctly', () => {
-    it('should format to "UTC"', () => {
+    it('should format to "UTC±0:00"', () => {
       const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z')
 
-      expect(timezone).toEqual('UTC')
+      expect(timezone).toEqual('UTC±0:00')
     })
 
-    it('should format to "UTC+12"', () => {
+    it('should format to "UTC+12:00"', () => {
       const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z', {
         timezone: TimezoneEnum.TzPacificAuckland,
       })
 
-      expect(timezone).toEqual('UTC+12')
+      expect(timezone).toEqual('UTC+12:00')
     })
 
-    it('should format to "UTC-4"', () => {
+    it('should format to "UTC-4:00"', () => {
       const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z', {
         timezone: TimezoneEnum.TzAmericaNewYork,
       })
 
-      expect(timezone).toEqual('UTC-4')
+      expect(timezone).toEqual('UTC-4:00')
     })
 
     it('should format to "PDT"', () => {
@@ -180,7 +180,7 @@ describe('intlFormatDateTime', () => {
       expect(result).toEqual('From Apr 2024 to Apr 2025')
     })
 
-    it('should format to "Apr 3, 2025, 6:06 PM UTC"', () => {
+    it('should format to "Apr 3, 2025, 6:06 PM UTC±0:00"', () => {
       const { date, time, timezone } = intlFormatDateTime('2025-04-03T18:06:33Z', {
         timezone: TimezoneEnum.TzUtc,
         formatDate: DateFormat.DATE_MED,
@@ -189,10 +189,10 @@ describe('intlFormatDateTime', () => {
 
       const result = `${date}, ${time} ${timezone}`
 
-      expect(result).toEqual('Apr 3, 2025, 6:06 PM UTC')
+      expect(result).toEqual('Apr 3, 2025, 6:06 PM UTC±0:00')
     })
 
-    it('should format to "Apr 18, 2025 UTC-11"', () => {
+    it('should format to "Apr 18, 2025 UTC-11:00"', () => {
       const { date, timezone } = intlFormatDateTime('2025-04-18T18:25:33Z', {
         timezone: TimezoneEnum.TzPacificMidway,
         formatDate: DateFormat.DATE_MED,
@@ -200,10 +200,10 @@ describe('intlFormatDateTime', () => {
 
       const result = `${date} ${timezone}`
 
-      expect(result).toEqual('Apr 18, 2025 UTC-11')
+      expect(result).toEqual('Apr 18, 2025 UTC-11:00')
     })
 
-    it('should format to "Saturday, April 19, 2025 UTC+8"', () => {
+    it('should format to "Saturday, April 19, 2025 UTC+8:00"', () => {
       const { date, timezone } = intlFormatDateTime('2025-04-18T18:25:33Z', {
         timezone: TimezoneEnum.TzAsiaSingapore,
         formatDate: DateFormat.DATE_HUGE,
@@ -211,10 +211,10 @@ describe('intlFormatDateTime', () => {
 
       const result = `${date} ${timezone}`
 
-      expect(result).toEqual('Saturday, April 19, 2025 UTC+8')
+      expect(result).toEqual('Saturday, April 19, 2025 UTC+8:00')
     })
 
-    it('should format to "April 2, 2025 at 3:30:13 PM UTC"', () => {
+    it('should format to "April 2, 2025 at 3:30:13 PM UTC±0:00"', () => {
       const { date, time, timezone } = intlFormatDateTime('2025-04-02T15:30:13Z', {
         formatDate: DateFormat.DATE_FULL,
         formatTime: TimeFormat.TIME_WITH_SECONDS,
@@ -222,7 +222,7 @@ describe('intlFormatDateTime', () => {
 
       const result = `${date} at ${time} ${timezone}`
 
-      expect(result).toEqual('April 2, 2025 at 3:30:13 PM UTC')
+      expect(result).toEqual('April 2, 2025 at 3:30:13 PM UTC±0:00')
     })
 
     it('should format to "Thu, Apr 3, 2025 09:32:01"', () => {
@@ -236,7 +236,7 @@ describe('intlFormatDateTime', () => {
       expect(result).toEqual('Thu, Apr 3, 2025 09:32:01')
     })
 
-    it('should format to "Apr 18, 2025 18:25:33 UTC"', () => {
+    it('should format to "Apr 18, 2025 18:25:33 UTC±0:00"', () => {
       const { date, time, timezone } = intlFormatDateTime('2025-04-18T18:25:33Z', {
         formatDate: DateFormat.DATE_MED,
         formatTime: TimeFormat.TIME_24_WITH_SECONDS,
@@ -244,7 +244,7 @@ describe('intlFormatDateTime', () => {
 
       const result = `${date} ${time} ${timezone}`
 
-      expect(result).toEqual('Apr 18, 2025 18:25:33 UTC')
+      expect(result).toEqual('Apr 18, 2025 18:25:33 UTC±0:00')
     })
   })
 })

--- a/src/core/timezone/utils.ts
+++ b/src/core/timezone/utils.ts
@@ -130,6 +130,9 @@ const getTimezoneString = (dateTime: DateTime, timezone: TimezoneEnum, format: T
   return timezoneString
 }
 
+/**
+ * @warning If you use it for organization-based dates, make sure to use the `formatTimeOrgaTZ` function instead.
+ */
 export const intlFormatDateTime = (
   date: string,
   options:

--- a/src/core/timezone/utils.ts
+++ b/src/core/timezone/utils.ts
@@ -98,7 +98,7 @@ const getDateString = (dateTime: DateTime, format: DateFormat) => {
   }
   return dateTime.toLocaleString(DateTime[format])
 }
-const getTimezoneString = (dateTime: DateTime, format: TimezoneFormat) => {
+const getTimezoneString = (dateTime: DateTime, timezone: TimezoneEnum, format: TimezoneFormat) => {
   let timeZoneName: DateTimeFormatOptions['timeZoneName'] | undefined
   let timezoneString: string | undefined
 
@@ -125,12 +125,7 @@ const getTimezoneString = (dateTime: DateTime, format: TimezoneFormat) => {
         })
         .find((part) => part.type === 'timeZoneName')?.value || ''
   } else {
-    const timezoneOffset = dateTime.offset / 60
-
-    timezoneString =
-      timezoneOffset === 0
-        ? 'UTC'
-        : `UTC${timezoneOffset > 0 ? `+${timezoneOffset}` : timezoneOffset}`
+    timezoneString = `UTC${getTimezoneConfig(timezone).offset}`
   }
   return timezoneString
 }
@@ -164,6 +159,7 @@ export const intlFormatDateTime = (
     time: localeDateTime.toLocaleString(DateTime[options?.formatTime || TimeFormat.TIME_SIMPLE]),
     timezone: getTimezoneString(
       localeDateTime,
+      timezone,
       options?.formatTimezone || TimezoneFormat.UTC_OFFSET,
     ),
   }


### PR DESCRIPTION
## Context

While migrating the formatDateToTZ function, I noticed that there's already an existing utility to get the UTC offset, which can be reused directly instead of duplicating the logic.

I also found that there's another function, formatTimeOrgaTZ, which formats dates using the organization's timezone internally. In my opinion, we should favor using this function more consistently, rather than relying on the default UTC timezone.
