### PR TITLE
bug: better spacing for details and navigation

### DIFF
--- a/src/components/subscriptions/SubscriptionActivityLogs.tsx
+++ b/src/components/subscriptions/SubscriptionActivityLogs.tsx
@@ -53,7 +53,7 @@ export const SubscriptionActivityLogs: FC<SubscriptionActivityLogsProps> = ({
   })
 
   return (
-    <div className="w-full px-12 pb-20 pt-8">
+    <div className="w-full pb-20 pt-8">
       <div className="flex flex-col gap-12">
         <div>
           <PageSectionTitle

--- a/src/pages/BillableMetricDetails.tsx
+++ b/src/pages/BillableMetricDetails.tsx
@@ -156,7 +156,7 @@ const BillableMetricDetails = () => {
       />
 
       <NavigationTab
-        className="px-12"
+        className="px-4 md:px-12"
         loading={loading}
         tabs={[
           {

--- a/src/pages/CouponDetails.tsx
+++ b/src/pages/CouponDetails.tsx
@@ -188,7 +188,7 @@ const CouponDetails = () => {
       />
 
       <NavigationTab
-        className="px-12"
+        className="px-4 md:px-12"
         loading={loading}
         tabs={[
           {

--- a/src/pages/PlanDetails.tsx
+++ b/src/pages/PlanDetails.tsx
@@ -161,7 +161,7 @@ const PlanDetails = () => {
       />
 
       <NavigationTab
-        className="px-12"
+        className="px-4 md:px-12"
         loading={isPlanLoading}
         tabs={[
           {

--- a/src/pages/SubscriptionDetails.tsx
+++ b/src/pages/SubscriptionDetails.tsx
@@ -15,6 +15,7 @@ import {
   Skeleton,
   Typography,
 } from '~/components/designSystem'
+import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { SubscriptionActivityLogs } from '~/components/subscriptions/SubscriptionActivityLogs'
 import { SubscriptionAlertsList } from '~/components/subscriptions/SubscriptionAlertsList'
 import { SubscriptionDetailsOverview } from '~/components/subscriptions/SubscriptionDetailsOverview'
@@ -288,9 +289,9 @@ const SubscriptionDetails = () => {
               }),
             ],
             component: (
-              <div className="max-w-2xl px-12 pb-20">
+              <DetailsPage.Container>
                 <SubscriptionDetailsOverview />
-              </div>
+              </DetailsPage.Container>
             ),
           },
           ...(subscription?.status !== StatusTypeEnum.Canceled &&
@@ -322,9 +323,9 @@ const SubscriptionDetails = () => {
                     }),
                   ],
                   component: (
-                    <div className="max-w-2xl px-12 pb-20">
+                    <DetailsPage.Container>
                       <SubscriptionUsageTabContent />
-                    </div>
+                    </DetailsPage.Container>
                   ),
                 },
               ]
@@ -355,9 +356,9 @@ const SubscriptionDetails = () => {
               }),
             ],
             component: (
-              <div className="px-12 pb-20">
+              <DetailsPage.Container>
                 <SubscriptionAlertsList subscriptionExternalId={subscription?.externalId} />
-              </div>
+              </DetailsPage.Container>
             ),
           },
           {
@@ -386,7 +387,9 @@ const SubscriptionDetails = () => {
               }),
             ],
             component: (
-              <SubscriptionActivityLogs externalSubscriptionId={subscription?.externalId || ''} />
+              <DetailsPage.Container>
+                <SubscriptionActivityLogs externalSubscriptionId={subscription?.externalId || ''} />
+              </DetailsPage.Container>
             ),
             hidden: !subscription?.externalId || !isPremium || !hasPermissions(['auditLogsView']),
           },

--- a/src/pages/SubscriptionDetails.tsx
+++ b/src/pages/SubscriptionDetails.tsx
@@ -259,7 +259,7 @@ const SubscriptionDetails = () => {
       </div>
 
       <NavigationTab
-        className="px-12"
+        className="px-4 md:px-12"
         loading={isSubscriptionLoading}
         tabs={[
           {


### PR DESCRIPTION
Initially fixing the navigation of some details pages to share the same look and feel as the rest of the app.

I noticed the subscription details also needed some adjustments to share the same look and feel as the other details page

Fixed both in the same PR.

<!-- Linear link -->
Fixes ISSUE-942