### PR TITLE
bug: restore old button version to fix auto spinner display

### DIFF
--- a/packages/design-system/src/components/Button.tsx
+++ b/packages/design-system/src/components/Button.tsx
@@ -175,11 +175,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       }
     }
 
-    const renderIcon = (name: IconName, isIconLoading: boolean) => {
-      if (isIconLoading) return <Icon animation="spin" name="processing" />
-      return <Icon name={name} />
-    }
-
     return (
       <MuiButton
         className={tw(
@@ -203,12 +198,32 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         disableRipple
         disabled={disabled}
         ref={ref}
-        endIcon={endIcon && renderIcon(endIcon, localLoading && !icon && !startIcon)}
-        startIcon={startIcon && renderIcon(startIcon, localLoading && !icon && !!startIcon)}
+        endIcon={
+          localLoading && !icon && !startIcon ? (
+            <Icon animation="spin" name="processing" />
+          ) : (
+            endIcon && <Icon name={endIcon} />
+          )
+        }
+        startIcon={
+          localLoading && !icon && !!startIcon ? (
+            <Icon animation="spin" name="processing" />
+          ) : (
+            startIcon && <Icon name={startIcon} />
+          )
+        }
         {...mapProperties(variant, !!inheritColor)}
         {...props}
       >
-        {icon ? renderIcon(icon, localLoading) : children}
+        {icon ? (
+          localLoading ? (
+            <Icon animation="spin" name="processing" />
+          ) : (
+            <Icon name={icon} />
+          )
+        ) : (
+          children
+        )}
       </MuiButton>
     )
   },


### PR DESCRIPTION
## Context

Button have been migrated to package recently and some code have been refactored.

This refactor removed a feature of this button --> showing a spinner if the `onClick` is a promise and is running.

## Description

Looking at the code I could not understand what's wrong and I don't have time to dig now.
Preferred to simply copy paste the app's button which works well.

So it means all button invocations from the package have this feature broken right now 😕 

