### PR TITLE
bug(Invoice): display up to 6 decimal for perPackageUnitAmount

### DIFF
--- a/src/components/invoices/details/InvoiceDetailsTableBodyLinePackage.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableBodyLinePackage.tsx
@@ -120,6 +120,8 @@ export const InvoiceDetailsTableBodyLinePackage = memo(
                     pricingUnitShortName: fee?.pricingUnitUsage?.shortName,
                     currencyDisplay: 'symbol',
                     currency,
+                    minimumFractionDigits: 2,
+                    maximumSignificantDigits: 6,
                   },
                 ),
                 perPackageSize: Number(amountDetails?.perPackageSize || 0),


### PR DESCRIPTION
## Context

Some numbers displayed in the invoice details can be very long suit of digits.

Even tho you pay with a currency that allow couple decimals after 0, the details of some charges models can aggregate cents up to a 15 precision.

For some being displayed, it makes sense to have the exact precise value, no matter the number of decimals.
Specially when you send events with some percentages rules, and the total of the charge's fee shows up to 15 digits.

When you have charge details displayed tho, we decided to apply a rule to not overwhelm the UI/PDF: do not display more than 6 digits after 0, even those there could be more.

The total of course keep the currency precision (e.g. 2 for USD)

So this could look like this

|fee name|units|unit price (display up to 6)|taxes|total (display currency precision|
|-|-|-|-|-|
|my fee|1|€0.0018 per 10|20.00%|€0.00|

## Description

We forgot to have to "up to 6" rule for the `perPackageUnitAmount` for package charges, hence using the fallback for the currency passed (e.g. 2 for USD)

This PR simply re-define the correct display rules for this attribute to allow displaying up to 6 digits