### PR TITLE
bug: reset externalCustomerId even during customer edition

### DIFF
--- a/src/components/customers/createCustomer/ExternalAppsAccordion/AccountingProvidersAccordion.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/AccountingProvidersAccordion.tsx
@@ -259,7 +259,7 @@ export const AccountingProvidersAccordion: FC<AccountingProvidersAccordionProps>
                     syncWithProvider: checked,
                   }
 
-                  if (!isEdition && checked) {
+                  if (checked) {
                     newNetsuiteIntegrationObject.externalCustomerId = ''
                     newNetsuiteIntegrationObject.subsidiaryId = ''
                   }
@@ -316,7 +316,7 @@ export const AccountingProvidersAccordion: FC<AccountingProvidersAccordionProps>
                     syncWithProvider: checked,
                   }
 
-                  if (!isEdition && checked) {
+                  if (checked) {
                     newXeroIntegrationObject.externalCustomerId = ''
                   }
 

--- a/src/components/customers/createCustomer/ExternalAppsAccordion/CRMProvidersAccordion.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/CRMProvidersAccordion.tsx
@@ -317,7 +317,7 @@ export const CRMProvidersAccordion: FC<CRMProvidersAccordionProps> = ({
                         syncWithProvider: checked,
                       }
 
-                      if (!isEdition && checked) {
+                      if (checked) {
                         newHubspotIntegrationObject.externalCustomerId = ''
                       }
 

--- a/src/components/customers/createCustomer/ExternalAppsAccordion/TaxProvidersAccordion.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/TaxProvidersAccordion.tsx
@@ -232,7 +232,7 @@ export const TaxProvidersAccordion: FC<TaxProvidersAccordionProps> = ({
                     syncWithProvider: checked,
                   }
 
-                  if (!isEdition && checked) {
+                  if (checked) {
                     newAnrokIntegrationObject.externalCustomerId = ''
                   }
 


### PR DESCRIPTION
## Context

When assigning an integration to a customer, we can chose to create this customer on the connected integration.

When we allow to create the customer on the integration, the typed `externalCustomerId` does not really matter as we just asked the integration to create it for us, hence generating an ID on their side.

## Description

The issue is that this condition that was supposed to "reset" the value of the typed ID was preventing this logic to occur during customer edition.
So the typed ID was only reset if the form was used to create a customer, and not during a customer edition.

It does not make much sense as the `syncWithProvider` checkbox is disabled if the integration was already there during edition.
So that was kinda conflicting with the rule that is supposed to reset the typed `externalCustomerId` -> when editing a customer and adding a new integration, this reset `externalCustomerId` logic was "not working"

This PR simply removed the condition based on the `!isEdition` to always trigger this logic.

<!-- Linear link -->
Fixes ISSUE-1275