### PR TITLE
bug: hide premium feature upgrade for end users

### DIFF
--- a/src/components/customerPortal/usage/UsagePage.tsx
+++ b/src/components/customerPortal/usage/UsagePage.tsx
@@ -177,6 +177,7 @@ const UsagePage = () => {
       {customerId && subscriptionId && (
         <div className="mt-12">
           <SubscriptionCurrentUsageTableComponent
+            isUsedinCustomerPortal
             activeTab={activeTab}
             setActiveTab={setActiveTab}
             showExcludingTaxLabel

--- a/src/components/subscriptions/SubscriptionCurrentUsageTable.tsx
+++ b/src/components/subscriptions/SubscriptionCurrentUsageTable.tsx
@@ -230,6 +230,7 @@ type SubscriptionCurrentUsageTableComponentProps = {
   setActiveTab: (t: number) => void
 
   hasAccessToProjectedUsage?: boolean
+  isUsedinCustomerPortal?: boolean
 }
 
 export const getPricingUnitAmountCents = (
@@ -270,6 +271,7 @@ export const SubscriptionCurrentUsageTableComponent = ({
   locale,
   activeTab,
   setActiveTab,
+  isUsedinCustomerPortal,
   hasAccessToProjectedUsage,
 }: SubscriptionCurrentUsageTableComponentProps) => {
   const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
@@ -359,6 +361,7 @@ export const SubscriptionCurrentUsageTableComponent = ({
           },
           {
             title: translate('text_1753094834414tu9mxavuco7'),
+            hidden: isUsedinCustomerPortal && !hasAccessToProjectedUsage,
           },
         ]}
       />


### PR DESCRIPTION
## Context

We display forecast usage in the sub usage tab.
This component is either rendered in the app or in the customer portal (for end users).
It does not make sense to display it if the feature is not enabled, as if it's shown, it contain a "upgrade" message anc CTA.

## Description

This PR allow to pass an attribute to this component, so we can hide the tab if feature is not enabled AND the component is rendered in the customer portal.

<!-- Linear link -->
Fixes ISSUE-1242