### PR TITLE
feat(formatInvoice): fixed charges fees display order

### DIFF
--- a/src/core/formats/__tests__/formatInvoiceItemsMap.test.ts
+++ b/src/core/formats/__tests__/formatInvoiceItemsMap.test.ts
@@ -1,6 +1,7 @@
 import { InvoiceSubscriptionsForDisplay } from '~/components/invoices/types'
 import { ALL_FILTER_VALUES } from '~/core/constants/form'
 import {
+  _newDeepFormatFees,
   composeChargeFilterDisplayName,
   composeGroupedByDisplayName,
   composeMultipleValuesWithSepator,
@@ -8,6 +9,7 @@ import {
   groupAndFormatFees,
   TExtendedRemainingFee,
 } from '~/core/formats/formatInvoiceItemsMap'
+import { FeeTypesEnum } from '~/generated/graphql'
 
 import {
   chargeZeroAmount,
@@ -299,6 +301,450 @@ describe('formatInvoiceItemsMap', () => {
       ])
 
       expect(result).toEqual('value1 • value2 • key2 • toto • tata')
+    })
+  })
+
+  describe('_newDeepFormatFees', () => {
+    describe('Subscription fees', () => {
+      it('should format subscription fee with custom display name', () => {
+        const fee = {
+          id: 'fee-sub',
+          feeType: FeeTypesEnum.Subscription,
+          invoiceDisplayName: 'Custom Subscription Name',
+          subscription: {
+            plan: {
+              name: 'Plan name',
+              interval: 'monthly',
+            },
+          },
+          amountCents: 5000,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata).toEqual({
+          isSubscriptionFee: true,
+          displayName: 'Custom Subscription Name',
+        })
+      })
+
+      it('should format subscription fee with generated display name', () => {
+        const fee = {
+          id: 'fee-sub',
+          feeType: FeeTypesEnum.Subscription,
+          invoiceDisplayName: null,
+          subscription: {
+            plan: {
+              name: 'Premium Plan',
+              interval: 'yearly',
+            },
+          },
+          amountCents: 5000,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata).toEqual({
+          isSubscriptionFee: true,
+          displayName: 'Yearly subscription fee - Premium Plan',
+        })
+      })
+    })
+
+    describe('Fixed charge fees', () => {
+      it('should format fixed charge fee with invoiceName as display name', () => {
+        const fee = {
+          id: 'fee-1',
+          feeType: FeeTypesEnum.FixedCharge,
+          invoiceName: 'Fixed Fee Invoice Name',
+          itemName: 'Fixed Fee Item Name',
+          amountCents: 1000,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata).toEqual({
+          isFixedCharge: true,
+          displayName: 'Fixed Fee Invoice Name',
+        })
+      })
+
+      it('should format fixed charge fee with itemName as fallback display name', () => {
+        const fee = {
+          id: 'fee-1',
+          feeType: FeeTypesEnum.FixedCharge,
+          invoiceName: null,
+          itemName: 'Fixed Fee Item Name',
+          amountCents: 1000,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata).toEqual({
+          isFixedCharge: true,
+          displayName: 'Fixed Fee Item Name',
+        })
+      })
+    })
+
+    describe('Commitment fees', () => {
+      it('should format commitment fee with custom display name', () => {
+        const fee = {
+          id: 'fee-commitment',
+          feeType: FeeTypesEnum.Commitment,
+          invoiceDisplayName: 'Custom Commitment Display',
+          amountCents: 2000,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata).toEqual({
+          isCommitmentFee: true,
+          displayName: 'Custom Commitment Display',
+        })
+      })
+
+      it('should format commitment fee with default display name', () => {
+        const fee = {
+          id: 'fee-commitment',
+          feeType: FeeTypesEnum.Commitment,
+          invoiceDisplayName: null,
+          amountCents: 2000,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata).toEqual({
+          isCommitmentFee: true,
+          displayName: 'Minimum commitment - True up',
+        })
+      })
+    })
+
+    describe('True-up fees', () => {
+      it('should format true-up fee with all components', () => {
+        const fee = {
+          id: 'fee-trueup',
+          feeType: FeeTypesEnum.Charge,
+          invoiceName: 'API Calls',
+          trueUpParentFee: { id: 'parent-fee-id' },
+          groupedBy: { region: 'US-East' },
+          chargeFilter: {
+            id: 'filter-id',
+            invoiceDisplayName: null,
+            values: { tier: ['premium'] },
+          },
+          charge: {
+            billableMetric: {
+              name: 'API Calls Metric',
+            },
+          },
+          amountCents: 1500,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata.isTrueUpFee).toBe(true)
+        expect(result[0].metadata.displayName).toBe('API Calls • US-East • premium - True-up')
+      })
+
+      it('should format true-up fee using billable metric name as fallback', () => {
+        const fee = {
+          id: 'fee-trueup',
+          feeType: FeeTypesEnum.Charge,
+          invoiceName: null,
+          trueUpParentFee: { id: 'parent-fee-id' },
+          charge: {
+            billableMetric: {
+              name: 'Bandwidth Usage',
+            },
+          },
+          amountCents: 1500,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata.isTrueUpFee).toBe(true)
+        expect(result[0].metadata.displayName).toBe('Bandwidth Usage - True-up')
+      })
+    })
+
+    describe('Filter child fees', () => {
+      it('should format filter child fee with custom invoiceDisplayName', () => {
+        const fee = {
+          id: 'fee-filter',
+          feeType: FeeTypesEnum.Charge,
+          invoiceDisplayName: 'Custom Filter Display',
+          chargeFilter: {
+            id: 'filter-id',
+            invoiceDisplayName: 'Filter Display Name',
+            values: { type: ['basic'] },
+          },
+          amountCents: 800,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata).toEqual({
+          isFilterChildFee: true,
+          displayName: 'Custom Filter Display',
+        })
+      })
+
+      it('should format filter child fee with composed display name', () => {
+        const fee = {
+          id: 'fee-filter',
+          feeType: FeeTypesEnum.Charge,
+          invoiceDisplayName: null,
+          invoiceName: 'Storage Usage',
+          groupedBy: { datacenter: 'DC1' },
+          chargeFilter: {
+            id: 'filter-id',
+            invoiceDisplayName: null,
+            values: { storage_type: ['ssd', 'nvme'] },
+          },
+          charge: {
+            billableMetric: {
+              name: 'Storage Metric',
+            },
+          },
+          amountCents: 1200,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata.isFilterChildFee).toBe(true)
+        expect(result[0].metadata.displayName).toBe('Storage Usage • DC1 • ssd • nvme')
+      })
+    })
+
+    describe('Normal fees', () => {
+      it('should format normal fee with invoiceDisplayName', () => {
+        const fee = {
+          id: 'fee-normal',
+          feeType: FeeTypesEnum.Charge,
+          invoiceDisplayName: 'Custom Normal Display',
+          invoiceName: 'Compute Usage',
+          charge: {
+            billableMetric: {
+              name: 'Compute Metric',
+            },
+          },
+          amountCents: 3000,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata).toEqual({
+          isNormalFee: true,
+          displayName: 'Custom Normal Display',
+        })
+      })
+
+      it('should format normal fee with invoiceName', () => {
+        const fee = {
+          id: 'fee-normal',
+          feeType: FeeTypesEnum.Charge,
+          invoiceDisplayName: null,
+          invoiceName: 'Network Transfer',
+          charge: {
+            billableMetric: {
+              name: 'Network Metric',
+            },
+          },
+          amountCents: 2500,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata).toEqual({
+          isNormalFee: true,
+          displayName: 'Network Transfer',
+        })
+      })
+
+      it('should format normal fee with billable metric name as fallback', () => {
+        const fee = {
+          id: 'fee-normal',
+          feeType: FeeTypesEnum.Charge,
+          invoiceDisplayName: null,
+          invoiceName: null,
+          charge: {
+            billableMetric: {
+              name: 'Database Operations',
+            },
+          },
+          amountCents: 1800,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata).toEqual({
+          isNormalFee: true,
+          displayName: 'Database Operations',
+        })
+      })
+
+      it('should format normal fee with groupedBy values', () => {
+        const fee = {
+          id: 'fee-normal',
+          feeType: FeeTypesEnum.Charge,
+          invoiceDisplayName: null,
+          invoiceName: 'Requests',
+          groupedBy: { region: 'EU-West', environment: 'production' },
+          charge: {
+            billableMetric: {
+              name: 'Request Count',
+            },
+          },
+          amountCents: 2200,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fee])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata.isNormalFee).toBe(true)
+        expect(result[0].metadata.displayName).toBe('Requests • EU-West • production')
+      })
+    })
+
+    describe('Sorting and ordering', () => {
+      it('should sort all fee types in correct order', () => {
+        const subscriptionFee = {
+          id: 'fee-sub',
+          feeType: FeeTypesEnum.Subscription,
+          invoiceDisplayName: 'Custom name',
+          subscription: {
+            plan: {
+              name: 'Custom name',
+              interval: 'monthly',
+            },
+          },
+          amountCents: 5000,
+        } as TExtendedRemainingFee
+
+        const fixedChargeFee = {
+          id: 'fee-fixed',
+          feeType: FeeTypesEnum.FixedCharge,
+          invoiceName: 'Custom name',
+          amountCents: 1000,
+        } as TExtendedRemainingFee
+
+        const commitmentFee = {
+          id: 'fee-commitment',
+          feeType: FeeTypesEnum.Commitment,
+          invoiceDisplayName: 'Custom name',
+          amountCents: 2000,
+        } as TExtendedRemainingFee
+
+        const normalFee = {
+          id: 'fee-normal',
+          feeType: FeeTypesEnum.Charge,
+          invoiceName: 'Custom name',
+          charge: {
+            billableMetric: {
+              name: 'Custom name',
+            },
+          },
+          amountCents: 3000,
+        } as TExtendedRemainingFee
+
+        const trueUpFee = {
+          id: 'fee-trueup',
+          feeType: FeeTypesEnum.Charge,
+          invoiceName: 'Custom name',
+          trueUpParentFee: { id: 'parent' },
+          charge: {
+            billableMetric: {
+              name: 'Custom name',
+            },
+          },
+          amountCents: 500,
+        } as TExtendedRemainingFee
+
+        const filterFee = {
+          id: 'fee-filter',
+          feeType: FeeTypesEnum.Charge,
+          invoiceName: 'Custom name',
+          chargeFilter: {
+            id: 'filter',
+            invoiceDisplayName: null,
+            values: { key: ['value'] },
+          },
+          charge: {
+            billableMetric: {
+              name: 'Custom name',
+            },
+          },
+          amountCents: 700,
+        } as TExtendedRemainingFee
+
+        // Test with fees in random order
+        const result = _newDeepFormatFees([
+          commitmentFee,
+          normalFee,
+          trueUpFee,
+          fixedChargeFee,
+          filterFee,
+          subscriptionFee,
+        ])
+
+        expect(result).toHaveLength(6)
+        // Subscription fees should always be first
+        expect(result[0].metadata.isSubscriptionFee).toBe(true)
+        // Fixed charge fees should always be second
+        expect(result[1].metadata.isFixedCharge).toBe(true)
+        // Normal, Filter, and True-up fees are sorted alphabetically within the middle group
+        // "Custom name" < "Custom name - True-up" < "Custom name • value"
+        expect(result[2].metadata.isNormalFee).toBe(true)
+        expect(result[3].metadata.isTrueUpFee).toBe(true)
+        expect(result[4].metadata.isFilterChildFee).toBe(true)
+        // Commitment fees should always be last
+        expect(result[5].metadata.isCommitmentFee).toBe(true)
+      })
+
+      it('should sort fees of same type alphabetically by display name', () => {
+        const fixedChargeFeeZ = {
+          id: 'fee-fixed-z',
+          feeType: FeeTypesEnum.FixedCharge,
+          invoiceName: 'Zebra Fixed Fee',
+          amountCents: 1000,
+        } as TExtendedRemainingFee
+
+        const fixedChargeFeeA = {
+          id: 'fee-fixed-a',
+          feeType: FeeTypesEnum.FixedCharge,
+          invoiceName: 'Apple Fixed Fee',
+          amountCents: 2000,
+        } as TExtendedRemainingFee
+
+        const fixedChargeFeeM = {
+          id: 'fee-fixed-m',
+          feeType: FeeTypesEnum.FixedCharge,
+          invoiceName: 'Mango Fixed Fee',
+          amountCents: 1500,
+        } as TExtendedRemainingFee
+
+        const result = _newDeepFormatFees([fixedChargeFeeZ, fixedChargeFeeM, fixedChargeFeeA])
+
+        expect(result).toHaveLength(3)
+        expect(result[0].metadata.displayName).toBe('Apple Fixed Fee')
+        expect(result[1].metadata.displayName).toBe('Mango Fixed Fee')
+        expect(result[2].metadata.displayName).toBe('Zebra Fixed Fee')
+      })
     })
   })
 })

