### PR TITLE
bug: make sure the dev panel is closed on on orga switch

### DIFF
--- a/src/hooks/useDeveloperTool.tsx
+++ b/src/hooks/useDeveloperTool.tsx
@@ -80,6 +80,8 @@ export function useDeveloperTool(): DeveloperToolContextType {
   useEffect(() => {
     // On mounted, check the params from the URL
     checkParamsFromUrl()
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // Throw an error if the hook is used outside of the provider

--- a/src/layouts/MainNavLayout.tsx
+++ b/src/layouts/MainNavLayout.tsx
@@ -109,7 +109,11 @@ const MainNavLayout = () => {
   } = useOrganizationInfos()
   const { translate } = useInternationalization()
   const { data, loading, error } = useSideNavInfosQuery()
-  const { openPanel: openInspector } = useDeveloperTool()
+  const {
+    openPanel: openInspector,
+    closePanel: closeInspector,
+    panelOpen: isInspectorOpen,
+  } = useDeveloperTool()
 
   const { pathname, state } = location as Location & { state: { disableScrollTop?: boolean } }
   const contentRef = useRef<HTMLDivElement>(null)
@@ -235,6 +239,7 @@ const MainNavLayout = () => {
                               endIcon={accessibleByCurrentSession ? undefined : 'lock'}
                               onClick={async () => {
                                 await switchCurrentOrganization(client, id)
+                                isInspectorOpen && closeInspector()
                                 navigate(HOME_ROUTE)
                                 await Promise.all([
                                   refetchOrganizationInfos(),


### PR DESCRIPTION
## Context

You can open the developer panel and then switch organization.

In such cases, the developer panel remains open, and the problem is its attempt to perform the call and sometimes with some ideas that are not available on the new organization. 
That results in the user receiving 404 errors and seeing an error toast. 
The user could also land into an organization where his permission doesn't allow him to see the developer panel. 

## Description

This pull request simply closes the developer panel whenever the user tries to switch organizations. 

<!-- Linear link -->
Fixes ISSUE-1084