### PR TITLE
fix(filters): fix customer filters when names are too long

### DIFF
--- a/src/components/designSystem/Filters/filtersElements/FiltersItemCustomer.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemCustomer.tsx
@@ -1,8 +1,9 @@
 import { gql } from '@apollo/client'
 import { useMemo } from 'react'
 
+import { Typography } from '~/components/designSystem'
 import { useFilters } from '~/components/designSystem/Filters/useFilters'
-import { ComboBox } from '~/components/form'
+import { ComboBox, ComboboxItem } from '~/components/form'
 import { useGetCustomersForFilterItemCustomerLazyQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
@@ -48,6 +49,18 @@ export const FiltersItemCustomer = ({ value, setFilterValue }: FiltersItemCustom
 
       return {
         label: `${customerName || externalId || ''}${customer.deletedAt ? ` (${translate('text_1743158702704o1juwxmr4ab')})` : ''}`,
+        labelNode: (
+          <ComboboxItem>
+            <Typography variant="body" color="grey700" noWrap>
+              {customerName || externalId || ''}
+            </Typography>
+            {customer.deletedAt && (
+              <Typography variant="caption" color="grey600" noWrap>
+                {` (${translate('text_1743158702704o1juwxmr4ab')})`}
+              </Typography>
+            )}
+          </ComboboxItem>
+        ),
         value: `${externalId}${filterDataInlineSeparator}${customerName}`,
       }
     })


### PR DESCRIPTION
## Context

When filtering on invoices page or any page allowing to filter per Customer, a Customer with a name too long may have it's content spill from the option. We want to improve readability by fixing this behaviour.

## Description

Uses the list wrapper to force content to be on one line. This improves readability of all other options but may hinder the readability of the long element

<!-- Linear link -->
Fixes [ISSUE-1176](https://linear.app/getlago/issue/ISSUE-1176/customer-filter-is-broken-if-name-is-too-long)