### PR TITLE
deps(redis): ensure we're using the same version everywhere

### DIFF
--- a/ci/docker-compose.ci.yml
+++ b/ci/docker-compose.ci.yml
@@ -16,7 +16,7 @@ services:
       - 5432:5432
     
   redis:
-    image: redis:6.2-alpine
+    image: redis:7-alpine
     container_name: lago_redis
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Context

We use redis however we have some inconsistency in some declared versions.

```
Found 6 matches for redis:*-alpine:

•  docker-compose.yml:9 - redis:6-alpine                        // wrong version
•  docker-compose.dev.yml:54 - redis:7-alpine
•  deploy/docker-compose.production.yml:13 - redis:7-alpine
•  deploy/docker-compose.local.yml:12 - redis:7-alpine
•  deploy/docker-compose.light.yml:12 - redis:7-alpine
•  front/ci/docker-compose.ci.yml:19 - redis:6.2-alpine         // wrong version
```

## Description

This PR updated the inconsistent version in this package.

Other PR can be found here: https://github.com/getlago/lago/pull/654