### PR TITLE
bug: make sure logo is display once uploaded in settings

### DIFF
--- a/src/components/settings/PreviewEmailLayout.tsx
+++ b/src/components/settings/PreviewEmailLayout.tsx
@@ -20,7 +20,7 @@ interface PreviewEmailLayoutProps extends PropsWithChildren {
   emailFrom?: string
   emailTo?: string
   isLoading?: boolean
-  logoUrl?: string | null
+  logoUrl: string | null | undefined
   name?: string | null
 }
 

--- a/src/pages/settings/BillingEntity/sections/BillingEntityEmailScenariosConfig.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityEmailScenariosConfig.tsx
@@ -228,6 +228,7 @@ const BillingEntityEmailScenariosConfig = () => {
             <PreviewEmailLayout
               isLoading={loading}
               language={invoiceLanguage}
+              logoUrl={billingEntity?.logoUrl}
               emailObject={translateWithContextualLocal(translationsKey.subject, {
                 organization: name,
               })}


### PR DESCRIPTION
## Context

You can upload a logo in the email configuration settings.
However once uploaded it does not show in the page.

## Description

The logo once uploaded was supposed to be passed via props to the component for display.

The props was missing but it's presence is mandatory (value can be null or undefined tho)

This PR makes sure this does not happen anymore.

I'll open a ticket to improve the logo removal experience.

<!-- Linear link -->
Fixes ISSUE-970