### PR TITLE
bug: format email correctly on customer save

### DIFF
--- a/src/pages/CreateCustomer.tsx
+++ b/src/pages/CreateCustomer.tsx
@@ -250,9 +250,15 @@ const CreateCustomer = () => {
     validateOnMount: true,
     enableReinitialize: true,
     validateOnChange: false,
-    onSubmit: async ({ metadata, ...values }, formikBag) => {
+    onSubmit: async ({ metadata, email, ...values }, formikBag) => {
+      const formattedEmail = email
+        ?.split(',')
+        .map((mail) => mail.trim())
+        .join(',')
+
       const answer = await onSave({
         ...values,
+        email: formattedEmail,
         metadata: ((metadata as LocalCustomerMetadata[]) || []).map(
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           ({ localId, ...rest }) => rest,


### PR DESCRIPTION
## Context

We noticed a Sentry where a customer tried to save information with a different format of email that the buyer can expect. 

## Description

The frontend application should be responsible for sending the correct data there, and the email should be a simple string separated by a comma without any spaces in it. 