### PR TITLE
Add dynamic import w/o the need of Suspense

### DIFF
--- a/src/core/utils/dynamicImport.tsx
+++ b/src/core/utils/dynamicImport.tsx
@@ -1,0 +1,101 @@
+import { ComponentType, ReactElement, useEffect, useRef, useState } from 'react'
+
+/**
+ * It's a function that dynamically imports a module on demand without the need of React Suspense.
+ * Supports both default exports and named exports.
+ *
+ * @param loader - Function that returns a Promise of the module to import
+ * @param options - Optional configuration object with delay and/or exportName
+ * @param options.delay - Delay in milliseconds before loading the component (default: 0)
+ * @param options.exportName - Name of the named export to use (default: 'default')
+ * @returns A React component that dynamically loads the target component
+ *
+ * @example
+ * ```tsx
+ * // Default export
+ * const LazyComponent = dynamicImport(
+ *   () => import('~/components/MyComponent'),
+ *   { delay: 200 }
+ * )
+ *
+ * // Named export
+ * const LazyComponent = dynamicImport(
+ *   () => import('~/components/MyComponent'),
+ *   { exportName: 'MyComponent' }
+ * )
+ *
+ * // Use as a normal component
+ * <LazyComponent prop1="value" prop2={123} />
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const dynamicImport = <Props = any,>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  loader: () => Promise<Record<string, any> & { default?: ComponentType<Props> }>,
+  options?: { delay?: number; exportName?: string },
+): ComponentType<Props> => {
+  const DynamicComponent = (props: Props): ReactElement | null => {
+    const [Component, setComponent] = useState<ComponentType<Props> | null>(null)
+    const loaderRef = useRef(loader)
+    const optionsRef = useRef(options)
+
+    loaderRef.current = loader
+    optionsRef.current = options
+
+    useEffect(() => {
+      let isMounted = true
+      let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+      const loadComponent = () => {
+        loaderRef
+          .current()
+          .then((module) => {
+            if (isMounted) {
+              const exportName = optionsRef.current?.exportName || 'default'
+              const component = exportName === 'default' ? module.default : module[exportName]
+
+              if (!component) {
+                // eslint-disable-next-line no-console
+                console.error(
+                  `Failed to load component: export "${exportName}" not found in module`,
+                  module,
+                )
+                return
+              }
+
+              setComponent(() => component as ComponentType<Props>)
+            }
+          })
+          .catch((error) => {
+            // eslint-disable-next-line no-console
+            console.error('Failed to load component:', error)
+          })
+      }
+
+      const delayMs = optionsRef.current?.delay ?? 0
+
+      if (delayMs > 0) {
+        timeoutId = setTimeout(loadComponent, delayMs)
+      } else {
+        loadComponent()
+      }
+
+      return () => {
+        isMounted = false
+        if (timeoutId) {
+          clearTimeout(timeoutId)
+        }
+      }
+    }, [])
+
+    if (!Component) {
+      return null
+    }
+
+    return <Component {...(props as Props & Record<string, unknown>)} />
+  }
+
+  DynamicComponent.displayName = 'DynamicComponent'
+
+  return DynamicComponent
+}

--- a/src/hooks/forms/useAppform.ts
+++ b/src/hooks/forms/useAppform.ts
@@ -1,17 +1,22 @@
 import { createFormHook } from '@tanstack/react-form'
-import { lazy } from 'react'
+
+import { dynamicImport } from '~/core/utils/dynamicImport.tsx'
 
 import { fieldContext, formContext } from './formContext.ts'
 
-/**
- * TODO: lazy import them once the routing is fixed.
- * We currently have a strange Suspense recursively called in RouteWrapper.tsx line 53
- */
-const CheckboxField = lazy(() => import('~/components/form/Checkbox/CheckboxFieldForTanstack.tsx'))
-const ComboBoxField = lazy(() => import('~/components/form/ComboBox/ComboBoxFieldForTanstack.tsx'))
-const SubmitButton = lazy(() => import('~/components/form/SubmitButton/SubmitButtonField.tsx'))
-const SwitchField = lazy(() => import('~/components/form/Switch/SwitchFieldForTanstack.tsx'))
-const TextInputField = lazy(
+const CheckboxField = dynamicImport(
+  () => import('~/components/form/Checkbox/CheckboxFieldForTanstack.tsx'),
+)
+const ComboBoxField = dynamicImport(
+  () => import('~/components/form/ComboBox/ComboBoxFieldForTanstack.tsx'),
+)
+const SubmitButton = dynamicImport(
+  () => import('~/components/form/SubmitButton/SubmitButtonField.tsx'),
+)
+const SwitchField = dynamicImport(
+  () => import('~/components/form/Switch/SwitchFieldForTanstack.tsx'),
+)
+const TextInputField = dynamicImport(
   () => import('~/components/form/TextInput/TextInputFieldForTanstack.tsx'),
 )
 


### PR DESCRIPTION
## Context

Replace React.lazy with custom dynamic import utility

## Description

Replaced React.lazy with a custom dynamicImport utility that loads components on demand without requiring Suspense boundaries.

### Benefits:

- No Suspense boundaries required
- Optional delay for performance optimization
- The browser handles module caching automatically, so no manual cache management is needed.