### PR TITLE
bug: only display fee boundary for one-off invoices

### DIFF
--- a/src/components/invoices/details/InvoiceDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTable.tsx
@@ -295,6 +295,7 @@ export const InvoiceDetailsTable = memo(
                   key={`one-off-fee-${i}`}
                   canHaveUnitPrice={canHaveUnitPrice}
                   currency={currency}
+                  displayFeeBoundaries={true}
                   displayName={
                     invoice.invoiceType === InvoiceTypeEnum.AddOn
                       ? translate('text_6388baa2e514213fed583611', { name: fee.itemName })

--- a/src/components/invoices/details/InvoiceDetailsTableBodyLine.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableBodyLine.tsx
@@ -107,6 +107,7 @@ type InvoiceDetailsTableBodyLineProps = {
   fee: TExtendedRemainingFee | undefined
   isDraftInvoice: boolean
   hideVat?: boolean
+  displayFeeBoundaries?: boolean
   editFeeDrawerRef?: RefObject<EditFeeDrawerRef>
   deleteAdjustedFeeDialogRef?: RefObject<DeleteAdjustedFeeDialogRef>
   succeededDate?: string
@@ -182,6 +183,7 @@ export const InvoiceDetailsTableBodyLine = memo(
     fee,
     hideVat,
     isDraftInvoice,
+    displayFeeBoundaries,
     succeededDate,
     hasTaxProviderError,
     onAdd,
@@ -264,14 +266,16 @@ export const InvoiceDetailsTableBodyLine = memo(
                 </Typography>
               )}
             </Stack>
-            {!!fee?.properties?.fromDatetime && !!fee?.properties?.toDatetime && (
-              <Typography variant="caption" color="grey600">
-                {translate('text_633dae57ca9a923dd53c2097', {
-                  fromDate: intlFormatDateTime(fee.properties.fromDatetime).date,
-                  toDate: intlFormatDateTime(fee.properties.toDatetime).date,
-                })}
-              </Typography>
-            )}
+            {displayFeeBoundaries &&
+              !!fee?.properties?.fromDatetime &&
+              !!fee?.properties?.toDatetime && (
+                <Typography variant="caption" color="grey600">
+                  {translate('text_633dae57ca9a923dd53c2097', {
+                    fromDate: intlFormatDateTime(fee.properties.fromDatetime).date,
+                    toDate: intlFormatDateTime(fee.properties.toDatetime).date,
+                  })}
+                </Typography>
+              )}
             {(succeededDate || !!subLabel) && (
               <Typography variant="caption" color="grey600">
                 {succeededDate}


### PR DESCRIPTION
## Context

We recently added the possibility to set boundaries on one of the invoices, however those were also shown on classic invoices details.

## Description

This RP fixes that, and only show the boundary when invoice displays a one-off invoice type.

<!-- Linear link -->
Fixes ISSUE-1053