### PR TITLE
misc: switch most of button with plus icon to inline variant

### DIFF
--- a/src/components/alerts/Thresholds.tsx
+++ b/src/components/alerts/Thresholds.tsx
@@ -138,7 +138,7 @@ const AlertThresholds = ({
         <Button
           className="mb-2 ml-auto"
           startIcon="plus"
-          variant="quaternary"
+          variant="inline"
           onClick={() => addThreshold()}
           data-test="add-new-non-recurring-threshold-button"
         >

--- a/src/components/billableMetrics/CustomExpressionDrawer.tsx
+++ b/src/components/billableMetrics/CustomExpressionDrawer.tsx
@@ -1,6 +1,5 @@
-import { Typography } from '@mui/material'
 import { useFormik } from 'formik'
-import { Icon } from 'lago-design-system'
+import { Icon, Typography } from 'lago-design-system'
 import { DateTime } from 'luxon'
 import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { mixed, object, string } from 'yup'

--- a/src/components/customers/CustomerPaymentsTab.tsx
+++ b/src/components/customers/CustomerPaymentsTab.tsx
@@ -1,8 +1,9 @@
 import { FC } from 'react'
-import { generatePath } from 'react-router-dom'
+import { generatePath, useNavigate } from 'react-router-dom'
 
 import { CustomerPaymentsList } from '~/components/customers/CustomerPaymentsList'
-import { ButtonLink, Skeleton, Typography } from '~/components/designSystem'
+import { Skeleton, Typography } from '~/components/designSystem'
+import { PageSectionTitle } from '~/components/layouts/Section'
 import { CREATE_PAYMENT_ROUTE } from '~/core/router'
 import { useGetPaymentsListQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -15,6 +16,7 @@ interface CustomerPaymentsTabProps {
 
 export const CustomerPaymentsTab: FC<CustomerPaymentsTabProps> = ({ externalCustomerId }) => {
   const { translate } = useInternationalization()
+  const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
   const { isPremium } = useCurrentUser()
 
@@ -31,28 +33,23 @@ export const CustomerPaymentsTab: FC<CustomerPaymentsTabProps> = ({ externalCust
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        {loading ? (
-          <Skeleton variant="text" className="w-56" />
-        ) : (
-          <div className="flex flex-1 items-center gap-4">
-            <Typography variant="subhead1" color="grey700" className="flex-1">
-              {translate('text_6672ebb8b1b50be550eccbed')}
-            </Typography>
-            {canRecordPayment && (
-              <ButtonLink
-                type="button"
-                to={generatePath(`${CREATE_PAYMENT_ROUTE}?${urlSearchParams.toString()}`)}
-                buttonProps={{
-                  variant: 'quaternary',
-                }}
-              >
-                {translate('text_1737471851634wpeojigr27w')}
-              </ButtonLink>
-            )}
-          </div>
-        )}
-      </div>
+      {loading ? (
+        <Skeleton variant="text" className="w-56" />
+      ) : (
+        <PageSectionTitle
+          title={translate('text_6672ebb8b1b50be550eccbed')}
+          action={
+            canRecordPayment
+              ? {
+                  title: translate('text_1737471851634wpeojigr27w'),
+                  onClick: () => {
+                    navigate(generatePath(`${CREATE_PAYMENT_ROUTE}?${urlSearchParams.toString()}`))
+                  },
+                }
+              : undefined
+          }
+        />
+      )}
 
       {!loading && !payments.length && (
         <Typography variant="body" color="grey500">

--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -263,7 +263,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                         {typeof customer?.billingConfiguration?.documentLocale !== 'string' ? (
                           <Button
                             disabled={loading}
-                            variant="quaternary"
+                            variant="inline"
                             endIcon={isPremium ? undefined : 'sparkles'}
                             onClick={() =>
                               isPremium
@@ -346,7 +346,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                     action={
                       <Button
                         disabled={loading}
-                        variant="quaternary"
+                        variant="inline"
                         onClick={() => editCustomerDunningCampaignDialogRef?.current?.openDialog()}
                       >
                         {translate('text_63e51ef4985f0ebd75c212fc')}
@@ -421,7 +421,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                     FinalizeZeroAmountInvoiceEnum.Inherit ? (
                       <Button
                         disabled={loading}
-                        variant="quaternary"
+                        variant="inline"
                         onClick={() =>
                           editFinalizeZeroAmountInvoiceDialogRef?.current?.openDialog()
                         }
@@ -498,7 +498,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                         {typeof customer?.invoiceGracePeriod !== 'number' ? (
                           <Button
                             disabled={loading}
-                            variant="quaternary"
+                            variant="inline"
                             endIcon={isPremium ? undefined : 'sparkles'}
                             onClick={() =>
                               isPremium
@@ -589,7 +589,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                     hasPermissions(['customersUpdate']) ? (
                       <Button
                         disabled={loading}
-                        variant="quaternary"
+                        variant="inline"
                         endIcon={isPremium ? undefined : 'sparkles'}
                         onClick={() =>
                           editCustomerInvoiceCustomSectionsDialogRef?.current?.openDialog()
@@ -655,7 +655,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                         {typeof customer?.netPaymentTerm !== 'number' ? (
                           <Button
                             disabled={loading}
-                            variant="quaternary"
+                            variant="inline"
                             onClick={() =>
                               editNetPaymentTermDialogRef?.current?.openDialog(customer)
                             }
@@ -737,12 +737,12 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                   action={
                     hasPermissions(['customerSettingsUpdateTaxRates']) ? (
                       <Button
-                        variant="quaternary"
+                        variant="inline"
                         disabled={loading}
                         onClick={() => editVATDialogRef?.current?.openDialog()}
                         data-test="add-vat-rate-button"
                       >
-                        {translate('text_62728ff857d47b013204cab3')}
+                        {translate('text_645bb193927b375079d28ad2')}
                       </Button>
                     ) : undefined
                   }

--- a/src/components/customers/createCustomer/ExternalAppsAccordion/index.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/index.tsx
@@ -108,7 +108,7 @@ export const ExternalAppsAccordion = ({ formikProps, isEdition }: TExternalAppsA
           opener={
             <Button
               startIcon="plus"
-              variant="quaternary"
+              variant="inline"
               disabled={
                 showAccountingSection && showPaymentSection && showTaxSection && showCRMSection
               }

--- a/src/components/customers/createCustomer/MetadataAccordion.tsx
+++ b/src/components/customers/createCustomer/MetadataAccordion.tsx
@@ -143,7 +143,7 @@ export const MetadataAccordion: FC<MetadataAccordionProps> = ({ formikProps }) =
         )}
         <Button
           startIcon="plus"
-          variant="quaternary"
+          variant="inline"
           disabled={(formikProps?.values?.metadata?.length || 0) >= MAX_METADATA_COUNT}
           onClick={() =>
             formikProps.setFieldValue('metadata', [

--- a/src/components/customers/overview/CustomerOverview.tsx
+++ b/src/components/customers/overview/CustomerOverview.tsx
@@ -1,5 +1,6 @@
 import { gql } from '@apollo/client'
-import { Skeleton, Stack } from '@mui/material'
+import { Stack } from '@mui/material'
+import { Skeleton } from 'lago-design-system'
 import { DateTime } from 'luxon'
 import { FC, useEffect, useMemo } from 'react'
 import { generatePath, useNavigate, useParams } from 'react-router-dom'

--- a/src/components/designSystem/Filters/ActiveFiltersList.tsx
+++ b/src/components/designSystem/Filters/ActiveFiltersList.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@mui/material'
+import { Typography } from 'lago-design-system'
 import { useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
 

--- a/src/components/designSystem/Filters/FiltersPanelPopper.tsx
+++ b/src/components/designSystem/Filters/FiltersPanelPopper.tsx
@@ -220,7 +220,7 @@ export const FiltersPanelPopper = () => {
                   })
                 })
               }}
-              variant="quaternary"
+              variant="inline"
             >
               {translate('text_66ab42d4ece7e6b7078993b9')}
             </Button>

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemAmount.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemAmount.tsx
@@ -1,5 +1,5 @@
-import { Typography } from '@mui/material'
 import { useFormik } from 'formik'
+import { Typography } from 'lago-design-system'
 import { useEffect } from 'react'
 
 import {

--- a/src/components/form/ButtonSelector/ButtonSelector.tsx
+++ b/src/components/form/ButtonSelector/ButtonSelector.tsx
@@ -47,7 +47,7 @@ export const ButtonSelector = ({
             {label}
           </Typography>
           {!!infoText && (
-            <Tooltip className="flex h-5 items-end" placement="bottom-start" title={infoText}>
+            <Tooltip placement="top-start" title={infoText}>
               <Icon name="info-circle" />
             </Tooltip>
           )}

--- a/src/components/graphs/MonthSelectorDropdown.tsx
+++ b/src/components/graphs/MonthSelectorDropdown.tsx
@@ -39,7 +39,7 @@ const MonthSelectorDropdown = ({
         <Popper
           PopperProps={{ placement: 'bottom-end' }}
           opener={
-            <Button variant="quaternary" endIcon={'chevron-down'}>
+            <Button variant="inline" endIcon={'chevron-down'}>
               {translate(PeriodScopeTranslationLookup[periodScope])}
             </Button>
           }

--- a/src/components/invoices/AddMetadataDrawer.tsx
+++ b/src/components/invoices/AddMetadataDrawer.tsx
@@ -211,7 +211,7 @@ export const AddMetadataDrawer = forwardRef<DrawerRef, AddMetadataDrawerProps>(
             )}
             <Button
               startIcon="plus"
-              variant="quaternary"
+              variant="inline"
               disabled={(formikProps?.values?.metadata?.length || 0) >= MAX_METADATA_COUNT}
               onClick={() =>
                 formikProps.setFieldValue('metadata', [

--- a/src/components/invoices/EditInvoiceItemTaxDialog.tsx
+++ b/src/components/invoices/EditInvoiceItemTaxDialog.tsx
@@ -205,7 +205,7 @@ export const EditInvoiceItemTaxDialog = forwardRef<EditInvoiceItemTaxDialogRef>(
       <Button
         className="mb-8 flex w-fit"
         startIcon="plus"
-        variant="quaternary"
+        variant="inline"
         onClick={() => {
           formikProps.setFieldValue('taxes', [...(formikProps.values.taxes || []), {}])
         }}

--- a/src/components/layouts/CenteredPage.tsx
+++ b/src/components/layouts/CenteredPage.tsx
@@ -4,7 +4,7 @@ import { Typography } from '~/components/designSystem'
 
 export const PageBannerHeaderWithBurgerMenu = ({ children }: PropsWithChildren) => {
   return (
-    <header className="sticky top-0 z-navBar flex min-h-nav flex-row items-center justify-between gap-2 bg-white px-17 py-4 shadow-b md:px-12">
+    <header className="sticky top-0 z-navBar flex h-nav items-center justify-between gap-2 bg-white px-17 shadow-b md:px-12">
       {children}
     </header>
   )
@@ -16,7 +16,7 @@ const CenteredPageWrapper = ({ children }: PropsWithChildren) => {
 
 const PageBannerHeader = ({ children }: PropsWithChildren) => {
   return (
-    <header className="sticky top-0 z-navBar flex min-h-nav flex-row items-center justify-between gap-2 bg-white p-4 shadow-b md:px-12">
+    <header className="sticky top-0 z-navBar flex h-nav items-center justify-between gap-2 bg-white p-4 shadow-b md:px-12">
       {children}
     </header>
   )
@@ -24,7 +24,7 @@ const PageBannerHeader = ({ children }: PropsWithChildren) => {
 
 const CenteredContainer = ({ children }: PropsWithChildren) => {
   return (
-    <div className="mx-auto flex w-full max-w-170 flex-1 flex-col gap-12 px-4 pb-20 pt-12 md:px-0">
+    <div className="mx-auto flex w-full max-w-170 flex-1 flex-col gap-12 px-4 pb-footer pt-12 md:px-0">
       {children}
     </div>
   )
@@ -33,7 +33,7 @@ const CenteredContainer = ({ children }: PropsWithChildren) => {
 const CenteredStickyFooter = ({ children }: PropsWithChildren) => {
   return (
     <footer className="sticky bottom-0 z-navBar w-full bg-white shadow-t">
-      <div className="mx-auto flex min-h-20 w-full max-w-170 flex-row flex-wrap-reverse items-center justify-end gap-3 p-4 md:px-0">
+      <div className="mx-auto flex min-h-footer w-full max-w-170 flex-wrap-reverse items-center justify-end gap-3 p-4 md:px-0">
         {children}
       </div>
     </footer>

--- a/src/components/layouts/Section.tsx
+++ b/src/components/layouts/Section.tsx
@@ -1,6 +1,5 @@
-import { Skeleton, Typography } from '@mui/material'
+import { Button, Skeleton, Typography } from 'lago-design-system'
 
-import { Button } from '~/components/designSystem'
 import { tw } from '~/styles/utils'
 
 export const PageSectionTitle = ({

--- a/src/components/layouts/Section.tsx
+++ b/src/components/layouts/Section.tsx
@@ -41,12 +41,12 @@ export const PageSectionTitle = ({
           </div>
 
           {action && (
-            <Button variant="quaternary" onClick={action.onClick} data-test={action.dataTest || ''}>
+            <Button variant="inline" onClick={action.onClick} data-test={action.dataTest || ''}>
               {action.title}
             </Button>
           )}
 
-          {customAction ? customAction : null}
+          {!!customAction && customAction}
         </>
       )}
     </div>

--- a/src/components/plans/ChargeAccordion.tsx
+++ b/src/components/plans/ChargeAccordion.tsx
@@ -839,10 +839,10 @@ export const ChargeAccordion = memo(
           )}
 
           {!!localCharge?.billableMetric?.filters?.length && (
-            <div className="mx-0 mb-4 mt-6 px-4">
+            <div className="mx-0 mb-4 mt-6 flex flex-wrap gap-4 px-4">
               {!!localCharge.billableMetric.filters?.length && (
                 <Button
-                  variant="quaternary"
+                  variant="inline"
                   startIcon="plus"
                   onClick={() => {
                     formikProps.setFieldValue(`charges.${index}.filters`, [
@@ -875,7 +875,7 @@ export const ChargeAccordion = memo(
 
               {!localCharge.properties && (
                 <Button
-                  variant="quaternary"
+                  variant="inline"
                   startIcon="plus"
                   onClick={() => {
                     formikProps.setFieldValue(`charges.${index}.properties`, getPropertyShape({}))
@@ -977,7 +977,7 @@ export const ChargeAccordion = memo(
                 {!showSpendingMinimum ? (
                   <Button
                     fitContent
-                    variant="quaternary"
+                    variant="inline"
                     startIcon="plus"
                     disabled={subscriptionFormType === FORM_TYPE_ENUM.edition || disabled}
                     endIcon={isPremium ? undefined : 'sparkles'}
@@ -1064,7 +1064,7 @@ export const ChargeAccordion = memo(
                 <Button
                   fitContent
                   startIcon="plus"
-                  variant="quaternary"
+                  variant="inline"
                   onClick={() => {
                     setShouldDisplayTaxesInput(true)
 

--- a/src/components/plans/ChargeFilter.tsx
+++ b/src/components/plans/ChargeFilter.tsx
@@ -139,7 +139,7 @@ export const ChargeFilter = memo(
           <div>
             <Button
               id={buildChargeFilterAddFilterButtonId(chargeIndex, filterIndex)}
-              variant="quaternary"
+              variant="inline"
               startIcon="plus"
               onClick={() => {
                 setShowComboBox(true)

--- a/src/components/plans/ChargePercentage.tsx
+++ b/src/components/plans/ChargePercentage.tsx
@@ -352,7 +352,7 @@ export const ChargePercentage = memo(
         <div className="flex flex-wrap gap-3">
           <Button
             startIcon="plus"
-            variant="quaternary"
+            variant="inline"
             disabled={disabled || valuePointer?.fixedAmount !== undefined}
             onClick={() =>
               formikProps.setFieldValue(`charges.${chargeIndex}.${propertyCursor}`, {
@@ -371,7 +371,7 @@ export const ChargePercentage = memo(
               <Button
                 startIcon="plus"
                 endIcon="chevron-down"
-                variant="quaternary"
+                variant="inline"
                 disabled={
                   disabled ||
                   (valuePointer?.freeUnitsPerEvents !== undefined &&
@@ -426,7 +426,7 @@ export const ChargePercentage = memo(
               <Button
                 startIcon="plus"
                 endIcon="chevron-down"
-                variant="quaternary"
+                variant="inline"
                 disabled={
                   disabled ||
                   (valuePointer?.perTransactionMinAmount !== undefined &&

--- a/src/components/plans/ChargesSection.tsx
+++ b/src/components/plans/ChargesSection.tsx
@@ -412,7 +412,7 @@ export const ChargesSection = memo(
                   <Button
                     fitContent
                     startIcon="plus"
-                    variant="quaternary"
+                    variant="inline"
                     data-test="add-metered-charge"
                     onClick={() => {
                       setShowAddMeteredCharge(true)
@@ -535,7 +535,7 @@ export const ChargesSection = memo(
                   <Button
                     fitContent
                     startIcon="plus"
-                    variant="quaternary"
+                    variant="inline"
                     data-test="add-recurring-charge"
                     onClick={() => {
                       setShowAddRecurringCharge(true)

--- a/src/components/plans/CommitmentsSection.tsx
+++ b/src/components/plans/CommitmentsSection.tsx
@@ -280,7 +280,7 @@ export const CommitmentsSection = ({
                     <Button
                       fitContent
                       startIcon="plus"
-                      variant="quaternary"
+                      variant="inline"
                       onClick={() => {
                         setShouldDisplayTaxesInput(true)
 
@@ -306,7 +306,7 @@ export const CommitmentsSection = ({
         </Accordion>
       ) : (
         <Button
-          variant="quaternary"
+          variant="inline"
           startIcon="plus"
           endIcon={isPremium ? undefined : 'sparkles'}
           disabled={displayMinimumCommitment}

--- a/src/components/plans/FixedFeeSection.tsx
+++ b/src/components/plans/FixedFeeSection.tsx
@@ -214,7 +214,7 @@ export const FixedFeeSection = memo(
                   disabled={
                     subscriptionFormType === FORM_TYPE_ENUM.edition || (isEdition && !canBeEdited)
                   }
-                  variant="quaternary"
+                  variant="inline"
                   data-test="show-trial-period"
                   onClick={() => setShouldDisplayTrialPeriod(true)}
                 >

--- a/src/components/plans/GraduatedChargeTable.tsx
+++ b/src/components/plans/GraduatedChargeTable.tsx
@@ -80,7 +80,7 @@ export const GraduatedChargeTable = memo(
         <Button
           className="mb-2 ml-auto"
           startIcon="plus"
-          variant="quaternary"
+          variant="inline"
           onClick={addRange}
           disabled={disabled}
           data-test="add-tier"

--- a/src/components/plans/GraduatedPercentageChargeTable.tsx
+++ b/src/components/plans/GraduatedPercentageChargeTable.tsx
@@ -80,7 +80,7 @@ export const GraduatedPercentageChargeTable = memo(
         <Button
           className="mb-2 ml-auto"
           startIcon="plus"
-          variant="quaternary"
+          variant="inline"
           onClick={addRange}
           disabled={disabled}
           data-test="add-tier"

--- a/src/components/plans/PlanSettingsSection.tsx
+++ b/src/components/plans/PlanSettingsSection.tsx
@@ -174,7 +174,7 @@ export const PlanSettingsSection = memo(
             <Button
               fitContent
               startIcon="plus"
-              variant="quaternary"
+              variant="inline"
               onClick={() => setShouldDisplayDescription(true)}
               data-test="show-description"
             >
@@ -298,7 +298,7 @@ export const PlanSettingsSection = memo(
           <Button
             className="self-start"
             startIcon="plus"
-            variant="quaternary"
+            variant="inline"
             onClick={() => {
               setShouldDisplayTaxesInput(true)
               setTimeout(() => {

--- a/src/components/plans/PlanSettingsSection.tsx
+++ b/src/components/plans/PlanSettingsSection.tsx
@@ -133,16 +133,29 @@ export const PlanSettingsSection = memo(
 
     return (
       <Card>
-        <div className="flex flex-col gap-8">
-          <TextInput
-            name="name"
-            label={translate('text_629728388c4d2300e2d38091')}
-            placeholder={translate('text_624453d52e945301380e499c')}
-            value={formikProps.values.name}
-            onChange={(name) => {
-              updateNameAndMaybeCode({ name, formikProps })
-            }}
-          />
+        <div className="flex flex-col gap-6">
+          <div className="flex gap-3">
+            <TextInput
+              className="flex-1"
+              name="name"
+              label={translate('text_629728388c4d2300e2d38091')}
+              placeholder={translate('text_624453d52e945301380e499c')}
+              value={formikProps.values.name}
+              onChange={(name) => {
+                updateNameAndMaybeCode({ name, formikProps })
+              }}
+            />
+            <TextInputField
+              className="flex-1"
+              name="code"
+              label={translate('text_62876e85e32e0300e1803127')}
+              infoText={translate('text_6661fc17337de3591e29e3cd')}
+              beforeChangeFormatter="code"
+              disabled={isInSubscriptionForm || (isEdition && !canBeEdited)}
+              placeholder={translate('text_624453d52e945301380e499e')}
+              formikProps={formikProps}
+            />
+          </div>
 
           {shouldDisplayDescription ? (
             <div className="flex items-center">
@@ -181,22 +194,13 @@ export const PlanSettingsSection = memo(
               {translate('text_642d5eb2783a2ad10d670324')}
             </Button>
           )}
-          <TextInputField
-            name="code"
-            label={translate('text_62876e85e32e0300e1803127')}
-            description={translate('text_6661fc17337de3591e29e3cd')}
-            beforeChangeFormatter="code"
-            disabled={isInSubscriptionForm || (isEdition && !canBeEdited)}
-            placeholder={translate('text_624453d52e945301380e499e')}
-            formikProps={formikProps}
-          />
         </div>
 
         <ButtonSelectorField
           disabled={isInSubscriptionForm || (isEdition && !canBeEdited)}
           name="interval"
           label={translate('text_6661fc17337de3591e29e3d1')}
-          description={translate('text_6661fc17337de3591e29e3d3')}
+          infoText={translate('text_6661fc17337de3591e29e3d3')}
           formikProps={formikProps}
           options={[
             {

--- a/src/components/plans/PricingGroupKeys.tsx
+++ b/src/components/plans/PricingGroupKeys.tsx
@@ -97,7 +97,7 @@ const PricingGroupKeys = ({
           <Button
             fitContent
             startIcon="plus"
-            variant="quaternary"
+            variant="inline"
             onClick={() => {
               setShouldDisplayPricingGroupKeys(true)
 

--- a/src/components/plans/ProgressiveBillingSection.tsx
+++ b/src/components/plans/ProgressiveBillingSection.tsx
@@ -124,7 +124,7 @@ export const ProgressiveBillingSection: FC<ProgressiveBillingSectionProps> = ({
               <Button
                 className="mb-2 ml-auto"
                 startIcon="plus"
-                variant="quaternary"
+                variant="inline"
                 onClick={addNonRecurringThreshold}
               >
                 {translate('text_1724233213997l2ksi40t8q6')}
@@ -303,7 +303,7 @@ export const ProgressiveBillingSection: FC<ProgressiveBillingSectionProps> = ({
 
       {hasPremiumIntegration && !displayProgressiveBillingAccordion && (
         <Button
-          variant="quaternary"
+          variant="inline"
           startIcon="plus"
           disabled={displayProgressiveBillingAccordion}
           onClick={() => {

--- a/src/components/plans/VolumeChargeTable.tsx
+++ b/src/components/plans/VolumeChargeTable.tsx
@@ -69,7 +69,7 @@ export const VolumeChargeTable = memo(
         <Button
           className="mb-2 ml-auto"
           startIcon="plus"
-          variant="quaternary"
+          variant="inline"
           onClick={addRange}
           disabled={disabled}
           data-test="add-tier"

--- a/src/components/settings/integrations/AddLagoTaxManagementDialog.tsx
+++ b/src/components/settings/integrations/AddLagoTaxManagementDialog.tsx
@@ -287,7 +287,7 @@ export const AddLagoTaxManagementDialog = forwardRef<
 
       <Button
         fitContent
-        variant="quaternary"
+        variant="inline"
         size="medium"
         startIcon="plus"
         disabled={!canCreateBillingEntity}

--- a/src/components/settings/integrations/AnrokIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AnrokIntegrationSettings.tsx
@@ -137,7 +137,7 @@ const AnrokIntegrationSettings = () => {
         <section>
           <IntegrationsPage.Headline label={translate('text_661ff6e56ef7e1b7c542b232')}>
             <Button
-              variant="quaternary"
+              variant="inline"
               disabled={loading}
               onClick={() => {
                 addAnrokDialogRef.current?.openDialog({
@@ -210,7 +210,7 @@ const AnrokIntegrationSettings = () => {
           </Stack>
 
           <Button
-            variant="quaternary"
+            variant="inline"
             disabled={!anrokIntegration?.failedInvoicesCount}
             onClick={async () => await retryAllInvoices({ variables: { input: {} } })}
           >

--- a/src/components/settings/integrations/AvalaraIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AvalaraIntegrationSettings.tsx
@@ -141,7 +141,7 @@ const AvalaraIntegrationSettings = () => {
           <IntegrationsPage.Headline label={translate('text_661ff6e56ef7e1b7c542b232')}>
             {!!avalaraIntegration && (
               <Button
-                variant="quaternary"
+                variant="inline"
                 disabled={loading}
                 onClick={() => {
                   addAvalaraDialogRef.current?.openDialog({
@@ -214,7 +214,7 @@ const AvalaraIntegrationSettings = () => {
           </div>
 
           <Button
-            variant="quaternary"
+            variant="inline"
             disabled={!avalaraIntegration?.failedInvoicesCount}
             onClick={async () => await retryAllAvalaraInvoices({ variables: { input: {} } })}
           >

--- a/src/components/settings/integrations/NetsuiteIntegrationSettings.tsx
+++ b/src/components/settings/integrations/NetsuiteIntegrationSettings.tsx
@@ -148,7 +148,7 @@ const NetsuiteIntegrationSettings = () => {
         <section>
           <IntegrationsPage.Headline label={translate('text_661ff6e56ef7e1b7c542b232')}>
             <Button
-              variant="quaternary"
+              variant="inline"
               disabled={loading}
               onClick={() => {
                 addNetsuiteDialogRef.current?.openDialog({

--- a/src/components/settings/integrations/XeroIntegrationSettings.tsx
+++ b/src/components/settings/integrations/XeroIntegrationSettings.tsx
@@ -149,7 +149,7 @@ const XeroIntegrationSettings = () => {
         <section>
           <IntegrationsPage.Headline label={translate('text_661ff6e56ef7e1b7c542b232')}>
             <Button
-              variant="quaternary"
+              variant="inline"
               disabled={loading}
               onClick={() => {
                 addXeroDialogRef.current?.openDialog({

--- a/src/components/wallets/CustomerWalletList.tsx
+++ b/src/components/wallets/CustomerWalletList.tsx
@@ -84,7 +84,7 @@ export const CustomerWalletsList = ({ customerId, customerTimezone }: CustomerWa
           <>
             {!activeWallet && hasPermissions(['walletsCreate']) && (
               <Button
-                variant="quaternary"
+                variant="inline"
                 onClick={() =>
                   navigate(
                     generatePath(CREATE_WALLET_ROUTE, {
@@ -98,7 +98,7 @@ export const CustomerWalletsList = ({ customerId, customerTimezone }: CustomerWa
             )}
             {activeWallet && hasPermissions(['walletsTopUp']) && (
               <Button
-                variant="quaternary"
+                variant="inline"
                 onClick={() =>
                   navigate(
                     generatePath(CREATE_WALLET_TOP_UP_ROUTE, {

--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -253,7 +253,7 @@ const CreateAddOn = () => {
                     <Button
                       className="self-start"
                       startIcon="plus"
-                      variant="quaternary"
+                      variant="inline"
                       onClick={() => setShouldDisplayDescription(true)}
                       data-test="show-description"
                     >
@@ -362,7 +362,7 @@ const CreateAddOn = () => {
                     <Button
                       className="self-start"
                       startIcon="plus"
-                      variant="quaternary"
+                      variant="inline"
                       onClick={() => {
                         setShouldDisplayTaxesInput(true)
 

--- a/src/pages/CreateBillableMetric.tsx
+++ b/src/pages/CreateBillableMetric.tsx
@@ -341,7 +341,7 @@ const CreateBillableMetric = () => {
                     <Button
                       className="self-start"
                       startIcon="plus"
-                      variant="quaternary"
+                      variant="inline"
                       onClick={() => setShouldDisplayDescription(true)}
                       data-test="show-description"
                     >
@@ -573,7 +573,7 @@ const CreateBillableMetric = () => {
                       {formikProps.values.roundingFunction === undefined && (
                         <div>
                           <Button
-                            variant="quaternary"
+                            variant="inline"
                             startIcon="plus"
                             onClick={() => {
                               formikProps.setFieldValue('roundingFunction', null)
@@ -808,7 +808,7 @@ const CreateBillableMetric = () => {
                     {/* NOTE: Div used to prevent button's full width. Caused because of the Stack container */}
                     <div>
                       <Button
-                        variant="quaternary"
+                        variant="inline"
                         startIcon="plus"
                         onClick={() => {
                           formikProps.setFieldValue('filters', [

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -308,7 +308,7 @@ const CreateCoupon = () => {
                     <Button
                       className="self-start"
                       startIcon="plus"
-                      variant="quaternary"
+                      variant="inline"
                       onClick={() => setShouldDisplayDescription(true)}
                       data-test="show-description"
                     >
@@ -589,9 +589,9 @@ const CreateCoupon = () => {
 
                       {(!isEdition || !coupon?.appliedCouponsCount) && (
                         <>
-                          <div className="flex flex-row flex-wrap gap-3">
+                          <div className="flex flex-row flex-wrap gap-4">
                             <Button
-                              variant="quaternary"
+                              variant="inline"
                               startIcon="plus"
                               disabled={hasBillableMetricLimit && !hasPlanLimit}
                               onClick={addPlanToCouponDialogRef.current?.openDialog}
@@ -600,7 +600,7 @@ const CreateCoupon = () => {
                               {translate('text_63d3a201113866a7fa5e6f6b')}
                             </Button>
                             <Button
-                              variant="quaternary"
+                              variant="inline"
                               startIcon="plus"
                               disabled={hasPlanLimit && !hasBillableMetricLimit}
                               onClick={addBillableMetricToCouponDialogRef.current?.openDialog}

--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -957,7 +957,7 @@ const CreateInvoice = () => {
                       </div>
                     ) : (
                       <Button
-                        variant="secondary"
+                        variant="inline"
                         startIcon="plus"
                         onClick={() => {
                           setShowAddItem(true)

--- a/src/pages/CreateSubscription.tsx
+++ b/src/pages/CreateSubscription.tsx
@@ -679,12 +679,12 @@ const CreateSubscription = () => {
                     )}
 
                     {(!shouldDisplaySubscriptionExternalId || !shouldDisplaySubscriptionName) && (
-                      <div className="flex items-center gap-3">
+                      <div className="flex items-center gap-4">
                         {!shouldDisplaySubscriptionExternalId && (
                           <Button
                             startIcon="plus"
                             disabled={formType !== FORM_TYPE_ENUM.creation}
-                            variant="quaternary"
+                            variant="inline"
                             onClick={() => setShouldDisplaySubscriptionExternalId(true)}
                             data-test="show-external-id"
                           >
@@ -694,7 +694,7 @@ const CreateSubscription = () => {
                         {!shouldDisplaySubscriptionName && (
                           <Button
                             startIcon="plus"
-                            variant="quaternary"
+                            variant="inline"
                             onClick={() => setShouldDisplaySubscriptionName(true)}
                             data-test="show-name"
                           >

--- a/src/pages/CreateTax.tsx
+++ b/src/pages/CreateTax.tsx
@@ -170,7 +170,7 @@ const CreateTaxRate = () => {
                     <Button
                       className="self-start"
                       startIcon="plus"
-                      variant="quaternary"
+                      variant="inline"
                       onClick={() => setShouldDisplayDescription(true)}
                       data-test="show-description"
                     >

--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -164,7 +164,7 @@ const CustomerDetails = () => {
           <Button
             className="shrink-0"
             startIcon="outside"
-            variant="quaternary"
+            variant="inline"
             onClick={async () => {
               await generatePortalUrl({ variables: { input: { id: customerId as string } } })
             }}

--- a/src/pages/OldAnalytics.tsx
+++ b/src/pages/OldAnalytics.tsx
@@ -78,7 +78,7 @@ const Analytics = () => {
                     }, 0)
                   }
                 }}
-                variant="quaternary"
+                variant="inline"
                 endIcon={'chevron-down'}
               >
                 {selectedCurrency}

--- a/src/pages/settings/AdyenIntegrationDetails.tsx
+++ b/src/pages/settings/AdyenIntegrationDetails.tsx
@@ -190,7 +190,7 @@ const AdyenIntegrationDetails = () => {
           <IntegrationsPage.Headline label={translate('text_645d071272418a14c1c76a9a')}>
             {canEditIntegration && (
               <Button
-                variant="quaternary"
+                variant="inline"
                 disabled={loading}
                 onClick={() => {
                   addAdyenDialogRef.current?.openDialog({
@@ -252,7 +252,7 @@ const AdyenIntegrationDetails = () => {
           <IntegrationsPage.Headline label={translate('text_65367cb78324b77fcb6af21c')}>
             {canEditIntegration && (
               <Button
-                variant="quaternary"
+                variant="inline"
                 disabled={!!adyenPaymentProvider?.successRedirectUrl}
                 onClick={() => {
                   successRedirectUrlDialogRef.current?.openDialog({

--- a/src/pages/settings/Authentication/OktaAuthenticationDetails.tsx
+++ b/src/pages/settings/Authentication/OktaAuthenticationDetails.tsx
@@ -143,7 +143,7 @@ const OktaAuthenticationDetails = () => {
         <section>
           <IntegrationsPage.Headline label={translate('text_664c732c264d7eed1c74fdc5')}>
             <Button
-              variant="quaternary"
+              variant="inline"
               disabled={loading}
               onClick={() =>
                 addOktaDialogRef.current?.openDialog({

--- a/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
@@ -230,7 +230,7 @@ const BillingEntityInvoiceSettings = () => {
       sublabel: translate('text_17280313005777h5bvs7okol'),
       action: (
         <Button
-          variant="quaternary"
+          variant="inline"
           disabled={!canEditInvoiceSettings}
           onClick={() => editDefaultCurrencyDialogRef?.current?.openDialog({ billingEntity })}
         >
@@ -246,7 +246,7 @@ const BillingEntityInvoiceSettings = () => {
       sublabel: translate('text_1728031300577ipb2cxnths3'),
       action: (
         <Button
-          variant="quaternary"
+          variant="inline"
           disabled={!canEditInvoiceSettings}
           onClick={editDocumentLanguageDialogRef?.current?.openDialog}
         >
@@ -268,7 +268,7 @@ const BillingEntityInvoiceSettings = () => {
       sublabel: translate('text_1725538340200495slgen6ji'),
       action: (
         <Button
-          variant="quaternary"
+          variant="inline"
           disabled={!canEditInvoiceSettings}
           onClick={() => editFinalizeZeroAmountInvoiceDialogRef?.current?.openDialog()}
         >
@@ -293,7 +293,7 @@ const BillingEntityInvoiceSettings = () => {
       sublabel: translate('text_1728031300577ozl3dbfygr7'),
       action: (
         <Button
-          variant="quaternary"
+          variant="inline"
           endIcon={isPremium ? undefined : 'sparkles'}
           disabled={!canEditInvoiceSettings}
           onClick={() => {
@@ -326,7 +326,7 @@ const BillingEntityInvoiceSettings = () => {
       visible: false,
       action: (
         <Button
-          variant="quaternary"
+          variant="inline"
           disabled={!canEditInvoiceSettings}
           onClick={() => navigate(CREATE_INVOICE_CUSTOM_SECTION)}
         >
@@ -428,7 +428,7 @@ const BillingEntityInvoiceSettings = () => {
       sublabel: translate('text_1728031300577nwh7oc3hawr'),
       action: (
         <Button
-          variant="quaternary"
+          variant="inline"
           disabled={!canEditInvoiceSettings}
           onClick={editInvoiceTemplateDialogRef?.current?.openDialog}
         >
@@ -465,7 +465,7 @@ const BillingEntityInvoiceSettings = () => {
       sublabel: translate('text_17280313005771cdjezfas2e'),
       action: (
         <Button
-          variant="quaternary"
+          variant="inline"
           disabled={!canEditInvoiceSettings}
           onClick={editInvoiceNumberingDialogRef?.current?.openDialog}
         >
@@ -504,7 +504,7 @@ const BillingEntityInvoiceSettings = () => {
       sublabel: translate('text_1728031300577aivplw3hqav'),
       action: (
         <Button
-          variant="quaternary"
+          variant="inline"
           disabled={!canEditInvoiceSettings}
           onClick={() => editNetPaymentTermDialogRef?.current?.openDialog(billingEntity)}
         >
@@ -535,7 +535,7 @@ const BillingEntityInvoiceSettings = () => {
         <>
           {hasPermissions(['billingEntitiesTaxesUpdate']) && (
             <Button
-              variant="quaternary"
+              variant="inline"
               disabled={!canEditInvoiceSettings}
               onClick={editVATDialogRef?.current?.openDialog}
               data-test="add-tax-button"

--- a/src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx
+++ b/src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx
@@ -98,7 +98,7 @@ const BillingEntityDunningCampaigns = () => {
                     <>
                       {hasPermissions(['billingEntitiesDunningCampaignsUpdate']) && (
                         <Button
-                          variant="quaternary"
+                          variant="inline"
                           disabled={loading || !!appliedDunningCampaign?.id}
                           onClick={() => {
                             if (billingEntity) {

--- a/src/pages/settings/BillingEntity/sections/general/InformationBlock.tsx
+++ b/src/pages/settings/BillingEntity/sections/general/InformationBlock.tsx
@@ -177,7 +177,7 @@ const InformationBlock = ({ billingEntity }: { billingEntity: BillingEntity }) =
           action={
             <>
               {hasPermissions(['organizationUpdate']) && (
-                <Button variant="quaternary" onClick={onEdit}>
+                <Button variant="inline" onClick={onEdit}>
                   {translate('text_6389099378112a8d8e2b73be')}
                 </Button>
               )}

--- a/src/pages/settings/BillingEntity/sections/general/TimezoneBlock.tsx
+++ b/src/pages/settings/BillingEntity/sections/general/TimezoneBlock.tsx
@@ -37,7 +37,7 @@ const TimezoneBlock = ({ billingEntity }: TimezoneBlockProps) => {
           <>
             {hasPermissions(['organizationUpdate']) && (
               <Button
-                variant="quaternary"
+                variant="inline"
                 endIcon={isPremium ? undefined : 'sparkles'}
                 onClick={() => {
                   isPremium

--- a/src/pages/settings/BillingEntity/sections/invoice-custom-sections/BillingEntityInvoiceCustomSections.tsx
+++ b/src/pages/settings/BillingEntity/sections/invoice-custom-sections/BillingEntityInvoiceCustomSections.tsx
@@ -96,7 +96,7 @@ const BillingEntityInvoiceCustomSections = () => {
                     <>
                       {hasPermissions(['billingEntitiesInvoicesUpdate']) && (
                         <Button
-                          variant="quaternary"
+                          variant="inline"
                           disabled={loading}
                           onClick={() => {
                             if (billingEntity) {

--- a/src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx
@@ -114,7 +114,7 @@ const BillingEntityTaxesSettings = () => {
                     <>
                       {hasPermissions(['billingEntitiesTaxesUpdate']) && (
                         <Button
-                          variant="quaternary"
+                          variant="inline"
                           disabled={loading}
                           onClick={() => {
                             if (billingEntity?.id) {

--- a/src/pages/settings/CashfreeIntegrationDetails.tsx
+++ b/src/pages/settings/CashfreeIntegrationDetails.tsx
@@ -206,7 +206,7 @@ const CashfreeIntegrationDetails = () => {
 
             {canEditIntegration && (
               <Button
-                variant="quaternary"
+                variant="inline"
                 align="left"
                 onClick={() => {
                   addDialogRef.current?.openDialog({

--- a/src/pages/settings/Dunnings/CreateDunning.tsx
+++ b/src/pages/settings/Dunnings/CreateDunning.tsx
@@ -233,7 +233,7 @@ const CreateDunning = () => {
                   ) : (
                     <Button
                       startIcon="plus"
-                      variant="quaternary"
+                      variant="inline"
                       onClick={() => setShouldDisplayDescription(true)}
                       data-test="show-description"
                     >
@@ -303,7 +303,7 @@ const CreateDunning = () => {
                     <div>
                       <Button
                         startIcon="plus"
-                        variant="quaternary"
+                        variant="inline"
                         onClick={() =>
                           formikProps.setFieldValue('thresholds', [
                             ...formikProps.values.thresholds,
@@ -393,7 +393,7 @@ const CreateDunning = () => {
                   ) : (
                     <Button
                       startIcon="plus"
-                      variant="quaternary"
+                      variant="inline"
                       onClick={() => setShouldDisplayBCCEmails(true)}
                       data-test="show-bcc-emails"
                     >

--- a/src/pages/settings/Dunnings/Dunnings.tsx
+++ b/src/pages/settings/Dunnings/Dunnings.tsx
@@ -123,7 +123,7 @@ const Dunnings = () => {
                   action={
                     hasAccessToFeature ? (
                       <Button
-                        variant="quaternary"
+                        variant="inline"
                         disabled={loading}
                         onClick={() => {
                           navigate(CREATE_DUNNING_ROUTE)

--- a/src/pages/settings/GocardlessIntegrationDetails.tsx
+++ b/src/pages/settings/GocardlessIntegrationDetails.tsx
@@ -226,7 +226,7 @@ const GocardlessIntegrationDetails = () => {
           <IntegrationsPage.Headline label={translate('text_637f813d31381b1ed90ab315')}>
             {canEditIntegration && (
               <Button
-                variant="quaternary"
+                variant="inline"
                 align="left"
                 onClick={() => {
                   addDialogRef.current?.openDialog({
@@ -294,7 +294,7 @@ const GocardlessIntegrationDetails = () => {
           <IntegrationsPage.Headline label={translate('text_65367cb78324b77fcb6af21c')}>
             {canEditIntegration && (
               <Button
-                variant="quaternary"
+                variant="inline"
                 disabled={!!gocardlessPaymentProvider?.successRedirectUrl}
                 onClick={() => {
                   successRedirectUrlDialogRef.current?.openDialog({

--- a/src/pages/settings/HubspotIntegrationDetails.tsx
+++ b/src/pages/settings/HubspotIntegrationDetails.tsx
@@ -174,7 +174,7 @@ const HubspotIntegrationDetails = () => {
         <section>
           <IntegrationsPage.Headline label={translate('text_664c732c264d7eed1c74fdc5')}>
             <Button
-              variant="quaternary"
+              variant="inline"
               disabled={loading}
               onClick={() => {
                 addHubspotDialogRef.current?.openDialog({

--- a/src/pages/settings/Invoices/CreateCustomSection.tsx
+++ b/src/pages/settings/Invoices/CreateCustomSection.tsx
@@ -179,7 +179,7 @@ const CreateInvoiceCustomSection = () => {
                   ) : (
                     <Button
                       startIcon="plus"
-                      variant="quaternary"
+                      variant="inline"
                       onClick={() => setShouldDisplayDescription(true)}
                       data-test="show-description"
                     >

--- a/src/pages/settings/Invoices/InvoiceSections.tsx
+++ b/src/pages/settings/Invoices/InvoiceSections.tsx
@@ -124,7 +124,7 @@ const InvoiceSections = () => {
                 sublabel={translate('text_1750250547628xsddx47vasu')}
                 action={
                   <Button
-                    variant="quaternary"
+                    variant="inline"
                     disabled={!canEditOrCreatePricingUnits}
                     onClick={() => navigate(CREATE_PRICING_UNIT)}
                   >
@@ -205,7 +205,7 @@ const InvoiceSections = () => {
               sublabel={translate('text_17422301910293sbjvqbbq2i')}
               action={
                 <Button
-                  variant="quaternary"
+                  variant="inline"
                   disabled={!canEditInvoiceSettings}
                   onClick={() => navigate(CREATE_INVOICE_CUSTOM_SECTION)}
                 >

--- a/src/pages/settings/LagoTaxManagementIntegration.tsx
+++ b/src/pages/settings/LagoTaxManagementIntegration.tsx
@@ -169,7 +169,7 @@ const LagoTaxManagementIntegration = () => {
             description={translate('text_1746697495328feu6uz9q6oo')}
           >
             <Button
-              variant="quaternary"
+              variant="inline"
               onClick={() => {
                 addLagoTaxManagementDialog.current?.openDialog()
               }}
@@ -223,7 +223,7 @@ const LagoTaxManagementIntegration = () => {
           <IntegrationsPage.Headline label={translate('text_657078c28394d6b1ae1b9743')}>
             {hasPermissions(['billingEntitiesTaxesView']) && (
               <Button
-                variant="quaternary"
+                variant="inline"
                 disabled={loading}
                 onClick={() => {
                   navigate(TAXES_SETTINGS_ROUTE)

--- a/src/pages/settings/Members.tsx
+++ b/src/pages/settings/Members.tsx
@@ -172,7 +172,7 @@ const Members = () => {
                     action={
                       !!hasInvites && hasPermissions(['organizationMembersCreate']) ? (
                         <Button
-                          variant="quaternary"
+                          variant="inline"
                           onClick={() => {
                             createInviteDialogRef.current?.openDialog()
                           }}
@@ -303,7 +303,7 @@ const Members = () => {
                   action={
                     !hasInvites && hasPermissions(['organizationMembersCreate']) ? (
                       <Button
-                        variant="quaternary"
+                        variant="inline"
                         onClick={() => {
                           createInviteDialogRef.current?.openDialog()
                         }}

--- a/src/pages/settings/MoneyhashIntegrationDetails.tsx
+++ b/src/pages/settings/MoneyhashIntegrationDetails.tsx
@@ -196,7 +196,7 @@ const MoneyhashIntegrationDetails = () => {
 
           {canEditIntegration && (
             <Button
-              variant="quaternary"
+              variant="inline"
               disabled={loading}
               onClick={() => {
                 addMoneyhashDialogRef.current?.openDialog({

--- a/src/pages/settings/SalesforceIntegrationDetails.tsx
+++ b/src/pages/settings/SalesforceIntegrationDetails.tsx
@@ -175,7 +175,7 @@ const SalesforceIntegrationDetails = () => {
           <div className="flex h-18 w-full items-center justify-between">
             <Typography variant="subhead1">{translate('text_664c732c264d7eed1c74fdc5')}</Typography>
             <Button
-              variant="quaternary"
+              variant="inline"
               disabled={loading}
               onClick={() => {
                 addSalesforceDialogRef.current?.openDialog({

--- a/src/pages/settings/StripeIntegrationDetails.tsx
+++ b/src/pages/settings/StripeIntegrationDetails.tsx
@@ -189,7 +189,7 @@ const StripeIntegrationDetails = () => {
           <IntegrationsPage.Headline label={translate('text_657078c28394d6b1ae1b9725')}>
             {canEditIntegration && (
               <Button
-                variant="quaternary"
+                variant="inline"
                 disabled={loading}
                 onClick={() => {
                   addDialogRef.current?.openDialog({
@@ -235,7 +235,7 @@ const StripeIntegrationDetails = () => {
           <IntegrationsPage.Headline label={translate('text_65367cb78324b77fcb6af21c')}>
             {canEditIntegration && (
               <Button
-                variant="quaternary"
+                variant="inline"
                 disabled={!!stripePaymentProvider?.successRedirectUrl || loading}
                 onClick={() => {
                   successRedirectUrlDialogRef.current?.openDialog({

--- a/src/pages/settings/TaxesSettings.tsx
+++ b/src/pages/settings/TaxesSettings.tsx
@@ -123,7 +123,7 @@ const TaxesSettings = () => {
                     <>
                       {hasPermissions(['organizationTaxesUpdate']) && (
                         <Button
-                          variant="quaternary"
+                          variant="inline"
                           disabled={loading}
                           onClick={() => {
                             navigate(CREATE_TAX_ROUTE)

--- a/src/pages/wallet/CreateWalletTopUp.tsx
+++ b/src/pages/wallet/CreateWalletTopUp.tsx
@@ -399,7 +399,7 @@ const CreateWalletTopUp = () => {
                   <Button
                     className="self-start"
                     startIcon="plus"
-                    variant="quaternary"
+                    variant="inline"
                     onClick={() =>
                       formikProps.setFieldValue('metadata', [
                         ...(formikProps.values.metadata ?? []),

--- a/src/styles/designSystem/PageHeader.tsx
+++ b/src/styles/designSystem/PageHeader.tsx
@@ -31,7 +31,7 @@ const PageHeaderWrapper: FC<PropsWithChildren<{ withSide?: boolean; className?: 
 const PageHeaderGroup: FC<PropsWithChildren<{ className?: string }>> = ({
   children,
   className,
-}) => <div className={tw('flex items-center gap-3', className)}>{children}</div>
+}) => <div className={tw('flex items-center gap-4', className)}>{children}</div>
 
 export const PageHeader = {
   Wrapper: PageHeaderWrapper,

--- a/translations/base.json
+++ b/translations/base.json
@@ -744,7 +744,6 @@
   "text_62ce85fb3fb6842020331d83": "Find all <a rel=\"external\" target=\"_blank\" href=\"https://docs.getlago.com/api-reference/webhooks/messages\">the events</a> this webhook is listening",
   "text_62728ff857d47b013204c726": "Settings",
   "text_62728ff857d47b013204c7e4": "Cancel",
-  "text_62728ff857d47b013204cab3": "Add a tax rate",
   "text_627387d5053a1000c5287cab": "Cancel",
   "text_64d23a81a7d807f8aa570509": "Edit this webhook endpoint",
   "text_64d23a81a7d807f8aa57050b": "Edit this webhook endpoint to receive live event from Lago.",

--- a/translations/pt_BR.json
+++ b/translations/pt_BR.json
@@ -746,7 +746,6 @@
   "text_62ce85fb3fb6842020331d83": "Encontre todos <a rel=\"external\" target=\"_blank\" href=\"https://docs.getlago.com/api-reference/webhooks/messages\">os eventos</a> que este webhook está escutando",
   "text_62728ff857d47b013204c726": "Configurações",
   "text_62728ff857d47b013204c7e4": "Cancelar",
-  "text_62728ff857d47b013204cab3": "Adicionar uma alíquota de imposto",
   "text_627387d5053a1000c5287cab": "Cancelar",
   "text_64d23a81a7d807f8aa570509": "Editar este endpoint de webhook",
   "text_64d23a81a7d807f8aa57050b": "Edite este endpoint de webhook para receber eventos ao vivo do Lago.",


### PR DESCRIPTION
## Context

We were discussing with design and wanted to implement more and more the button `inline` pattern in the app.

## Description

This PR switches the `quaternary` buttons with a `startIcon-"plus"` to be inline variant.

Also took the opportunity to fix some UI elements.

<!-- Linear link -->
Fixes ISSUE-969