### PR TITLE
fix: add missing intl translations for projected usage

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -176,5 +176,18 @@
   "text_1726576554903s2dddtq5qz4": "{{rate}} verbraucht",
   "text_1726576554903930hsa8vg23": "{{rate}} verbleibend",
   "text_62c3f454e5d7f4ec8888c1d7": "Fügen Sie diesem Kunden einen Tarif mit Gebühren hinzu, um die aktuelle Nutzung zu erfassen.",
-  "text_1753094834414fgnvuior3iv": "Aktuelle Nutzung"
+  "text_1753094834414fgnvuior3iv": "Aktuelle Nutzung",
+  "text_1753094834414tu9mxavuco7": "Prognostizierte Nutzung",
+  "text_1753095692838zn4t5a0wrg1": "Gesamtprognostizierte Nutzung",
+  "text_17531019276915hby502cvzy": "Prognostizierte Einheiten",
+  "text_1753101927691j5chrkhmoma": "Prognostizierter Betrag",
+  "text_1754662542899l1ms7k49n67": "Fügen Sie diesem Kunden einen Tarif mit Gebühren hinzu, um mit der Berichterstattung über die prognostizierte Nutzung zu beginnen",
+  "text_1754662684478jvakvxllwie": "Dieses Abonnement ist noch nicht aktiv. Die prognostizierte Nutzung wird nur für aktive Abonnements angezeigt.",
+  "text_1755599398258j905gj9xihx": "Prognostizierten Verbrauch freischalten",
+  "text_1755599398258ce1ilgc5swg": "Schalten Sie den prognostizierten Verbrauch frei, damit Kunden ihren voraussichtlichen Verbrauch am Ende jedes Zeitraums einsehen und die anfallenden Kosten planen können.",
+  "text_1755599398258mj61iwjhhfk": "Zugriff auf den prognostizierten Verbrauch anfordern",
+  "text_1755599398258w59pin31rfe": "Hallo, ich möchte auf Ihr Add-on für den prognostizierten Verbrauch zugreifen. \n\nBitte lassen Sie mich wissen, wenn Sie weitere Informationen benötigen!",
+  "text_65ae73ebe3a66bec2b91d72d": "Kontaktieren Sie uns",
+  "text_661ff6e56ef7e1b7c542b1ea": "Dies ist ein Premium-Add-on",
+  "text_661ff6e56ef7e1b7c542b1f6": "Premium-Add-ons sind auf Anfrage erhältlich. Bitte kontaktieren Sie Lago, um diese neue Funktion freizuschalten."
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -176,5 +176,18 @@
   "text_1726576554903s2dddtq5qz4": "{{rate}} consumido",
   "text_1726576554903930hsa8vg23": "{{rate}} restante",
   "text_62c3f454e5d7f4ec8888c1d7": "Agrega un plan con cargos a este cliente para empezar a reportar el uso actual.",
-  "text_1753094834414fgnvuior3iv": "Uso actual"
+  "text_1753094834414fgnvuior3iv": "Uso actual",
+  "text_1753094834414tu9mxavuco7": "Uso previsto",
+  "text_1753095692838zn4t5a0wrg1": "Uso total previsto",
+  "text_17531019276915hby502cvzy": "Unidades previstas",
+  "text_1753101927691j5chrkhmoma": "Importe previsto",
+  "text_1754662542899l1ms7k49n67": "Añada un plan con cargos a este cliente para empezar a informar del uso previsto",
+  "text_1754662684478jvakvxllwie": "Esta suscripción aún no está activa. El uso previsto solo se muestra para las suscripciones activas.",
+  "text_1755599398258j905gj9xihx": "Desbloquear el uso previsto",
+  "text_1755599398258ce1ilgc5swg": "Desbloquee el uso previsto para que los clientes puedan ver su uso esperado al final de cada período y planificar los próximos costes.",
+  "text_1755599398258mj61iwjhhfk": "Solicitar acceso al uso previsto",
+  "text_1755599398258w59pin31rfe": "Hola, me gustaría acceder a su complemento de uso previsto. \n\n¡Por favor, avíseme si necesita más información!",
+  "text_65ae73ebe3a66bec2b91d72d": "Contáctenos",
+  "text_661ff6e56ef7e1b7c542b1ea": "Este es un complemento premium",
+  "text_661ff6e56ef7e1b7c542b1f6": "Los complementos premium están disponibles bajo petición. Póngase en contacto con Lago para desbloquear esta nueva función."
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -176,5 +176,18 @@
   "text_1726576554903s2dddtq5qz4": "{{rate}} consommé",
   "text_1726576554903930hsa8vg23": "{{rate}} restant",
   "text_62c3f454e5d7f4ec8888c1d7": "Ajoutez un plan avec des frais à ce client pour commencer à suivre l’utilisation actuelle.",
