### PR TITLE
bug: display alert if no access to feature

### DIFF
--- a/src/pages/CustomerRequestOverduePayment/index.tsx
+++ b/src/pages/CustomerRequestOverduePayment/index.tsx
@@ -209,7 +209,7 @@ const CustomerRequestOverduePayment: FC = () => {
 
       <main className="height-minus-nav-footer overflow-auto md:height-minus-nav md:flex md:overflow-auto">
         <section className="bg-white md:height-minus-nav-footer md:shrink md:grow md:basis-1/2 md:overflow-auto">
-          {hasDunningIntegration && <FreemiumAlert />}
+          {!hasDunningIntegration && <FreemiumAlert />}
           <div className="px-4 py-12 md:px-12">
             <RequestPaymentForm
               invoicesLoading={loading}


### PR DESCRIPTION
## Context

We're displaying an alert in the "request payment" form if user does not have access to the feature.

This same check is used in the same component as `!hasDunningIntegration` but not the one about displaying this alert

## Description

Fixing the check for displaying alert so it uses the exact same condition all over the places

