### PR TITLE
fix: disable button to delete ourselves

### DIFF
--- a/src/pages/settings/Members.tsx
+++ b/src/pages/settings/Members.tsx
@@ -377,6 +377,10 @@ const Members = () => {
                         return undefined
                       }
 
+                      const canDeleteMember =
+                        membership.user.id !== currentUser?.id &&
+                        hasPermissions(['organizationMembersDelete'])
+
                       return [
                         ...(hasPermissions(['organizationMembersUpdate'])
                           ? [
@@ -397,7 +401,7 @@ const Members = () => {
                             ]
                           : []),
 
-                        ...(hasPermissions(['organizationMembersDelete'])
+                        ...(canDeleteMember
                           ? [
                               {
                                 startIcon: 'trash',


### PR DESCRIPTION
## Context

When trying to delete ourselves in the app (members section), it throws an 500 error because the api does not allow it

## Description

This PR should not render the delete button for ourselves

<img width="756" height="454" alt="Capture d’écran 2025-07-18 à 17 24 44" src="https://github.com/user-attachments/assets/af1c49cb-7663-4865-aaa3-c5efe1a4428c" />