-  "text_1753094834414fgnvuior3iv": "Utilisation actuelle"
+  "text_1753094834414fgnvuior3iv": "Utilisation actuelle",
+  "text_1753094834414tu9mxavuco7": "Utilisation prévisionnelle",
+  "text_1753095692838zn4t5a0wrg1": "Utilisation totale prévisionnelle",
+  "text_17531019276915hby502cvzy": "Unités prévisionnelles",
+  "text_1753101927691j5chrkhmoma": "Montant prévisionnel",
+  "text_1754662542899l1ms7k49n67": "Ajoutez un plan avec des charges à ce client pour commencer à suivre l’utilisation prévisionnelle",
+  "text_1754662684478jvakvxllwie": "Cette abonnement n'est pas encore actif. L'utilisation prévisionnelle n'est affichée que pour les abonnements actifs.",
+  "text_1755599398258j905gj9xihx": "Débloquer l'utilisation prévisionnelle",
+  "text_1755599398258ce1ilgc5swg": "Débloquez l'utilisation prévisionnelle pour que les clients puissent voir leur utilisation prévisionnelle à la fin de chaque période et planifier leurs futurs coûts.",
+  "text_1755599398258mj61iwjhhfk": "Demander l'accès à l'utilisation prévisionnelle",
+  "text_1755599398258w59pin31rfe": "Bonjour, je souhaiterais accéder à votre complément d'utilisation prévisionnelle. \n\nVeuillez me contacter si vous avez besoin de plus d'informations !",
+  "text_65ae73ebe3a66bec2b91d72d": "Nous contacter",
+  "text_661ff6e56ef7e1b7c542b1ea": "Il s'agit d'un module complémentaire premium",
+  "text_661ff6e56ef7e1b7c542b1f6": "Les modules complémentaires premium sont disponibles sur demande. Veuillez contacter Lago pour débloquer cette nouvelle fonctionnalité."
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -149,5 +149,18 @@
   "text_1726576554903s2dddtq5qz4": "{{rate}} consumato",
   "text_1726576554903930hsa8vg23": "{{rate}} rimanente",
   "text_62c3f454e5d7f4ec8888c1d7": "Aggiungi un piano con costi a questo cliente per iniziare a segnalare l’utilizzo attuale.",
-  "text_1753094834414fgnvuior3iv": "Utilizzo attuale"
+  "text_1753094834414fgnvuior3iv": "Utilizzo attuale",
+  "text_1753094834414tu9mxavuco7": "Utilizzo previsto",
+  "text_1753095692838zn4t5a0wrg1": "Utilizzo totale previsto",
+  "text_17531019276915hby502cvzy": "Unità previste",
+  "text_1753101927691j5chrkhmoma": "Importo previsto",
+  "text_1754662542899l1ms7k49n67": "Aggiungi un piano con costi a questo cliente per iniziare a segnalare l'utilizzo previsto",
+  "text_1754662684478jvakvxllwie": "Questo abbonamento non è ancora attivo. L'utilizzo previsto viene visualizzato solo per gli abbonamenti attivi.",
+  "text_1755599398258j905gj9xihx": "Sblocca l'utilizzo previsto",
+  "text_1755599398258ce1ilgc5swg": "Sblocca l'utilizzo previsto in modo che i clienti possano vedere il loro utilizzo previsto alla fine di ogni periodo e pianificare i costi futuri.",
+  "text_1755599398258mj61iwjhhfk": "Richiedi l'accesso all'utilizzo previsto",
+  "text_1755599398258w59pin31rfe": "Salve, vorrei accedere al vostro add-on per l'utilizzo previsto. \n\nFatemelo sapere se avete bisogno di ulteriori informazioni!",
+  "text_65ae73ebe3a66bec2b91d72d": "Contattaci",
+  "text_661ff6e56ef7e1b7c542b1ea": "Questo è un add-on premium",
+  "text_661ff6e56ef7e1b7c542b1f6": "Gli add-on premium sono disponibili su richiesta. Contatta Lago per sbloccare questa nuova funzionalità."
 }

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -175,5 +175,18 @@
   "text_1726576554903s2dddtq5qz4": "{{rate}} forbrukt",
   "text_1726576554903930hsa8vg23": "{{rate}} gjenstår",
   "text_62c3f454e5d7f4ec8888c1d7": "Legg til en plan med kostnader for denne kunden for å begynne å rapportere nåværende bruk.",
