### PR TITLE
fix: redirect after delete BM

### DIFF
--- a/src/components/billableMetrics/DeleteBillableMetricDialog.tsx
+++ b/src/components/billableMetrics/DeleteBillableMetricDialog.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { DialogRef, Skeleton } from '~/components/designSystem'
 import { WarningDialog } from '~/components/WarningDialog'
@@ -31,14 +31,20 @@ gql`
   }
 `
 
+type DeleteBillableMetricDialogProps = {
+  billableMetricId: string
+  callback?: () => void
+}
+
 export interface DeleteBillableMetricDialogRef {
-  openDialog: (billableMetricId: string) => unknown
+  openDialog: (props: DeleteBillableMetricDialogProps) => unknown
   closeDialog: () => unknown
 }
 
 export const DeleteBillableMetricDialog = forwardRef<DeleteBillableMetricDialogRef>((_, ref) => {
-  const dialogRef = useRef<DialogRef>(null)
   const { translate } = useInternationalization()
+  const dialogRef = useRef<DialogRef>(null)
+  const [localData, setLocalData] = useState<DeleteBillableMetricDialogProps | undefined>(undefined)
   const [getBillableMetricToDelete, { data, loading }] = useGetBillableMetricToDeleteLazyQuery()
 
   const billableMetric = data?.billableMetric
@@ -52,14 +58,21 @@ export const DeleteBillableMetricDialog = forwardRef<DeleteBillableMetricDialogR
           message: translate('text_6256f9f1184d3301290c7299'),
           severity: 'success',
         })
+
+        localData?.callback && localData.callback()
       }
     },
     refetchQueries: ['billableMetrics'],
   })
 
   useImperativeHandle(ref, () => ({
-    openDialog: (billableMetricId) => {
-      getBillableMetricToDelete({ variables: { id: billableMetricId } })
+    openDialog: (args) => {
+      setLocalData(args)
+      getBillableMetricToDelete({
+        variables: {
+          id: args.billableMetricId,
+        },
+      })
       dialogRef.current?.openDialog()
     },
     closeDialog: () => dialogRef.current?.closeDialog(),

--- a/src/pages/BillableMetricDetails.tsx
+++ b/src/pages/BillableMetricDetails.tsx
@@ -130,7 +130,12 @@ const BillableMetricDetails = () => {
                   variant="quaternary"
                   align="left"
                   onClick={() => {
-                    deleteBillableMetricDialogRef.current?.openDialog(billableMetricId as string)
+                    deleteBillableMetricDialogRef.current?.openDialog({
+                      billableMetricId: billableMetricId as string,
+                      callback: () => {
+                        navigate(generatePath(BILLABLE_METRICS_ROUTE))
+                      },
+                    })
                     closePopper()
                   }}
                 >

--- a/src/pages/BillableMetricsList.tsx
+++ b/src/pages/BillableMetricsList.tsx
@@ -156,7 +156,7 @@ const BillableMetricsList = () => {
                 ? {
                     startIcon: 'trash',
                     title: translate('text_6256de3bba111e00b3bfa533'),
-                    onAction: () => deleteDialogRef.current?.openDialog(id),
+                    onAction: () => deleteDialogRef.current?.openDialog({ billableMetricId: id }),
                   }
                 : null,
             ]


### PR DESCRIPTION
## Context

It seems like after deleting a billable metric in the detail page, the customer is not redirect to the list page and it throws an error