### PR TITLE
bug: prevent null destructuring errors on auth token expiration

### DIFF
--- a/src/components/customers/createCustomer/ExternalAppsAccordion/PaymentProvidersAccordion.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/PaymentProvidersAccordion.tsx
@@ -93,11 +93,11 @@ export const PaymentProvidersAccordion: FC<PaymentProvidersAccordionProps> = ({
   setShowPaymentSection,
 }) => {
   const { translate } = useInternationalization()
-  const { data: { paymentProviders } = {}, loading } =
-    usePaymentProvidersListForCustomerCreateEditExternalAppsAccordionQuery({
-      variables: { limit: 1000 },
-    })
+  const { data, loading } = usePaymentProvidersListForCustomerCreateEditExternalAppsAccordionQuery({
+    variables: { limit: 1000 },
+  })
 
+  const paymentProviders = data?.paymentProviders
   const selectedPaymentProvider = paymentProviders?.collection.find(
     (p) => p.code === formikProps.values.paymentProviderCode,
   )

--- a/src/components/customers/overview/CustomerOverview.tsx
+++ b/src/components/customers/overview/CustomerOverview.tsx
@@ -84,7 +84,7 @@ export const CustomerOverview: FC<CustomerOverviewProps> = ({
   const { customerId } = useParams()
   const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
-  const { data: isCustomerReadyForOverduePayment, loading: isPaymentProcessingStatusLoading } =
+  const { isCustomerReadyForOverduePayment, loading: isPaymentProcessingStatusLoading } =
     useIsCustomerReadyForOverduePayment()
 
   const currency = userCurrency ?? organization?.defaultCurrency ?? CurrencyEnum.Usd

--- a/src/components/customers/overview/__tests__/CustomerOverview.test.tsx
+++ b/src/components/customers/overview/__tests__/CustomerOverview.test.tsx
@@ -99,42 +99,45 @@ describe('CustomerOverview', () => {
     it.each([
       {
         description: 'not displayed when payment processing status is loading',
-        data: false,
+        isCustomerReadyForOverduePayment: false,
         loading: true,
         expectedVisible: false,
       },
       {
         description: 'not displayed when data is not ready for overdue payment',
-        data: false,
+        isCustomerReadyForOverduePayment: false,
         loading: false,
         expectedVisible: false,
       },
       {
         description: 'displayed when payment processing status is not loading and data is ready',
-        data: true,
+        isCustomerReadyForOverduePayment: true,
         loading: false,
         expectedVisible: true,
       },
-    ])('should be $description', async ({ data, loading, expectedVisible }) => {
-      jest
-        .mocked(useIsCustomerReadyForOverduePaymentModule.useIsCustomerReadyForOverduePayment)
-        .mockReturnValue({
-          data,
-          loading,
-          error: undefined,
+    ])(
+      'should be $description',
+      async ({ isCustomerReadyForOverduePayment, loading, expectedVisible }) => {
+        jest
+          .mocked(useIsCustomerReadyForOverduePaymentModule.useIsCustomerReadyForOverduePayment)
+          .mockReturnValue({
+            isCustomerReadyForOverduePayment,
+            loading,
+            error: undefined,
+          })
+
+        await act(async () => {
+          return render(<CustomerOverview externalCustomerId="ext-123" />)
         })
 
-      await act(async () => {
-        return render(<CustomerOverview externalCustomerId="ext-123" />)
-      })
-
-      await waitFor(() => {
-        if (expectedVisible) {
-          expect(screen.getByTestId(OVERDUE_INVOICES_ALERT_TEST_ID)).toBeInTheDocument()
-        } else {
-          expect(screen.queryByTestId(OVERDUE_INVOICES_ALERT_TEST_ID)).not.toBeInTheDocument()
-        }
-      })
-    })
+        await waitFor(() => {
+          if (expectedVisible) {
+            expect(screen.getByTestId(OVERDUE_INVOICES_ALERT_TEST_ID)).toBeInTheDocument()
+          } else {
+            expect(screen.queryByTestId(OVERDUE_INVOICES_ALERT_TEST_ID)).not.toBeInTheDocument()
+          }
+        })
+      },
+    )
   })
 })

--- a/src/hooks/__tests__/useIsCustomerReadyForOverduePayment.test.ts
+++ b/src/hooks/__tests__/useIsCustomerReadyForOverduePayment.test.ts
@@ -65,7 +65,7 @@ describe('useIsCustomerReadyForOverduePayment', () => {
       // Wait for the mock query to complete
       await act(() => wait(0))
 
-      expect(result.current.data).toBe(true)
+      expect(result.current.isCustomerReadyForOverduePayment).toBe(true)
     })
   })
 
