### PR TITLE
fix(features): display correct error when feature is unavailable

### DIFF
--- a/src/core/apolloClient/init.ts
+++ b/src/core/apolloClient/init.ts
@@ -32,6 +32,10 @@ const AUTH_ERRORS = [
   LagoApiError.Unauthorized,
 ]
 
+const FEATURE_ERRORS = {
+  featureUnavailable: 'feature_unavailable',
+} as const
+
 const TIMEOUT = 300000 // 5 minutes timeout
 const { apiUrl, appVersion } = envGlobalVar()
 
@@ -108,7 +112,7 @@ export const initializeApolloClient = async () => {
     const { silentError = false, silentErrorCodes = [] } = operation.getContext()
 
     // Silent auth and permissions related errors by default
-    silentErrorCodes.push(...AUTH_ERRORS, LagoApiError.Forbidden)
+    silentErrorCodes.push(...AUTH_ERRORS, LagoApiError.Forbidden, FEATURE_ERRORS.featureUnavailable)
 
     if (graphQLErrors) {
       graphQLErrors.forEach((value) => {
@@ -145,6 +149,13 @@ export const initializeApolloClient = async () => {
           addToast({
             severity: 'danger',
             translateKey: 'text_622f7a3dc32ce100c46a5154',
+          })
+        }
+
+        if (!silentError && extensions?.code === FEATURE_ERRORS.featureUnavailable) {
+          addToast({
+            severity: 'danger',
+            translateKey: 'text_1764173599248crllj6h1tg9',
           })
         }
 

--- a/translations/base.json
+++ b/translations/base.json
@@ -3541,5 +3541,6 @@
   "text_1764107468210ibi78qsrukx": "Support 3DSecure",
   "text_1764107468210lbhkj5no1vh": "If 3DSecure is required the invoice will stay pending until the customer completes the action.",
   "text_1764160009979jzn4xunn1z8": "Yes",
-  "text_176416000997957yqelmt2m2": "No"
+  "text_176416000997957yqelmt2m2": "No",
+  "text_1764173599248crllj6h1tg9": "Feature is unavailable"
 }


### PR DESCRIPTION
## Context

When on activity log but not authorized, we display a generic error message

## Description

This PR improves error handling

<!-- Linear link -->
Fixes [ISSUE-1258](https://linear.app/getlago/issue/ISSUE-1258/wrong-error-message-accessing-activity-logs-in-lago-self-hosted)