### PR TITLE
fix: generate payment link tab

### DIFF
--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -178,14 +178,19 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
   })
 
   const [generatePaymentUrl] = useGeneratePaymentUrlMutation({
+    context: {
+      silentErrorCodes: [LagoApiError.UnprocessableEntity],
+    },
     onCompleted({ generatePaymentUrl: generatedPaymentUrl }) {
       if (generatedPaymentUrl?.paymentUrl) {
         openNewTab(generatedPaymentUrl.paymentUrl)
       }
     },
+    onError(error) {
+      if (hasDefinedGQLError('MissingPaymentProviderCustomer', error)) {
         addToast({
-          severity: 'info',
-          translateKey: 'text_1753384873899kf7djox30b6',
+          severity: 'danger',
+          translateKey: 'text_1756225393560tonww8d3bgq',
         })
       }
     },

--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -35,7 +35,7 @@ import {
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { getTimezoneConfig, intlFormatDateTime } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
-import { handleDownloadFile } from '~/core/utils/downloadFiles'
+import { handleDownloadFile, openNewTab } from '~/core/utils/downloadFiles'
 import {
   CurrencyEnum,
   InvoiceForFinalizeInvoiceFragmentDoc,
@@ -180,7 +180,9 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
   const [generatePaymentUrl] = useGeneratePaymentUrlMutation({
     onCompleted({ generatePaymentUrl: generatedPaymentUrl }) {
       if (generatedPaymentUrl?.paymentUrl) {
-        copyToClipboard(generatedPaymentUrl.paymentUrl)
+        openNewTab(generatedPaymentUrl.paymentUrl)
+      }
+    },
         addToast({
           severity: 'info',
           translateKey: 'text_1753384873899kf7djox30b6',

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -128,9 +128,20 @@ const InvoicesList = ({
   })
 
   const [generatePaymentUrl] = useGeneratePaymentUrlMutation({
+    context: {
+      silentErrorCodes: [LagoApiError.UnprocessableEntity],
+    },
     onCompleted({ generatePaymentUrl: generatedPaymentUrl }) {
       if (generatedPaymentUrl?.paymentUrl) {
         openNewTab(generatedPaymentUrl.paymentUrl)
+      }
+    },
+    onError(resError) {
+      if (hasDefinedGQLError('MissingPaymentProviderCustomer', resError)) {
+        addToast({
+          severity: 'danger',
+          translateKey: 'text_1756225393560tonww8d3bgq',
+        })
       }
     },
   })

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -48,7 +48,7 @@ import {
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { intlFormatDateTime } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
-import { handleDownloadFile } from '~/core/utils/downloadFiles'
+import { handleDownloadFile, openNewTab } from '~/core/utils/downloadFiles'
 import { regeneratePath } from '~/core/utils/regenerateUtils'
 import {
   CurrencyEnum,
@@ -130,11 +130,7 @@ const InvoicesList = ({
   const [generatePaymentUrl] = useGeneratePaymentUrlMutation({
     onCompleted({ generatePaymentUrl: generatedPaymentUrl }) {
       if (generatedPaymentUrl?.paymentUrl) {
-        copyToClipboard(generatedPaymentUrl.paymentUrl)
-        addToast({
-          severity: 'info',
-          translateKey: 'text_1753384873899kf7djox30b6',
-        })
+        openNewTab(generatedPaymentUrl.paymentUrl)
       }
     },
   })

--- a/src/core/apolloClient/graphqlResolvers.tsx
+++ b/src/core/apolloClient/graphqlResolvers.tsx
@@ -35,6 +35,7 @@ export const typeDefs = gql`
     invoices_not_overdue
 
     # Object not found
+    missing_payment_provider_customer
     plan_not_found
 
     # SSO errors

--- a/src/core/utils/downloadFiles.ts
+++ b/src/core/utils/downloadFiles.ts
@@ -1,15 +1,13 @@
 import { addToast } from '~/core/apolloClient'
 
-export const handleDownloadFile = (fileUrl?: string | null) => {
-  const showError = () => {
-    addToast({
-      severity: 'danger',
-      translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-    })
-  }
+const showError = () => {
+  addToast({
+    severity: 'danger',
+    translateKey: 'text_62b31e1f6a5b8b1b745ece48',
+  })
+}
 
-  if (!fileUrl) return showError()
-
+export const openNewTab = (url: string) => {
   // We open a window, add url then focus on different lines, in order to prevent browsers to block page opening
   // It could be seen as unexpected popup as not immediatly done on user action
   // https://stackoverflow.com/questions/2587677/avoid-browser-popup-blockers
@@ -18,11 +16,17 @@ export const handleDownloadFile = (fileUrl?: string | null) => {
     const myWindow = window.open('', '_blank')
 
     if (myWindow?.location?.href) {
-      myWindow.location.href = fileUrl
+      myWindow.location.href = url
       return myWindow?.focus()
     }
 
     myWindow?.close()
     showError()
   }, 0)
+}
+
+export const handleDownloadFile = (fileUrl?: string | null) => {
+  if (!fileUrl) return showError()
+
+  openNewTab(fileUrl)
 }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -4063,6 +4063,7 @@ export enum LagoApiError {
   InviteNotFound = 'invite_not_found',
   InvoicesNotOverdue = 'invoices_not_overdue',
   LoginMethodNotAuthorized = 'login_method_not_authorized',
+  MissingPaymentProviderCustomer = 'missing_payment_provider_customer',
   NotFound = 'not_found',
   NotOrganizationMember = 'not_organization_member',
   OktaLoginMethodNotAuthorized = 'okta_login_method_not_authorized',

--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -53,7 +53,7 @@ import {
 } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
-import { handleDownloadFile } from '~/core/utils/downloadFiles'
+import { handleDownloadFile, openNewTab } from '~/core/utils/downloadFiles'
 import { regeneratePath } from '~/core/utils/regenerateUtils'
 import {
   AllInvoiceDetailsForCustomerInvoiceDetailsFragment,
@@ -416,11 +416,7 @@ const CustomerInvoiceDetails = () => {
   const [generatePaymentUrl] = useGeneratePaymentUrlMutation({
     onCompleted({ generatePaymentUrl: generatedPaymentUrl }) {
       if (generatedPaymentUrl?.paymentUrl) {
-        copyToClipboard(generatedPaymentUrl.paymentUrl)
-        addToast({
-          severity: 'info',
-          translateKey: 'text_1753384873899kf7djox30b6',
-        })
+        openNewTab(generatedPaymentUrl.paymentUrl)
       }
     },
   })

--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -34,7 +34,7 @@ import { InvoiceCreditNoteList } from '~/components/invoices/InvoiceCreditNoteLi
 import { InvoicePaymentList } from '~/components/invoices/InvoicePaymentList'
 import { VoidInvoiceDialog, VoidInvoiceDialogRef } from '~/components/invoices/VoidInvoiceDialog'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
-import { addToast, envGlobalVar, LagoGQLError } from '~/core/apolloClient'
+import { addToast, envGlobalVar, hasDefinedGQLError, LagoGQLError } from '~/core/apolloClient'
 import { LocalTaxProviderErrorsEnum } from '~/core/constants/form'
 import { invoiceStatusMapping, paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
 import {
@@ -414,9 +414,20 @@ const CustomerInvoiceDetails = () => {
   })
 
   const [generatePaymentUrl] = useGeneratePaymentUrlMutation({
+    context: {
+      silentErrorCodes: [LagoApiError.UnprocessableEntity],
+    },
     onCompleted({ generatePaymentUrl: generatedPaymentUrl }) {
       if (generatedPaymentUrl?.paymentUrl) {
         openNewTab(generatedPaymentUrl.paymentUrl)
+      }
+    },
+    onError(resError) {
+      if (hasDefinedGQLError('MissingPaymentProviderCustomer', resError)) {
+        addToast({
+          severity: 'danger',
+          translateKey: 'text_1756225393560tonww8d3bgq',
+        })
       }
     },
   })

--- a/translations/base.json
+++ b/translations/base.json
@@ -3420,7 +3420,6 @@
   "text_1755599398258j905gj9xihx": "Unlock projected usage",
   "text_1755599398258ce1ilgc5swg": "Unlock projected usage so customers can see their expected usage at the end of each period and plan for upcoming costs.",
   "text_1755599398258mj61iwjhhfk": "Request access to projected usage",
-  "text_1755599398258w59pin31rfe": "Hello, I would like to access your projected usageadd-on. \n\nPlease let me know if you need more info!",
   "text_17538642230602p03937fj0f": "Control when customers gain or lose access to product features. Entitlements let you define which features are included in a plan or subscription.",
   "text_1753864223060kmmxk4a59aj": "Unlock Entitlements",
   "text_17538642230601w4ue2sz9iy": "Define the conditions under which customers receive or lose access to product features.",
@@ -3454,5 +3453,6 @@
   "text_17561254890574dcio8alli4": "Create entitlement",
   "text_17561254890579cfr8pj6afl": "By clicking 'Leave', the unsaved entitlement data will be lost forever. Are you sure you want to leave?",
   "text_1756217474408noiuzsd087w": "Edit feature",
+  "text_1755599398258w59pin31rfe": "Hello, I would like to access your projected usage add-on. \n\nPlease let me know if you need more info!",
   "text_1756225393560tonww8d3bgq": "We couldn’t generate a payment link for this invoice because the customer is not linked to a valid payment provider."
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -3454,5 +3454,6 @@
   "text_1756125489057qfgsq8im2b2": "Select a feature first",
   "text_17561254890574dcio8alli4": "Create entitlement",
   "text_17561254890579cfr8pj6afl": "By clicking 'Leave', the unsaved entitlement data will be lost forever. Are you sure you want to leave?",
-  "text_1756217474408noiuzsd087w": "Edit feature"
+  "text_1756217474408noiuzsd087w": "Edit feature",
+  "text_1756225393560tonww8d3bgq": "We couldn’t generate a payment link for this invoice because the customer is not linked to a valid payment provider."
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -3363,7 +3363,6 @@
   "text_175287350361170qk4c93fmm": "Privilege type",
   "text_1753122279978r7koj4iy2vy": "Privilege name (optional)",
   "text_1753384709668qrxbzpbskn8": "Get payment link",
-  "text_1753384873899kf7djox30b6": "Payment link have been copied to your clipboard",
   "text_1753094834414fgnvuior3iv": "Current usage",
   "text_1753094834414tu9mxavuco7": "Projected usage",
   "text_17530956928381jy5n59318d": "Total current usage",


### PR DESCRIPTION
## Context

On Safari, the copy to clipboard should follow a direct user interaction.
But in this case we're waiting for the BE to answer with the call. It's called transient user activation


## Description

When the url is fetched, open a new tab with the URL.
That will allow to manually copy the URL and fix the issue with Safari users

I've also add an error catching in case we're flagging an error with the PSP to display relevant toast message to the customer


Fixes issue-1044