### PR TITLE
misc: autofill code on name update in form

### DIFF
--- a/cypress/e2e/10-resources/t10-create-taxes.cy.ts
+++ b/cypress/e2e/10-resources/t10-create-taxes.cy.ts
@@ -1,4 +1,9 @@
-import { TAX_TEN_CODE, TAX_TWENTY_CODE } from '../../support/reusableConstants'
+import {
+  TAX_TEN_CODE,
+  TAX_TEN_NAME,
+  TAX_TWENTY_CODE,
+  TAX_TWENTY_NAME,
+} from '../../support/reusableConstants'
 
 describe.skip('Create taxes', () => {
   beforeEach(() => {
@@ -15,16 +20,16 @@ describe.skip('Create taxes', () => {
     // Create tax 10%
     cy.get('[data-test="create-tax-button"]').click()
     cy.url().should('include', '/create/tax')
-    cy.get('input[name="name"]').type(TAX_TEN_CODE)
-    cy.get('input[name="code"]').type(TAX_TEN_CODE)
+    cy.get('input[name="name"]').type(TAX_TEN_NAME)
+    cy.get('input[name="code"]').should('have.value', TAX_TEN_CODE)
     cy.get('input[name="rate"]').type('10')
     cy.get('[data-test="submit"]').click()
 
     // Create tax 20%
     cy.get('[data-test="create-tax-button"]').click()
     cy.url().should('include', '/create/tax')
-    cy.get('input[name="name"]').type(TAX_TWENTY_CODE)
-    cy.get('input[name="code"]').type(TAX_TWENTY_CODE)
+    cy.get('input[name="name"]').type(TAX_TWENTY_NAME)
+    cy.get('input[name="code"]').should('have.value', TAX_TWENTY_CODE)
     cy.get('input[name="rate"]').type('20')
     cy.get('[data-test="submit"]').click()
 

--- a/cypress/e2e/10-resources/t30-create-bm.cy.ts
+++ b/cypress/e2e/10-resources/t30-create-bm.cy.ts
@@ -6,12 +6,13 @@ describe('Create billable metrics', () => {
   it('should create count billable metric', () => {
     const randomId = Math.round(Math.random() * 1000)
     const bmName = `bm count ${randomId}`
+    const bmCode = `bm_count_${randomId}`
 
     cy.get('button[data-test="create-bm"]').click()
     cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
     cy.get('input[name="name"]').type(bmName)
     cy.get('[data-test="submit"]').should('be.disabled')
-    cy.get('input[name="code"]').type(bmName)
+    cy.get('input[name="code"]').should('have.value', bmCode)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('[data-test="show-description"]').click()
     cy.get('textarea[name="description"]').type('I am a description')
@@ -28,12 +29,13 @@ describe('Create billable metrics', () => {
   it('should create uniq count billable metric', () => {
     const randomId = Math.round(Math.random() * 1000)
     const bmName = `bm uniq count ${randomId}`
+    const bmCode = `bm_uniq_count_${randomId}`
 
     cy.get('[data-test="create-bm"]').click()
     cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
     cy.get('input[name="name"]').type(bmName)
     cy.get('[data-test="submit"]').should('be.disabled')
-    cy.get('input[name="code"]').type(bmName)
+    cy.get('input[name="code"]').should('have.value', bmCode)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('[data-test="show-description"]').click()
     cy.get('textarea[name="description"]').type('I am a description')
@@ -52,12 +54,13 @@ describe('Create billable metrics', () => {
   it('should create max billable metric', () => {
     const randomId = Math.round(Math.random() * 1000)
     const bmName = `bm max ${randomId}`
+    const bmCode = `bm_max_${randomId}`
 
     cy.get('[data-test="create-bm"]').click()
     cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
     cy.get('input[name="name"]').type(bmName)
     cy.get('[data-test="submit"]').should('be.disabled')
-    cy.get('input[name="code"]').type(bmName)
+    cy.get('input[name="code"]').should('have.value', bmCode)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('[data-test="show-description"]').click()
     cy.get('textarea[name="description"]').type('I am a description')
@@ -75,12 +78,13 @@ describe('Create billable metrics', () => {
   it('should create sum billable metric', () => {
     const randomId = Math.round(Math.random() * 1000)
     const bmName = `bm sum ${randomId}`
+    const bmCode = `bm_sum_${randomId}`
 
     cy.get('[data-test="create-bm"]').click()
     cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
     cy.get('input[name="name"]').type(bmName)
     cy.get('[data-test="submit"]').should('be.disabled')
-    cy.get('input[name="code"]').type(bmName)
+    cy.get('input[name="code"]').should('have.value', bmCode)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('[data-test="show-description"]').click()
     cy.get('textarea[name="description"]').type('I am a description')
@@ -98,12 +102,13 @@ describe('Create billable metrics', () => {
   it('should create recurring count billable metric', () => {
     const randomId = Math.round(Math.random() * 1000)
     const bmName = `bm recurring count ${randomId}`
+    const bmCode = `bm_recurring_count_${randomId}`
 
     cy.get('[data-test="create-bm"]').click()
     cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
     cy.get('input[name="name"]').type(bmName)
     cy.get('[data-test="submit"]').should('be.disabled')
-    cy.get('input[name="code"]').type(bmName)
+    cy.get('input[name="code"]').should('have.value', bmCode)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('[data-test="show-description"]').click()
     cy.get('textarea[name="description"]').type('I am a description')
@@ -120,6 +125,7 @@ describe('Create billable metrics', () => {
   it('should create recurring count billable metric', () => {
     const randomId = Math.round(Math.random() * 1000)
     const bmName = `bm weighted sum ${randomId}`
+    const bmCode = `bm_weighted_sum_${randomId}`
 
     cy.get('[data-test="create-bm"]').click()
     cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
@@ -127,7 +133,7 @@ describe('Create billable metrics', () => {
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('[data-test="recurring-switch"] [data-test="button-selector-true"]').click()
     cy.get('[data-test="submit"]').should('be.disabled')
-    cy.get('input[name="code"]').type(bmName)
+    cy.get('input[name="code"]').should('have.value', bmCode)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('[data-test="show-description"]').click()
     cy.get('textarea[name="description"]').type('I am a description')

--- a/cypress/e2e/10-resources/t40-create-plan.cy.ts
+++ b/cypress/e2e/10-resources/t40-create-plan.cy.ts
@@ -13,11 +13,12 @@ describe('Create plan', () => {
   it('should be able to create a simple plan', () => {
     const randomId = Math.round(Math.random() * 1000)
     const planName = `plan ${randomId}`
+    const planCode = `plan_${randomId}`
 
     cy.get('[data-test="create-plan"]').click({ force: true })
     cy.url().should('be.equal', Cypress.config().baseUrl + '/create/plans')
     cy.get('input[name="name"]').type(planName)
-    cy.get('input[name="code"]').type(planName)
+    cy.get('input[name="code"]').should('have.value', planCode)
     cy.get('[data-test="show-description"]').click({ force: true })
     cy.get('textarea[name="description"]').type('I am a description')
     cy.get('input[name="amountCents"]').type('30000')
@@ -31,7 +32,7 @@ describe('Create plan', () => {
     cy.url().should('be.equal', Cypress.config().baseUrl + '/create/plans')
     cy.get('input[name="name"]').type(planWithChargesName)
     cy.get('[data-test="submit"]').should('be.disabled')
-    cy.get('input[name="code"]').type(planWithChargesName)
+    cy.get('input[name="code"]').clear().type(planWithChargesName)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('[data-test="show-description"]').click({ force: true })
     cy.get('textarea[name="description"]').type('I am a description')
@@ -147,12 +148,13 @@ describe('Create plan', () => {
     it('should be able to edit percentage charge without data loss', () => {
       const randomId = Math.round(Math.random() * 1000)
       const planName = `plan ${randomId}`
+      const planCode = `plan_${randomId}`
 
       // Default plan data
       cy.get('[data-test="create-plan"]').click({ force: true })
       cy.url().should('be.equal', Cypress.config().baseUrl + '/create/plans')
       cy.get('input[name="name"]').type(planName)
-      cy.get('input[name="code"]').type(planName)
+      cy.get('input[name="code"]').should('have.value', planCode)
       cy.get('[data-test="show-description"]').click({ force: true })
       cy.get('textarea[name="description"]').type('I am a description')
       cy.get('input[name="amountCents"]').type('30000')

--- a/cypress/e2e/10-resources/t60-coupons-create-edit-apply.cy.ts
+++ b/cypress/e2e/10-resources/t60-coupons-create-edit-apply.cy.ts
@@ -1,6 +1,8 @@
 import { customerName } from '../../support/reusableConstants'
 
-const couponName = `Coupon-${Math.round(Math.random() * 10000)}`
+const randomId = Math.round(Math.random() * 10000)
+const couponName = `Coupon ${randomId}`
+const couponCode = `coupon_${randomId}`
 
 describe('Coupons', () => {
   beforeEach(() => {
@@ -12,7 +14,7 @@ describe('Coupons', () => {
     cy.get(`[data-test="add-coupon"]`).click()
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('input[name="name"]').type(couponName)
-    cy.get('input[name="code"]').type(couponName)
+    cy.get('input[name="code"]').should('have.value', couponCode)
     cy.get('input[name="amountCents"]').type('30')
     cy.get('[data-test="submit"]').should('be.enabled')
 

--- a/cypress/e2e/10-resources/t70-addon-create-edit.cy.ts
+++ b/cypress/e2e/10-resources/t70-addon-create-edit.cy.ts
@@ -3,7 +3,9 @@ describe('Add On', () => {
     cy.login()
   })
 
-  const addOnName = `AddOn-${Math.round(Math.random() * 10000)}`
+  const randomId = Math.round(Math.random() * 10000)
+  const addOnName = `AddOn ${randomId}`
+  const addOnCode = `addon_${randomId}`
   const description =
     'Lorem ipsum dolor sit amet consectetur adipisicing elit. Necessitatibus aliquam at dolor consectetur tempore quis molestiae cumque voluptatem deserunt similique blanditiis aperiam, distinctio nam, asperiores enim officiis culpa aut. Molestias?'
 
@@ -16,7 +18,7 @@ describe('Add On', () => {
     // Basic form infos
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('input[name="name"]').type(addOnName)
-    cy.get('input[name="code"]').type(addOnName)
+    cy.get('input[name="code"]').should('have.value', addOnCode)
     cy.get('input[name="amountCents"]').type('30')
     cy.get('[data-test="submit"]').should('be.enabled')
     cy.get('[data-test="show-description"]').click()

--- a/cypress/support/reusableConstants.ts
+++ b/cypress/support/reusableConstants.ts
@@ -5,5 +5,7 @@ export const userEmail = 'user-e2e-tests@lago.com'
 export const userPassword = 'P@ssw0rdd'
 
 // Form variable
-export const TAX_TWENTY_CODE = 'twenty'
-export const TAX_TEN_CODE = 'ten'
+export const TAX_TWENTY_NAME = 'Twenty tax'
+export const TAX_TWENTY_CODE = 'twenty_tax'
+export const TAX_TEN_NAME = 'Ten tax'
+export const TAX_TEN_CODE = 'ten_tax'

--- a/src/components/form/TextInput/TextInput.tsx
+++ b/src/components/form/TextInput/TextInput.tsx
@@ -206,6 +206,7 @@ export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
           ref={ref}
           value={localValue}
           name={name}
+          id={name}
           type={password && !isVisible ? 'password' : type !== 'number' ? type : 'text'}
           onChange={handleChange}
           variant="outlined"

--- a/src/components/plans/PlanSettingsSection.tsx
+++ b/src/components/plans/PlanSettingsSection.tsx
@@ -135,6 +135,7 @@ export const PlanSettingsSection = memo(
       <Card>
         <div className="flex flex-col gap-8">
           <TextInput
+            name="name"
             label={translate('text_629728388c4d2300e2d38091')}
             placeholder={translate('text_624453d52e945301380e499c')}
             value={formikProps.values.name}

--- a/src/components/plans/PlanSettingsSection.tsx
+++ b/src/components/plans/PlanSettingsSection.tsx
@@ -8,6 +8,7 @@ import {
   ComboBox,
   ComboBoxField,
   ComboboxItem,
+  TextInput,
   TextInputField,
 } from '~/components/form'
 import {
@@ -18,6 +19,7 @@ import {
   SEARCH_TAX_INPUT_FOR_PLAN_CLASSNAME,
 } from '~/core/constants/form'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { updateNameAndMaybeCode } from '~/core/utils/updateNameAndMaybeCode'
 import { CurrencyEnum, PlanInterval, useGetTaxesForPlanLazyQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
@@ -132,13 +134,13 @@ export const PlanSettingsSection = memo(
     return (
       <Card>
         <div className="flex flex-col gap-8">
-          <TextInputField
-            name="name"
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus={!isInSubscriptionForm}
+          <TextInput
             label={translate('text_629728388c4d2300e2d38091')}
             placeholder={translate('text_624453d52e945301380e499c')}
-            formikProps={formikProps}
+            value={formikProps.values.name}
+            onChange={(name) => {
+              updateNameAndMaybeCode({ name, formikProps })
+            }}
           />
 
           {shouldDisplayDescription ? (

--- a/src/core/utils/__tests__/updateNameAndMaybeCode.test.tsx
+++ b/src/core/utils/__tests__/updateNameAndMaybeCode.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Formik, FormikProps } from 'formik'
+
+import { TextInput, TextInputField } from '~/components/form'
+
+import { updateNameAndMaybeCode } from '../updateNameAndMaybeCode'
+
+// We use a simple component that replicates the behavior of TextInputs in a Formik form.
+const TestFormComponent = ({
+  initialValues,
+}: {
+  initialValues: { name: string; code?: string }
+}) => {
+  return (
+    <Formik initialValues={initialValues} onSubmit={() => {}}>
+      {(formikProps: FormikProps<{ name: string; code?: string }>) => (
+        <form>
+          <TextInput
+            name="name"
+            label="Name"
+            value={formikProps.values.name}
+            onChange={(name) => {
+              updateNameAndMaybeCode({ name, formikProps })
+            }}
+            data-test="name-input"
+          />
+
+          <TextInputField
+            name="code"
+            label="Code"
+            formikProps={formikProps}
+            data-test="code-input"
+          />
+        </form>
+      )}
+    </Formik>
+  )
+}
+
+describe('updateNameAndMaybeCode', () => {
+  it('updates the code when a name is entered and code is empty and untouched', async () => {
+    const user = userEvent.setup()
+
+    render(<TestFormComponent initialValues={{ name: '', code: '' }} />)
+
+    const nameInput = screen.getByLabelText('Name')
+    const codeInput = screen.getByLabelText('Code')
+
+    await user.type(nameInput, 'My Awesome Plan')
+
+    expect(nameInput).toHaveValue('My Awesome Plan')
+    expect(codeInput).toHaveValue('my_awesome_plan')
+  })
+
+  it('does not update the code if the code field has an initial value', async () => {
+    const user = userEvent.setup()
+
+    render(<TestFormComponent initialValues={{ name: '', code: 'existing_code' }} />)
+
+    const nameInput = screen.getByLabelText('Name')
+    const codeInput = screen.getByLabelText('Code')
+
+    await user.type(nameInput, 'My Awesome Plan')
+
+    expect(nameInput).toHaveValue('My Awesome Plan')
+    expect(codeInput).toHaveValue('existing_code')
+  })
+
+  it('does not update the code if the code field has been touched (by focusing and blurring)', async () => {
+    const user = userEvent.setup()
+
+    render(<TestFormComponent initialValues={{ name: '', code: '' }} />)
+
+    const nameInput = screen.getByLabelText('Name')
+    const codeInput = screen.getByLabelText('Code')
+
+    await user.click(codeInput)
+    await user.tab() // This will blur the code input and touch it
+
+    await user.type(nameInput, 'My Awesome Plan')
+
+    expect(nameInput).toHaveValue('My Awesome Plan')
+    expect(codeInput).toHaveValue('')
+  })
+
+  it('does not update the code if the user types in the code field first', async () => {
+    const user = userEvent.setup()
+
+    render(<TestFormComponent initialValues={{ name: '', code: '' }} />)
+
+    const nameInput = screen.getByLabelText('Name')
+    const codeInput = screen.getByLabelText('Code')
+
+    await user.type(codeInput, 'user_defined_code')
+    await user.type(nameInput, 'My Awesome Plan')
+
+    expect(nameInput).toHaveValue('My Awesome Plan')
+    expect(codeInput).toHaveValue('user_defined_code')
+  })
+
+  it('updates the code correctly for names with multiple spaces and mixed case', async () => {
+    const user = userEvent.setup()
+
+    render(<TestFormComponent initialValues={{ name: '', code: '' }} />)
+
+    const nameInput = screen.getByLabelText('Name')
+    const codeInput = screen.getByLabelText('Code')
+
+    await user.type(nameInput, 'Another Plan With  More   Spaces')
+
+    expect(nameInput).toHaveValue('Another Plan With  More   Spaces')
+    expect(codeInput).toHaveValue('another_plan_with__more___spaces')
+  })
+
+  it('clears the code when the name is cleared, if code was being auto-generated', async () => {
+    const user = userEvent.setup()
+
+    render(<TestFormComponent initialValues={{ name: '', code: '' }} />)
+
+    const nameInput = screen.getByLabelText('Name')
+    const codeInput = screen.getByLabelText('Code')
+
+    await user.type(nameInput, 'Temporary Name')
+    expect(codeInput).toHaveValue('temporary_name')
+
+    await user.clear(nameInput)
+    expect(codeInput).toHaveValue('')
+  })
+})

--- a/src/core/utils/updateNameAndMaybeCode.ts
+++ b/src/core/utils/updateNameAndMaybeCode.ts
@@ -1,0 +1,22 @@
+import { FormikProps } from 'formik'
+
+const formatCodeFromName = (name: string) => {
+  return name.toLowerCase().replace(/ /g, '_')
+}
+
+export const updateNameAndMaybeCode = <T extends { name?: string | null; code?: string | null }>({
+  name,
+  formikProps,
+}: {
+  name: string
+  formikProps: FormikProps<T>
+}) => {
+  const hasCodeBeenTouched = !!formikProps.touched.code
+  const hadInitialCode = !!formikProps.initialValues.code
+
+  formikProps.setValues({
+    ...(formikProps.values as T),
+    name,
+    code: hasCodeBeenTouched || hadInitialCode ? formikProps.values.code : formatCodeFromName(name),
+  })
+}

--- a/src/pages/AlertForm.tsx
+++ b/src/pages/AlertForm.tsx
@@ -7,13 +7,14 @@ import { array, boolean, number, object, string } from 'yup'
 
 import AlertThresholds, { isThresholdValueValid } from '~/components/alerts/Thresholds'
 import { Button, Typography } from '~/components/designSystem'
-import { ComboBox, ComboBoxField, ComboboxItem, TextInputField } from '~/components/form'
+import { ComboBox, ComboBoxField, ComboboxItem, TextInput, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { CustomerSubscriptionDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, PLAN_SUBSCRIPTION_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount, serializeAmount } from '~/core/serializers/serializeAmount'
+import { updateNameAndMaybeCode } from '~/core/utils/updateNameAndMaybeCode'
 import {
   AlertThreshold,
   AlertTypeEnum,
@@ -435,11 +436,14 @@ const AlertForm = () => {
                     </Typography>
                   </div>
                   <div className="flex gap-6 *:flex-1">
-                    <TextInputField
+                    <TextInput
                       name="name"
                       label={translate('text_1732286530467zstzwbegfiq')}
                       placeholder={translate('text_62876e85e32e0300e1803121')}
-                      formikProps={formikProps}
+                      value={formikProps.values.name || ''}
+                      onChange={(name) => {
+                        updateNameAndMaybeCode({ name, formikProps })
+                      }}
                     />
                     <TextInputField
                       name="code"

--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -12,6 +12,7 @@ import {
   ComboBox,
   ComboBoxField,
   ComboboxItem,
+  TextInput,
   TextInputField,
 } from '~/components/form'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
@@ -23,6 +24,7 @@ import {
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { ADD_ON_DETAILS_ROUTE, ADD_ONS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { updateNameAndMaybeCode } from '~/core/utils/updateNameAndMaybeCode'
 import {
   CurrencyEnum,
   TaxOnAddOnEditCreateFragmentDoc,
@@ -198,14 +200,17 @@ const CreateAddOn = () => {
                   </Typography>
 
                   <div className="flex flex-wrap gap-3">
-                    <TextInputField
+                    <TextInput
                       className="min-w-[110px] flex-1"
                       name="name"
                       label={translate('text_629728388c4d2300e2d38091')}
                       placeholder={translate('text_629728388c4d2300e2d380a5')}
                       // eslint-disable-next-line jsx-a11y/no-autofocus
                       autoFocus
-                      formikProps={formikProps}
+                      value={formikProps.values.name}
+                      onChange={(name) => {
+                        updateNameAndMaybeCode({ name, formikProps })
+                      }}
                     />
                     <TextInputField
                       className="min-w-[110px] flex-1"

--- a/src/pages/CreateBillableMetric.tsx
+++ b/src/pages/CreateBillableMetric.tsx
@@ -27,6 +27,7 @@ import {
   ComboBoxField,
   JsonEditorField,
   MultipleComboBox,
+  TextInput,
   TextInputField,
 } from '~/components/form'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
@@ -36,6 +37,7 @@ import {
   formatRoundingFunction,
 } from '~/core/formats/formatBillableMetricsItems'
 import { BILLABLE_METRICS_ROUTE, DUPLICATE_BILLABLE_METRIC_ROUTE } from '~/core/router'
+import { updateNameAndMaybeCode } from '~/core/utils/updateNameAndMaybeCode'
 import {
   AggregationTypeEnum,
   CreateBillableMetricInput,
@@ -286,13 +288,16 @@ const CreateBillableMetric = () => {
                   </Typography>
 
                   <div className="flex flex-wrap gap-3 *:flex-1">
-                    <TextInputField
+                    <TextInput
                       name="name"
                       label={translate('text_623b42ff8ee4e000ba87d0be')}
                       placeholder={translate('text_6241cc759211e600ea57f4c7')}
                       // eslint-disable-next-line jsx-a11y/no-autofocus
                       autoFocus
-                      formikProps={formikProps}
+                      value={formikProps.values.name}
+                      onChange={(name) => {
+                        updateNameAndMaybeCode({ name, formikProps })
+                      }}
                     />
                     <TextInputField
                       name="code"

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -258,11 +258,11 @@ const CreateCoupon = () => {
                   </Typography>
 
                   <TextInput
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                    autoFocus
                     name="name"
                     label={translate('text_62876e85e32e0300e180311b')}
                     placeholder={translate('text_62876e85e32e0300e1803121')}
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
-                    autoFocus
                     value={formikProps.values.name}
                     onChange={(name) => {
                       updateNameAndMaybeCode({ name, formikProps })

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -22,6 +22,7 @@ import {
   Checkbox,
   ComboBoxField,
   DatePicker,
+  TextInput,
   TextInputField,
 } from '~/components/form'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
@@ -30,6 +31,7 @@ import { CouponDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { COUPON_DETAILS_ROUTE, COUPONS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { endOfDayIso } from '~/core/utils/dateUtils'
+import { updateNameAndMaybeCode } from '~/core/utils/updateNameAndMaybeCode'
 import {
   BillableMetricsForCouponsFragment,
   CouponExpiration,
@@ -255,13 +257,16 @@ const CreateCoupon = () => {
                     {translate('text_62876e85e32e0300e1803115')}
                   </Typography>
 
-                  <TextInputField
+                  <TextInput
                     name="name"
                     label={translate('text_62876e85e32e0300e180311b')}
                     placeholder={translate('text_62876e85e32e0300e1803121')}
                     // eslint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus
-                    formikProps={formikProps}
+                    value={formikProps.values.name}
+                    onChange={(name) => {
+                      updateNameAndMaybeCode({ name, formikProps })
+                    }}
                   />
                   <TextInputField
                     name="code"

--- a/src/pages/CreateTax.tsx
+++ b/src/pages/CreateTax.tsx
@@ -4,11 +4,12 @@ import { useEffect, useRef, useState } from 'react'
 import { number, object, string } from 'yup'
 
 import { Button, Card, Skeleton, Tooltip, Typography } from '~/components/designSystem'
-import { TextInputField } from '~/components/form'
+import { TextInput, TextInputField } from '~/components/form'
 import { TaxCodeSnippet } from '~/components/taxes/TaxCodeSnippet'
 import { TaxFormInput } from '~/components/taxes/types'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import { FORM_ERRORS_ENUM } from '~/core/constants/form'
+import { updateNameAndMaybeCode } from '~/core/utils/updateNameAndMaybeCode'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCreateEditTax } from '~/hooks/useCreateEditTax'
 import { PageHeader } from '~/styles'
@@ -113,14 +114,17 @@ const CreateTaxRate = () => {
                   </Typography>
 
                   <div className="flex gap-3">
-                    <TextInputField
+                    <TextInput
                       className="flex-1"
                       name="name"
                       label={translate('text_645bb193927b375079d28ab1')}
                       placeholder={translate('text_645bb193927b375079d28ace')}
                       // eslint-disable-next-line jsx-a11y/no-autofocus
                       autoFocus
-                      formikProps={formikProps}
+                      value={formikProps.values.name || ''}
+                      onChange={(name) => {
+                        updateNameAndMaybeCode({ name, formikProps })
+                      }}
                     />
                     <TextInputField
                       className="flex-1"

--- a/src/pages/settings/BillingEntity/sections/BillingEntityCreateEdit.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityCreateEdit.tsx
@@ -3,12 +3,13 @@ import { useEffect, useRef, useState } from 'react'
 import { object, string } from 'yup'
 
 import { Button, Typography } from '~/components/designSystem'
-import { ComboBoxField, TextInputField } from '~/components/form'
+import { ComboBoxField, TextInput, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { LogoPicker } from '~/components/LogoPicker'
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import { FORM_ERRORS_ENUM } from '~/core/constants/form'
 import { countryDataForCombobox } from '~/core/formats/countryDataForCombobox'
+import { updateNameAndMaybeCode } from '~/core/utils/updateNameAndMaybeCode'
 import { CreateBillingEntityInput, UpdateBillingEntityInput } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import useCreateEditBillingEntity from '~/hooks/useCreateEditBillingEntity'
@@ -107,13 +108,16 @@ const BillingEntityCreateEdit = () => {
                     </Typography>
                   </div>
                   <div className="flex items-start gap-6 *:flex-1">
-                    <TextInputField
-                      name="name"
-                      formikProps={formikProps}
-                      label={translate('text_6419c64eace749372fc72b0f')}
-                      placeholder={translate('text_6584550dc4cec7adf861504f')}
+                    <TextInput
                       // eslint-disable-next-line jsx-a11y/no-autofocus
                       autoFocus
+                      name="name"
+                      value={formikProps.values.name || ''}
+                      onChange={(name) => {
+                        updateNameAndMaybeCode({ name, formikProps })
+                      }}
+                      label={translate('text_6419c64eace749372fc72b0f')}
+                      placeholder={translate('text_6584550dc4cec7adf861504f')}
                     />
 
                     <TextInputField

--- a/src/pages/settings/Dunnings/CreateDunning.tsx
+++ b/src/pages/settings/Dunnings/CreateDunning.tsx
@@ -5,7 +5,13 @@ import { useNavigate } from 'react-router-dom'
 import { array, boolean, number, object, string } from 'yup'
 
 import { Alert, Button, Tooltip, Typography } from '~/components/designSystem'
-import { AmountInputField, ComboBoxField, SwitchField, TextInputField } from '~/components/form'
+import {
+  AmountInputField,
+  ComboBoxField,
+  SwitchField,
+  TextInput,
+  TextInputField,
+} from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import {
   DefaultCampaignDialog,
@@ -19,6 +25,7 @@ import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import { FORM_ERRORS_ENUM } from '~/core/constants/form'
 import { DUNNINGS_SETTINGS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { updateNameAndMaybeCode } from '~/core/utils/updateNameAndMaybeCode'
 import { CurrencyEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import {
@@ -184,11 +191,14 @@ const CreateDunning = () => {
                     </Typography>
                   </div>
                   <div className="flex items-start gap-6 *:flex-1">
-                    <TextInputField
+                    <TextInput
                       // eslint-disable-next-line jsx-a11y/no-autofocus
                       autoFocus
                       name="name"
-                      formikProps={formikProps}
+                      value={formikProps.values.name}
+                      onChange={(name) => {
+                        updateNameAndMaybeCode({ name, formikProps })
+                      }}
                       label={translate('text_6419c64eace749372fc72b0f')}
                       placeholder={translate('text_6584550dc4cec7adf861504f')}
                     />

--- a/src/pages/settings/Invoices/CreateCustomSection.tsx
+++ b/src/pages/settings/Invoices/CreateCustomSection.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import { boolean, object, string } from 'yup'
 
 import { Button, Tooltip, Typography } from '~/components/designSystem'
-import { SwitchField, TextInputField } from '~/components/form'
+import { SwitchField, TextInput, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import {
   DefaultCustomSectionDialog,
@@ -17,6 +17,7 @@ import {
 import { WarningDialog, WarningDialogRef } from '~/components/WarningDialog'
 import { FORM_ERRORS_ENUM } from '~/core/constants/form'
 import { INVOICE_SETTINGS_ROUTE } from '~/core/router'
+import { updateNameAndMaybeCode } from '~/core/utils/updateNameAndMaybeCode'
 import { CreateInvoiceCustomSectionInput } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCreateEditInvoiceCustomSection } from '~/hooks/useCreateEditInvoiceCustomSection'
@@ -130,11 +131,14 @@ const CreateInvoiceCustomSection = () => {
                     </Typography>
                   </div>
                   <div className="flex items-start gap-6 *:flex-1">
-                    <TextInputField
+                    <TextInput
                       // eslint-disable-next-line jsx-a11y/no-autofocus
                       autoFocus
                       name="name"
-                      formikProps={formikProps}
+                      value={formikProps.values.name}
+                      onChange={(name) => {
+                        updateNameAndMaybeCode({ name, formikProps })
+                      }}
                       label={translate('text_6419c64eace749372fc72b0f')}
                       placeholder={translate('text_6584550dc4cec7adf861504f')}
                     />


### PR DESCRIPTION
We want to improve the experience in forms, when typing the name to be able to pre-fill the code.

It makes sure the code is not updated on edit (if form has initial props) and if the user manually edited the code in the meantime (if the field is touched)

<!-- Linear link -->
Fixes ISSUE-939