### PR TITLE
misc: improve cache management on orga switch and logout

### DIFF
--- a/src/core/apolloClient/cacheUtils.ts
+++ b/src/core/apolloClient/cacheUtils.ts
@@ -59,10 +59,10 @@ export const removeItemFromLS = (key: string) => {
 
 // --------------------- Auth utils ---------------------
 export const logOut = async (client: ApolloClient<object>, resetLocationHistory?: boolean) => {
-  // Prevent active queries re-fetch
+  // Cancels active operations
+  client.stop()
+  // Removes cached data and prevents active queries re-fetch
   await client.clearStore()
-  // Clear store
-  await client.cache.reset()
   updateAuthTokenVar()
 
   resetLocationHistory && resetLocationHistoryVar()
@@ -163,10 +163,8 @@ export const switchCurrentOrganization = async (
   client: ApolloClient<object>,
   organizationId: string,
 ) => {
-  // Stop the client to prevent active queries re-fetch
+  // Removes cached data and prevents active queries re-fetch
   await client.clearStore()
-  // Clear store
-  await client.cache.reset()
 
   // We should not be redirected to any route on orga switch, but rather bring to home (prevent )
   removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)


### PR DESCRIPTION
## Context

I've noticed we receive some [Sentry](https://lago.sentry.io/issues/6929255885) about queries being canceled while on-flight.
Seems related to the logout logic when the user is de-authenticated.

The cache and active queries management there is not optimal so I've made some update.

Also notice some redundancy in cache cleaning for the logout and the orga switch that feels better to simplify.

## Description

We now have that sequence

`logout`
1. `client.stop()` to cancel running queries. So if the logout happen after the user focuses the app and fires many queries to refresh cache, they'll be canceled. This action does not need to be awaited
2. `await client.clearStore()` removes all data from the store. Unlike `resetStore`, `clearStore` will not refetch any active queries. 
3. the `await client.cache.reset()` is not necessary and did sort of the same job as `clearStore`

`switchCurrentOrganization`
1. `await client.clearStore()` removes all data from the store and will not refetch any active queries.
2. the `await client.cache.reset()` is not necessary and did sort of the same job as `clearStore`

I'm not getting in the details of the following command related ot token management in the code, those stay unchanged.
