### PR TITLE
fix: remove payment tab for draft invoice

### DIFF
--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -566,7 +566,10 @@ const CustomerInvoiceDetails = () => {
           />
         ),
       },
-      {
+    ]
+
+    if (status === InvoiceStatusTypeEnum.Pending || status === InvoiceStatusTypeEnum.Finalized) {
+      tabs.push({
         title: translate('text_6672ebb8b1b50be550eccbed'),
         link: generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
           customerId: customerId as string,
@@ -583,8 +586,8 @@ const CustomerInvoiceDetails = () => {
         component: (
           <InvoicePaymentList invoiceTotalDueAmount={data?.invoice?.totalDueAmountCents} />
         ),
-      },
-    ]
+      })
+    }
 
     if (
       ![


### PR DESCRIPTION
## Context

It seems like we shouldn't be able to create manual payment for draft invoice, so we should remove it from the navigation tab when navigating to invoice details