### PR TITLE
bug: ensure luxon zone is UTC when running test

### DIFF
--- a/src/components/graphs/__tests__/utils.test.ts
+++ b/src/components/graphs/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { DateTime } from 'luxon'
+import { DateTime, Settings } from 'luxon'
 
 import {
   formatDataForAreaChart,
@@ -10,7 +10,16 @@ import {
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CurrencyEnum } from '~/generated/graphql'
 
+const originalDefaultZone = Settings.defaultZone
+
+afterEach(() => {
+  Settings.defaultZone = originalDefaultZone
+})
+
 describe('components/graphs/utils', () => {
+  beforeEach(() => {
+    Settings.defaultZone = 'UTC'
+  })
   describe('getLastTwelveMonthsNumbersUntilNow', () => {
     it('should return an array of 12 months', () => {
       const builtArray = getLastTwelveMonthsNumbersUntilNow()


### PR DESCRIPTION
I had issues running locally a test as I am currently in UTC -3. 

This pull request simply makes sure that every time the test runs, it runs with the time zone UTC 0, ensuring that the expected data are exactly the one that are printed here, no matter where you run the test. 