### PR TITLE
fix(customerPortal): prevent TypeError when checking usage data after a potential session timeout

### DIFF
--- a/src/components/customers/usage/SubscriptionUsageDetailDrawer.tsx
+++ b/src/components/customers/usage/SubscriptionUsageDetailDrawer.tsx
@@ -193,10 +193,12 @@ gql`
   }
 `
 
+export type SubscriptionUsageDetailDrawerUsage = ChargeUsage | ProjectedChargeUsage
+
 export interface SubscriptionUsageDetailDrawerRef {
   openDrawer: (
-    usage: ChargeUsage | ProjectedChargeUsage,
-    refreshUsage: () => Promise<ChargeUsage | ProjectedChargeUsage | undefined>,
+    usage: SubscriptionUsageDetailDrawerUsage,
+    refreshUsage: () => Promise<SubscriptionUsageDetailDrawerUsage | undefined>,
     defaultTab?: number,
   ) => unknown
   closeDialog: () => unknown
@@ -227,10 +229,10 @@ export const SubscriptionUsageDetailDrawer = forwardRef<
     ref,
   ) => {
     const drawerRef = useRef<DrawerRef>(null)
-    const [usage, setUsage] = useState<ChargeUsage | ProjectedChargeUsage>()
+    const [usage, setUsage] = useState<SubscriptionUsageDetailDrawerUsage>()
     const [refreshFunction, setRefreshFunction] =
       useState<
-        (forceProjected?: boolean) => Promise<ChargeUsage | ProjectedChargeUsage | undefined>
+        (forceProjected?: boolean) => Promise<SubscriptionUsageDetailDrawerUsage | undefined>
       >()
     const [activeTab, setActiveTab] = useState<number>(0)
     const [fetchedProjected, setFetchedProjected] = useState(false)

--- a/src/components/subscriptions/__tests__/utils.test.ts
+++ b/src/components/subscriptions/__tests__/utils.test.ts
@@ -1,5 +1,17 @@
-import { getLifetimeGraphPercentages } from '~/components/subscriptions/utils'
-import { SubscriptionLifetimeUsage } from '~/generated/graphql'
+import {
+  findChargeUsageByBillableMetricId,
+  getLifetimeGraphPercentages,
+} from '~/components/subscriptions/utils'
+import {
+  ChargeUsage,
+  CurrencyEnum,
+  GetCustomerProjectedUsageForPortalQuery,
+  GetCustomerUsageForPortalQuery,
+  ProjectedChargeUsage,
+  ProjectedUsageForSubscriptionUsageQuery,
+  SubscriptionLifetimeUsage,
+  UsageForSubscriptionUsageQuery,
+} from '~/generated/graphql'
 
 describe('subscriptions utils tests', () => {
   it('should return the appropriate calculated percentages', () => {
@@ -67,6 +79,169 @@ describe('subscriptions utils tests', () => {
     ).toEqual({
       lastThresholdPercentage: 100,
       nextThresholdPercentage: 0,
+    })
+  })
+
+  describe('findChargeUsageByBillableMetricId', () => {
+    const mockBillableMetricId = 'bm-123'
+    const mockChargeUsage: ChargeUsage = {
+      id: 'charge-usage-1',
+      billableMetric: {
+        id: mockBillableMetricId,
+        code: 'test-metric',
+        name: 'Test Metric',
+      },
+      units: 10,
+      amountCents: '1000',
+    } as ChargeUsage
+
+    const mockOtherChargeUsage: ChargeUsage = {
+      id: 'charge-usage-2',
+      billableMetric: {
+        id: 'bm-456',
+        code: 'other-metric',
+        name: 'Other Metric',
+      },
+      units: 5,
+      amountCents: '500',
+    } as ChargeUsage
+
+    it('should return undefined when data is null', () => {
+      expect(findChargeUsageByBillableMetricId(null, mockBillableMetricId)).toBeUndefined()
+    })
+
+    it('should return undefined when data is undefined', () => {
+      expect(findChargeUsageByBillableMetricId(undefined, mockBillableMetricId)).toBeUndefined()
+    })
+
+    it('should find charge usage in customerUsage data', () => {
+      const mockData: UsageForSubscriptionUsageQuery = {
+        customerUsage: {
+          amountCents: '1500',
+          currency: CurrencyEnum.Usd,
+          fromDatetime: '2024-01-01T00:00:00Z',
+          toDatetime: '2024-01-31T23:59:59Z',
+          chargesUsage: [mockChargeUsage, mockOtherChargeUsage],
+        },
+      } as UsageForSubscriptionUsageQuery
+
+      const result = findChargeUsageByBillableMetricId(mockData, mockBillableMetricId)
+
+      expect(result).toEqual(mockChargeUsage)
+    })
+
+    it('should find charge usage in customerProjectedUsage data', () => {
+      const mockProjectedChargeUsage: ProjectedChargeUsage = {
+        ...mockChargeUsage,
+        projectedUnits: 15,
+        projectedAmountCents: '1500',
+      } as ProjectedChargeUsage
+
+      const mockProjectedOtherChargeUsage: ProjectedChargeUsage = {
+        ...mockOtherChargeUsage,
+        projectedUnits: 8,
+        projectedAmountCents: '800',
+      } as ProjectedChargeUsage
+
+      const mockData: ProjectedUsageForSubscriptionUsageQuery = {
+        customerProjectedUsage: {
+          amountCents: '1500000',
+          projectedAmountCents: '2000000',
+          currency: CurrencyEnum.Usd,
+          fromDatetime: '2024-01-01T00:00:00Z',
+          toDatetime: '2024-01-31T23:59:59Z',
+          chargesUsage: [mockProjectedChargeUsage, mockProjectedOtherChargeUsage],
+        },
+      } as ProjectedUsageForSubscriptionUsageQuery
+
+      const result = findChargeUsageByBillableMetricId(mockData, mockBillableMetricId)
+
+      expect(result).toEqual(mockProjectedChargeUsage)
+    })
+
+    it('should find charge usage in customerPortalCustomerUsage data', () => {
+      const mockData: GetCustomerUsageForPortalQuery = {
+        customerPortalCustomerUsage: {
+          amountCents: '1500000',
+          currency: CurrencyEnum.Usd,
+          fromDatetime: '2024-01-01T00:00:00Z',
+          toDatetime: '2024-01-31T23:59:59Z',
+          chargesUsage: [mockChargeUsage, mockOtherChargeUsage],
+        },
+      } as GetCustomerUsageForPortalQuery
+
+      const result = findChargeUsageByBillableMetricId(mockData, mockBillableMetricId)
+
+      expect(result).toEqual(mockChargeUsage)
+    })
+
+    it('should find charge usage in customerPortalCustomerProjectedUsage data', () => {
+      const mockProjectedChargeUsage: ProjectedChargeUsage = {
+        ...mockChargeUsage,
+        projectedUnits: 15,
+        projectedAmountCents: '1500',
+      } as ProjectedChargeUsage
+
+      const mockProjectedOtherChargeUsage: ProjectedChargeUsage = {
+        ...mockOtherChargeUsage,
+        projectedUnits: 8,
+        projectedAmountCents: '800',
+      } as ProjectedChargeUsage
+
+      const mockData: GetCustomerProjectedUsageForPortalQuery = {
+        customerPortalCustomerProjectedUsage: {
+          amountCents: '1500000',
+          projectedAmountCents: '2000000',
+          currency: CurrencyEnum.Usd,
+          fromDatetime: '2024-01-01T00:00:00Z',
+          toDatetime: '2024-01-31T23:59:59Z',
+          chargesUsage: [mockProjectedChargeUsage, mockProjectedOtherChargeUsage],
+        },
+      } as GetCustomerProjectedUsageForPortalQuery
+
+      const result = findChargeUsageByBillableMetricId(mockData, mockBillableMetricId)
+
+      expect(result).toEqual(mockProjectedChargeUsage)
+    })
+
+    it('should return undefined when charge usage is not found', () => {
+      const mockData: UsageForSubscriptionUsageQuery = {
+        customerUsage: {
+          amountCents: '1500000',
+          currency: CurrencyEnum.Usd,
+          fromDatetime: '2024-01-01T00:00:00Z',
+          toDatetime: '2024-01-31T23:59:59Z',
+          chargesUsage: [mockOtherChargeUsage],
+        },
+      } as UsageForSubscriptionUsageQuery
+
+      const result = findChargeUsageByBillableMetricId(mockData, mockBillableMetricId)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined when chargesUsage array is empty', () => {
+      const mockData: UsageForSubscriptionUsageQuery = {
+        customerUsage: {
+          amountCents: '1500000',
+          currency: CurrencyEnum.Usd,
+          fromDatetime: '2024-01-01T00:00:00Z',
+          toDatetime: '2024-01-31T23:59:59Z',
+          chargesUsage: [],
+        },
+      } as UsageForSubscriptionUsageQuery
+
+      const result = findChargeUsageByBillableMetricId(mockData, mockBillableMetricId)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined when data does not have any expected properties', () => {
+      const mockData = {} as UsageForSubscriptionUsageQuery
+
+      const result = findChargeUsageByBillableMetricId(mockData, mockBillableMetricId)
+
+      expect(result).toBeUndefined()
     })
   })
 })

--- a/src/components/subscriptions/utils.ts
+++ b/src/components/subscriptions/utils.ts
@@ -1,4 +1,59 @@
+import {
+  ChargeUsage,
+  GetCustomerProjectedUsageForPortalQuery,
+  GetCustomerUsageForPortalQuery,
+  ProjectedUsageForSubscriptionUsageQuery,
+  UsageForSubscriptionUsageQuery,
+} from '~/generated/graphql'
+
 import { TSubscriptionUsageLifetimeGraphDataResult } from './SubscriptionUsageLifetimeGraph'
+
+type UsageQueryResult =
+  | UsageForSubscriptionUsageQuery
+  | ProjectedUsageForSubscriptionUsageQuery
+  | GetCustomerUsageForPortalQuery
+  | GetCustomerProjectedUsageForPortalQuery
+
+/**
+ * Finds a charge usage by billable metric ID from various usage query result types
+ * @param data - The usage query result data
+ * @param billableMetricId - The billable metric ID to search for
+ * @returns The matching ChargeUsage or undefined if not found
+ */
+export const findChargeUsageByBillableMetricId = (
+  data: UsageQueryResult | null | undefined,
+  billableMetricId: string,
+): ChargeUsage | undefined => {
+  if (!data) {
+    return undefined
+  }
+
+  if ('customerPortalCustomerUsage' in data) {
+    return data?.customerPortalCustomerUsage.chargesUsage.find(
+      (usage) => usage.billableMetric.id === billableMetricId,
+    ) as ChargeUsage | undefined
+  }
+
+  if ('customerUsage' in data) {
+    return data?.customerUsage.chargesUsage.find(
+      (usage) => usage.billableMetric.id === billableMetricId,
+    ) as ChargeUsage | undefined
+  }
+
+  if ('customerProjectedUsage' in data) {
+    return data?.customerProjectedUsage.chargesUsage.find(
+      (usage) => usage.billableMetric.id === billableMetricId,
+    ) as ChargeUsage | undefined
+  }
+
+  if ('customerPortalCustomerProjectedUsage' in data) {
+    return data?.customerPortalCustomerProjectedUsage.chargesUsage.find(
+      (usage) => usage.billableMetric.id === billableMetricId,
+    ) as ChargeUsage | undefined
+  }
+
+  return undefined
+}
 
 export const getLifetimeGraphPercentages = (
   lifetimeUsage?: TSubscriptionUsageLifetimeGraphDataResult,


### PR DESCRIPTION
## Context

When a GraphQL query fails due to session timeout (e.g., "no_active_subscription" error), the data object can be null. Using the 'in' operator directly on null data causes a TypeError: "Cannot use 'in' operator to search for 'customerPortalCustomerUsage' in null".

## Description

Add null check before using 'in' operator in findChargeUsageByBillableMetricId function. The function now returns early if data is null or undefined, preventing the TypeError when GraphQL queries fail due to authentication issues or expired session.

The function handles all four possible usage query result types (customerUsage, customerProjectedUsage, customerPortalCustomerUsage, customerPortalCustomerProjectedUsage) with proper null safety.

Also, the function has been isolated and unit tested.

<!-- Linear link -->
Fixes ISSUE-1324