### PR TITLE
bug(coupons): expirationAt should be set at end of day

### DIFF
--- a/src/core/utils/__tests__/dateUtils.test.ts
+++ b/src/core/utils/__tests__/dateUtils.test.ts
@@ -1,0 +1,44 @@
+import { DateTime } from 'luxon'
+
+import { endOfDayIso } from '../dateUtils'
+
+describe('dateUtils', () => {
+  describe('endOfDayIso', () => {
+    it('should convert a date string to end of day ISO format', () => {
+      const inputDate = '2023-12-15T10:30:00.000Z'
+      const result = endOfDayIso(inputDate)
+
+      // The result should be the same date but at the end of the day
+      const expected = DateTime.fromISO(inputDate).endOf('day').toISO()
+
+      expect(result).toBe(expected)
+    })
+
+    it('should return empty string for null input', () => {
+      const result = endOfDayIso(null)
+
+      expect(result).toBe('')
+    })
+
+    it('should return empty string for undefined input', () => {
+      const result = endOfDayIso(undefined)
+
+      expect(result).toBe('')
+    })
+
+    it('should return empty string for empty string input', () => {
+      const result = endOfDayIso('')
+
+      expect(result).toBe('')
+    })
+
+    it('should handle different date formats', () => {
+      const inputDate = '2023-12-15'
+      const result = endOfDayIso(inputDate)
+
+      const expected = DateTime.fromISO(inputDate).endOf('day').toISO()
+
+      expect(result).toBe(expected)
+    })
+  })
+})

--- a/src/core/utils/dateUtils.ts
+++ b/src/core/utils/dateUtils.ts
@@ -1,0 +1,12 @@
+import { DateTime } from 'luxon'
+
+/**
+ * Converts a date string to the end of day in ISO format
+ * @param dateString - The input date string in ISO format
+ * @returns The date string converted to end of day in ISO format, or empty string if input is falsy
+ */
+export const endOfDayIso = (dateString: string | null | undefined): string => {
+  if (!dateString) return ''
+
+  return DateTime.fromISO(dateString).endOf('day').toISO() || ''
+}

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -28,6 +28,7 @@ import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import { FORM_ERRORS_ENUM } from '~/core/constants/form'
 import { COUPON_DETAILS_ROUTE, COUPONS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { endOfDayIso } from '~/core/utils/dateUtils'
 import {
   BillableMetricsForCouponsFragment,
   CouponExpiration,
@@ -463,11 +464,7 @@ const CreateCoupon = () => {
                           onChange={(expirationAt) => {
                             formikProps.setFieldValue(
                               'expirationAt',
-                              expirationAt
-                                ? DateTime.fromISO(expirationAt as string)
-                                    .endOf('day')
-                                    .toISO()
-                                : '',
+                              endOfDayIso(expirationAt as string),
                             )
                           }}
                           value={formikProps.values.expirationAt || ''}

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -21,7 +21,7 @@ import {
   AmountInputField,
   Checkbox,
   ComboBoxField,
-  DatePickerField,
+  DatePicker,
   TextInputField,
 } from '~/components/form'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
@@ -454,13 +454,23 @@ const CreateCoupon = () => {
                         <Typography variant="body" color="grey700" className="shrink-0">
                           {translate('text_632d68358f1fedc68eed3eb1')}
                         </Typography>
-                        <DatePickerField
-                          className="flex-1"
+                        <DatePicker
                           disablePast
+                          className="flex-1"
                           name="expirationAt"
                           placement="top-end"
                           placeholder={translate('text_632d68358f1fedc68eed3ea5')}
-                          formikProps={formikProps}
+                          onChange={(expirationAt) => {
+                            formikProps.setFieldValue(
+                              'expirationAt',
+                              expirationAt
+                                ? DateTime.fromISO(expirationAt as string)
+                                    .endOf('day')
+                                    .toISO()
+                                : '',
+                            )
+                          }}
+                          value={formikProps.values.expirationAt || ''}
                         />
                       </div>
                     )}


### PR DESCRIPTION
## Context

When creating a coupon, you can set a date so it expires.

You can set this date to the current day (expected). However the BE checks the date is in the future.

When clicking on a date with the DatePicker, it set's it with the current datetime. Hence the date sent to the BE for today never valid.

## Description

This PR transforms the date set to be at the endOf day time. 

<!-- Linear link -->
Fixes ISSUE-894