### PR TITLE
feat: add billable metric limitation on wallet

### DIFF
--- a/src/core/constants/form.ts
+++ b/src/core/constants/form.ts
@@ -45,6 +45,7 @@ export const ADD_CUSTOMER_TAX_PROVIDER_ACCORDION = 'addCustomerTaxProviderAccord
 export const ADD_CUSTOMER_CRM_PROVIDER_ACCORDION = 'addCustomerCrmProviderAccordion'
 // Wallets
 export const SEARCH_APPLIES_TO_FEE_TYPE_CLASSNAME = 'searchAppliesToFeeTypeInput'
+export const SEARCH_APPLIES_TO_BILLABLE_METRIC_CLASSNAME = 'searchAppliesToBillableMetricInput'
 
 /**** DATA ****/
 // Plan form types

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -472,6 +472,7 @@ export type AppliedTax = {
 };
 
 export type AppliesToInput = {
+  billableMetricIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   feeTypes?: InputMaybe<Array<FeeTypesEnum>>;
 };
 
@@ -7981,6 +7982,7 @@ export type Wallet = {
 
 export type WalletAppliesTo = {
   __typename?: 'WalletAppliesTo';
+  billableMetrics?: Maybe<Array<BillableMetric>>;
   feeTypes?: Maybe<Array<FeeTypesEnum>>;
 };
 
@@ -10479,7 +10481,7 @@ export type DeleteTaxMutationVariables = Exact<{
 
 export type DeleteTaxMutation = { __typename?: 'Mutation', destroyTax?: { __typename?: 'DestroyTaxPayload', id?: string | null } | null };
 
-export type CustomerWalletFragment = { __typename?: 'Wallet', id: string, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', lagoId: string, method: RecurringTransactionMethodEnum, trigger: RecurringTransactionTriggerEnum, interval?: RecurringTransactionIntervalEnum | null, targetOngoingBalance?: string | null, paidCredits: string, grantedCredits: string, thresholdCredits?: string | null, startedAt?: any | null, invoiceRequiresSuccessfulPayment: boolean, expirationAt?: any | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null };
+export type CustomerWalletFragment = { __typename?: 'Wallet', id: string, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, name: string, code: string }> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', lagoId: string, method: RecurringTransactionMethodEnum, trigger: RecurringTransactionTriggerEnum, interval?: RecurringTransactionIntervalEnum | null, targetOngoingBalance?: string | null, paidCredits: string, grantedCredits: string, thresholdCredits?: string | null, startedAt?: any | null, invoiceRequiresSuccessfulPayment: boolean, expirationAt?: any | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null };
 
 export type GetCustomerWalletListQueryVariables = Exact<{
   customerId: Scalars['ID']['input'];
@@ -10488,7 +10490,7 @@ export type GetCustomerWalletListQueryVariables = Exact<{
 }>;
 
 
-export type GetCustomerWalletListQuery = { __typename?: 'Query', wallets: { __typename?: 'WalletCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Wallet', id: string, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', lagoId: string, method: RecurringTransactionMethodEnum, trigger: RecurringTransactionTriggerEnum, interval?: RecurringTransactionIntervalEnum | null, targetOngoingBalance?: string | null, paidCredits: string, grantedCredits: string, thresholdCredits?: string | null, startedAt?: any | null, invoiceRequiresSuccessfulPayment: boolean, expirationAt?: any | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null }> } };
+export type GetCustomerWalletListQuery = { __typename?: 'Query', wallets: { __typename?: 'WalletCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Wallet', id: string, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, name: string, code: string }> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', lagoId: string, method: RecurringTransactionMethodEnum, trigger: RecurringTransactionTriggerEnum, interval?: RecurringTransactionIntervalEnum | null, targetOngoingBalance?: string | null, paidCredits: string, grantedCredits: string, thresholdCredits?: string | null, startedAt?: any | null, invoiceRequiresSuccessfulPayment: boolean, expirationAt?: any | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null }> } };
 
 export type TerminateCustomerWalletMutationVariables = Exact<{
   input: TerminateCustomerWalletInput;
@@ -11942,7 +11944,7 @@ export type GetXeroIntegrationsListQueryVariables = Exact<{
 
 export type GetXeroIntegrationsListQuery = { __typename?: 'Query', integrations?: { __typename?: 'IntegrationCollection', collection: Array<{ __typename?: 'AnrokIntegration' } | { __typename?: 'AvalaraIntegration' } | { __typename?: 'HubspotIntegration' } | { __typename?: 'NetsuiteIntegration' } | { __typename?: 'OktaIntegration' } | { __typename?: 'SalesforceIntegration' } | { __typename?: 'XeroIntegration', id: string, name: string, code: string, connectionId: string, hasMappingsConfigured?: boolean | null, syncCreditNotes?: boolean | null, syncInvoices?: boolean | null, syncPayments?: boolean | null }> } | null };
 
-export type WalletForUpdateFragment = { __typename?: 'Wallet', id: string, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', lagoId: string, method: RecurringTransactionMethodEnum, trigger: RecurringTransactionTriggerEnum, interval?: RecurringTransactionIntervalEnum | null, targetOngoingBalance?: string | null, paidCredits: string, grantedCredits: string, thresholdCredits?: string | null, startedAt?: any | null, invoiceRequiresSuccessfulPayment: boolean, expirationAt?: any | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null };
+export type WalletForUpdateFragment = { __typename?: 'Wallet', id: string, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, name: string, code: string }> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', lagoId: string, method: RecurringTransactionMethodEnum, trigger: RecurringTransactionTriggerEnum, interval?: RecurringTransactionIntervalEnum | null, targetOngoingBalance?: string | null, paidCredits: string, grantedCredits: string, thresholdCredits?: string | null, startedAt?: any | null, invoiceRequiresSuccessfulPayment: boolean, expirationAt?: any | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null };
 
 export type GetCustomerInfosForWalletFormQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -11956,7 +11958,7 @@ export type GetWalletInfosForWalletFormQueryVariables = Exact<{
 }>;
 
 
-export type GetWalletInfosForWalletFormQuery = { __typename?: 'Query', wallet?: { __typename?: 'Wallet', id: string, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', lagoId: string, method: RecurringTransactionMethodEnum, trigger: RecurringTransactionTriggerEnum, interval?: RecurringTransactionIntervalEnum | null, targetOngoingBalance?: string | null, paidCredits: string, grantedCredits: string, thresholdCredits?: string | null, startedAt?: any | null, invoiceRequiresSuccessfulPayment: boolean, expirationAt?: any | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null } | null };
+export type GetWalletInfosForWalletFormQuery = { __typename?: 'Query', wallet?: { __typename?: 'Wallet', id: string, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, name: string, code: string }> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', lagoId: string, method: RecurringTransactionMethodEnum, trigger: RecurringTransactionTriggerEnum, interval?: RecurringTransactionIntervalEnum | null, targetOngoingBalance?: string | null, paidCredits: string, grantedCredits: string, thresholdCredits?: string | null, startedAt?: any | null, invoiceRequiresSuccessfulPayment: boolean, expirationAt?: any | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null } | null };
 
 export type CreateCustomerWalletMutationVariables = Exact<{
   input: CreateCustomerWalletInput;
@@ -11970,7 +11972,7 @@ export type UpdateCustomerWalletMutationVariables = Exact<{
 }>;
 
 
-export type UpdateCustomerWalletMutation = { __typename?: 'Mutation', updateCustomerWallet?: { __typename?: 'Wallet', id: string, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', lagoId: string, method: RecurringTransactionMethodEnum, trigger: RecurringTransactionTriggerEnum, interval?: RecurringTransactionIntervalEnum | null, targetOngoingBalance?: string | null, paidCredits: string, grantedCredits: string, thresholdCredits?: string | null, startedAt?: any | null, invoiceRequiresSuccessfulPayment: boolean, expirationAt?: any | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null } | null };
+export type UpdateCustomerWalletMutation = { __typename?: 'Mutation', updateCustomerWallet?: { __typename?: 'Wallet', id: string, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, name: string, code: string }> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', lagoId: string, method: RecurringTransactionMethodEnum, trigger: RecurringTransactionTriggerEnum, interval?: RecurringTransactionIntervalEnum | null, targetOngoingBalance?: string | null, paidCredits: string, grantedCredits: string, thresholdCredits?: string | null, startedAt?: any | null, invoiceRequiresSuccessfulPayment: boolean, expirationAt?: any | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null } | null };
 
 export type GetWalletForTopUpQueryVariables = Exact<{
   walletId: Scalars['ID']['input'];
@@ -11980,6 +11982,19 @@ export type GetWalletForTopUpQueryVariables = Exact<{
 export type GetWalletForTopUpQuery = { __typename?: 'Query', wallet?: { __typename?: 'Wallet', id: string, currency: CurrencyEnum, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean } | null };
 
 export type WalletForTopUpFragment = { __typename?: 'Wallet', id: string, currency: CurrencyEnum, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean };
+
+export type BillableMetricForWalletScopeSectionFragment = { __typename?: 'BillableMetric', id: string, name: string, code: string };
+
+export type WalletForScopeSectionFragment = { __typename?: 'Wallet', id: string, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, name: string, code: string }> | null } | null };
+
+export type GetBillableMetricsForWalletQueryVariables = Exact<{
+  page?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  searchTerm?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type GetBillableMetricsForWalletQuery = { __typename?: 'Query', billableMetrics: { __typename?: 'BillableMetricCollection', collection: Array<{ __typename?: 'BillableMetric', id: string, name: string, code: string }>, metadata: { __typename?: 'CollectionMetadata', totalCount: number } } };
 
 export const ActivityLogsTableDataFragmentDoc = gql`
     fragment ActivityLogsTableData on ActivityLog {
@@ -13577,6 +13592,24 @@ export const SubscriptionUsageLifetimeGraphForLifetimeGraphFragmentDoc = gql`
   }
 }
     `;
+export const BillableMetricForWalletScopeSectionFragmentDoc = gql`
+    fragment BillableMetricForWalletScopeSection on BillableMetric {
+  id
+  name
+  code
+}
+    `;
+export const WalletForScopeSectionFragmentDoc = gql`
+    fragment WalletForScopeSection on Wallet {
+  id
+  appliesTo {
+    feeTypes
+    billableMetrics {
+      ...BillableMetricForWalletScopeSection
+    }
+  }
+}
+    ${BillableMetricForWalletScopeSectionFragmentDoc}`;
 export const WalletForUpdateFragmentDoc = gql`
     fragment WalletForUpdate on Wallet {
   id
@@ -13604,8 +13637,9 @@ export const WalletForUpdateFragmentDoc = gql`
       value
     }
   }
+  ...WalletForScopeSection
 }
-    `;
+    ${WalletForScopeSectionFragmentDoc}`;
 export const WalletInfosForTransactionsFragmentDoc = gql`
     fragment WalletInfosForTransactions on Wallet {
   id
@@ -34200,3 +34234,50 @@ export type GetWalletForTopUpQueryHookResult = ReturnType<typeof useGetWalletFor
 export type GetWalletForTopUpLazyQueryHookResult = ReturnType<typeof useGetWalletForTopUpLazyQuery>;
 export type GetWalletForTopUpSuspenseQueryHookResult = ReturnType<typeof useGetWalletForTopUpSuspenseQuery>;
 export type GetWalletForTopUpQueryResult = Apollo.QueryResult<GetWalletForTopUpQuery, GetWalletForTopUpQueryVariables>;
+export const GetBillableMetricsForWalletDocument = gql`
+    query getBillableMetricsForWallet($page: Int, $limit: Int, $searchTerm: String) {
+  billableMetrics(page: $page, limit: $limit, searchTerm: $searchTerm) {
+    collection {
+      ...BillableMetricForWalletScopeSection
+    }
+    metadata {
+      totalCount
+    }
+  }
+}
+    ${BillableMetricForWalletScopeSectionFragmentDoc}`;
+
+/**
+ * __useGetBillableMetricsForWalletQuery__
+ *
+ * To run a query within a React component, call `useGetBillableMetricsForWalletQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetBillableMetricsForWalletQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetBillableMetricsForWalletQuery({
+ *   variables: {
+ *      page: // value for 'page'
+ *      limit: // value for 'limit'
+ *      searchTerm: // value for 'searchTerm'
+ *   },
+ * });
+ */
+export function useGetBillableMetricsForWalletQuery(baseOptions?: Apollo.QueryHookOptions<GetBillableMetricsForWalletQuery, GetBillableMetricsForWalletQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetBillableMetricsForWalletQuery, GetBillableMetricsForWalletQueryVariables>(GetBillableMetricsForWalletDocument, options);
+      }
+export function useGetBillableMetricsForWalletLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetBillableMetricsForWalletQuery, GetBillableMetricsForWalletQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetBillableMetricsForWalletQuery, GetBillableMetricsForWalletQueryVariables>(GetBillableMetricsForWalletDocument, options);
+        }
+export function useGetBillableMetricsForWalletSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetBillableMetricsForWalletQuery, GetBillableMetricsForWalletQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetBillableMetricsForWalletQuery, GetBillableMetricsForWalletQueryVariables>(GetBillableMetricsForWalletDocument, options);
+        }
+export type GetBillableMetricsForWalletQueryHookResult = ReturnType<typeof useGetBillableMetricsForWalletQuery>;
+export type GetBillableMetricsForWalletLazyQueryHookResult = ReturnType<typeof useGetBillableMetricsForWalletLazyQuery>;
+export type GetBillableMetricsForWalletSuspenseQueryHookResult = ReturnType<typeof useGetBillableMetricsForWalletSuspenseQuery>;
+export type GetBillableMetricsForWalletQueryResult = Apollo.QueryResult<GetBillableMetricsForWalletQuery, GetBillableMetricsForWalletQueryVariables>;

--- a/src/pages/wallet/components/ScopeSection.tsx
+++ b/src/pages/wallet/components/ScopeSection.tsx
@@ -1,0 +1,331 @@
+import { gql } from '@apollo/client'
+import { FormikProps } from 'formik'
+import { Alert, Chip } from 'lago-design-system'
+import { FC, useEffect, useMemo, useState } from 'react'
+
+import { Button, Tooltip, Typography } from '~/components/designSystem'
+import { ComboBox, ComboboxItem } from '~/components/form'
+import {
+  MUI_INPUT_BASE_ROOT_CLASSNAME,
+  SEARCH_APPLIES_TO_BILLABLE_METRIC_CLASSNAME,
+  SEARCH_APPLIES_TO_FEE_TYPE_CLASSNAME,
+} from '~/core/constants/form'
+import { FeeTypesEnum, useGetBillableMetricsForWalletLazyQuery } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { TWalletDataForm } from '~/pages/wallet/types'
+
+gql`
+  fragment BillableMetricForWalletScopeSection on BillableMetric {
+    id
+    name
+    code
+  }
+
+  fragment WalletForScopeSection on Wallet {
+    id
+    appliesTo {
+      feeTypes
+      billableMetrics {
+        ...BillableMetricForWalletScopeSection
+      }
+    }
+  }
+
+  query getBillableMetricsForWallet($page: Int, $limit: Int, $searchTerm: String) {
+    billableMetrics(page: $page, limit: $limit, searchTerm: $searchTerm) {
+      collection {
+        ...BillableMetricForWalletScopeSection
+      }
+      metadata {
+        totalCount
+      }
+    }
+  }
+`
+interface ScopeSectionProps {
+  formikProps: FormikProps<TWalletDataForm>
+}
+
+type AvailableFeeTypes = FeeTypesEnum.Charge | FeeTypesEnum.Commitment | FeeTypesEnum.Subscription
+
+const availableFeeTypesTranslation: Record<AvailableFeeTypes, string> = {
+  [FeeTypesEnum.Charge]: 'text_1748441354191rj96qhw3twa',
+  [FeeTypesEnum.Commitment]: 'text_1748441354191cnp0tm4ubf0',
+  [FeeTypesEnum.Subscription]: 'text_6630e3210c13c500cd398ea2',
+}
+
+export const ScopeSection: FC<ScopeSectionProps> = ({ formikProps }) => {
+  const { translate } = useInternationalization()
+  const [showObjectLimitationInput, setShowObjectLimitationInput] = useState(false)
+  const [showBillableMetricLimitationInput, setShowBillableMetricLimitationInput] = useState(false)
+
+  const [
+    getBillableMetricsForWallet,
+    { loading: billableMetricsLoading, data: billableMetricsData },
+  ] = useGetBillableMetricsForWalletLazyQuery({
+    variables: { limit: 50 },
+  })
+
+  const comboboxFeeTypesData = useMemo(() => {
+    return [
+      {
+        label: translate(availableFeeTypesTranslation[FeeTypesEnum.Charge]),
+        value: FeeTypesEnum.Charge,
+        disabled: formikProps.values.appliesTo?.feeTypes?.includes(FeeTypesEnum.Charge) ?? false,
+      },
+      {
+        label: translate(availableFeeTypesTranslation[FeeTypesEnum.Commitment]),
+        value: FeeTypesEnum.Commitment,
+        disabled:
+          formikProps.values.appliesTo?.feeTypes?.includes(FeeTypesEnum.Commitment) ?? false,
+      },
+      {
+        label: translate(availableFeeTypesTranslation[FeeTypesEnum.Subscription]),
+        value: FeeTypesEnum.Subscription,
+        disabled:
+          formikProps.values.appliesTo?.feeTypes?.includes(FeeTypesEnum.Subscription) ?? false,
+      },
+    ]
+  }, [formikProps.values.appliesTo?.feeTypes, translate])
+
+  const comboboxBillableMetricsData = useMemo(() => {
+    if (!billableMetricsData?.billableMetrics?.collection?.length) return []
+
+    return billableMetricsData?.billableMetrics?.collection.map((billableMetric) => {
+      const { id, name, code } = billableMetric
+
+      return {
+        label: `${name} (${code})`,
+        labelNode: (
+          <ComboboxItem>
+            <Typography variant="body" color="grey700" noWrap>
+              {name}
+            </Typography>
+            <Typography variant="caption" color="grey600" noWrap>
+              {code}
+            </Typography>
+          </ComboboxItem>
+        ),
+        value: id,
+        disabled:
+          formikProps.values.appliesTo?.billableMetrics?.some((bm) => bm.id === id) || false,
+      }
+    })
+  }, [
+    billableMetricsData?.billableMetrics?.collection,
+    formikProps.values.appliesTo?.billableMetrics,
+  ])
+
+  const hasSelectedAllFeeTypes = useMemo(
+    () =>
+      formikProps.values.appliesTo?.feeTypes?.length ===
+      Object.keys(availableFeeTypesTranslation).length,
+    [formikProps.values.appliesTo?.feeTypes?.length],
+  )
+
+  useEffect(() => {
+    getBillableMetricsForWallet()
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <section className="flex flex-col gap-6 pb-12 shadow-b">
+      <div className="flex flex-col gap-1">
+        <Typography variant="subhead1">{translate('text_1753215016828tqecv5jeg4e')}</Typography>
+        <Typography variant="caption">{translate('text_1753215016828d5b7ocbawmp')}</Typography>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <Typography variant="captionHl" color="grey700">
+            {translate('text_17484224585599hnm61rdb6d')}
+          </Typography>
+          <Typography variant="caption" color="grey600">
+            {translate('text_17484378349895wl4yqkmqj9')}
+          </Typography>
+        </div>
+
+        {!!formikProps.values.appliesTo?.feeTypes?.length && (
+          <div className="flex flex-wrap items-center gap-3">
+            {formikProps.values.appliesTo?.feeTypes?.map((feeType) => {
+              const feeTypeTranslation = availableFeeTypesTranslation[feeType as AvailableFeeTypes]
+
+              return (
+                <Chip
+                  key={feeType}
+                  label={translate(feeTypeTranslation)}
+                  onDelete={() => {
+                    formikProps.setFieldValue(
+                      'appliesTo.feeTypes',
+                      formikProps.values.appliesTo?.feeTypes?.filter((ft) => ft !== feeType),
+                    )
+                  }}
+                />
+              )
+            })}
+          </div>
+        )}
+
+        {hasSelectedAllFeeTypes && (
+          <Alert type="info">{translate('text_17484418620700x4nxxdfenm')}</Alert>
+        )}
+
+        {showObjectLimitationInput ? (
+          <div className="flex items-center gap-4">
+            <ComboBox
+              containerClassName="flex-1"
+              className={SEARCH_APPLIES_TO_FEE_TYPE_CLASSNAME}
+              placeholder={translate('text_17484381918689r63e54hrh1')}
+              data={comboboxFeeTypesData}
+              onChange={(value: string) => {
+                const newFeeTypes = [...(formikProps.values.appliesTo?.feeTypes ?? [])]
+
+                if (value === '') {
+                  formikProps.setFieldValue('appliesTo.feeTypes', [])
+                } else if (newFeeTypes.includes(value as FeeTypesEnum)) {
+                  formikProps.setFieldValue(
+                    'appliesTo.feeTypes',
+                    newFeeTypes.filter((feeType) => feeType !== value),
+                  )
+                } else {
+                  formikProps.setFieldValue('appliesTo.feeTypes', [
+                    ...newFeeTypes,
+                    value as FeeTypesEnum,
+                  ])
+                }
+                setShowObjectLimitationInput(false)
+              }}
+            />
+            <Tooltip placement="top-end" title={translate('text_63aa085d28b8510cd46443ff')}>
+              <Button
+                icon="trash"
+                variant="quaternary"
+                onClick={() => {
+                  setShowObjectLimitationInput(false)
+                }}
+              />
+            </Tooltip>
+          </div>
+        ) : (
+          <Button
+            className="self-start"
+            startIcon="plus"
+            variant="inline"
+            disabled={hasSelectedAllFeeTypes}
+            onClick={() => {
+              setShowObjectLimitationInput(true)
+
+              setTimeout(() => {
+                const element = document.querySelector(
+                  `.${SEARCH_APPLIES_TO_FEE_TYPE_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+                ) as HTMLElement
+
+                if (!element) return
+
+                element.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                element.click()
+              }, 0)
+            }}
+            data-test="show-limit-input"
+          >
+            {translate('text_1748442650797pz30j2eeiv4')}
+          </Button>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <Typography variant="captionHl" color="grey700">
+            {translate('text_1753215016828k1x6yv1pwcc')}
+          </Typography>
+          <Typography variant="caption" color="grey600">
+            {translate('text_1753215016828vpzdzmz23rw')}
+          </Typography>
+        </div>
+
+        {!!formikProps.values.appliesTo?.billableMetrics?.length && (
+          <div className="flex flex-wrap items-center gap-3">
+            {formikProps.values.appliesTo?.billableMetrics?.map((appliedBillableMetric) => {
+              return (
+                <Chip
+                  key={appliedBillableMetric.id}
+                  label={appliedBillableMetric.name}
+                  onDelete={() => {
+                    formikProps.setFieldValue(
+                      'appliesTo.billableMetrics',
+                      formikProps.values.appliesTo?.billableMetrics?.filter(
+                        (appliedBillableMetricForFilter) =>
+                          appliedBillableMetricForFilter.id !== appliedBillableMetric.id,
+                      ),
+                    )
+                  }}
+                />
+              )
+            })}
+          </div>
+        )}
+
+        {showBillableMetricLimitationInput ? (
+          <div className="flex items-center gap-4">
+            <ComboBox
+              containerClassName="flex-1"
+              placeholder={translate('text_17484381918689r63e54hrh1')}
+              className={SEARCH_APPLIES_TO_BILLABLE_METRIC_CLASSNAME}
+              loading={billableMetricsLoading}
+              data={comboboxBillableMetricsData}
+              searchQuery={getBillableMetricsForWallet}
+              onChange={(value: string) => {
+                if (!!value) {
+                  const addedBillableMetric = billableMetricsData?.billableMetrics?.collection.find(
+                    (b) => b.id === value,
+                  )
+                  const newBillableMetrics = [
+                    ...(formikProps.values.appliesTo?.billableMetrics ?? []),
+                    addedBillableMetric,
+                  ]
+
+                  formikProps.setFieldValue('appliesTo.billableMetrics', newBillableMetrics)
+                } else {
+                  formikProps.setFieldValue('appliesTo.billableMetrics', [])
+                }
+                setShowBillableMetricLimitationInput(false)
+              }}
+            />
+            <Tooltip placement="top-end" title={translate('text_63aa085d28b8510cd46443ff')}>
+              <Button
+                icon="trash"
+                variant="quaternary"
+                onClick={() => {
+                  setShowBillableMetricLimitationInput(false)
+                }}
+              />
+            </Tooltip>
+          </div>
+        ) : (
+          <Button
+            className="self-start"
+            startIcon="plus"
+            variant="inline"
+            onClick={() => {
+              setShowBillableMetricLimitationInput(true)
+
+              setTimeout(() => {
+                const element = document.querySelector(
+                  `.${SEARCH_APPLIES_TO_BILLABLE_METRIC_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+                ) as HTMLElement
+
+                if (!element) return
+
+                element.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                element.click()
+              }, 0)
+            }}
+          >
+            {translate('text_17532150168286lki5kmbqfo')}
+          </Button>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/pages/wallet/components/SettingsSection.tsx
+++ b/src/pages/wallet/components/SettingsSection.tsx
@@ -1,26 +1,19 @@
 import { InputAdornment } from '@mui/material'
 import { FormikProps } from 'formik'
-import { Alert, Chip } from 'lago-design-system'
 import { DateTime } from 'luxon'
-import { FC, useMemo, useState } from 'react'
+import { FC } from 'react'
 
 import { Button, Tooltip, Typography } from '~/components/designSystem'
 import {
   AmountInputField,
-  ComboBox,
   ComboBoxField,
   DatePickerField,
   TextInput,
   TextInputField,
 } from '~/components/form'
-import {
-  dateErrorCodes,
-  FORM_TYPE_ENUM,
-  MUI_INPUT_BASE_ROOT_CLASSNAME,
-  SEARCH_APPLIES_TO_FEE_TYPE_CLASSNAME,
-} from '~/core/constants/form'
+import { dateErrorCodes, FORM_TYPE_ENUM } from '~/core/constants/form'
 import { getCurrencySymbol } from '~/core/formats/intlFormatNumber'
-import { CurrencyEnum, FeeTypesEnum, GetCustomerInfosForWalletFormQuery } from '~/generated/graphql'
+import { CurrencyEnum, GetCustomerInfosForWalletFormQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { TWalletDataForm } from '~/pages/wallet/types'
 import { tw } from '~/styles/utils'
@@ -33,14 +26,6 @@ interface SettingsSectionProps {
   formType: keyof typeof FORM_TYPE_ENUM
 }
 
-type AvailableFeeTypes = FeeTypesEnum.Charge | FeeTypesEnum.Commitment | FeeTypesEnum.Subscription
-
-const availableFeeTypesTranslation: Record<AvailableFeeTypes, string> = {
-  [FeeTypesEnum.Charge]: 'text_1748441354191rj96qhw3twa',
-  [FeeTypesEnum.Commitment]: 'text_1748441354191cnp0tm4ubf0',
-  [FeeTypesEnum.Subscription]: 'text_6630e3210c13c500cd398ea2',
-}
-
 export const SettingsSection: FC<SettingsSectionProps> = ({
   formikProps,
   formType,
@@ -49,36 +34,6 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
   setShowExpirationDate,
 }) => {
   const { translate } = useInternationalization()
-  const [showLimitInput, setShowLimitInput] = useState(false)
-
-  const comboboxFeeTypesData = useMemo(() => {
-    return [
-      {
-        label: translate(availableFeeTypesTranslation[FeeTypesEnum.Charge]),
-        value: FeeTypesEnum.Charge,
-        disabled: formikProps.values.appliesTo?.feeTypes?.includes(FeeTypesEnum.Charge) ?? false,
-      },
-      {
-        label: translate(availableFeeTypesTranslation[FeeTypesEnum.Commitment]),
-        value: FeeTypesEnum.Commitment,
-        disabled:
-          formikProps.values.appliesTo?.feeTypes?.includes(FeeTypesEnum.Commitment) ?? false,
-      },
-      {
-        label: translate(availableFeeTypesTranslation[FeeTypesEnum.Subscription]),
-        value: FeeTypesEnum.Subscription,
-        disabled:
-          formikProps.values.appliesTo?.feeTypes?.includes(FeeTypesEnum.Subscription) ?? false,
-      },
-    ]
-  }, [formikProps.values.appliesTo?.feeTypes, translate])
-
-  const hasSelectedAllFeeTypes = useMemo(
-    () =>
-      formikProps.values.appliesTo?.feeTypes?.length ===
-      Object.keys(availableFeeTypesTranslation).length,
-    [formikProps.values.appliesTo?.feeTypes?.length],
-  )
 
   return (
     <section className="flex flex-col gap-6 pb-12 shadow-b">
@@ -182,105 +137,6 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
             data-test="show-expiration-at"
           >
             {translate('text_6560809c38fb9de88d8a517e')}
-          </Button>
-        )}
-      </div>
-
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
-          <Typography variant="captionHl" color="grey700">
-            {translate('text_17484224585599hnm61rdb6d')}
-          </Typography>
-          <Typography variant="caption" color="grey600">
-            {translate('text_17484378349895wl4yqkmqj9')}
-          </Typography>
-        </div>
-
-        {!!formikProps.values.appliesTo?.feeTypes?.length && (
-          <div className="flex flex-wrap items-center gap-3">
-            {formikProps.values.appliesTo?.feeTypes?.map((feeType) => {
-              const feeTypeTranslation = availableFeeTypesTranslation[feeType as AvailableFeeTypes]
-
-              return (
-                <Chip
-                  key={feeType}
-                  label={translate(feeTypeTranslation)}
-                  onDelete={() => {
-                    formikProps.setFieldValue('appliesTo', {
-                      feeTypes: formikProps.values.appliesTo?.feeTypes?.filter(
-                        (ft) => ft !== feeType,
-                      ),
-                    })
-                  }}
-                />
-              )
-            })}
-          </div>
-        )}
-
-        {hasSelectedAllFeeTypes && (
-          <Alert type="info">{translate('text_17484418620700x4nxxdfenm')}</Alert>
-        )}
-
-        {showLimitInput ? (
-          <div className="flex items-center gap-4">
-            <ComboBox
-              containerClassName="flex-1"
-              className={SEARCH_APPLIES_TO_FEE_TYPE_CLASSNAME}
-              placeholder={translate('text_17484381918689r63e54hrh1')}
-              data={comboboxFeeTypesData}
-              onChange={(value: string) => {
-                const newFeeTypes = [...(formikProps.values.appliesTo?.feeTypes ?? [])]
-
-                if (value === '') {
-                  formikProps.setFieldValue('appliesTo', {
-                    feeTypes: [],
-                  })
-                } else if (newFeeTypes.includes(value as FeeTypesEnum)) {
-                  formikProps.setFieldValue('appliesTo', {
-                    feeTypes: newFeeTypes.filter((feeType) => feeType !== value),
-                  })
-                } else {
-                  formikProps.setFieldValue('appliesTo', {
-                    feeTypes: [...newFeeTypes, value as FeeTypesEnum],
-                  })
-                }
-                setShowLimitInput(false)
-              }}
-            />
-            <Tooltip placement="top-end" title={translate('text_63aa085d28b8510cd46443ff')}>
-              <Button
-                icon="trash"
-                variant="quaternary"
-                onClick={() => {
-                  setShowLimitInput(false)
-                }}
-              />
-            </Tooltip>
-          </div>
-        ) : (
-          <Button
-            className="self-start"
-            startIcon="plus"
-            variant="inline"
-            disabled={hasSelectedAllFeeTypes}
-            onClick={() => {
-              setShowLimitInput(true)
-
-              setTimeout(() => {
-                const element = document.querySelector(
-                  `.${SEARCH_APPLIES_TO_FEE_TYPE_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
-                ) as HTMLElement
-
-                if (!element) return
-
-                element.scrollIntoView({ behavior: 'smooth', block: 'center' })
-                element.click()
-              }, 0)
-            }}
-            data-test="show-limit-input"
-          >
-            {translate('text_1748442650797pz30j2eeiv4')}
           </Button>
         )}
       </div>

--- a/src/pages/wallet/types.ts
+++ b/src/pages/wallet/types.ts
@@ -1,4 +1,10 @@
-import { CreateCustomerWalletInput, UpdateCustomerWalletInput } from '~/generated/graphql'
+import {
+  CreateCustomerWalletInput,
+  UpdateCustomerWalletInput,
+  WalletForScopeSectionFragment,
+} from '~/generated/graphql'
 
 export type TWalletDataForm = Omit<CreateCustomerWalletInput, 'customerId'> &
-  Omit<UpdateCustomerWalletInput, 'id'>
+  Omit<UpdateCustomerWalletInput, 'id'> & {
+    appliesTo?: WalletForScopeSectionFragment['appliesTo']
+  }

--- a/translations/base.json
+++ b/translations/base.json
@@ -3166,8 +3166,8 @@
   "text_1748422458559917eelhobh5": "A wallet is an object for free or prepaid credits, enabling users to prepay for their usage.",
   "text_1748422458559n8iqcz37i2z": "Define an expiration date",
   "text_17484224585596yw31vih46t": "By default, the wallet stays active until you set an expiration date or terminate it manually.",
-  "text_17484224585599hnm61rdb6d": "Limit wallet credits to specific object",
-  "text_17484378349895wl4yqkmqj9": "By default, wallet credits apply to all items on subscription invoices.",
+  "text_17484224585599hnm61rdb6d": "Limit wallet credits to specific objects",
+  "text_17484378349895wl4yqkmqj9": "Choose whether wallet credits apply to usage based charges, subscription fees, or other object.",
   "text_17484381918689r63e54hrh1": "Search and select an object",
   "text_1748441354191rj96qhw3twa": "Charges fees",
   "text_1748441354191cnp0tm4ubf0": "Commitment fees",
@@ -3310,5 +3310,10 @@
   "text_1752158380555tozrnmtmxc1": "Your current logged in method isn’t allowed by this organization. To access it, please log out and sign in again using a different login method.",
   "text_1752158380555al7jwgd0hfk": "{{method}} login method has been disabled successfully.",
   "text_1752158380555fssagh1zpp1": "{{method}} login method has been enabled successfully.",
-  "text_17522481192202remk2eytrr": "Delete Okta connection"
+  "text_17522481192202remk2eytrr": "Delete Okta connection",
+  "text_1753215016828tqecv5jeg4e": "Wallet scope limitation",
+  "text_1753215016828d5b7ocbawmp": "By default, wallet credits apply to all items on subscription invoices. Limit the scope for more control.",
+  "text_1753215016828k1x6yv1pwcc": "Limit wallet credits to specific billable metrics",
+  "text_1753215016828vpzdzmz23rw": "Select one or more billable metrics that wallet credits should apply to.",
+  "text_17532150168286lki5kmbqfo": "Add a billable metric limitation"
 }


### PR DESCRIPTION
## Context

We would love to add a limitation on the wallet where you can only apply the amount on certain fees related to certain billable metrics. 

## Description

This pull request refactors the wallet form to add a new section.
This new section contains the expiration dates that were already present on the different places of the form.
This new section also adds the possibility to select billable metrics on your wallet, so the amount will be only scoped to them. 

<!-- Linear link -->
Fixes LAGO-918