### PR TITLE
fix(integrations): fix xero payment item not loaded

### DIFF
--- a/packages/configs/eslint.config.mjs
+++ b/packages/configs/eslint.config.mjs
@@ -14,7 +14,15 @@ import noFormikPropsInEffect from './eslint-rules/no-formik-props-in-effect.js'
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   {
-    ignores: ['**/dist/*', '.github/**/*', '**/globals.d.ts', '**/generated/**/*', 'cypress/**/*'],
+    ignores: [
+      '**/dist/*',
+      '.github/**/*',
+      '**/globals.d.ts',
+      '**/generated/**/*',
+      'cypress/**/*',
+      'coverage/**/*',
+      '**/node_modules/**/*',
+    ],
   },
 
   {

--- a/src/pages/settings/integrations/XeroIntegrationMapItemDrawer/XeroIntegrationMapItemFormWrapper.tsx
+++ b/src/pages/settings/integrations/XeroIntegrationMapItemDrawer/XeroIntegrationMapItemFormWrapper.tsx
@@ -56,9 +56,7 @@ const XeroInput = ({
 
   const isAccountContext = formType === MappingTypeEnum.Account
 
-  const searchQuery = !isAccountContext
-    ? (getXeroIntegrationItems as unknown as ComboBoxProps['searchQuery'])
-    : undefined
+  const searchQuery = getXeroIntegrationItems as unknown as ComboBoxProps['searchQuery']
 
   const helperText =
     !isLoading && !comboboxData.length ? translate('text_6630ec823adac97d3bf0fb4b') : undefined


### PR DESCRIPTION
## Context

Was not able to load Xero Payment entities in integration mappings

## Description

PR fixes this behaviour

<!-- Linear link -->
Fixes [ISSUE-1303](https://linear.app/getlago/issue/ISSUE-1303/cannot-select-payment-accounts-in-xero-mapping)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 99a8de733a4a30c0c596d8a92dc001d01ca48eb6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->