### PR TITLE
misc(Customer): add random external id generate button

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "react-router-dom": "6.15.0",
     "recharts": "^2.15.1",
     "sanitize-html": "2.12.1",
+    "uuid": "^11.1.0",
     "yup": "1.2.0"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       sanitize-html:
         specifier: 2.12.1
         version: 2.12.1
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       yup:
         specifier: 1.2.0
         version: 1.2.0
@@ -7206,6 +7209,10 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
   uuid@8.3.2:
@@ -15385,6 +15392,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
+
+  uuid@11.1.0: {}
 
   uuid@8.3.2: {}
 

--- a/src/components/customers/createCustomer/CustomerInformation.tsx
+++ b/src/components/customers/createCustomer/CustomerInformation.tsx
@@ -1,5 +1,7 @@
 import { FormikProps } from 'formik'
+import { Button } from 'lago-design-system'
 import { FC, useMemo } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 
 import { TRANSLATIONS_MAP_CUSTOMER_TYPE } from '~/components/customers/utils'
 import { Typography } from '~/components/designSystem'
@@ -67,15 +69,29 @@ export const CustomerInformation: FC<CustomerInformationProps> = ({
         disableClearable={isEdition && !customer?.canEditAttributes}
         sortValues={false}
       />
-      <TextInputField
-        // eslint-disable-next-line jsx-a11y/no-autofocus
-        autoFocus={!isEdition}
-        name="externalId"
-        disabled={isEdition && !customer?.canEditAttributes}
-        label={translate('text_624efab67eb2570101d117ce')}
-        placeholder={translate('text_624efab67eb2570101d117d6')}
-        formikProps={formikProps}
-      />
+      <div className="flex items-start gap-2">
+        <TextInputField
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus={!isEdition}
+          className="flex-1"
+          name="externalId"
+          disabled={isEdition && !customer?.canEditAttributes}
+          label={translate('text_624efab67eb2570101d117ce')}
+          placeholder={translate('text_624efab67eb2570101d117d6')}
+          formikProps={formikProps}
+        />
+        {!isEdition && (
+          <Button
+            className="mt-8"
+            variant="quaternary"
+            onClick={() => {
+              formikProps.setFieldValue('externalId', uuidv4())
+            }}
+          >
+            {translate('text_1751011689111g64bkbodslm')}
+          </Button>
+        )}
+      </div>
       <ComboBoxField
         name="customerType"
         label={translate('text_1726128938631ioz4orixel3')}

--- a/translations/base.json
+++ b/translations/base.json
@@ -3257,5 +3257,6 @@
   "text_1749819999030uz8ddys1puu": "API endpoint",
   "text_1749819999031vobdu7h2c7c": "HTTP Method",
   "text_17498224925954a8mk0enwdj": "Response body",
-  "text_1749822492595ayr96w7ez17": "Request body"
+  "text_1749822492595ayr96w7ez17": "Request body",
+  "text_1751011689111g64bkbodslm": "Generate random"
 }


### PR DESCRIPTION
Adding a button to generate a random UUID for the externalCustomerId field.

This is only visible on creation form.

Aim to improve the experience on this form, as it's the only field required.