### PR TITLE
bug: allow to reset invoice display name value

### DIFF
--- a/src/components/invoices/EditInvoiceDisplayName.tsx
+++ b/src/components/invoices/EditInvoiceDisplayName.tsx
@@ -32,7 +32,7 @@ export const EditInvoiceDisplayName = forwardRef<EditInvoiceDisplayNameRef>((_, 
     validateOnMount: true,
     enableReinitialize: true,
     onSubmit: async (values, formikBag) => {
-      !!values.invoiceDisplayName && data?.callback(values.invoiceDisplayName)
+      data?.callback(values.invoiceDisplayName || '')
 
       dialogRef?.current?.closeDialog()
       formikBag.resetForm()


### PR DESCRIPTION
Noticed we were not able to submit after reseting the invoice display name input value