### PR TITLE
deps: fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,6 @@
   "prCreation": "immediate",
   "minimumReleaseAge": "7 days",
   "pinVersions": true,
-  "preserveSemverRanges": true,
   "addLabels": ["🔗 dependencies"],
   "schedule": ["every weekend", "before 5am every weekday"],
   "dependencyDashboardTitle": "👷‍♀️ Dependency Dashboard",
@@ -19,7 +18,8 @@
   "packageRules": [
     {
       "matchPackageNames": ["node"],
-      "pinVersions": false
+      "pinVersions": false,
+      "rangeStrategy": "preserve"
     },
     {
       "matchPackageNames": ["@types/react", "@types/react-dom", "@types/react-router-dom"],


### PR DESCRIPTION
Confirmed it works using `npx --yes --package renovate -- renovate-config-validato`

`preserveSemverRanges` is not a valid options, and should be `"rangeStrategy": "preserve"` within the specified package scope (here for node)