### PR TITLE
misc: make invoice related permissions relies on the same logic

### DIFF
--- a/src/hooks/__tests__/usePermissionsInvoiceActions.test.ts
+++ b/src/hooks/__tests__/usePermissionsInvoiceActions.test.ts
@@ -32,6 +32,7 @@ jest.mock('~/core/apolloClient', () => ({
 const DEFAULT_PERMISSIONS = {
   invoicesView: true,
   invoicesUpdate: true,
+  draftInvoicesUpdate: true,
   invoicesSend: true,
   invoicesVoid: true,
   creditNotesCreate: true,
@@ -257,6 +258,39 @@ describe('usePermissionsInvoiceActions', () => {
       const { result } = await prepare({ invoicesUpdate: false })
 
       expect(result.current.canFinalize({ status: InvoiceStatusTypeEnum.Draft })).toBe(false)
+    })
+
+    it('should return false when user does not have draftInvoicesUpdate permission', async () => {
+      const { result } = await prepare({ draftInvoicesUpdate: false })
+
+      expect(result.current.canFinalize({ status: InvoiceStatusTypeEnum.Draft })).toBe(false)
+    })
+
+    it('should return false when user has invoicesUpdate but not draftInvoicesUpdate', async () => {
+      const { result } = await prepare({
+        invoicesUpdate: true,
+        draftInvoicesUpdate: false,
+      })
+
+      expect(result.current.canFinalize({ status: InvoiceStatusTypeEnum.Draft })).toBe(false)
+    })
+
+    it('should return false when user has draftInvoicesUpdate but not invoicesUpdate', async () => {
+      const { result } = await prepare({
+        invoicesUpdate: false,
+        draftInvoicesUpdate: true,
+      })
+
+      expect(result.current.canFinalize({ status: InvoiceStatusTypeEnum.Draft })).toBe(false)
+    })
+
+    it('should return true when user has both invoicesUpdate and draftInvoicesUpdate permissions', async () => {
+      const { result } = await prepare({
+        invoicesUpdate: true,
+        draftInvoicesUpdate: true,
+      })
+
+      expect(result.current.canFinalize({ status: InvoiceStatusTypeEnum.Draft })).toBe(true)
     })
 
     it('should return true for voided invoice', async () => {

--- a/src/hooks/usePermissionsInvoiceActions.ts
+++ b/src/hooks/usePermissionsInvoiceActions.ts
@@ -32,7 +32,9 @@ export const usePermissionsInvoiceActions = () => {
         InvoiceStatusTypeEnum.Failed,
         InvoiceStatusTypeEnum.Pending,
         InvoiceStatusTypeEnum.Finalized,
-      ].includes(invoice.status) && hasPermissions(['invoicesUpdate'])
+      ].includes(invoice.status) &&
+      hasPermissions(['invoicesUpdate']) &&
+      hasPermissions(['draftInvoicesUpdate'])
     )
   }
 

--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -34,7 +34,7 @@ import { InvoiceCreditNoteList } from '~/components/invoices/InvoiceCreditNoteLi
 import { InvoicePaymentList } from '~/components/invoices/InvoicePaymentList'
 import { VoidInvoiceDialog, VoidInvoiceDialogRef } from '~/components/invoices/VoidInvoiceDialog'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
-import { addToast, envGlobalVar, hasDefinedGQLError, LagoGQLError } from '~/core/apolloClient'
+import { addToast, hasDefinedGQLError, LagoGQLError } from '~/core/apolloClient'
 import { LocalTaxProviderErrorsEnum } from '~/core/constants/form'
 import { invoiceStatusMapping, paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
 import {
@@ -102,8 +102,6 @@ import { usePermissionsInvoiceActions } from '~/hooks/usePermissionsInvoiceActio
 import InvoiceOverview from '~/pages/InvoiceOverview'
 import ErrorImage from '~/public/images/maneki/error.svg'
 import { MenuPopper, PageHeader } from '~/styles'
-
-const { disablePdfGeneration } = envGlobalVar()
 
 gql`
   fragment AllInvoiceDetailsForCustomerInvoiceDetails on Invoice {
@@ -749,16 +747,6 @@ const CustomerInvoiceDetails = () => {
     canRecordPayment,
   ])
 
-  // TODO: Compare this with src/hooks/usePermissionsInvoiceActions.ts:
-  // We don't check the same permissions here, but we could refactor this to use the same logic
-  const canFinalizeInvoice =
-    status === InvoiceStatusTypeEnum.Draft &&
-    taxStatus !== InvoiceTaxStatusTypeEnum.Pending &&
-    hasPermissions(['draftInvoicesUpdate'])
-  const canDownloadInvoice =
-    (status !== InvoiceStatusTypeEnum.Pending || taxStatus !== InvoiceTaxStatusTypeEnum.Pending) &&
-    !disablePdfGeneration
-
   return (
     <>
       <PageHeader.Wrapper withSide>
@@ -795,7 +783,7 @@ const CustomerInvoiceDetails = () => {
                     >
                       {translate('text_1724164767403kyknbaw13mg')}
                     </Button>
-                  ) : canFinalizeInvoice ? (
+                  ) : actions.canFinalize({ status }) ? (
                     <>
                       <Button
                         variant="quaternary"
@@ -821,7 +809,7 @@ const CustomerInvoiceDetails = () => {
                         {translate('text_63a41a8eabb9ae67047c1c06')}
                       </Button>
                     </>
-                  ) : canDownloadInvoice ? (
+                  ) : actions.canDownload({ status, taxStatus }) ? (
                     <Button
                       variant="quaternary"
                       align="left"


### PR DESCRIPTION
Taking the opportunity to remove the `TODO: Compare this with src/hooks/usePermissionsInvoiceActions.ts:` comments in the app.

I've come to the conclusion that `canFinalize` should check for an additional permission so i changed it and adapted the related test