### PR TITLE
chore(Tooltip) style should live in the component directly

### DIFF
--- a/packages/design-system/src/components/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip.tsx
@@ -1,7 +1,37 @@
 import { Tooltip as MuiTooltip, TooltipProps as MuiTooltipProps } from '@mui/material'
+import { styled } from '@mui/material/styles'
+import { colors } from 'lago-configs/tailwind'
 import { forwardRef, ReactNode, useCallback, useState } from 'react'
 
 import { tw } from '~/lib'
+
+// Styled Tooltip with design system styles applied at component level
+const StyledTooltip = styled(MuiTooltip)({
+  // Target the tooltip slot directly
+  '& .MuiTooltip-tooltip': {
+    // Typography (caption style)
+    fontSize: '14px',
+    lineHeight: '24px',
+    letterSpacing: '-0.16px',
+    fontWeight: 400,
+    // Colors & spacing (using the shared color palette)
+    backgroundColor: colors.grey[700],
+    padding: '12px 16px',
+  },
+  // Placement-specific margins using MUI's class modifiers
+  '& .MuiTooltip-tooltipPlacementBottom': {
+    marginTop: '8px',
+  },
+  '& .MuiTooltip-tooltipPlacementTop': {
+    marginBottom: '8px',
+  },
+  '& .MuiTooltip-tooltipPlacementLeft': {
+    marginRight: '8px',
+  },
+  '& .MuiTooltip-tooltipPlacementRight': {
+    marginLeft: '8px',
+  },
+})
 
 export interface TooltipProps
   extends Pick<
@@ -34,10 +64,10 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
         onFocus={handleOpen}
         onBlur={handleClose}
       >
-        <MuiTooltip
-          componentsProps={{
+        <StyledTooltip
+          slotProps={{
             tooltip: {
-              style: {
+              sx: {
                 maxWidth: maxWidth,
               },
             },
@@ -49,7 +79,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
         >
           {/* eslint-disable-next-line */}
           <div onClick={handleClose}>{children}</div>
-        </MuiTooltip>
+        </StyledTooltip>
       </div>
     )
   },

--- a/src/components/designSystem/Tooltip.tsx
+++ b/src/components/designSystem/Tooltip.tsx
@@ -1,7 +1,37 @@
 import { Tooltip as MuiTooltip, TooltipProps as MuiTooltipProps } from '@mui/material'
+import { styled } from '@mui/material/styles'
 import { forwardRef, ReactNode, useState } from 'react'
 
+import { palette } from '~/styles'
 import { tw } from '~/styles/utils'
+
+// Styled Tooltip with design system styles applied at component level
+const StyledTooltip = styled(MuiTooltip)({
+  // Target the tooltip slot directly
+  '& .MuiTooltip-tooltip': {
+    // Typography (caption style)
+    fontSize: '14px',
+    lineHeight: '24px',
+    letterSpacing: '-0.16px',
+    fontWeight: 400,
+    // Colors & spacing
+    backgroundColor: palette.grey[700],
+    padding: '12px 16px',
+  },
+  // Placement-specific margins using MUI's class modifiers
+  '& .MuiTooltip-tooltipPlacementBottom': {
+    marginTop: '8px',
+  },
+  '& .MuiTooltip-tooltipPlacementTop': {
+    marginBottom: '8px',
+  },
+  '& .MuiTooltip-tooltipPlacementLeft': {
+    marginRight: '8px',
+  },
+  '& .MuiTooltip-tooltipPlacementRight': {
+    marginLeft: '8px',
+  },
+})
 
 export interface TooltipProps
   extends Pick<
@@ -24,10 +54,10 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
         onMouseEnter={() => !disableHoverListener && setIsOpen(true)}
         onMouseLeave={() => setIsOpen(false)}
       >
-        <MuiTooltip
-          componentsProps={{
+        <StyledTooltip
+          slotProps={{
             tooltip: {
-              style: {
+              sx: {
                 maxWidth: maxWidth,
               },
             },
@@ -39,7 +69,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
         >
           {/* eslint-disable-next-line */}
           <div onClick={() => setIsOpen(false)}>{children}</div>
-        </MuiTooltip>
+        </StyledTooltip>
       </div>
     )
   },

--- a/src/styles/muiTheme.ts
+++ b/src/styles/muiTheme.ts
@@ -374,29 +374,6 @@ export const theme = createTheme({
         },
       },
     },
-    MuiTooltip: {
-      styleOverrides: {
-        tooltip: {
-          ...typographyCaption,
-          backgroundColor: palette.grey[700],
-          padding: '12px 16px',
-        },
-        // MUI positions poppers using CSS, per position
-        // !important is ugly, but required
-        tooltipPlacementBottom: {
-          marginTop: '8px !important',
-        },
-        tooltipPlacementTop: {
-          marginBottom: '8px !important',
-        },
-        tooltipPlacementLeft: {
-          marginRight: '8px !important',
-        },
-        tooltipPlacementRight: {
-          marginLeft: '8px !important',
-        },
-      },
-    },
     MuiAccordion: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
## Context

We should prevent relying on this huge style file, but rather have the style the nearest possible from the component code.

This is also a good way to easily switch to other component lib later.
Another advantage, it would simplify the style provider usage, as the component itself would own it's style, rather that expecting it to come from it's wrapper provider.

Don't mind the double tooltip implementation, it should be unified later

## Description

This PR moves the style to the component.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves Tooltip styling into component-level styled wrappers and removes global MuiTooltip theme overrides, updating usage to slotProps.
> 
> - **Tooltip components**:
>   - Introduce `StyledTooltip` using `styled(MuiTooltip)` in `packages/design-system/src/components/Tooltip.tsx` and `src/components/designSystem/Tooltip.tsx`.
>   - Apply inline typography, background, padding, and placement margins directly to the tooltip slot.
>   - Switch from `componentsProps` to `slotProps` and use `sx` to set `maxWidth`.
>   - Preserve open/close behavior; add focus handlers in the design-system variant.
> - **Theme**:
>   - Remove `MuiTooltip` `styleOverrides` from `src/styles/muiTheme.ts` (tooltip styling now owned by components).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44bedc7e3df4a0bb8eaf88ad03393f1f66450255. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->