### PR TITLE
chore: define a browserlist for support

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,14 @@
   "engines": {
     "node": ">=20"
   },
+  "browserslist": [
+    "> 1%",
+    "last 3 versions",
+    "Firefox ESR",
+    "not dead",
+    "not ie 11",
+    "not op_mini all"
+  ],
   "pnpm": {
     "overrides": {
       "@babel/helpers": "7.26.10",


### PR DESCRIPTION
## Context

We do not explicitly set the support for browsers in our application, which leads to our tooling chain to potentially have different standards and rely on different rules regarding this. 

## Description

This pull request aims to define this list, and so it follows the same standard for all the tooling chains in the application. This setup gives up to 89.68% support, so pretty big.
Also, I tried to reduce the number of supported browsers to only three, the three latest versions. However, the bundle size hasn't changed at all because most of the recent versions of browsers support most of the features we're using either for CSS or JavaScript, so it doesn't change that much. I prefer to have a broader role for theirs in case something changes later, and to support our customers for a longer time. 

<!-- Linear link -->
Fixes ISSUE-1190