### PR TITLE
bug: always hide entitlements on subscription details overview

### DIFF
--- a/src/components/plans/details/PlanDetailsAdvancedSettingsSection.tsx
+++ b/src/components/plans/details/PlanDetailsAdvancedSettingsSection.tsx
@@ -12,15 +12,17 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 export const PlanDetailsAdvancedSettingsSection = ({
   currency,
   plan,
+  showEntitlementSection = true,
 }: {
   currency: CurrencyEnum
   plan?: EditPlanFragment | null
+  showEntitlementSection?: boolean
 }) => {
   const { translate } = useInternationalization()
   const hasMinimumCommitment =
     !!plan?.minimumCommitment?.amountCents && !isNaN(Number(plan?.minimumCommitment?.amountCents))
   const hasProgressiveBilling = !!plan?.usageThresholds?.length
-  const hasEntitlements = !!plan?.entitlements?.length
+  const hasEntitlements = showEntitlementSection && !!plan?.entitlements?.length
 
   if (!hasMinimumCommitment && !hasProgressiveBilling && !hasEntitlements) return null
 

--- a/src/components/plans/details/PlanDetailsOverview.tsx
+++ b/src/components/plans/details/PlanDetailsOverview.tsx
@@ -25,7 +25,13 @@ gql`
   ${EditPlanFragmentDoc}
 `
 
-export const PlanDetailsOverview = ({ planId }: { planId?: string }) => {
+export const PlanDetailsOverview = ({
+  planId,
+  showEntitlementSection = true,
+}: {
+  planId?: string
+  showEntitlementSection?: boolean
+}) => {
   const { translate } = useInternationalization()
   const { data: planResult, loading: isPlanLoading } = useGetPlanForDetailsOverviewSectionQuery({
     variables: { plan: planId as string },
@@ -102,6 +108,7 @@ export const PlanDetailsOverview = ({ planId }: { planId?: string }) => {
       <PlanDetailsAdvancedSettingsSection
         plan={plan}
         currency={plan?.amountCurrency || CurrencyEnum.Usd}
+        showEntitlementSection={showEntitlementSection}
       />
     </section>
   )

--- a/src/components/subscriptions/SubscriptionDetailsOverview.tsx
+++ b/src/components/subscriptions/SubscriptionDetailsOverview.tsx
@@ -45,7 +45,7 @@ export const SubscriptionDetailsOverview = () => {
   return (
     <div className="flex flex-col gap-12">
       <SubscriptionInformations subscription={subscription} />
-      <PlanDetailsOverview planId={subscription?.plan.id} />
+      <PlanDetailsOverview planId={subscription?.plan.id} showEntitlementSection={false} />
     </div>
   )
 }


### PR DESCRIPTION
## Context

A plan can hold entitlements.
You can override this at the subscription level, and they are visible on a dedicated tab, outside of the `Overview` details of the subscription, that mainly display the plan's details.

Historically, this overview section uses the `EditPlan` fragment, that todays fetches the plan's entitlements.
And we use the same components to display the plan details in the plan details page and the subscription's>plan details.

So we have the "original" entitlements of the plan displayed in the `Overview` tab, and the overriden ones in the `Entitlements` tab in the subscription details.

## Description

This pull request adds a new attribute to this plan details components, and you can now manually say if you want the entitlements section to be hidden or not (default to shown).

So the subscription's plan overview can call it with `showEntitlementSection={false}`

<!-- Linear link -->
Fixes ISSUE-1139