### PR TITLE
fix: prevent active queries

### DIFF
--- a/src/core/apolloClient/cacheUtils.ts
+++ b/src/core/apolloClient/cacheUtils.ts
@@ -84,7 +84,9 @@ export const switchCurrentOrganization = async (
   organizationId: string,
 ) => {
   // Stop the client to prevent active queries re-fetch
-  client.stop()
+  await client.clearStore()
+  // Clear store
+  await client.cache.reset()
 
   // We should not be redirected to any route on orga switch, but rather bring to home (prevent )
   removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)


### PR DESCRIPTION
## Context

When switching organization, we should called the same method as in `logOut` to prevent active queries from running