### PR TITLE
feat: log gql extention attribute in console on error

### DIFF
--- a/src/core/apolloClient/init.ts
+++ b/src/core/apolloClient/init.ts
@@ -152,7 +152,7 @@ export const initializeApolloClient = async () => {
         console.warn(
           `[GraphQL error]: Message: ${message}, Path: ${path}, Location: ${JSON.stringify(
             locations,
-          )}`,
+          )}, Extensions: ${JSON.stringify(extensions)}`,
         )
       })
     }


### PR DESCRIPTION
When a user experience an error, we print a log on the console. This is very useful for the support when customers send us screenshots/video recordings.

Unfortunately, we put all the interesting stuff in the `extension` attribute. 

This PR also logs the `extensions`

<img width="1758" height="138" alt="CleanShot 2025-10-24 at 15 46 07@2x" src="https://github.com/user-attachments/assets/30c767d5-f7ad-4690-b1e7-a274a02b26af" />
