### PR TITLE
bug: prevent cache manipulation after deletion

### DIFF
--- a/src/components/addOns/DeleteAddOnDialog.tsx
+++ b/src/components/addOns/DeleteAddOnDialog.tsx
@@ -48,15 +48,7 @@ export const DeleteAddOnDialog = forwardRef<DeleteAddOnDialogRef>((_, ref) => {
         localData?.callback && localData.callback()
       }
     },
-    update(cache, { data }) {
-      if (!data?.destroyAddOn) return
-      const cacheId = cache.identify({
-        id: data?.destroyAddOn.id,
-        __typename: 'AddOn',
-      })
-
-      cache.evict({ id: cacheId })
-    },
+    refetchQueries: ['addOns'],
   })
 
   useImperativeHandle(ref, () => ({

--- a/src/components/customers/DeleteCustomerDialog.tsx
+++ b/src/components/customers/DeleteCustomerDialog.tsx
@@ -57,16 +57,7 @@ export const DeleteCustomerDialog = forwardRef<DeleteCustomerDialogRef, unknown>
         })
       }
     },
-    update(cache, { data }) {
-      if (!data?.destroyCustomer) return
-
-      const cacheId = cache.identify({
-        id: data?.destroyCustomer.id,
-        __typename: 'Customer',
-      })
-
-      cache.evict({ id: cacheId })
-    },
+    refetchQueries: ['customers'],
   })
 
   return (

--- a/src/components/plans/DeletePlanDialog.tsx
+++ b/src/components/plans/DeletePlanDialog.tsx
@@ -54,16 +54,7 @@ export const DeletePlanDialog = forwardRef<DeletePlanDialogRef>((_, ref) => {
         localData?.callback && localData.callback()
       }
     },
-    update(cache, { data }) {
-      if (!data?.destroyPlan) return
-
-      const cacheId = cache.identify({
-        id: data?.destroyPlan.id,
-        __typename: 'Plan',
-      })
-
-      cache.evict({ id: cacheId })
-    },
+    refetchQueries: ['plans'],
   })
 
   useImperativeHandle(ref, () => ({


### PR DESCRIPTION
Manually manipulating the cache makes apollo re-trigger active queries. 

We should instead let him handle re-fetch and cache update.

Did that for 3 different resources

Fixes ISSUE-857