### PR TITLE
misc: migrate some formatDateToTZ usage to intlFormatDateTime

### DIFF
--- a/src/components/creditNote/CreditNoteDetailsOverview.tsx
+++ b/src/components/creditNote/CreditNoteDetailsOverview.tsx
@@ -15,7 +15,7 @@ import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/tabsOpti
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CUSTOMER_DETAILS_ROUTE, CUSTOMER_INVOICE_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { formatDateToTZ } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import {
   CreditNoteDetailsForOverviewTableFragmentDoc,
   CurrencyEnum,
@@ -172,10 +172,11 @@ export const CreditNoteDetailsOverview: FC<CreditNoteDetailsOverviewProps> = ({
             {creditNote?.createdAt && (
               <DetailsPage.OverviewLine
                 title={translate('text_637655cb50f04bf1c8379d06')}
-                value={formatDateToTZ(
-                  creditNote?.createdAt,
-                  creditNote?.customer.applicableTimezone,
-                )}
+                value={
+                  intlFormatDateTime(creditNote?.createdAt, {
+                    timezone: creditNote?.customer.applicableTimezone,
+                  }).date
+                }
               />
             )}
           </>
@@ -207,10 +208,9 @@ export const CreditNoteDetailsOverview: FC<CreditNoteDetailsOverviewProps> = ({
                 <Status
                   {...status}
                   labelVariables={{
-                    date: formatDateToTZ(
-                      creditNote?.refundedAt,
-                      creditNote?.customer.applicableTimezone,
-                    ),
+                    date: intlFormatDateTime(creditNote?.refundedAt, {
+                      timezone: creditNote?.customer.applicableTimezone,
+                    }).date,
                   }}
                 />
               }

--- a/src/components/creditNote/CreditNotesTable.tsx
+++ b/src/components/creditNote/CreditNotesTable.tsx
@@ -21,7 +21,7 @@ import { CREDIT_NOTE_LIST_FILTER_PREFIX } from '~/core/constants/filters'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CUSTOMER_INVOICE_CREDIT_NOTE_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { formatDateToTZ } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import { handleDownloadFile } from '~/core/utils/downloadFiles'
 import { ResponsiveStyleValue } from '~/core/utils/responsiveProps'
@@ -124,7 +124,7 @@ const CreditNotesTable = ({
 }: TCreditNoteTableProps) => {
   const { translate } = useInternationalization()
   const voidCreditNoteDialogRef = useRef<VoidCreditNoteDialogRef>(null)
-  const { formatTimeOrgaTZ, organization: { premiumIntegrations } = {} } = useOrganizationInfos()
+  const { organization: { premiumIntegrations } = {} } = useOrganizationInfos()
   const { hasPermissions } = usePermissions()
 
   const hasAccessToRevenueShare = !!premiumIntegrations?.includes(
@@ -334,9 +334,11 @@ const CreditNotesTable = ({
               title: translate('text_62544c1db13ca10187214d7f'),
               content: ({ createdAt }) => (
                 <Typography variant="body" color="grey600" noWrap>
-                  {customerTimezone
-                    ? formatDateToTZ(createdAt, customerTimezone)
-                    : formatTimeOrgaTZ(createdAt)}
+                  {
+                    intlFormatDateTime(createdAt, {
+                      timezone: customerTimezone,
+                    }).date
+                  }
                 </Typography>
               ),
             },

--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -33,7 +33,7 @@ import {
   CUSTOMER_INVOICE_VOID_ROUTE,
 } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { formatDateToTZ, getTimezoneConfig } from '~/core/timezone'
+import { getTimezoneConfig, intlFormatDateTime } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import { handleDownloadFile } from '~/core/utils/downloadFiles'
 import {
@@ -371,7 +371,9 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
                 </Tooltip>
               ),
               content: ({ issuingDate, customer }) =>
-                formatDateToTZ(issuingDate, customer.applicableTimezone),
+                intlFormatDateTime(issuingDate, {
+                  timezone: customer.applicableTimezone,
+                }).date,
             },
           ]}
           actionColumn={(invoice) => {

--- a/src/components/customers/CustomerPaymentsList.tsx
+++ b/src/components/customers/CustomerPaymentsList.tsx
@@ -8,7 +8,7 @@ import { payablePaymentStatusMapping } from '~/core/constants/statusInvoiceMappi
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CUSTOMER_PAYMENT_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { formatDateToTZ } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import {
   CurrencyEnum,
@@ -154,7 +154,9 @@ export const CustomerPaymentsList: FC<CustomerPaymentsListProps> = ({
             key: 'createdAt',
             title: translate('text_664cb90097bfa800e6efa3f5'),
             content: ({ createdAt, customer }) =>
-              formatDateToTZ(createdAt, customer.applicableTimezone),
+              intlFormatDateTime(createdAt, {
+                timezone: customer.applicableTimezone,
+              }).date,
           },
         ]}
       />

--- a/src/components/customers/usage/SubscriptionUsageDetailDrawer.tsx
+++ b/src/components/customers/usage/SubscriptionUsageDetailDrawer.tsx
@@ -19,7 +19,7 @@ import {
 } from '~/core/formats/formatInvoiceItemsMap'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { formatDateToTZ, intlFormatDateTime } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import { LocaleEnum } from '~/core/translations'
 import {
   ChargeFilterUsage,
@@ -226,12 +226,14 @@ export const SubscriptionUsageDetailDrawer = forwardRef<
             </Typography>
             <Typography>
               {translate('text_633dae57ca9a923dd53c2097', {
-                fromDate: locale
-                  ? intlFormatDateTime(fromDatetime, { timezone: customerTimezone, locale }).date
-                  : formatDateToTZ(fromDatetime, customerTimezone),
-                toDate: locale
-                  ? intlFormatDateTime(toDatetime, { timezone: customerTimezone, locale }).date
-                  : formatDateToTZ(toDatetime, customerTimezone),
+                fromDate: intlFormatDateTime(fromDatetime, {
+                  locale,
+                  timezone: customerTimezone,
+                }).date,
+                toDate: intlFormatDateTime(toDatetime, {
+                  locale,
+                  timezone: customerTimezone,
+                }).date,
               })}
             </Typography>
           </div>

--- a/src/components/designSystem/graphs/MultipleLineChart.tsx
+++ b/src/components/designSystem/graphs/MultipleLineChart.tsx
@@ -25,7 +25,7 @@ import {
   intlFormatNumber,
 } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { formatDateToTZ } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import { CurrencyEnum, TimeGranularityEnum, TimezoneEnum } from '~/generated/graphql'
 import { theme } from '~/styles'
 
@@ -329,7 +329,11 @@ const MultipleLineChart = <T extends DataItem>({
                       textAnchor: index === 0 ? 'start' : 'end',
                     }}
                   >
-                    {formatDateToTZ(dateValue, TimezoneEnum.TzUtc, 'LLL dd yyyy')}
+                    {
+                      intlFormatDateTime(dateValue, {
+                        timezone: TimezoneEnum.TzUtc,
+                      }).time
+                    }
                   </text>
                 </g>
               )

--- a/src/components/designSystem/graphs/StackedBarChart.tsx
+++ b/src/components/designSystem/graphs/StackedBarChart.tsx
@@ -23,7 +23,7 @@ import {
 import { ChartWrapper } from '~/components/layouts/Charts'
 import { bigNumberShortenNotationFormater } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { formatDateToTZ } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import { CurrencyEnum, TimeGranularityEnum, TimezoneEnum } from '~/generated/graphql'
 import { theme } from '~/styles'
 
@@ -334,7 +334,11 @@ const StackedBarChart = <T extends DataItem>({
                       textAnchor: index === 0 ? 'start' : 'end',
                     }}
                   >
-                    {formatDateToTZ(dateValue, TimezoneEnum.TzUtc, 'LLL dd yyyy')}
+                    {
+                      intlFormatDateTime(dateValue, {
+                        timezone: TimezoneEnum.TzUtc,
+                      }).date
+                    }
                   </text>
                 </g>
               )

--- a/src/components/developers/apiKeys/DeleteApiKeyDialog.tsx
+++ b/src/components/developers/apiKeys/DeleteApiKeyDialog.tsx
@@ -3,7 +3,7 @@ import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { Button, Dialog, DialogRef, Typography } from '~/components/designSystem'
 import { addToast } from '~/core/apolloClient'
-import { formatDateToTZ } from '~/core/timezone/utils'
+import { intlFormatDateTime } from '~/core/timezone/utils'
 import {
   ApiKeyForDeleteApiKeyDialogFragment,
   TimezoneEnum,
@@ -93,7 +93,9 @@ export const DeleteApiKeyDialog = forwardRef<DeleteApiKeyDialogRef>((_, ref) => 
           </Typography>
           <Typography className="flex-1" variant="body" color="grey700">
             {!!apiKey?.lastUsedAt
-              ? formatDateToTZ(apiKey?.lastUsedAt, TimezoneEnum.TzUtc, 'LLL. dd, yyyy')
+              ? intlFormatDateTime(apiKey?.lastUsedAt, {
+                  timezone: TimezoneEnum.TzUtc,
+                }).date
               : '-'}
           </Typography>
         </div>

--- a/src/components/developers/apiKeys/RotateApiKeyDialog.tsx
+++ b/src/components/developers/apiKeys/RotateApiKeyDialog.tsx
@@ -8,7 +8,7 @@ import { object, string } from 'yup'
 import { Button, Dialog, DialogRef, Typography } from '~/components/designSystem'
 import { RadioField } from '~/components/form'
 import { addToast } from '~/core/apolloClient'
-import { formatDateToTZ } from '~/core/timezone/utils'
+import { intlFormatDateTime } from '~/core/timezone/utils'
 import {
   ApiKeyForRotateApiKeyDialogFragment,
   ApiKeyRevealedForApiKeysListFragment,
@@ -171,7 +171,9 @@ export const RotateApiKeyDialog = forwardRef<
           </Typography>
           <Typography className="flex-1" variant="body" color="grey700">
             {!!apiKey?.lastUsedAt
-              ? formatDateToTZ(apiKey?.lastUsedAt, TimezoneEnum.TzUtc, 'LLL. dd, yyyy')
+              ? intlFormatDateTime(apiKey?.lastUsedAt, {
+                  timezone: TimezoneEnum.TzUtc,
+                }).date
               : '-'}
           </Typography>
         </div>

--- a/src/components/invoices/InvoicePaymentList.tsx
+++ b/src/components/invoices/InvoicePaymentList.tsx
@@ -9,7 +9,7 @@ import { payablePaymentStatusMapping } from '~/core/constants/statusInvoiceMappi
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CREATE_INVOICE_PAYMENT_ROUTE, PAYMENT_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { formatDateToTZ } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import {
   CurrencyEnum,
   Invoice,
@@ -172,7 +172,7 @@ export const InvoicePaymentList: FC<{
                 key: 'createdAt',
                 title: translate('text_664cb90097bfa800e6efa3f5'),
                 content: ({ createdAt, customer }) =>
-                  formatDateToTZ(createdAt, customer.applicableTimezone),
+                  intlFormatDateTime(createdAt, { timezone: customer.applicableTimezone }).date,
               },
             ]}
           />

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -46,7 +46,7 @@ import {
   INVOICE_SETTINGS_ROUTE,
 } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { formatDateToTZ } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import { handleDownloadFile } from '~/core/utils/downloadFiles'
 import {
@@ -483,7 +483,7 @@ const InvoicesList = ({
               minWidth: 104,
               content: ({ issuingDate, customer }) => (
                 <Typography variant="body" noWrap>
-                  {formatDateToTZ(issuingDate, customer.applicableTimezone)}
+                  {intlFormatDateTime(issuingDate, { timezone: customer.applicableTimezone }).date}
                 </Typography>
               ),
             },

--- a/src/components/invoices/PaymentsList.tsx
+++ b/src/components/invoices/PaymentsList.tsx
@@ -9,7 +9,7 @@ import { payablePaymentStatusMapping } from '~/core/constants/statusInvoiceMappi
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { PAYMENT_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { formatDateToTZ } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import {
   CurrencyEnum,
@@ -203,7 +203,7 @@ export const PaymentsList: FC<PaymentsListProps> = ({
             key: 'createdAt',
             title: translate('text_664cb90097bfa800e6efa3f5'),
             content: ({ createdAt, customer }) =>
-              formatDateToTZ(createdAt, customer.applicableTimezone),
+              intlFormatDateTime(createdAt, { timezone: customer.applicableTimezone }).date,
           },
         ]}
         placeholder={{

--- a/src/components/invoices/details/InvoiceDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTable.tsx
@@ -13,7 +13,7 @@ import { InvoiceDetailsTablePeriodLine } from '~/components/invoices/details/Inv
 import { InvoiceFeeAdvanceDetailsTable } from '~/components/invoices/details/InvoiceFeeAdvanceDetailsTable'
 import { InvoiceFeeArrearsDetailsTable } from '~/components/invoices/details/InvoiceFeeArrearsDetailsTable'
 import { groupAndFormatFees, TExtendedRemainingFee } from '~/core/formats/formatInvoiceItemsMap'
-import { formatDateToTZ } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import {
   CurrencyEnum,
   Customer,
@@ -322,16 +322,12 @@ export const InvoiceDetailsTable = memo(
                         canHaveUnitPrice={canHaveUnitPrice}
                         isDraftInvoice={false}
                         period={translate('text_6499a4e4db5730004703f36b', {
-                          from: formatDateToTZ(
-                            subscription?.metadata?.fromDatetime,
-                            customer?.applicableTimezone,
-                            'LLL. dd, yyyy',
-                          ),
-                          to: formatDateToTZ(
-                            subscription?.metadata?.toDatetime,
-                            customer?.applicableTimezone,
-                            'LLL. dd, yyyy',
-                          ),
+                          from: intlFormatDateTime(subscription?.metadata?.fromDatetime, {
+                            timezone: customer?.applicableTimezone,
+                          }).date,
+                          to: intlFormatDateTime(subscription?.metadata?.toDatetime, {
+                            timezone: customer?.applicableTimezone,
+                          }).date,
                         })}
                       />
 

--- a/src/components/invoices/details/InvoiceFeeAdvanceDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceFeeAdvanceDetailsTable.tsx
@@ -5,7 +5,7 @@ import { memo, RefObject, useState } from 'react'
 
 import { Button } from '~/components/designSystem'
 import { TSubscriptionDataForDisplay } from '~/core/formats/formatInvoiceItemsMap'
-import { formatDateToTZ } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import {
   CurrencyEnum,
   Customer,
@@ -67,22 +67,20 @@ export const InvoiceFeeAdvanceDetailsTable = memo(
               canHaveUnitPrice={canHaveUnitPrice}
               isDraftInvoice={isDraftInvoice}
               period={translate('text_6499a4e4db5730004703f36b', {
-                from: formatDateToTZ(
+                from: intlFormatDateTime(
                   subscription?.metadata?.differentBoundariesForSubscriptionAndCharges
                     ? subscription?.metadata.fromDatetime
                     : subscription?.metadata?.inAdvanceChargesFromDatetime ||
                         subscription?.metadata?.chargesFromDatetime,
-                  customer?.applicableTimezone,
-                  'LLL. dd, yyyy',
-                ),
-                to: formatDateToTZ(
+                  { timezone: customer?.applicableTimezone },
+                ).date,
+                to: intlFormatDateTime(
                   subscription?.metadata?.differentBoundariesForSubscriptionAndCharges
                     ? subscription?.metadata.toDatetime
                     : subscription?.metadata?.inAdvanceChargesToDatetime ||
                         subscription?.metadata?.chargesToDatetime,
-                  customer?.applicableTimezone,
-                  'LLL. dd, yyyy',
-                ),
+                  { timezone: customer?.applicableTimezone },
+                ).date,
               })}
             />
             {subscription.feesInAdvance.map((feeInAdvance) => {

--- a/src/components/invoices/details/InvoiceFeeArrearsDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceFeeArrearsDetailsTable.tsx
@@ -8,7 +8,7 @@ import {
   TExtendedRemainingFee,
   TSubscriptionDataForDisplay,
 } from '~/core/formats/formatInvoiceItemsMap'
-import { formatDateToTZ } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import {
   CurrencyEnum,
   Customer,
@@ -70,20 +70,18 @@ export const InvoiceFeeArrearsDetailsTable = memo(
               canHaveUnitPrice={canHaveUnitPrice}
               isDraftInvoice={isDraftInvoice}
               period={translate('text_6499a4e4db5730004703f36b', {
-                from: formatDateToTZ(
+                from: intlFormatDateTime(
                   subscription?.metadata?.differentBoundariesForSubscriptionAndCharges
                     ? subscription?.metadata?.chargesFromDatetime
                     : subscription?.metadata?.fromDatetime,
-                  customer?.applicableTimezone,
-                  'LLL. dd, yyyy',
-                ),
-                to: formatDateToTZ(
+                  { timezone: customer?.applicableTimezone },
+                ).date,
+                to: intlFormatDateTime(
                   subscription?.metadata?.differentBoundariesForSubscriptionAndCharges
                     ? subscription?.metadata?.chargesToDatetime
                     : subscription?.metadata?.toDatetime,
-                  customer?.applicableTimezone,
-                  'LLL. dd, yyyy',
-                ),
+                  { timezone: customer?.applicableTimezone },
+                ).date,
               })}
             />
 

--- a/src/components/subscriptions/SubscriptionUsageLifetimeGraph.tsx
+++ b/src/components/subscriptions/SubscriptionUsageLifetimeGraph.tsx
@@ -12,7 +12,7 @@ import { hasDefinedGQLError } from '~/core/apolloClient'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { UPDATE_PLAN_ROUTE, UPDATE_SUBSCRIPTION } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { formatDateToTZ, intlFormatDateTime } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import { LocaleEnum } from '~/core/translations'
 import {
   CurrencyEnum,
@@ -141,18 +141,14 @@ export const SubscriptionUsageLifetimeGraphComponent = ({
             noWrap
           >
             {translate('text_633dae57ca9a923dd53c2097', {
-              fromDate: locale
-                ? intlFormatDateTime(lifetimeUsage.totalUsageFromDatetime, {
-                    timezone: customerTimezone,
-                    locale,
-                  }).date
-                : formatDateToTZ(lifetimeUsage.totalUsageFromDatetime, customerTimezone),
-              toDate: locale
-                ? intlFormatDateTime(lifetimeUsage.totalUsageToDatetime, {
-                    timezone: customerTimezone,
-                    locale,
-                  }).date
-                : formatDateToTZ(lifetimeUsage.totalUsageToDatetime, customerTimezone),
+              fromDate: intlFormatDateTime(lifetimeUsage.totalUsageFromDatetime, {
+                timezone: customerTimezone,
+                locale,
+              }).date,
+              toDate: intlFormatDateTime(lifetimeUsage.totalUsageToDatetime, {
+                timezone: customerTimezone,
+                locale,
+              }).date,
             })}
           </Typography>
         )}

--- a/src/core/timezone/utils.ts
+++ b/src/core/timezone/utils.ts
@@ -131,8 +131,32 @@ const getTimezoneString = (dateTime: DateTime, timezone: TimezoneEnum, format: T
 }
 
 /**
- * @warning If you use it for organization-based dates, make sure to use the `formatTimeOrgaTZ` function instead.
+ * Formats a date/time string according to the specified timezone and locale options.
+ *
+ * @param date - ISO date string to format
+ * @param options - Formatting options
+ * @param options.timezone - Target timezone to format the date in. Defaults to UTC.
+ * @param options.locale - Locale to use for formatting. Defaults to English.
+ * @param options.formatDate - Format to use for the date portion. Default is `DATE_MED` (Apr 18, 2025).
+ * @param options.formatTime - Format to use for the time portion. Default is `TIME_SIMPLE` (12:00 AM).
+ * @param options.formatTimezone - Format to use for the timezone. Default is `UTC_OFFSET` (UTC±0:00).
+ * @returns Object containing formatted date, time and timezone strings
+ * @example
+ * ```ts
+ * // Format a date in UTC
+ * intlFormatDateTime('2023-01-01T00:00:00Z')
+ * // Returns: { date: 'Jan 1, 2023', time: '12:00 AM', timezone: 'UTC±0:00' }
+ *
+ * // Format with custom timezone and formats
+ * intlFormatDateTime('2023-01-01T00:00:00Z', {
+ *   timezone: TimezoneEnum.TzAmericaNewYork,
+ *   formatDate: DateFormat.DATE_MED_SHORT_YEAR,
+ *   formatTime: TimeFormat.TIME_24_SIMPLE
+ * })
+ * // Returns: { date: 'Dec 31, 22', time: '19:00', timezone: 'UTC-4:00' }
+ * ```
  */
+
 export const intlFormatDateTime = (
   date: string,
   options:

--- a/src/hooks/useOrganizationInfos.ts
+++ b/src/hooks/useOrganizationInfos.ts
@@ -38,6 +38,9 @@ type UseOrganizationInfos = () => {
   organization?: MainOrganizationInfosFragment
   timezone: TimezoneEnum
   timezoneConfig: TimezoneConfigObject
+  /**
+   * @deprecated Use `intlFormatDateTime` instead.
+   */
   formatTimeOrgaTZ: (date: string, format?: string) => string
   hasOrganizationPremiumAddon: (integration: PremiumIntegrationTypeEnum) => boolean
   refetchOrganizationInfos: () => void

--- a/src/pages/developers/ApiKeysForm.tsx
+++ b/src/pages/developers/ApiKeysForm.tsx
@@ -10,7 +10,7 @@ import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { addToast } from '~/core/apolloClient'
 import { HOME_ROUTE } from '~/core/router'
-import { formatDateToTZ } from '~/core/timezone'
+import { intlFormatDateTime } from '~/core/timezone'
 import {
   ApiKeysPermissionsEnum,
   CreateApiKeyInput,
@@ -281,7 +281,9 @@ const ApiKeysForm = () => {
                 <Alert type="info">
                   <Typography variant="body" color="grey700">
                     {translate('text_1732286530467pwhhpj0aczl', {
-                      date: formatDateToTZ(apiKey?.lastUsedAt, TimezoneEnum.TzUtc, 'LLL. dd, yyyy'),
+                      date: intlFormatDateTime(apiKey?.lastUsedAt, {
+                        timezone: TimezoneEnum.TzUtc,
+                      }).date,
                     })}
                   </Typography>
                 </Alert>


### PR DESCRIPTION
## Context

We've marked `formatDateToTZ` as deprecated and it should be replaced by `intlFormatDateTime` method

## Description

This PR perform some changes but many remains.

It focuses on the "simple" ones that I could found. Those don't really need special props and works out of the box with the default options of `intlFormatDateTime`.

Later PRs will make sure to migrate the rest, had no time to keep on with this task for now

