### PR TITLE
fix: local storage logic for developer tools and redirection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Panel, PanelGroup } from 'react-resizable-panels'
 import { BrowserRouter, MemoryRouter } from 'react-router-dom'
 
 import { ToastContainer } from '~/components/designSystem/Toasts'
+import { DEVTOOL_ROUTE } from '~/components/developers/DevtoolsRouter'
 import { DevtoolsView } from '~/components/developers/DevtoolsView'
 import { ErrorBoundary } from '~/components/ErrorBoundary'
 import { RouteWrapper } from '~/components/RouteWrapper'
@@ -56,7 +57,7 @@ const App = () => {
                       </BrowserRouter>
                     </div>
                   </Panel>
-                  <MemoryRouter initialEntries={['/devtool']}>
+                  <MemoryRouter initialEntries={[DEVTOOL_ROUTE]}>
                     <DevtoolsView />
                   </MemoryRouter>
                 </PanelGroup>

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -3,9 +3,11 @@ import type { RouteObject } from 'react-router-dom'
 import { useLocation, useRoutes } from 'react-router-dom'
 
 import { Icon } from '~/components/designSystem'
+import { DEVTOOL_ROUTE } from '~/components/developers/DevtoolsRouter'
 import { CustomRouteObject, routes } from '~/core/router'
 import { useIsAuthenticated } from '~/hooks/auth/useIsAuthenticated'
 import { useLocationHistory } from '~/hooks/core/useLocationHistory'
+import { DEVTOOL_TAB_PARAMS } from '~/hooks/useDeveloperTool'
 
 interface PageWrapperProps {
   routeConfig: CustomRouteObject
@@ -19,6 +21,23 @@ const PageWrapper = ({ children, routeConfig }: PageWrapperProps) => {
   useEffect(() => {
     onRouteEnter(routeConfig, location)
   }, [location, routeConfig, onRouteEnter])
+
+  // Redirect to '/' and open devtools if path starts with DEVTOOL_ROUTE
+  useEffect(() => {
+    if (location.pathname.startsWith(DEVTOOL_ROUTE)) {
+      // Set the devtool param in the URL for the homepage
+      const url = new URL(window.location.href)
+
+      url.pathname = '/'
+      url.searchParams.set(DEVTOOL_TAB_PARAMS, encodeURIComponent(location.pathname))
+      window.location.replace(url.toString())
+    }
+  }, [location])
+
+  if (location.pathname.startsWith(DEVTOOL_ROUTE)) {
+    // Prevent rendering anything while redirecting
+    return null
+  }
 
   return <>{children}</>
 }

--- a/src/components/developers/DevtoolsRouter.tsx
+++ b/src/components/developers/DevtoolsRouter.tsx
@@ -4,17 +4,19 @@ import { ActivityLogs, ApiKeys, Events, WebhookLogs, Webhooks } from '~/componen
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { usePermissions } from '~/hooks/usePermissions'
 
-export const API_KEYS_ROUTE = '/devtool'
+export const DEVTOOL_ROUTE = '/devtool'
 
-export const WEBHOOKS_ROUTE = '/webhooks'
-export const WEBHOOK_ROUTE = '/webhooks/:webhookId'
-export const WEBHOOK_LOGS_ROUTE = '/webhooks/:webhookId/logs/:logId'
+export const API_KEYS_ROUTE = `${DEVTOOL_ROUTE}`
 
-export const EVENTS_ROUTE = '/events'
-export const EVENT_LOG_ROUTE = '/events/:eventId'
+export const WEBHOOKS_ROUTE = `${DEVTOOL_ROUTE}/webhooks`
+export const WEBHOOK_ROUTE = `${DEVTOOL_ROUTE}/webhooks/:webhookId`
+export const WEBHOOK_LOGS_ROUTE = `${DEVTOOL_ROUTE}/webhooks/:webhookId/logs/:logId`
 
-export const ACTIVITY_ROUTE = '/activity-logs'
-export const ACTIVITY_LOG_ROUTE = '/activity-logs/:logId'
+export const EVENTS_ROUTE = `${DEVTOOL_ROUTE}/events`
+export const EVENT_LOG_ROUTE = `${DEVTOOL_ROUTE}/events/:eventId`
+
+export const ACTIVITY_ROUTE = `${DEVTOOL_ROUTE}/activity-logs`
+export const ACTIVITY_LOG_ROUTE = `${DEVTOOL_ROUTE}/activity-logs/:logId`
 
 export const DevtoolsRouter = () => {
   const routes = useRoutes([

--- a/src/core/apolloClient/cacheUtils.ts
+++ b/src/core/apolloClient/cacheUtils.ts
@@ -5,7 +5,6 @@ import {
   ORGANIZATION_LS_KEY_ID,
 } from '~/core/constants/localStorageKeys'
 import { CurrentUserFragment } from '~/generated/graphql'
-import { DEVTOOL_STORAGE_KEY } from '~/hooks/useDeveloperTool'
 
 import {
   resetLocationHistoryVar,
@@ -90,9 +89,6 @@ export const switchCurrentOrganization = async (
 
   // We should not be redirected to any route on orga switch, but rather bring to home (prevent )
   removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
-
-  // Close the devtools
-  removeItemFromLS(DEVTOOL_STORAGE_KEY)
 
   // Set the new organization id in local storage
   setItemFromLS(ORGANIZATION_LS_KEY_ID, organizationId)

--- a/src/hooks/useDeveloperTool.tsx
+++ b/src/hooks/useDeveloperTool.tsx
@@ -5,7 +5,6 @@ import { useCurrentUser } from '~/hooks/useCurrentUser'
 
 const DeveloperToolContext = createContext<DeveloperToolContextType | undefined>(undefined)
 
-export const DEVTOOL_STORAGE_KEY = 'devtoolIsOpen'
 export const DEVTOOL_TAB_PARAMS = 'devtool-tab'
 
 export enum ConsoleTabs {
@@ -46,9 +45,6 @@ export function useDeveloperTool(): DeveloperToolContextType {
   const { currentUser } = useCurrentUser()
 
   const navigate = useNavigate()
-  const [isMounted, setIsMounted] = useState(false)
-
-  const lsItem = localStorage.getItem(DEVTOOL_STORAGE_KEY)
 
   // We can copy/paste the URL of the devtools in the browser and it will open the devtools with the correct tab
   const checkParamsFromUrl = () => {
@@ -70,34 +66,10 @@ export function useDeveloperTool(): DeveloperToolContextType {
     window.history.replaceState({}, '', url)
   }
 
-  // If we have previously opened the devtools, we open it again in the same tab
-  const checkLocalStorage = () => {
-    if (lsItem !== null) {
-      lsItem === 'true' && context?.open()
-    }
-  }
-
-  // On mounted, check the params from the URL and the local storage
   useEffect(() => {
+    // On mounted, check the params from the URL
     checkParamsFromUrl()
-    checkLocalStorage()
-
-    setIsMounted(true)
   }, [])
-
-  // After the component is mounted, save the state of the devtools in the local storage
-  useEffect(() => {
-    if (isMounted) {
-      localStorage.setItem(DEVTOOL_STORAGE_KEY, String(context?.isOpen))
-    }
-  }, [context?.isOpen, isMounted])
-
-  // After the component is mounted, close the devtools if the local storage is empty
-  useEffect(() => {
-    if (isMounted) {
-      lsItem === null && context?.close()
-    }
-  }, [context, isMounted, lsItem])
 
   // Throw an error if the hook is used outside of the provider
   if (!context) {


### PR DESCRIPTION
## Context

- Simplified developer tools state management by removing local storage persistence used to detect if the console is open.

- Fixed an issue where opening a console link in a new tab resulted in a 404 error due to missing route definitions in the browser router. Now, such links correctly redirect to the homepage and open the console on the appropriate tab.