### PR TITLE
misc: delay the API wait until last moment in CI

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -37,17 +37,6 @@ jobs:
       - name: Launch API
         run: docker compose -f ./ci/docker-compose.ci.yml --env-file ./.env up -d api
 
-      - name: Wait for API to be ready
-        run: |
-          timeout 60s bash -c '
-            until curl -s -f -X POST http://localhost:3000/graphql \
-              -H "Content-Type: application/json" \
-              -d "{\"query\": \"query { __typename }\"}" > /dev/null; do
-              echo "Waiting for API to be ready..."
-              sleep 2
-            done
-          '
-
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
@@ -59,6 +48,17 @@ jobs:
 
       - name: Install Node.js dependencies
         run: pnpm install
+
+      - name: Wait for API to be ready
+        run: |
+          timeout 60s bash -c '
+            until curl -s -f -X POST http://localhost:3000/graphql \
+              -H "Content-Type: application/json" \
+              -d "{\"query\": \"query { __typename }\"}" > /dev/null; do
+              echo "Waiting for API to be ready..."
+              sleep 2
+            done
+          '
 
       - name: Run codegen
         env:


### PR DESCRIPTION
PNPM and Vite now makes the CI too fast, and sometimes we need to wait for the API wi be ready to perform some actions (here the codegen)

The wait done maybe too early tho