### PR TITLE
misc: fix LS old data shape wrong access

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -32,7 +32,8 @@ const Home = () => {
 
       if (
         !!lastPrivateVisitedRouteWhileNotConnected &&
-        lastPrivateVisitedRouteWhileNotConnected.location.pathname !== '/'
+        !!lastPrivateVisitedRouteWhileNotConnected?.organizationId &&
+        lastPrivateVisitedRouteWhileNotConnected?.location?.pathname !== '/'
       ) {
         const currentOrganizationId = getItemFromLS(ORGANIZATION_LS_KEY_ID)
 


### PR DESCRIPTION
I changed the LS value shape but customer can still have the old value type there (just a string)

This PR makes sure we check on the shape before entering the if.

Thankfully, the Sentry error just mean it was raising a console error but redirection still hapened