### PR TITLE
fix: warning filters

### DIFF
--- a/src/components/designSystem/Filters/ActiveFiltersList.tsx
+++ b/src/components/designSystem/Filters/ActiveFiltersList.tsx
@@ -28,7 +28,7 @@ export const ActiveFiltersList = () => {
         return [
           ...acc,
           {
-            label: translate(mapFilterToTranslationKey(_keyWithoutPrefix)),
+            label: mapFilterToTranslationKey(_keyWithoutPrefix),
             value: formatActiveFilterValueDisplay(_keyWithoutPrefix, value, translate),
           },
         ]

--- a/src/components/form/ComboBox/ComboBoxVirtualizedList.tsx
+++ b/src/components/form/ComboBox/ComboBoxVirtualizedList.tsx
@@ -82,6 +82,7 @@ export const ComboBoxVirtualizedList = ({ elements, value }: ComboBoxVirtualized
           <div
             key={virtualRow.key}
             ref={rowVirtualizer.measureElement}
+            data-index={virtualRow.index}
             className="absolute left-0 top-0 w-full"
             style={{
               height: `${virtualRow.size}px`,


### PR DESCRIPTION
## Context

<img width="454" height="635" alt="Capture d’écran 2025-08-12 à 13 54 14" src="https://github.com/user-attachments/assets/bfecd348-b53a-48eb-91fa-0cc931c6c96e" />
<img width="447" height="392" alt="Capture d’écran 2025-08-12 à 13 54 04" src="https://github.com/user-attachments/assets/4680e968-2f3a-4784-ab33-6ae28b4f5451" />


## Description

Should addressed these warnings

