### PR TITLE
bug: prevent sub display if parent is terminated

### DIFF
--- a/src/components/customers/overview/CustomerSubscriptionsList.tsx
+++ b/src/components/customers/overview/CustomerSubscriptionsList.tsx
@@ -134,6 +134,7 @@ const annotateSubscriptions = (
     }
 
     const _subDowngrade = isDowngrading &&
+      status !== StatusTypeEnum.Terminated &&
       nextPlan && {
         id: nextSubscription?.id || nextPlan.id,
         externalId: nextSubscription?.externalId,


### PR DESCRIPTION
Make sure we don't displayed unnecessary children sub if the parent one is terminated. It happen when we perform a downgrade.
Occurs since we removed the sub filter by status 

<!-- Linear link -->
Fixes ISSUE-866