### PR TITLE
fix: get payment link wording

### DIFF
--- a/translations/base.json
+++ b/translations/base.json
@@ -3362,7 +3362,7 @@
   "text_1752863499298r6x9j41ndoy": "Add predefined privilege values",
   "text_175287350361170qk4c93fmm": "Privilege type",
   "text_1753122279978r7koj4iy2vy": "Privilege name (optional)",
-  "text_1753384709668qrxbzpbskn8": "Get payment link",
+  "text_1753384709668qrxbzpbskn8": "Open payment link",
   "text_1753094834414fgnvuior3iv": "Current usage",
   "text_1753094834414tu9mxavuco7": "Projected usage",
   "text_17530956928381jy5n59318d": "Total current usage",


### PR DESCRIPTION
## Context

We now open a new tab instead of copy the link in the clipboard so we need to change to button label