-  "text_1753094834414fgnvuior3iv": "Nåværende bruk"
+  "text_1753094834414fgnvuior3iv": "Nåværende bruk",
+  "text_1753094834414tu9mxavuco7": "Projisert bruk",
+  "text_1753095692838zn4t5a0wrg1": "Total projisert bruk",
+  "text_17531019276915hby502cvzy": "Projiserte enheter",
+  "text_1753101927691j5chrkhmoma": "Projisert beløp",
+  "text_1754662542899l1ms7k49n67": "Legg til en plan med kostnader for denne kunden for å begynne å rapportere den projiserte bruken",
+  "text_1754662684478jvakvxllwie": "Dette abonnementet er ennå ikke aktivt. Projisert bruk vises bare for aktive abonnementer.",
+  "text_1755599398258j905gj9xihx": "Lås opp forventet bruk",
+  "text_1755599398258ce1ilgc5swg": "Lås opp forventet bruk slik at kundene kan se forventet bruk ved slutten av hver periode og planlegge kommende kostnader.",
+  "text_1755599398258mj61iwjhhfk": "Be om tilgang til forventet bruk",
+  "text_1755599398258w59pin31rfe": "Hei, jeg ønsker tilgang til tilleggsfunksjonen for forventet bruk. \n\nGi meg beskjed hvis du trenger mer informasjon!",
+  "text_65ae73ebe3a66bec2b91d72d": "Kontakt oss",
+  "text_661ff6e56ef7e1b7c542b1ea": "Dette er en premium-tilleggsfunksjon",
+  "text_661ff6e56ef7e1b7c542b1f6": "Premium-tilleggsfunksjoner er tilgjengelige på forespørsel. Kontakt Lago for å låse opp denne nye funksjonen."
 }

--- a/translations/pt_BR.json
+++ b/translations/pt_BR.json
@@ -3185,5 +3185,15 @@
   "text_1753095789277h17a2varizl": "(sem impostos)",
   "text_1753095789277t9kbe8y5pmh": "Unidades atuais",
   "text_1753101927691fbbwyk7p39q": "Valor atual",
-  "text_1753094834414fgnvuior3iv": "Uso atual"
+  "text_1753094834414fgnvuior3iv": "Uso actual",
+  "text_1753094834414tu9mxavuco7": "Uso projetado",
+  "text_1753095692838zn4t5a0wrg1": "Uso total projetado",
+  "text_17531019276915hby502cvzy": "Unidades projetadas",
+  "text_1753101927691j5chrkhmoma": "Valor projetado",
+  "text_1754662542899l1ms7k49n67": "Adicione um plano com cobranças a este cliente para começar a relatar o uso projetado",
+  "text_1754662684478jvakvxllwie": "Esta assinatura ainda não está ativa. O uso projetado é exibido apenas para assinaturas ativas.",
+  "text_1755599398258j905gj9xihx": "Desbloquear uso projetado",
+  "text_1755599398258ce1ilgc5swg": "Desbloqueie o uso projetado para que os clientes possam ver o uso esperado no final de cada período e planejar os custos futuros.",
+  "text_1755599398258mj61iwjhhfk": "Solicitar acesso ao uso projetado",
+  "text_1755599398258w59pin31rfe": "Olá, gostaria de acessar seu complemento de uso projetado. \n\nEntre em contato se precisar de mais informações!"
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -176,5 +176,18 @@
   "text_1726576554903s2dddtq5qz4": "{{rate}} förbrukad",
   "text_1726576554903930hsa8vg23": "{{rate}} gjenstår",
   "text_62c3f454e5d7f4ec8888c1d7": "Lägg till en plan med avgifter för den här kunden för att börja rapportera den aktuella användningen.",
-  "text_1753094834414fgnvuior3iv": "Aktuell användning"
+  "text_1753094834414fgnvuior3iv": "Aktuell användning",
+  "text_1753094834414tu9mxavuco7": "Beräknad användning",
+  "text_1753095692838zn4t5a0wrg1": "Total beräknad användning",
+  "text_17531019276915hby502cvzy": "Beräknade enheter",
+  "text_1753101927691j5chrkhmoma": "Beräknat belopp",
+  "text_1754662542899l1ms7k49n67": "Lägg till en plan med avgifter för denna kund för att börja rapportera den beräknade användningen",
+  "text_1754662684478jvakvxllwie": "Denna prenumeration är ännu inte aktiv. Beräknad användning visas endast för aktiva prenumerationer.",
+  "text_1755599398258j905gj9xihx": "Lås upp beräknad användning",
+  "text_1755599398258ce1ilgc5swg": "Lås upp beräknad användning så att kunderna kan se sin förväntade användning i slutet av varje period och planera för kommande kostnader.",
+  "text_1755599398258mj61iwjhhfk": "Begär åtkomst till beräknad användning",
+  "text_1755599398258w59pin31rfe": "Hej, jag skulle vilja få åtkomst till ert tillägg för beräknad användning. \n\nHör av er om ni behöver mer information!",
+  "text_65ae73ebe3a66bec2b91d72d": "Kontakta oss",
+  "text_661ff6e56ef7e1b7c542b1ea": "Detta är ett premiumtillägg",
+  "text_661ff6e56ef7e1b7c542b1f6": "Premiumtillägg är tillgängliga på begäran. Kontakta Lago för att låsa upp den här nya funktionen."
 }


### PR DESCRIPTION
## Context

Add missing translations for projected usage

## Description

https://lago-eu.sentry.io/issues/59256593/?referrer=slack&notification_uuid=a1bd1c6c-3d60-4b2e-8748-d45d3768cf78&alert_rule_id=172021&alert_type=issue