### PR TITLE
misc: simplify copy for tax provider invoice sync

### DIFF
--- a/src/components/settings/integrations/AnrokIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AnrokIntegrationSettings.tsx
@@ -193,23 +193,15 @@ const AnrokIntegrationSettings = () => {
             {loading ? (
               <Skeleton className="mb-1 mt-2" variant="text" />
             ) : !!anrokIntegration?.failedInvoicesCount ? (
-              <Stack display="inline" divider={<>{/* Space here is important */} </>}>
-                <Typography component="span" variant="caption" color="grey600">
-                  {translate('text_66ba5a76e614f000a738c97b')}
-                </Typography>
-                <Typography component="span" variant="caption" color="grey700">
-                  {translate(
-                    'text_66ba5a76e614f000a738c97c',
-                    {
-                      failedInvoicesCount: anrokIntegration?.failedInvoicesCount,
-                    },
-                    anrokIntegration?.failedInvoicesCount || 1,
-                  )}
-                </Typography>
-                <Typography component="span" variant="caption" color="grey600">
-                  {translate('text_66ba5a76e614f000a738c97d')}
-                </Typography>
-              </Stack>
+              <Typography variant="caption" color="grey600">
+                {translate(
+                  'text_1746004262383fhhy4jl1g6o',
+                  {
+                    failedInvoicesCount: anrokIntegration?.failedInvoicesCount,
+                  },
+                  anrokIntegration?.failedInvoicesCount,
+                )}
+              </Typography>
             ) : (
               <Typography variant="caption" color="grey600">
                 {retryAllInvoicesLoading

--- a/src/components/settings/integrations/AnrokIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AnrokIntegrationSettings.tsx
@@ -78,7 +78,7 @@ const AnrokIntegrationSettings = () => {
   const addAnrokDialogRef = useRef<AddAnrokDialogRef>(null)
   const deleteDialogRef = useRef<DeleteAnrokIntegrationDialogRef>(null)
   const { translate } = useInternationalization()
-  const [retryAllInvoices, { loading: retryAllInvoicesLoading }] = useRetryAllInvoicesMutation({
+  const [retryAllInvoices] = useRetryAllInvoicesMutation({
     onCompleted(result) {
       if (!!result?.retryAllInvoices?.metadata?.totalCount) {
         addToast({
@@ -190,9 +190,8 @@ const AnrokIntegrationSettings = () => {
             <Typography variant="bodyHl" color="grey700">
               {translate('text_66ba5a76e614f000a738c97a')}
             </Typography>
-            {loading ? (
-              <Skeleton className="mb-1 mt-2" variant="text" />
-            ) : !!anrokIntegration?.failedInvoicesCount ? (
+            {loading && <Skeleton className="mb-1 mt-2" variant="text" />}
+            {!loading && !!anrokIntegration?.failedInvoicesCount && (
               <Typography variant="caption" color="grey600">
                 {translate(
                   'text_1746004262383fhhy4jl1g6o',
@@ -202,11 +201,10 @@ const AnrokIntegrationSettings = () => {
                   anrokIntegration?.failedInvoicesCount,
                 )}
               </Typography>
-            ) : (
+            )}
+            {!loading && !anrokIntegration?.failedInvoicesCount && (
               <Typography variant="caption" color="grey600">
-                {retryAllInvoicesLoading
-                  ? translate('text_66ba5ca33713b600c4e8fcf0')
-                  : translate('text_66ba5ca33713b600c4e8fcf1')}
+                {translate('text_66ba5ca33713b600c4e8fcf1')}
               </Typography>
             )}
           </Stack>

--- a/src/components/settings/integrations/AvalaraIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AvalaraIntegrationSettings.tsx
@@ -197,23 +197,15 @@ const AvalaraIntegrationSettings = () => {
             {loading ? (
               <Skeleton className="mb-1 mt-2" variant="text" />
             ) : !!avalaraIntegration?.failedInvoicesCount ? (
-              <div className="inline-flex flex-row gap-1">
-                <Typography component="span" variant="caption" color="grey600">
-                  {translate('text_66ba5a76e614f000a738c97b')}
-                </Typography>
-                <Typography component="span" variant="caption" color="grey700">
-                  {translate(
-                    'text_66ba5a76e614f000a738c97c',
-                    {
-                      failedInvoicesCount: avalaraIntegration?.failedInvoicesCount,
-                    },
-                    avalaraIntegration?.failedInvoicesCount || 1,
-                  )}
-                </Typography>
-                <Typography component="span" variant="caption" color="grey600">
-                  {translate('text_66ba5a76e614f000a738c97d')}
-                </Typography>
-              </div>
+              <Typography variant="caption" color="grey600">
+                {translate(
+                  'text_1746004262383fhhy4jl1g6o',
+                  {
+                    failedInvoicesCount: avalaraIntegration?.failedInvoicesCount,
+                  },
+                  avalaraIntegration?.failedInvoicesCount,
+                )}
+              </Typography>
             ) : (
               <Typography variant="caption" color="grey600">
                 {retryAllAvalaraInvoicesLoading

--- a/src/components/settings/integrations/AvalaraIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AvalaraIntegrationSettings.tsx
@@ -79,18 +79,17 @@ const AvalaraIntegrationSettings = () => {
   const deleteDialogRef = useRef<DeleteAvalaraIntegrationDialogRef>(null)
   const { translate } = useInternationalization()
 
-  const [retryAllAvalaraInvoices, { loading: retryAllAvalaraInvoicesLoading }] =
-    useRetryAllAvalaraInvoicesMutation({
-      onCompleted(result) {
-        if (!!result?.retryAllInvoices?.metadata?.totalCount) {
-          addToast({
-            severity: 'info',
-            message: translate('text_66ba5a76e614f000a738c97f'),
-          })
-        }
-      },
-      refetchQueries: ['getAvalaraIntegrationsSettings'],
-    })
+  const [retryAllAvalaraInvoices] = useRetryAllAvalaraInvoicesMutation({
+    onCompleted(result) {
+      if (!!result?.retryAllInvoices?.metadata?.totalCount) {
+        addToast({
+          severity: 'info',
+          message: translate('text_66ba5a76e614f000a738c97f'),
+        })
+      }
+    },
+    refetchQueries: ['getAvalaraIntegrationsSettings'],
+  })
 
   const { data, loading } = useGetAvalaraIntegrationSettingsQuery({
     variables: {
@@ -114,6 +113,7 @@ const AvalaraIntegrationSettings = () => {
       )
     }
   }
+
   return (
     <>
       <IntegrationsPage.Container className="my-4 md:my-8">
@@ -194,9 +194,8 @@ const AvalaraIntegrationSettings = () => {
             <Typography variant="bodyHl" color="grey700">
               {translate('text_66ba5a76e614f000a738c97a')}
             </Typography>
-            {loading ? (
-              <Skeleton className="mb-1 mt-2" variant="text" />
-            ) : !!avalaraIntegration?.failedInvoicesCount ? (
+            {loading && <Skeleton className="mb-1 mt-2" variant="text" />}
+            {!loading && !!avalaraIntegration?.failedInvoicesCount && (
               <Typography variant="caption" color="grey600">
                 {translate(
                   'text_1746004262383fhhy4jl1g6o',
@@ -206,11 +205,10 @@ const AvalaraIntegrationSettings = () => {
                   avalaraIntegration?.failedInvoicesCount,
                 )}
               </Typography>
-            ) : (
+            )}
+            {!loading && !avalaraIntegration?.failedInvoicesCount && (
               <Typography variant="caption" color="grey600">
-                {retryAllAvalaraInvoicesLoading
-                  ? translate('text_66ba5ca33713b600c4e8fcf0')
-                  : translate('text_66ba5ca33713b600c4e8fcf2')}
+                {translate('text_66ba5ca33713b600c4e8fcf2')}
               </Typography>
             )}
           </div>

--- a/translations/base.json
+++ b/translations/base.json
@@ -2980,5 +2980,6 @@
   "text_1745415984416mjvvaj4ahgp": "Type an Avalara tax code",
   "text_1745827156646ff5h5i281gc": "Avalara customer code",
   "text_1745827156646zoyf7wmog2m": "Type an Avalara customer code",
-  "text_1745919770448pvibiukolis": "We cannot access your clipboard. Please try again."
+  "text_1745919770448pvibiukolis": "We cannot access your clipboard. Please try again.",
+  "text_1746004262383fhhy4jl1g6o": "Restart the synchronization of {{failedInvoicesCount}} failed invoice to recalculate tax information.|Restart the synchronization of {{failedInvoicesCount}} failed invoices to recalculate tax information."
 }


### PR DESCRIPTION
Working on integrations, spotted this part to improve.

I unified sync copy, simplified code and removed 3 warnings about nested ternaries and missing space.

Please note `retryAllAvalaraInvoicesLoading` condition was never reached, as the button was disabled if invoice count was 0.