### PR TITLE
chore: add missing copy and fix missing trad stack location

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -168,12 +168,13 @@
   "text_1736972452609g2v8mzgvi2t": "Geplant",
   "text_17429854230668s8zhn9ujq6": "Abgebrochen",
   "text_1746621029319goh9pr7g67d": "Geliefert",
-  "text_17265631916994iccuwziryu": "Letzte Schwelle: {{amount}}",
-  "text_172656319170006dm5ta4sd8": "Nächste Schwelle: {{amount}}",
   "text_17265631917004vcwz8zc0gy": "Nächste Schwelle nicht festgelegt",
   "text_17530956928381jy5n59318d": "Aktueller Gesamtverbrauch",
   "text_1753095789277h17a2varizl": "(ohne MwSt.)",
   "text_1753095789277t9kbe8y5pmh": "Aktuelle Einheiten",
-  "text_1753101927691fbbwyk7p39q": "Aktueller Betrag"
+  "text_1753101927691fbbwyk7p39q": "Aktueller Betrag",
+  "text_1726576554903s2dddtq5qz4": "{{rate}} verbraucht",
+  "text_1726576554903930hsa8vg23": "{{rate}} verbleibend",
+  "text_62c3f454e5d7f4ec8888c1d7": "Fügen Sie diesem Kunden einen Tarif mit Gebühren hinzu, um die aktuelle Nutzung zu erfassen.",
+  "text_1753094834414fgnvuior3iv": "Aktuelle Nutzung"
 }
-

--- a/translations/es.json
+++ b/translations/es.json
@@ -168,12 +168,13 @@
   "text_1736972452609g2v8mzgvi2t": "Programado",
   "text_17429854230668s8zhn9ujq6": "Cancelado",
   "text_1746621029319goh9pr7g67d": "Entregado",
-  "text_17265631916994iccuwziryu": "Último umbral: {{amount}}",
-  "text_172656319170006dm5ta4sd8": "Próximo umbral: {{amount}}",
   "text_17265631917004vcwz8zc0gy": "Próximo umbral no establecido",
   "text_17530956928381jy5n59318d": "Uso total actual",
   "text_1753095789277h17a2varizl": "(sin impuestos)",
   "text_1753095789277t9kbe8y5pmh": "Unidades actuales",
-  "text_1753101927691fbbwyk7p39q": "Monto actual"
+  "text_1753101927691fbbwyk7p39q": "Monto actual",
+  "text_1726576554903s2dddtq5qz4": "{{rate}} consumido",
+  "text_1726576554903930hsa8vg23": "{{rate}} restante",
+  "text_62c3f454e5d7f4ec8888c1d7": "Agrega un plan con cargos a este cliente para empezar a reportar el uso actual.",
+  "text_1753094834414fgnvuior3iv": "Uso actual"
 }
-

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -168,12 +168,13 @@
   "text_1736972452609g2v8mzgvi2t": "Planifié",
   "text_17429854230668s8zhn9ujq6": "Annulé",
   "text_1746621029319goh9pr7g67d": "Livré",
-  "text_17265631916994iccuwziryu": "Dernier seuil : {{amount}}",
-  "text_172656319170006dm5ta4sd8": "Prochain seuil : {{amount}}",
   "text_17265631917004vcwz8zc0gy": "Prochain seuil non défini",
   "text_17530956928381jy5n59318d": "Utilisation totale actuelle",
   "text_1753095789277h17a2varizl": "(hors taxe)",
   "text_1753095789277t9kbe8y5pmh": "Unités actuelles",
-  "text_1753101927691fbbwyk7p39q": "Montant actuel"
+  "text_1753101927691fbbwyk7p39q": "Montant actuel",
+  "text_1726576554903s2dddtq5qz4": "{{rate}} consommé",
+  "text_1726576554903930hsa8vg23": "{{rate}} restant",
+  "text_62c3f454e5d7f4ec8888c1d7": "Ajoutez un plan avec des frais à ce client pour commencer à suivre l’utilisation actuelle.",
+  "text_1753094834414fgnvuior3iv": "Utilisation actuelle"
 }
-

--- a/translations/it.json
+++ b/translations/it.json
@@ -141,12 +141,13 @@
   "text_1736972452609g2v8mzgvi2t": "Programmato",
   "text_17429854230668s8zhn9ujq6": "Annullato",
   "text_1746621029319goh9pr7g67d": "Consegnato",
-  "text_17265631916994iccuwziryu": "Ultima soglia: {{amount}}",
-  "text_172656319170006dm5ta4sd8": "Prossima soglia: {{amount}}",
   "text_17265631917004vcwz8zc0gy": "Prossima soglia non impostata",
   "text_17530956928381jy5n59318d": "Utilizzo totale attuale",
   "text_1753095789277h17a2varizl": "(escl. tasse)",
   "text_1753095789277t9kbe8y5pmh": "Unità attuali",
