### PR TITLE
bug: handle search in tax rate input in plan form

### DIFF
--- a/src/components/plans/PlanSettingsSection.tsx
+++ b/src/components/plans/PlanSettingsSection.tsx
@@ -45,8 +45,8 @@ gql`
     }
   }
 
-  query getTaxesForPlan($limit: Int, $page: Int) {
-    taxes(limit: $limit, page: $page) {
+  query getTaxesForPlan($limit: Int, $page: Int, $searchTerm: String) {
+    taxes(limit: $limit, page: $page, searchTerm: $searchTerm) {
       metadata {
         currentPage
         totalPages

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -9002,6 +9002,7 @@ export type PlanForSettingsSectionFragment = { __typename?: 'Plan', id: string, 
 export type GetTaxesForPlanQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
   page?: InputMaybe<Scalars['Int']['input']>;
+  searchTerm?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
@@ -20924,8 +20925,8 @@ export type DeletePlanMutationHookResult = ReturnType<typeof useDeletePlanMutati
 export type DeletePlanMutationResult = Apollo.MutationResult<DeletePlanMutation>;
 export type DeletePlanMutationOptions = Apollo.BaseMutationOptions<DeletePlanMutation, DeletePlanMutationVariables>;
 export const GetTaxesForPlanDocument = gql`
-    query getTaxesForPlan($limit: Int, $page: Int) {
-  taxes(limit: $limit, page: $page) {
+    query getTaxesForPlan($limit: Int, $page: Int, $searchTerm: String) {
+  taxes(limit: $limit, page: $page, searchTerm: $searchTerm) {
     metadata {
       currentPage
       totalPages
@@ -20952,6 +20953,7 @@ export const GetTaxesForPlanDocument = gql`
  *   variables: {
  *      limit: // value for 'limit'
  *      page: // value for 'page'
+ *      searchTerm: // value for 'searchTerm'
  *   },
  * });
  */


### PR DESCRIPTION
## Context

The options in the "Tax rates" autocomplete in the Plan form do not match the text search.

## Description

- Add the `searchTerm` parameter in the `getTaxesForPlan` GraphQL query

<!-- Linear link -->
Fixes getlago/lago#551