### PR TITLE
fix(bcp-languages): Add LocaleBCPMapping constant

### DIFF
--- a/src/components/customerPortal/common/useCustomerPortalTranslate.ts
+++ b/src/components/customerPortal/common/useCustomerPortalTranslate.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 import { useParams } from 'react-router-dom'
 
-import { Locale, LocaleEnum } from '~/core/translations'
+import { Locale, LocaleBCPMapping, LocaleEnum } from '~/core/translations'
 import { useGetPortalLocaleQuery } from '~/generated/graphql'
 import { useIsAuthenticated } from '~/hooks/auth/useIsAuthenticated'
 import { useContextualLocale } from '~/hooks/core/useContextualLocale'
@@ -45,7 +45,7 @@ const useCustomerPortalTranslate = () => {
 
   return {
     translate,
-    documentLocale: documentLocale as LocaleEnum,
+    documentLocale: LocaleBCPMapping[documentLocale] as LocaleEnum,
     error,
     loading,
   }

--- a/src/core/translations/types.ts
+++ b/src/core/translations/types.ts
@@ -16,4 +16,17 @@ export enum LocaleEnum {
   sv = 'sv', // Swedish
   pt_BR = 'pt_BR', // Brazilian Portuguese
 }
+
+// Available locales in BCP 47 language formats
+export const LocaleBCPMapping: Record<LocaleEnum, string> = {
+  [LocaleEnum.en]: 'en',
+  [LocaleEnum.fr]: 'fr',
+  [LocaleEnum.nb]: 'nb',
+  [LocaleEnum.de]: 'de',
+  [LocaleEnum.it]: 'it',
+  [LocaleEnum.es]: 'es',
+  [LocaleEnum.sv]: 'sv',
+  [LocaleEnum.pt_BR]: 'pt-BR',
+}
+
 export type Locale = keyof typeof LocaleEnum


### PR DESCRIPTION
This allows the pt_BR language to used in Customer Portal. 
<img width="3024" height="1646" alt="app lago dev_customer-portal_eyJfcmFpbHMiOnsiZGF0YSI6ImEyYzhjMGNlLTQxNzktNGNjZC05NjIyLWM3N2RlODg1MTRkMiIsImV4cCI6IjIwMjUtMDgtMzBUMDI6MzA6NTUuNDI2WiJ9fQ==--4981fa579743bb5f858c7a85240fda283b5f9f1e" src="https://github.com/user-attachments/assets/7fd9c057-9dae-495e-a9a9-7e91b0e0040b" />

### Notice here that are 2 missing places that need to have the translations. 
Below the `mario's test` with `Manage your plans & billing`
At the invoice status, is `unpaid` and it should be translated to `Aberta` (or something like this, `Aberta` translation is `Open`, but for financial context is commonly used as unpaid status)
