### PR TITLE
bug: prevent firing active queries after cache manual update

### DIFF
--- a/src/components/customers/overview/CustomerSubscriptionsList.tsx
+++ b/src/components/customers/overview/CustomerSubscriptionsList.tsx
@@ -71,6 +71,7 @@ export const CustomerSubscriptionsList = () => {
   const { data, loading } = useGetCustomerSubscriptionForListQuery({
     variables: { id: customerId as string },
     skip: !customerId,
+    notifyOnNetworkStatusChange: true,
   })
   const subscriptions = data?.customer?.subscriptions as Subscription[]
   const hasNoSubscription = !subscriptions || !subscriptions.length

--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -17,7 +17,6 @@ import { serializePlanInput } from '~/core/serializers'
 import {
   BillingTimeEnum,
   CreateSubscriptionInput,
-  CustomerDetailsFragment,
   CustomerDetailsFragmentDoc,
   GetSubscriptionForCreateSubscriptionQuery,
   LagoApiError,
@@ -153,28 +152,6 @@ export const useAddSubscription: UseAddSubscription = ({
           )
         }
       }
-    },
-    update(cache, { data: updatedData }) {
-      if (!updatedData?.createSubscription) return
-
-      const cachedCustomerId = `Customer:${updatedData?.createSubscription.customer.id}`
-
-      const previousData: CustomerDetailsFragment | null = cache.readFragment({
-        id: cachedCustomerId,
-        fragment: CustomerDetailsFragmentDoc,
-        fragmentName: 'CustomerDetails',
-      })
-
-      cache.writeFragment({
-        id: cachedCustomerId,
-        fragment: CustomerDetailsFragmentDoc,
-        fragmentName: 'CustomerDetails',
-        data: {
-          ...previousData,
-          activeSubscriptionsCount:
-            updatedData.createSubscription.customer.activeSubscriptionsCount,
-        },
-      })
     },
     refetchQueries: ['getCustomerSubscriptionForList'],
   })


### PR DESCRIPTION
## Context

Whenever you write manually to the cache, Apollo GraphQL will re-trigger what they consider as active query attached to this model. 
When you create a subscription, we are manually writing to the cache, and as of today, all active queries a fired.

In an ideal world, there will be no issue with this. But if it happens that you have an active query that should be discarded, you will create errors infinitely every time you trigger this action. 

There exist some manual ways to prevent that to happen, but it's very custom and sounds like we're gonna have to be very verbose and/or place this kind of logic on very precise places of the app.

Here, the current situation was
- I navigate to customer A details page
- I delete customer A
- I navigate to customer B details page
- I add a subscription 
- after being redirected to customer B details page, I can see 2 toasts
  - Success: for the subscription creation
  - Error: For an active query being refetch for customer A
 
This is because writeFragment does re-trigger active queries and customer does not exists anymore (404)

## Description

Managing manually the cache would be awesome in a perfect world, however with Apollo it sounds like it's very flaky and lead to some unexpected situations. 
So the quick fix is to just prevent manually managing the cache and just rely on the Refetch queries. 
When you do so, it can be important to tell the query to notify whenever there is a new change so the loading states are shown and then we can rely on cache to display data faster in the UI. 
