### PR TITLE
bug: wrong billing entity fetched in settings

### DIFF
--- a/src/pages/settings/SettingsHomePage.tsx
+++ b/src/pages/settings/SettingsHomePage.tsx
@@ -7,7 +7,12 @@ import { useGetBillingEntitiesQuery } from '~/generated/graphql'
 const SettingsHomePage = () => {
   const navigate = useNavigate()
 
-  const { data: billingEntitiesData } = useGetBillingEntitiesQuery()
+  const { data: billingEntitiesData } = useGetBillingEntitiesQuery({
+    // This endpoint is not cached to prevent error after logout + organization switch
+    // https://github.com/getlago/lago-front/pull/2233/files
+    fetchPolicy: 'no-cache',
+    nextFetchPolicy: 'no-cache',
+  })
 
   useEffect(() => {
     if (!billingEntitiesData?.billingEntities?.collection?.length) {


### PR DESCRIPTION
## Context

We receive some Sentry error about billing entity being wrongly fetch in the settings page.

The billing entity is fetched when the users land in the settings page.

There the value is fetched, cached and used to redirect to the correct url.
If you were in some specific situations, you could end up having the wrong billing entity used.

The flow was the following
1. Connect to organisation A
2. Go to settings (billing entity A1 is fetched)
3. Wait until you get disconnected from the app.
4. Connect again but the switch to Organisation B
5. Go to settings. Billing entity A1 will be used as still in cache, but there you were expected to have billing entity B1 used by organisation B and face error

## Description


This PR makes sure the billing entity used to redirect to the correct url is never cached so fetched each time with it's correct context

<!-- Linear link -->
Fixes ISSUE-905