### PR TITLE
bug: prevent redirection route to be in history

### DIFF
--- a/src/pages/settings/SettingsHomePage.tsx
+++ b/src/pages/settings/SettingsHomePage.tsx
@@ -31,6 +31,7 @@ const SettingsHomePage = () => {
       generatePath(BILLING_ENTITY_ROUTE, {
         billingEntityCode: defaultBillingEntity.code,
       }),
+      { replace: true },
     )
   }, [billingEntitiesData, navigate])
 


### PR DESCRIPTION
## Context

When navigating to the settings route, we land on a first page that builds the route to be redirected to.

This page holding a redirection logic and part of the history, if you decide to navigate back to it, the redirection logic fires again.

## Description

This PR makes sure this redirection replaces the current history, so it's no longer there if you navigate back.
Doing so will now bring you back to the main app.

<!-- Linear link -->
Fixes ISSUE-897