### PR TITLE
bug: prevent double scroll in wallet topup page

### DIFF
--- a/src/pages/wallet/CreateWalletTopUp.tsx
+++ b/src/pages/wallet/CreateWalletTopUp.tsx
@@ -415,22 +415,22 @@ const CreateWalletTopUp = () => {
             </section>
           </CenteredPage.Container>
         )}
-      </CenteredPage.Wrapper>
 
-      <CenteredPage.StickyFooter>
-        <Button size="large" variant="quaternary" onClick={onAbort}>
-          {translate('text_62e79671d23ae6ff149de968')}
-        </Button>
-        <Button
-          size="large"
-          variant="primary"
-          disabled={!formikProps.isValid || !formikProps.dirty}
-          onClick={() => formikProps.handleSubmit()}
-          data-test="submit-wallet"
-        >
-          {translate('text_1741103892833yi7redcuhoc')}
-        </Button>
-      </CenteredPage.StickyFooter>
+        <CenteredPage.StickyFooter>
+          <Button size="large" variant="quaternary" onClick={onAbort}>
+            {translate('text_62e79671d23ae6ff149de968')}
+          </Button>
+          <Button
+            size="large"
+            variant="primary"
+            disabled={!formikProps.isValid || !formikProps.dirty}
+            onClick={() => formikProps.handleSubmit()}
+            data-test="submit-wallet"
+          >
+            {translate('text_1741103892833yi7redcuhoc')}
+          </Button>
+        </CenteredPage.StickyFooter>
+      </CenteredPage.Wrapper>
 
       <WarningDialog
         ref={warningDialogRef}


### PR DESCRIPTION
## Context

In wallet top-up page, you have 2 level of scroll, one for the content and one for the whole container.

This second should not be there as it hides/show topbar when happening.

The scroll should only be for content

## Description

Reorder DOM to make the sticky footer part of the `CenteredPage.Wrapper`
This is the case on all other pages, was miss-placed here

<!-- Linear link -->
Fixes ISSUE-977