### PR TITLE
fix: add searchTerm parameter to getTaxesForPlan gql query

### DIFF
--- a/src/components/plans/PlanSettingsSection.tsx
+++ b/src/components/plans/PlanSettingsSection.tsx
@@ -45,8 +45,8 @@ gql`
     }
   }
 
-  query getTaxesForPlan($limit: Int, $page: Int) {
-    taxes(limit: $limit, page: $page) {
+  query getTaxesForPlan($limit: Int, $page: Int, $searchTerm: String) {
+    taxes(limit: $limit, page: $page, searchTerm: $searchTerm) {
       metadata {
         currentPage
         totalPages

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -9111,6 +9111,7 @@ export type PlanForSettingsSectionFragment = { __typename?: 'Plan', id: string, 
 export type GetTaxesForPlanQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
   page?: InputMaybe<Scalars['Int']['input']>;
+  searchTerm?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
@@ -21252,8 +21253,8 @@ export type DeletePlanMutationHookResult = ReturnType<typeof useDeletePlanMutati
 export type DeletePlanMutationResult = Apollo.MutationResult<DeletePlanMutation>;
 export type DeletePlanMutationOptions = Apollo.BaseMutationOptions<DeletePlanMutation, DeletePlanMutationVariables>;
 export const GetTaxesForPlanDocument = gql`
-    query getTaxesForPlan($limit: Int, $page: Int) {
-  taxes(limit: $limit, page: $page) {
+    query getTaxesForPlan($limit: Int, $page: Int, $searchTerm: String) {
+  taxes(limit: $limit, page: $page, searchTerm: $searchTerm) {
     metadata {
       currentPage
       totalPages
@@ -21280,6 +21281,7 @@ export const GetTaxesForPlanDocument = gql`
  *   variables: {
  *      limit: // value for 'limit'
  *      page: // value for 'page'
+ *      searchTerm: // value for 'searchTerm'
  *   },
  * });
  */


### PR DESCRIPTION
Refs: getlago/lago#551

## Context

The options in the "Tax rates" autocomplete in the Plan form do not match the text search.

## Description

Add the searchTerm parameter in the getTaxesForPlan GraphQL query

Fixes https://github.com/getlago/lago/issues/551 and ISSUE-958