### PR TITLE
misc: change already used charge alert logic

### DIFF
--- a/src/components/plans/UsageChargeAccordion.tsx
+++ b/src/components/plans/UsageChargeAccordion.tsx
@@ -147,14 +147,14 @@ interface UsageChargeAccordionProps {
   editInvoiceDisplayNameDialogRef: RefObject<EditInvoiceDisplayNameDialogRef>
   removeChargeWarningDialogRef?: RefObject<RemoveChargeWarningDialogRef>
   subscriptionFormType?: keyof typeof FORM_TYPE_ENUM
-  shouldDisplayAlreadyUsedChargeAlert: boolean
+  alreadyUsedChargeAlertMessage: string | undefined
 }
 
 export const UsageChargeAccordion = memo(
   ({
     currency,
     disabled,
-    shouldDisplayAlreadyUsedChargeAlert,
+    alreadyUsedChargeAlertMessage,
     removeChargeWarningDialogRef,
     premiumWarningDialogRef,
     editInvoiceDisplayNameDialogRef,
@@ -362,7 +362,7 @@ export const UsageChargeAccordion = memo(
           />
 
           <ChargeModelSelector
-            shouldDisplayAlreadyUsedChargeAlert={shouldDisplayAlreadyUsedChargeAlert}
+            alreadyUsedChargeAlertMessage={alreadyUsedChargeAlertMessage}
             isInSubscriptionForm={isInSubscriptionForm}
             disabled={disabled}
             localCharge={localCharge}

--- a/src/components/plans/UsageChargesSection.tsx
+++ b/src/components/plans/UsageChargesSection.tsx
@@ -317,8 +317,10 @@ export const UsageChargesSection = memo(
                     const isNew = !alreadyExistingCharges?.find(
                       (chargeFetched) => chargeFetched?.id === charge.id,
                     )
-                    const shouldDisplayAlreadyUsedChargeAlert =
+                    const alreadyUsedChargeAlertMessage =
                       (alreadyUsedBmsIds.get(charge.billableMetric.id) || 0) > 1
+                        ? translate('text_6435895831d323008a47911f')
+                        : undefined
 
                     return (
                       <UsageChargeAccordion
@@ -327,7 +329,7 @@ export const UsageChargesSection = memo(
                         isInitiallyOpen={isInitiallyOpen}
                         isInSubscriptionForm={isInSubscriptionForm}
                         subscriptionFormType={subscriptionFormType}
-                        shouldDisplayAlreadyUsedChargeAlert={shouldDisplayAlreadyUsedChargeAlert}
+                        alreadyUsedChargeAlertMessage={alreadyUsedChargeAlertMessage}
                         removeChargeWarningDialogRef={removeChargeWarningDialogRef}
                         premiumWarningDialogRef={premiumWarningDialogRef}
                         editInvoiceDisplayNameDialogRef={editInvoiceDisplayNameDialogRef}
@@ -443,8 +445,10 @@ export const UsageChargesSection = memo(
                     const isNew = !alreadyExistingCharges?.find(
                       (chargeFetched) => chargeFetched?.id === charge.id,
                     )
-                    const shouldDisplayAlreadyUsedChargeAlert =
+                    const alreadyUsedChargeAlertMessage =
                       (alreadyUsedBmsIds.get(charge.billableMetric.id) || 0) > 1
+                        ? translate('text_6435895831d323008a47911f')
+                        : undefined
 
                     return (
                       <UsageChargeAccordion
@@ -453,7 +457,7 @@ export const UsageChargesSection = memo(
                         isInitiallyOpen={isInitiallyOpen}
                         isInSubscriptionForm={isInSubscriptionForm}
                         subscriptionFormType={subscriptionFormType}
-                        shouldDisplayAlreadyUsedChargeAlert={shouldDisplayAlreadyUsedChargeAlert}
+                        alreadyUsedChargeAlertMessage={alreadyUsedChargeAlertMessage}
                         removeChargeWarningDialogRef={removeChargeWarningDialogRef}
                         premiumWarningDialogRef={premiumWarningDialogRef}
                         editInvoiceDisplayNameDialogRef={editInvoiceDisplayNameDialogRef}

--- a/src/components/plans/__tests__/UsageChargeAccordion.test.tsx
+++ b/src/components/plans/__tests__/UsageChargeAccordion.test.tsx
@@ -59,7 +59,7 @@ async function prepare({ filters, properties }: PrepareProps = {}) {
         id="0"
         index={0}
         currency={CurrencyEnum.Usd}
-        shouldDisplayAlreadyUsedChargeAlert={false}
+        alreadyUsedChargeAlertMessage={undefined}
         formikProps={formikProps as unknown as FormikProps<PlanFormInput>}
         editInvoiceDisplayNameDialogRef={{} as React.RefObject<EditInvoiceDisplayNameDialogRef>}
       />

--- a/src/components/plans/chargeAccordion/ChargeModelSelector.tsx
+++ b/src/components/plans/chargeAccordion/ChargeModelSelector.tsx
@@ -7,14 +7,14 @@ import { getChargeModelHelpTextTranslationKey } from '~/core/constants/form'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 export const ChargeModelSelector = ({
-  shouldDisplayAlreadyUsedChargeAlert,
+  alreadyUsedChargeAlertMessage,
   isInSubscriptionForm,
   disabled,
   localCharge,
   chargeModelComboboxData,
   handleUpdate,
 }: {
-  shouldDisplayAlreadyUsedChargeAlert: boolean
+  alreadyUsedChargeAlertMessage: string | undefined
   isInSubscriptionForm: boolean | undefined
   disabled: boolean | undefined
   localCharge: LocalUsageChargeInput
@@ -28,9 +28,9 @@ export const ChargeModelSelector = ({
 
   return (
     <div className="p-4 pb-0" data-test="charge-model-wrapper">
-      {!!shouldDisplayAlreadyUsedChargeAlert && (
+      {!!alreadyUsedChargeAlertMessage && (
         <Alert type="warning" className="mb-4">
-          {translate('text_6435895831d323008a47911f')}
+          {alreadyUsedChargeAlertMessage}
         </Alert>
       )}
       <ComboBox


### PR DESCRIPTION
Small adjustment about how we manage to display the alert for a charge that has already been added to a plan "based on the BM id.

Made this to ease future change related to fixed charges