### PR TITLE
misc: add alert permissions and improve default state

### DIFF
--- a/src/core/apolloClient/graphqlResolvers.tsx
+++ b/src/core/apolloClient/graphqlResolvers.tsx
@@ -62,6 +62,7 @@ export const typeDefs = gql`
   enum ApiKeysPermissionsEnum {
     # activity_log # Need to add the corresponding translation in src/pages/developers/ApiKeysForm.tsx
     add_on
+    alert
     analytic
     applied_coupon
     billable_metric

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -349,6 +349,7 @@ export type ApiKey = {
 
 export enum ApiKeysPermissionsEnum {
   AddOn = 'add_on',
+  Alert = 'alert',
   Analytic = 'analytic',
   AppliedCoupon = 'applied_coupon',
   BillableMetric = 'billable_metric',


### PR DESCRIPTION
## Context

We missed adding the new `alert` permission to the list of the api keys.

While adding, I noticed a wrong behaviour to our default state and decided to improve it and make it more deterministic.

## Description

This PR
- adds the `alert` permission to the list of available permissions
- Mark it as "unchecked" by default on creation
- make sure the default permissions correctly reads the enum to build values
- make sure that a missing permission key is shown as unchecked in the edit form