### PR TITLE
bug: make sure inputs are aligned when error is displayed

### DIFF
--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -267,7 +267,7 @@ const CreateAddOn = () => {
                     {translate('text_629728388c4d2300e2d38117')}
                   </Typography>
 
-                  <div className="flex flex-row items-end gap-3">
+                  <div className="flex flex-row items-start gap-3">
                     <AmountInputField
                       className="flex-1"
                       name="amountCents"
@@ -277,7 +277,7 @@ const CreateAddOn = () => {
                       formikProps={formikProps}
                     />
                     <ComboBoxField
-                      className="max-w-30"
+                      className="mt-7 max-w-30"
                       name="amountCurrency"
                       data={Object.values(CurrencyEnum).map((currencyType) => ({
                         value: currencyType,


### PR DESCRIPTION
If there is an error, the inputs on the same line are not aligned anymore with an `items-start` rule.

Had to align top and push the second input with a margin as it does not have a label.

<!-- Linear link -->
Fixes ISSUE-945