@@ -82,16 +82,16 @@ describe('useIsCustomerReadyForOverduePayment', () => {
       // Wait for the mock query to complete
       await act(() => wait(0))
 
-      expect(result.current.data).toBe(false)
+      expect(result.current.isCustomerReadyForOverduePayment).toBe(false)
     })
   })
 
   describe('WHEN query is loading', () => {
-    it('THEN returns loading as true and data as false', async () => {
+    it('THEN returns loading as true and isCustomerReadyForOverduePayment as false', async () => {
       const { result } = await prepare({ delay: 100 })
 
       expect(result.current.loading).toBeTruthy()
-      expect(result.current.data).toBe(false)
+      expect(result.current.isCustomerReadyForOverduePayment).toBe(false)
     })
   })
 })

--- a/src/hooks/useCreateEditCustomer.ts
+++ b/src/hooks/useCreateEditCustomer.ts
@@ -187,16 +187,14 @@ export const useCreateEditCustomer: UseCreateEditCustomer = () => {
   const navigate = useNavigate()
   const { customerId } = useParams<{ customerId: string }>()
 
-  const {
-    data: { customer } = {},
-    loading,
-    error,
-  } = useGetSingleCustomerQuery({
+  const { data, loading, error } = useGetSingleCustomerQuery({
     variables: {
       id: customerId as string,
     },
     skip: !customerId,
   })
+
+  const customer = data?.customer
 
   const goToCustomerInformationPage = (_customerId: string) =>
     navigate(

--- a/src/hooks/useIsCustomerReadyForOverduePayment.ts
+++ b/src/hooks/useIsCustomerReadyForOverduePayment.ts
@@ -14,7 +14,7 @@ gql`
 `
 
 interface UseIsCustomerReadyForOverduePaymentReturn {
-  data: boolean
+  isCustomerReadyForOverduePayment: boolean
   error: ApolloError | undefined
   loading: boolean
 }
@@ -22,23 +22,21 @@ interface UseIsCustomerReadyForOverduePaymentReturn {
 export const useIsCustomerReadyForOverduePayment =
   (): UseIsCustomerReadyForOverduePaymentReturn => {
     const { customerId } = useParams()
-    const {
-      data: { invoices } = {},
-      loading,
-      error,
-    } = useGetCustomerOverdueInvoicesReadyForPaymentProcessingQuery({
+    const { data, loading, error } = useGetCustomerOverdueInvoicesReadyForPaymentProcessingQuery({
       variables: { id: customerId ?? '' },
       skip: !customerId,
       fetchPolicy: 'network-only',
     })
 
+    const invoices = data?.invoices
     const invoicesNotReadyForPaymentProcessing =
       invoices?.collection?.filter((invoice) => !invoice.readyForPaymentProcessing) || []
 
-    const data = !loading && !error && invoicesNotReadyForPaymentProcessing.length === 0
+    const isCustomerReadyForOverduePayment =
+      !loading && !error && invoicesNotReadyForPaymentProcessing.length === 0
 
     return {
-      data,
+      isCustomerReadyForOverduePayment,
       loading,
       error,
     }

--- a/src/pages/CreatePayment.tsx
+++ b/src/pages/CreatePayment.tsx
@@ -111,10 +111,12 @@ const CreatePayment = () => {
     },
   })
 
-  const { data: { invoice } = {}, loading: invoiceLoading } = useGetPayableInvoiceQuery({
+  const { data, loading: invoiceLoading } = useGetPayableInvoiceQuery({
     variables: { id: formikProps.values.invoiceId },
     skip: !formikProps.values.invoiceId,
   })
+
+  const invoice = data?.invoice
 
   useEffect(() => {
     if (invoice && invoice.invoiceType === InvoiceTypeEnum.Credit) {

--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -109,7 +109,7 @@ const CustomerDetails = () => {
   const { customerId, tab } = useParams()
   const { handleDownloadFile } = useDownloadFile()
 
-  const { data: isCustomerReadyForOverduePayment, loading: isPaymentProcessingStatusLoading } =
+  const { isCustomerReadyForOverduePayment, loading: isPaymentProcessingStatusLoading } =
     useIsCustomerReadyForOverduePayment()
 
   const { data, loading, error } = useGetCustomerQuery({

--- a/src/pages/CustomerRequestOverduePayment/__tests__/index.test.tsx
+++ b/src/pages/CustomerRequestOverduePayment/__tests__/index.test.tsx
@@ -147,7 +147,7 @@ describe('CustomerRequestOverduePayment', () => {
       jest
         .mocked(useIsCustomerReadyForOverduePaymentModule.useIsCustomerReadyForOverduePayment)
         .mockReturnValue({
-          data: false,
+          isCustomerReadyForOverduePayment: false,
           loading: false,
           error: undefined,
         })

--- a/src/pages/CustomerRequestOverduePayment/index.tsx
+++ b/src/pages/CustomerRequestOverduePayment/index.tsx
@@ -80,16 +80,17 @@ const CustomerRequestOverduePayment: FC = () => {
   const { customerId } = useParams()
   const navigate = useNavigate()
   const { isPremium } = useCurrentUser()
-  const { data: isCustomerReadyForOverduePayment, loading: isPaymentProcessingStatusLoading } =
+  const { isCustomerReadyForOverduePayment, loading: isPaymentProcessingStatusLoading } =
     useIsCustomerReadyForOverduePayment()
 
-  const {
-    data: { customer, organization, paymentRequests, invoices } = {},
-    loading,
-    error,
-  } = useGetRequestOverduePaymentInfosQuery({
+  const { data, loading, error } = useGetRequestOverduePaymentInfosQuery({
     variables: { id: customerId ?? '' },
   })
+
+  const customer = data?.customer
+  const organization = data?.organization
+  const paymentRequests = data?.paymentRequests
+  const invoices = data?.invoices
 
   const hasDunningIntegration = !!isPremium
 

--- a/src/pages/wallet/CreateWalletTopUp.tsx
+++ b/src/pages/wallet/CreateWalletTopUp.tsx
@@ -93,12 +93,14 @@ const CreateWalletTopUp = () => {
 
   const fetchedWalletId = walletId === CREATE_ACTIVE_WALLET_TOP_UP_ID ? activeWallet?.id : walletId
 
-  const { data: { wallet } = {}, loading } = useGetWalletForTopUpQuery({
+  const { data, loading } = useGetWalletForTopUpQuery({
     variables: {
       walletId: fetchedWalletId as string,
     },
     skip: !fetchedWalletId,
   })
+
+  const wallet = data?.wallet
 
   const currency = wallet?.currency || defaultCurrency || CurrencyEnum.Usd
 


### PR DESCRIPTION
## Context

Sentry reported `TypeError: Cannot destructure property 'invoices' of '{}' as it is null` errors occurring on the `/login` route. Investigation revealed a race condition during authentication token expiration:

1. When users return after ~1 hour of inactivity, their auth token has expired
2. All components fire GraphQL queries simultaneously, which fail with 401 errors
3. The auth error handler triggers `logOut()`, which calls `client.clearStore()` to clear the Apollo cache
4. The router redirects to `/login`
5. **However**, queries that are still processing receive `null` from the cleared cache instead of `{}`
6. Destructuring patterns like `{ invoices } = {}` throw errors because they can't destructure from `null`

This explains why Sentry reports the error on `/login` even though the queries originated from other routes (invoice, customer pages).

## Description

Fixed race condition by replacing unsafe destructuring patterns with null-safe optional chaining across 6 files:

**Before (unsafe):**
```typescript
const { data: { invoices } = {}, loading } = useQuery(...)
```

**After (safe):**
```typescript
const { data, loading } = useQuery(...)
const invoices = data?.invoices
```

**Changes:**
- Updated GraphQL query hooks to use optional chaining for data access
- Fixed `useIsCustomerReadyForOverduePayment` hook and updated its unit tests to match the correct return type
- Applied the pattern consistently across all vulnerable query locations

This ensures graceful handling when the Apollo cache is cleared during logout, preventing destructuring errors while maintaining existing functionality.
