### PR TITLE
misc: reset sub name during upgrade/downgrade

### DIFF
--- a/src/pages/subscriptions/CreateSubscription.tsx
+++ b/src/pages/subscriptions/CreateSubscription.tsx
@@ -266,7 +266,7 @@ const CreateSubscription = () => {
   const subscriptionFormikProps = useFormik<Omit<CreateSubscriptionInput, 'customerId'>>({
     initialValues: {
       planId: formType !== FORM_TYPE_ENUM.upgradeDowngrade ? subscription?.plan?.id || '' : '',
-      name: subscription?.name || '',
+      name: formType !== FORM_TYPE_ENUM.upgradeDowngrade ? subscription?.name || '' : '',
       externalId: subscription?.externalId || '',
       subscriptionAt: subscription?.subscriptionAt || currentDateRef?.current,
       endingAt: subscription?.endingAt || undefined,


### PR DESCRIPTION
Better to now copy the subscription name if you intend to perform an upgrade/downgrade.

Does not make much sense in this case.