### PR TITLE
bug: prevent Table to call actionColumn wrongly

### DIFF
--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -253,9 +253,8 @@ const LoadingRows = <T,>({
   columns,
   id,
   shouldDisplayActionColumn,
-  actionColumn,
   loadingRowCount = LOADING_ROW_COUNT,
-}: Pick<TableProps<T>, 'actionColumn' | 'loadingRowCount'> & {
+}: Pick<TableProps<T>, 'loadingRowCount'> & {
   columns: Array<TableColumn<T>>
   id: string
   shouldDisplayActionColumn: boolean
@@ -282,11 +281,7 @@ const LoadingRows = <T,>({
       {shouldDisplayActionColumn && (
         <TableActionCell>
           <TableInnerCell>
-            {Array.isArray(actionColumn?.({} as T)) ? (
-              <Button disabled icon="dots-horizontal" variant="quaternary" />
-            ) : (
-              (actionColumn?.({} as T) as ReactNode)
-            )}
+            <Button disabled icon="dots-horizontal" variant="quaternary" />
           </TableInnerCell>
         </TableActionCell>
       )}
@@ -634,7 +629,6 @@ export const Table = <T extends DataItem>({
               id: TABLE_ID,
               loadingRowCount,
               shouldDisplayActionColumn,
-              actionColumn,
             })}
         </MUITableBody>
       </MUITable>


### PR DESCRIPTION
While investigating a bug on the membership list, I noticed the root cause was the Table calling a method `actionColumn` that is supposed to have a real item passed in props.

However at this point the data was not present and this call just had the same render each time -> a disabled button.

Just removing this call prevent deep object assertions to fail (e.g. `membership.user.id`)

<!-- Linear link -->
Fixes ISSUE-1020