### PR TITLE
bug: make sure margin is correct to prevent cropped dots on hover

### DIFF
--- a/src/components/designSystem/graphs/AreaChart.tsx
+++ b/src/components/designSystem/graphs/AreaChart.tsx
@@ -95,8 +95,8 @@ const AreaChart = memo(
         <ResponsiveContainer width="100%" height={height}>
           <RechartAreaChart
             margin={{
-              top: 1,
-              left: 1,
+              top: 3,
+              left: 3,
               right: getCurrencySymbol(currency).length > 1 ? 12 : 2,
               bottom: -2,
             }}


### PR DESCRIPTION
Fixes the spacing on top and left of area chart.

We recently added to dot visible on hover but first and last ones were cropped. The last one was cropped only if placed at top right corner of the graph

<!-- Linear link -->
Fixes ISSUE-892