### PR TITLE
fix: convert duration using Intl.DurationFormat

### DIFF
--- a/src/components/aiAgent/ChatMessages.tsx
+++ b/src/components/aiAgent/ChatMessages.tsx
@@ -7,14 +7,17 @@ import { ReactNode } from 'react'
  * @param seconds - The duration in seconds
  * @returns A human-readable duration string (e.g., "2m 30s", "1h 15m", "45s")
  */
+
 export const formatDuration = (seconds: number): string => {
-  const duration = Duration.fromObject({ seconds }).reconfigure({ locale: 'en-US' })
-  const shifted = duration.shiftTo('minutes', 'seconds').toObject()
+  const locale = 'en-US'
+  const durationObject = Duration.fromObject({ minutes: 0, seconds })
+    .reconfigure({ locale })
+    .normalize()
+    .toObject()
 
-  const minutes = shifted.minutes ? `${shifted.minutes}m` : ''
-  const secondsStr = shifted.seconds !== undefined ? `${shifted.seconds}s` : ''
-
-  return [minutes, secondsStr].filter(Boolean).join(' ')
+  // @ts-expect-error Intl.DurationFormat is not typed
+  // https://github.com/microsoft/TypeScript/issues/60608
+  return new Intl.DurationFormat(locale, { style: 'narrow' }).format(durationObject)
 }
 
 const SentMessage = ({ children }: { children: ReactNode }) => {


### PR DESCRIPTION
## Context

Use Intl.DurationFormat api instead of manually handling duration conversion.
Expecting an typescript error because the API isn't typed on typescript side yet.