### PR TITLE
fix: Revenue streams - Show customers gross instead of net

### DIFF
--- a/src/components/analytics/revenueStreams/RevenueStreamsCustomerBreakdownSection.tsx
+++ b/src/components/analytics/revenueStreams/RevenueStreamsCustomerBreakdownSection.tsx
@@ -28,8 +28,8 @@ gql`
         customerDeletedAt
         customerName
         externalCustomerId
-        netRevenueAmountCents
-        netRevenueShare
+        grossRevenueAmountCents
+        grossRevenueShare
       }
       metadata {
         currentPage
@@ -175,16 +175,16 @@ export const RevenueStreamsCustomerBreakdownSection = ({
               },
             },
             {
-              key: 'netRevenueShare',
+              key: 'grossRevenueShare',
               title: translate('text_17422232171950c2u9u3vuq7'),
               textAlign: 'right',
               minWidth: 134,
-              content({ netRevenueShare, netRevenueAmountCents, amountCurrency }) {
+              content({ grossRevenueShare, grossRevenueAmountCents, amountCurrency }) {
                 return (
                   <div className="flex items-center gap-2">
                     <Typography variant="body" color="grey700">
                       {intlFormatNumber(
-                        deserializeAmount(netRevenueAmountCents || 0, amountCurrency),
+                        deserializeAmount(grossRevenueAmountCents || 0, amountCurrency),
                         {
                           style: 'currency',
                           currency: amountCurrency,
@@ -192,7 +192,7 @@ export const RevenueStreamsCustomerBreakdownSection = ({
                       )}
                     </Typography>
                     <Typography className="w-16 text-right" variant="body" color="grey600">
-                      {intlFormatNumber(netRevenueShare || 0, { style: 'percent' })}
+                      {intlFormatNumber(grossRevenueShare || 0, { style: 'percent' })}
                     </Typography>
                   </div>
                 )

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -854,7 +854,7 @@ export enum CommitmentTypeEnum {
 export enum CountryCode {
   /** Andorra */
   Ad = 'AD',
-  /** United Arab Emirates (the) */
+  /** United Arab Emirates */
   Ae = 'AE',
   /** Afghanistan */
   Af = 'AF',
@@ -914,7 +914,7 @@ export enum CountryCode {
   Bq = 'BQ',
   /** Brazil */
   Br = 'BR',
-  /** Bahamas (the) */
+  /** Bahamas */
   Bs = 'BS',
   /** Bhutan */
   Bt = 'BT',
@@ -928,19 +928,19 @@ export enum CountryCode {
   Bz = 'BZ',
   /** Canada */
   Ca = 'CA',
-  /** Cocos (Keeling) Islands (the) */
+  /** Cocos (Keeling) Islands */
   Cc = 'CC',
-  /** Congo (the Democratic Republic of the) */
+  /** Congo (Democratic Republic of the) */
   Cd = 'CD',
-  /** Central African Republic (the) */
+  /** Central African Republic */
   Cf = 'CF',
-  /** Congo (the) */
+  /** Congo */
   Cg = 'CG',
   /** Switzerland */
   Ch = 'CH',
   /** Côte d'Ivoire */
   Ci = 'CI',
-  /** Cook Islands (the) */
+  /** Cook Islands */
   Ck = 'CK',
   /** Chile */
   Cl = 'CL',
@@ -972,7 +972,7 @@ export enum CountryCode {
   Dk = 'DK',
   /** Dominica */
   Dm = 'DM',
-  /** Dominican Republic (the) */
+  /** Dominican Republic */
   Do = 'DO',
   /** Algeria */
   Dz = 'DZ',
@@ -994,17 +994,17 @@ export enum CountryCode {
   Fi = 'FI',
   /** Fiji */
   Fj = 'FJ',
-  /** Falkland Islands (the) [Malvinas] */
+  /** Falkland Islands (Malvinas) */
   Fk = 'FK',
   /** Micronesia (Federated States of) */
   Fm = 'FM',
-  /** Faroe Islands (the) */
+  /** Faroe Islands */
   Fo = 'FO',
   /** France */
   Fr = 'FR',
   /** Gabon */
   Ga = 'GA',
-  /** United Kingdom of Great Britain and Northern Ireland (the) */
+  /** United Kingdom of Great Britain and Northern Ireland */
   Gb = 'GB',
   /** Grenada */
   Gd = 'GD',
@@ -1020,7 +1020,7 @@ export enum CountryCode {
   Gi = 'GI',
   /** Greenland */
   Gl = 'GL',
-  /** Gambia (the) */
+  /** Gambia */
   Gm = 'GM',
   /** Guinea */
   Gn = 'GN',
@@ -1062,7 +1062,7 @@ export enum CountryCode {
   Im = 'IM',
   /** India */
   In = 'IN',
-  /** British Indian Ocean Territory (the) */
+  /** British Indian Ocean Territory */
   Io = 'IO',
   /** Iraq */
   Iq = 'IQ',
@@ -1088,21 +1088,21 @@ export enum CountryCode {
   Kh = 'KH',
   /** Kiribati */
   Ki = 'KI',
-  /** Comoros (the) */
+  /** Comoros */
   Km = 'KM',
   /** Saint Kitts and Nevis */
   Kn = 'KN',
-  /** Korea (the Democratic People's Republic of) */
+  /** Korea (Democratic People's Republic of) */
   Kp = 'KP',
-  /** Korea (the Republic of) */
+  /** Korea (Republic of) */
   Kr = 'KR',
   /** Kuwait */
   Kw = 'KW',
-  /** Cayman Islands (the) */
+  /** Cayman Islands */
   Ky = 'KY',
   /** Kazakhstan */
   Kz = 'KZ',
-  /** Lao People's Democratic Republic (the) */
+  /** Lao People's Democratic Republic */
   La = 'LA',
   /** Lebanon */
   Lb = 'LB',
@@ -1128,7 +1128,7 @@ export enum CountryCode {
   Ma = 'MA',
   /** Monaco */
   Mc = 'MC',
-  /** Moldova (the Republic of) */
+  /** Moldova (Republic of) */
   Md = 'MD',
   /** Montenegro */
   Me = 'ME',
@@ -1136,7 +1136,7 @@ export enum CountryCode {
   Mf = 'MF',
   /** Madagascar */
   Mg = 'MG',
-  /** Marshall Islands (the) */
+  /** Marshall Islands */
   Mh = 'MH',
   /** North Macedonia */
   Mk = 'MK',
@@ -1148,7 +1148,7 @@ export enum CountryCode {
   Mn = 'MN',
   /** Macao */
   Mo = 'MO',
-  /** Northern Mariana Islands (the) */
+  /** Northern Mariana Islands */
   Mp = 'MP',
   /** Martinique */
   Mq = 'MQ',
@@ -1174,7 +1174,7 @@ export enum CountryCode {
   Na = 'NA',
   /** New Caledonia */
   Nc = 'NC',
-  /** Niger (the) */
+  /** Niger */
   Ne = 'NE',
   /** Norfolk Island */
   Nf = 'NF',
@@ -1182,7 +1182,7 @@ export enum CountryCode {
   Ng = 'NG',
   /** Nicaragua */
   Ni = 'NI',
-  /** Netherlands (the) */
+  /** Netherlands */
   Nl = 'NL',
   /** Norway */
   No = 'NO',
@@ -1204,7 +1204,7 @@ export enum CountryCode {
   Pf = 'PF',
   /** Papua New Guinea */
   Pg = 'PG',
-  /** Philippines (the) */
+  /** Philippines */
   Ph = 'PH',
   /** Pakistan */
   Pk = 'PK',
@@ -1232,7 +1232,7 @@ export enum CountryCode {
   Ro = 'RO',
   /** Serbia */
   Rs = 'RS',
-  /** Russian Federation (the) */
+  /** Russian Federation */
   Ru = 'RU',
   /** Rwanda */
   Rw = 'RW',
@@ -1242,7 +1242,7 @@ export enum CountryCode {
   Sb = 'SB',
   /** Seychelles */
   Sc = 'SC',
-  /** Sudan (the) */
+  /** Sudan */
   Sd = 'SD',
   /** Sweden */
   Se = 'SE',
@@ -1278,11 +1278,11 @@ export enum CountryCode {
   Sy = 'SY',
   /** Eswatini */
   Sz = 'SZ',
-  /** Turks and Caicos Islands (the) */
+  /** Turks and Caicos Islands */
   Tc = 'TC',
   /** Chad */
   Td = 'TD',
-  /** French Southern Territories (the) */
+  /** French Southern Territories */
   Tf = 'TF',
   /** Togo */
   Tg = 'TG',
@@ -1306,7 +1306,7 @@ export enum CountryCode {
   Tt = 'TT',
   /** Tuvalu */
   Tv = 'TV',
-  /** Taiwan (Province of China) */
+  /** Taiwan, Province of China */
   Tw = 'TW',
   /** Tanzania, United Republic of */
   Tz = 'TZ',
@@ -1314,15 +1314,15 @@ export enum CountryCode {
   Ua = 'UA',
   /** Uganda */
   Ug = 'UG',
-  /** United States Minor Outlying Islands (the) */
+  /** United States Minor Outlying Islands */
   Um = 'UM',
-  /** United States of America (the) */
+  /** United States of America */
   Us = 'US',
   /** Uruguay */
   Uy = 'UY',
   /** Uzbekistan */
   Uz = 'UZ',
-  /** Holy See (the) */
+  /** Holy See */
   Va = 'VA',
   /** Saint Vincent and the Grenadines */
   Vc = 'VC',
@@ -1340,8 +1340,6 @@ export enum CountryCode {
   Wf = 'WF',
   /** Samoa */
   Ws = 'WS',
-  /** Kosovo */
-  Xk = 'XK',
   /** Yemen */
   Ye = 'YE',
   /** Mayotte */
@@ -5663,6 +5661,7 @@ export type PlanEntitlementPrivilegeObject = {
 export enum PlanInterval {
   Monthly = 'monthly',
   Quarterly = 'quarterly',
+  Semiannual = 'semiannual',
   Weekly = 'weekly',
   Yearly = 'yearly'
 }
@@ -6810,6 +6809,7 @@ export type QueryWebhooksArgs = {
 export enum RecurringTransactionIntervalEnum {
   Monthly = 'monthly',
   Quarterly = 'quarterly',
+  Semiannual = 'semiannual',
   Weekly = 'weekly',
   Yearly = 'yearly'
 }
@@ -8540,7 +8540,7 @@ export type GetRevenueStreamsCustomerBreakdownQueryVariables = Exact<{
 }>;
 
 
-export type GetRevenueStreamsCustomerBreakdownQuery = { __typename?: 'Query', dataApiRevenueStreamsCustomers: { __typename?: 'DataApiRevenueStreamsCustomers', collection: Array<{ __typename?: 'DataApiRevenueStreamCustomer', amountCurrency: CurrencyEnum, customerDeletedAt?: any | null, customerName?: string | null, externalCustomerId: string, netRevenueAmountCents: any, netRevenueShare?: number | null }>, metadata: { __typename?: 'DataApiMetadata', currentPage: number, totalPages: number } } };
+export type GetRevenueStreamsCustomerBreakdownQuery = { __typename?: 'Query', dataApiRevenueStreamsCustomers: { __typename?: 'DataApiRevenueStreamsCustomers', collection: Array<{ __typename?: 'DataApiRevenueStreamCustomer', amountCurrency: CurrencyEnum, customerDeletedAt?: any | null, customerName?: string | null, externalCustomerId: string, grossRevenueAmountCents: any, grossRevenueShare?: number | null }>, metadata: { __typename?: 'DataApiMetadata', currentPage: number, totalPages: number } } };
 
 export type RevenueStreamDataForOverviewSectionFragment = { __typename?: 'DataApiRevenueStream', commitmentFeeAmountCents: any, couponsAmountCents: any, endOfPeriodDt: any, grossRevenueAmountCents: any, netRevenueAmountCents: any, oneOffFeeAmountCents: any, startOfPeriodDt: any, subscriptionFeeAmountCents: any, usageBasedFeeAmountCents: any, contraRevenueAmountCents?: any | null, creditNotesCreditsAmountCents?: any | null, freeCreditsAmountCents?: any | null, prepaidCreditsAmountCents?: any | null, progressiveBillingCreditAmountCents?: any | null };
 
@@ -16947,8 +16947,8 @@ export const GetRevenueStreamsCustomerBreakdownDocument = gql`
       customerDeletedAt
       customerName
       externalCustomerId
