### PR TITLE
bug: fix date format tests

### DIFF
--- a/src/core/timezone/__tests__/utils.test.ts
+++ b/src/core/timezone/__tests__/utils.test.ts
@@ -1,250 +1,541 @@
+import { DateTime, Settings } from 'luxon'
+
 import { DateFormat, intlFormatDateTime } from '~/core/timezone/utils'
 import { LocaleEnum } from '~/core/translations'
 import { TimezoneEnum } from '~/generated/graphql'
 
 import { TimeFormat, TimezoneFormat } from './../utils'
 
+const originalNow = Settings.now
+
+afterEach(() => {
+  Settings.now = originalNow
+})
+
 describe('intlFormatDateTime', () => {
-  describe('it should format dates correctly', () => {
-    it('should format to "Apr 18, 2025"', () => {
-      const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
-        formatDate: DateFormat.DATE_MED,
-      })
+  describe('In summer date', () => {
+    beforeEach(() => {
+      const summerDate = DateTime.fromISO('2025-08-01T12:00:00', { zone: 'Europe/Paris' })
 
-      expect(date).toEqual('Apr 18, 2025')
+      Settings.now = () => summerDate.toMillis()
     })
 
-    it('should format to "4/18/2025"', () => {
-      const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
-        formatDate: DateFormat.DATE_SHORT,
+    describe('it should format dates correctly', () => {
+      it('should format to "Apr 18, 2025"', () => {
+        const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
+          formatDate: DateFormat.DATE_MED,
+        })
+
+        expect(date).toEqual('Apr 18, 2025')
       })
 
-      expect(date).toEqual('4/18/2025')
+      it('should format to "4/18/2025"', () => {
+        const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
+          formatDate: DateFormat.DATE_SHORT,
+        })
+
+        expect(date).toEqual('4/18/2025')
+      })
+
+      it('should format to "18/04/2025" in French', () => {
+        const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
+          formatDate: DateFormat.DATE_SHORT,
+          locale: LocaleEnum.fr,
+        })
+
+        expect(date).toEqual('18/04/2025')
+      })
+
+      it('should format to "April 18, 2025"', () => {
+        const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
+          formatDate: DateFormat.DATE_FULL,
+        })
+
+        expect(date).toEqual('April 18, 2025')
+      })
+
+      it('should format to "Friday, April 18, 2025"', () => {
+        const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
+          formatDate: DateFormat.DATE_HUGE,
+        })
+
+        expect(date).toEqual('Friday, April 18, 2025')
+      })
+
+      it('should format to "Fri, Apr 18, 2025"', () => {
+        const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
+          formatDate: DateFormat.DATE_MED_WITH_WEEKDAY,
+        })
+
+        expect(date).toEqual('Fri, Apr 18, 2025')
+      })
+
+      it('should format to "Apr 18, 25"', () => {
+        const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
+          formatDate: DateFormat.DATE_MED_SHORT_YEAR,
+        })
+
+        expect(date).toEqual('Apr 18, 25')
+      })
+
+      it('should format to "Apr 2024"', () => {
+        const { date } = intlFormatDateTime('2024-04-18T00:00:00Z', {
+          formatDate: DateFormat.DATE_MONTH_YEAR,
+        })
+
+        expect(date).toEqual('Apr 2024')
+      })
     })
 
