### PR TITLE
fix: some warnings on runtime

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,11 +3,11 @@ server {
   listen [::]:80;
 
   location / {
-    add_header Content-Security-Policy "frame-ancestors *.force.com *.zive.app *.zive.dev *.localhost *.systeminit.com *.storecommander.com *.storecommander.eu *.dev.storecommander.eu *.ojin.ai *.ojin.foo ojin-staging*.web.app *.web.app localhost;" always;
+    add_header Content-Security-Policy "frame-ancestors *.force.com *.zive.app *.zive.dev *.localhost *.systeminit.com *.storecommander.com *.storecommander.eu *.dev.storecommander.eu *.ojin.ai *.ojin.foo *.web.app localhost;" always;
     root /usr/share/nginx/html;
     index index.html index.htm;
     try_files $uri $uri/ /index.html =404;
   }
-
+  
   include /etc/nginx/extra-conf.d/*.conf;
 }

--- a/src/core/apolloClient/cache.ts
+++ b/src/core/apolloClient/cache.ts
@@ -119,6 +119,10 @@ export const cache = new InMemoryCache({
           keyArgs: false,
           merge: mergePaginatedCollection,
         },
+        customerPortalUser: {
+          keyArgs: ['id'],
+          merge: mergePaginatedCollection,
+        },
         webhooks: {
           keyArgs: ['webhookEndpointId', 'status', 'searchTerm'],
           merge: mergePaginatedCollection,


### PR DESCRIPTION
## Context

- frame-ancestors does not support * in the middle of a domain.
```
The Content-Security-Policy directive 'frame-ancestors' does not support the source expression 'ojin-staging*.web.app'
eyJfcmFpbHMiOnsiZGF0…a84596ee851ff3a14:1 The Content-Security-Policy directive 'frame-ancestors' does not support the source expression 'ojin-staging*.web.app'
```


- Cache isssue
```Cache data may be lost when replacing the customerPortalUser field of a Query object.

This could cause additional (usually avoidable) network requests to fetch data that were otherwise cached.

To address this problem (which is not a bug in Apollo Client), either ensure all objects of type CustomerPortalCustomer have an ID or a custom merge function, or define a custom merge function for the Query.customerPortalUser field, so InMemoryCache can safely merge these objects:

  existing: {__typename: 'CustomerPortalCustomer', applicableTimezone: 'TZ_UTC', premium: true}
  incoming: {__typename: 'CustomerPortalCustomer', currency: 'USD'}

```