### PR TITLE
misc(creditNotes): validate form has at least one fee checked

### DIFF
--- a/src/components/creditNote/__tests__/utils.test.ts
+++ b/src/components/creditNote/__tests__/utils.test.ts
@@ -4,9 +4,11 @@ import {
   feeMockFormatedForEstimate,
   feesMock,
 } from '~/components/creditNote/__tests__/fixtures'
+import { CreditNoteForm } from '~/components/creditNote/types'
 import {
   creditNoteFormCalculationCalculation,
   CreditNoteFormCalculationCalculationProps,
+  creditNoteFormHasAtLeastOneFeeChecked,
 } from '~/components/creditNote/utils'
 import { CurrencyEnum } from '~/generated/graphql'
 
@@ -42,6 +44,496 @@ describe('CreditNote utils', () => {
       const { feeForEstimate } = prepare({ addonFees: addOnFeeMock })
 
       expect(feeForEstimate).toEqual(addonMockFormatedForEstimate)
+    })
+  })
+})
+
+describe('creditNoteFormHasAtLeastOneFeeChecked', () => {
+  describe('when addOnFee is present', () => {
+    it('returns true when at least one addon fee is checked', () => {
+      const formValues = {
+        addOnFee: [
+          {
+            id: '1',
+            checked: true,
+            maxAmount: 100,
+            name: 'Test Addon 1',
+            value: 50,
+          },
+          {
+            id: '2',
+            checked: false,
+            maxAmount: 200,
+            name: 'Test Addon 2',
+            value: 75,
+          },
+        ],
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false when no addon fees are checked', () => {
+      const formValues = {
+        addOnFee: [
+          {
+            id: '1',
+            checked: false,
+            maxAmount: 100,
+            name: 'Test Addon 1',
+            value: 50,
+          },
+          {
+            id: '2',
+            checked: false,
+            maxAmount: 200,
+            name: 'Test Addon 2',
+            value: 75,
+          },
+        ],
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when addOnFee array is empty', () => {
+      const formValues = {
+        addOnFee: [],
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('when creditFee is present (and no addOnFee)', () => {
+    it('returns true when at least one credit fee is checked', () => {
+      const formValues = {
+        creditFee: [
+          {
+            id: '1',
+            checked: true,
+            maxAmount: 100,
+            name: 'Test Credit 1',
+            value: 50,
+          },
+          {
+            id: '2',
+            checked: false,
+            maxAmount: 200,
+            name: 'Test Credit 2',
+            value: 75,
+          },
+        ],
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false when no credit fees are checked', () => {
+      const formValues = {
+        creditFee: [
+          {
+            id: '1',
+            checked: false,
+            maxAmount: 100,
+            name: 'Test Credit 1',
+            value: 50,
+          },
+          {
+            id: '2',
+            checked: false,
+            maxAmount: 200,
+            name: 'Test Credit 2',
+            value: 75,
+          },
+        ],
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when creditFee array is empty', () => {
+      const formValues = {
+        creditFee: [],
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('when regular fees are present (and no addOnFee or creditFee)', () => {
+    it('returns true when at least one regular fee is checked', () => {
+      const formValues = {
+        fees: {
+          subscription1: {
+            subscriptionName: 'Test Subscription',
+            fees: {
+              fee1: {
+                id: '1',
+                checked: true,
+                maxAmount: 100,
+                name: 'Test Fee 1',
+                value: 50,
+              },
+              fee2: {
+                id: '2',
+                checked: false,
+                maxAmount: 200,
+                name: 'Test Fee 2',
+                value: 75,
+              },
+            },
+          },
+        },
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false when no regular fees are checked', () => {
+      const formValues = {
+        fees: {
+          subscription1: {
+            subscriptionName: 'Test Subscription',
+            fees: {
+              fee1: {
+                id: '1',
+                checked: false,
+                maxAmount: 100,
+                name: 'Test Fee 1',
+                value: 50,
+              },
+              fee2: {
+                id: '2',
+                checked: false,
+                maxAmount: 200,
+                name: 'Test Fee 2',
+                value: 75,
+              },
+            },
+          },
+        },
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(false)
+    })
+
+    it('returns true when at least one grouped fee is checked', () => {
+      const formValues = {
+        fees: {
+          subscription1: {
+            subscriptionName: 'Test Subscription',
+            fees: {
+              groupedFee1: {
+                name: 'Grouped Fee',
+                grouped: {
+                  subFee1: {
+                    id: '1',
+                    checked: true,
+                    maxAmount: 100,
+                    name: 'Sub Fee 1',
+                    value: 50,
+                  },
+                  subFee2: {
+                    id: '2',
+                    checked: false,
+                    maxAmount: 200,
+                    name: 'Sub Fee 2',
+                    value: 75,
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false when no grouped fees are checked', () => {
+      const formValues = {
+        fees: {
+          subscription1: {
+            subscriptionName: 'Test Subscription',
+            fees: {
+              groupedFee1: {
+                name: 'Grouped Fee',
+                grouped: {
+                  subFee1: {
+                    id: '1',
+                    checked: false,
+                    maxAmount: 100,
+                    name: 'Sub Fee 1',
+                    value: 50,
+                  },
+                  subFee2: {
+                    id: '2',
+                    checked: false,
+                    maxAmount: 200,
+                    name: 'Sub Fee 2',
+                    value: 75,
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(false)
+    })
+
+    it('returns true when fees contain both regular and grouped fees with at least one checked', () => {
+      const formValues = {
+        fees: {
+          subscription1: {
+            subscriptionName: 'Test Subscription',
+            fees: {
+              regularFee: {
+                id: '1',
+                checked: false,
+                maxAmount: 100,
+                name: 'Regular Fee',
+                value: 50,
+              },
+              groupedFee1: {
+                name: 'Grouped Fee',
+                grouped: {
+                  subFee1: {
+                    id: '2',
+                    checked: true,
+                    maxAmount: 200,
+                    name: 'Sub Fee 1',
+                    value: 75,
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false when fees object is empty', () => {
+      const formValues = {
+        fees: {},
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(false)
+    })
+
+    it('handles multiple subscriptions and returns true if any fee is checked', () => {
+      const formValues = {
+        fees: {
+          subscription1: {
+            subscriptionName: 'Test Subscription 1',
+            fees: {
+              fee1: {
+                id: '1',
+                checked: false,
+                maxAmount: 100,
+                name: 'Test Fee 1',
+                value: 50,
+              },
+            },
+          },
+          subscription2: {
+            subscriptionName: 'Test Subscription 2',
+            fees: {
+              fee2: {
+                id: '2',
+                checked: true,
+                maxAmount: 200,
+                name: 'Test Fee 2',
+                value: 75,
+              },
+            },
+          },
+        },
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns false when grouped property is not present', () => {
+      const formValues = {
+        fees: {
+          subscription1: {
+            subscriptionName: 'Test Subscription',
+            fees: {
+              groupedFee1: {
+                name: 'Grouped Fee',
+                grouped: {
+                  subFee1: {
+                    id: '1',
+                    maxAmount: 100,
+                    name: 'Sub Fee 1',
+                    value: 50,
+                  },
+                  subFee2: {
+                    id: '2',
+                    maxAmount: 200,
+                    name: 'Sub Fee 2',
+                    value: 75,
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(
+        formValues as unknown as Partial<CreditNoteForm>,
+      )
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when all fee types are undefined', () => {
+      const formValues = {}
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when all fee types are null/empty', () => {
+      const formValues = {
+        addOnFee: undefined,
+        creditFee: undefined,
+        fees: undefined,
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(false)
+    })
+
+    it('handles grouped fee with empty grouped object', () => {
+      const formValues = {
+        fees: {
+          subscription1: {
+            subscriptionName: 'Test Subscription',
+            fees: {
+              groupedFee1: {
+                name: 'Grouped Fee',
+                grouped: {},
+              },
+            },
+          },
+        },
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      expect(result).toBe(false)
+    })
+
+    it('prioritizes addOnFee over other fee types', () => {
+      const formValues = {
+        addOnFee: [
+          {
+            id: '1',
+            checked: false,
+            maxAmount: 100,
+            name: 'Test Addon',
+            value: 50,
+          },
+        ],
+        creditFee: [
+          {
+            id: '2',
+            checked: true,
+            maxAmount: 200,
+            name: 'Test Credit',
+            value: 75,
+          },
+        ],
+        fees: {
+          subscription1: {
+            subscriptionName: 'Test Subscription',
+            fees: {
+              fee1: {
+                id: '3',
+                checked: true,
+                maxAmount: 300,
+                name: 'Test Fee',
+                value: 100,
+              },
+            },
+          },
+        },
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      // Should return false because addOnFee takes precedence and none are checked
+      expect(result).toBe(false)
+    })
+
+    it('prioritizes creditFee over regular fees when addOnFee is not present', () => {
+      const formValues = {
+        creditFee: [
+          {
+            id: '2',
+            checked: false,
+            maxAmount: 200,
+            name: 'Test Credit',
+            value: 75,
+          },
+        ],
+        fees: {
+          subscription1: {
+            subscriptionName: 'Test Subscription',
+            fees: {
+              fee1: {
+                id: '3',
+                checked: true,
+                maxAmount: 300,
+                name: 'Test Fee',
+                value: 100,
+              },
+            },
+          },
+        },
+      }
+
+      const result = creditNoteFormHasAtLeastOneFeeChecked(formValues)
+
+      // Should return false because creditFee takes precedence and none are checked
+      expect(result).toBe(false)
     })
   })
 })

--- a/src/components/creditNote/utils.ts
+++ b/src/components/creditNote/utils.ts
@@ -8,7 +8,7 @@ import {
   InvoiceTypeEnum,
 } from '~/generated/graphql'
 
-import { FeesPerInvoice, FromFee, GroupedFee } from './types'
+import { CreditNoteForm, FeesPerInvoice, FromFee, GroupedFee } from './types'
 
 export type CreditNoteFormCalculationCalculationProps = {
   currency: CurrencyEnum
@@ -159,4 +159,39 @@ export const createCreditNoteForInvoiceButtonProps = ({
     disabledIssueCreditNoteButton,
     disabledIssueCreditNoteButtonLabel,
   }
+}
+
+export const creditNoteFormHasAtLeastOneFeeChecked = (
+  formValues: Partial<CreditNoteForm>,
+): boolean => {
+  const { fees, addOnFee, creditFee } = formValues
+  const groupedFeesValues = Object.values(fees || {})
+
+  if (addOnFee?.length) {
+    return addOnFee?.some((aof) => {
+      return aof?.checked
+    })
+  } else if (creditFee?.length) {
+    return creditFee?.some((cf) => {
+      return cf?.checked
+    })
+  } else if (groupedFeesValues.length) {
+    return groupedFeesValues.some((fee) => {
+      const feesToInspect = Object.values(fee?.fees || {})
+
+      return feesToInspect.some((f) => {
+        // Fees of type GroupedFee
+        if ('grouped' in f) {
+          const feesGroupedValues = Object.values(f?.grouped || {})
+
+          return feesGroupedValues.some((g) => g?.checked)
+        }
+
+        // Fees of type FromFee
+        return f?.checked
+      })
+    })
+  }
+
+  return false
 }

--- a/src/pages/CreateCreditNote.tsx
+++ b/src/pages/CreateCreditNote.tsx
@@ -10,7 +10,10 @@ import { CreditNoteEstimationLine } from '~/components/creditNote/CreditNoteEsti
 import { CreditNoteFormCalculation } from '~/components/creditNote/CreditNoteFormCalculation'
 import { CreditNoteItemsForm } from '~/components/creditNote/CreditNoteItemsForm'
 import { CreditNoteForm, CreditTypeEnum } from '~/components/creditNote/types'
-import { creditNoteFormCalculationCalculation } from '~/components/creditNote/utils'
+import {
+  creditNoteFormCalculationCalculation,
+  creditNoteFormHasAtLeastOneFeeChecked,
+} from '~/components/creditNote/utils'
 import {
   Alert,
   Button,
@@ -124,6 +127,8 @@ const CreateCreditNote = () => {
   const [payBackValidation, setPayBackValidation] = useState<Schema>(array())
 
   const formikProps = useFormik<Partial<CreditNoteForm>>({
+    validateOnMount: true,
+    enableReinitialize: true,
     initialValues: {
       description: undefined,
       reason: undefined,
@@ -146,8 +151,6 @@ const CreateCreditNote = () => {
       creditFee: creditFeeValidation,
       payBack: payBackValidation,
     }),
-    validateOnMount: true,
-    enableReinitialize: true,
     onSubmit: async (values, formikBag) => {
       const answer = await onCreate(values as CreditNoteForm)
 
@@ -194,6 +197,10 @@ const CreateCreditNote = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPrepaidCreditsInvoice, creditFeeValue])
+
+  const formHasAtLeastOneFeeChecked: boolean = useMemo(() => {
+    return creditNoteFormHasAtLeastOneFeeChecked(formikProps.values)
+  }, [formikProps.values])
 
   return (
     <div>
@@ -406,7 +413,7 @@ const CreateCreditNote = () => {
                 </Card>
                 <div className="mb-20 px-8">
                   <Button
-                    disabled={!formikProps.isValid}
+                    disabled={!formikProps.isValid || !formHasAtLeastOneFeeChecked}
                     fullWidth
                     size="large"
                     onClick={formikProps.submitForm}


### PR DESCRIPTION
## Context

When creating a credit note, you can subit the form after unchecking all fees.

Recently, Backend made a bugfix to return an error un such case, but it's still allowed to submit the form like this and receive an error.

This form can accept 3 "shapes" of fee.
Classic ones for addOn and credit fees. And more "complex" ones that has a different level of "checked" attribute.

## Description

This PR creates a check to prevent submitting the form if no fees are selected.

Had to make a different function is used at the submit button level. As it's checking on different attributes of the form, it was creating a complex code there and was hard to test that way.
Preferred to extract the logic in the existing util and test the method there.

<!-- Linear link -->
Fixes ISSUE-1108