### PR TITLE
misc: remove duplicate copy and related logic

### DIFF
--- a/src/components/LogoPicker.tsx
+++ b/src/components/LogoPicker.tsx
@@ -60,9 +60,7 @@ export const LogoPicker = ({ className, logoValue, onChange, logoUrl, name }: Lo
           {translate('text_62ab2d0396dd6b0361614d18')}
         </Button>
         <Typography variant="caption" color={logoUploadError ? 'danger600' : undefined}>
-          {logoUploadError
-            ? translate('text_62ab2d0396dd6b0361614d1e')
-            : translate('text_62ab2d0396dd6b0361614d20')}
+          {translate('text_62ab2d0396dd6b0361614d20')}
         </Typography>
       </div>
       <input

--- a/src/components/OrganizationLogoPicker.tsx
+++ b/src/components/OrganizationLogoPicker.tsx
@@ -70,9 +70,7 @@ export const OrganizationLogoPicker = ({
           {translate('text_62ab2d0396dd6b0361614d18')}
         </Button>
         <Typography variant="caption" color={logoUploadError ? 'danger600' : undefined}>
-          {logoUploadError
-            ? translate('text_62ab2d0396dd6b0361614d1e')
-            : translate('text_62ab2d0396dd6b0361614d20')}
+          {translate('text_62ab2d0396dd6b0361614d20')}
         </Typography>
       </div>
       <input

--- a/translations/base.json
+++ b/translations/base.json
@@ -716,7 +716,6 @@
   "text_62ab2d0396dd6b0361614d98": "State",
   "text_62ab2d0396dd6b0361614da0": "Country",
   "text_63b6d06df1a53b7e2ad973ad": "The payment provider is currently processing the payment. Please try again later.",
-  "text_62ab2d0396dd6b0361614d1e": "JPG or PNG. Max size of 800K",
   "text_62ab2d0396dd6b0361614d24": "Invoice settings",
   "text_62ab2d0396dd6b0361614d44": "Information",
   "text_62ab2d0396dd6b0361614d6c": "Legal name",


### PR DESCRIPTION
`text_62ab2d0396dd6b0361614d1e` and `text_62ab2d0396dd6b0361614d20` copy values are the same.

Saw that during investigation to improve the logo removal experience. Have to jump to another topic in the meantime but always better to remove now