### PR TITLE
fix: undo dynamic width / move delete button in td

### DIFF
--- a/src/components/designSystem/Table/ChargeTable.tsx
+++ b/src/components/designSystem/Table/ChargeTable.tsx
@@ -92,15 +92,43 @@ export const ChargeTable = <T extends Record<string, unknown>>({
               data-test={`row-${i}`}
             >
               <>
-                {columns.map(({ content, mapKey }, j) => {
+                {columns.map(({ content, mapKey, size = 124 }, j) => {
+                  const sizeStyle = {
+                    width: `${size}px`,
+                    minWidth: `${size}px`,
+                    maxWidth: `${size}px`,
+                  }
                   return (
                     <td
                       className={tw(
                         CELL_HEIGHT,
-                        'w-full border-b border-r border-solid border-grey-300 p-0',
+                        'border-b border-r border-solid border-grey-300 p-0',
                       )}
+                      style={sizeStyle}
                       key={`table-${name}-cell-${i}-${j}`}
                     >
+                      {onDeleteRow && !row.disabledDelete && j === 0 && (
+                        <td
+                          className={tw(
+                            'absolute hidden w-fit rounded-lg bg-white',
+                            'group-hover/row:left-0 group-hover/row:top-0 group-hover/row:flex group-hover/row:-translate-x-3 group-hover/row:translate-y-3',
+                          )}
+                        >
+                          <Tooltip
+                            title={
+                              deleteTooltipContent ?? translate('text_62793bbb599f1c01522e9239')
+                            }
+                            placement="top-start"
+                          >
+                            <Button
+                              variant="tertiary"
+                              size="small"
+                              icon="trash"
+                              onClick={() => onDeleteRow(row, i)}
+                            />
+                          </Tooltip>
+                        </td>
+                      )}
                       {mapKey ? (
                         <Typography variant="body">{_get(row, mapKey) as string}</Typography>
                       ) : typeof content === 'function' ? (
@@ -111,26 +139,6 @@ export const ChargeTable = <T extends Record<string, unknown>>({
                     </td>
                   )
                 })}
-                {onDeleteRow && !row.disabledDelete && (
-                  <td
-                    className={tw(
-                      'absolute hidden w-fit rounded-lg bg-white',
-                      'group-hover/row:left-0 group-hover/row:top-0 group-hover/row:flex group-hover/row:-translate-x-3 group-hover/row:translate-y-3',
-                    )}
-                  >
-                    <Tooltip
-                      title={deleteTooltipContent ?? translate('text_62793bbb599f1c01522e9239')}
-                      placement="top-start"
-                    >
-                      <Button
-                        variant="tertiary"
-                        size="small"
-                        icon="trash"
-                        onClick={() => onDeleteRow(row, i)}
-                      />
-                    </Tooltip>
-                  </td>
-                )}
               </>
             </tr>
           )

--- a/src/components/designSystem/Table/ChargeTable.tsx
+++ b/src/components/designSystem/Table/ChargeTable.tsx
@@ -102,7 +102,7 @@ export const ChargeTable = <T extends Record<string, unknown>>({
                     <td
                       className={tw(
                         CELL_HEIGHT,
-                        'border-b border-r border-solid border-grey-300 p-0',
+                        'relative border-b border-r border-solid border-grey-300 p-0',
                       )}
                       style={sizeStyle}
                       key={`table-${name}-cell-${i}-${j}`}


### PR DESCRIPTION
## Context

Reverts the change done in https://github.com/getlago/lago-front/pull/2415 and moves the delete button into the first cell.

## Description

The fluid width was breaking the table in some screens (progressive billing recurring thresholds, alert thresholds), because the first cell was being width-greedy. Reverted the change, and fixed the initial issue (the delete button making the table render and extra cell, thus making it jump around).

<!-- Linear link -->
Fixes LAGO-1098