### PR TITLE
fix: Wallet min/max removal on edits

### DIFF
--- a/src/pages/wallet/CreateWallet.tsx
+++ b/src/pages/wallet/CreateWallet.tsx
@@ -328,7 +328,9 @@ const CreateWallet = () => {
                   valuesCurrency,
                 ),
               }
-            : {}),
+            : {
+                paidTopUpMinAmountCents: null,
+              }),
           ...(values.paidTopUpMaxAmountCents
             ? {
                 paidTopUpMaxAmountCents: serializeAmount(
@@ -336,7 +338,9 @@ const CreateWallet = () => {
                   valuesCurrency,
                 ),
               }
-            : {}),
+            : {
+                paidTopUpMaxAmountCents: null,
+              }),
           priority: priority || WALLET_DEFAULT_PRIORITY,
         } satisfies UpdateCustomerWalletInput
 

--- a/src/pages/wallet/components/SettingsSection.tsx
+++ b/src/pages/wallet/components/SettingsSection.tsx
@@ -184,6 +184,8 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
             name: 'paidTopUpMinAmountCents',
             label: translate('text_1758286730208kztcznofxvr'),
             onDelete: () => {
+              formikProps?.setFieldValue('paidTopUpMinAmountCents', undefined)
+
               setShowMinTopUp(false)
             },
             errorLabel: translate('text_175872290080132j1em37b08'),
@@ -193,6 +195,8 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
             name: 'paidTopUpMaxAmountCents',
             label: translate('text_1758286730208ey87jz8nzuz'),
             onDelete: () => {
+              formikProps?.setFieldValue('paidTopUpMaxAmountCents', undefined)
+
               setShowMaxTopUp(false)
             },
             errorLabel: translate('text_1758722900801nbox9c5bgnn'),


### PR DESCRIPTION
## Context

Before we weren't sending the updates properly to the backend when removing a wallet min/max on edition.

## Description

Empty the fields and send "null" to the backend (setting them to null directly would trigger formik errors).

<!-- Linear link -->
Fixes LAGO-1238