### PR TITLE
bug: make sure cache is up to date after evict

### DIFF
--- a/src/components/settings/integrations/DeleteAdyenIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteAdyenIntegrationDialog.tsx
@@ -56,6 +56,7 @@ export const DeleteAdyenIntegrationDialog = forwardRef<DeleteAdyenIntegrationDia
       update(cache) {
         cache.evict({ id: `AdyenProvider:${adyenProvider?.id}` })
       },
+      refetchQueries: ['getAdyenIntegrationsList'],
     })
 
     useImperativeHandle(ref, () => ({

--- a/src/components/settings/integrations/DeleteCashfreeIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteCashfreeIntegrationDialog.tsx
@@ -57,6 +57,7 @@ export const DeleteCashfreeIntegrationDialog = forwardRef<DeleteCashfreeIntegrat
       update(cache) {
         cache.evict({ id: `CashfreeProvider:${cashfreeProvider?.id}` })
       },
+      refetchQueries: ['getCashfreeIntegrationsList'],
     })
 
     useImperativeHandle(ref, () => ({

--- a/src/components/settings/integrations/DeleteFlutterwaveIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteFlutterwaveIntegrationDialog.tsx
@@ -55,6 +55,7 @@ export const DeleteFlutterwaveIntegrationDialog = forwardRef<DeleteFlutterwaveIn
       update(cache) {
         cache.evict({ id: `FlutterwaveProvider:${flutterwaveProvider?.id}` })
       },
+      refetchQueries: ['getFlutterwaveIntegrationsList'],
     })
 
     useImperativeHandle(ref, () => ({

--- a/src/components/settings/integrations/DeleteGocardlessIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteGocardlessIntegrationDialog.tsx
@@ -57,6 +57,7 @@ export const DeleteGocardlessIntegrationDialog = forwardRef<DeleteGocardlessInte
       update(cache) {
         cache.evict({ id: `GocardlessProvider:${gocardlessProvider?.id}` })
       },
+      refetchQueries: ['getGocardlessIntegrationsList'],
     })
 
     useImperativeHandle(ref, () => ({

--- a/src/components/settings/integrations/DeleteMoneyhashIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteMoneyhashIntegrationDialog.tsx
@@ -55,6 +55,7 @@ export const DeleteMoneyhashIntegrationDialog = forwardRef<DeleteMoneyhashIntegr
       update(cache) {
         cache.evict({ id: `MoneyhashProvider:${moneyhashProvider?.id}` })
       },
+      refetchQueries: ['getMoneyhashIntegrationsList'],
     })
 
     useImperativeHandle(ref, () => ({

--- a/src/components/settings/integrations/DeleteStripeIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteStripeIntegrationDialog.tsx
@@ -54,6 +54,7 @@ export const DeleteStripeIntegrationDialog = forwardRef<DeleteStripeIntegrationD
       update(cache) {
         cache.evict({ id: `StripeProvider:${stripeProvider?.id}` })
       },
+      refetchQueries: ['getStripeIntegrationsList'],
     })
 
     useImperativeHandle(ref, () => ({


### PR DESCRIPTION
## Context

When deleting an integration, we always evict the data from the cache. When doing so, it happens that you land on the integration list and create another integration. In such a case, the cache is still considering the recently deleted data. 
I believe this is a bug in Apollo GraphQL. However, I love to keep the cache eviction logic in order to make the application more responsive. 

## Description

A - not so nice -workaround for this issue is to make sure the cache is up-to-date with the latest data after something has been evicted. 
Doing so, it prevents Apollo from retrying an active query with a wrong/unexisting data ID, leading to not show an error toast. anymore.

I've added this `refetchQueries` in the integration delete modal that was missing them (some had it already)

<!-- Linear link -->
Fixes ISSUE-1240