### PR TITLE
[ISSUE-1148] Prevent cached usage data

### DIFF
--- a/src/components/subscriptions/SubscriptionCurrentUsageTable.tsx
+++ b/src/components/subscriptions/SubscriptionCurrentUsageTable.tsx
@@ -683,6 +683,9 @@ export const SubscriptionCurrentUsageTable = ({
   } = useUsageForSubscriptionUsageQuery({
     ...queryParams,
     skip: queryParams.skip || fetchProjected,
+    // Removing the no-cache policies will break the rendered data
+    fetchPolicy: 'no-cache',
+    nextFetchPolicy: 'no-cache',
   })
 
   const {
@@ -693,6 +696,9 @@ export const SubscriptionCurrentUsageTable = ({
   } = useProjectedUsageForSubscriptionUsageQuery({
     ...queryParams,
     skip: queryParams.skip || !fetchProjected,
+    // Removing the no-cache policies will break the rendered data
+    fetchPolicy: 'no-cache',
+    nextFetchPolicy: 'no-cache',
   })
 
   const refetchUsage = (forceProjected?: boolean) =>


### PR DESCRIPTION
## Context

The usage query was caching the first values received, making the drawer data innacurate.

## Description

Prevent caching of the usage query.

<!-- Linear link -->
Fixes ISSUE-1148