### PR TITLE
fix: display error below tabs / improve translations

### DIFF
--- a/src/components/subscriptions/SubscriptionCurrentUsageTable.tsx
+++ b/src/components/subscriptions/SubscriptionCurrentUsageTable.tsx
@@ -215,11 +215,19 @@ export const SubscriptionCurrentUsageTableComponent = ({
         title: translate('text_1753095692838zn4t5a0wrg1'),
         unitsHeader: translate('text_17531019276915hby502cvzy'),
         amountHeader: translate('text_1753101927691j5chrkhmoma'),
+        emptyUsage:
+          subscription?.status === StatusTypeEnum.Pending
+            ? translate('text_1754662684478jvakvxllwie')
+            : translate('text_1754662542899l1ms7k49n67'),
       }
     : {
         title: translate('text_17530956928381jy5n59318d'),
         unitsHeader: translate('text_1753095789277t9kbe8y5pmh'),
         amountHeader: translate('text_1753101927691fbbwyk7p39q'),
+        emptyUsage:
+          subscription?.status === StatusTypeEnum.Pending
+            ? translate('text_173142196943714qsq737sre')
+            : translate('text_62c3f454e5d7f4ec8888c1d7'),
       }
 
   const amountCentsKey = showProjected ? 'projectedAmountCents' : 'amountCents'
@@ -265,6 +273,19 @@ export const SubscriptionCurrentUsageTableComponent = ({
         )}
       </div>
 
+      <NavigationTab
+        managedBy={TabManagedBy.INDEX}
+        onChange={(index) => setActiveTab(index)}
+        tabs={[
+          {
+            title: translate('text_1753094834414fgnvuior3iv'),
+          },
+          {
+            title: translate('text_1753094834414tu9mxavuco7'),
+          },
+        ]}
+      />
+
       {!!hasError && !isLoading && (
         <>
           {(usageError?.graphQLErrors?.length || 0) > 0 &&
@@ -303,29 +324,12 @@ export const SubscriptionCurrentUsageTableComponent = ({
           ) : (
             <GenericPlaceholder
               title={translate('text_62c3f454e5d7f4ec8888c1d5')}
-              subtitle={
-                subscription?.status === StatusTypeEnum.Pending
-                  ? translate('text_173142196943714qsq737sre')
-                  : translate('text_62c3f454e5d7f4ec8888c1d7')
-              }
+              subtitle={TRANSLATION_MAP.emptyUsage}
               image={<EmptyImage width="136" height="104" />}
             />
           )}
         </>
       )}
-
-      <NavigationTab
-        managedBy={TabManagedBy.INDEX}
-        onChange={(index) => setActiveTab(index)}
-        tabs={[
-          {
-            title: translate('text_1753094834414fgnvuior3iv'),
-          },
-          {
-            title: translate('text_1753094834414tu9mxavuco7'),
-          },
-        ]}
-      />
 
       {!hasError && !!usageData?.chargesUsage.length && (
         <>

--- a/translations/base.json
+++ b/translations/base.json
@@ -3385,6 +3385,8 @@
   "text_17519914705750hjw95snsdf": "Void and regenerate an invoice to correct the initial one, these invoices will be linked together.",
   "text_1751991518313o0xwbo9xf0y": "Void and regenerate invoice",
   "text_1752580912616sr615x718w7": "Add fee",
-  "text_175334713974444hpp5yt2ab": "Related to existing voided invoice"
+  "text_175334713974444hpp5yt2ab": "Related to existing voided invoice",
+  "text_1754662542899l1ms7k49n67": "Add a plan with charges to this customer to start reporting the projected usage",
+  "text_1754662684478jvakvxllwie": "This subscription is not yet active. Projected usage is displayed only for active subscriptions."
 }
 


### PR DESCRIPTION
Empty usage would show the error above the tabs + the translations weren't updated for the projected usage.