### PR TITLE
fix(ComboBox): add dependency to useEffect for rawData updates

### DIFF
--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -57,7 +57,7 @@ export const ComboBox = ({
 
   useEffect(() => {
     prevRawDataRef.current = rawData
-  })
+  }, [rawData])
   const prevRawData = prevRawDataRef.current
 
   // when `data` gets updated, make sure that if the current value is not belonging to


### PR DESCRIPTION
## Context

During the edition of a plan, each key stroke in the amount input is trigger a re-render of the ComboBox components that encapsulate the charge model. In a plan with a large amount of charges it gets really clunky and this makes difficult to edit the amount value. I gave more details of the in the issue #2407. 

## Description

Added the rawData as dependency in the useEffect from ComboBox component, this prevents the re-renders.