### PR TITLE
bug: allow to create invoice with null addon description

### DIFF
--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -269,7 +269,7 @@ const CreateInvoice = () => {
         .of(
           object().shape({
             addOnId: string().required(''),
-            description: string(),
+            description: string().nullable(),
             units: number().min(1, 'text_645381a65b99559adf6401f0').required(''),
           }),
         )


### PR DESCRIPTION
## Context

Creating an addon via the API allows to set the description to nil.
Leading to "unsubmitable" form


## Description

Allows to create an invoice when the addon's description is null

Fixes ISSUE-990