### PR TITLE
bug: define default dateTo on some logs queries

### DIFF
--- a/src/components/designSystem/Filters/filtersElements/FiltersItemLoggedDate.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemLoggedDate.tsx
@@ -35,6 +35,7 @@ export const FiltersItemLoggedDate = ({ value = ',', setFilterValue }: FiltersIt
         </div>
       </Typography>
       <DatePicker
+        disableFuture
         showErrorInTooltip
         className="flex-1"
         defaultZone={getTimezoneConfig(TimezoneEnum.TzUtc).name}

--- a/src/components/designSystem/Filters/types.ts
+++ b/src/components/designSystem/Filters/types.ts
@@ -158,6 +158,8 @@ export const AnalyticsInvoicesAvailableFilters = [
   AvailableFiltersEnum.isCustomerTinEmpty,
 ]
 
+export const WebhookLogsAvailableFilters = [AvailableFiltersEnum.webhookStatus]
+
 export const UsageOverviewAvailableFilters = [
   AvailableFiltersEnum.date,
   AvailableFiltersEnum.country,

--- a/src/components/designSystem/Filters/useFilters.ts
+++ b/src/components/designSystem/Filters/useFilters.ts
@@ -4,6 +4,7 @@ import { TimeGranularityEnum } from '~/generated/graphql'
 
 import { useFilterContext } from './context'
 import { AvailableFiltersEnum, AvailableQuickFilters, FiltersFormValues } from './types'
+import { keyWithPrefix } from './utils'
 
 export const useFilters = () => {
   const context = useFilterContext()
@@ -15,7 +16,7 @@ export const useFilters = () => {
   const prefix = context.filtersNamePrefix
 
   const keyWithoutPrefix = (key: string) => (prefix ? key.replace(`${prefix}_`, '') : key)
-  const keyWithPrefix = (key: string) => (prefix ? `${prefix}_${key}` : key)
+  const localKeyWithPrefix = (key: string) => keyWithPrefix(key, prefix)
 
   const removeExistingFilters = () => {
     // Only remove the filters from the URL that are currently applied and are removable (availableFilters)
@@ -46,7 +47,7 @@ export const useFilters = () => {
         return
       }
 
-      const withPrefix = keyWithPrefix(filter.filterType) as AvailableFiltersEnum
+      const withPrefix = localKeyWithPrefix(filter.filterType) as AvailableFiltersEnum
       const withoutPrefix = keyWithoutPrefix(filter.filterType) as AvailableFiltersEnum
 
       if (
@@ -101,11 +102,11 @@ export const useFilters = () => {
 
   const buildQuickFilterUrlParams = (filters: { [key: string]: unknown }) => {
     const staticFilters = Object.entries(context.staticFilters ?? {})
-      .map(([key, value]) => `${keyWithPrefix(key)}=${value}`)
+      .map(([key, value]) => `${localKeyWithPrefix(key)}=${value}`)
       .join('&')
 
     let newFilters = Object.entries(filters).map(([_key, value]) => {
-      const key = keyWithPrefix(_key)
+      const key = localKeyWithPrefix(_key)
 
       if (Array.isArray(value)) {
         return `${key}=${value.join(',')}`
@@ -129,14 +130,14 @@ export const useFilters = () => {
   const selectTimeGranularity = (timeGranularity: TimeGranularityEnum): string => {
     const newSearchParams = new URLSearchParams(searchParams)
 
-    newSearchParams.set(keyWithPrefix(AvailableQuickFilters.timeGranularity), timeGranularity)
+    newSearchParams.set(localKeyWithPrefix(AvailableQuickFilters.timeGranularity), timeGranularity)
 
     return newSearchParams.toString()
   }
 
   const isQuickFilterActive = (filters: { [key: string]: unknown }) => {
     for (const [_key, value] of Object.entries(filters)) {
-      const key = keyWithPrefix(_key)
+      const key = localKeyWithPrefix(_key)
 
       if (Array.isArray(value)) {
         if (searchParamsObject[key] !== value.join(',')) {
@@ -161,7 +162,7 @@ export const useFilters = () => {
     buildQuickFilterUrlParams,
     isQuickFilterActive,
     keyWithoutPrefix,
-    keyWithPrefix,
+    localKeyWithPrefix,
     resetFilters,
     selectTimeGranularity,
   }

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -61,7 +61,7 @@ import {
   UsageOverviewAvailableFilters,
 } from './types'
 
-const keyWithPrefix = (key: string, prefix?: string) => (prefix ? `${prefix}_${key}` : key)
+export const keyWithPrefix = (key: string, prefix?: string) => (prefix ? `${prefix}_${key}` : key)
 
 export const parseFromToValue = (value: string, keys: { from: string; to: string }) => {
   const [interval, from, to] = value.split(',')

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon'
+
 import { formatActivityType } from '~/components/activityLogs/utils'
 import { IsCustomerTinEmptyEnum } from '~/components/designSystem/Filters/filtersElements/FiltersItemIsCustomerTinEmpty'
 import {
@@ -59,6 +61,7 @@ import {
   UsageBreakdownMeteredAvailableFilters,
   UsageBreakdownRecurringAvailableFilters,
   UsageOverviewAvailableFilters,
+  WebhookLogsAvailableFilters,
 } from './types'
 
 export const keyWithPrefix = (key: string, prefix?: string) => (prefix ? `${prefix}_${key}` : key)
@@ -100,6 +103,12 @@ export const parseFromToValue = (value: string, keys: { from: string; to: string
   }
 }
 
+export const FiltersItemDates = [
+  AvailableFiltersEnum.date,
+  AvailableFiltersEnum.issuingDate,
+  AvailableFiltersEnum.loggedDate,
+]
+
 export const FILTER_VALUE_MAP: Record<AvailableFiltersEnum, Function> = {
   [AvailableFiltersEnum.activityIds]: (value: string) => value.split(',').map((v) => v.trim()),
   [AvailableFiltersEnum.activitySources]: (value: string) => (value as string).split(','),
@@ -139,8 +148,8 @@ export const FILTER_VALUE_MAP: Record<AvailableFiltersEnum, Function> = {
   },
   [AvailableFiltersEnum.loggedDate]: (value: string) => {
     return {
-      fromDate: (value as string).split(',')[0],
-      toDate: (value as string).split(',')[1],
+      fromDate: (value as string).split(',')[0] || undefined,
+      toDate: (value as string).split(',')[1] || undefined,
     }
   },
   [AvailableFiltersEnum.overriden]: (value: string) => value === 'true',
@@ -163,11 +172,44 @@ export const FILTER_VALUE_MAP: Record<AvailableFiltersEnum, Function> = {
   [AvailableFiltersEnum.webhookStatus]: (value: string) => (value as string).split(','),
 }
 
-export const FiltersItemDates = [
-  AvailableFiltersEnum.date,
-  AvailableFiltersEnum.issuingDate,
-  AvailableFiltersEnum.loggedDate,
-]
+// NOTE: this is fixing list fetching issue when new item are added to the DB and user scrolls to the bottom of the list
+// In that case, we fetch new elements and display between older ones
+// This is due to the pagination system, using pages instead of cursors
+// This workaround is to set the default toDate value to the current time, hence enforcing a fake cursor
+// The toDate is the minimum date between the fromDate and the current time
+export const defineDefaultToDateValue = (
+  searchParams: URLSearchParams,
+  filtersNamePrefix: string,
+): URLSearchParams => {
+  const now = DateTime.now()
+  const searchParamsCopy = new URLSearchParams(searchParams)
+
+  const searchParamsLoggedDateEntryKey = keyWithPrefix(
+    AvailableFiltersEnum.loggedDate,
+    filtersNamePrefix,
+  )
+  const searchParamsLoggedDateEntryValue: string | undefined = Object.fromEntries(
+    searchParamsCopy.entries(),
+  )[searchParamsLoggedDateEntryKey]
+
+  if (!searchParamsLoggedDateEntryValue) {
+    searchParamsCopy.set(searchParamsLoggedDateEntryKey, `,${now.toISO()}`)
+    return searchParamsCopy
+  }
+
+  const [fromDate, toDate = now.toISO()] = searchParamsLoggedDateEntryValue.split(',')
+  const dateToEndOfDay = DateTime.fromISO(toDate).endOf('day')
+
+  const earliestToDateVsNow = dateToEndOfDay < now ? dateToEndOfDay.toISO() : now.toISO()
+
+  searchParamsCopy.set(searchParamsLoggedDateEntryKey, `${fromDate},${earliestToDateVsNow}`)
+
+  return searchParamsCopy
+}
+
+type TformatFiltersForQueryReturn = {
+  [key: string]: string | string[] | boolean
+}
 
 export const formatFiltersForQuery = ({
   searchParams,
@@ -179,40 +221,37 @@ export const formatFiltersForQuery = ({
   keyMap?: Record<string, string>
   availableFilters: AvailableFiltersEnum[]
   filtersNamePrefix: string
-}) => {
+}): TformatFiltersForQueryReturn => {
   const filtersSetInUrl = Object.fromEntries(searchParams.entries())
 
-  return Object.entries(filtersSetInUrl).reduce(
-    (acc, cur) => {
-      const current = cur as [AvailableFiltersEnum, string | string[] | boolean]
-      const _key = current[0]
+  return Object.entries(filtersSetInUrl).reduce((acc, cur) => {
+    const current = cur as [AvailableFiltersEnum, string | string[] | boolean]
+    const _key = current[0]
 
-      const key = (
-        filtersNamePrefix ? _key.replace(`${filtersNamePrefix}_`, '') : _key
-      ) as AvailableFiltersEnum
+    const key = (
+      filtersNamePrefix ? _key.replace(`${filtersNamePrefix}_`, '') : _key
+    ) as AvailableFiltersEnum
 
-      if (!availableFilters.includes(key)) {
-        return acc
-      }
+    if (!availableFilters.includes(key)) {
+      return acc
+    }
 
-      const filterFunction = FILTER_VALUE_MAP[key]
+    const filterFunction = FILTER_VALUE_MAP[key]
 
-      const value = filterFunction ? filterFunction(current[1]) : current[1]
+    const value = filterFunction ? filterFunction(current[1]) : current[1]
 
-      if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
-        return {
-          ...acc,
-          ...value,
-        }
-      }
-
+    if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
       return {
         ...acc,
-        [keyMap?.[key] || key]: value,
+        ...value,
       }
-    },
-    {} as Record<string, string | string[] | boolean>,
-  )
+    }
+
+    return {
+      ...acc,
+      [keyMap?.[key] || key]: value,
+    }
+  }, {} as TformatFiltersForQueryReturn)
 }
 
 export const formatFiltersForCreditNotesQuery = (searchParams: URLSearchParams) => {
@@ -361,7 +400,7 @@ export const formatFiltersForAnalyticsInvoicesQuery = (searchParams: URLSearchPa
 export const formatFiltersForWebhookLogsQuery = (searchParams: URLSearchParams) => {
   const filters = formatFiltersForQuery({
     searchParams,
-    availableFilters: [AvailableFiltersEnum.webhookStatus],
+    availableFilters: WebhookLogsAvailableFilters,
     filtersNamePrefix: WEBHOOK_LOGS_FILTER_PREFIX,
   })
 
@@ -440,7 +479,7 @@ export const formatFiltersForUsageBillableMetricQuery = (searchParams: URLSearch
 
 export const formatFiltersForActivityLogsQuery = (searchParams: URLSearchParams) => {
   const formatted = formatFiltersForQuery({
-    searchParams,
+    searchParams: defineDefaultToDateValue(searchParams, ACTIVITY_LOG_FILTER_PREFIX),
     availableFilters: ActivityLogsAvailableFilters,
     filtersNamePrefix: ACTIVITY_LOG_FILTER_PREFIX,
   })
@@ -459,7 +498,7 @@ export const formatFiltersForActivityLogsQuery = (searchParams: URLSearchParams)
 
 export const formatFiltersForApiLogsQuery = (searchParams: URLSearchParams) => {
   return formatFiltersForQuery({
-    searchParams,
+    searchParams: defineDefaultToDateValue(searchParams, API_LOGS_FILTER_PREFIX),
     availableFilters: ApiLogsAvailableFilters,
     filtersNamePrefix: API_LOGS_FILTER_PREFIX,
   })

--- a/src/components/developers/activityLogs/ActivityLogs.tsx
+++ b/src/components/developers/activityLogs/ActivityLogs.tsx
@@ -154,7 +154,10 @@ export const ActivityLogs = () => {
           startIcon="reload"
           loading={loading}
           onClick={async () => {
-            const result = await refetch()
+            const result = await refetch({
+              ...formatFiltersForActivityLogsQuery(searchParams),
+              page: 1,
+            })
 
             navigateToFirstLog(result.data?.activityLogs?.collection, searchParams)
           }}

--- a/src/components/developers/apiLogs/ApiLogs.tsx
+++ b/src/components/developers/apiLogs/ApiLogs.tsx
@@ -147,7 +147,10 @@ export const ApiLogs = () => {
           startIcon="reload"
           loading={loading}
           onClick={async () => {
-            const result = await refetch()
+            const result = await refetch({
+              ...formatFiltersForApiLogsQuery(searchParams),
+              page: 1,
+            })
 
             navigateToFirstLog(result.data?.apiLogs?.collection, searchParams)
           }}


### PR DESCRIPTION
## Context

We have a bug when within a log list you fetch some collection, then a lot of items are added in the database, and you keep scrolling the page. The bug is about the fact that those new database elements will be fetched and displayed after the old elements even though they are earlier in the history. 

This is due to our pagination system that is not using cursor-based pagination but page-based pagination. 

## Description

This pull request aims to fix this behavior by setting a default to date with the value either to now or to the selected date by the customer.

<!-- Linear link -->
Fixes ISSUE-1071