### PR TITLE
misc: unify tax error translations

### DIFF
--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -35,6 +35,7 @@ import { InvoicePaymentList } from '~/components/invoices/InvoicePaymentList'
 import { VoidInvoiceDialog, VoidInvoiceDialogRef } from '~/components/invoices/VoidInvoiceDialog'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { addToast, envGlobalVar, LagoGQLError } from '~/core/apolloClient'
+import { LocalTaxProviderErrorsEnum } from '~/core/constants/form'
 import { invoiceStatusMapping, paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
 import {
   CustomerDetailsTabsOptions,
@@ -245,21 +246,21 @@ const getErrorMessageFromErrorDetails = (
 
   if (errorCode === ErrorCodesEnum.TaxError) {
     if (errorDetails === LagoApiError.CurrencyCodeNotSupported) {
-      return 'text_17238318811308wqpult4i7r'
+      return LocalTaxProviderErrorsEnum.CurrencyCodeNotSupported
     }
 
     if (
       errorDetails === LagoApiError.CustomerAddressCouldNotResolve ||
       errorDetails === LagoApiError.CustomerAddressCountryNotSupported
     ) {
-      return 'text_1723831881130x4cfh6qr6o8'
+      return LocalTaxProviderErrorsEnum.CustomerAddressError
     }
 
     if (errorDetails === LagoApiError.ProductExternalIdUnknown) {
-      return 'text_1723831881130g8hv6qzqe57'
+      return LocalTaxProviderErrorsEnum.ProductExternalIdUnknown
     }
 
-    return 'text_17238318811307ghoc4v7mt9'
+    return LocalTaxProviderErrorsEnum.GenericErrorMessage
   }
 }
 

--- a/translations/base.json
+++ b/translations/base.json
@@ -2254,7 +2254,7 @@
   "text_1724165657161stcilcabm7x": "Invoice could not be issued.",
   "text_17238318811308wqpult4i7r": "Currency defined is not supported for taxes calculation. Please contact the Lago team to resolve this issue.",
   "text_1723831881130x4cfh6qr6o8": "Customer address information has issues preventing calculating taxes. Please update the information to generate the invoice.",
-  "text_1723831881130g8hv6qzqe57": "Anrok connection items mapping has issues preventing calculating taxes. Please update the mapping to generate the invoice.",
+  "text_1723831881130g8hv6qzqe57": "Tax provider items mapping has issues preventing calculating taxes. Please update the mapping to generate the invoice.",
   "text_17238318811307ghoc4v7mt9": "An issue with your tax provider connection occurred. Please contact the Lago team to solve this issue.",
   "text_1724166369123t6c4k8zn80c": "Credit notes & prepaid credit will impact the invoice once it's finalized.",
   "text_1724170152395tr7v0f15xsv": "This invoice is in draft mode. You have until {{issuingDate}} to adjust it.",


### PR DESCRIPTION
This PR does 2 things
- use the same LocalTaxProviderErrorsEnum to manage translations in all places of the app
- make `text_1723831881130g8hv6qzqe57` translation more generic, se we can use it for both Anrok and (next to come) Alavara tax providers