### PR TITLE
misc: show subscription terminatedAt when relevant

### DIFF
--- a/src/components/customers/overview/CustomerSubscriptionsList.tsx
+++ b/src/components/customers/overview/CustomerSubscriptionsList.tsx
@@ -55,6 +55,7 @@ gql`
         externalId
         subscriptionAt
         endingAt
+        terminatedAt
         plan {
           id
           amountCurrency
@@ -88,6 +89,7 @@ type AnnotatedSubscription = {
   name: Subscription['name']
   startedAt: Subscription['startedAt']
   endingAt?: Subscription['endingAt']
+  terminatedAt?: Subscription['terminatedAt']
   status?: Subscription['status']
   frequency: Plan['interval']
   statusType: {
@@ -116,6 +118,7 @@ const annotateSubscriptions = (
       startedAt,
       subscriptionAt,
       endingAt,
+      terminatedAt,
       customer,
       nextSubscription,
     } = subscription || {}
@@ -129,6 +132,7 @@ const annotateSubscriptions = (
       status,
       startedAt: startedAt || subscriptionAt,
       endingAt: endingAt,
+      terminatedAt,
       frequency: plan.interval,
       startDate: startedAt || subscriptionAt,
       statusType: subscriptionStatusMapping(status),
@@ -356,11 +360,11 @@ export const CustomerSubscriptionsList = ({ customerTimezone }: CustomerSubscrip
               {
                 key: 'endingAt',
                 title: translate('text_65201c5a175a4b0238abf2a0'),
-                content: ({ endingAt }) =>
-                  endingAt ? (
+                content: ({ endingAt, status, terminatedAt }) =>
+                  endingAt || terminatedAt ? (
                     <TimezoneDate
                       typographyClassName="text-nowrap text-base font-normal text-grey-600"
-                      date={endingAt}
+                      date={status === StatusTypeEnum.Terminated ? terminatedAt : endingAt}
                       customerTimezone={customerTimezone}
                     />
                   ) : (

--- a/src/components/subscriptions/SubscriptionInformations.tsx
+++ b/src/components/subscriptions/SubscriptionInformations.tsx
@@ -10,6 +10,7 @@ import { PlanDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { CUSTOMER_DETAILS_ROUTE, CUSTOMER_SUBSCRIPTION_PLAN_DETAILS } from '~/core/router'
 import {
   NextSubscriptionTypeEnum,
+  StatusTypeEnum,
   SubscriptionForSubscriptionInformationsFragment,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -22,6 +23,7 @@ gql`
     status
     subscriptionAt
     endingAt
+    terminatedAt
     nextSubscriptionAt
     nextSubscriptionType
     nextPlan {
@@ -43,6 +45,22 @@ gql`
     }
   }
 `
+
+const SubscriptionEndOrTerminatedAt = ({
+  subscription,
+}: {
+  subscription?: SubscriptionForSubscriptionInformationsFragment | null
+}) => {
+  if (subscription?.status === StatusTypeEnum.Terminated) {
+    return DateTime.fromISO(subscription?.terminatedAt).toFormat('LLL. dd, yyyy')
+  }
+
+  if (subscription?.endingAt) {
+    return DateTime.fromISO(subscription?.endingAt).toFormat('LLL. dd, yyyy')
+  }
+
+  return '-'
+}
 
 export const SubscriptionInformations = ({
   subscription,
@@ -105,9 +123,7 @@ export const SubscriptionInformations = ({
             },
             {
               label: translate('text_65201c5a175a4b0238abf2a0'),
-              value: !!subscription?.endingAt
-                ? DateTime.fromISO(subscription?.endingAt).toFormat('LLL. dd, yyyy')
-                : '-',
+              value: <SubscriptionEndOrTerminatedAt subscription={subscription} />,
             },
             !!subscription?.plan?.parent?.id && {
               label: translate('text_65201c5a175a4b0238abf2a2'),

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -8069,7 +8069,7 @@ export type GetCustomerSubscriptionForListQueryVariables = Exact<{
 }>;
 
 
-export type GetCustomerSubscriptionForListQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, name?: string | null, nextName?: string | null, externalId: string, subscriptionAt?: any | null, endingAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, interval: PlanInterval }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string, interval: PlanInterval } | null, nextSubscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, status?: StatusTypeEnum | null } | null }> } | null };
+export type GetCustomerSubscriptionForListQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, subscriptions: Array<{ __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, startedAt?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, name?: string | null, nextName?: string | null, externalId: string, subscriptionAt?: any | null, endingAt?: any | null, terminatedAt?: any | null, plan: { __typename?: 'Plan', id: string, amountCurrency: CurrencyEnum, name: string, interval: PlanInterval }, nextPlan?: { __typename?: 'Plan', id: string, name: string, code: string, interval: PlanInterval } | null, nextSubscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, status?: StatusTypeEnum | null } | null }> } | null };
 
 export type TerminateCustomerSubscriptionMutationVariables = Exact<{
   input: TerminateSubscriptionInput;
@@ -9442,9 +9442,9 @@ export type GetSubscriptionForDetailsOverviewQueryVariables = Exact<{
 }>;
 
 
-export type GetSubscriptionForDetailsOverviewQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null }, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string } } | null };
+export type GetSubscriptionForDetailsOverviewQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, terminatedAt?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null }, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string } } | null };
 
-export type SubscriptionForSubscriptionInformationsFragment = { __typename?: 'Subscription', id: string, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null } };
+export type SubscriptionForSubscriptionInformationsFragment = { __typename?: 'Subscription', id: string, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, terminatedAt?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null } };
 
 export type SubscriptionUsageLifetimeGraphForLifetimeGraphFragment = { __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, lifetimeUsage?: { __typename?: 'SubscriptionLifetimeUsage', lastThresholdAmountCents?: any | null, nextThresholdAmountCents?: any | null, totalUsageAmountCents: any, totalUsageFromDatetime: any, totalUsageToDatetime: any } | null, customer: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null, applicableTimezone: TimezoneEnum }, plan: { __typename?: 'Plan', id: string } };
 
@@ -12011,6 +12011,7 @@ export const SubscriptionForSubscriptionInformationsFragmentDoc = gql`
   status
   subscriptionAt
   endingAt
+  terminatedAt
   nextSubscriptionAt
   nextSubscriptionType
   nextPlan {
@@ -17190,6 +17191,7 @@ export const GetCustomerSubscriptionForListDocument = gql`
       externalId
       subscriptionAt
       endingAt
+      terminatedAt
       plan {
         id
         amountCurrency


### PR DESCRIPTION
Better to show `terminatedAt` for a terminated subscription than an empty end date.

Note this adjustment is no done in plan > subscriptions list cause it only show active ones.