-    it('should format to "18/04/2025" in French', () => {
-      const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
-        formatDate: DateFormat.DATE_SHORT,
-        locale: LocaleEnum.fr,
+    describe('it should format times correctly', () => {
+      it('should format to "1:41 AM"', () => {
+        const { time } = intlFormatDateTime('2025-04-18T01:41:39Z', {
+          formatTime: TimeFormat.TIME_SIMPLE,
+        })
+
+        expect(time).toEqual('1:41\u202FAM')
       })
 
-      expect(date).toEqual('18/04/2025')
+      it('should format to "1:41 PM"', () => {
+        const { time } = intlFormatDateTime('2025-04-18T13:41:39Z', {
+          formatTime: TimeFormat.TIME_SIMPLE,
+        })
+
+        expect(time).toEqual('1:41\u202FPM')
+      })
+
+      it('should format to "6:00:39\u202FPM"', () => {
+        const { time } = intlFormatDateTime('2025-04-18T18:00:39Z', {
+          formatTime: TimeFormat.TIME_WITH_SECONDS,
+        })
+
+        expect(time).toEqual('6:00:39\u202FPM')
+      })
+
+      it('should format to "13:41"', () => {
+        const { time } = intlFormatDateTime('2025-04-18T13:41:39Z', {
+          formatTime: TimeFormat.TIME_24_SIMPLE,
+        })
+
+        expect(time).toEqual('13:41')
+      })
+
+      it('should format to "13:41:39"', () => {
+        const { time } = intlFormatDateTime('2025-04-18T13:41:39Z', {
+          formatTime: TimeFormat.TIME_24_WITH_SECONDS,
+        })
+
+        expect(time).toEqual('13:41:39')
+      })
     })
 
-    it('should format to "April 18, 2025"', () => {
-      const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
-        formatDate: DateFormat.DATE_FULL,
+    describe('it should format timezones correctly', () => {
+      it('should format to "UTC±0:00"', () => {
+        const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z')
+
+        expect(timezone).toEqual('UTC±0:00')
       })
 
-      expect(date).toEqual('April 18, 2025')
+      it('should format to "UTC+12:00" (Auckland in April - standard time)', () => {
+        const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z', {
+          timezone: TimezoneEnum.TzPacificAuckland,
+        })
+
+        expect(timezone).toEqual('UTC+12:00')
+      })
+
+      it('should format to "UTC-4:00"', () => {
+        const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z', {
+          timezone: TimezoneEnum.TzAmericaNewYork,
+        })
+
+        expect(timezone).toEqual('UTC-4:00')
+      })
+
+      it('should format to "PDT"', () => {
+        const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z', {
+          timezone: TimezoneEnum.TzAmericaLosAngeles,
+          formatTimezone: TimezoneFormat.TIMEZONE_SHORT,
+        })
+
+        expect(timezone).toEqual('PDT')
+      })
+
+      it('should format to "Pacific Daylight Time"', () => {
+        const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z', {
+          timezone: TimezoneEnum.TzAmericaLosAngeles,
+          formatTimezone: TimezoneFormat.TIMEZONE_LONG,
+        })
+
+        expect(timezone).toEqual('Pacific Daylight Time')
+      })
+
+      it('should format to "GMT-7"', () => {
+        const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z', {
+          timezone: TimezoneEnum.TzAmericaLosAngeles,
+          formatTimezone: TimezoneFormat.TIMEZONE_OFFSET,
+        })
+
+        expect(timezone).toEqual('GMT-7')
+      })
     })
 
