### PR TITLE
misc: clear LS last visited route before goBack on home

### DIFF
--- a/src/hooks/core/useLocationHistory.ts
+++ b/src/hooks/core/useLocationHistory.ts
@@ -67,6 +67,12 @@ export const useLocationHistory: UseLocationHistoryReturn = () => {
   const goBack: GoBack = (fallback, options) => {
     const { previous, remaingHistory } = getPreviousLocation(options || {})
 
+    if (fallback === HOME_ROUTE) {
+      // Make sure the LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY is not set
+      // Otherwise, the back redirection will not always work in Home page
+      removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
+    }
+
     navigate(previous || fallback)
 
     locationHistoryVar(remaingHistory || [])
@@ -82,7 +88,7 @@ export const useLocationHistory: UseLocationHistoryReturn = () => {
          * In case of navigation to a only public route while authenticated
          * Go back to previously visited page in app or fallback to the home
          */
-        goBack(HOME_ROUTE, { previousCount: 0 })
+        navigate(HOME_ROUTE)
       } else if (routeConfig.private && !isAuthenticated) {
         /**
          * In case of navigation to a private route while NOT authenticated

--- a/src/layouts/Settings.tsx
+++ b/src/layouts/Settings.tsx
@@ -80,11 +80,11 @@ const Settings = () => {
             <Button
               variant="quaternary"
               startIcon="arrow-left"
-              onClick={() =>
+              onClick={() => {
                 goBack(HOME_ROUTE, {
                   exclude: routesToExcludeFromBackRedirection,
                 })
-              }
+              }}
             >
               <Typography variant="body" color="textSecondary" noWrap>
                 {translate('text_65df4fc6314ffd006ce0a537')}


### PR DESCRIPTION
This is a hairy one.

If you get kicked out the app (e.g. JWT expiration), we set the last visited route to LS.
If you do it on any settings page, 404 or forbidden one, you will face a bug when clicking on "back" or "Back to the app" button.
They all use the goBack method, and in those 3 pages it sets the home page as a fallback.
Issue is that if you navigate this route, you will perform the home hook logic that checks the LS last visited route, hence being redirected to your LS last visited route, again.

This is edge but can happen.
As we still live with the custom navigation LS and the localHistory var, this is more a patch than a real fix.
And going back with HOME as a fallback is deterministic, users intentionally know where he'll be redirected so we can clear this LS place.

Also thought about clearing the LS more often in the route handler hook, but felt it was introducing a new volatile behaviour, hard to always catch

<!-- Linear link -->
Fixes ISSUE-860