### PR TITLE
feat(Analytics): Daily usage - fixes

### DIFF
--- a/src/components/analytics/usage/UsageBreakdownBillableMetrics.tsx
+++ b/src/components/analytics/usage/UsageBreakdownBillableMetrics.tsx
@@ -1,4 +1,4 @@
-import { Icon, Typography } from 'lago-design-system'
+import { GenericPlaceholder, Icon, Skeleton, Typography } from 'lago-design-system'
 import _groupBy from 'lodash/groupBy'
 import { useMemo } from 'react'
 import { generatePath, Link } from 'react-router-dom'
@@ -12,10 +12,12 @@ import { ANALYTIC_USAGE_BILLABLE_METRIC_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { CurrencyEnum, DataApiUsage, TimeGranularityEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import EmptyImage from '~/public/images/maneki/empty.svg'
+import ErrorImage from '~/public/images/maneki/error.svg'
 import { theme } from '~/styles'
 
 type UsageBreakdownBillableMetricsProps = {
-  data: DataApiUsage[]
+  data?: DataApiUsage[]
   defaultStaticDatePeriod: string
   defaultStaticTimeGranularity: TimeGranularityEnum
   selectedCurrency: CurrencyEnum
@@ -23,6 +25,7 @@ type UsageBreakdownBillableMetricsProps = {
   loading: boolean
   valueKey: 'units' | 'amountCents'
   displayFormat?: (value: string | number, currency: CurrencyEnum) => string
+  hasError: boolean
 }
 
 const UsageBreakdownBillableMetrics = ({
@@ -34,6 +37,7 @@ const UsageBreakdownBillableMetrics = ({
   loading,
   valueKey,
   displayFormat,
+  hasError,
 }: UsageBreakdownBillableMetricsProps) => {
   const { translate } = useInternationalization()
   const [searchParams] = useSearchParams()
@@ -77,6 +81,49 @@ const UsageBreakdownBillableMetrics = ({
     searchParams,
     valueKey,
   ])
+
+  if (hasError) {
+    return (
+      <GenericPlaceholder
+        className="pt-12"
+        title={translate('text_634812d6f16b31ce5cbf4126')}
+        subtitle={translate('text_634812d6f16b31ce5cbf4128')}
+        buttonTitle={translate('text_634812d6f16b31ce5cbf412a')}
+        buttonVariant="primary"
+        buttonAction={() => location.reload()}
+        image={<ErrorImage width="136" height="104" />}
+      />
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="mt-6 grid grid-cols-2 gap-6">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            className="flex flex-col gap-2"
+            key={`usage-breakdown-billable-metrics-loading-${i}`}
+          >
+            <Skeleton variant="text" className="w-20" />
+            <Skeleton variant="text" className="w-40" />
+            <Skeleton variant="text" className="w-40" />
+            <Skeleton variant="text" className="w-40" />
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (!loading && !data?.length) {
+    return (
+      <GenericPlaceholder
+        className="pt-12"
+        title={translate('text_1747819375043rmg1hu54ul7')}
+        subtitle={translate('text_1747820933511hc5y0fv9pae')}
+        image={<EmptyImage width="136" height="104" />}
+      />
+    )
+  }
 
   return (
     <div className="mt-6 grid grid-cols-2 gap-6">

--- a/src/components/analytics/usage/UsageBreakdownBillableMetrics.tsx
+++ b/src/components/analytics/usage/UsageBreakdownBillableMetrics.tsx
@@ -115,6 +115,7 @@ const UsageBreakdownBillableMetrics = ({
               data={grouped[key]}
               loading={loading}
               timeGranularity={defaultStaticTimeGranularity}
+              inlineTooltip={true}
               bars={[
                 {
                   tooltipIndex: 0,

--- a/src/components/analytics/usage/UsageBreakdownIndividualSection.tsx
+++ b/src/components/analytics/usage/UsageBreakdownIndividualSection.tsx
@@ -11,7 +11,7 @@ type UsageBreakdownIndividualSectionProps = {
   premiumWarningDialogRef: React.RefObject<PremiumWarningDialogRef>
   availableFilters: AvailableFiltersEnum[]
   filtersPrefix: string
-  isBillableMetricRecurring?: boolean
+  isBillableMetricRecurring: boolean
   breakdownType: UsageBreakdownType
 }
 

--- a/src/components/analytics/usage/UsageBreakdownIndividualSection.tsx
+++ b/src/components/analytics/usage/UsageBreakdownIndividualSection.tsx
@@ -32,6 +32,7 @@ const UsageBreakdownIndividualSection = ({
     hasAccessToAnalyticsDashboardsFeature,
     selectedCurrency,
     isLoading,
+    hasError,
     valueKey,
     displayFormat,
   } = useUsageAnalyticsBreakdown({
@@ -76,18 +77,17 @@ const UsageBreakdownIndividualSection = ({
         </Filters.Provider>
       </div>
 
-      {data && (
-        <UsageBreakdownBillableMetrics
-          data={data}
-          defaultStaticDatePeriod={getDefaultStaticDateFilter()}
-          defaultStaticTimeGranularity={getDefaultStaticTimeGranularityFilter()}
-          selectedCurrency={selectedCurrency}
-          filtersPrefix={filtersPrefix}
-          loading={isLoading}
-          valueKey={valueKey}
-          displayFormat={displayFormat}
-        />
-      )}
+      <UsageBreakdownBillableMetrics
+        data={data}
+        defaultStaticDatePeriod={getDefaultStaticDateFilter()}
+        defaultStaticTimeGranularity={getDefaultStaticTimeGranularityFilter()}
+        selectedCurrency={selectedCurrency}
+        filtersPrefix={filtersPrefix}
+        loading={isLoading}
+        valueKey={valueKey}
+        displayFormat={displayFormat}
+        hasError={hasError}
+      />
     </>
   )
 }

--- a/src/components/analytics/usage/UsageBreakdownSection.tsx
+++ b/src/components/analytics/usage/UsageBreakdownSection.tsx
@@ -31,7 +31,7 @@ const UsageBreakdownSection = ({ premiumWarningDialogRef }: UsageBreakdownSectio
 
   return (
     <section className="flex flex-col">
-      <div className="mb-4 flex justify-between gap-2">
+      <div className="mb-4 flex items-center justify-between">
         <Typography variant="subhead" color="grey700">
           {translate('text_1746541426463uvvcg8inufk')}
         </Typography>
@@ -42,6 +42,7 @@ const UsageBreakdownSection = ({ premiumWarningDialogRef }: UsageBreakdownSectio
               key={`usage-breakdown-section-${index}`}
               variant={_breakdownType === breakdownType ? 'secondary' : 'quaternary'}
               onClick={() => setBreakdownType(_breakdownType)}
+              size="small"
             >
               {translate(TRANSLATIONS_MAP[_breakdownType])}
             </Button>
@@ -60,6 +61,7 @@ const UsageBreakdownSection = ({ premiumWarningDialogRef }: UsageBreakdownSectio
                 filtersPrefix={ANALYTICS_USAGE_BREAKDOWN_METERED_FILTER_PREFIX}
                 breakdownType={breakdownType}
                 premiumWarningDialogRef={premiumWarningDialogRef}
+                isBillableMetricRecurring={false}
               />
             ),
           },

--- a/src/components/analytics/usage/UsageOverviewSection.tsx
+++ b/src/components/analytics/usage/UsageOverviewSection.tsx
@@ -73,7 +73,7 @@ const UsageOverviewSection = ({ premiumWarningDialogRef }: UsageOverviewSectionP
 
               <Tooltip
                 placement="top-start"
-                title={translate('text_17465414264635ktqocy7leo')}
+                title={translate('text_1747817451282js22pfg16gg')}
                 className="flex"
               >
                 <Icon name="info-circle" className="text-grey-600" />

--- a/src/components/analytics/usage/useUsageAnalyticsBreakdown.ts
+++ b/src/components/analytics/usage/useUsageAnalyticsBreakdown.ts
@@ -132,11 +132,7 @@ export const useUsageAnalyticsBreakdown = ({
     return {
       ...filters,
       timeGranularity: getDefaultStaticTimeGranularityFilter(),
-      ...(isBillableMetricRecurring
-        ? {
-            isBillableMetricRecurring: true,
-          }
-        : {}),
+      isBillableMetricRecurring,
     }
   }, [
     hasAccessToAnalyticsDashboardsFeature,

--- a/src/pages/analytics/UsageBillableMetric.tsx
+++ b/src/pages/analytics/UsageBillableMetric.tsx
@@ -151,7 +151,7 @@ const UsageBillableMetric = () => {
               </Button>
             )}
           >
-            <div className="flex items-start justify-between">
+            <div className="flex items-center justify-between">
               <Typography className="text-lg font-semibold text-grey-700">
                 {billableMetricCode}
               </Typography>
@@ -214,6 +214,7 @@ const UsageBillableMetric = () => {
                     },
                   ]}
                   customFormatter={displayFormat}
+                  inlineTooltip={true}
                 />
 
                 <HorizontalDataTable

--- a/translations/base.json
+++ b/translations/base.json
@@ -3075,5 +3075,9 @@
   "text_1746541426463hwo4t13lp09": "Recurring",
   "text_17465414264637hzft31ck6c": "Units",
   "text_1746541426463wcwfuryd12g": "Amount",
-  "text_17476657511358tgyvof5x1u": "units|unit|units"
+  "text_17476657511358tgyvof5x1u": "units|unit|units",
+  "text_1747817451282js22pfg16gg": "This reflects the consumption of your usage-based components, whether they are metered or recurring.",
+  "text_1747819375043rmg1hu54ul7": "There are no billable metrics",
+  "text_1747820933511hc5y0fv9pae": "Please create subscriptions with charges for customers to populate the data."
 }
+


### PR DESCRIPTION
## Context

After using the new usage section in prod, found some small UI issues.

## Description

- Recurring metric is included in the metered section
- Units / Amount button size should be small
- No empty state for the breakdown section, when there aren't any metrics returned
- Main tooltip text needs to be updated
- Hover state should be simpler, just date and amount