### PR TITLE
misc: make sure to build packages on install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage
 cypress/downloads
 .swc/
 .pnpm-store/
+node-jiti/
+v8-compile-cache*

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   ],
   "scripts": {
     "dev": "vite",
-    "prebuild": "pnpm --filter lago-design-system build",
+    "build:packages": "pnpm --filter lago-design-system build",
+    "postinstall": "pnpm run build:packages",
+    "prebuild": "pnpm run build:packages",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "prettier --check src/**/*.{ts,tsx,svg} --check index.html --check cypress/**/*.ts && eslint",


### PR DESCRIPTION
## Context

We have some packages in the app. Only the design system one need to be build to be used.
We have to build also when working locally, at least once.

## Description

I've added a `postinstall` to build the packages too, so the `start.dev.sh` commands don't have to be updated and developers/contributors don't have to find out how to run the app locally for the first time and don't face this error.

![Screenshot 2025-04-28 at 11 09 09](https://github.com/user-attachments/assets/8ba1f09c-f3d3-454a-bff2-e2eac23dcdb9)


I had to add some new ignored files in the list tho. For some reasons, building through docker generated other folders that were not listed there.

<!-- Linear link -->
Fixes ISSUE-856