### PR TITLE
misc: use plural copy

### DIFF
--- a/translations/base.json
+++ b/translations/base.json
@@ -717,7 +717,7 @@
   "text_62ab2d0396dd6b0361614da0": "Country",
   "text_63b6d06df1a53b7e2ad973ad": "The payment provider is currently processing the payment. Please try again later.",
   "text_62ab2d0396dd6b0361614d24": "Invoice settings",
-  "text_62ab2d0396dd6b0361614d44": "Information",
+  "text_62ab2d0396dd6b0361614d44": "Informations",
   "text_62ab2d0396dd6b0361614d6c": "Legal name",
   "text_62ab2d0396dd6b0361614d7c": "Legal number",
   "text_62ab2d0396dd6b0361614d8c": "Email",

--- a/translations/pt_BR.json
+++ b/translations/pt_BR.json
@@ -719,7 +719,7 @@
   "text_63b6d06df1a53b7e2ad973ad": "O provedor de pagamento está processando o pagamento no momento. Por favor, tente novamente mais tarde.",
   "text_62ab2d0396dd6b0361614d1e": "JPG ou PNG. Tamanho máximo de 800K",
   "text_62ab2d0396dd6b0361614d24": "Configurações da fatura",
-  "text_62ab2d0396dd6b0361614d44": "Informação",
+  "text_62ab2d0396dd6b0361614d44": "Informações",
   "text_62ab2d0396dd6b0361614d6c": "Razão Social",
   "text_62ab2d0396dd6b0361614d7c": "Número de registro (CNPJ/CPF)",
   "text_62ab2d0396dd6b0361614d8c": "E-mail",


### PR DESCRIPTION
While working on the doc, I noticed this copy should be using plural form in the app.