### PR TITLE
fix: fetch finalized or draft invoices only

### DIFF
--- a/src/pages/InvoicesPage.tsx
+++ b/src/pages/InvoicesPage.tsx
@@ -27,6 +27,7 @@ import {
   CurrencyEnum,
   InvoiceExportTypeEnum,
   InvoiceListItemFragmentDoc,
+  InvoiceStatusTypeEnum,
   LagoApiError,
   useCreateInvoicesDataExportMutation,
   useGetInvoicesListLazyQuery,
@@ -156,6 +157,13 @@ const InvoicesPage = () => {
       nextFetchPolicy: 'network-only',
       variables: {
         limit: 20,
+        status: [
+          InvoiceStatusTypeEnum.Draft,
+          InvoiceStatusTypeEnum.Failed,
+          InvoiceStatusTypeEnum.Finalized,
+          InvoiceStatusTypeEnum.Voided,
+          InvoiceStatusTypeEnum.Pending,
+        ],
         ...formatAmountCurrency(filtersForInvoiceQuery, amountCurrency),
       },
     },


### PR DESCRIPTION
## Context

Attempt to fix these kind of errors: https://lago.sentry.io/issues/6581756497/events/7798dea65999490c80b47d48db013558/?project=6458937&referrer=replay-errors

## Description

In invoice list, we're fetching all invoices depending on their status including generating invoices which could be the reason of `Resource not found` type of error as the invoice is not completely "closed". 

This is an attempt to resolve the issue by only fetching finalized+draft invoices by default, and still be able to overwrite them with the filters object.
