### PR TITLE
Fix spelling mistake in payment receipt

### DIFF
--- a/translations/base.json
+++ b/translations/base.json
@@ -2873,7 +2873,7 @@
   "text_1733992108437qlovqhjhqj4": "Create automatically this customer in MoneyHash",
   "text_1741334140002zdl3cl599ib": "Send an email when a payment receipt is created",
   "text_1741334140002wx0sbk2bd13": "receipt.created",
-  "text_17413343926218dbogzsvk4w": "Your payement receipt from {{organization}} #2465-1465",
+  "text_17413343926218dbogzsvk4w": "Your payment receipt from {{organization}} #2465-1465",
   "text_1741334392621wr13yk143fc": "Receipt from {{organization}}",
   "text_17413343926218vamtw2ybko": "$730.00",
   "text_1741334392621yu0957trt4n": "Paid on February 17, 2025",


### PR DESCRIPTION
## Context

This PR addresses a spelling mistake reported in Linear issue ISSUE-1104, where "payement" was used instead of "payment" in the payment receipt email template.

## Description

Corrected the spelling of "payement" to "payment" in the `translations/base.json` file.

Fixes ISSUE-1104

---
Linear Issue: [ISSUE-1104](https://linear.app/getlago/issue/ISSUE-1104/spelling-mistake-your-payement-receipt-from-org-name)

<a href="https://cursor.com/background-agent?bcId=bc-86873d55-60c1-4799-8fca-990255005ee5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86873d55-60c1-4799-8fca-990255005ee5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

