### PR TITLE
refactor(eslint): Fix some eslint warnings through refactoring nested ternary expressions

### DIFF
--- a/src/components/customers/createCustomer/MetadataAccordion.tsx
+++ b/src/components/customers/createCustomer/MetadataAccordion.tsx
@@ -67,17 +67,19 @@ export const MetadataAccordion: FC<MetadataAccordionProps> = ({ formikProps }) =
                 const hasCustomValueError =
                   Object.keys(MetadataErrorsEnum).includes(metadataItemValueError)
 
+                let keyErrorTitle: string | undefined = undefined
+
+                if (metadataItemKeyError === MetadataErrorsEnum.uniqueness) {
+                  keyErrorTitle = translate('text_63fcc3218d35b9377840f5dd')
+                } else if (metadataItemKeyError === MetadataErrorsEnum.maxLength) {
+                  keyErrorTitle = translate('text_63fcc3218d35b9377840f5d9')
+                }
+
                 return (
                   <React.Fragment key={`metadata-item-${m.id || m.localId || i}`}>
                     <Tooltip
                       placement="top-end"
-                      title={
-                        metadataItemKeyError === MetadataErrorsEnum.uniqueness
-                          ? translate('text_63fcc3218d35b9377840f5dd')
-                          : metadataItemKeyError === MetadataErrorsEnum.maxLength
-                            ? translate('text_63fcc3218d35b9377840f5d9')
-                            : undefined
-                      }
+                      title={keyErrorTitle}
                       disableHoverListener={!hasCustomKeyError}
                     >
                       <TextInputField

--- a/src/components/designSystem/__tests__/Popper.test.tsx
+++ b/src/components/designSystem/__tests__/Popper.test.tsx
@@ -341,6 +341,8 @@ describe('Popper', () => {
       const { container } = await act(() =>
         render(
           <Popper
+            // Disabled eslint rule for testing purposes
+            // eslint-disable-next-line tailwindcss/no-custom-classname
             className="custom-class"
             opener={<button data-test="opener-button">Click me</button>}
           >

--- a/src/components/form/TextInput/TextInputField.tsx
+++ b/src/components/form/TextInput/TextInputField.tsx
@@ -28,6 +28,16 @@ export const TextInputField = memo(
     ) => {
       const { values, errors, touched, handleBlur, setFieldValue } = formikProps
 
+      let error = undefined
+
+      if (!silentError) {
+        if (displayErrorText) {
+          error = _get(touched, name) && (_get(errors, name) as string)
+        } else {
+          error = !!_get(errors, name)
+        }
+      }
+
       return (
         <TextInput
           name={name}
@@ -35,13 +45,7 @@ export const TextInputField = memo(
           ref={ref}
           onBlur={handleBlur}
           cleanable={cleanable}
-          error={
-            !silentError
-              ? displayErrorText
-                ? _get(touched, name) && (_get(errors, name) as string)
-                : !!_get(errors, name)
-              : undefined
-          }
+          error={error}
           onChange={(value: string | number | undefined) => {
             setFieldValue(name, value)
           }}

--- a/src/components/invoices/AddMetadataDrawer.tsx
+++ b/src/components/invoices/AddMetadataDrawer.tsx
@@ -145,17 +145,19 @@ export const AddMetadataDrawer = forwardRef<DrawerRef, AddMetadataDrawerProps>(
                     const hasCustomValueError =
                       Object.keys(MetadataErrorsEnum).includes(metadataItemValueError)
 
+                    let keyErrorTitle: string | undefined = undefined
+
+                    if (metadataItemKeyError === MetadataErrorsEnum.uniqueness) {
+                      keyErrorTitle = translate('text_63fcc3218d35b9377840f5dd')
+                    } else if (metadataItemKeyError === MetadataErrorsEnum.maxLength) {
+                      keyErrorTitle = translate('text_63fcc3218d35b9377840f5d9')
+                    }
+
                     return (
                       <React.Fragment key={`metadata-item-${m.id || i}`}>
                         <Tooltip
                           placement="top-end"
-                          title={
-                            metadataItemKeyError === MetadataErrorsEnum.uniqueness
-                              ? translate('text_63fcc3218d35b9377840f5dd')
-                              : metadataItemKeyError === MetadataErrorsEnum.maxLength
-                                ? translate('text_63fcc3218d35b9377840f5d9')
-                                : undefined
-                          }
+                          title={keyErrorTitle}
                           disableHoverListener={!hasCustomKeyError}
                         >
                           <TextInputField

--- a/src/components/invoices/InvoiceCreditNotesTable.tsx
+++ b/src/components/invoices/InvoiceCreditNotesTable.tsx
@@ -162,6 +162,28 @@ export const InvoiceCreditNotesTable = memo(
                               key={`formatedCreditNote-${i}-subscriptionItem-${j}-charge-${k}`}
                             >
                               {charge.map((item, l) => {
+                                let feeDisplayText: string
+
+                                if (item?.fee?.feeType === FeeTypesEnum.AddOn) {
+                                  feeDisplayText = translate('text_6388baa2e514213fed583611', {
+                                    name: item.fee.invoiceName || item?.fee?.itemName,
+                                  })
+                                } else if (item?.fee?.feeType === FeeTypesEnum.Commitment) {
+                                  feeDisplayText =
+                                    item.fee.invoiceName || 'Minimum commitment - True up'
+                                } else {
+                                  feeDisplayText = composeMultipleValuesWithSepator([
+                                    item.fee?.invoiceName ||
+                                      item.fee.charge?.billableMetric.name ||
+                                      creditNoteDisplayName,
+                                    composeGroupedByDisplayName(item.fee.groupedBy),
+                                    composeChargeFilterDisplayName(item.fee.chargeFilter),
+                                    item?.fee?.trueUpParentFee?.id
+                                      ? ` - ${translate('text_64463aaa34904c00a23be4f7')}`
+                                      : '',
+                                  ])
+                                }
+
                                 return (
                                   <React.Fragment
                                     key={`formatedCreditNote-${i}-subscriptionItem-${j}-charge-${k}-item-${l}`}
@@ -174,27 +196,7 @@ export const InvoiceCreditNotesTable = memo(
                                           </Typography>
                                         ) : (
                                           <Typography variant="bodyHl" color="grey700">
-                                            {item?.fee?.feeType === FeeTypesEnum.AddOn
-                                              ? translate('text_6388baa2e514213fed583611', {
-                                                  name: item.fee.invoiceName || item?.fee?.itemName,
-                                                })
-                                              : item?.fee?.feeType === FeeTypesEnum.Commitment
-                                                ? item.fee.invoiceName ||
-                                                  'Minimum commitment - True up'
-                                                : composeMultipleValuesWithSepator([
-                                                    item.fee?.invoiceName ||
-                                                      item.fee.charge?.billableMetric.name ||
-                                                      creditNoteDisplayName,
-                                                    composeGroupedByDisplayName(item.fee.groupedBy),
-                                                    composeChargeFilterDisplayName(
-                                                      item.fee.chargeFilter,
-                                                    ),
-                                                    item?.fee?.trueUpParentFee?.id
-                                                      ? ` - ${translate(
-                                                          'text_64463aaa34904c00a23be4f7',
-                                                        )}`
-                                                      : '',
-                                                  ])}
+                                            {feeDisplayText}
                                           </Typography>
                                         )}
                                       </td>

--- a/src/components/plans/DeletePlanDialog.tsx
+++ b/src/components/plans/DeletePlanDialog.tsx
@@ -65,6 +65,22 @@ export const DeletePlanDialog = forwardRef<DeletePlanDialogRef>((_, ref) => {
     closeDialog: () => dialogRef.current?.closeDialog(),
   }))
 
+  let usedObject1 = translate('text_63d18d34f90cc83a038f843b', { count: 0 }, 0)
+
+  if (activeSubscriptionsCount > 0) {
+    usedObject1 = translate(
+      'text_63d18d34f90cc83a038f843b',
+      { count: activeSubscriptionsCount },
+      activeSubscriptionsCount,
+    )
+  } else if (draftInvoicesCount > 0) {
+    usedObject1 = translate(
+      'text_63d18d3edaed7e11710b4d25',
+      { count: draftInvoicesCount },
+      draftInvoicesCount,
+    )
+  }
+
   return (
     <WarningDialog
       ref={dialogRef}
@@ -87,20 +103,7 @@ export const DeletePlanDialog = forwardRef<DeletePlanDialogRef>((_, ref) => {
               ),
             }
           : {
-              usedObject1:
-                activeSubscriptionsCount > 0
-                  ? translate(
-                      'text_63d18d34f90cc83a038f843b',
-                      { count: activeSubscriptionsCount },
-                      activeSubscriptionsCount,
-                    )
-                  : draftInvoicesCount > 0
-                    ? translate(
-                        'text_63d18d3edaed7e11710b4d25',
-                        { count: draftInvoicesCount },
-                        draftInvoicesCount,
-                      )
-                    : translate('text_63d18d34f90cc83a038f843b', { count: 0 }, 0),
+              usedObject1,
             },
         draftInvoicesCount > 0 && activeSubscriptionsCount > 0 ? 2 : 0,
       )}


### PR DESCRIPTION
## Context

The linter flagged nested ternary expressions in multiple components, reducing readability and violating code quality rules.