### PR TITLE
misc: fix conflicting rules on version pin for engines packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:recommended", ":preserveSemverRanges"],
+  "extends": ["config:recommended"],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 10,
   "branchConcurrentLimit": 10,
@@ -16,6 +16,11 @@
     "schedule": "at any time"
   },
   "packageRules": [
+    {
+      "matchDepTypes": ["engines"],
+      "rangeStrategy": "replace",
+      "commitMessagePrefix": "chore(deps-engines):"
+    },
     {
       "matchPackageNames": ["@types/react", "@types/react-dom", "@types/react-router-dom"],
       "groupName": "React types",


### PR DESCRIPTION
The `preserveSemverRanges` is conflicting with the `"rangeStrategy": "pin",` making them not pin any package version anymore.

The `"matchDepTypes": ["engines"],` and `"rangeStrategy": "replace",` is the correct way to handle this non-pin behaviour for packages like node