-    it('should format to "Friday, April 18, 2025"', () => {
-      const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
-        formatDate: DateFormat.DATE_HUGE,
+    describe('it should format date time and timezones correctly', () => {
+      it('should format to "From Apr 2024 to Apr 2025"', () => {
+        const { date: from } = intlFormatDateTime('2024-04-01T00:00:00Z', {
+          formatDate: DateFormat.DATE_MONTH_YEAR,
+        })
+
+        const { date: to } = intlFormatDateTime('2025-04-01T00:00:00Z', {
+          formatDate: DateFormat.DATE_MONTH_YEAR,
+        })
+
+        const result = `From ${from} to ${to}`
+
+        expect(result).toEqual('From Apr 2024 to Apr 2025')
       })
 
-      expect(date).toEqual('Friday, April 18, 2025')
-    })
+      it('should format to "Apr 3, 2025, 6:06 PM UTC±0:00"', () => {
+        const { date, time, timezone } = intlFormatDateTime('2025-04-03T18:06:33Z', {
+          timezone: TimezoneEnum.TzUtc,
+          formatDate: DateFormat.DATE_MED,
+          formatTime: TimeFormat.TIME_SIMPLE,
+        })
 
-    it('should format to "Fri, Apr 18, 2025"', () => {
-      const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
-        formatDate: DateFormat.DATE_MED_WITH_WEEKDAY,
+        const result = `${date}, ${time} ${timezone}`
+
+        expect(result).toEqual('Apr 3, 2025, 6:06 PM UTC±0:00')
       })
 
-      expect(date).toEqual('Fri, Apr 18, 2025')
-    })
+      it('should format to "Apr 18, 2025 UTC-11:00"', () => {
+        const { date, timezone } = intlFormatDateTime('2025-04-18T18:25:33Z', {
+          timezone: TimezoneEnum.TzPacificMidway,
+          formatDate: DateFormat.DATE_MED,
+        })
 
-    it('should format to "Apr 18, 25"', () => {
-      const { date } = intlFormatDateTime('2025-04-18T00:00:00Z', {
-        formatDate: DateFormat.DATE_MED_SHORT_YEAR,
+        const result = `${date} ${timezone}`
+
+        expect(result).toEqual('Apr 18, 2025 UTC-11:00')
       })
 
-      expect(date).toEqual('Apr 18, 25')
-    })
+      it('should format to "Saturday, April 19, 2025 UTC+8:00"', () => {
+        const { date, timezone } = intlFormatDateTime('2025-04-18T18:25:33Z', {
+          timezone: TimezoneEnum.TzAsiaSingapore,
+          formatDate: DateFormat.DATE_HUGE,
+        })
 
-    it('should format to "Apr 2024"', () => {
-      const { date } = intlFormatDateTime('2024-04-18T00:00:00Z', {
-        formatDate: DateFormat.DATE_MONTH_YEAR,
+        const result = `${date} ${timezone}`
+
+        expect(result).toEqual('Saturday, April 19, 2025 UTC+8:00')
       })
 
-      expect(date).toEqual('Apr 2024')
+      it('should format to "April 2, 2025 at 3:30:13 PM UTC±0:00"', () => {
+        const { date, time, timezone } = intlFormatDateTime('2025-04-02T15:30:13Z', {
+          formatDate: DateFormat.DATE_FULL,
+          formatTime: TimeFormat.TIME_WITH_SECONDS,
+        })
+
+        const result = `${date} at ${time} ${timezone}`
+
+        expect(result).toEqual('April 2, 2025 at 3:30:13 PM UTC±0:00')
+      })
+
+      it('should format to "Thu, Apr 3, 2025 09:32:01"', () => {
+        const { date, time } = intlFormatDateTime('2025-04-03T09:32:01Z', {
+          formatDate: DateFormat.DATE_MED_WITH_WEEKDAY,
+          formatTime: TimeFormat.TIME_24_WITH_SECONDS,
+        })
+
+        const result = `${date} ${time}`
+
+        expect(result).toEqual('Thu, Apr 3, 2025 09:32:01')
+      })
+
+      it('should format to "Apr 18, 2025 18:25:33 UTC±0:00"', () => {
+        const { date, time, timezone } = intlFormatDateTime('2025-04-18T18:25:33Z', {
+          formatDate: DateFormat.DATE_MED,
+          formatTime: TimeFormat.TIME_24_WITH_SECONDS,
+        })
+
+        const result = `${date} ${time} ${timezone}`
+
+        expect(result).toEqual('Apr 18, 2025 18:25:33 UTC±0:00')
+      })
+
+      it('should convert UTC time to New York EDT correctly', () => {
+        const { date, time } = intlFormatDateTime('2025-04-18T18:25:33Z', {
+          timezone: TimezoneEnum.TzAmericaNewYork,
+          formatDate: DateFormat.DATE_MED,
+          formatTime: TimeFormat.TIME_SIMPLE,
+        })
+
+        const result = `${date} ${time}`
+
+        expect(result).toEqual('Apr 18, 2025 2:25 PM')
+      })
     })
   })
 
-  describe('it should format times correctly', () => {
-    it('should format to "1:41 AM"', () => {
-      const { time } = intlFormatDateTime('2025-04-18T01:41:39Z', {
-        formatTime: TimeFormat.TIME_SIMPLE,
-      })
+  describe('In winter date', () => {
+    beforeEach(() => {
+      const winterDate = DateTime.fromISO('2025-01-01T12:00:00', { zone: 'Europe/Paris' })
 
-      expect(time).toEqual('1:41 AM')
+      Settings.now = () => winterDate.toMillis()
     })
 
-    it('should format to "1:41 PM"', () => {
-      const { time } = intlFormatDateTime('2025-04-18T13:41:39Z', {
-        formatTime: TimeFormat.TIME_SIMPLE,
+    describe('it should format dates correctly', () => {
+      it('should format to "Jan 15, 2025"', () => {
+        const { date } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          formatDate: DateFormat.DATE_MED,
+        })
+
+        expect(date).toEqual('Jan 15, 2025')
       })
 
-      expect(time).toEqual('1:41 PM')
+      it('should format to "1/15/2025"', () => {
+        const { date } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          formatDate: DateFormat.DATE_SHORT,
+        })
+
+        expect(date).toEqual('1/15/2025')
+      })
+
+      it('should format to "15/01/2025" in French', () => {
+        const { date } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          formatDate: DateFormat.DATE_SHORT,
+          locale: LocaleEnum.fr,
+        })
+
+        expect(date).toEqual('15/01/2025')
+      })
+
+      it('should format to "January 15, 2025"', () => {
+        const { date } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          formatDate: DateFormat.DATE_FULL,
+        })
+
+        expect(date).toEqual('January 15, 2025')
+      })
+
+      it('should format to "Wednesday, January 15, 2025"', () => {
+        const { date } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          formatDate: DateFormat.DATE_HUGE,
+        })
+
+        expect(date).toEqual('Wednesday, January 15, 2025')
+      })
+
+      it('should format to "Wed, Jan 15, 2025"', () => {
+        const { date } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          formatDate: DateFormat.DATE_MED_WITH_WEEKDAY,
+        })
+
+        expect(date).toEqual('Wed, Jan 15, 2025')
+      })
+
+      it('should format to "Jan 15, 25"', () => {
+        const { date } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          formatDate: DateFormat.DATE_MED_SHORT_YEAR,
+        })
+
+        expect(date).toEqual('Jan 15, 25')
+      })
+
+      it('should format to "Jan 2025"', () => {
+        const { date } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          formatDate: DateFormat.DATE_MONTH_YEAR,
+        })
+
+        expect(date).toEqual('Jan 2025')
+      })
     })
 
