### PR TITLE
fix(integrations): fix wording for integration mapping

### DIFF
--- a/src/pages/settings/integrations/AnrokIntegrationMapItemDrawer/useAnrokIntegrationTitleAndDescriptionMapping.ts
+++ b/src/pages/settings/integrations/AnrokIntegrationMapItemDrawer/useAnrokIntegrationTitleAndDescriptionMapping.ts
@@ -18,89 +18,62 @@ export const useAnrokIntegrationTitleAndDescriptionMapping = () => {
       }
 
     switch (formType) {
-      case MappingTypeEnum.Coupon:
-        return {
-          title: translate('text_6630e57386f8a700a3318cc8', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
-          }),
-          description: translate('text_6630e57386f8a700a3318cc9', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
-          }),
-        }
-      case MappingTypeEnum.CreditNote:
-        return {
-          title: translate('text_66461b36b4b38c006e8b5067', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
-          }),
-          description: translate('text_66461b36b4b38c006e8b5068', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
-          }),
-        }
       case MappingTypeEnum.FallbackItem:
         return {
           title: translate('text_6630e51df0a194013daea61f'),
           description: translate('text_6668821d94e4da4dfd8b3890', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
+            integrationType: translate('text_6668821d94e4da4dfd8b3834'),
           }),
         }
       case MappingTypeEnum.MinimumCommitment:
         return {
           title: translate('text_6668821d94e4da4dfd8b3822', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
+            integrationType: translate('text_6668821d94e4da4dfd8b3834'),
           }),
           description: translate('text_6668821d94e4da4dfd8b382e', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
+            integrationType: translate('text_6668821d94e4da4dfd8b3834'),
           }),
         }
       case MappingTypeEnum.PrepaidCredit:
         return {
           title: translate('text_6668821d94e4da4dfd8b3884', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
+            integrationType: translate('text_6668821d94e4da4dfd8b3834'),
           }),
           description: translate('text_6668821d94e4da4dfd8b389a', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
+            integrationType: translate('text_6668821d94e4da4dfd8b3834'),
           }),
         }
       case MappingTypeEnum.SubscriptionFee:
         return {
           title: translate('text_666886c73a2ea34eb2aa3e33', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
+            integrationType: translate('text_6668821d94e4da4dfd8b3834'),
           }),
           description: translate('text_666886c73a2ea34eb2aa3e34', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
-          }),
-        }
-      case MappingTypeEnum.Account:
-        return {
-          title: translate('text_6672ebb8b1b50be550ecca50', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
-          }),
-          description: translate('text_6672ebb8b1b50be550ecca58', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
+            integrationType: translate('text_6668821d94e4da4dfd8b3834'),
           }),
         }
       case MappableTypeEnum.AddOn:
         return {
           title: translate('text_6668821d94e4da4dfd8b3820', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
             addOnName: isDefaultMappingInMappableContext(dataToTest)
               ? dataToTest.itemMappings.default.lagoMappableName
               : '',
+            integrationType: translate('text_6668821d94e4da4dfd8b3834'),
           }),
           description: translate('text_6668821d94e4da4dfd8b382c', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
+            integrationType: translate('text_6668821d94e4da4dfd8b3834'),
           }),
         }
       case MappableTypeEnum.BillableMetric:
         return {
           title: translate('text_6668821d94e4da4dfd8b3824', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
             billableMetricName: isDefaultMappingInMappableContext(dataToTest)
               ? dataToTest.itemMappings.default.lagoMappableName
               : '',
+            integrationType: translate('text_6668821d94e4da4dfd8b3834'),
           }),
           description: translate('text_6668821d94e4da4dfd8b3830', {
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
+            integrationType: translate('text_6668821d94e4da4dfd8b3834'),
           }),
         }
       default:

--- a/src/pages/settings/integrations/XeroIntegrationMapItemDrawer/useXeroIntegrationTitleAndDescriptionMapping.ts
+++ b/src/pages/settings/integrations/XeroIntegrationMapItemDrawer/useXeroIntegrationTitleAndDescriptionMapping.ts
@@ -82,10 +82,10 @@ export const useXeroIntegrationTitleAndDescriptionMapping = () => {
       case MappableTypeEnum.AddOn:
         return {
           title: translate('text_6668821d94e4da4dfd8b3820', {
+            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
             addOnName: isDefaultMappingInMappableContext(dataToTest)
               ? dataToTest.itemMappings.default.lagoMappableName
               : '',
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
           }),
           description: translate('text_6668821d94e4da4dfd8b382c', {
             integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
@@ -94,10 +94,10 @@ export const useXeroIntegrationTitleAndDescriptionMapping = () => {
       case MappableTypeEnum.BillableMetric:
         return {
           title: translate('text_6668821d94e4da4dfd8b3824', {
+            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
             billableMetricName: isDefaultMappingInMappableContext(dataToTest)
               ? dataToTest.itemMappings.default.lagoMappableName
               : '',
-            integrationType: translate('text_6672ebb8b1b50be550eccaf8'),
           }),
           description: translate('text_6668821d94e4da4dfd8b3830', {
             integrationType: translate('text_6672ebb8b1b50be550eccaf8'),


### PR DESCRIPTION
## Context

After complete integration mapping refactor, there was an issue on wording. 

## Description

This PR focuses on fixing those wording issues, especially on anrok and xero

<!-- Linear link -->
Fixes [ISSUE-1297](https://linear.app/getlago/issue/ISSUE-1297/wording-is-not-accurate-when-you-perform-items-mapping-in-intergration)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Anrok mapping titles/descriptions to use the Anrok-specific i18n key and removes unused cases; ensures Xero titles include integrationType for add-on and billable metric.
> 
> - **Integrations**:
>   - **Anrok**:
>     - Use Anrok-specific `integrationType` key `text_6668821d94e4da4dfd8b3834` across `FallbackItem`, `MinimumCommitment`, `PrepaidCredit`, `SubscriptionFee`, `AddOn`, and `BillableMetric`.
>     - Remove unused cases: `Coupon`, `CreditNote`, `Account`.
>   - **Xero**:
>     - Ensure `integrationType` is passed in title for `AddOn` and `BillableMetric`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88d10cf1338a1117d76b4e093ebbf36fbbe2e028. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->