### PR TITLE
bug: prevent wrong copy displayed for invoice sync

### DIFF
--- a/src/components/settings/integrations/AnrokIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AnrokIntegrationSettings.tsx
@@ -83,7 +83,7 @@ const AnrokIntegrationSettings = () => {
   const deleteDialogRef = useRef<DeleteAnrokIntegrationDialogRef>(null)
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
-  const [retryAllInvoices] = useRetryAllInvoicesMutation({
+  const [retryAllInvoices, { loading: retryAllInvoicesLoading }] = useRetryAllInvoicesMutation({
     onCompleted(result) {
       if (!!result?.retryAllInvoices?.metadata?.totalCount) {
         addToast({
@@ -217,7 +217,9 @@ const AnrokIntegrationSettings = () => {
               </Stack>
             ) : (
               <Typography variant="caption" color="grey600">
-                {translate('text_66ba5ca33713b600c4e8fcf0')}
+                {retryAllInvoicesLoading
+                  ? translate('text_66ba5ca33713b600c4e8fcf0')
+                  : translate('text_66ba5ca33713b600c4e8fcf1')}
               </Typography>
             )}
           </Stack>

--- a/translations/base.json
+++ b/translations/base.json
@@ -2956,5 +2956,6 @@
   "text_1744192691931pjtht59xxk0": "Offered credits",
   "text_17441926919314anbpq9h0t3": "Paid credits",
   "text_17441926919313u9z1er36fh": "Consumed credits",
-  "text_1744192691931co5ozcxf9qw": "Voided credits"
+  "text_1744192691931co5ozcxf9qw": "Voided credits",
+  "text_66ba5ca33713b600c4e8fcf1": "All invoices has been successfully synchronized to Anrok!"
 }


### PR DESCRIPTION
The default copy was showing "sync in progress" even tho the call was not triggered.

This fixed the copy depending on the loading state

Fixes ISSUE-843