### PR TITLE
bug: make sure expected not found error don't raise alert

### DIFF
--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -338,6 +338,12 @@ const CustomerInvoiceDetails = () => {
   const { data: customerData, loading: customerLoading } = useGetInvoiceCustomerQuery({
     variables: { id: invoice?.customer?.id as string },
     skip: !invoice?.customer?.id,
+    context: {
+      // NOTE: This call is not critical, it aims to get the customer infos for display purpose.
+      // It can happen the customer have been deleted meanwhile hence having a not found error.
+      // We just don't want to display an error in this case.
+      silentErrorCodes: [LagoApiError.NotFound],
+    },
   })
 
   const customer = customerData?.customer


### PR DESCRIPTION
## Context

We're fetching customer informations on the invoice preview, for display purpose.

It can happen the customer is deleted hence cannot be fetched, resulting in a not_found error and triggering an alert toast + sentry error.

## Description

This customer fetch is expected to potentially fetch and should not raise "visual" error. We can then silent it!