### PR TITLE
fix: remove useless text in multicombo label

### DIFF
--- a/src/components/form/MultipleComboBox/MultipleComboBox.tsx
+++ b/src/components/form/MultipleComboBox/MultipleComboBox.tsx
@@ -149,17 +149,23 @@ export const MultipleComboBox = ({
         }
 
         return tagValues.map((option, index) => {
-          // Happens when `freeSolo` is true and user types a value that is not in the list and press enter
-          const optionToDisplay =
-            typeof option === 'string' ? { value: option, label: option } : option
           const tagOptions = getTagProps({ index })
+          // Happens when `freeSolo` is true and user types a value that is not in the list and press enter
+          const optionValue = typeof option === 'string' ? option : option.value
+          const optionLabel = typeof option === 'string' ? option : option.label || optionValue
+
+          // Happens when `freeSolo` is true and we click on the option instead of submitting by using the enter key
+          const labelContainsCreateText =
+            optionLabel === translate('text_65ef30711cfd3e0083135de8', { value: optionValue })
+
+          const labelToUse = labelContainsCreateText ? optionValue : optionLabel
 
           return (
             <Chip
               {...tagOptions}
               className="my-2 ml-2 mr-0"
               key={tagOptions.key}
-              label={optionToDisplay.label ?? optionToDisplay.value}
+              label={labelToUse}
             />
           )
         })


### PR DESCRIPTION
## Context

While on a multicombo box that accept adding content (freeSolo option), you can either `press enter` or `click` to add value. An example for this is the zipcode filter in Customer.

If you press enter, everything work as intended. But if you click on the visible option, the content of the Chip becomes `Click or press enter to add "test"` instead of just "test".

This PR intends to fix this behaviour

## Description

I at first started to look at how the value is defined and tried to redefine the onClick action but since it's coming from the MUI Autocomplete, it was hard to change the onClick without potentially creating side effects.

It's for this reason that I chose to modify the label of the Chip and "filter out" the label if it is equal to the "add text" (translation key `text_65ef30711cfd3e0083135de8`)

The fix is still up for debate, if anybody has another idea

<!-- Linear link -->
Fixes [ISSUE-1209](https://linear.app/getlago/issue/ISSUE-1209/multiple-combobox-free-solo-adds-wrong-value-when-clicking-on-the)