### PR TITLE
misc: align action with label baseline

### DIFF
--- a/src/components/layouts/Section.tsx
+++ b/src/components/layouts/Section.tsx
@@ -18,9 +18,9 @@ export const PageSectionTitle = ({
   loading?: boolean
 }) => {
   return (
-    <div className={tw('mb-4 flex items-center justify-between gap-2', className)}>
+    <div className={tw('mb-4 flex items-baseline justify-between gap-2', className)}>
       {loading && (
-        <div className="flex h-7 w-full items-center">
+        <div className="flex h-7 w-full items-baseline">
           <Skeleton variant="text" className="w-40" />
         </div>
       )}

--- a/src/components/layouts/Settings.tsx
+++ b/src/components/layouts/Settings.tsx
@@ -50,7 +50,7 @@ export const SettingsListItemHeader = ({
   sublabel?: string
   action?: JSX.Element
 }) => (
-  <div className="flex min-h-12 flex-row items-center justify-between gap-4">
+  <div className="flex min-h-12 flex-row items-baseline justify-between gap-4">
     <div className="flex flex-col gap-2">
       <Typography variant="subhead1" color="grey700">
         {label}

--- a/src/components/settings/integrations/AnrokIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AnrokIntegrationSettings.tsx
@@ -182,7 +182,7 @@ const AnrokIntegrationSettings = () => {
           direction="row"
           gap={4}
           justifyContent="space-between"
-          alignItems="center"
+          alignItems="baseline"
           paddingBottom={6}
           sx={{ boxShadow: theme.shadows[7] }}
         >

--- a/src/components/settings/integrations/AvalaraIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AvalaraIntegrationSettings.tsx
@@ -189,7 +189,7 @@ const AvalaraIntegrationSettings = () => {
           )}
         </section>
 
-        <div className="flex flex-row items-center justify-between gap-4 pb-6 shadow-b">
+        <div className="flex flex-row items-baseline justify-between gap-4 pb-6 shadow-b">
           <div className="flex-1">
             <Typography variant="bodyHl" color="grey700">
               {translate('text_66ba5a76e614f000a738c97a')}


### PR DESCRIPTION
## Context

Recently changes most of the actions in pages to be inline buttons.

## Description

We decided to align the button with the baseline, making it aligned with the title next to it in all cases.
More natural and elegant placement

<!-- Linear link -->
Fixes ISSUE-1004