### PR TITLE
bug: improve activity logs unavailable error state

### DIFF
--- a/src/components/billableMetrics/BillableMetricDetailsActivityLogs.tsx
+++ b/src/components/billableMetrics/BillableMetricDetailsActivityLogs.tsx
@@ -6,6 +6,7 @@ import { InfiniteScroll } from '~/components/designSystem'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import {
   ActivityLogsTableDataFragmentDoc,
+  LagoApiError,
   ResourceTypeEnum,
   useBillableMetricActivityLogsQuery,
 } from '~/generated/graphql'
@@ -60,6 +61,9 @@ export const BillableMetricDetailsActivityLogs = ({
       resourceIds: [billableMetricId],
       limit: 20,
     },
+    context: {
+      silentErrorCodes: [LagoApiError.FeatureUnavailable],
+    },
     skip: !canViewLogs,
   })
 
@@ -85,7 +89,7 @@ export const BillableMetricDetailsActivityLogs = ({
           <ActivityLogsTable
             containerSize={4}
             data={data?.activityLogs?.collection ?? []}
-            hasError={!!error}
+            error={error}
             isLoading={loading}
             refetch={refetch}
             onRowActionLink={(row) => {

--- a/src/components/coupons/CouponDetailsActivityLogs.tsx
+++ b/src/components/coupons/CouponDetailsActivityLogs.tsx
@@ -6,6 +6,7 @@ import { InfiniteScroll } from '~/components/designSystem'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import {
   ActivityLogsTableDataFragmentDoc,
+  LagoApiError,
   ResourceTypeEnum,
   useCouponDetailsActivityLogsQuery,
 } from '~/generated/graphql'
@@ -58,6 +59,9 @@ export const CouponDetailsActivityLogs = ({ couponId }: CouponDetailsActivityLog
       resourceIds: [couponId],
       limit: 20,
     },
+    context: {
+      silentErrorCodes: [LagoApiError.FeatureUnavailable],
+    },
     skip: !canViewLogs,
   })
 
@@ -83,7 +87,7 @@ export const CouponDetailsActivityLogs = ({ couponId }: CouponDetailsActivityLog
           <ActivityLogsTable
             containerSize={4}
             data={data?.activityLogs?.collection ?? []}
-            hasError={!!error}
+            error={error}
             isLoading={loading}
             refetch={refetch}
             onRowActionLink={(row) => {

--- a/src/components/creditNote/CreditNoteDetailsActivityLogs.tsx
+++ b/src/components/creditNote/CreditNoteDetailsActivityLogs.tsx
@@ -6,6 +6,7 @@ import { InfiniteScroll } from '~/components/designSystem'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import {
   ActivityLogsTableDataFragmentDoc,
+  LagoApiError,
   ResourceTypeEnum,
   useInvoiceActivityLogsQuery,
 } from '~/generated/graphql'
@@ -60,6 +61,9 @@ export const CreditNoteDetailsActivityLogs = ({
       resourceIds: [creditNoteId],
       limit: 20,
     },
+    context: {
+      silentErrorCodes: [LagoApiError.FeatureUnavailable],
+    },
     skip: !canViewLogs,
   })
 
@@ -85,7 +89,7 @@ export const CreditNoteDetailsActivityLogs = ({
           <ActivityLogsTable
             containerSize={4}
             data={data?.activityLogs?.collection ?? []}
-            hasError={!!error}
+            error={error}
             isLoading={loading}
             refetch={refetch}
             onRowActionLink={(row) => {

--- a/src/components/customers/CustomerActivityLogs.tsx
+++ b/src/components/customers/CustomerActivityLogs.tsx
@@ -4,7 +4,11 @@ import { ActivityLogsTable } from '~/components/activityLogs/ActivityLogsTable'
 import { buildLinkToActivityLog } from '~/components/activityLogs/utils'
 import { InfiniteScroll } from '~/components/designSystem'
 import { PageSectionTitle } from '~/components/layouts/Section'
-import { ActivityLogsTableDataFragmentDoc, useCustomerActivityLogsQuery } from '~/generated/graphql'
+import {
+  ActivityLogsTableDataFragmentDoc,
+  LagoApiError,
+  useCustomerActivityLogsQuery,
+} from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { useDeveloperTool } from '~/hooks/useDeveloperTool'
@@ -43,6 +47,9 @@ export const CustomerActivityLogs = ({ externalCustomerId }: CustomerActivityLog
       externalCustomerId: externalCustomerId,
       limit: 20,
     },
+    context: {
+      silentErrorCodes: [LagoApiError.FeatureUnavailable],
+    },
     skip: !canViewLogs,
   })
 
@@ -68,7 +75,7 @@ export const CustomerActivityLogs = ({ externalCustomerId }: CustomerActivityLog
           <ActivityLogsTable
             containerSize={4}
             data={data?.activityLogs?.collection ?? []}
-            hasError={!!error}
+            error={error}
             isLoading={loading}
             refetch={refetch}
             onRowActionLink={(row) => {

--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -69,6 +69,11 @@ export type ActionItem<T> = {
 export type TableContainerSize = 0 | 4 | 16 | 48
 type RowSize = 48 | 72
 
+export type TablePlaceholder = {
+  emptyState?: Partial<GenericPlaceholderProps>
+  errorState?: Partial<GenericPlaceholderProps>
+}
+
 export interface TableProps<T> {
   name: string
   data: T[]
@@ -76,10 +81,7 @@ export interface TableProps<T> {
   isLoading?: boolean
   hasError?: boolean
   loadingRowCount?: number
-  placeholder?: {
-    emptyState?: Partial<GenericPlaceholderProps>
-    errorState?: Partial<GenericPlaceholderProps>
-  }
+  placeholder?: TablePlaceholder
   onRowActionLink?: (item: T) => string
   onRowActionClick?: (item: T) => void
   actionColumn?: (item: T) => Array<ActionItem<T> | null> | ReactNode

--- a/src/components/developers/activityLogs/ActivityLogTable.tsx
+++ b/src/components/developers/activityLogs/ActivityLogTable.tsx
@@ -34,8 +34,8 @@ export const ActivityLogTable: FC<ActivityLogTableProps> = ({
     >
       <Table
         data={data?.activityLogs?.collection ?? []}
-        hasError={!!error}
         isLoading={loading}
+        error={error}
         refetch={refetch}
         onRowActionLink={({ activityId }) => {
           if (getCurrentBreakpoint() === 'sm') {

--- a/src/components/developers/activityLogs/ActivityLogs.tsx
+++ b/src/components/developers/activityLogs/ActivityLogs.tsx
@@ -14,7 +14,7 @@ import { ACTIVITY_LOG_ROUTE } from '~/components/developers/DevtoolsRouter'
 import { ListSectionRef, LogsLayout } from '~/components/developers/LogsLayout'
 import { ACTIVITY_LOG_FILTER_PREFIX } from '~/core/constants/filters'
 import { getCurrentBreakpoint } from '~/core/utils/getCurrentBreakpoint'
-import { ActivityItemFragment, useActivityLogsQuery } from '~/generated/graphql'
+import { ActivityItemFragment, LagoApiError, useActivityLogsQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useDeveloperTool } from '~/hooks/useDeveloperTool'
 
@@ -84,6 +84,9 @@ export const ActivityLogs = () => {
   const getActivityLogsResult = useActivityLogsQuery({
     variables: { limit: 20, ...filtersForActivityLogsQuery },
     notifyOnNetworkStatusChange: true,
+    context: {
+      silentErrorCodes: [LagoApiError.FeatureUnavailable],
+    },
   })
 
   const { data, loading, refetch } = getActivityLogsResult

--- a/src/components/features/FeatureDetailsActivityLogs.tsx
+++ b/src/components/features/FeatureDetailsActivityLogs.tsx
@@ -6,6 +6,7 @@ import { InfiniteScroll } from '~/components/designSystem'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import {
   ActivityLogsTableDataFragmentDoc,
+  LagoApiError,
   ResourceTypeEnum,
   useFeatureDetailsActivityLogsQuery,
 } from '~/generated/graphql'
@@ -58,6 +59,9 @@ export const FeatureDetailsActivityLogs = ({ featureId }: FeatureDetailsActivity
       resourceIds: [featureId],
       limit: 20,
     },
+    context: {
+      silentErrorCodes: [LagoApiError.FeatureUnavailable],
+    },
     skip: !canViewLogs,
   })
 
@@ -84,7 +88,7 @@ export const FeatureDetailsActivityLogs = ({ featureId }: FeatureDetailsActivity
             <ActivityLogsTable
               containerSize={4}
               data={data?.activityLogs?.collection ?? []}
-              hasError={!!error}
+              error={error}
               isLoading={loading}
               refetch={refetch}
               onRowActionLink={(row) => {

--- a/src/components/invoices/InvoiceActivityLogs.tsx
+++ b/src/components/invoices/InvoiceActivityLogs.tsx
@@ -6,6 +6,7 @@ import { InfiniteScroll } from '~/components/designSystem'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import {
   ActivityLogsTableDataFragmentDoc,
+  LagoApiError,
   ResourceTypeEnum,
   useInvoiceActivityLogsQuery,
 } from '~/generated/graphql'
@@ -58,6 +59,9 @@ export const InvoiceActivityLogs = ({ invoiceId }: InvoiceActivityLogsProps) => 
       resourceIds: [invoiceId],
       limit: 20,
     },
+    context: {
+      silentErrorCodes: [LagoApiError.FeatureUnavailable],
+    },
     skip: !canViewLogs,
   })
 
@@ -83,7 +87,7 @@ export const InvoiceActivityLogs = ({ invoiceId }: InvoiceActivityLogsProps) => 
           <ActivityLogsTable
             containerSize={4}
             data={data?.activityLogs?.collection ?? []}
-            hasError={!!error}
+            error={error}
             isLoading={loading}
             refetch={refetch}
             onRowActionLink={(row) => {

--- a/src/components/plans/details/PlanDetailsActivityLogs.tsx
+++ b/src/components/plans/details/PlanDetailsActivityLogs.tsx
@@ -6,6 +6,7 @@ import { InfiniteScroll } from '~/components/designSystem'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import {
   ActivityLogsTableDataFragmentDoc,
+  LagoApiError,
   ResourceTypeEnum,
   usePlanDetailsActivityLogsQuery,
 } from '~/generated/graphql'
@@ -58,6 +59,9 @@ export const PlanDetailsActivityLogs = ({ planId }: PlanDetailsActivityLogsProps
       resourceIds: [planId],
       limit: 20,
     },
+    context: {
+      silentErrorCodes: [LagoApiError.FeatureUnavailable],
+    },
     skip: !canViewLogs,
   })
 
@@ -84,7 +88,7 @@ export const PlanDetailsActivityLogs = ({ planId }: PlanDetailsActivityLogsProps
             <ActivityLogsTable
               containerSize={4}
               data={data?.activityLogs?.collection ?? []}
-              hasError={!!error}
+              error={error}
               isLoading={loading}
               refetch={refetch}
               onRowActionLink={(row) => {

--- a/src/components/subscriptions/SubscriptionActivityLogs.tsx
+++ b/src/components/subscriptions/SubscriptionActivityLogs.tsx
@@ -7,6 +7,7 @@ import { InfiniteScroll } from '~/components/designSystem'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import {
   ActivityLogsTableDataFragmentDoc,
+  LagoApiError,
   useSubscriptionActivityLogsQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -49,6 +50,9 @@ export const SubscriptionActivityLogs: FC<SubscriptionActivityLogsProps> = ({
       externalSubscriptionId: externalSubscriptionId,
       limit: 20,
     },
+    context: {
+      silentErrorCodes: [LagoApiError.FeatureUnavailable],
+    },
     skip: !canViewLogs,
   })
 
@@ -75,7 +79,7 @@ export const SubscriptionActivityLogs: FC<SubscriptionActivityLogsProps> = ({
             <ActivityLogsTable
               containerSize={4}
               data={data?.activityLogs?.collection ?? []}
-              hasError={!!error}
+              error={error}
               isLoading={loading}
               refetch={refetch}
               onRowActionLink={(row) => {

--- a/src/core/apolloClient/graphqlResolvers.tsx
+++ b/src/core/apolloClient/graphqlResolvers.tsx
@@ -5,6 +5,7 @@ export const typeDefs = gql`
     internal_error
     unauthorized
     forbidden
+    feature_unavailable
     not_found
     unprocessable_entity
 

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -4286,6 +4286,7 @@ export enum LagoApiError {
   DomainNotConfigured = 'domain_not_configured',
   EmailAlreadyUsed = 'email_already_used',
   ExpiredJwtToken = 'expired_jwt_token',
+  FeatureUnavailable = 'feature_unavailable',
   Forbidden = 'forbidden',
   GoogleAuthMissingSetup = 'google_auth_missing_setup',
   GoogleLoginMethodNotAuthorized = 'google_login_method_not_authorized',

--- a/translations/base.json
+++ b/translations/base.json
@@ -3541,5 +3541,6 @@
   "text_1764107468210ibi78qsrukx": "Support 3DSecure",
   "text_1764107468210lbhkj5no1vh": "If 3DSecure is required the invoice will stay pending until the customer completes the action.",
   "text_1764160009979jzn4xunn1z8": "Yes",
-  "text_176416000997957yqelmt2m2": "No"
+  "text_176416000997957yqelmt2m2": "No",
+  "text_1764181883406sg3ir0pbxkt": "It seems you don't have the permission to view activity logs. If you think this is an error contact an admin of your organization or Lago support."
 }


### PR DESCRIPTION
## Context

User can access an activity logs list within the application.

This list is available on different objects (user, plan, billable metrics, ...) but it also exist a "general" activity logs tab, where you can apply filters to refine results.

This feature is only available for premium user AND those who have performed the setup with Lago team to have this feature working.
So it can happen our users have a paying license but does not have the exact configuration yet to have access to this feature.

In such case, we currently display the default error state.

## Description

This PR make sure we catch the correct error and display a better placeholder message.

<!-- Linear link -->
Fixes ISSUE-1258