### PR TITLE
misc(Sentry): remove too noisy error catch

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -31,15 +31,7 @@ if (!!sentryDsn && appEnv !== AppEnvEnum.development) {
     tracesSampleRate: 0.3,
   })
 
-  // Capture unhandled exceptions and promise rejections
-  window.addEventListener('error', (event) => {
-    Sentry.withScope((scope) => {
-      scope.setTag('errorType', 'uncaughtException')
-      scope.setTag('location', 'window')
-      Sentry.captureException(event.error)
-    })
-  })
-
+  // Capture unhandled promise rejections
   window.addEventListener('unhandledrejection', (event) => {
     Sentry.withScope((scope) => {
       scope.setTag('errorType', 'unhandledRejection')


### PR DESCRIPTION
Removing for now, it catches some query retry and auth error that does not affect UX.
Let's hide them for now