### PR TITLE
bug: fixing missed combobox invocation updates

### DIFF
--- a/src/components/coupons/AddBillableMetricToCouponDialog.tsx
+++ b/src/components/coupons/AddBillableMetricToCouponDialog.tsx
@@ -60,7 +60,7 @@ export const AddBillableMetricToCouponDialog = forwardRef<
               {name}
             </Typography>
             <Typography variant="caption" color="grey600" noWrap>
-              ({code})
+              {code}
             </Typography>
           </ComboboxItem>
         ),

--- a/src/components/coupons/AddPlanToCouponDialog.tsx
+++ b/src/components/coupons/AddPlanToCouponDialog.tsx
@@ -56,7 +56,7 @@ export const AddPlanToCouponDialog = forwardRef<DialogRef, AddPlanToCouponDialog
                 {name}
               </Typography>
               <Typography variant="caption" color="grey600" noWrap>
-                ({code})
+                {code}
               </Typography>
             </ComboboxItem>
           ),

--- a/src/components/customers/AddCouponToCustomerDialog.tsx
+++ b/src/components/customers/AddCouponToCustomerDialog.tsx
@@ -5,7 +5,13 @@ import { number, object, string } from 'yup'
 
 import { CouponCaption } from '~/components/coupons/CouponCaption'
 import { Alert, Button, Chip, Dialog, DialogRef, Typography } from '~/components/designSystem'
-import { AmountInputField, ComboBox, ComboBoxField, TextInputField } from '~/components/form'
+import {
+  AmountInputField,
+  ComboBox,
+  ComboBoxField,
+  ComboboxItem,
+  TextInputField,
+} from '~/components/form'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { deserializeAmount, serializeAmount } from '~/core/serializers/serializeAmount'
 import {
@@ -267,9 +273,12 @@ export const AddCouponToCustomerDialog = forwardRef<
       return {
         label: name,
         labelNode: (
-          <div className="flex whitespace-pre">
-            {name} - <CouponCaption coupon={coupon as CouponItemFragment} variant="body" />
-          </div>
+          <ComboboxItem>
+            <Typography variant="body" color="grey700" noWrap>
+              {name}
+            </Typography>
+            <CouponCaption coupon={coupon as CouponItemFragment} variant="caption" />
+          </ComboboxItem>
         ),
         value: id,
       }

--- a/src/components/customers/createCustomer/ExternalAppsAccordion/ExternalAppsAccordionLayout.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/ExternalAppsAccordionLayout.tsx
@@ -15,7 +15,7 @@ const ExternalAppsAccordionComboboxItem: FC<{
         {label}
       </Typography>
       <Typography variant="caption" color="grey600" noWrap>
-        ({subLabel})
+        {subLabel}
       </Typography>
     </ComboboxItem>
   )

--- a/src/components/form/ComboBox/ComboBoxItem.tsx
+++ b/src/components/form/ComboBox/ComboBoxItem.tsx
@@ -9,7 +9,10 @@ export const ComboboxItem: FC<PropsWithChildren<{ virtualized?: boolean; classNa
   ...props
 }) => (
   <div
-    className={tw('flex cursor-pointer flex-col items-start rounded-xl', className)}
+    className={tw(
+      'flex w-full cursor-pointer flex-col !items-start !justify-center rounded-xl',
+      className,
+    )}
     style={{
       width: !!virtualized ? 'initial' : 'inherit',
     }}

--- a/src/components/form/ComboBox/ComboBoxItemWrapper.tsx
+++ b/src/components/form/ComboBox/ComboBoxItemWrapper.tsx
@@ -43,6 +43,7 @@ export const ComboBoxItemWrapper = ({
           id={id}
           virtualized={virtualized}
           className={cx(
+            'items-start',
             {
               'cursor-auto': disabled,
             },
@@ -53,12 +54,12 @@ export const ComboBoxItemWrapper = ({
           {...allProps}
         >
           {customValue ? (
-            <>
+            <ComboboxItem className="flex-row !items-center !justify-start">
               <Icon className="mr-4" color="dark" name="plus" />
               <Typography variant="body" noWrap>
                 {labelNode ?? label}
               </Typography>
-            </>
+            </ComboboxItem>
           ) : (
             <Radio
               disabled={disabled}

--- a/src/components/form/MultipleComboBox/MultipleComboBoxItemWrapper.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBoxItemWrapper.tsx
@@ -43,6 +43,7 @@ export const MultipleComboBoxItemWrapper = ({
           id={id}
           virtualized={virtualized}
           className={cx(
+            'items-start',
             {
               'cursor-auto': disabled,
             },
@@ -53,12 +54,12 @@ export const MultipleComboBoxItemWrapper = ({
           {...allProps}
         >
           {customValue ? (
-            <>
+            <ComboboxItem className="flex-row !items-center !justify-start">
               <Icon className="mr-4" color="dark" name="plus" />
               <Typography variant="body" noWrap>
                 {labelNode ?? label}
               </Typography>
-            </>
+            </ComboboxItem>
           ) : (
             <Checkbox
               disabled={disabled}

--- a/src/pages/AlertForm.tsx
+++ b/src/pages/AlertForm.tsx
@@ -329,12 +329,12 @@ const AlertForm = () => {
         value: id,
         disabled: hasAlertOnBillableMetric,
         labelNode: (
-          <ComboboxItem className="flex flex-col items-start">
-            <Typography color="grey700" noWrap>
+          <ComboboxItem>
+            <Typography variant="body" color="grey700" noWrap>
               {name}
             </Typography>
-            <Typography color="textPrimary" noWrap>
-              ({code})
+            <Typography variant="caption" color="grey600" noWrap>
+              {code}
             </Typography>
           </ComboboxItem>
         ),

--- a/src/pages/CreateBillableMetric.tsx
+++ b/src/pages/CreateBillableMetric.tsx
@@ -25,6 +25,7 @@ import {
   BasicMultipleComboBoxData,
   ButtonSelector,
   ComboBoxField,
+  ComboboxItem,
   JsonEditorField,
   MultipleComboBox,
   TextInput,
@@ -447,14 +448,14 @@ const CreateBillableMetric = () => {
                         },
                         {
                           labelNode: (
-                            <div className="flex items-center gap-2">
-                              <Typography variant="body" color="grey700">
+                            <ComboboxItem>
+                              <Typography variant="body" color="grey700" noWrap>
                                 {translate(
                                   formatAggregationType(AggregationTypeEnum.WeightedSumAgg)
                                     ?.label || '',
                                 )}
                               </Typography>
-                            </div>
+                            </ComboboxItem>
                           ),
                           label: translate(
                             formatAggregationType(AggregationTypeEnum.WeightedSumAgg)?.label || '',


### PR DESCRIPTION
## Context

Recently updated the ComboboxItem internal classes and unified invocation.

Missed some cases

## Description

This PR make sure ALL invocations respects the same pattern and fixes the alignment if only one value is displayed in the dropdown.
Had to use important tailwind classes to prevent UI to mess with display

