### PR TITLE
misc(design-system): move AiBadge back to the app

### DIFF
--- a/packages/design-system/playground/components/IconsSection.tsx
+++ b/packages/design-system/playground/components/IconsSection.tsx
@@ -1,4 +1,4 @@
-import { AiBadge, ALL_ICONS, Icon, IconName, Typography } from '~/components'
+import { ALL_ICONS, Icon, IconName, Typography } from '~/components'
 
 export const IconsSection = () => {
   return (
@@ -58,7 +58,6 @@ export const IconsSection = () => {
           <Typography className="mb-4" variant="subhead1">
             AI Badge
           </Typography>
-          <AiBadge />
         </section>
       </div>
     </div>

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -1,4 +1,3 @@
-export * from './AiBadge'
 export * from './Avatar'
 export * from './Button'
 export * from './Icon'

--- a/src/components/designSystem/AiBadge.tsx
+++ b/src/components/designSystem/AiBadge.tsx
@@ -1,4 +1,4 @@
-import { tw } from '~/lib'
+import { tw } from 'lago-design-system'
 
 type AiBadgeProps = {
   className?: string

--- a/src/components/designSystem/__tests__/AiBadge.test.tsx
+++ b/src/components/designSystem/__tests__/AiBadge.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup, screen } from '@testing-library/react'
+
+import { render } from '~/test-utils'
+
+import { AiBadge } from '../AiBadge'
+
+describe('AiBadge', () => {
+  afterEach(cleanup)
+
+  it('renders without children', () => {
+    const { container } = render(<AiBadge />)
+
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders with children', () => {
+    render(<AiBadge>AI Powered</AiBadge>)
+
+    expect(screen.getByText('AI Powered')).toBeInTheDocument()
+  })
+
+  it('applies custom className', () => {
+    const { container } = render(<AiBadge className="custom-class" />)
+
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+
+  it('renders SVG icon with default size', () => {
+    const { container } = render(<AiBadge />)
+
+    const svg = container.querySelector('svg')
+
+    expect(svg).toHaveAttribute('width', '16')
+    expect(svg).toHaveAttribute('height', '16')
+  })
+
+  it('renders SVG icon with custom size', () => {
+    const { container } = render(<AiBadge iconSize={24} />)
+
+    const svg = container.querySelector('svg')
+
+    expect(svg).toHaveAttribute('width', '24')
+    expect(svg).toHaveAttribute('height', '24')
+  })
+})

--- a/src/components/designSystem/index.ts
+++ b/src/components/designSystem/index.ts
@@ -1,4 +1,5 @@
 export * from './Accordion'
+export * from './AiBadge'
 export * from './Alert'
 export * from './Button'
 export * from './ButtonLink'

--- a/src/pages/forecasts/Forecasts.tsx
+++ b/src/pages/forecasts/Forecasts.tsx
@@ -1,7 +1,7 @@
-import { AiBadge, Icon, tw, Typography } from 'lago-design-system'
+import { Icon, tw, Typography } from 'lago-design-system'
 import { useRef } from 'react'
 
-import { Chip, Tooltip } from '~/components/designSystem'
+import { AiBadge, Chip, Tooltip } from '~/components/designSystem'
 import { FullscreenPage } from '~/components/layouts/FullscreenPage'
 import PremiumFeature from '~/components/premium/PremiumFeature'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'


### PR DESCRIPTION
## Context

We decided to move back all of our components from the design-system package to our app

## Description

This PR moves back AiBadge to the app and adds some much needed testing

<!-- Linear link -->
Fixes [ISSUE-1316](https://linear.app/getlago/issue/ISSUE-1321/aibadge)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves `AiBadge` from the design-system to the app, updates references, and adds unit tests.
> 
> - **Components (app)**:
>   - Migrate `AiBadge` to `src/components/designSystem/AiBadge.tsx` and export via `src/components/designSystem/index.ts`.
>   - Update `src/pages/forecasts/Forecasts.tsx` to import/use app `AiBadge`.
> - **Design System**:
>   - Remove `AiBadge` export from `packages/design-system/src/components/index.ts`.
>   - Remove `AiBadge` from playground `packages/design-system/playground/components/IconsSection.tsx`.
> - **Tests**:
>   - Add unit tests for `AiBadge` in `src/components/designSystem/__tests__/AiBadge.test.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ac2ae3594851c315f451fb68acba8bf10fb69f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->