### PR TITLE
fix(graphql): Fix date filters in API Logs and Activity Logs resolvers

### DIFF
--- a/src/components/developers/activityLogs/ActivityLogs.tsx
+++ b/src/components/developers/activityLogs/ActivityLogs.tsx
@@ -37,10 +37,10 @@ gql`
     $apiKeyIds: [String!]
     $externalCustomerId: String
     $externalSubscriptionId: String
-    $fromDate: ISO8601Date
+    $fromDate: ISO8601DateTime
     $resourceIds: [String!]
     $resourceTypes: [ResourceTypeEnum!]
-    $toDate: ISO8601Date
+    $toDate: ISO8601DateTime
     $userEmails: [String!]
   ) {
     activityLogs(
@@ -52,10 +52,10 @@ gql`
       apiKeyIds: $apiKeyIds
       externalCustomerId: $externalCustomerId
       externalSubscriptionId: $externalSubscriptionId
-      fromDate: $fromDate
+      fromDatetime: $fromDate
       resourceIds: $resourceIds
       resourceTypes: $resourceTypes
-      toDate: $toDate
+      toDatetime: $toDate
       userEmails: $userEmails
     ) {
       collection {

--- a/src/components/developers/apiLogs/ApiLogs.tsx
+++ b/src/components/developers/apiLogs/ApiLogs.tsx
@@ -31,8 +31,8 @@ gql`
     $page: Int
     $limit: Int
     $requestIds: [String!]
-    $fromDate: ISO8601Date
-    $toDate: ISO8601Date
+    $fromDate: ISO8601DateTime
+    $toDate: ISO8601DateTime
     $apiKeyIds: [String!]
     $httpMethods: [HttpMethodEnum!]
     $httpStatuses: [HttpStatus!]
@@ -41,8 +41,8 @@ gql`
     apiLogs(
       page: $page
       limit: $limit
-      fromDate: $fromDate
-      toDate: $toDate
+      fromDatetime: $fromDate
+      toDatetime: $toDate
       apiKeyIds: $apiKeyIds
       httpMethods: $httpMethods
       httpStatuses: $httpStatuses

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -6125,11 +6125,13 @@ export type QueryActivityLogsArgs = {
   externalCustomerId?: InputMaybe<Scalars['String']['input']>;
   externalSubscriptionId?: InputMaybe<Scalars['String']['input']>;
   fromDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
+  fromDatetime?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   page?: InputMaybe<Scalars['Int']['input']>;
   resourceIds?: InputMaybe<Array<Scalars['String']['input']>>;
   resourceTypes?: InputMaybe<Array<ResourceTypeEnum>>;
   toDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
+  toDatetime?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
   userEmails?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
@@ -6176,14 +6178,14 @@ export type QueryApiLogArgs = {
 
 export type QueryApiLogsArgs = {
   apiKeyIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  fromDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
+  fromDatetime?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
   httpMethods?: InputMaybe<Array<HttpMethodEnum>>;
   httpStatuses?: InputMaybe<Array<Scalars['HttpStatus']['input']>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   page?: InputMaybe<Scalars['Int']['input']>;
   requestIds?: InputMaybe<Array<Scalars['String']['input']>>;
   requestPaths?: InputMaybe<Array<Scalars['String']['input']>>;
-  toDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
+  toDatetime?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
 };
 
 
@@ -9306,10 +9308,10 @@ export type ActivityLogsQueryVariables = Exact<{
   apiKeyIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
   externalCustomerId?: InputMaybe<Scalars['String']['input']>;
   externalSubscriptionId?: InputMaybe<Scalars['String']['input']>;
-  fromDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
+  fromDate?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
   resourceIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
   resourceTypes?: InputMaybe<Array<ResourceTypeEnum> | ResourceTypeEnum>;
-  toDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
+  toDate?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
   userEmails?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
 }>;
 
@@ -9371,8 +9373,8 @@ export type GetApiLogsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   requestIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  fromDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
-  toDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
+  fromDate?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
+  toDate?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
   apiKeyIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
   httpMethods?: InputMaybe<Array<HttpMethodEnum> | HttpMethodEnum>;
   httpStatuses?: InputMaybe<Array<Scalars['HttpStatus']['input']> | Scalars['HttpStatus']['input']>;
@@ -20902,7 +20904,7 @@ export type GetSubscriptionIdForActivityLogDetailsLazyQueryHookResult = ReturnTy
 export type GetSubscriptionIdForActivityLogDetailsSuspenseQueryHookResult = ReturnType<typeof useGetSubscriptionIdForActivityLogDetailsSuspenseQuery>;
 export type GetSubscriptionIdForActivityLogDetailsQueryResult = Apollo.QueryResult<GetSubscriptionIdForActivityLogDetailsQuery, GetSubscriptionIdForActivityLogDetailsQueryVariables>;
 export const ActivityLogsDocument = gql`
-    query activityLogs($page: Int, $limit: Int, $activityIds: [String!], $activitySources: [ActivitySourceEnum!], $activityTypes: [ActivityTypeEnum!], $apiKeyIds: [String!], $externalCustomerId: String, $externalSubscriptionId: String, $fromDate: ISO8601Date, $resourceIds: [String!], $resourceTypes: [ResourceTypeEnum!], $toDate: ISO8601Date, $userEmails: [String!]) {
+    query activityLogs($page: Int, $limit: Int, $activityIds: [String!], $activitySources: [ActivitySourceEnum!], $activityTypes: [ActivityTypeEnum!], $apiKeyIds: [String!], $externalCustomerId: String, $externalSubscriptionId: String, $fromDate: ISO8601DateTime, $resourceIds: [String!], $resourceTypes: [ResourceTypeEnum!], $toDate: ISO8601DateTime, $userEmails: [String!]) {
   activityLogs(
     page: $page
     limit: $limit
@@ -20912,10 +20914,10 @@ export const ActivityLogsDocument = gql`
     apiKeyIds: $apiKeyIds
     externalCustomerId: $externalCustomerId
     externalSubscriptionId: $externalSubscriptionId
-    fromDate: $fromDate
+    fromDatetime: $fromDate
     resourceIds: $resourceIds
     resourceTypes: $resourceTypes
-    toDate: $toDate
+    toDatetime: $toDate
     userEmails: $userEmails
   ) {
     collection {
@@ -21219,12 +21221,12 @@ export type GetApiLogDetailsLazyQueryHookResult = ReturnType<typeof useGetApiLog
 export type GetApiLogDetailsSuspenseQueryHookResult = ReturnType<typeof useGetApiLogDetailsSuspenseQuery>;
 export type GetApiLogDetailsQueryResult = Apollo.QueryResult<GetApiLogDetailsQuery, GetApiLogDetailsQueryVariables>;
 export const GetApiLogsDocument = gql`
-    query getApiLogs($page: Int, $limit: Int, $requestIds: [String!], $fromDate: ISO8601Date, $toDate: ISO8601Date, $apiKeyIds: [String!], $httpMethods: [HttpMethodEnum!], $httpStatuses: [HttpStatus!], $requestPaths: [String!]) {
+    query getApiLogs($page: Int, $limit: Int, $requestIds: [String!], $fromDate: ISO8601DateTime, $toDate: ISO8601DateTime, $apiKeyIds: [String!], $httpMethods: [HttpMethodEnum!], $httpStatuses: [HttpStatus!], $requestPaths: [String!]) {
   apiLogs(
     page: $page
     limit: $limit
-    fromDate: $fromDate
-    toDate: $toDate
+    fromDatetime: $fromDate
+    toDatetime: $toDate
     apiKeyIds: $apiKeyIds
     httpMethods: $httpMethods
     httpStatuses: $httpStatuses


### PR DESCRIPTION
## Context

Offset pagination is fragile: if new record arrive between fetching page 1 and page 2, rows shift and clients either miss or re‑read items. This is what happened with the Activity Logs and API Logs feature for which we create new records more often that other features.

In order to mitigate this issue, the frontend is now always sending the `to_date` filter with the following rules:

1. If the filter is not set, we default to the timestamp at which we loaded the data for the first time
2. If the filter is set, we make sure that the value cannot be later than the timestamp at which we loaded the data for the first time

This ensures that no matter the requested page, we will never receive newer records.

The issue is that the backend GraphQL resolver did not accept `to_date` as a `ISO8601DateTime` but as a `ISO8601Date`. So the backend will convert the datetime into a date and back to a date time when querying clickhouse:

```ruby
lago-api(dev)> Clickhouse::ApiLog.where(logged_at: ..Date.today).to_sql
=> "SELECT api_logs.* FROM api_logs WHERE api_logs.logged_at <= '2025-09-11 00:00:00.000'"
```

https://github.com/getlago/lago-api/pull/4275 introduced a fix for this by adding the `toDatetime` and `fromDatetime` filters.

## Description

This updates the `apiLogs` and `activityLogs` queries to rely on those filters instead of `fromDate` and `toDate`.