### PR TITLE
misc: allow Combobox components to set variant on input

### DIFF
--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -38,6 +38,7 @@ export const ComboBox = ({
   renderGroupInputStartAdornment,
   onOpen,
   onChange,
+  variant = 'default',
 }: ComboBoxProps) => {
   const { translate } = useInternationalization()
 
@@ -113,6 +114,7 @@ export const ComboBox = ({
             placeholder={placeholder}
             startAdornmentValue={startAdornmentValue}
             params={params}
+            variant={variant}
           />
         )
       }}

--- a/src/components/form/ComboBox/ComboBoxInput.tsx
+++ b/src/components/form/ComboBox/ComboBoxInput.tsx
@@ -22,11 +22,13 @@ export const ComboBoxInput = ({
   disableClearable,
   startAdornmentValue,
   hasValueSelected,
+  variant = 'default',
 }: ComboBoxInputProps) => {
   const { inputProps, InputProps, ...restParams } = params
 
   return (
     <TextInput
+      variant={variant}
       onChange={(newVal) => {
         // needed because useAutocomplete expect a DOM onChange listener...
         inputProps.onChange({ target: { value: newVal } })

--- a/src/components/form/ComboBox/types.ts
+++ b/src/components/form/ComboBox/types.ts
@@ -77,6 +77,7 @@ export type ComboBoxInputProps = Pick<
   | 'className'
   | 'infoText'
   | 'startAdornmentValue'
+  | 'variant'
 > & {
   disableClearable?: boolean
   hasValueSelected?: boolean

--- a/src/components/form/MultipleComboBox/MultipleComboBox.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBox.tsx
@@ -45,6 +45,7 @@ export const MultipleComboBox = ({
   virtualized = true,
   limitTags,
   onChange,
+  variant = 'default',
 }: MultipleComboBoxProps) => {
   const { translate } = useInternationalization()
   const [open, setOpen] = useState(false)
@@ -112,6 +113,7 @@ export const MultipleComboBox = ({
           label={label}
           name={name}
           placeholder={placeholder}
+          variant={variant}
         />
       )}
       onChange={(_, newValue) => {

--- a/src/components/form/MultipleComboBox/types.ts
+++ b/src/components/form/MultipleComboBox/types.ts
@@ -62,6 +62,7 @@ export type MultipleComboBoxInputProps = Pick<
   | 'className'
   | 'infoText'
   | 'startAdornmentValue'
+  | 'variant'
 > & {
   disableClearable?: boolean
   disableCloseOnSelect?: boolean


### PR DESCRIPTION
## Context

Need to have a outlined variant combobox and multiple combobox in a feature I'm working on. However it's not a customisation we allow on those components.

## Description

Allow to pass a variant attribute on `ComboBox` and `MultipleComboBox`, so it's passed along it's inner trigger input.