### PR TITLE
misc: improve sentry error messages

### DIFF
--- a/src/core/apolloClient/init.ts
+++ b/src/core/apolloClient/init.ts
@@ -84,7 +84,7 @@ export const initializeApolloClient = async () => {
             message !== 'PersistedQueryNotFound'
           ) {
             // Capture in Sentry with operation details
-            captureException(value, {
+            captureException(message, {
               tags: {
                 errorType: 'GraphQLError',
                 operationName: operation.operationName,
@@ -93,6 +93,7 @@ export const initializeApolloClient = async () => {
                 path,
                 locations,
                 extensions,
+                value,
                 variables: operation.variables,
               },
             })


### PR DESCRIPTION
## Context

We receive a lot of sentries but message is not explicit.

This is because the error type is not an JS error type but a GQL serialized one.

## Description

This PR makes sure we pass the message to the error, and all the value as additional data so we don't miss anything.

So error willl now be like `Resource not found` instead of the autogenerated random letters we got