### PR TITLE
bug: prevent displaying empty div in dom on error

### DIFF
--- a/src/components/form/TextInput/TextInput.tsx
+++ b/src/components/form/TextInput/TextInput.tsx
@@ -278,7 +278,7 @@ export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
           }
           {...props}
         />
-        {(typeof helperText === 'string' || typeof error === 'string') && (
+        {(!!helperText || (!!error && typeof error === 'string')) && (
           <Typography
             variant="caption"
             data-test={error ? 'text-field-error' : 'text-field-helpertext'}


### PR DESCRIPTION
This condition changed 2 month ago during a refactor.

This PR updates the condition to make sure it matches the inner typography content display rule (using the same logic).
Doing so we prevent displaying empty div in dom. 

<!-- Linear link -->
Fixes ISSUE-836