### PR TITLE
misc: add key for the dash, as passed to translate method

### DIFF
--- a/src/components/designSystem/Status.tsx
+++ b/src/components/designSystem/Status.tsx
@@ -71,7 +71,7 @@ const statusLabelMapping: Record<StatusLabel, string> = {
   processing: 'text_1740135074392314rc3ldv02',
   canceled: 'text_17429854230668s8zhn9ujq6',
   delivered: 'text_1746621029319goh9pr7g67d',
-  ['n/a']: '-',
+  ['n/a']: 'text_1754570508183hxl33n573yi',
   // These keys below are displayed in the customer portal
   // Hence they must be translated in all available languages
   pay: 'text_6419c64eace749372fc72b54',

--- a/translations/base.json
+++ b/translations/base.json
@@ -3408,5 +3408,6 @@
   "text_1753198825180e09v150qcko": "You’re about to terminate this subscription. The customer will be charged for usage and a prorated subscription fee. Choose how the invoice should be generated below.",
   "text_1753198825180dxhl10ooij3": "Choose whether to generate an invoice when the subscription ends.",
   "text_1753198825180w91fhv7612n": "Generate a final invoice on termination",
-  "text_1753274319009dha80usx9zz": "If turned off, the subscription will end without creating an invoice."
+  "text_1753274319009dha80usx9zz": "If turned off, the subscription will end without creating an invoice.",
+  "text_1754570508183hxl33n573yi": "-"
 }


### PR DESCRIPTION
Tired of those missing translation for `-`