### PR TITLE
fix(PrepaidCreditsAnalytics): fix formatting ticks with big number short notation

### DIFF
--- a/src/components/designSystem/graphs/StackedBarChart.tsx
+++ b/src/components/designSystem/graphs/StackedBarChart.tsx
@@ -325,11 +325,14 @@ const StackedBarChart = <T extends DataItem>({
                 return <></>
               }
 
-              const deserialized = deserializeAmount(payload.value, currency)
+              const isNegative = payload.value < 0
 
-              const formatted = bigNumberShortenNotationFormater(deserialized, {
-                currency,
-              })
+              const formatted = bigNumberShortenNotationFormater(
+                isNegative ? -payload.value : payload.value,
+                {
+                  currency,
+                },
+              )
 
               if (loading) {
                 return (
@@ -352,7 +355,14 @@ const StackedBarChart = <T extends DataItem>({
                       letterSpacing: '-0.16px',
                     }}
                   >
-                    {index !== 0 && hasOnlyZeroValues ? '-' : formatted}
+                    {index !== 0 && hasOnlyZeroValues ? (
+                      '-'
+                    ) : (
+                      <>
+                        {isNegative && '-'}
+                        {formatted}
+                      </>
+                    )}
                   </text>
                 </g>
               )


### PR DESCRIPTION
<img width="266" alt="image" src="https://github.com/user-attachments/assets/11c55d81-ecab-4b9b-9ba2-956c9a21ce20" />
