### PR TITLE
fix: issue credit note check

### DIFF
--- a/src/hooks/usePermissionsInvoiceActions.ts
+++ b/src/hooks/usePermissionsInvoiceActions.ts
@@ -68,9 +68,15 @@ export const usePermissionsInvoiceActions = () => {
     )
   }
 
-  const canIssueCreditNote = (invoice: Pick<Invoice, 'status'>): boolean => {
+  const canIssueCreditNote = (invoice: Pick<Invoice, 'status' | 'taxStatus'>): boolean => {
     return (
-      ![InvoiceStatusTypeEnum.Draft, InvoiceStatusTypeEnum.Voided].includes(invoice.status) &&
+      ![
+        InvoiceStatusTypeEnum.Draft,
+        InvoiceStatusTypeEnum.Failed,
+        InvoiceStatusTypeEnum.Pending,
+        InvoiceStatusTypeEnum.Voided,
+      ].includes(invoice.status) &&
+      invoice.taxStatus !== InvoiceTaxStatusTypeEnum.Pending &&
       hasPermissions(['creditNotesCreate'])
     )
   }


### PR DESCRIPTION
## Context

We should not be able to issue a credit note that has a failing state on tax status 