### PR TITLE
bug: prevent skeleton to overflow

### DIFF
--- a/packages/design-system/src/components/Skeleton.tsx
+++ b/packages/design-system/src/components/Skeleton.tsx
@@ -29,7 +29,7 @@ interface SkeletonGenericProps {
   variant: Extract<SkeletonVariant, 'text'>
 }
 
-const textWrapperStyles = cva('flex w-full items-center', {
+const textWrapperStyles = cva('flex w-full max-w-full items-center', {
   variants: {
     textVariant: {
       headline: 'h-8',

--- a/src/components/designSystem/Skeleton.tsx
+++ b/src/components/designSystem/Skeleton.tsx
@@ -31,7 +31,7 @@ interface SkeletonGenericProps {
   variant: Extract<SkeletonVariant, 'text'>
 }
 
-const textWrapperStyles = cva('flex w-full items-center', {
+const textWrapperStyles = cva('flex w-full max-w-full items-center', {
   variants: {
     textVariant: {
       headline: 'h-8',


### PR DESCRIPTION
## Context

Skeletons sometimes overflow their container when they have a width defined.

## Description

This PR makes sure that even if a `className` gives a precise width to a skeleton, it won't overflow size of it's container.

<!-- Linear link -->
Fixes ISSUE-966