### PR TITLE
feat: Only call projected usage on tab switch

### DIFF
--- a/src/components/customers/usage/SubscriptionUsageDetailDrawer.tsx
+++ b/src/components/customers/usage/SubscriptionUsageDetailDrawer.tsx
@@ -1,5 +1,6 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { update } from 'lodash'
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
 
 import {
   Button,
@@ -229,10 +230,27 @@ export const SubscriptionUsageDetailDrawer = forwardRef<
     const drawerRef = useRef<DrawerRef>(null)
     const [usage, setUsage] = useState<ChargeUsage | ProjectedChargeUsage>()
     const [refreshFunction, setRefreshFunction] =
-      useState<() => Promise<ChargeUsage | ProjectedChargeUsage | undefined>>()
+      useState<
+        (forceProjected?: boolean) => Promise<ChargeUsage | ProjectedChargeUsage | undefined>
+      >()
     const [activeTab, setActiveTab] = useState<number>(0)
+    const [fetchedProjected, setFetchedProjected] = useState(false)
 
     const showProjected = activeTab === 1
+
+    useEffect(() => {
+      const f = async () => {
+        if (showProjected && !fetchedProjected) {
+          const res = await refreshFunction?.(true)
+
+          setUsage(res)
+
+          setFetchedProjected(true)
+        }
+      }
+
+      f()
+    }, [fetchedProjected, refreshFunction, showProjected])
 
     const TRANSLATION_MAP = showProjected
       ? {
@@ -258,6 +276,11 @@ export const SubscriptionUsageDetailDrawer = forwardRef<
         setUsage(data)
         setRefreshFunction(() => refreshData)
         setActiveTab(defaultTab || 0)
+
+        if (defaultTab === 1) {
+          setFetchedProjected(true)
+        }
+
         drawerRef.current?.openDrawer()
       },
       closeDialog: () => drawerRef.current?.closeDrawer(),

--- a/src/components/customers/usage/SubscriptionUsageDetailDrawer.tsx
+++ b/src/components/customers/usage/SubscriptionUsageDetailDrawer.tsx
@@ -275,10 +275,7 @@ export const SubscriptionUsageDetailDrawer = forwardRef<
         setUsage(data)
         setRefreshFunction(() => refreshData)
         setActiveTab(defaultTab || 0)
-
-        if (defaultTab === 1) {
-          setFetchedProjected(true)
-        }
+        setFetchedProjected(defaultTab === 1)
 
         drawerRef.current?.openDrawer()
       },

--- a/src/components/customers/usage/SubscriptionUsageDetailDrawer.tsx
+++ b/src/components/customers/usage/SubscriptionUsageDetailDrawer.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { update } from 'lodash'
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
 
 import {


### PR DESCRIPTION
## Context

Jeremy suggested that we should only call the projected usage endpoint after switching tabs. This is to prevent an extra heavy call going to the API.

## Description

Since the initial implementation assumed that we either call the regular query or the projected one, we had to do some changes:
- Hoist tab state
- Make sure to call the projected usage query only once (no matter how many times the user switches the tab)
- Enable drawer to call projected refetch directly

<!-- Linear link -->
Fixes LAGO-964