-    it('should format to "6:00:39 PM"', () => {
-      const { time } = intlFormatDateTime('2025-04-18T18:00:39Z', {
-        formatTime: TimeFormat.TIME_WITH_SECONDS,
+    describe('it should format times correctly', () => {
+      it('should format to "1:41 AM"', () => {
+        const { time } = intlFormatDateTime('2025-01-15T01:41:39Z', {
+          formatTime: TimeFormat.TIME_SIMPLE,
+        })
+
+        expect(time).toEqual('1:41\u202FAM')
       })
 
-      expect(time).toEqual('6:00:39 PM')
+      it('should format to "1:41 PM"', () => {
+        const { time } = intlFormatDateTime('2025-01-15T13:41:39Z', {
+          formatTime: TimeFormat.TIME_SIMPLE,
+        })
+
+        expect(time).toEqual('1:41\u202FPM')
+      })
+
+      it('should format to "6:00:39 PM"', () => {
+        const { time } = intlFormatDateTime('2025-01-15T18:00:39Z', {
+          formatTime: TimeFormat.TIME_WITH_SECONDS,
+        })
+
+        expect(time).toEqual('6:00:39\u202FPM')
+      })
+
+      it('should format to "13:41"', () => {
+        const { time } = intlFormatDateTime('2025-01-15T13:41:39Z', {
+          formatTime: TimeFormat.TIME_24_SIMPLE,
+        })
+
+        expect(time).toEqual('13:41')
+      })
+
+      it('should format to "13:41:39"', () => {
+        const { time } = intlFormatDateTime('2025-01-15T13:41:39Z', {
+          formatTime: TimeFormat.TIME_24_WITH_SECONDS,
+        })
+
+        expect(time).toEqual('13:41:39')
+      })
     })
 
-    it('should format to "13:41"', () => {
-      const { time } = intlFormatDateTime('2025-04-18T13:41:39Z', {
-        formatTime: TimeFormat.TIME_24_SIMPLE,
+    describe('it should format timezones correctly in winter (DST differences)', () => {
+      it('should format to "UTC±0:00"', () => {
+        const { timezone } = intlFormatDateTime('2025-01-15T00:00:00Z')
+
+        expect(timezone).toEqual('UTC±0:00')
       })
 
-      expect(time).toEqual('13:41')
+      it('should format to "UTC+13:00"', () => {
+        const { timezone } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          timezone: TimezoneEnum.TzPacificAuckland,
+        })
+
+        expect(timezone).toEqual('UTC+13:00')
+      })
+
+      it('should format to "UTC-5:00" (New York in winter - EST)', () => {
+        const { timezone } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          timezone: TimezoneEnum.TzAmericaNewYork,
+        })
+
+        expect(timezone).toEqual('UTC-5:00')
+      })
+
+      it('should format to "EST" (Eastern Standard Time in winter)', () => {
+        const { timezone } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          timezone: TimezoneEnum.TzAmericaNewYork,
+          formatTimezone: TimezoneFormat.TIMEZONE_SHORT,
+        })
+
+        expect(timezone).toEqual('EST')
+      })
+
+      it('should format to "Eastern Standard Time"', () => {
+        const { timezone } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          timezone: TimezoneEnum.TzAmericaNewYork,
+          formatTimezone: TimezoneFormat.TIMEZONE_LONG,
+        })
+
+        expect(timezone).toEqual('Eastern Standard Time')
+      })
+
+      it('should format to "GMT-5" (correct for actual date)', () => {
+        const { timezone } = intlFormatDateTime('2025-01-15T00:00:00Z', {
+          timezone: TimezoneEnum.TzAmericaNewYork,
+          formatTimezone: TimezoneFormat.TIMEZONE_OFFSET,
+        })
+
+        expect(timezone).toEqual('GMT-5')
+      })
     })
 
