### PR TITLE
misc: prevent showing too much elements on loading

### DIFF
--- a/src/layouts/MainNavLayout.tsx
+++ b/src/layouts/MainNavLayout.tsx
@@ -334,7 +334,7 @@ const MainNavLayout = () => {
               />
               <VerticalMenu
                 loading={currentUserLoading}
-                loadingComponent={<VerticalMenuSkeleton numberOfElements={7} />}
+                loadingComponent={<VerticalMenuSkeleton numberOfElements={2} />}
                 onClick={() => setOpen(false)}
                 tabs={[
                   {


### PR DESCRIPTION
## Context

We recently reworked the nav UI.

This contain multiple sections each ones responsible of their own loading.

## Description

This PR makes sure a section showing 2 elements does not show 7 during loading.

This also removes the "scroll state" on loading, that was showing extra shadows before hiding them back after loading