--- a/src/core/formats/formatInvoiceItemsMap.ts
+++ b/src/core/formats/formatInvoiceItemsMap.ts
@@ -60,11 +60,12 @@ gql`
 export type TExtendedRemainingFee = Fee & {
   metadata: {
     displayName: string
-    isSubscriptionFee?: boolean
-    isFilterChildFee?: boolean
-    isTrueUpFee?: boolean
-    isNormalFee?: boolean
     isCommitmentFee?: boolean
+    isFilterChildFee?: boolean
+    isFixedCharge?: boolean
+    isNormalFee?: boolean
+    isSubscriptionFee?: boolean
+    isTrueUpFee?: boolean
   }
 }
 export type TSubscriptionDataForDisplay = {
@@ -304,6 +305,14 @@ export const _newDeepFormatFees = (
           displayName: getSubscriptionFeeDisplayName(fee),
         },
       })
+    } else if (fee.feeType === FeeTypesEnum.FixedCharge) {
+      feesData.push({
+        ...fee,
+        metadata: {
+          isFixedCharge: true,
+          displayName: fee?.invoiceName || fee?.itemName,
+        },
+      })
     } else if (fee.feeType === FeeTypesEnum.Commitment) {
       feesData.push({
         ...fee,
@@ -362,6 +371,10 @@ export const _newDeepFormatFees = (
     if (!!a?.metadata?.isSubscriptionFee && !b?.metadata?.isSubscriptionFee) {
       return -1
     } else if (!a?.metadata?.isSubscriptionFee && !!b?.metadata?.isSubscriptionFee) {
+      return 1
+    } else if (!!a?.metadata?.isFixedCharge && !b?.metadata?.isFixedCharge) {
+      return -1
+    } else if (!a?.metadata?.isFixedCharge && !!b?.metadata?.isFixedCharge) {
       return 1
     } else if (!!a?.metadata?.isCommitmentFee && !b?.metadata?.isCommitmentFee) {
       return 1


### PR DESCRIPTION
## Context

We'll soon release the fixed fee feature on the application, and we also need to make sure that those are correctly displayed in the invoice preview. 

## Description

This pull request only updates the logic that defines in which order the fees are placed on the invoice overview. 
That now makes sure that fixed charge fees are displayed right after the subscription ones. 
I also added tests for the existing logic that was not covered. 

<!-- Linear link -->
Fixes LAGO-982