### PR TITLE
feat: include fixed fee in edit fee drawer combobox data

### DIFF
--- a/src/components/invoices/details/EditFeeDrawer.tsx
+++ b/src/components/invoices/details/EditFeeDrawer.tsx
@@ -72,6 +72,15 @@ gql`
             code
           }
         }
+        fixedCharges {
+          id
+          invoiceDisplayName
+          addOn {
+            id
+            name
+            code
+          }
+        }
       }
     }
     fees {
@@ -96,6 +105,9 @@ gql`
             toValue
           }
         }
+      }
+      fixedCharge {
+        id
       }
       chargeFilter {
         id
@@ -292,9 +304,11 @@ export const EditFeeDrawer = forwardRef<EditFeeDrawerRef>((_, ref) => {
 
   const chargesComboboxData = useMemo(() => {
     return getChargesComboboxDataFromInvoiceSubscription({
+      chargesGroupLabel: translate('text_6435888d7cc86500646d8977'),
+      fixedChargesGroupLabel: translate('text_176072970726728iw4tc8ucl'),
       invoiceSubscription: currentInvoiceSubscription,
     })
-  }, [currentInvoiceSubscription])
+  }, [currentInvoiceSubscription, translate])
 
   const chargeFiltersComboboxData = useMemo(() => {
     return getChargesFiltersComboboxDataFromInvoiceSubscription({

--- a/src/components/invoices/details/__tests__/fixture.ts
+++ b/src/components/invoices/details/__tests__/fixture.ts
@@ -12,6 +12,7 @@ export const invoiceSubTwoChargeOneFilter: InvoiceSubscriptionForCreateFeeDrawer
           chargeModel: ChargeModelEnum.Standard,
           prorated: false,
           filters: [],
+          properties: null,
           billableMetric: {
             id: 'e30d1853-461b-4107-a92a-55dd0752663a',
             name: 'Count BM',
@@ -41,6 +42,7 @@ export const invoiceSubTwoChargeOneFilter: InvoiceSubscriptionForCreateFeeDrawer
               },
             },
           ],
+          properties: null,
           billableMetric: {
             id: '2a9dae43-b07b-4717-bf23-1b8d704d4ec5',
             name: 'bm with filters',
@@ -53,6 +55,7 @@ export const invoiceSubTwoChargeOneFilter: InvoiceSubscriptionForCreateFeeDrawer
           chargeModel: ChargeModelEnum.Standard,
           prorated: false,
           filters: [],
+          properties: null,
           billableMetric: {
             id: '2020007c-1c98-4df6-90c9-747990cc988f',
             name: 'Sum BM',
@@ -60,6 +63,7 @@ export const invoiceSubTwoChargeOneFilter: InvoiceSubscriptionForCreateFeeDrawer
           },
         },
       ],
+      fixedCharges: [],
     },
   },
   fees: [
@@ -68,13 +72,18 @@ export const invoiceSubTwoChargeOneFilter: InvoiceSubscriptionForCreateFeeDrawer
       charge: {
         id: '9191b741-ee76-4cae-b9e2-c34f2f0d7b15',
         filters: [],
+        properties: null,
       },
+      fixedCharge: null,
       chargeFilter: null,
+      pricingUnitUsage: null,
     },
     {
       id: 'f435a64d-f470-4cec-97a8-52c08d665af7',
       charge: null,
+      fixedCharge: null,
       chargeFilter: null,
+      pricingUnitUsage: null,
     },
     {
       id: 'bf091d61-df22-4642-a5d5-30f814bb5b7f',
@@ -96,10 +105,13 @@ export const invoiceSubTwoChargeOneFilter: InvoiceSubscriptionForCreateFeeDrawer
             },
           },
         ],
+        properties: null,
       },
+      fixedCharge: null,
       chargeFilter: {
         id: '77d0f439-1e06-4766-a754-537a8aeecf72',
       },
+      pricingUnitUsage: null,
     },
   ],
 }
@@ -381,13 +393,16 @@ export const invoiceSubAllFilterChargesSelected: InvoiceSubscriptionForCreateFee
           },
         },
       ],
+      fixedCharges: [],
     },
   },
   fees: [
     {
       id: '824f455a-f865-4b7c-a318-d1527c488b84',
       charge: null,
+      fixedCharge: null,
       chargeFilter: null,
+      pricingUnitUsage: null,
     },
     {
       id: 'cbdb54f4-b717-4417-be10-2c2d96784199',
@@ -409,10 +424,13 @@ export const invoiceSubAllFilterChargesSelected: InvoiceSubscriptionForCreateFee
             },
           },
         ],
