### PR TITLE
feat(wallet_transactions): add wallet transaction sources

### DIFF
--- a/src/components/wallets/WalletAccordion.tsx
+++ b/src/components/wallets/WalletAccordion.tsx
@@ -38,6 +38,7 @@ import {
   WalletAccordionFragment,
   WalletInfosForTransactionsFragmentDoc,
   WalletStatusEnum,
+  WalletTransactionSourceEnum,
   WalletTransactionStatusEnum,
   WalletTransactionTransactionTypeEnum,
 } from '~/generated/graphql'
@@ -510,6 +511,7 @@ export const WalletAccordion: FC<WalletAccordionProps> = ({
                   status: WalletTransactionStatusEnum.Settled,
                   transactionType: WalletTransactionTransactionTypeEnum.Outbound,
                   transactionStatus: undefined,
+                  source: WalletTransactionSourceEnum.Manual,
                 }}
                 customerTimezone={customerTimezone}
                 isWalletActive={isWalletActive}

--- a/src/components/wallets/WalletDetailsDrawer.tsx
+++ b/src/components/wallets/WalletDetailsDrawer.tsx
@@ -37,6 +37,7 @@ import {
   ProviderTypeEnum,
   useGetWalletTransactionDetailsLazyQuery,
   WalletInfosForTransactionsFragment,
+  WalletTransactionSourceEnum,
   WalletTransactionStatusEnum,
   WalletTransactionTransactionStatusEnum,
   WalletTransactionTransactionTypeEnum,
@@ -57,6 +58,7 @@ gql`
     failedAt
     status
     transactionStatus
+    source
     invoiceRequiresSuccessfulPayment
     metadata {
       key
@@ -104,6 +106,12 @@ interface WalletDetailsDrawerProps {
 const GRID =
   'grid grid-cols-1 gap-y-1 [&>*:nth-child(even)]:mb-3 sm:[&>*:nth-child(even)]:mb-0 sm:grid-cols-[fit-content(100%)_1fr] sm:auto-rows-[minmax(40px,1fr)] items-center sm:gap-x-8 sm:gap-y-2'
 
+const WALLET_TRANSACTION_SOURCE_TRANSLATIONS: Record<WalletTransactionSourceEnum, string> = {
+  [WalletTransactionSourceEnum.Interval]: 'text_1751530295201vhd64062mii',
+  [WalletTransactionSourceEnum.Threshold]: 'text_1751530295201xyz98abc123',
+  [WalletTransactionSourceEnum.Manual]: 'text_1751530295201def456ghi78',
+}
+
 export const WalletDetailsDrawer = forwardRef<WalletDetailsDrawerRef, WalletDetailsDrawerProps>(
   ({ wallet }: WalletDetailsDrawerProps, ref) => {
     const drawerRef = useRef<DrawerRef>(null)
@@ -139,6 +147,7 @@ export const WalletDetailsDrawer = forwardRef<WalletDetailsDrawerRef, WalletDeta
       transactionStatus,
       invoiceRequiresSuccessfulPayment,
       invoice,
+      source,
     } = data?.walletTransaction || {}
 
     const formatted = useMemo(() => {
@@ -352,6 +361,10 @@ export const WalletDetailsDrawer = forwardRef<WalletDetailsDrawerRef, WalletDeta
                           translate('text_63e27c56dfe64b846474ef4e')}
                       </>
                     }
+                  />
+                  <DetailRow
+                    label={translate('text_1751530295201wwh8zbwv2w9')}
+                    value={source && translate(WALLET_TRANSACTION_SOURCE_TRANSLATIONS[source])}
                   />
                   <DetailRow
                     label={translate('text_1741943835752e00705sjtf8')}

--- a/src/components/wallets/WalletTransactionListItem/ListItem.tsx
+++ b/src/components/wallets/WalletTransactionListItem/ListItem.tsx
@@ -71,7 +71,11 @@ export const ListItem: FC<ListItemProps> = ({
             {isFailed && <AvatarBadge icon="stop" color="warning" />}
           </Avatar>
           <div className="flex flex-col justify-end">
-            <Typography variant="bodyHl" color={isPending || isFailed ? 'grey500' : labelColor}>
+            <Typography
+              variant="bodyHl"
+              color={isPending || isFailed ? 'grey500' : labelColor}
+              data-test="transaction-label"
+            >
               {label}
             </Typography>
             {date && (

--- a/src/components/wallets/WalletTransactionListItem/__tests__/index.test.tsx
+++ b/src/components/wallets/WalletTransactionListItem/__tests__/index.test.tsx
@@ -8,6 +8,7 @@ import {
 import {
   GetOrganizationInfosDocument,
   TimezoneEnum,
+  WalletTransactionSourceEnum,
   WalletTransactionStatusEnum,
   WalletTransactionTransactionStatusEnum,
   WalletTransactionTransactionTypeEnum,
@@ -59,6 +60,7 @@ async function prepare(
     creditAmount: CREDITS,
     settledAt: DateTime.local(2022, 2, 2).toISO(),
     createdAt: DateTime.local(2022, 1, 1).toISO(),
+    source: WalletTransactionSourceEnum.Manual,
     ...overriddenTransaction,
   }
 
@@ -88,7 +90,7 @@ describe('WalletTransactionListItem', () => {
 
     expect(screen.getByTitle('sync/xsmall')).toBeInTheDocument()
     expect(screen.getByTestId('caption-pending')).toBeInTheDocument()
-    expect(screen.getByText('Credits purchased')).toBeInTheDocument()
+    expect(screen.getByTestId('transaction-label')).toBeInTheDocument()
     expect(screen.getByTestId('credits')).toHaveTextContent(`+ ${CREDITS}`)
     expect(screen.getByTestId('amount')).toHaveTextContent(AMOUNT)
   })
@@ -101,7 +103,7 @@ describe('WalletTransactionListItem', () => {
 
     expect(screen.getByTitle('sync/xsmall')).toBeInTheDocument()
     expect(screen.getByTestId('caption-pending')).toBeInTheDocument()
-    expect(screen.getByText('Credits invoiced')).toBeInTheDocument()
+    expect(screen.getByTestId('transaction-label')).toBeInTheDocument()
     expect(screen.getByTestId('credits')).toHaveTextContent(`- ${CREDITS}`)
     expect(screen.getByTestId('amount')).toHaveTextContent(AMOUNT)
   })
@@ -133,7 +135,7 @@ describe('WalletTransactionListItem', () => {
     })
 
     expect(screen.getByTitle('plus/medium')).toBeInTheDocument()
-    expect(screen.getByText('Credits offered')).toBeInTheDocument()
+    expect(screen.getByTestId('transaction-label')).toBeInTheDocument()
   })
 
   it('should render voided item properly', async () => {
@@ -143,7 +145,7 @@ describe('WalletTransactionListItem', () => {
     })
 
     expect(screen.getByTitle('minus/medium')).toBeInTheDocument()
-    expect(screen.getByText('Credits voided')).toBeInTheDocument()
+    expect(screen.getByTestId('transaction-label')).toBeInTheDocument()
   })
 
   it('should render real time transaction', async () => {
@@ -153,6 +155,26 @@ describe('WalletTransactionListItem', () => {
     expect(screen.queryByTestId('caption-pending')).not.toBeInTheDocument()
     expect(screen.getByTestId('credits')).toHaveTextContent(CREDITS)
     expect(screen.getByTestId('amount')).toHaveTextContent(AMOUNT)
+  })
+
+  it('should render automatic credits purchased for interval source', async () => {
+    await prepare({
+      source: WalletTransactionSourceEnum.Interval,
+      transactionStatus: WalletTransactionTransactionStatusEnum.Purchased,
+      transactionType: WalletTransactionTransactionTypeEnum.Inbound,
+    })
+
+    expect(screen.getByTestId('transaction-label')).toBeInTheDocument()
+  })
+
+  it('should render automatic credits purchased for threshold source', async () => {
+    await prepare({
+      source: WalletTransactionSourceEnum.Threshold,
+      transactionStatus: WalletTransactionTransactionStatusEnum.Purchased,
+      transactionType: WalletTransactionTransactionTypeEnum.Inbound,
+    })
+
+    expect(screen.getByTestId('transaction-label')).toBeInTheDocument()
   })
 
   it('should render real time transaction with zero amount for non premium user', async () => {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -5656,6 +5656,8 @@ export type Query = {
   wallet?: Maybe<Wallet>;
   /** Query a single wallet transaction */
   walletTransaction?: Maybe<WalletTransaction>;
+  /** Query wallet transaction sources */
+  walletTransactionSources: Array<WalletTransactionSourceEnum>;
   /** Query wallet transactions */
   walletTransactions: WalletTransactionCollection;
   /** Query wallets */
@@ -7732,6 +7734,7 @@ export type WalletTransaction = {
   invoiceRequiresSuccessfulPayment: Scalars['Boolean']['output'];
   metadata?: Maybe<Array<WalletTransactionMetadataObject>>;
   settledAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  source: WalletTransactionSourceEnum;
   status: WalletTransactionStatusEnum;
   transactionStatus: WalletTransactionTransactionStatusEnum;
   transactionType: WalletTransactionTransactionTypeEnum;
@@ -7758,6 +7761,12 @@ export type WalletTransactionMetadataObject = {
   key: Scalars['String']['output'];
   value: Scalars['String']['output'];
 };
+
+export enum WalletTransactionSourceEnum {
+  Interval = 'interval',
+  Manual = 'manual',
+  Threshold = 'threshold'
+}
 
 export enum WalletTransactionStatusEnum {
   Failed = 'failed',
@@ -10176,14 +10185,14 @@ export type WalletForVoidTransactionFragment = { __typename?: 'Wallet', id: stri
 
 export type WalletAccordionFragment = { __typename?: 'Wallet', id: string, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, expirationAt?: any | null, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, name?: string | null, rateAmount: number, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number };
 
-export type WalletTransactionDetailsFragment = { __typename?: 'WalletTransaction', id: string, amount: string, createdAt: any, transactionType: WalletTransactionTransactionTypeEnum, creditAmount: string, settledAt?: any | null, failedAt?: any | null, status: WalletTransactionStatusEnum, transactionStatus: WalletTransactionTransactionStatusEnum, invoiceRequiresSuccessfulPayment: boolean, metadata?: Array<{ __typename?: 'WalletTransactionMetadataObject', key: string, value: string }> | null, invoice?: { __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, invoiceType: InvoiceTypeEnum, number: string, paymentStatus: InvoicePaymentStatusTypeEnum, customer: { __typename?: 'Customer', id: string }, payments?: Array<{ __typename?: 'Payment', id: string, providerPaymentId?: string | null, paymentProviderType?: ProviderTypeEnum | null, payablePaymentStatus?: PayablePaymentStatusEnum | null }> | null } | null };
+export type WalletTransactionDetailsFragment = { __typename?: 'WalletTransaction', id: string, amount: string, createdAt: any, transactionType: WalletTransactionTransactionTypeEnum, creditAmount: string, settledAt?: any | null, failedAt?: any | null, status: WalletTransactionStatusEnum, transactionStatus: WalletTransactionTransactionStatusEnum, source: WalletTransactionSourceEnum, invoiceRequiresSuccessfulPayment: boolean, metadata?: Array<{ __typename?: 'WalletTransactionMetadataObject', key: string, value: string }> | null, invoice?: { __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, invoiceType: InvoiceTypeEnum, number: string, paymentStatus: InvoicePaymentStatusTypeEnum, customer: { __typename?: 'Customer', id: string }, payments?: Array<{ __typename?: 'Payment', id: string, providerPaymentId?: string | null, paymentProviderType?: ProviderTypeEnum | null, payablePaymentStatus?: PayablePaymentStatusEnum | null }> | null } | null };
 
 export type GetWalletTransactionDetailsQueryVariables = Exact<{
   transactionId: Scalars['ID']['input'];
 }>;
 
 
-export type GetWalletTransactionDetailsQuery = { __typename?: 'Query', walletTransaction?: { __typename?: 'WalletTransaction', id: string, amount: string, createdAt: any, transactionType: WalletTransactionTransactionTypeEnum, creditAmount: string, settledAt?: any | null, failedAt?: any | null, status: WalletTransactionStatusEnum, transactionStatus: WalletTransactionTransactionStatusEnum, invoiceRequiresSuccessfulPayment: boolean, metadata?: Array<{ __typename?: 'WalletTransactionMetadataObject', key: string, value: string }> | null, invoice?: { __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, invoiceType: InvoiceTypeEnum, number: string, paymentStatus: InvoicePaymentStatusTypeEnum, customer: { __typename?: 'Customer', id: string }, payments?: Array<{ __typename?: 'Payment', id: string, providerPaymentId?: string | null, paymentProviderType?: ProviderTypeEnum | null, payablePaymentStatus?: PayablePaymentStatusEnum | null }> | null } | null } | null };
+export type GetWalletTransactionDetailsQuery = { __typename?: 'Query', walletTransaction?: { __typename?: 'WalletTransaction', id: string, amount: string, createdAt: any, transactionType: WalletTransactionTransactionTypeEnum, creditAmount: string, settledAt?: any | null, failedAt?: any | null, status: WalletTransactionStatusEnum, transactionStatus: WalletTransactionTransactionStatusEnum, source: WalletTransactionSourceEnum, invoiceRequiresSuccessfulPayment: boolean, metadata?: Array<{ __typename?: 'WalletTransactionMetadataObject', key: string, value: string }> | null, invoice?: { __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, invoiceType: InvoiceTypeEnum, number: string, paymentStatus: InvoicePaymentStatusTypeEnum, customer: { __typename?: 'Customer', id: string }, payments?: Array<{ __typename?: 'Payment', id: string, providerPaymentId?: string | null, paymentProviderType?: ProviderTypeEnum | null, payablePaymentStatus?: PayablePaymentStatusEnum | null }> | null } | null } | null };
 
 export type WalletInfosForTransactionsFragment = { __typename?: 'Wallet', id: string, currency: CurrencyEnum, status: WalletStatusEnum, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number };
 
@@ -10194,9 +10203,9 @@ export type GetWalletTransactionsQueryVariables = Exact<{
 }>;
 
 
-export type GetWalletTransactionsQuery = { __typename?: 'Query', walletTransactions: { __typename?: 'WalletTransactionCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'WalletTransaction', id: string, status: WalletTransactionStatusEnum, transactionStatus: WalletTransactionTransactionStatusEnum, transactionType: WalletTransactionTransactionTypeEnum, amount: string, creditAmount: string, settledAt?: any | null, failedAt?: any | null, createdAt: any, wallet?: { __typename?: 'Wallet', id: string, currency: CurrencyEnum } | null }> } };
+export type GetWalletTransactionsQuery = { __typename?: 'Query', walletTransactions: { __typename?: 'WalletTransactionCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'WalletTransaction', id: string, status: WalletTransactionStatusEnum, transactionStatus: WalletTransactionTransactionStatusEnum, transactionType: WalletTransactionTransactionTypeEnum, amount: string, creditAmount: string, settledAt?: any | null, failedAt?: any | null, createdAt: any, source: WalletTransactionSourceEnum, wallet?: { __typename?: 'Wallet', id: string, currency: CurrencyEnum } | null }> } };
 
-export type WalletTransactionForTransactionListItemFragment = { __typename?: 'WalletTransaction', id: string, status: WalletTransactionStatusEnum, transactionStatus: WalletTransactionTransactionStatusEnum, transactionType: WalletTransactionTransactionTypeEnum, amount: string, creditAmount: string, settledAt?: any | null, failedAt?: any | null, createdAt: any, wallet?: { __typename?: 'Wallet', id: string, currency: CurrencyEnum } | null };
+export type WalletTransactionForTransactionListItemFragment = { __typename?: 'WalletTransaction', id: string, status: WalletTransactionStatusEnum, transactionStatus: WalletTransactionTransactionStatusEnum, transactionType: WalletTransactionTransactionTypeEnum, amount: string, creditAmount: string, settledAt?: any | null, failedAt?: any | null, createdAt: any, source: WalletTransactionSourceEnum, wallet?: { __typename?: 'Wallet', id: string, currency: CurrencyEnum } | null };
 
 export type CurrentUserFragment = { __typename?: 'User', id: string, organizations: Array<{ __typename?: 'Organization', id: string, name: string, timezone?: TimezoneEnum | null }> };
 
@@ -13238,6 +13247,7 @@ export const WalletTransactionDetailsFragmentDoc = gql`
   failedAt
   status
   transactionStatus
+  source
   invoiceRequiresSuccessfulPayment
   metadata {
     key
@@ -13272,6 +13282,7 @@ export const WalletTransactionForTransactionListItemFragmentDoc = gql`
   settledAt
   failedAt
   createdAt
+  source
   wallet {
     id
     currency

--- a/translations/base.json
+++ b/translations/base.json
@@ -767,6 +767,8 @@
   "text_6560c252c4f33631aff1ab27": "Search and select an interval",
   "text_662fc05d2cfe3a0596b29d98": "Credit voided|Credits voided",
   "text_662fc05d2cfe3a0596b29db0": "Credit offered|Credits offered",
+  "text_194a7e73e00a1b2c3d4e5f67": "Manual credits purchased",
+  "text_194a7e73e00b8c9d0e1f2a34": "Automatic credits purchased",
   "text_662fc2730f9a31fe564e9dad": "Define number of credits to void. This action will impact instantly the wallet balance.",
   "text_662fc2730f9a31fe564e9db1": "Credits to void",
   "text_662fc2730f9a31fe564e9dbd": "You will void {{credits}}.",
@@ -3262,5 +3264,9 @@
   "text_1750864025932bnohjbzci3f": "Reports",
   "text_1750864088654kxz304zdo2z": "Configuration",
   "text_1750864088654s9qo2h9fvp7": "Billing & operations",
-  "text_1751039646310obdq6n385sc": "Conversion rate: 1 {{pricingUnitShortName}} = ${{conversionRateAmount}}"
+  "text_1751039646310obdq6n385sc": "Conversion rate: 1 {{pricingUnitShortName}} = ${{conversionRateAmount}}",
+  "text_1751530295201wwh8zbwv2w9": "Source",
+  "text_1751530295201vhd64062mii": "Automatic interval",
+  "text_1751530295201xyz98abc123": "Automatic threshold",
+  "text_1751530295201def456ghi78": "Manual"
 }


### PR DESCRIPTION
The goal of this PR is to expose the `wallet_transactions.sources` in the GQL schemas. This source is going to be used on the UI to segregate the type of transaction:
- If source = manual -> Manual credits
- If source = threshold -> Automatic credits
- If source = interval -> Automatic credits

The source has been added to:
1. The wallet transactions view of a customer's wallet
- If source = manual -> Manual credits
- If source = threshold -> Automatic credits
- If source = interval -> Automatic credits

2. The wallet transaction details drawer
Source: 
- Automatic threshold
- Automatic interval
- Manual