### PR TITLE
bug(customerPortal): prevent unexpected calls to be triggered

### DIFF
--- a/src/pages/auth/PortalInit.tsx
+++ b/src/pages/auth/PortalInit.tsx
@@ -1,17 +1,35 @@
+import { useApolloClient } from '@apollo/client'
+import { Icon } from 'lago-design-system'
 import { useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { onAccessCustomerPortal } from '~/core/apolloClient'
+import {
+  CUSTOMER_PORTAL_TOKEN_LS_KEY,
+  getItemFromLS,
+  onAccessCustomerPortal,
+} from '~/core/apolloClient'
 import CustomerPortal from '~/pages/customerPortal/CustomerPortal'
 
 const PortalInit = () => {
   const { token } = useParams()
+  const client = useApolloClient()
 
   useEffect(() => {
     if (token) {
+      // Prevent active queries from "main" app to re-fetch
+      client.clearStore()
+
       onAccessCustomerPortal(token)
     }
-  }, [token])
+  }, [client, token])
+
+  if (!token || !getItemFromLS(CUSTOMER_PORTAL_TOKEN_LS_KEY)) {
+    return (
+      <div className="flex size-full items-center justify-center">
+        <Icon name="processing" color="info" size="large" animation="spin" />
+      </div>
+    )
+  }
 
   return <CustomerPortal />
 }


### PR DESCRIPTION
## Context

Many customers faces errors when opening the customer portal from the "main" application. Leading to see only error states.
Also, most of the time when you open the customer portal, you're disconnected from the "main" app.

While those 2 issues seems non related they have the same root cause and can be mitigated.

## Description

This PR adds an instruction when opening the customer portal that will prevent any "active" queries to be re-triggered.
That was the root cause of the 2 error described above.
This was the flow:
1. I log in my Lago app
2. I go to a customer details page and click on the "Customer Portal" button to open it
3. Once open in a new window, this app starts to fire new queries needed for the portal to init, but also re-sync the previous active queries
4. This causes the first portal query to be triggered without the correct portal header. A race condition cause it thinks it has all it needs to query the BE so it does. That leads to error state and an unauthorised error response. This error lead to loging out the customer, so going back to the app redirects you to the login page. It also can cause following queries to fail.

Preventing active queries there will ensure the customer is not triggering unexpected calls when opening the portal. Also added a spinner in case portal is not in the LS so it don't render the portal component, hence not firing queries too soon.

<!-- Linear link -->
Fixes ISSUE-898