### PR TITLE
bug: make sure sparkle is aligned with label

### DIFF
--- a/src/components/plans/ProgressiveBillingSection.tsx
+++ b/src/components/plans/ProgressiveBillingSection.tsx
@@ -84,9 +84,12 @@ export const ProgressiveBillingSection: FC<ProgressiveBillingSectionProps> = ({
       {!hasPremiumIntegration && (
         <div className="flex items-center justify-between gap-4 rounded-lg bg-grey-100 px-6 py-4">
           <Box>
-            <Typography variant="bodyHl" color="textSecondary">
-              {translate('text_1724345142892pcnx5m2k3r2')} <Icon name="sparkles" />
-            </Typography>
+            <div className="flex items-center gap-2">
+              <Typography variant="bodyHl" color="textSecondary">
+                {translate('text_1724345142892pcnx5m2k3r2')}
+              </Typography>
+              <Icon name="sparkles" />
+            </div>
             <Typography variant="caption">{translate('text_1724345142892ljzi79afhmc')}</Typography>
           </Box>
           <ButtonLink

--- a/src/components/plans/chargeAccordion/options/ChargeInvoicingStrategyOption.tsx
+++ b/src/components/plans/chargeAccordion/options/ChargeInvoicingStrategyOption.tsx
@@ -77,10 +77,12 @@ export const ChargeInvoicingStrategyOption: FC<ChargeInvoicingStrategyOptionProp
       {!isPremium && (
         <div className="flex items-center justify-between gap-4 rounded-lg bg-grey-100 px-6 py-4">
           <div>
-            <Typography className="flex items-center" variant="bodyHl" color="textSecondary">
-              {translate('text_6682c52081acea90520744d0')}
-              <Icon className="ml-2" name="sparkles" />
-            </Typography>
+            <div className="flex items-center gap-2">
+              <Typography variant="bodyHl" color="textSecondary">
+                {translate('text_6682c52081acea90520744d0')}
+              </Typography>
+              <Icon name="sparkles" />
+            </div>
 
             <Typography variant="caption">{translate('text_6682c52081acea90520744d2')}</Typography>
           </div>

--- a/src/components/subscriptions/SubscriptionUsageLifetimeGraph.tsx
+++ b/src/components/subscriptions/SubscriptionUsageLifetimeGraph.tsx
@@ -312,7 +312,7 @@ export const SubscriptionUsageLifetimeGraphComponent = ({
             {!isLoading && !hasProgressiveBillingPremiumIntegration && (
               <div className="flex flex-row items-center justify-between gap-4 rounded-sm bg-grey-100 px-6 py-4">
                 <div className="flex flex-col">
-                  <div className="flex flex-row items-center gap-1">
+                  <div className="flex flex-row items-center gap-2">
                     <Typography variant="bodyHl" color="grey700">
                       {translate('text_1724345142892pcnx5m2k3r2')}
                     </Typography>

--- a/src/components/wallets/WalletAccordion.tsx
+++ b/src/components/wallets/WalletAccordion.tsx
@@ -334,7 +334,7 @@ export const WalletAccordion: FC<WalletAccordionProps> = ({
             {!isPremium && (
               <div className="flex items-center justify-between gap-4 bg-grey-100 p-4 shadow-y">
                 <div>
-                  <div className="flex flex-row items-baseline gap-1">
+                  <div className="flex flex-row items-center gap-2">
                     <Typography variant="bodyHl" color="grey700">
                       {translate('text_65ae73ebe3a66bec2b91d721')}
                     </Typography>


### PR DESCRIPTION
## Context

The freemium alerts displayed throughout the application (for features like Progressive Billing, Projected Usage, etc.) had a layout issue where the sparkles icon would wrap to a new line instead of staying next to the label text. This occurred when the icon was placed inline within the `Typography` component, causing inconsistent and unpolished UI presentation.

## Description

This PR fixes the sparkles icon positioning in all freemium alert blocks across the application to ensure the icon consistently stays next to the label text.

**Changes made:**

- **ProgressiveBillingSection.tsx**: Wrapped Typography and Icon in a flex container with `gap-2` instead of placing the icon inline within Typography
- **SubscriptionUsageLifetimeGraph.tsx**: Updated flex container to use `items-center gap-2` for proper alignment
- **WalletAccordion.tsx**: Changed from `items-baseline gap-1` to `items-center gap-2` for consistent spacing and alignment
- **ChargeInvoicingStrategyOption.tsx**: Replaced inline Icon (with `ml-2` class) with a proper flex container using `gap-2`

All freemium blocks now follow the same pattern


We have a ticket open to centralise all those freemium blocks, won't do it now

<!-- Linear link -->
Fixes ISSUE-1301