### PR TITLE
misc: set column maxWidth on maxSpace columns

### DIFF
--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -347,7 +347,13 @@ export const Table = <T extends DataItem>({
   rowDataTestId,
 }: TableProps<T>) => {
   const TABLE_ID = `table-${name}`
-  const filteredColumns = columns.filter((column) => !!column)
+  const filteredColumns = columns
+    .filter((column) => !!column)
+    .map((column) => ({
+      ...column,
+      // Make sure maxWidth is set to 600 if maxSpace is true
+      maxWidth: column.maxSpace ? 600 : column.maxWidth,
+    }))
   const maxSpaceColumns = countMaxSpaceColumns(filteredColumns)
   const tableRef = useRef<HTMLTableElement>(null)
   const { translate } = useInternationalization()

--- a/src/pages/features/FeaturesList.tsx
+++ b/src/pages/features/FeaturesList.tsx
@@ -213,7 +213,6 @@ const FeaturesList = () => {
                   title: translate('text_6419c64eace749372fc72b0f'),
                   maxSpace: true,
                   minWidth: 200,
-                  maxWidth: 600,
                   content: (feature) => (
                     <div className="flex items-center gap-3">
                       <Avatar size="big" variant="connector">


### PR DESCRIPTION
Recently fixed the customer list to prevent name too long to create extra space.

This should be the case everywhere if the `maxSpace` is true IMO.