+        properties: null,
       },
+      fixedCharge: null,
       chargeFilter: {
         id: '203c0ec9-7811-4a46-8762-94504b1872ac',
       },
+      pricingUnitUsage: null,
     },
     {
       id: 'fb479c76-56de-4335-a343-880840ccf790',
@@ -434,10 +452,13 @@ export const invoiceSubAllFilterChargesSelected: InvoiceSubscriptionForCreateFee
             },
           },
         ],
+        properties: null,
       },
+      fixedCharge: null,
       chargeFilter: {
         id: 'ababbf42-80d7-4d20-9561-c4f19ca7f9e1',
       },
+      pricingUnitUsage: null,
     },
     {
       id: 'd87e44fa-3814-4c6b-a1e8-4894add44f06',
@@ -459,8 +480,117 @@ export const invoiceSubAllFilterChargesSelected: InvoiceSubscriptionForCreateFee
             },
           },
         ],
+        properties: null,
+      },
+      fixedCharge: null,
+      chargeFilter: null,
+      pricingUnitUsage: null,
+    },
+  ],
+}
+
+export const invoiceSubOnlyFixedCharges: InvoiceSubscriptionForCreateFeeDrawerFragment = {
+  subscription: {
+    id: 'af2b4c1e-8d3a-4f9b-b5c6-12345678abcd',
+    plan: {
+      id: 'dc3e5f2g-9e4b-5g0c-c6d7-23456789bcde',
+      charges: [],
+      fixedCharges: [
+        {
+          id: 'fc1a2b3c-4d5e-6f7g-8h9i-0j1k2l3m4n5o',
+          invoiceDisplayName: 'Setup Fee',
+          addOn: {
+            id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+            name: 'Onboarding Setup',
+            code: 'onboarding_setup',
+          },
+        },
+        {
+          id: 'fc2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p',
+          invoiceDisplayName: '',
+          addOn: {
+            id: 'b2c3d4e5-f6g7-8901-bcde-f12345678901',
+            name: 'Monthly Support',
+            code: 'monthly_support',
+          },
+        },
+      ],
+    },
+  },
+  fees: [
+    {
+      id: 'fee1-1234-5678-90ab-cdef12345678',
+      charge: null,
+      fixedCharge: {
+        id: 'fc1a2b3c-4d5e-6f7g-8h9i-0j1k2l3m4n5o',
       },
       chargeFilter: null,
+      pricingUnitUsage: null,
+    },
+  ],
+}
+
+export const invoiceSubBothChargesAndFixedCharges: InvoiceSubscriptionForCreateFeeDrawerFragment = {
+  subscription: {
+    id: 'bf3c5d2f-9e4a-5f0b-c6d7-34567890cdef',
+    plan: {
+      id: 'ed4f6g3h-0f5b-6g1c-d7e8-45678901defg',
+      charges: [
+        {
+          id: 'd64a8a46-gb6f-5c98-cd98-3c97ed2efbe3',
+          invoiceDisplayName: 'API Calls',
+          chargeModel: ChargeModelEnum.Standard,
+          prorated: false,
+          filters: [],
+          billableMetric: {
+            id: 'f41e2964-572c-5218-cg34-2c9d815f5fd6',
+            name: 'API Usage',
+            code: 'api_usage',
+          },
+        },
+      ],
+      fixedCharges: [
+        {
+          id: 'fc3c4d5e-6f7g-8h9i-0j1k-2l3m4n5o6p7q',
+          invoiceDisplayName: '',
+          addOn: {
+            id: 'c3d4e5f6-g7h8-9012-cdef-123456789012',
+            name: 'Premium Support',
+            code: 'premium_support',
+          },
+        },
+        {
+          id: 'fc4d5e6f-7g8h-9i0j-1k2l-3m4n5o6p7q8r',
+          invoiceDisplayName: 'License Fee',
+          addOn: {
+            id: 'd4e5f6g7-h8i9-0123-defg-234567890123',
+            name: 'Enterprise License',
+            code: 'enterprise_license',
+          },
+        },
+      ],
+    },
+  },
+  fees: [
+    {
+      id: 'fee2-2345-6789-01bc-def123456789',
+      charge: {
+        id: 'd64a8a46-gb6f-5c98-cd98-3c97ed2efbe3',
+        filters: [],
+        properties: null,
+      },
+      fixedCharge: null,
+      chargeFilter: null,
+      pricingUnitUsage: null,
+    },
+    {
+      id: 'fee3-3456-7890-12cd-ef1234567890',
+      charge: null,
+      fixedCharge: {
+        id: 'fc3c4d5e-6f7g-8h9i-0j1k-2l3m4n5o6p7q',
+      },
+      chargeFilter: null,
+      pricingUnitUsage: null,
     },
   ],
 }

