### PR TITLE
bug(ApiKeysForm): prevent checkbox's focus ring crop

### DIFF
--- a/src/pages/developers/ApiKeysForm.tsx
+++ b/src/pages/developers/ApiKeysForm.tsx
@@ -335,6 +335,8 @@ const ApiKeysForm = () => {
                         minWidth: 176,
                         title: (
                           <Checkbox
+                            // The pl-1 class is used to prevent the focus ring from being cropped.
+                            className="pl-1"
                             canBeIndeterminate
                             label={
                               <Typography variant="captionHl" color="grey600">
@@ -370,6 +372,8 @@ const ApiKeysForm = () => {
                         content: ({ id, canRead }) => {
                           return (
                             <Checkbox
+                              // The pl-1 class is used to prevent the focus ring from being cropped.
+                              className="pl-1"
                               label={translate('text_17328934519835pubx8tx7k7')}
                               value={canRead}
                               onChange={() => {
@@ -388,9 +392,11 @@ const ApiKeysForm = () => {
                       },
                       {
                         key: 'canWrite',
-                        minWidth: 144,
+                        minWidth: 150,
                         title: (
                           <Checkbox
+                            // The pl-1 class is used to prevent the focus ring from being cropped.
+                            className="pl-1"
                             canBeIndeterminate
                             label={
                               <Typography variant="captionHl" color="grey600">
@@ -432,6 +438,8 @@ const ApiKeysForm = () => {
 
                           return (
                             <Checkbox
+                              // The pl-1 class is used to prevent the focus ring from being cropped.
+                              className="pl-1"
                               label={translate('text_1732893451983ghftswenkuh')}
                               value={canWrite}
                               onChange={() => {


### PR DESCRIPTION
## Context

Checkboxes' focus ring is cropped in the API keys form. Those elements are part of a Table.

## Description

This is not an ideal fix however any other approach won't be as short or easy to implement.

The root issue is the Table's internal cell that renders the content, which wraps the content within a Typography that uses a `noWrap` props, adding an overflow hidden. Hence cropping the ring.

Removing the `noWrap` does break an expected behaviour, that forces the cell to expend if the content goes beyond it's "default" width. leading to the table to expend and it's content to be reachable with an horizontal scroll.
So it's kinda what we want.

I would love to avoid adding an extra attribute to the table's cell. Reason is that while investigating I discovered some, and I felt adding more could lead to extend the API for some edgy cases and keep making is not really visible.
That's my assuption, could be wrong so please tell me.

So I preferred adding a padding to all checkboxes and extending a bit the default width of one column so it does not wrap the title on 2 lines.

<!-- Linear link -->
Fixes ISSUE-884