### PR TITLE
deps(config): group apollo package bump together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,16 @@
       "commitMessagePrefix": "chore(deps):"
     },
     {
+      "matchPackageNames": [
+        "@apollo/*",
+        "apollo-*",
+        "@types/apollo-*",
+        "@graphql-codegen/typescript-react-apollo"
+      ],
+      "groupName": "Apollo",
+      "commitMessagePrefix": "chore(deps):"
+    },
+    {
       "matchUpdateTypes": ["major"],
       "commitMessagePrefix": "chore(deps-major)"
     },


### PR DESCRIPTION
There is a hairy v5 upgrade, and managing the different packages in separated PR makes no sense. 
Better to have them all together to ease the the upgrade and related code refactoring