### PR TITLE
misc: break email if no space to display

### DIFF
--- a/src/components/invoices/InvoiceCustomerInfos.tsx
+++ b/src/components/invoices/InvoiceCustomerInfos.tsx
@@ -129,7 +129,7 @@ export const InvoiceCustomerInfos = memo(({ invoice }: InvoiceCustomerInfosProps
             <Typography variant="caption" color="grey600" noWrap>
               {translate('text_634687079be251fdb43833e3')}
             </Typography>
-            <Typography variant="body" color="grey700">
+            <Typography variant="body" color="grey700" forceBreak>
               {customer?.email.split(',').join(', ')}
             </Typography>
           </InfoLine>


### PR DESCRIPTION
Noticed the email does not break and overlaps on other column on the right, if no enough space to be displayed.

This forces the value to break and goes on multiple lines if needed. It's well displayed in such case and the display here is handling those multiline display