### PR TITLE
bug: make sure the button bar takes full width

### DIFF
--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -346,11 +346,11 @@ const MainMinimumContent: FC<PropsWithChildren> = ({ children }) => (
 )
 
 const SectionFooter: FC<PropsWithChildren> = ({ children }) => (
-  <div className="sticky bottom-0 z-navBar -mx-4 mt-20 h-20 w-full !max-w-none border-t border-solid border-grey-200 bg-white px-4 py-0 md:-mx-12 md:w-auto md:px-12">
+  <div className="sticky bottom-0 z-navBar -mx-4 mt-20 h-20 !max-w-none border-t border-solid border-grey-200 bg-white px-4 py-0 md:-mx-12 md:px-12">
     {children}
   </div>
 )
 
 const SectionFooterWrapper: FC<PropsWithChildren> = ({ children }) => (
-  <div className="flex h-full max-w-[720px] items-center justify-end">{children}</div>
+  <div className="flex h-full items-center justify-end">{children}</div>
 )


### PR DESCRIPTION
Those extra rules made the bar broken on responsive screens.

Removing them allows the div to naturally takes full width.

It still need to hold the `!max-w-none` as it's part of a shared component `Main` that applied this max-w to all it's children div

<!-- Linear link -->
Fixes ISSUE-935