### PR TITLE
fix: nested buttons on selectors

### DIFF
--- a/packages/design-system/src/components/Selector.tsx
+++ b/packages/design-system/src/components/Selector.tsx
@@ -73,11 +73,10 @@ export const Selector = ({
   const [loading, setLoading] = useState(false)
   const clickable = !!onClick && !loading && !disabled
 
-  const Component = clickable ? 'button' : 'div'
-
   return (
-    <Component
-      disabled={disabled}
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+    <div
+      role="button"
       tabIndex={clickable ? 0 : -1}
       className={tw(
         selectorVariants({
@@ -132,7 +131,7 @@ export const Selector = ({
       ) : (
         endIcon
       )}
-    </Component>
+    </div>
   )
 }
 

--- a/src/components/designSystem/Selector.tsx
+++ b/src/components/designSystem/Selector.tsx
@@ -72,11 +72,10 @@ export const Selector = ({
   const [loading, setLoading] = useState(false)
   const clickable = !!onClick && !loading && !disabled
 
-  const Component = clickable ? 'button' : 'div'
-
   return (
-    <Component
-      disabled={disabled}
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+    <div
+      role="button"
       tabIndex={clickable ? 0 : -1}
       className={tw(
         selectorVariants({
@@ -131,7 +130,7 @@ export const Selector = ({
       ) : (
         endIcon
       )}
-    </Component>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Context

<img width="719" height="431" alt="image" src="https://github.com/user-attachments/assets/3e1c00a0-e63a-4015-822c-ec0809ad4091" />

## Description

Use div inside of button to avoid nested button DOM issue 
