### PR TITLE
misc: use cached contextual translations

### DIFF
--- a/src/components/customerPortal/common/useCustomerPortalTranslate.ts
+++ b/src/components/customerPortal/common/useCustomerPortalTranslate.ts
@@ -31,7 +31,7 @@ const useCustomerPortalTranslate = () => {
   const { token } = useParams()
   const { isPortalAuthenticated } = useIsAuthenticated()
   const { data, error, loading } = useGetPortalLocaleQuery({
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
     nextFetchPolicy: 'cache-first',
     skip: !isPortalAuthenticated || !token,
   })


### PR DESCRIPTION
## Context

We are having issues in the application where we are importing contextual translations. 
Those translations are different than the English one, and usually they are imported in some components or they are used within the whole Customer Portal side of the application. 

We face two issues:
1. When a component is rendered in a list, every time a new component is drawn on the page, the hook about loading the contextual translation will fire again, and you will face some kind of loading state even though those translations are already available somehow.
2. The second issue is about the customer portal that explicitly fetches the new local every time we navigate within the customer portal. That led to having some flag-key translations displayed, and it would be better to rely on the cache as the translation in the local is not supposed to change when you are navigating within the same customer portal instance. 

## Description

This pull request solves those two issues:
1. It fixes it by just caching them at the module level within the simple constant. So if that constant is fulfilled with the correct local, we'll just use the same values there, preventing the glitch in the UI when we display the same component multiple times.
2. Solved by simply changing the cache policy for the portal local query that fetches those translations to be displayed on the screen.

<!-- Linear link -->
Fixes ISSUE-1145