### PR TITLE
bug: fix wrong redirections

### DIFF
--- a/src/hooks/core/useLocationHistory.ts
+++ b/src/hooks/core/useLocationHistory.ts
@@ -8,7 +8,10 @@ import {
   removeItemFromLS,
   setItemFromLS,
 } from '~/core/apolloClient'
-import { LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY } from '~/core/constants/localStorageKeys'
+import {
+  LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY,
+  ORGANIZATION_LS_KEY_ID,
+} from '~/core/constants/localStorageKeys'
 import { CustomRouteObject, FORBIDDEN_ROUTE, HOME_ROUTE, LOGIN_ROUTE } from '~/core/router'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { usePermissions } from '~/hooks/usePermissions'
@@ -90,8 +93,11 @@ export const useLocationHistory: UseLocationHistoryReturn = () => {
           search: location.search,
         })
 
-        // If user is kickd out or logs out, we save the last private route visited to redirect after login
-        setItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY, location)
+        // If user is kickd out or logs out, we save manually the last private route visited to redirect after login
+        setItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY, {
+          location,
+          organizationId: getItemFromLS(ORGANIZATION_LS_KEY_ID),
+        })
       } else if (
         isAuthenticated &&
         routeConfig.permissions?.length &&

--- a/src/hooks/core/useLocationHistory.ts
+++ b/src/hooks/core/useLocationHistory.ts
@@ -89,7 +89,6 @@ export const useLocationHistory: UseLocationHistoryReturn = () => {
           pathname: LOGIN_ROUTE,
           search: location.search,
         })
-        addLocationToHistory(location)
 
         // If user is kickd out or logs out, we save the last private route visited to redirect after login
         setItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY, location)

--- a/src/hooks/core/useLocationHistory.ts
+++ b/src/hooks/core/useLocationHistory.ts
@@ -93,7 +93,7 @@ export const useLocationHistory: UseLocationHistoryReturn = () => {
           search: location.search,
         })
 
-        // If user is kickd out or logs out, we save manually the last private route visited to redirect after login
+        // If user is kicked out or logs out, we save manually the last private route visited to redirect after login
         setItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY, {
           location,
           organizationId: getItemFromLS(ORGANIZATION_LS_KEY_ID),

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,7 +3,10 @@ import { generatePath, useNavigate } from 'react-router-dom'
 
 import { Icon } from '~/components/designSystem'
 import { getItemFromLS, removeItemFromLS } from '~/core/apolloClient'
-import { LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY } from '~/core/constants/localStorageKeys'
+import {
+  LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY,
+  ORGANIZATION_LS_KEY_ID,
+} from '~/core/constants/localStorageKeys'
 import { NewAnalyticsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { ANALYTIC_ROUTE, ANALYTIC_TABS_ROUTE, CUSTOMERS_LIST_ROUTE } from '~/core/router'
 import { PremiumIntegrationTypeEnum } from '~/generated/graphql'
@@ -31,10 +34,18 @@ const Home = () => {
         !!lastPrivateVisitedRouteWhileNotConnected &&
         lastPrivateVisitedRouteWhileNotConnected.location.pathname !== '/'
       ) {
-        navigate(lastPrivateVisitedRouteWhileNotConnected, { replace: true })
-        // This is a temp value for redirection, should be removed after redirection have been performed
+        const currentOrganizationId = getItemFromLS(ORGANIZATION_LS_KEY_ID)
+
+        if (lastPrivateVisitedRouteWhileNotConnected.organizationId === currentOrganizationId) {
+          // Return navigation to prevent later ones to be performed
+          return navigate(lastPrivateVisitedRouteWhileNotConnected.location, { replace: true })
+        }
+
+        // This is a temp value for redirection, should be removed if it does not match the current organization
         removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
-      } else if (hasPermissions(['analyticsView']) && !hasAccessToAnalyticsDashboardsFeature) {
+      }
+
+      if (hasPermissions(['analyticsView']) && !hasAccessToAnalyticsDashboardsFeature) {
         navigate(ANALYTIC_ROUTE, { replace: true })
       } else if (hasPermissions(['dataApiView']) && hasAccessToAnalyticsDashboardsFeature) {
         navigate(

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -23,13 +23,13 @@ const Home = () => {
   useEffect(() => {
     // Make sure user permissions are loaded before performing redirection
     if (!isUserLoading && !!currentMembership) {
-      const lastPrivateVisitedRouteWhileNotConnected: Location | undefined = getItemFromLS(
-        LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY,
-      )
+      const lastPrivateVisitedRouteWhileNotConnected:
+        | { location: Location; organizationId: string }
+        | undefined = getItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
 
       if (
         !!lastPrivateVisitedRouteWhileNotConnected &&
-        lastPrivateVisitedRouteWhileNotConnected.pathname !== '/'
+        lastPrivateVisitedRouteWhileNotConnected.location.pathname !== '/'
       ) {
         navigate(lastPrivateVisitedRouteWhileNotConnected, { replace: true })
         // This is a temp value for redirection, should be removed after redirection have been performed

--- a/src/pages/Invitation.tsx
+++ b/src/pages/Invitation.tsx
@@ -8,8 +8,9 @@ import { object, string } from 'yup'
 import GoogleAuthButton from '~/components/auth/GoogleAuthButton'
 import { Alert, Button, Skeleton, Typography } from '~/components/designSystem'
 import { TextInput } from '~/components/form'
-import { hasDefinedGQLError, onLogIn } from '~/core/apolloClient'
+import { hasDefinedGQLError, onLogIn, removeItemFromLS } from '~/core/apolloClient'
 import { DOCUMENTATION_ENV_VARS } from '~/core/constants/externalUrls'
+import { LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY } from '~/core/constants/localStorageKeys'
 import { LOGIN_ROUTE } from '~/core/router'
 import { addValuesToUrlState } from '~/core/utils/urlUtils'
 import {
@@ -168,6 +169,9 @@ const Invitation = () => {
   )
   const onInvitation = async () => {
     const { password } = formFields
+
+    // make sure no previous visited route is saved in the LS
+    removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
 
     await acceptInvite({
       variables: {


### PR DESCRIPTION
## Context

We're experiencing many 404 errors on Sentry.
It cames to conclusion that most of them are due to a wrong redirection after login.

Today, we have 2 ways to manage location history and redirections:
- The react router one, handled in a reactive var called `locationHistory`
- The Local Storage (LS) one, handled by the value stored in `LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY`

## Description

This PR makes sure redirection logics are not conflicting and don't lead to wrong redirections anymore.
On logout (or JWT expiration), we not only rely on the LS logic, and we also store the organization ID there.
So on login we can compare the orga ID and determine if the redirection should occur or of we should rely on the default one (done in `Home.tsx`).
LS key should also be removed in the invitation flow, as we could perform the invitation flow on the same browser that was connected before.

Note that the location history routing is still usefull mainly to handle our `goBack` logic.

This is not an ideal approach IMO but should solve some 404 Sentry alerts

<!-- Linear link -->
Fixes ISSUE-835