-    it('should format to "13:41:39"', () => {
-      const { time } = intlFormatDateTime('2025-04-18T13:41:39Z', {
-        formatTime: TimeFormat.TIME_24_WITH_SECONDS,
+    describe('it should format date time and timezones correctly', () => {
+      it('should format to "From Jan 2024 to Jan 2025"', () => {
+        const { date: from } = intlFormatDateTime('2024-01-01T00:00:00Z', {
+          formatDate: DateFormat.DATE_MONTH_YEAR,
+        })
+
+        const { date: to } = intlFormatDateTime('2025-01-01T00:00:00Z', {
+          formatDate: DateFormat.DATE_MONTH_YEAR,
+        })
+
+        const result = `From ${from} to ${to}`
+
+        expect(result).toEqual('From Jan 2024 to Jan 2025')
       })
 
-      expect(time).toEqual('13:41:39')
-    })
-  })
+      it('should format to "Jan 15, 2025, 6:06 PM UTC±0:00"', () => {
+        const { date, time, timezone } = intlFormatDateTime('2025-01-15T18:06:33Z', {
+          timezone: TimezoneEnum.TzUtc,
+          formatDate: DateFormat.DATE_MED,
+          formatTime: TimeFormat.TIME_SIMPLE,
+        })
 
-  describe('it should format timezones correctly', () => {
-    it('should format to "UTC±0:00"', () => {
-      const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z')
+        const result = `${date}, ${time} ${timezone}`
 
-      expect(timezone).toEqual('UTC±0:00')
-    })
-
-    it('should format to "UTC+12:00"', () => {
-      const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z', {
-        timezone: TimezoneEnum.TzPacificAuckland,
+        expect(result).toEqual('Jan 15, 2025, 6:06\u202FPM UTC±0:00')
       })
 
-      expect(timezone).toEqual('UTC+12:00')
-    })
+      it('should format to "Jan 15, 2025 UTC-11:00"', () => {
+        const { date, timezone } = intlFormatDateTime('2025-01-15T18:25:33Z', {
+          timezone: TimezoneEnum.TzPacificMidway,
+          formatDate: DateFormat.DATE_MED,
+        })
 
-    it('should format to "UTC-4:00"', () => {
-      const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z', {
-        timezone: TimezoneEnum.TzAmericaNewYork,
+        const result = `${date} ${timezone}`
+
+        expect(result).toEqual('Jan 15, 2025 UTC-11:00')
       })
 
-      expect(timezone).toEqual('UTC-4:00')
-    })
+      it('should format to "Thursday, January 16, 2025 UTC+8:00"', () => {
+        const { date, timezone } = intlFormatDateTime('2025-01-15T18:25:33Z', {
+          timezone: TimezoneEnum.TzAsiaSingapore,
+          formatDate: DateFormat.DATE_HUGE,
+        })
 
-    it('should format to "PDT"', () => {
-      const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z', {
-        timezone: TimezoneEnum.TzAmericaLosAngeles,
-        formatTimezone: TimezoneFormat.TIMEZONE_SHORT,
+        const result = `${date} ${timezone}`
+
+        expect(result).toEqual('Thursday, January 16, 2025 UTC+8:00')
       })
 
-      expect(timezone).toEqual('PDT')
-    })
+      it('should format to "January 15, 2025 at 3:30:13 PM UTC±0:00"', () => {
+        const { date, time, timezone } = intlFormatDateTime('2025-01-15T15:30:13Z', {
+          formatDate: DateFormat.DATE_FULL,
+          formatTime: TimeFormat.TIME_WITH_SECONDS,
+        })
 
-    it('should format to "Pacific Daylight Time"', () => {
-      const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z', {
-        timezone: TimezoneEnum.TzAmericaLosAngeles,
-        formatTimezone: TimezoneFormat.TIMEZONE_LONG,
+        const result = `${date} at ${time} ${timezone}`
+
+        expect(result).toEqual('January 15, 2025 at 3:30:13\u202FPM UTC±0:00')
       })
 
-      expect(timezone).toEqual('Pacific Daylight Time')
-    })
+      it('should format to "Wed, Jan 15, 2025 09:32:01"', () => {
+        const { date, time } = intlFormatDateTime('2025-01-15T09:32:01Z', {
+          formatDate: DateFormat.DATE_MED_WITH_WEEKDAY,
+          formatTime: TimeFormat.TIME_24_WITH_SECONDS,
+        })
 
-    it('should format to "GMT-7"', () => {
-      const { timezone } = intlFormatDateTime('2025-04-18T00:00:00Z', {
-        timezone: TimezoneEnum.TzAmericaLosAngeles,
-        formatTimezone: TimezoneFormat.TIMEZONE_OFFSET,
+        const result = `${date} ${time}`
+
+        expect(result).toEqual('Wed, Jan 15, 2025 09:32:01')
       })
 
-      expect(timezone).toEqual('GMT-7')
-    })
-  })
+      it('should format to "Jan 15, 2025 18:25:33 UTC±0:00"', () => {
+        const { date, time, timezone } = intlFormatDateTime('2025-01-15T18:25:33Z', {
+          formatDate: DateFormat.DATE_MED,
+          formatTime: TimeFormat.TIME_24_WITH_SECONDS,
+        })
 
-  describe('it should format date time and timezones correctly', () => {
-    it('should format to "From Apr 2024 to Apr 2025"', () => {
-      const { date: from } = intlFormatDateTime('2024-04-01T00:00:00Z', {
-        formatDate: DateFormat.DATE_MONTH_YEAR,
+        const result = `${date} ${time} ${timezone}`
+
+        expect(result).toEqual('Jan 15, 2025 18:25:33 UTC±0:00')
       })
 
-      const { date: to } = intlFormatDateTime('2025-04-01T00:00:00Z', {
-        formatDate: DateFormat.DATE_MONTH_YEAR,
+      it('should convert UTC time to New York EST correctly', () => {
+        const { date, time } = intlFormatDateTime('2025-01-15T18:25:33Z', {
+          timezone: TimezoneEnum.TzAmericaNewYork,
+          formatDate: DateFormat.DATE_MED,
+          formatTime: TimeFormat.TIME_SIMPLE,
+        })
+
+        const result = `${date} ${time}`
+
+        expect(result).toEqual('Jan 15, 2025 1:25 PM')
       })
-
-      const result = `From ${from} to ${to}`
-
-      expect(result).toEqual('From Apr 2024 to Apr 2025')
-    })
-
-    it('should format to "Apr 3, 2025, 6:06 PM UTC±0:00"', () => {
-      const { date, time, timezone } = intlFormatDateTime('2025-04-03T18:06:33Z', {
-        timezone: TimezoneEnum.TzUtc,
-        formatDate: DateFormat.DATE_MED,
-        formatTime: TimeFormat.TIME_SIMPLE,
-      })
-
-      const result = `${date}, ${time} ${timezone}`
-
-      expect(result).toEqual('Apr 3, 2025, 6:06 PM UTC±0:00')
-    })
-
-    it('should format to "Apr 18, 2025 UTC-11:00"', () => {
-      const { date, timezone } = intlFormatDateTime('2025-04-18T18:25:33Z', {
-        timezone: TimezoneEnum.TzPacificMidway,
-        formatDate: DateFormat.DATE_MED,
-      })
-
-      const result = `${date} ${timezone}`
-
-      expect(result).toEqual('Apr 18, 2025 UTC-11:00')
-    })
-
-    it('should format to "Saturday, April 19, 2025 UTC+8:00"', () => {
-      const { date, timezone } = intlFormatDateTime('2025-04-18T18:25:33Z', {
-        timezone: TimezoneEnum.TzAsiaSingapore,
-        formatDate: DateFormat.DATE_HUGE,
-      })
-
-      const result = `${date} ${timezone}`
-
-      expect(result).toEqual('Saturday, April 19, 2025 UTC+8:00')
-    })
-
-    it('should format to "April 2, 2025 at 3:30:13 PM UTC±0:00"', () => {
-      const { date, time, timezone } = intlFormatDateTime('2025-04-02T15:30:13Z', {
-        formatDate: DateFormat.DATE_FULL,
-        formatTime: TimeFormat.TIME_WITH_SECONDS,
-      })
-
-      const result = `${date} at ${time} ${timezone}`
-
-      expect(result).toEqual('April 2, 2025 at 3:30:13 PM UTC±0:00')
-    })
-
-    it('should format to "Thu, Apr 3, 2025 09:32:01"', () => {
-      const { date, time } = intlFormatDateTime('2025-04-03T09:32:01Z', {
-        formatDate: DateFormat.DATE_MED_WITH_WEEKDAY,
-        formatTime: TimeFormat.TIME_24_WITH_SECONDS,
-      })
-
-      const result = `${date} ${time}`
-
-      expect(result).toEqual('Thu, Apr 3, 2025 09:32:01')
-    })
-
-    it('should format to "Apr 18, 2025 18:25:33 UTC±0:00"', () => {
-      const { date, time, timezone } = intlFormatDateTime('2025-04-18T18:25:33Z', {
-        formatDate: DateFormat.DATE_MED,
-        formatTime: TimeFormat.TIME_24_WITH_SECONDS,
-      })
-
-      const result = `${date} ${time} ${timezone}`
-
-      expect(result).toEqual('Apr 18, 2025 18:25:33 UTC±0:00')
     })
   })
 })

--- a/src/core/timezone/config.ts
+++ b/src/core/timezone/config.ts
@@ -6,14 +6,15 @@ const currentDate = DateTime.now().toISO()
 
 const getOffsetInMinute = (zone: string) => DateTime.fromISO(currentDate as string, { zone }).offset
 
-const getOffset = (zone: string) => {
-  const offsetInMinute = getOffsetInMinute(zone)
+export const getOffset = (zone: string, forDate?: string) => {
+  const dateToUse = forDate || currentDate
+  const offsetInMinute = DateTime.fromISO(dateToUse as string, { zone }).offset
   const sign = Math.sign(offsetInMinute)
 
   return isNaN(offsetInMinute)
     ? 'NaN'
     : Duration.fromObject({
-        minutes: Math.abs(DateTime.fromISO(currentDate as string, { zone }).offset),
+        minutes: Math.abs(offsetInMinute),
       }).toFormat(`${sign === -1 ? '-' : offsetInMinute === 0 ? '±' : '+'}h:mm`)
 }
 

--- a/src/core/timezone/utils.ts
+++ b/src/core/timezone/utils.ts
@@ -2,7 +2,7 @@ import { captureMessage } from '@sentry/react'
 import { DateTime, DateTimeFormatOptions } from 'luxon'
 
 import { envGlobalVar } from '~/core/apolloClient'
-import { TimeZonesConfig } from '~/core/timezone/config'
+import { getOffset, TimeZonesConfig } from '~/core/timezone/config'
 import { LocaleEnum } from '~/core/translations'
 import { TimezoneEnum } from '~/generated/graphql'
 
@@ -125,7 +125,11 @@ const getTimezoneString = (dateTime: DateTime, timezone: TimezoneEnum, format: T
         })
         .find((part) => part.type === 'timeZoneName')?.value || ''
   } else {
-    timezoneString = `UTC${getTimezoneConfig(timezone).offset}`
+    // Use centralized offset calculation that handles DST properly
+    const zoneName = getTimezoneConfig(timezone).name
+    const offset = getOffset(zoneName, dateTime.toISO() || undefined)
+
+    timezoneString = `UTC${offset}`
   }
   return timezoneString
 }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -2560,6 +2560,11 @@ export type CustomerMetadata = {
   value: Scalars['String']['output'];
 };
 
+export type CustomerMetadataFilter = {
+  key: Scalars['String']['input'];
+  value: Scalars['String']['input'];
+};
+
 export type CustomerMetadataInput = {
   displayInInvoice: Scalars['Boolean']['input'];
   id?: InputMaybe<Scalars['ID']['input']>;
@@ -6392,10 +6397,18 @@ export type QueryCustomersArgs = {
   activeSubscriptionsCountFrom?: InputMaybe<Scalars['Int']['input']>;
   activeSubscriptionsCountTo?: InputMaybe<Scalars['Int']['input']>;
   billingEntityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  countries?: InputMaybe<Array<CountryCode>>;
+  currencies?: InputMaybe<Array<CurrencyEnum>>;
+  customerType?: InputMaybe<CustomerTypeEnum>;
+  hasCustomerType?: InputMaybe<Scalars['Boolean']['input']>;
+  hasTaxIdentificationNumber?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  metadata?: InputMaybe<Array<CustomerMetadataFilter>>;
   page?: InputMaybe<Scalars['Int']['input']>;
   searchTerm?: InputMaybe<Scalars['String']['input']>;
+  states?: InputMaybe<Array<Scalars['String']['input']>>;
   withDeleted?: InputMaybe<Scalars['Boolean']['input']>;
+  zipcodes?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 


### PR DESCRIPTION
Fixing a date test that fails due to summer/winter changes.

It now makes sure we control the period before format assertions and checks the formats in both cases.

Noticed after Aukland changed from winter to summer time during the night (+12 to +13)

Also got the last GQL schema


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors timezone offset calculation to be date-aware (DST-safe), updates utils to use it, overhauls tests to control summer/winter contexts, and refreshes GraphQL schema with new customer filters.
> 
> - **Timezone**:
>   - **DST-aware offsets**: Export `getOffset(zone, forDate?)` in `src/core/timezone/config.ts` to compute offsets for a specific ISO date.
>   - **Utils update**: `getTimezoneString` in `src/core/timezone/utils.ts` now uses `getOffset(zoneName, dateTime.toISO())` for `UTC`-style offsets; import adjusted.
> - **Tests**:
>   - **Stability across seasons**: Mock `luxon.Settings.now` and split suites into summer/winter to assert date/time/zone outputs reliably.
>   - Add/adjust expectations (including narrow no‑break space in AM/PM) and more timezone cases (offset/short/long names, conversions).
> - **GraphQL**:
>   - Schema refresh: add `CustomerMetadataFilter` and extend `QueryCustomersArgs` with filters (`countries`, `currencies`, `customerType`, flags, `metadata`, `states`, `zipcodes`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1731b3a84ab0b207b726dcbf69862d1e045194de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->