### PR TITLE
misc: allow to select accordion summary text

### DIFF
--- a/packages/design-system/src/components/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion.tsx
@@ -68,15 +68,20 @@ export const Accordion = ({
         className,
       )}
       onChange={(_, expanded) => {
-        setIsOpen(expanded)
+        const selection = window.getSelection()
 
-        if (expanded && !!onOpen) onOpen()
+        if (selection?.type !== 'Range') {
+          setIsOpen(expanded)
+
+          if (expanded && !!onOpen) onOpen()
+        }
       }}
       TransitionProps={{ unmountOnExit: true, ...transitionProps }}
       {...props}
     >
       <AccordionSummary
         className={tw(
+          'select-text focus:bg-inherit focus-visible:ring focus-visible:hover:bg-grey-100',
           {
             'h-23': size === AccordionSizeEnum.large,
             'h-18': size === AccordionSizeEnum.medium,
@@ -86,7 +91,6 @@ export const Accordion = ({
             'hover:bg-grey-100 active:bg-grey-200': variant === 'card',
             'h-auto focus:rounded-lg': variant === 'borderless',
           },
-          'focus:bg-inherit focus-visible:ring focus-visible:hover:bg-grey-100',
         )}
         sx={{
           '& .MuiAccordionSummary-content': {

--- a/src/components/designSystem/Accordion.tsx
+++ b/src/components/designSystem/Accordion.tsx
@@ -70,15 +70,20 @@ export const Accordion = ({
         className,
       )}
       onChange={(_, expanded) => {
-        setIsOpen(expanded)
+        const selection = window.getSelection()
 
-        if (expanded && !!onOpen) onOpen()
+        if (selection?.type !== 'Range') {
+          setIsOpen(expanded)
+
+          if (expanded && !!onOpen) onOpen()
+        }
       }}
       TransitionProps={{ unmountOnExit: true, ...transitionProps }}
       {...props}
     >
       <AccordionSummary
         className={tw(
+          'select-text focus:bg-inherit focus-visible:ring focus-visible:hover:bg-grey-100',
           {
             'h-23': size === AccordionSizeEnum.large,
             'h-18': size === AccordionSizeEnum.medium,
@@ -88,7 +93,6 @@ export const Accordion = ({
             'hover:bg-grey-100 active:bg-grey-200': variant === 'card',
             'h-auto focus:rounded-lg': variant === 'borderless',
           },
-          'focus:bg-inherit focus-visible:ring focus-visible:hover:bg-grey-100',
         )}
         sx={{
           '& .MuiAccordionSummary-content': {


### PR DESCRIPTION
## Context

You cannot select the text in an accordion' summary.

## Description

This PR allow to select the text in an accordion summary.

If we detect the user is selecting the text, we prevent the `onClick` logic to fire, so the accordion remain in it's current position (open or closed)

Also changes the order of TW classes, as default should be first. We can probably have a linter rule for this (if none exists already)

Had to port this change to the design-system component too, as it's present but usage is not migrated yet

<!-- Linear link -->
Fixes ISSUE-980