### PR TITLE
fix(console): set active row

### DIFF
--- a/src/components/developers/events/EventTable.tsx
+++ b/src/components/developers/events/EventTable.tsx
@@ -1,4 +1,4 @@
-import { FC, RefObject } from 'react'
+import { FC, RefObject, useMemo } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { InfiniteScroll, Table, Typography } from '~/components/designSystem'
@@ -20,6 +20,16 @@ export const EventTable: FC<EventTableProps> = ({ getEventsResult, logListRef })
 
   const { data, error, loading, fetchMore, refetch } = getEventsResult
 
+  const events = useMemo(
+    () =>
+      data?.events?.collection.map((event) => ({
+        ...event,
+        // We need to use the transactionId as the id because the eventId is not always available (for Clickhouse events)
+        id: event.transactionId as string,
+      })) || [],
+    [data?.events?.collection],
+  )
+
   return (
     <InfiniteScroll
       mode="element"
@@ -38,12 +48,7 @@ export const EventTable: FC<EventTableProps> = ({ getEventsResult, logListRef })
         containerClassName="h-auto"
         containerSize={16}
         rowSize={48}
-        data={
-          data?.events?.collection.map((event) => ({
-            ...event,
-            id: event.transactionId as string,
-          })) || []
-        }
+        data={events}
         hasError={!!error}
         isLoading={loading}
         onRowActionLink={({ transactionId }) => {

--- a/src/components/developers/events/EventTable.tsx
+++ b/src/components/developers/events/EventTable.tsx
@@ -38,7 +38,12 @@ export const EventTable: FC<EventTableProps> = ({ getEventsResult, logListRef })
         containerClassName="h-auto"
         containerSize={16}
         rowSize={48}
-        data={data?.events?.collection || []}
+        data={
+          data?.events?.collection.map((event) => ({
+            ...event,
+            id: event.transactionId as string,
+          })) || []
+        }
         hasError={!!error}
         isLoading={loading}
         onRowActionLink={({ transactionId }) => {

--- a/src/components/developers/events/Events.tsx
+++ b/src/components/developers/events/Events.tsx
@@ -53,6 +53,7 @@ export const Events = () => {
         const firstEvent = eventCollection[0]
 
         if (firstEvent && getCurrentBreakpoint() !== 'sm') {
+          // We need to use the transactionId as the id because the eventId is not always available (for Clickhouse events)
           navigate(generatePath(EVENT_LOG_ROUTE, { eventId: firstEvent.transactionId as string }), {
             replace: true,
           })

--- a/src/components/developers/webhooks/WebhookLogs.tsx
+++ b/src/components/developers/webhooks/WebhookLogs.tsx
@@ -129,14 +129,15 @@ export const WebhookLogs = () => {
       navigateToFirstLog(data?.webhooks?.collection)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, logId])
+  }, [data?.webhooks.collection, logId])
 
   // The table should highlight the selected row when the logId is provided in params
   useLayoutEffect(() => {
-    if (logId) {
-      logListRef.current?.setActiveRow(logId)
+    if (logId && logListRef.current) {
+      logListRef.current.setActiveRow(logId)
     }
-  }, [logId])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [logId, logListRef.current])
 
   const shouldDisplayLogDetails = !!logId && !!data?.webhooks.collection.length
 


### PR DESCRIPTION


## Description

- When using transactionId instead of eventId, i've forgotten a logic to set the active row that was still using eventId.
- I've also fixed the webhook active row that was having an issue on closing/opening the console