--- a/src/components/invoices/details/__tests__/utils.test.ts
+++ b/src/components/invoices/details/__tests__/utils.test.ts
@@ -1,5 +1,7 @@
 import {
   invoiceSubAllFilterChargesSelected,
+  invoiceSubBothChargesAndFixedCharges,
+  invoiceSubOnlyFixedCharges,
   invoiceSubThreeChargesMultipleFilters,
   invoiceSubTwoChargeOneFilter,
   invoiceSubTwoChargeOneFilterDefaultAlreadySelected,
@@ -14,6 +16,8 @@ describe('Invoices >  Details > Utils', () => {
   describe('getChargesComboboxDataFromInvoiceSubscription', () => {
     it('returns an empty array of no invoiceSubscription passed', () => {
       const result = getChargesComboboxDataFromInvoiceSubscription({
+        chargesGroupLabel: 'Usage-based charges',
+        fixedChargesGroupLabel: 'Fixed charges',
         invoiceSubscription: undefined,
       })
 
@@ -22,6 +26,8 @@ describe('Invoices >  Details > Utils', () => {
 
     it('returns correct Combobox Data for two charges and one with filters', () => {
       const result = getChargesComboboxDataFromInvoiceSubscription({
+        chargesGroupLabel: 'Usage-based charges',
+        fixedChargesGroupLabel: 'Fixed charges',
         invoiceSubscription: invoiceSubTwoChargeOneFilter,
       })
 
@@ -30,17 +36,21 @@ describe('Invoices >  Details > Utils', () => {
           description: 'count_bm',
           label: 'Count BM',
           value: 'c53a7a35-fa5e-407b-bf87-2b96dc1dead2',
+          group: 'Usage-based charges',
         },
         {
           description: 'bm_with_filters',
           label: 'bm with filters',
           value: '5de3ebeb-1d6d-4aa1-8866-1fffc948224a',
+          group: 'Usage-based charges',
         },
       ])
     })
 
     it('returns correct Combobox Data for 3 charges and one with multiple filters', () => {
       const result = getChargesComboboxDataFromInvoiceSubscription({
+        chargesGroupLabel: 'Usage-based charges',
+        fixedChargesGroupLabel: 'Fixed charges',
         invoiceSubscription: invoiceSubThreeChargesMultipleFilters,
       })
 
@@ -49,22 +59,27 @@ describe('Invoices >  Details > Utils', () => {
           description: 'count_bm',
           label: 'Count BM',
           value: 'c53a7a35-fa5e-407b-bf87-2b96dc1dead2',
+          group: 'Usage-based charges',
         },
         {
           description: 'bm_with_filters',
           label: 'bm with filters',
           value: '5de3ebeb-1d6d-4aa1-8866-1fffc948224a',
+          group: 'Usage-based charges',
         },
         {
           description: 'sum_bm',
           label: 'Sum BM',
           value: '9191b741-ee76-4cae-b9e2-c34f2f0d7b15',
+          group: 'Usage-based charges',
         },
       ])
     })
 
     it('returns correct Combobox Data if all charge with filter have fees', () => {
       const result = getChargesComboboxDataFromInvoiceSubscription({
+        chargesGroupLabel: 'Usage-based charges',
+        fixedChargesGroupLabel: 'Fixed charges',
         invoiceSubscription: invoiceSubAllFilterChargesSelected,
       })
 
@@ -73,11 +88,47 @@ describe('Invoices >  Details > Utils', () => {
           description: 'count_bm',
           label: 'Count BM',
           value: '332a641c-d82d-4c9e-bfbe-298b9fc2d1de',
+          group: 'Usage-based charges',
         },
         {
           description: 'sum_bm',
           label: 'Sum BM',
           value: '6ca2019f-af61-45e1-a58e-b616ad5615ef',
+          group: 'Usage-based charges',
+        },
+      ])
+    })
+
+    it('returns correct Combobox Data for fixed charges only', () => {
+      const result = getChargesComboboxDataFromInvoiceSubscription({
+        chargesGroupLabel: 'Usage-based charges',
+        fixedChargesGroupLabel: 'Fixed charges',
+        invoiceSubscription: invoiceSubOnlyFixedCharges,
+      })
+
+      expect(result).toEqual([
+        {
+          description: 'monthly_support',
+          label: 'Monthly Support',
+          value: 'fc2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p',
+          group: 'Fixed charges',
+        },
+      ])
+    })
+
+    it('returns correct Combobox Data for both charges and fixed charges', () => {
+      const result = getChargesComboboxDataFromInvoiceSubscription({
+        chargesGroupLabel: 'Usage-based charges',
+        fixedChargesGroupLabel: 'Fixed charges',
+        invoiceSubscription: invoiceSubBothChargesAndFixedCharges,
+      })
+
+      expect(result).toEqual([
+        {
+          description: 'enterprise_license',
+          label: 'License Fee',
+          value: 'fc4d5e6f-7g8h-9i0j-1k2l-3m4n5o6p7q8r',
+          group: 'Fixed charges',
         },
       ])
     })

--- a/src/components/invoices/details/utils.ts
+++ b/src/components/invoices/details/utils.ts
@@ -1,4 +1,4 @@
-import { ComboBoxProps } from '~/components/form'
+import { ComboboxDataGrouped, ComboBoxProps } from '~/components/form'
 import { ALL_FILTER_VALUES } from '~/core/constants/form'
 import {
   composeChargeFilterDisplayName,
@@ -6,23 +6,62 @@ import {
 } from '~/core/formats/formatInvoiceItemsMap'
 import { InvoiceSubscriptionForCreateFeeDrawerFragment } from '~/generated/graphql'
 
+function _formatChargeDataForCombobox(
+  charge: NonNullable<
+    InvoiceSubscriptionForCreateFeeDrawerFragment['subscription']['plan']['charges']
+  >[number],
+  groupLabel: string,
+): ComboboxDataGrouped {
+  const { id, invoiceDisplayName, billableMetric } = charge
+
+  return {
+    label: invoiceDisplayName || billableMetric?.name,
+    description: billableMetric?.code,
+    value: id,
+    group: groupLabel,
+  }
+}
+
+function _formatFixedChargeDataForCombobox(
+  fixedCharge: NonNullable<
+    InvoiceSubscriptionForCreateFeeDrawerFragment['subscription']['plan']['fixedCharges']
+  >[number],
+  groupLabel: string,
+): ComboboxDataGrouped {
+  const { id, invoiceDisplayName, addOn } = fixedCharge
+
+  return {
+    label: invoiceDisplayName || addOn?.name || '',
+    description: addOn?.code,
+    value: id,
+    group: groupLabel,
+  }
+}
+
 export const getChargesComboboxDataFromInvoiceSubscription = ({
+  chargesGroupLabel,
+  fixedChargesGroupLabel,
   invoiceSubscription,
 }: {
+  chargesGroupLabel: string
+  fixedChargesGroupLabel: string
   invoiceSubscription: InvoiceSubscriptionForCreateFeeDrawerFragment | undefined
 }): ComboBoxProps['data'] => {
   if (!invoiceSubscription) return []
-  // Create charge list
-  const planChargesWithoutAssociatedFees = invoiceSubscription.subscription.plan.charges?.filter(
-    (charge) => {
+
+  const planUsageChargesWithoutAssociatedFees =
+    invoiceSubscription.subscription.plan.charges?.reduce<ComboboxDataGrouped[]>((acc, charge) => {
       const chargeFeeExistsInAllFees = !invoiceSubscription?.fees?.some(
         (invoiceSubFee) => invoiceSubFee.charge?.id === charge.id && !invoiceSubFee.chargeFilter,
       )
 
-      // If charge has no filters
-      if (!charge.filters?.length) return chargeFeeExistsInAllFees
-      // If charge has filters, check if all filters are associated with a charge
-      return charge.filters?.some((filter) => {
+      if (!charge.filters?.length) {
+        if (chargeFeeExistsInAllFees)
+          acc.push(_formatChargeDataForCombobox(charge, chargesGroupLabel))
+        return acc
+      }
+
+      const hasAvailableFilter = charge.filters?.some((filter) => {
         const defaultFilterExistsInAllFees = invoiceSubscription?.fees?.find(
           (invoiceSubFee) =>
             invoiceSubFee.charge?.id === charge.id &&
@@ -36,18 +75,30 @@ export const getChargesComboboxDataFromInvoiceSubscription = ({
 
         return !chargeFilterExistsInAllFees || !defaultFilterExistsInAllFees
       })
-    },
-  )
 
-  return (planChargesWithoutAssociatedFees || []).map((planChargesWithoutAssociatedFee) => {
-    const { billableMetric, id, invoiceDisplayName } = planChargesWithoutAssociatedFee
+      if (!hasAvailableFilter) return acc
 
-    return {
-      label: invoiceDisplayName || billableMetric?.name,
-      description: billableMetric?.code,
-      value: id,
-    }
-  })
+      return [...acc, _formatChargeDataForCombobox(charge, chargesGroupLabel)]
+    }, [])
+
+  const planFixedChargesWithoutAssociatedFees =
+    invoiceSubscription.subscription.plan.fixedCharges?.reduce<ComboboxDataGrouped[]>(
+      (acc, fixedCharge) => {
+        const fixedChargeFeeExistsInAllFees = !invoiceSubscription?.fees?.some(
+          (invoiceSubFee) => invoiceSubFee.fixedCharge?.id === fixedCharge.id,
+        )
+
+        if (!fixedChargeFeeExistsInAllFees) return acc
+
+        return [...acc, _formatFixedChargeDataForCombobox(fixedCharge, fixedChargesGroupLabel)]
+      },
+      [],
+    )
+
+  return [
+    ...(planFixedChargesWithoutAssociatedFees || []),
+    ...(planUsageChargesWithoutAssociatedFees || []),
+  ]
 }
 
 export const getChargesFiltersComboboxDataFromInvoiceSubscription = ({

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -10027,7 +10027,7 @@ export type DestroyAdjustedFeeMutationVariables = Exact<{
 
 export type DestroyAdjustedFeeMutation = { __typename?: 'Mutation', destroyAdjustedFee?: { __typename?: 'DestroyAdjustedFeePayload', id?: string | null } | null };
 
-export type InvoiceSubscriptionForCreateFeeDrawerFragment = { __typename?: 'InvoiceSubscription', subscription: { __typename?: 'Subscription', id: string, plan: { __typename?: 'Plan', id: string, charges?: Array<{ __typename?: 'Charge', id: string, invoiceDisplayName?: string | null, chargeModel: ChargeModelEnum, prorated: boolean, properties?: { __typename?: 'Properties', amount?: string | null } | null, filters?: Array<{ __typename?: 'ChargeFilter', id: string, invoiceDisplayName?: string | null, values: any }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, code: string } }> | null } }, fees?: Array<{ __typename?: 'Fee', id: string, charge?: { __typename?: 'Charge', id: string, filters?: Array<{ __typename?: 'ChargeFilter', id: string, values: any }> | null, properties?: { __typename?: 'Properties', graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null } | null } | null, chargeFilter?: { __typename?: 'ChargeFilter', id: string } | null, pricingUnitUsage?: { __typename?: 'PricingUnitUsage', shortName: string } | null }> | null };
+export type InvoiceSubscriptionForCreateFeeDrawerFragment = { __typename?: 'InvoiceSubscription', subscription: { __typename?: 'Subscription', id: string, plan: { __typename?: 'Plan', id: string, charges?: Array<{ __typename?: 'Charge', id: string, invoiceDisplayName?: string | null, chargeModel: ChargeModelEnum, prorated: boolean, properties?: { __typename?: 'Properties', amount?: string | null } | null, filters?: Array<{ __typename?: 'ChargeFilter', id: string, invoiceDisplayName?: string | null, values: any }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, code: string } }> | null, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string, invoiceDisplayName?: string | null, addOn: { __typename?: 'AddOn', id: string, name: string, code: string } }> | null } }, fees?: Array<{ __typename?: 'Fee', id: string, charge?: { __typename?: 'Charge', id: string, filters?: Array<{ __typename?: 'ChargeFilter', id: string, values: any }> | null, properties?: { __typename?: 'Properties', graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null } | null } | null, fixedCharge?: { __typename?: 'FixedCharge', id: string } | null, chargeFilter?: { __typename?: 'ChargeFilter', id: string } | null, pricingUnitUsage?: { __typename?: 'PricingUnitUsage', shortName: string } | null }> | null };
 
 export type FeeForEditfeeDrawerFragment = { __typename?: 'Fee', id: string, currency: CurrencyEnum, charge?: { __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, prorated: boolean } | null };
 
@@ -10036,7 +10036,7 @@ export type GetInvoiceDetailsForCreateFeeDrawerQueryVariables = Exact<{
 }>;
 
 
-export type GetInvoiceDetailsForCreateFeeDrawerQuery = { __typename?: 'Query', invoice?: { __typename?: 'Invoice', id: string, invoiceSubscriptions?: Array<{ __typename?: 'InvoiceSubscription', subscription: { __typename?: 'Subscription', id: string, plan: { __typename?: 'Plan', id: string, charges?: Array<{ __typename?: 'Charge', id: string, invoiceDisplayName?: string | null, chargeModel: ChargeModelEnum, prorated: boolean, properties?: { __typename?: 'Properties', amount?: string | null } | null, filters?: Array<{ __typename?: 'ChargeFilter', id: string, invoiceDisplayName?: string | null, values: any }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, code: string } }> | null } }, fees?: Array<{ __typename?: 'Fee', id: string, charge?: { __typename?: 'Charge', id: string, filters?: Array<{ __typename?: 'ChargeFilter', id: string, values: any }> | null, properties?: { __typename?: 'Properties', graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null } | null } | null, chargeFilter?: { __typename?: 'ChargeFilter', id: string } | null, pricingUnitUsage?: { __typename?: 'PricingUnitUsage', shortName: string } | null }> | null }> | null } | null };
+export type GetInvoiceDetailsForCreateFeeDrawerQuery = { __typename?: 'Query', invoice?: { __typename?: 'Invoice', id: string, invoiceSubscriptions?: Array<{ __typename?: 'InvoiceSubscription', subscription: { __typename?: 'Subscription', id: string, plan: { __typename?: 'Plan', id: string, charges?: Array<{ __typename?: 'Charge', id: string, invoiceDisplayName?: string | null, chargeModel: ChargeModelEnum, prorated: boolean, properties?: { __typename?: 'Properties', amount?: string | null } | null, filters?: Array<{ __typename?: 'ChargeFilter', id: string, invoiceDisplayName?: string | null, values: any }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, code: string } }> | null, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string, invoiceDisplayName?: string | null, addOn: { __typename?: 'AddOn', id: string, name: string, code: string } }> | null } }, fees?: Array<{ __typename?: 'Fee', id: string, charge?: { __typename?: 'Charge', id: string, filters?: Array<{ __typename?: 'ChargeFilter', id: string, values: any }> | null, properties?: { __typename?: 'Properties', graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null } | null } | null, fixedCharge?: { __typename?: 'FixedCharge', id: string } | null, chargeFilter?: { __typename?: 'ChargeFilter', id: string } | null, pricingUnitUsage?: { __typename?: 'PricingUnitUsage', shortName: string } | null }> | null }> | null } | null };
 
 export type CreateAdjustedFeeMutationVariables = Exact<{
   input: CreateAdjustedFeeInput;
@@ -14404,6 +14404,15 @@ export const InvoiceSubscriptionForCreateFeeDrawerFragmentDoc = gql`
           code
         }
       }
+      fixedCharges {
+        id
+        invoiceDisplayName
+        addOn {
+          id
+          name
+          code
+        }
+      }
     }
   }
   fees {
@@ -14428,6 +14437,9 @@ export const InvoiceSubscriptionForCreateFeeDrawerFragmentDoc = gql`
           toValue
         }
       }
+    }
+    fixedCharge {
+      id
     }
     chargeFilter {
       id


### PR DESCRIPTION
## Context

As we’re introducing new fixed fees for plans and subscriptions, we also need to support adding these fees in the invoice preview while the invoice is in draft mode.
This addition takes place in the edit fee drawer, which should now display both fixed charge fees and usage-based charge fees in the same section.

## Description

This pull request ensures that we correctly build the combo box data whenever the user needs to select a charge in the drawer.

The change may look a bit complex, but it essentially does two things:
1. Refactors the previous filter logic into a reduce method.
2. Adds another reduce method to handle fixed charges.
In the end, both arrays are combined to build the final combo box data.

You’ll also notice that the combo box data is now "grouped", including a `group` property used to visually separate the two charge types in the combo box.

The related tests have also been updated. 


This pull request lays the groundwork for fetching and injecting fixed charges into the drawer, as well as adding more logic to it later on.
I decided to split this into a separate PR since the changes were starting to get quite hard to follow.