### PR TITLE
misc: extract formikProps from charge accordion elements

### DIFF
--- a/src/components/plans/ChargePercentage.tsx
+++ b/src/components/plans/ChargePercentage.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { InputAdornment } from '@mui/material'
-import { FormikProps } from 'formik'
+import { FormikProps, FormikState } from 'formik'
 import _get from 'lodash/get'
 import { memo, RefObject, useCallback, useMemo } from 'react'
 
@@ -31,33 +31,35 @@ gql`
 
 interface ChargePercentageProps {
   chargeCursor: ChargeCursor
+  chargeErrors: FormikState<PlanFormInput>['errors']
   chargeIndex: number
   chargePricingUnitShortName: string | undefined
   currency: CurrencyEnum
   disabled?: boolean
   filterIndex?: number
-  formikProps: FormikProps<PlanFormInput>
   premiumWarningDialogRef?: RefObject<PremiumWarningDialogRef>
   propertyCursor: string
+  setFieldValue: FormikProps<PlanFormInput>['setFieldValue']
   valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
 }
 
 export const ChargePercentage = memo(
   ({
     chargeCursor,
+    chargeErrors: chargeErrorsProps,
     chargeIndex,
     chargePricingUnitShortName,
     currency,
     disabled,
     filterIndex,
-    formikProps,
     premiumWarningDialogRef,
     propertyCursor,
+    setFieldValue,
     valuePointer,
   }: ChargePercentageProps) => {
     const { translate } = useInternationalization()
     const { isPremium } = useCurrentUser()
-    const chargeErrors = _get(formikProps?.errors, `${chargeCursor}.${chargeIndex}`)
+    const chargeErrors = _get(chargeErrorsProps, `${chargeCursor}.${chargeIndex}`)
     const showFixedAmount = valuePointer?.fixedAmount !== undefined
     const showFreeUnitsPerEvents = valuePointer?.freeUnitsPerEvents !== undefined
     const showFreeUnitsPerTotalAggregation =
@@ -88,7 +90,7 @@ export const ChargePercentage = memo(
 
     const handleUpdate = useCallback(
       (name: string, value: string | string[]) => {
-        formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
+        setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
       },
 
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -152,7 +154,7 @@ export const ChargePercentage = memo(
                 disabled={disabled}
                 variant="quaternary"
                 onClick={() => {
-                  formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
+                  setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
                     ...valuePointer,
                     fixedAmount: undefined,
                   })
@@ -194,7 +196,7 @@ export const ChargePercentage = memo(
                 disabled={disabled}
                 variant="quaternary"
                 onClick={() => {
-                  formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
+                  setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
                     ...valuePointer,
                     freeUnitsPerEvents: undefined,
                   })
@@ -244,7 +246,7 @@ export const ChargePercentage = memo(
                 disabled={disabled}
                 variant="quaternary"
                 onClick={() => {
-                  formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
+                  setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
                     ...valuePointer,
                     freeUnitsPerTotalAggregation: undefined,
                   })
@@ -301,7 +303,7 @@ export const ChargePercentage = memo(
                 disabled={disabled}
                 variant="quaternary"
                 onClick={() => {
-                  formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
+                  setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
                     ...valuePointer,
                     perTransactionMinAmount: undefined,
                   })
@@ -345,7 +347,7 @@ export const ChargePercentage = memo(
                 disabled={disabled}
                 variant="quaternary"
                 onClick={() => {
-                  formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
+                  setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
                     ...valuePointer,
                     perTransactionMaxAmount: undefined,
                   })
@@ -362,7 +364,7 @@ export const ChargePercentage = memo(
             variant="inline"
             disabled={disabled || valuePointer?.fixedAmount !== undefined}
             onClick={() =>
-              formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
+              setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
                 ...valuePointer,
                 fixedAmount: '',
               })
@@ -397,7 +399,7 @@ export const ChargePercentage = memo(
                   variant="quaternary"
                   disabled={disabled || valuePointer?.freeUnitsPerEvents !== undefined}
                   onClick={() => {
-                    formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
+                    setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
                       ...valuePointer,
                       freeUnitsPerEvents: '',
                     })
@@ -412,7 +414,7 @@ export const ChargePercentage = memo(
                   variant="quaternary"
                   disabled={disabled || valuePointer?.freeUnitsPerTotalAggregation !== undefined}
                   onClick={() => {
-                    formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
+                    setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
                       ...valuePointer,
                       freeUnitsPerTotalAggregation: '',
                     })
@@ -454,13 +456,10 @@ export const ChargePercentage = memo(
                   disabled={disabled || valuePointer?.perTransactionMinAmount !== undefined}
                   onClick={() => {
                     if (isPremium) {
-                      formikProps.setFieldValue(
-                        `${chargeCursor}.${chargeIndex}.${propertyCursor}`,
-                        {
-                          ...valuePointer,
-                          perTransactionMinAmount: '',
-                        },
-                      )
+                      setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
+                        ...valuePointer,
+                        perTransactionMinAmount: '',
+                      })
                     } else {
                       premiumWarningDialogRef?.current?.openDialog()
                     }
@@ -478,13 +477,10 @@ export const ChargePercentage = memo(
                   disabled={disabled || valuePointer?.perTransactionMaxAmount !== undefined}
                   onClick={() => {
                     if (isPremium) {
-                      formikProps.setFieldValue(
-                        `${chargeCursor}.${chargeIndex}.${propertyCursor}`,
-                        {
-                          ...valuePointer,
-                          perTransactionMaxAmount: '',
-                        },
-                      )
+                      setFieldValue(`${chargeCursor}.${chargeIndex}.${propertyCursor}`, {
+                        ...valuePointer,
+                        perTransactionMaxAmount: '',
+                      })
                     } else {
                       premiumWarningDialogRef?.current?.openDialog()
                     }

--- a/src/components/plans/CustomCharge.tsx
+++ b/src/components/plans/CustomCharge.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { FormikProps } from 'formik'
+import { FormikProps, FormikState } from 'formik'
 import _get from 'lodash/get'
 import { memo, useCallback, useRef } from 'react'
 
@@ -22,20 +22,22 @@ gql`
 
 interface CustomChargeProps {
   chargeCursor: ChargeCursor
+  chargeErrors: FormikState<PlanFormInput>['errors']
   chargeIndex: number
-  formikProps: FormikProps<PlanFormInput>
-  propertyCursor: string
-  valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
   disabled?: boolean
+  propertyCursor: string
+  setFieldValue: FormikProps<PlanFormInput>['setFieldValue']
+  valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
 }
 
 export const CustomCharge = memo(
   ({
     chargeCursor,
+    chargeErrors,
     chargeIndex,
     disabled,
-    formikProps,
     propertyCursor,
+    setFieldValue,
     valuePointer,
   }: CustomChargeProps) => {
     const { translate } = useInternationalization()
@@ -46,7 +48,7 @@ export const CustomCharge = memo(
 
     const handleUpdate = useCallback(
       (value: string) => {
-        formikProps.setFieldValue(inputId, value)
+        setFieldValue(inputId, value)
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [inputId],
@@ -60,10 +62,10 @@ export const CustomCharge = memo(
             label={translate('text_663dea5702b60301d8d06502')}
             value={valuePointer?.customProperties}
             disabled={disabled}
-            error={_get(formikProps.errors, inputId)}
+            error={_get(chargeErrors, inputId)}
             onExpand={() =>
               drawerRef.current?.openDrawer({
-                customProperties: _get(formikProps.values, inputId),
+                customProperties: valuePointer?.customProperties,
               })
             }
           />

--- a/src/components/plans/DynamicCharge.tsx
+++ b/src/components/plans/DynamicCharge.tsx
@@ -18,10 +18,10 @@ gql`
 type DynamicChargeProps = {
   chargeCursor: ChargeCursor
   chargeIndex: number
-  formikProps: FormikProps<PlanFormInput>
-  propertyCursor: string
-  valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
   disabled?: boolean
+  propertyCursor: string
+  setFieldValue: FormikProps<PlanFormInput>['setFieldValue']
+  valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
 }
 
 export const DynamicCharge = memo(
@@ -29,15 +29,15 @@ export const DynamicCharge = memo(
     chargeCursor,
     chargeIndex,
     disabled,
-    formikProps,
     propertyCursor,
+    setFieldValue,
     valuePointer,
   }: DynamicChargeProps) => {
     const { translate } = useInternationalization()
 
     const handleUpdate = useCallback(
       (name: string, value: string | string[]) => {
-        formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
+        setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [chargeCursor, chargeIndex],

--- a/src/components/plans/GraduatedChargeTable.tsx
+++ b/src/components/plans/GraduatedChargeTable.tsx
@@ -30,8 +30,8 @@ interface GraduatedChargeTableProps {
   chargePricingUnitShortName: string | undefined
   currency: CurrencyEnum
   disabled?: boolean
-  formikProps: FormikProps<PlanFormInput>
   propertyCursor: string
+  setFieldValue: FormikProps<PlanFormInput>['setFieldValue']
   valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
 }
 
@@ -61,8 +61,8 @@ export const GraduatedChargeTable = memo(
     chargePricingUnitShortName,
     currency,
     disabled,
-    formikProps,
     propertyCursor,
+    setFieldValue,
     valuePointer,
   }: GraduatedChargeTableProps) => {
     const { translate } = useInternationalization()
@@ -72,8 +72,8 @@ export const GraduatedChargeTable = memo(
         chargeCursor,
         chargeIndex,
         disabled,
-        formikProps,
         propertyCursor,
+        setFieldValue,
         valuePointer,
       })
 
@@ -325,7 +325,7 @@ export const GraduatedChargeTable = memo(
           <PricingGroupKeys
             disabled={disabled}
             handleUpdate={(name, value) => {
-              formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
+              setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
             }}
             propertyCursor={propertyCursor}
             valuePointer={valuePointer}

--- a/src/components/plans/GraduatedPercentageChargeTable.tsx
+++ b/src/components/plans/GraduatedPercentageChargeTable.tsx
@@ -30,8 +30,8 @@ interface GraduatedPercentageChargeTableProps {
   chargePricingUnitShortName: string | undefined
   currency: CurrencyEnum
   disabled?: boolean
-  formikProps: FormikProps<PlanFormInput>
   propertyCursor: string
+  setFieldValue: FormikProps<PlanFormInput>['setFieldValue']
   valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
 }
 
@@ -61,8 +61,8 @@ export const GraduatedPercentageChargeTable = memo(
     chargePricingUnitShortName,
     currency,
     disabled,
-    formikProps,
     propertyCursor,
+    setFieldValue,
     valuePointer,
   }: GraduatedPercentageChargeTableProps) => {
     const { translate } = useInternationalization()
@@ -72,8 +72,8 @@ export const GraduatedPercentageChargeTable = memo(
         chargeCursor,
         chargeIndex,
         disabled,
-        formikProps,
         propertyCursor,
+        setFieldValue,
         valuePointer,
       })
 
@@ -304,7 +304,7 @@ export const GraduatedPercentageChargeTable = memo(
           <PricingGroupKeys
             disabled={disabled}
             handleUpdate={(name, value) => {
-              formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
+              setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
             }}
             propertyCursor={propertyCursor}
             valuePointer={valuePointer}

--- a/src/components/plans/PackageCharge.tsx
+++ b/src/components/plans/PackageCharge.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { InputAdornment } from '@mui/material'
-import { FormikProps } from 'formik'
+import { FormikProps, FormikState } from 'formik'
 import _get from 'lodash/get'
 import { memo, useCallback } from 'react'
 
@@ -24,30 +24,32 @@ gql`
 
 interface PackageChargeProps {
   chargeCursor: ChargeCursor
+  chargeErrors: FormikState<PlanFormInput>['errors']
   chargeIndex: number
   chargePricingUnitShortName: string | undefined
   currency: CurrencyEnum
   disabled?: boolean
-  formikProps: FormikProps<PlanFormInput>
   propertyCursor: string
+  setFieldValue: FormikProps<PlanFormInput>['setFieldValue']
   valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
 }
 
 export const PackageCharge = memo(
   ({
     chargeCursor,
+    chargeErrors,
     chargeIndex,
     chargePricingUnitShortName,
     currency,
     disabled,
-    formikProps,
     propertyCursor,
+    setFieldValue,
     valuePointer,
   }: PackageChargeProps) => {
     const { translate } = useInternationalization()
     const handleUpdate = useCallback(
       (name: string, value: string | string[]) => {
-        formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
+        setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [chargeIndex],
@@ -77,7 +79,7 @@ export const PackageCharge = memo(
         <TextInput
           name={`${propertyCursor}.packageSize`}
           beforeChangeFormatter={['positiveNumber', 'int']}
-          error={_get(formikProps.errors, `${chargeCursor}.${chargeIndex}.properties.packageSize`)}
+          error={_get(chargeErrors, `${chargeCursor}.${chargeIndex}.${propertyCursor}.packageSize`)}
           disabled={disabled}
           value={serializedPackageCharge}
           onChange={(value) => handleUpdate(`${propertyCursor}.packageSize`, value)}

--- a/src/components/plans/StandardCharge.tsx
+++ b/src/components/plans/StandardCharge.tsx
@@ -26,8 +26,8 @@ interface StandardChargeProps {
   chargePricingUnitShortName: string | undefined
   currency: CurrencyEnum
   disabled?: boolean
-  formikProps: FormikProps<PlanFormInput>
   propertyCursor: string
+  setFieldValue: FormikProps<PlanFormInput>['setFieldValue']
   valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
 }
 
@@ -38,18 +38,19 @@ export const StandardCharge = memo(
     chargePricingUnitShortName,
     currency,
     disabled,
-    formikProps,
     propertyCursor,
+    setFieldValue,
     valuePointer,
   }: StandardChargeProps) => {
     const { translate } = useInternationalization()
 
     const handleUpdate = useCallback(
       (name: string, value: string | string[]) => {
-        formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
+        setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
       },
+
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [chargeIndex],
+      [chargeCursor, chargeIndex],
     )
 
     return (

--- a/src/components/plans/UsageChargeAccordion.tsx
+++ b/src/components/plans/UsageChargeAccordion.tsx
@@ -441,12 +441,14 @@ export const UsageChargeAccordion = memo(
                   >
                     <ChargeWrapperSwitch
                       chargeCursor="charges"
+                      chargeErrors={formikProps.errors}
                       chargeIndex={index}
                       chargePricingUnitShortName={chargePricingUnitShortName}
                       currency={currency}
                       formikProps={formikProps}
                       premiumWarningDialogRef={premiumWarningDialogRef}
                       propertyCursor="properties"
+                      setFieldValue={formikProps.setFieldValue}
                       valuePointer={localCharge?.properties}
                     />
                   </ConditionalWrapper>
@@ -551,6 +553,7 @@ export const UsageChargeAccordion = memo(
 
                           <ChargeWrapperSwitch
                             chargeCursor="charges"
+                            chargeErrors={formikProps.errors}
                             chargeIndex={index}
                             chargePricingUnitShortName={chargePricingUnitShortName}
                             currency={currency}
@@ -558,6 +561,7 @@ export const UsageChargeAccordion = memo(
                             formikProps={formikProps}
                             premiumWarningDialogRef={premiumWarningDialogRef}
                             propertyCursor={`filters.${filterIndex}.properties`}
+                            setFieldValue={formikProps.setFieldValue}
                             valuePointer={filter.properties}
                           />
                         </div>

--- a/src/components/plans/VolumeChargeTable.tsx
+++ b/src/components/plans/VolumeChargeTable.tsx
@@ -29,8 +29,8 @@ interface VolumeChargeTableProps {
   chargePricingUnitShortName: string | undefined
   currency: CurrencyEnum
   disabled?: boolean
-  formikProps: FormikProps<PlanFormInput>
   propertyCursor: string
+  setFieldValue: FormikProps<PlanFormInput>['setFieldValue']
   valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
 }
 
@@ -50,8 +50,8 @@ export const VolumeChargeTable = memo(
     chargePricingUnitShortName,
     currency,
     disabled,
-    formikProps,
     propertyCursor,
+    setFieldValue,
     valuePointer,
   }: VolumeChargeTableProps) => {
     const { translate } = useInternationalization()
@@ -61,8 +61,8 @@ export const VolumeChargeTable = memo(
         chargeCursor,
         chargeIndex,
         disabled,
-        formikProps,
         propertyCursor,
+        setFieldValue,
         valuePointer,
       })
 
@@ -246,7 +246,7 @@ export const VolumeChargeTable = memo(
           <PricingGroupKeys
             disabled={disabled}
             handleUpdate={(name, value) => {
-              formikProps.setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
+              setFieldValue(`${chargeCursor}.${chargeIndex}.${name}`, value)
             }}
             propertyCursor={propertyCursor}
             valuePointer={valuePointer}

--- a/src/components/plans/chargeAccordion/ChargeWrapperSwitch.tsx
+++ b/src/components/plans/chargeAccordion/ChargeWrapperSwitch.tsx
@@ -1,4 +1,4 @@
-import { FormikProps } from 'formik'
+import { FormikProps, FormikState } from 'formik'
 import { memo, RefObject } from 'react'
 
 import { ChargePercentage } from '~/components/plans/ChargePercentage'
@@ -17,6 +17,7 @@ export type ChargeCursor = keyof Pick<PlanFormInput, 'charges' | 'fixedCharges'>
 
 interface ChargeWrapperSwitchProps {
   chargeCursor: ChargeCursor
+  chargeErrors: FormikState<PlanFormInput>['errors']
   chargeIndex: number
   chargePricingUnitShortName: string | undefined
   currency: CurrencyEnum
@@ -25,6 +26,7 @@ interface ChargeWrapperSwitchProps {
   formikProps: FormikProps<PlanFormInput>
   premiumWarningDialogRef?: RefObject<PremiumWarningDialogRef>
   propertyCursor: string
+  setFieldValue: FormikProps<PlanFormInput>['setFieldValue']
   valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
 }
 
@@ -32,6 +34,7 @@ export const ChargeWrapperSwitch = memo(
   ({
     chargeCursor,
     chargeIndex,
+    chargeErrors,
     chargePricingUnitShortName,
     currency,
     disabled,
@@ -39,6 +42,7 @@ export const ChargeWrapperSwitch = memo(
     formikProps,
     premiumWarningDialogRef,
     propertyCursor,
+    setFieldValue,
     valuePointer,
   }: ChargeWrapperSwitchProps) => {
     const localCharge = formikProps.values[chargeCursor]?.[chargeIndex]
@@ -52,20 +56,21 @@ export const ChargeWrapperSwitch = memo(
             chargePricingUnitShortName={chargePricingUnitShortName}
             currency={currency}
             disabled={disabled}
-            formikProps={formikProps}
             propertyCursor={propertyCursor}
+            setFieldValue={setFieldValue}
             valuePointer={valuePointer}
           />
         )}
         {localCharge?.chargeModel === ChargeModelEnum.Package && (
           <PackageCharge
             chargeCursor={chargeCursor}
+            chargeErrors={chargeErrors}
             chargeIndex={chargeIndex}
             chargePricingUnitShortName={chargePricingUnitShortName}
             currency={currency}
             disabled={disabled}
-            formikProps={formikProps}
             propertyCursor={propertyCursor}
+            setFieldValue={setFieldValue}
             valuePointer={valuePointer}
           />
         )}
@@ -76,8 +81,8 @@ export const ChargeWrapperSwitch = memo(
             chargePricingUnitShortName={chargePricingUnitShortName}
             currency={currency}
             disabled={disabled}
-            formikProps={formikProps}
             propertyCursor={propertyCursor}
+            setFieldValue={setFieldValue}
             valuePointer={valuePointer}
           />
         )}
@@ -88,22 +93,23 @@ export const ChargeWrapperSwitch = memo(
             chargePricingUnitShortName={chargePricingUnitShortName}
             currency={currency}
             disabled={disabled}
-            formikProps={formikProps}
             propertyCursor={propertyCursor}
+            setFieldValue={setFieldValue}
             valuePointer={valuePointer}
           />
         )}
         {localCharge?.chargeModel === ChargeModelEnum.Percentage && (
           <ChargePercentage
             chargeCursor={chargeCursor}
+            chargeErrors={chargeErrors}
             chargeIndex={chargeIndex}
             chargePricingUnitShortName={chargePricingUnitShortName}
             currency={currency}
             disabled={disabled}
             filterIndex={filterIndex}
-            formikProps={formikProps}
             premiumWarningDialogRef={premiumWarningDialogRef}
             propertyCursor={propertyCursor}
+            setFieldValue={setFieldValue}
             valuePointer={valuePointer}
           />
         )}
@@ -114,18 +120,19 @@ export const ChargeWrapperSwitch = memo(
             chargePricingUnitShortName={chargePricingUnitShortName}
             currency={currency}
             disabled={disabled}
-            formikProps={formikProps}
             propertyCursor={propertyCursor}
+            setFieldValue={setFieldValue}
             valuePointer={valuePointer}
           />
         )}
         {localCharge?.chargeModel === ChargeModelEnum.Custom && (
           <CustomCharge
             chargeCursor={chargeCursor}
+            chargeErrors={chargeErrors}
             chargeIndex={chargeIndex}
             disabled={disabled}
-            formikProps={formikProps}
             propertyCursor={propertyCursor}
+            setFieldValue={setFieldValue}
             valuePointer={valuePointer}
           />
         )}
@@ -134,8 +141,8 @@ export const ChargeWrapperSwitch = memo(
             chargeCursor={chargeCursor}
             chargeIndex={chargeIndex}
             disabled={disabled}
-            formikProps={formikProps}
             propertyCursor={propertyCursor}
+            setFieldValue={setFieldValue}
             valuePointer={valuePointer}
           />
         )}

--- a/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
@@ -86,10 +86,10 @@ const prepare = async ({
 
     return useGraduatedChargeForm({
       chargeCursor,
-      formikProps,
       chargeIndex,
       disabled,
       propertyCursor,
+      setFieldValue: formikProps.setFieldValue,
       valuePointer,
     })
   })

--- a/src/hooks/plans/__tests__/useGraduatedPercentageChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useGraduatedPercentageChargeForm.test.tsx
@@ -86,10 +86,10 @@ const prepare = async ({
 
     return useGraduatedPercentageChargeForm({
       chargeCursor,
-      formikProps,
       chargeIndex,
       disabled,
       propertyCursor,
+      setFieldValue: formikProps.setFieldValue,
       valuePointer,
     })
   })

--- a/src/hooks/plans/__tests__/useVolumeChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useVolumeChargeForm.test.tsx
@@ -83,10 +83,10 @@ const prepare = async ({
 
     return useVolumeChargeForm({
       chargeCursor,
-      formikProps,
       chargeIndex,
       disabled,
       propertyCursor,
+      setFieldValue: formikProps.setFieldValue,
       valuePointer,
     })
   })

--- a/src/hooks/plans/useGraduatedChargeForm.ts
+++ b/src/hooks/plans/useGraduatedChargeForm.ts
@@ -19,15 +19,15 @@ type UseGraduatedChargeForm = ({
   chargeCursor,
   chargeIndex,
   disabled,
-  formikProps,
   propertyCursor,
+  setFieldValue,
   valuePointer,
 }: {
   chargeCursor: ChargeCursor
   chargeIndex: number
   disabled?: boolean
-  formikProps: FormikProps<PlanFormInput>
   propertyCursor: string
+  setFieldValue: FormikProps<PlanFormInput>['setFieldValue']
   valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
 }) => {
   handleUpdate: (rangeIndex: number, fieldName: string, value?: number | string | string[]) => void
@@ -56,7 +56,7 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
   chargeCursor,
   chargeIndex,
   disabled,
-  formikProps,
+  setFieldValue,
   propertyCursor,
   valuePointer,
 }) => {
@@ -66,7 +66,7 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
   useEffect(() => {
     if (!graduatedRanges.length) {
       // if no existing charge, initialize it with 2 pre-filled lines
-      formikProps.setFieldValue(formikIdentifier, DEFAULT_GRADUATED_CHARGES)
+      setFieldValue(formikIdentifier, DEFAULT_GRADUATED_CHARGES)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formikIdentifier])
@@ -158,14 +158,14 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
         [],
       )
 
-      formikProps.setFieldValue(
+      setFieldValue(
         `${chargeCursor}.${chargeIndex}.${propertyCursor}.graduatedRanges`,
         newGraduatedRanges,
       )
     },
     handleUpdate: (rangeIndex, fieldName, value) => {
       if (fieldName !== 'toValue') {
-        formikProps.setFieldValue(`${formikIdentifier}.${rangeIndex}.${fieldName}`, value)
+        setFieldValue(`${formikIdentifier}.${rangeIndex}.${fieldName}`, value)
       } else {
         const newGraduatedRanges = graduatedRanges.reduce<GraduatedRangeInput[]>(
           (acc, range, i) => {
@@ -195,7 +195,7 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
           [],
         )
 
-        formikProps.setFieldValue(formikIdentifier, newGraduatedRanges)
+        setFieldValue(formikIdentifier, newGraduatedRanges)
       }
     },
     deleteRange: (rangeIndex) => {
@@ -216,7 +216,7 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
       // Last row needs to has toValue null
       newGraduatedRanges[newGraduatedRanges.length - 1].toValue = null
 
-      formikProps.setFieldValue(formikIdentifier, newGraduatedRanges)
+      setFieldValue(formikIdentifier, newGraduatedRanges)
     },
   }
 }

--- a/src/hooks/plans/useGraduatedPercentageChargeForm.ts
+++ b/src/hooks/plans/useGraduatedPercentageChargeForm.ts
@@ -14,17 +14,17 @@ type InfoCalculationRow = {
 
 type useGraduatedPercentageChargeForm = ({
   chargeCursor,
-  formikProps,
   chargeIndex,
   disabled,
   propertyCursor,
+  setFieldValue,
   valuePointer,
 }: {
   chargeCursor: ChargeCursor
   chargeIndex: number
   disabled?: boolean
-  formikProps: FormikProps<PlanFormInput>
   propertyCursor: string
+  setFieldValue: FormikProps<PlanFormInput>['setFieldValue']
   valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
 }) => {
   handleUpdate: (rangeIndex: number, fieldName: string, value?: number | string) => void
@@ -53,8 +53,8 @@ export const useGraduatedPercentageChargeForm: useGraduatedPercentageChargeForm 
   chargeCursor,
   chargeIndex,
   disabled,
-  formikProps,
   propertyCursor,
+  setFieldValue,
   valuePointer,
 }) => {
   const formikIdentifier = `${chargeCursor}.${chargeIndex}.${propertyCursor}.graduatedPercentageRanges`
@@ -66,7 +66,7 @@ export const useGraduatedPercentageChargeForm: useGraduatedPercentageChargeForm 
   useEffect(() => {
     if (!graduatedPercentageRanges.length) {
       // if no existing charge, initialize it with 2 pre-filled lines
-      formikProps.setFieldValue(formikIdentifier, DEFAULT_GRADUATED_PERCENTAGE_CHARGES)
+      setFieldValue(formikIdentifier, DEFAULT_GRADUATED_PERCENTAGE_CHARGES)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formikIdentifier])
@@ -134,14 +134,14 @@ export const useGraduatedPercentageChargeForm: useGraduatedPercentageChargeForm 
         return acc
       }, [])
 
-      formikProps.setFieldValue(
+      setFieldValue(
         `${chargeCursor}.${chargeIndex}.${propertyCursor}.graduatedPercentageRanges`,
         newgraduatedPercentageRanges,
       )
     },
     handleUpdate: (rangeIndex, fieldName, value) => {
       if (fieldName !== 'toValue') {
-        formikProps.setFieldValue(
+        setFieldValue(
           `${formikIdentifier}.${rangeIndex}.${fieldName}`,
           value !== '' ? Number(value) : value,
         )
@@ -173,7 +173,7 @@ export const useGraduatedPercentageChargeForm: useGraduatedPercentageChargeForm 
           return acc
         }, [])
 
-        formikProps.setFieldValue(formikIdentifier, newgraduatedPercentageRanges)
+        setFieldValue(formikIdentifier, newgraduatedPercentageRanges)
       }
     },
     deleteRange: (rangeIndex) => {
@@ -196,7 +196,7 @@ export const useGraduatedPercentageChargeForm: useGraduatedPercentageChargeForm 
       // Last row needs to has toValue equal to null (infinite)
       newgraduatedPercentageRanges[newgraduatedPercentageRanges.length - 1].toValue = null
 
-      formikProps.setFieldValue(formikIdentifier, newgraduatedPercentageRanges)
+      setFieldValue(formikIdentifier, newgraduatedPercentageRanges)
     },
   }
 }

--- a/src/hooks/plans/useVolumeChargeForm.ts
+++ b/src/hooks/plans/useVolumeChargeForm.ts
@@ -34,15 +34,15 @@ type UseVolumeChargeForm = ({
   chargeCursor,
   chargeIndex,
   disabled,
-  formikProps,
   propertyCursor,
+  setFieldValue,
   valuePointer,
 }: {
   chargeCursor: ChargeCursor
   chargeIndex: number
   disabled?: boolean
-  formikProps: FormikProps<PlanFormInput>
   propertyCursor: string
+  setFieldValue: FormikProps<PlanFormInput>['setFieldValue']
   valuePointer: PropertiesInput | LocalChargeFilterInput['properties'] | undefined
 }) => {
   handleUpdate: (rangeIndex: number, fieldName: string, value?: number | string) => void
@@ -56,8 +56,8 @@ export const useVolumeChargeForm: UseVolumeChargeForm = ({
   chargeCursor,
   chargeIndex,
   disabled,
-  formikProps,
   propertyCursor,
+  setFieldValue,
   valuePointer,
 }) => {
   const formikIdentifier = `${chargeCursor}.${chargeIndex}.${propertyCursor}.volumeRanges`
@@ -66,7 +66,7 @@ export const useVolumeChargeForm: UseVolumeChargeForm = ({
   useEffect(() => {
     if (!volumeRanges.length) {
       // if no existing charge, initialize it with 2 pre-filled lines
-      formikProps.setFieldValue(formikIdentifier, DEFAULT_VOLUME_CHARGES)
+      setFieldValue(formikIdentifier, DEFAULT_VOLUME_CHARGES)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formikIdentifier])
@@ -121,14 +121,14 @@ export const useVolumeChargeForm: UseVolumeChargeForm = ({
         return acc
       }, [])
 
-      formikProps.setFieldValue(
+      setFieldValue(
         `${chargeCursor}.${chargeIndex}.${propertyCursor}.volumeRanges`,
         newVolumeRanges,
       )
     },
     handleUpdate: (rangeIndex, fieldName, value) => {
       if (fieldName !== 'toValue') {
-        formikProps.setFieldValue(`${formikIdentifier}.${rangeIndex}.${fieldName}`, value)
+        setFieldValue(`${formikIdentifier}.${rangeIndex}.${fieldName}`, value)
       } else {
         const newVolumeRanges = volumeRanges.reduce<VolumeRangeInput[]>((acc, range, i) => {
           if (rangeIndex === i) {
@@ -155,7 +155,7 @@ export const useVolumeChargeForm: UseVolumeChargeForm = ({
           return acc
         }, [])
 
-        formikProps.setFieldValue(formikIdentifier, newVolumeRanges)
+        setFieldValue(formikIdentifier, newVolumeRanges)
       }
     },
     deleteRange: (rangeIndex) => {
@@ -176,7 +176,7 @@ export const useVolumeChargeForm: UseVolumeChargeForm = ({
       // Last row needs to has toValue null
       newVolumeRanges[newVolumeRanges.length - 1].toValue = null
 
-      formikProps.setFieldValue(formikIdentifier, newVolumeRanges)
+      setFieldValue(formikIdentifier, newVolumeRanges)
     },
   }
 }


### PR DESCRIPTION
This PR refactors the `src/components/plans/chargeAccordion/ChargeWrapperSwitch.tsx` so it does not pass the whole `formikProps` object down it's components.

It was kinda annoying me for a task I'm working on and it makes the code simpler.
It's also a sort of first step to improve the perf of this form later. We need to decouple the form from the components elements themself