### PR TITLE
fix: display loading state on subscription page

### DIFF
--- a/src/pages/SubscriptionsPage.tsx
+++ b/src/pages/SubscriptionsPage.tsx
@@ -101,6 +101,7 @@ const SubscriptionsPage = () => {
 
   const [getSubscriptions, { data, error, loading, variables, fetchMore }] =
     useGetSubscriptionsListLazyQuery({
+      notifyOnNetworkStatusChange: true,
       variables: {
         limit: 20,
         ...filtersForSubscriptionQuery,


### PR DESCRIPTION
## Context

Forgot to add this props to update the loading state on subscription page