### PR TITLE
misc: make CMD + click redirects to the package component

### DIFF
--- a/packages/design-system/tsconfig.build.json
+++ b/packages/design-system/tsconfig.build.json
@@ -4,6 +4,7 @@
   "exclude": ["**/__tests__/**", "**/*.test.{ts,tsx}", "playground", "dist", "node_modules"],
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "noEmit": false,
     "outDir": "./dist/types",


### PR DESCRIPTION
## Context

When `CMD + Click` on a component from the `/package/design-system` (path named `lago-design-system`), the components opens on the `dist/` file export. Not showing the exact/complete code of the component. 

## Description

This change make sure the source map is generated for `/package/design-system` components, so TS understand where to find the component code's location itself.

Reference: https://www.typescriptlang.org/tsconfig/#declarationMap
