### PR TITLE
bug: prevent infinite loop in credit note form

### DIFF
--- a/src/components/creditNote/CreditNoteFormCalculation.tsx
+++ b/src/components/creditNote/CreditNoteFormCalculation.tsx
@@ -258,10 +258,12 @@ export const CreditNoteFormCalculation = ({
     )
 
     formikProps.setTouched({ payBack: true })
+
+    // NEVER watch formikProps as a dependency to avoid re-rendering loop: https://github.com/getlago/lago-front/pull/2689
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     canRefund,
     currencyPrecision,
-    formikProps,
     maxCreditableAmount,
     maxRefundableAmount,
     setPayBackValidation,


### PR DESCRIPTION
## Context

A recent update changed this useEffect watch list. 
This useEffect now watch a form and at the same time update its value, generating an infinite loop. 

## Description

This pull request makes sure we do not watch the form object entirely. It is still working because all the necessary values are watched, and the value will be correct when the effect will be fired. 
I added a note to make sure we don't make the same mistake later. We'll need to refactor this component to make sure the design pattern of it does not allow search issues. 

<!-- Linear link -->
Fixes ISSUE-1229