-      netRevenueAmountCents
-      netRevenueShare
+      grossRevenueAmountCents
+      grossRevenueShare
     }
     metadata {
       currentPage

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -854,7 +854,7 @@ export enum CommitmentTypeEnum {
 export enum CountryCode {
   /** Andorra */
   Ad = 'AD',
-  /** United Arab Emirates */
+  /** United Arab Emirates (the) */
   Ae = 'AE',
   /** Afghanistan */
   Af = 'AF',
@@ -914,7 +914,7 @@ export enum CountryCode {
   Bq = 'BQ',
   /** Brazil */
   Br = 'BR',
-  /** Bahamas */
+  /** Bahamas (the) */
   Bs = 'BS',
   /** Bhutan */
   Bt = 'BT',
@@ -928,19 +928,19 @@ export enum CountryCode {
   Bz = 'BZ',
   /** Canada */
   Ca = 'CA',
-  /** Cocos (Keeling) Islands */
+  /** Cocos (Keeling) Islands (the) */
   Cc = 'CC',
-  /** Congo (Democratic Republic of the) */
+  /** Congo (the Democratic Republic of the) */
   Cd = 'CD',
-  /** Central African Republic */
+  /** Central African Republic (the) */
   Cf = 'CF',
-  /** Congo */
+  /** Congo (the) */
   Cg = 'CG',
   /** Switzerland */
   Ch = 'CH',
   /** Côte d'Ivoire */
   Ci = 'CI',
-  /** Cook Islands */
+  /** Cook Islands (the) */
   Ck = 'CK',
   /** Chile */
   Cl = 'CL',
@@ -972,7 +972,7 @@ export enum CountryCode {
   Dk = 'DK',
   /** Dominica */
   Dm = 'DM',
-  /** Dominican Republic */
+  /** Dominican Republic (the) */
   Do = 'DO',
   /** Algeria */
   Dz = 'DZ',
@@ -994,17 +994,17 @@ export enum CountryCode {
   Fi = 'FI',
   /** Fiji */
   Fj = 'FJ',
-  /** Falkland Islands (Malvinas) */
+  /** Falkland Islands (the) [Malvinas] */
   Fk = 'FK',
   /** Micronesia (Federated States of) */
   Fm = 'FM',
-  /** Faroe Islands */
+  /** Faroe Islands (the) */
   Fo = 'FO',
   /** France */
   Fr = 'FR',
   /** Gabon */
   Ga = 'GA',
-  /** United Kingdom of Great Britain and Northern Ireland */
+  /** United Kingdom of Great Britain and Northern Ireland (the) */
   Gb = 'GB',
   /** Grenada */
   Gd = 'GD',
@@ -1020,7 +1020,7 @@ export enum CountryCode {
   Gi = 'GI',
   /** Greenland */
   Gl = 'GL',
-  /** Gambia */
+  /** Gambia (the) */
   Gm = 'GM',
   /** Guinea */
   Gn = 'GN',
@@ -1062,7 +1062,7 @@ export enum CountryCode {
   Im = 'IM',
   /** India */
   In = 'IN',
-  /** British Indian Ocean Territory */
+  /** British Indian Ocean Territory (the) */
   Io = 'IO',
   /** Iraq */
   Iq = 'IQ',
@@ -1088,21 +1088,21 @@ export enum CountryCode {
   Kh = 'KH',
   /** Kiribati */
   Ki = 'KI',
-  /** Comoros */
+  /** Comoros (the) */
   Km = 'KM',
   /** Saint Kitts and Nevis */
   Kn = 'KN',
-  /** Korea (Democratic People's Republic of) */
+  /** Korea (the Democratic People's Republic of) */
   Kp = 'KP',
-  /** Korea (Republic of) */
+  /** Korea (the Republic of) */
   Kr = 'KR',
   /** Kuwait */
   Kw = 'KW',
-  /** Cayman Islands */
+  /** Cayman Islands (the) */
   Ky = 'KY',
   /** Kazakhstan */
   Kz = 'KZ',
-  /** Lao People's Democratic Republic */
+  /** Lao People's Democratic Republic (the) */
   La = 'LA',
   /** Lebanon */
   Lb = 'LB',
@@ -1128,7 +1128,7 @@ export enum CountryCode {
   Ma = 'MA',
   /** Monaco */
   Mc = 'MC',
-  /** Moldova (Republic of) */
+  /** Moldova (the Republic of) */
   Md = 'MD',
   /** Montenegro */
   Me = 'ME',
@@ -1136,7 +1136,7 @@ export enum CountryCode {
   Mf = 'MF',
   /** Madagascar */
   Mg = 'MG',
-  /** Marshall Islands */
+  /** Marshall Islands (the) */
   Mh = 'MH',
   /** North Macedonia */
   Mk = 'MK',
@@ -1148,7 +1148,7 @@ export enum CountryCode {
   Mn = 'MN',
   /** Macao */
   Mo = 'MO',
-  /** Northern Mariana Islands */
+  /** Northern Mariana Islands (the) */
   Mp = 'MP',
   /** Martinique */
   Mq = 'MQ',
@@ -1174,7 +1174,7 @@ export enum CountryCode {
   Na = 'NA',
   /** New Caledonia */
   Nc = 'NC',
-  /** Niger */
+  /** Niger (the) */
   Ne = 'NE',
   /** Norfolk Island */
   Nf = 'NF',
@@ -1182,7 +1182,7 @@ export enum CountryCode {
   Ng = 'NG',
   /** Nicaragua */
   Ni = 'NI',
-  /** Netherlands */
+  /** Netherlands (the) */
   Nl = 'NL',
   /** Norway */
   No = 'NO',
@@ -1204,7 +1204,7 @@ export enum CountryCode {
   Pf = 'PF',
   /** Papua New Guinea */
   Pg = 'PG',
-  /** Philippines */
+  /** Philippines (the) */
   Ph = 'PH',
   /** Pakistan */
   Pk = 'PK',
@@ -1232,7 +1232,7 @@ export enum CountryCode {
   Ro = 'RO',
   /** Serbia */
   Rs = 'RS',
-  /** Russian Federation */
+  /** Russian Federation (the) */
   Ru = 'RU',
   /** Rwanda */
   Rw = 'RW',
@@ -1242,7 +1242,7 @@ export enum CountryCode {
   Sb = 'SB',
   /** Seychelles */
   Sc = 'SC',
-  /** Sudan */
+  /** Sudan (the) */
   Sd = 'SD',
   /** Sweden */
   Se = 'SE',
@@ -1278,11 +1278,11 @@ export enum CountryCode {
   Sy = 'SY',
   /** Eswatini */
   Sz = 'SZ',
-  /** Turks and Caicos Islands */
+  /** Turks and Caicos Islands (the) */
   Tc = 'TC',
   /** Chad */
   Td = 'TD',
-  /** French Southern Territories */
+  /** French Southern Territories (the) */
   Tf = 'TF',
   /** Togo */
   Tg = 'TG',
@@ -1306,7 +1306,7 @@ export enum CountryCode {
   Tt = 'TT',
   /** Tuvalu */
   Tv = 'TV',
-  /** Taiwan, Province of China */
+  /** Taiwan (Province of China) */
   Tw = 'TW',
   /** Tanzania, United Republic of */
   Tz = 'TZ',
@@ -1314,15 +1314,15 @@ export enum CountryCode {
   Ua = 'UA',
   /** Uganda */
   Ug = 'UG',
-  /** United States Minor Outlying Islands */
+  /** United States Minor Outlying Islands (the) */
   Um = 'UM',
-  /** United States of America */
+  /** United States of America (the) */
   Us = 'US',
   /** Uruguay */
   Uy = 'UY',
   /** Uzbekistan */
   Uz = 'UZ',
-  /** Holy See */
+  /** Holy See (the) */
   Va = 'VA',
   /** Saint Vincent and the Grenadines */
   Vc = 'VC',
@@ -1340,6 +1340,8 @@ export enum CountryCode {
   Wf = 'WF',
   /** Samoa */
   Ws = 'WS',
+  /** Kosovo */
+  Xk = 'XK',
   /** Yemen */
   Ye = 'YE',
   /** Mayotte */
@@ -3528,6 +3530,15 @@ export type FixedChargeInput = {
   units?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type FixedChargeOverridesInput = {
+  addOnId: Scalars['ID']['input'];
+  id?: InputMaybe<Scalars['ID']['input']>;
+  invoiceDisplayName?: InputMaybe<Scalars['String']['input']>;
+  properties?: InputMaybe<FixedChargePropertiesInput>;
+  taxCodes?: InputMaybe<Array<Scalars['String']['input']>>;
+  units: Scalars['String']['input'];
+};
+
 export type FixedChargeProperties = {
   __typename?: 'FixedChargeProperties';
   amount?: Maybe<Scalars['String']['output']>;
@@ -5609,6 +5620,8 @@ export type Plan = {
   draftInvoicesCount: Scalars['Int']['output'];
   entitlements?: Maybe<Array<PlanEntitlement>>;
   fixedCharges?: Maybe<Array<FixedCharge>>;
+  /** Number of fixed charges attached to a plan */
+  fixedChargesCount: Scalars['Int']['output'];
   hasActiveSubscriptions: Scalars['Boolean']['output'];
   hasCharges: Scalars['Boolean']['output'];
   hasCustomers: Scalars['Boolean']['output'];
@@ -5661,7 +5674,6 @@ export type PlanEntitlementPrivilegeObject = {
 export enum PlanInterval {
   Monthly = 'monthly',
   Quarterly = 'quarterly',
-  Semiannual = 'semiannual',
   Weekly = 'weekly',
   Yearly = 'yearly'
 }
@@ -5671,6 +5683,7 @@ export type PlanOverridesInput = {
   amountCurrency?: InputMaybe<CurrencyEnum>;
   charges?: InputMaybe<Array<ChargeOverridesInput>>;
   description?: InputMaybe<Scalars['String']['input']>;
+  fixedCharges?: InputMaybe<Array<FixedChargeOverridesInput>>;
   invoiceDisplayName?: InputMaybe<Scalars['String']['input']>;
   minimumCommitment?: InputMaybe<CommitmentInput>;
   name?: InputMaybe<Scalars['String']['input']>;
@@ -6809,7 +6822,6 @@ export type QueryWebhooksArgs = {
 export enum RecurringTransactionIntervalEnum {
   Monthly = 'monthly',
   Quarterly = 'quarterly',
-  Semiannual = 'semiannual',
   Weekly = 'weekly',
   Yearly = 'yearly'
 }


### PR DESCRIPTION
## Context

We need to show the gross amounts instead of the net ones.

## Description

- Updated graphql query
- Updated rendering