### PR TITLE
deps: bump node required version to 22 (LTS)

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -8,7 +8,7 @@ on:
       api_branch:
         description: Api Branch
         required: true
-        default: 'main'
+        default: "main"
 
 jobs:
   codegen:
@@ -43,8 +43,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: 'pnpm'
+          node-version: 22
+          cache: "pnpm"
 
       - name: Install Node.js dependencies
         run: pnpm install

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: 'pnpm'
+          node-version: 22
+          cache: "pnpm"
           cache-dependency-path: ./pnpm-lock.yaml
 
       - name: Install dependencies

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: 'pnpm'
+          node-version: 22
+          cache: "pnpm"
 
       - name: Install Node.js dependencies
         run: pnpm install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: 'pnpm'
+          node-version: 22
+          cache: "pnpm"
 
       - name: Install Node.js dependencies
         run: pnpm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS build
+FROM node:22-alpine AS build
 
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "yup": "1.2.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
Let's use the current LTS version of node

I realised I was already running my local app with 22 so that does not break anything 
We also already use `@types/node: ^22.`