### PR TITLE
fix: allow scroll in navigation tab on small screens

### DIFF
--- a/src/components/designSystem/NavigationTab.tsx
+++ b/src/components/designSystem/NavigationTab.tsx
@@ -123,7 +123,7 @@ export const NavigationTab = ({
     <>
       <div className={tw('flex flex-row shadow-b', className)}>
         <Tabs
-          className={tw('min-h-0 flex-1 items-center overflow-visible', {
+          className={tw('min-h-0 w-full flex-1 items-center overflow-visible', {
             'min-h-13': nonHiddenTabs.length > 1,
           })}
           variant="scrollable"


### PR DESCRIPTION
## Context

On the Customer Details page, we have a very long navigation tab. On small screns (tablet and smaller), we cannot scoll inside of it to select the last elements

## Description

This PR fixes this issue by limiting the size of the element encapsulating the navigation. This in turn allows for the overflows to properly handle the scrolling

<!-- Linear link -->
Fixes [ISSUE-993](https://linear.app/getlago/issue/ISSUE-993/navigationtab-is-broken-on-small-screens)