-  "text_1753101927691fbbwyk7p39q": "Importo attuale"
+  "text_1753101927691fbbwyk7p39q": "Importo attuale",
+  "text_1726576554903s2dddtq5qz4": "{{rate}} consumato",
+  "text_1726576554903930hsa8vg23": "{{rate}} rimanente",
+  "text_62c3f454e5d7f4ec8888c1d7": "Aggiungi un piano con costi a questo cliente per iniziare a segnalare l’utilizzo attuale.",
+  "text_1753094834414fgnvuior3iv": "Utilizzo attuale"
 }
-

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -167,12 +167,13 @@
   "text_1736972452609g2v8mzgvi2t": "Planlagt",
   "text_17429854230668s8zhn9ujq6": "Kansellert",
   "text_1746621029319goh9pr7g67d": "Levert",
-  "text_17265631916994iccuwziryu": "Last threshold: {{amount}}",
-  "text_172656319170006dm5ta4sd8": "Next threshold: {{amount}}",
-  "text_17265631917004vcwz8zc0gy": "Next threshold not set",
-  "text_17530956928381jy5n59318d": "Total current usage",
-  "text_1753095789277h17a2varizl": "(excl. tax)",
-  "text_1753095789277t9kbe8y5pmh": "Current units",
-  "text_1753101927691fbbwyk7p39q": "Current amount"
+  "text_17265631917004vcwz8zc0gy": "Neste terskel ikke satt",
+  "text_17530956928381jy5n59318d": "Totalt nåværende bruk",
+  "text_1753095789277h17a2varizl": "(ekskl. mva.)",
+  "text_1753095789277t9kbe8y5pmh": "Nåværende enheter",
+  "text_1753101927691fbbwyk7p39q": "Nåværende beløp",
+  "text_1726576554903s2dddtq5qz4": "{{rate}} forbrukt",
+  "text_1726576554903930hsa8vg23": "{{rate}} gjenstår",
+  "text_62c3f454e5d7f4ec8888c1d7": "Legg til en plan med kostnader for denne kunden for å begynne å rapportere nåværende bruk.",
+  "text_1753094834414fgnvuior3iv": "Nåværende bruk"
 }
-

--- a/translations/pt_BR.json
+++ b/translations/pt_BR.json
@@ -3181,11 +3181,9 @@
   "text_1748441354191cnp0tm4ubf0": "Taxas de compromisso",
   "text_17484418620700x4nxxdfenm": "Selecionar todos os itens funciona da mesma forma que não selecionar nenhum — recomendamos deixar tudo desmarcado.",
   "text_1748442650797pz30j2eeiv4": "Adicionar uma limitação de objeto",
-  "text_17265631916994iccuwziryu": "Último limite: {{amount}}",
-  "text_172656319170006dm5ta4sd8": "Próximo limite: {{amount}}",
-  "text_17265631917004vcwz8zc0gy": "Próximo limite não definido",
   "text_17530956928381jy5n59318d": "Uso total atual",
   "text_1753095789277h17a2varizl": "(sem impostos)",
   "text_1753095789277t9kbe8y5pmh": "Unidades atuais",
-  "text_1753101927691fbbwyk7p39q": "Valor atual"
+  "text_1753101927691fbbwyk7p39q": "Valor atual",
+  "text_1753094834414fgnvuior3iv": "Uso atual"
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -168,12 +168,13 @@
   "text_1736972452609g2v8mzgvi2t": "Schemalagd",
   "text_17429854230668s8zhn9ujq6": "Status: Avbruten",
   "text_1746621029319goh9pr7g67d": "Levererad",
-  "text_17265631916994iccuwziryu": "Senaste tröskel: {{amount}}",
-  "text_172656319170006dm5ta4sd8": "Nästa tröskel: {{amount}}",
   "text_17265631917004vcwz8zc0gy": "Nästa tröskel ej angiven",
   "text_17530956928381jy5n59318d": "Total aktuell användning",
   "text_1753095789277h17a2varizl": "(exkl. moms)",
   "text_1753095789277t9kbe8y5pmh": "Nuvarande enheter",
-  "text_1753101927691fbbwyk7p39q": "Nuvarande belopp"
+  "text_1753101927691fbbwyk7p39q": "Nuvarande belopp",
+  "text_1726576554903s2dddtq5qz4": "{{rate}} förbrukad",
+  "text_1726576554903930hsa8vg23": "{{rate}} gjenstår",
+  "text_62c3f454e5d7f4ec8888c1d7": "Lägg till en plan med avgifter för den här kunden för att börja rapportera den aktuella användningen.",
+  "text_1753094834414fgnvuior3iv": "Aktuell användning"
 }
-


### PR DESCRIPTION
We have some missing translations for some languages, fixing them.

Also, making sure we raise the prod sentry alert only for non-english locales.
Adding the fulls tack as on prod the error location may not be on the first stack line