### PR TITLE
fix(payments): Fix "Multiple invoices (1)" when it's just 1 invoice

### DIFF
--- a/src/components/customers/CustomerPaymentsList.tsx
+++ b/src/components/customers/CustomerPaymentsList.tsx
@@ -10,13 +10,12 @@ import { CUSTOMER_PAYMENT_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { intlFormatDateTime } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
+import { isInvoice, isPaymentRequest } from '~/core/utils/payableUtils'
 import {
   CurrencyEnum,
   GetPaymentsListQuery,
   GetPaymentsListQueryHookResult,
-  Invoice,
   PaymentForPaymentsListFragment,
-  PaymentRequest,
   PaymentTypeEnum,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -109,17 +108,16 @@ export const CustomerPaymentsList: FC<CustomerPaymentsListProps> = ({
             minWidth: 160,
             maxSpace: true,
             content: ({ payable }) => {
-              if (payable.payableType === 'Invoice') {
-                const payableInvoice = payable as Invoice
-
-                return payableInvoice.number
+              if (isInvoice(payable)) {
+                return payable.number
               }
-              if (payable.payableType === 'PaymentRequest') {
-                const payablePaymentRequest = payable as PaymentRequest
-
-                return translate('text_17370296250898eqj4qe4qg9', {
-                  count: payablePaymentRequest.invoices.length,
-                })
+              if (isPaymentRequest(payable)) {
+                if (payable.invoices.length > 1) {
+                  return translate('text_17370296250898eqj4qe4qg9', {
+                    count: payable.invoices.length,
+                  })
+                }
+                return payable.invoices[0]?.number
               }
             },
           },

--- a/src/components/invoices/InvoicePaymentList.tsx
+++ b/src/components/invoices/InvoicePaymentList.tsx
@@ -10,13 +10,8 @@ import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CREATE_INVOICE_PAYMENT_ROUTE, PAYMENT_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { intlFormatDateTime } from '~/core/timezone'
-import {
-  CurrencyEnum,
-  Invoice,
-  PaymentRequest,
-  PaymentTypeEnum,
-  useGetPaymentsListQuery,
-} from '~/generated/graphql'
+import { isInvoice, isPaymentRequest } from '~/core/utils/payableUtils'
+import { CurrencyEnum, PaymentTypeEnum, useGetPaymentsListQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import useDownloadPaymentReceipts from '~/hooks/paymentReceipts/useDownloadPaymentReceipts'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
@@ -127,17 +122,16 @@ export const InvoicePaymentList: FC<{
                 minWidth: 160,
                 maxSpace: true,
                 content: ({ payable }) => {
-                  if (payable.payableType === 'Invoice') {
-                    const payableInvoice = payable as Invoice
-
-                    return payableInvoice.number
+                  if (isInvoice(payable)) {
+                    return payable.number
                   }
-                  if (payable.payableType === 'PaymentRequest') {
-                    const payablePaymentRequest = payable as PaymentRequest
-
-                    return translate('text_17370296250898eqj4qe4qg9', {
-                      count: payablePaymentRequest.invoices.length,
-                    })
+                  if (isPaymentRequest(payable)) {
+                    if (payable.invoices.length > 1) {
+                      return translate('text_17370296250898eqj4qe4qg9', {
+                        count: payable.invoices.length,
+                      })
+                    }
+                    return payable.invoices[0]?.number
                   }
                 },
               },

--- a/src/components/invoices/PaymentsList.tsx
+++ b/src/components/invoices/PaymentsList.tsx
@@ -11,13 +11,12 @@ import { PAYMENT_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { intlFormatDateTime } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
+import { isInvoice, isPaymentRequest } from '~/core/utils/payableUtils'
 import {
   CurrencyEnum,
   GetPaymentsListQuery,
   GetPaymentsListQueryHookResult,
-  Invoice,
   PaymentForPaymentsListFragment,
-  PaymentRequest,
   PaymentTypeEnum,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -39,6 +38,7 @@ gql`
         payableType
         invoices {
           id
+          number
         }
       }
     }
@@ -152,17 +152,16 @@ export const PaymentsList: FC<PaymentsListProps> = ({
             title: translate('text_63ac86d797f728a87b2f9fad'),
             minWidth: 160,
             content: ({ payable }) => {
-              if (payable.payableType === 'Invoice') {
-                const payableInvoice = payable as Invoice
-
-                return payableInvoice.number
+              if (isInvoice(payable)) {
+                return payable.number
               }
-              if (payable.payableType === 'PaymentRequest') {
-                const payablePaymentRequest = payable as PaymentRequest
-
-                return translate('text_17370296250898eqj4qe4qg9', {
-                  count: payablePaymentRequest.invoices.length,
-                })
+              if (isPaymentRequest(payable)) {
+                if (payable.invoices.length > 1) {
+                  return translate('text_17370296250898eqj4qe4qg9', {
+                    count: payable.invoices.length,
+                  })
+                }
+                return payable.invoices[0]?.number
               }
             },
           },

--- a/src/core/types/payable.ts
+++ b/src/core/types/payable.ts
@@ -1,0 +1,9 @@
+import { PaymentForPaymentsListFragment } from '~/generated/graphql'
+
+/**
+ * Payable type extracted from PaymentForPaymentsListFragment
+ *
+ * Represents a union type that can be either an Invoice or a PaymentRequest.
+ * This type is used for type guards to safely narrow down the payable type.
+ */
+export type Payable = PaymentForPaymentsListFragment['payable']

--- a/src/core/utils/__tests__/payableUtils.test.ts
+++ b/src/core/utils/__tests__/payableUtils.test.ts
@@ -1,0 +1,50 @@
+import { Payable } from '~/core/types/payable'
+import { isInvoice, isPaymentRequest } from '~/core/utils/payableUtils'
+
+describe('payableUtils', () => {
+  describe('isInvoice', () => {
+    it('should return true when payable is an Invoice', () => {
+      const payable: Payable = {
+        __typename: 'Invoice',
+        id: 'invoice-1',
+        number: 'INV-001',
+        payableType: 'Invoice',
+      }
+
+      expect(isInvoice(payable)).toBe(true)
+    })
+
+    it('should return false when payable is a PaymentRequest', () => {
+      const payable: Payable = {
+        __typename: 'PaymentRequest',
+        payableType: 'PaymentRequest',
+        invoices: [],
+      }
+
+      expect(isInvoice(payable)).toBe(false)
+    })
+  })
+
+  describe('isPaymentRequest', () => {
+    it('should return true when payable is a PaymentRequest', () => {
+      const payable: Payable = {
+        __typename: 'PaymentRequest',
+        payableType: 'PaymentRequest',
+        invoices: [{ __typename: 'Invoice', id: 'invoice-1', number: 'INV-001' }],
+      }
+
+      expect(isPaymentRequest(payable)).toBe(true)
+    })
+
+    it('should return false when payable is an Invoice', () => {
+      const payable: Payable = {
+        __typename: 'Invoice',
+        id: 'invoice-1',
+        number: 'INV-001',
+        payableType: 'Invoice',
+      }
+
+      expect(isPaymentRequest(payable)).toBe(false)
+    })
+  })
+})

--- a/src/core/utils/payableUtils.ts
+++ b/src/core/utils/payableUtils.ts
@@ -1,0 +1,25 @@
+import { Payable } from '~/core/types/payable'
+
+/**
+ * Type guard to check if a payable is an Invoice
+ *
+ * @param payable - The payable object to check
+ * @returns True if the payable is an Invoice, false otherwise
+ */
+export const isInvoice = (
+  payable: Payable,
+): payable is Extract<Payable, { __typename?: 'Invoice' }> => {
+  return payable.payableType === 'Invoice'
+}
+
+/**
+ * Type guard to check if a payable is a PaymentRequest
+ *
+ * @param payable - The payable object to check
+ * @returns True if the payable is a PaymentRequest, false otherwise
+ */
+export const isPaymentRequest = (
+  payable: Payable,
+): payable is Extract<Payable, { __typename?: 'PaymentRequest' }> => {
+  return payable.payableType === 'PaymentRequest'
+}

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -10145,7 +10145,7 @@ export type GetInvoiceMetadatasQuery = { __typename?: 'Query', invoice?: { __typ
 
 export type PaymentForPaymentsListFragment = { __typename?: 'Payment', amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, id: string, payablePaymentStatus?: PayablePaymentStatusEnum | null, paymentProviderType?: ProviderTypeEnum | null, paymentType: PaymentTypeEnum, providerPaymentId?: string | null, reference?: string | null, payable:
     | { __typename?: 'Invoice', id: string, number: string, payableType: string }
-    | { __typename?: 'PaymentRequest', payableType: string, invoices: Array<{ __typename?: 'Invoice', id: string }> }
+    | { __typename?: 'PaymentRequest', payableType: string, invoices: Array<{ __typename?: 'Invoice', id: string, number: string }> }
   , customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, applicableTimezone: TimezoneEnum }, paymentReceipt?: { __typename?: 'PaymentReceipt', id: string } | null };
 
 export type InvoiceForVoidInvoiceDialogFragment = { __typename?: 'Invoice', id: string, number: string };
@@ -12257,7 +12257,7 @@ export type GetPaymentsListQueryVariables = Exact<{
 
 export type GetPaymentsListQuery = { __typename?: 'Query', payments: { __typename?: 'PaymentCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Payment', amountCents: any, amountCurrency: CurrencyEnum, createdAt: any, id: string, payablePaymentStatus?: PayablePaymentStatusEnum | null, paymentProviderType?: ProviderTypeEnum | null, paymentType: PaymentTypeEnum, providerPaymentId?: string | null, reference?: string | null, payable:
         | { __typename?: 'Invoice', id: string, number: string, payableType: string }
-        | { __typename?: 'PaymentRequest', payableType: string, invoices: Array<{ __typename?: 'Invoice', id: string }> }
+        | { __typename?: 'PaymentRequest', payableType: string, invoices: Array<{ __typename?: 'Invoice', id: string, number: string }> }
       , customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, applicableTimezone: TimezoneEnum }, paymentReceipt?: { __typename?: 'PaymentReceipt', id: string } | null }> } };
 
 export type GetPlanForDetailsQueryVariables = Exact<{
@@ -14586,6 +14586,7 @@ export const PaymentForPaymentsListFragmentDoc = gql`
       payableType
       invoices {
         id
+        number
       }
     }
   }


### PR DESCRIPTION
## Note

This fix mitigates the frontend display issue, but it's unclear whether the backend correctly prevents creating PaymentRequests with a single invoice. Further investigation may be needed on the the backend as well.

## Context

Payment lists showed "Multiple invoices (1)" for PaymentRequests with a single invoice. They should show the invoice number when there's only one invoice, and "Multiple invoices" only when there are multiple.

## Description

- Updated GraphQL fragment to include number in PaymentRequest invoices
- Added reusable type guards (isInvoice, isPaymentRequest) in src/core/utils/payableUtils.ts
- Fixed display logic in CustomerPaymentsList, PaymentsList, and InvoicePaymentList:
- Show invoice number if PaymentRequest has exactly 1 invoice
- Show "Multiple invoices" message only if there are more than 1 invoices
- Replaced type assertions with type guards for better type safety
- Added unit tests for the type guards

All payment list components now use consistent logic and improved type safety.

<!-- Linear link -->
Fixes [ISSUE-1310](https://linear.app/getlago/issue/ISSUE-1310)