### PR TITLE
chore(eslint): add custom rule to prevent formikProps array dependency issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,12 @@
     ["tw\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
   ],
   "eslint.useFlatConfig": true,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
   "javascript.preferences.importModuleSpecifier": "non-relative",
   "typescript.preferences.importModuleSpecifier": "non-relative",
 }

--- a/packages/configs/eslint-rules/no-formik-props-in-effect.js
+++ b/packages/configs/eslint-rules/no-formik-props-in-effect.js
@@ -1,0 +1,85 @@
+/**
+ * ESLint rule to prevent formikProps from being used as a dependency in React hooks.
+ * This prevents infinite re-rendering loops since formikProps is a new object reference on every render.
+ * Also, this rule should be used as long as we are using Formik in the project.
+ */
+
+const HOOKS_WITH_DEPENDENCIES = ['useEffect'] // this may be extended in the future to include other hooks
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow formikProps as a dependency in React ({{hookName}}) hooks to prevent infinite re-rendering loops',
+      category: 'Possible Errors',
+      recommended: true,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noFormikPropsInEffect:
+        'formikProps should not be used as a dependency in {{hookName}}. It causes infinite re-rendering loops. Use specific formikProps properties instead (e.g., formikProps.values, formikProps.setFieldValue).',
+    },
+  },
+  create(context) {
+    /**
+     * Checks if a node is a formikProps identifier
+     */
+    function isFormikProps(node) {
+      return node && node.type === 'Identifier' && node.name === 'formikProps'
+    }
+
+    /**
+     * Checks if a node contains formikProps as a direct dependency (not as a property access)
+     * We allow formikProps.something but not formikProps directly
+     */
+    function containsFormikProps(node) {
+      if (!node) return false
+
+      // Direct identifier: formikProps (this is what we want to catch)
+      if (isFormikProps(node)) {
+        return true
+      }
+
+      // Member expression: formikProps.something (this is allowed, so we don't check deeper)
+      if (node.type === 'MemberExpression') {
+        // Only check if the object itself is formikProps directly
+        // If it's a nested property access, we allow it
+        return false
+      }
+
+      // Array expression: check all elements
+      if (node.type === 'ArrayExpression') {
+        return node.elements.some((element) => containsFormikProps(element))
+      }
+
+      return false
+    }
+
+    return {
+      CallExpression(node) {
+        // Check if this is a React hook call with dependencies
+        if (node.callee && node.callee.type === 'Identifier') {
+          const hookName = node.callee.name
+
+          if (HOOKS_WITH_DEPENDENCIES.includes(hookName)) {
+            // These hooks have two arguments: callback/factory and dependencies array
+            const dependencies = node.arguments[1]
+
+            // Check if formikProps is in dependencies (should not be)
+            if (dependencies && containsFormikProps(dependencies)) {
+              context.report({
+                node: dependencies,
+                messageId: 'noFormikPropsInEffect',
+                data: {
+                  hookName,
+                },
+              })
+            }
+          }
+        }
+      },
+    }
+  },
+}

--- a/packages/configs/eslint.config.mjs
+++ b/packages/configs/eslint.config.mjs
@@ -9,6 +9,8 @@ import pluginTailwind from 'eslint-plugin-tailwindcss'
 import globals from 'globals'
 import pluginTypescriptEslint from 'typescript-eslint'
 
+import noFormikPropsInEffect from './eslint-rules/no-formik-props-in-effect.js'
+
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   {
@@ -38,6 +40,11 @@ export default [
       import: fixupPluginRules(pluginImport),
       'jsx-a11y': pluginJsxA11y,
       'react-hooks': pluginReactHooks,
+      lago: {
+        rules: {
+          'no-formik-props-in-effect': noFormikPropsInEffect,
+        },
+      },
     },
     languageOptions: {
       parser: pluginTypescriptEslint.parser,
@@ -87,6 +94,7 @@ export default [
       ],
       '@typescript-eslint/no-unsafe-function-type': 'warn',
       '@typescript-eslint/ban-ts-comment': 'warn',
+      'lago/no-formik-props-in-effect': 'error',
     },
   },
   {


### PR DESCRIPTION
## Context

Add custom ESLint rule to prevent formikProps usage as dependency in React hooks

## Description

A new custom ESLint rule (`lago/no-formik-props-in-effect`) has been implemented to prevent the use of `formikProps` as a dependency in React hooks (only `useEffect` for now).

## 🎯 Problem

Using `formikProps` directly as a dependency in React hooks causes infinite re-rendering loops, since `formikProps` is a new object reference on every render. This can lead to:
- Performance degradation
- Infinite rendering loops
- Unexpected application behavior

## ✅ Temporary solution implemented to prevent its usage

A custom ESLint rule has been created that:
- **Reports an error** when `formikProps` is used directly as a dependency in React hooks
- **Allows** the use of specific `formikProps` properties (e.g., `formikProps.values`, `formikProps.setFieldValue`) as dependencies
- **Prevents** developers from accidentally adding `formikProps` to dependency arrays

Once the issues with formik are solve, we may remove this rule

<!-- Linear link -->
Fixes LAGO-987