### PR TITLE
misc: use shared component for CN details

### DIFF
--- a/src/components/creditNote/CreditNoteDetailsOverviewTable.tsx
+++ b/src/components/creditNote/CreditNoteDetailsOverviewTable.tsx
@@ -28,10 +28,13 @@ const TableSection: FC<{ children: React.ReactNode }> = ({ children }) => {
   )
 
   const tableBodyClasses = tw(
-    '[&>table>tbody>tr>td:not(:first-child)]:text-right [&>table>tbody>tr>td]:min-h-11 [&>table>tbody>tr>td]:overflow-hidden [&>table>tbody>tr>td]:py-3 [&>table>tbody>tr>td]:align-top [&>table>tbody>tr>td]:shadow-b [&>table>tbody>tr>td]:line-break-anywhere',
+    '[&>table>tbody>tr>td:not(:first-child)]:text-right [&>table>tbody>tr>td:not(:last-child)]:pr-3 [&>table>tbody>tr>td]:min-h-11 [&>table>tbody>tr>td]:overflow-hidden [&>table>tbody>tr>td]:py-3 [&>table>tbody>tr>td]:align-top [&>table>tbody>tr>td]:shadow-b [&>table>tbody>tr>td]:line-break-anywhere',
   )
 
-  const tableFootClasses = tw('[&>table>tfoot>tr>td]:py-3 [&>table>tfoot>tr>td]:text-right')
+  const tableFootClasses = tw(
+    '[&>table>tfoot>tr>td:nth-child(2)]:text-left [&>table>tfoot>tr>td:nth-child(2)]:shadow-b [&>table>tfoot>tr>td:nth-child(3)]:shadow-b [&>table>tfoot>tr>td]:py-3 [&>table>tfoot>tr>td]:text-right',
+    '[&>table>tfoot>tr>td:nth-child(1)]:w-[50%] [&>table>tfoot>tr>td:nth-child(2)]:w-[40%] [&>table>tfoot>tr>td:nth-child(3)]:w-[10%]',
+  )
 
   return (
     <section

--- a/src/components/creditNote/CreditNoteDetailsOverviewTable.tsx
+++ b/src/components/creditNote/CreditNoteDetailsOverviewTable.tsx
@@ -20,7 +20,7 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { tw } from '~/styles/utils'
 
-const TableSection: FC<{ children: React.ReactNode }> = ({ children }) => {
+export const CreditNoteTableSection: FC<{ children: React.ReactNode }> = ({ children }) => {
   const tableHeadClasses = tw(
     '[&>table>thead>tr>th]:sticky [&>table>thead>tr>th]:top-18 [&>table>thead>tr>th]:z-10 [&>table>thead>tr>th]:box-border [&>table>thead>tr>th]:overflow-hidden [&>table>thead>tr>th]:bg-white [&>table>thead>tr>th]:py-8 [&>table>thead>tr>th]:pb-3 [&>table>thead>tr>th]:text-right [&>table>thead>tr>th]:shadow-b [&>table>thead>tr>th]:line-break-anywhere',
     '[&>table>thead>tr>th:not(:last-child)]:pr-3',
@@ -132,7 +132,7 @@ export const CreditNoteDetailsOverviewTable: FC<CreditNoteDetailsOverviewTablePr
   const groupedData = formatCreditNotesItems(creditNote?.items as CreditNoteItem[])
 
   return (
-    <TableSection>
+    <CreditNoteTableSection>
       {groupedData.map((groupSubscriptionItem, i) => {
         const subscription =
           groupSubscriptionItem[0] && groupSubscriptionItem[0][0]
@@ -435,6 +435,6 @@ export const CreditNoteDetailsOverviewTable: FC<CreditNoteDetailsOverviewTablePr
           </tfoot>
         </table>
       )}
-    </TableSection>
+    </CreditNoteTableSection>
   )
 }

--- a/src/components/invoices/InvoiceCreditNotesTable.tsx
+++ b/src/components/invoices/InvoiceCreditNotesTable.tsx
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
 import React, { memo } from 'react'
 import { generatePath } from 'react-router-dom'
-import styled from 'styled-components'
 
+import { CreditNoteTableSection } from '~/components/creditNote/CreditNoteDetailsOverviewTable'
 import { Typography } from '~/components/designSystem'
 import {
   composeChargeFilterDisplayName,
@@ -20,7 +20,6 @@ import {
   InvoiceTypeEnum,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { theme } from '~/styles'
 
 gql`
   fragment InvoiceForCreditNotesTable on Invoice {
@@ -105,7 +104,7 @@ export const InvoiceCreditNotesTable = memo(
     const isPrepaidCreditsInvoice = invoiceType === InvoiceTypeEnum.Credit
 
     return (
-      <Wrapper>
+      <CreditNoteTableSection>
         {formatedCreditNotes.map((formatedCreditNote, i) => {
           const creditNote = formatedCreditNote.creditNote
 
@@ -122,7 +121,8 @@ export const InvoiceCreditNotesTable = memo(
 
                 return (
                   <React.Fragment key={`formatedCreditNote-${i}-subscriptionItem-${j}`}>
-                    <table>
+                    {/* eslint-disable-next-line tailwindcss/no-custom-classname */}
+                    <table className="main-table">
                       <thead>
                         <tr>
                           <th>
@@ -394,81 +394,9 @@ export const InvoiceCreditNotesTable = memo(
             </React.Fragment>
           )
         })}
-      </Wrapper>
+      </CreditNoteTableSection>
     )
   },
 )
 
 InvoiceCreditNotesTable.displayName = 'InvoiceCreditNotesTable'
-
-const Wrapper = styled.section`
-  > table {
-    width: 100%;
-    border-collapse: collapse;
-    table-layout: fixed;
-
-    > thead > tr > th,
-    > tbody > tr > td {
-      overflow: hidden;
-      text-align: right;
-
-      &:not(:first-child) {
-        line-break: anywhere;
-      }
-
-      &:not(:last-child) {
-        padding-right: ${theme.spacing(8)};
-        box-sizing: border-box;
-      }
-
-      &:nth-child(1) {
-        width: 75%;
-        text-align: left;
-      }
-      &:nth-child(2) {
-        width: 10%;
-      }
-      &:nth-child(3) {
-        width: 15%;
-      }
-    }
-
-    > thead > tr > th {
-      position: sticky;
-      top: 72px;
-      background-color: ${theme.palette.common.white};
-      padding: ${theme.spacing(8)} 0 ${theme.spacing(3)} 0;
-      box-sizing: border-box;
-      box-shadow: ${theme.shadows[7]};
-    }
-
-    > tbody > tr > td {
-      vertical-align: top;
-      min-height: 44px;
-      padding: ${theme.spacing(3)} 0;
-      box-sizing: border-box;
-      box-shadow: ${theme.shadows[7]};
-    }
-
-    > tfoot > tr > td {
-      text-align: right;
-      padding: ${theme.spacing(3)} 0;
-      box-sizing: border-box;
-
-      &:nth-child(1) {
-        width: 50%;
-      }
-      &:nth-child(2) {
-        width: 35%;
-        text-align: left;
-        box-shadow: ${theme.shadows[7]};
-      }
-      &:nth-child(3) {
-        width: 15%;
-        box-shadow: ${theme.shadows[7]};
-        /* Allow huge amount to be displayed on 2 lines */
-        line-break: anywhere;
-      }
-    }
-  }
-`

--- a/src/components/invoices/details/InvoiceDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTable.tsx
@@ -414,7 +414,7 @@ export const InvoiceWrapper = styled.section<{
       }
 
       &:not(:last-child) {
-        padding-right: ${theme.spacing(8)};
+        padding-right: ${theme.spacing(3)};
         box-sizing: border-box;
       }
 
@@ -500,14 +500,14 @@ export const InvoiceWrapper = styled.section<{
 
       &.has-details td {
         min-height: 24px;
-        padding: ${theme.spacing(3)} ${theme.spacing(8)} ${theme.spacing(1)} 0;
+        padding: ${theme.spacing(3)} ${theme.spacing(3)} ${theme.spacing(1)} 0;
         box-shadow: none;
       }
 
       &.details-line td {
         vertical-align: top;
         min-height: 24px;
-        padding: ${theme.spacing(1)} ${theme.spacing(8)} ${theme.spacing(1)} ${theme.spacing(4)};
+        padding: ${theme.spacing(1)} ${theme.spacing(3)} ${theme.spacing(1)} ${theme.spacing(4)};
         box-sizing: border-box;
         box-shadow: initial;
 
@@ -518,7 +518,7 @@ export const InvoiceWrapper = styled.section<{
 
       &.subtotal td {
         box-shadow: ${theme.shadows[7]};
-        padding: ${theme.spacing(1)} ${theme.spacing(8)} ${theme.spacing(3)} ${theme.spacing(4)};
+        padding: ${theme.spacing(1)} ${theme.spacing(3)} ${theme.spacing(3)} ${theme.spacing(4)};
         &:last-child {
           padding-right: 0;
         }


### PR DESCRIPTION
## Context

Still aiming to remove styled-components (SC) from the app and migrate to Tailwind.

## Description

This PR does
- change some spacing in the invoice overview, so they match with the spacing in the credit note (CN) overview and in the invoice->CN list
- Fix some styles previously done in the credit note list
- Use this same component across both CN details pages so we unify style and can remove SC from one of them

Bringing our remaining places with SC to 2