### PR TITLE
misc(design-system): move Avatar back to the app

### DIFF
--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -1,3 +1,2 @@
-export * from './Avatar'
 export * from './Icon'
 export * from './Typography'

--- a/src/components/LogoPicker.tsx
+++ b/src/components/LogoPicker.tsx
@@ -1,7 +1,7 @@
-import { Avatar, Typography } from 'lago-design-system'
+import { Typography } from 'lago-design-system'
 import { useMemo, useRef, useState } from 'react'
 
-import { Button } from '~/components/designSystem'
+import { Avatar, Button } from '~/components/designSystem'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { tw } from '~/styles/utils'
 

--- a/src/components/PaymentProviderChip.tsx
+++ b/src/components/PaymentProviderChip.tsx
@@ -1,8 +1,8 @@
 import { TypographyProps as MuiTypographyProps } from '@mui/material'
-import { Avatar, Icon, TypographyColor } from 'lago-design-system'
+import { Icon, TypographyColor } from 'lago-design-system'
 import { FC } from 'react'
 
-import { Typography } from '~/components/designSystem'
+import { Avatar, Typography } from '~/components/designSystem'
 import { ProviderTypeEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import Adyen from '~/public/images/adyen.svg'

--- a/src/components/customers/CustomerCreditNotesList.tsx
+++ b/src/components/customers/CustomerCreditNotesList.tsx
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 
 import CreditNotesTable from '~/components/creditNote/CreditNotesTable'
-import { GenericPlaceholder, Typography } from '~/components/designSystem'
+import { Avatar, GenericPlaceholder, Typography } from '~/components/designSystem'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import { SearchInput } from '~/components/SearchInput'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'

--- a/src/components/customers/CustomerIntegrationRows.tsx
+++ b/src/components/customers/CustomerIntegrationRows.tsx
@@ -1,9 +1,9 @@
 import { gql } from '@apollo/client'
-import { Avatar, AvatarConnectorVariant, AvatarSize, Icon, Typography } from 'lago-design-system'
+import { Icon, Typography } from 'lago-design-system'
 
 import { LinkedPaymentProvider } from '~/components/customers/types'
 import { getConnectedIntegrations } from '~/components/customers/utils'
-import { Skeleton } from '~/components/designSystem'
+import { Avatar, AvatarConnectorVariant, AvatarSize, Skeleton } from '~/components/designSystem'
 import { InfoRow } from '~/components/InfoRow'
 import { InlineLink } from '~/components/InlineLink'
 import { PaymentProviderChip } from '~/components/PaymentProviderChip'

--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { useRef } from 'react'
 
 import {
@@ -43,6 +43,7 @@ import {
   EditCustomerVatRateDialogRef,
 } from '~/components/customers/EditCustomerVatRateDialog'
 import {
+  Avatar,
   Button,
   Chip,
   GenericPlaceholder,

--- a/src/components/customers/createCustomer/ExternalAppsAccordion/AccountingProvidersAccordion.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/AccountingProvidersAccordion.tsx
@@ -1,9 +1,8 @@
 import { gql } from '@apollo/client'
 import { FormikProps } from 'formik'
-import { Avatar } from 'lago-design-system'
 import { Dispatch, FC, SetStateAction, useMemo } from 'react'
 
-import { Accordion, Alert, Typography } from '~/components/designSystem'
+import { Accordion, Alert, Avatar, Typography } from '~/components/designSystem'
 import {
   BasicComboBoxData,
   Checkbox,

--- a/src/components/customers/createCustomer/ExternalAppsAccordion/CRMProvidersAccordion.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/CRMProvidersAccordion.tsx
@@ -1,9 +1,8 @@
 import { gql } from '@apollo/client'
 import { FormikProps } from 'formik'
-import { Avatar } from 'lago-design-system'
 import { Dispatch, FC, SetStateAction, useMemo } from 'react'
 
-import { Accordion, Alert, Typography } from '~/components/designSystem'
+import { Accordion, Alert, Avatar, Typography } from '~/components/designSystem'
 import {
   Checkbox,
   ComboBox,

--- a/src/components/customers/createCustomer/ExternalAppsAccordion/ExternalAppsAccordionLayout.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/ExternalAppsAccordionLayout.tsx
@@ -1,7 +1,7 @@
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { FC, ReactNode } from 'react'
 
-import { Button, Skeleton, Typography } from '~/components/designSystem'
+import { Avatar, Button, Skeleton, Typography } from '~/components/designSystem'
 import { ComboboxItem } from '~/components/form'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 

--- a/src/components/customers/createCustomer/ExternalAppsAccordion/PaymentProvidersAccordion.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/PaymentProvidersAccordion.tsx
@@ -1,9 +1,8 @@
 import { gql } from '@apollo/client'
 import { FormikProps } from 'formik'
-import { Avatar } from 'lago-design-system'
 import { Dispatch, FC, ReactNode, SetStateAction, useMemo } from 'react'
 
-import { Accordion, Alert, Typography } from '~/components/designSystem'
+import { Accordion, Alert, Avatar, Typography } from '~/components/designSystem'
 import { Checkbox, ComboBox, ComboboxDataGrouped, TextInputField } from '~/components/form'
 import { ADD_CUSTOMER_PAYMENT_PROVIDER_ACCORDION } from '~/core/constants/form'
 import {

--- a/src/components/customers/createCustomer/ExternalAppsAccordion/TaxProvidersAccordion.tsx
+++ b/src/components/customers/createCustomer/ExternalAppsAccordion/TaxProvidersAccordion.tsx
@@ -1,9 +1,8 @@
 import { gql } from '@apollo/client'
 import { FormikProps } from 'formik'
-import { Avatar } from 'lago-design-system'
 import { Dispatch, FC, SetStateAction, useMemo } from 'react'
 
-import { Accordion, Typography } from '~/components/designSystem'
+import { Accordion, Avatar, Typography } from '~/components/designSystem'
 import { Checkbox, ComboBox, ComboboxDataGrouped, TextInputField } from '~/components/form'
 import { ADD_CUSTOMER_TAX_PROVIDER_ACCORDION } from '~/core/constants/form'
 import {

--- a/src/components/designSystem/Avatar.tsx
+++ b/src/components/designSystem/Avatar.tsx
@@ -1,11 +1,9 @@
 import { cva, cx, VariantProps } from 'class-variance-authority'
 import { colors } from 'lago-configs/tailwind'
+import { Icon, IconName, IconProps, Typography } from 'lago-design-system'
 import { FC, ReactNode } from 'react'
 
-import { tw } from '~/lib'
-
-import { Icon, IconName, IconProps } from './Icon'
-import { Typography } from './Typography'
+import { tw } from '~/styles/utils'
 
 export type AvatarSize = 'tiny' | 'small' | 'intermediate' | 'medium' | 'big' | 'large'
 export type AvatarUserCompanyVariant = 'user' | 'company'
@@ -49,7 +47,7 @@ const getBackgroundColorKey = (identifier?: string): keyof typeof colors.avatar 
 
   // Get the sum of the UTF-16 code for each char
   const charcodeSum = identifier.split('').reduce((acc, char) => {
-    acc = acc + char.charCodeAt(0)
+    acc = acc + (char.codePointAt(0) ?? 0)
     return acc
   }, 0)
 
@@ -126,7 +124,7 @@ export const Avatar = ({
   const getContent = () => {
     // Remove all non-alphanumeric characters
     const text = initials || identifier || ''
-    const sanitizedText = text.replace(/[^a-zA-Z0-9]/g, '')
+    const sanitizedText = text.replaceAll(/[^a-zA-Z0-9]/g, '')
 
     const cursor = size === 'small' || size === 'intermediate' ? 1 : 2
 

--- a/src/components/designSystem/Selector.tsx
+++ b/src/components/designSystem/Selector.tsx
@@ -1,9 +1,10 @@
 import { cva } from 'class-variance-authority'
-import { Avatar, Icon, IconName } from 'lago-design-system'
+import { Icon, IconName } from 'lago-design-system'
 import { ReactElement, useState } from 'react'
 
 import { tw } from '~/styles/utils'
 
+import { Avatar } from './Avatar'
 import { Typography } from './Typography'
 
 interface SelectorProps {
@@ -100,7 +101,7 @@ export const Selector = ({
       <div className="mr-3">
         {typeof icon === 'string' ? (
           <Avatar size="big" variant="connector">
-            <Icon color="dark" name={icon as IconName} />
+            <Icon color="dark" name={icon} />
           </Avatar>
         ) : (
           icon
@@ -124,7 +125,7 @@ export const Selector = ({
         </Typography>
       </div>
       {loading && <Icon animation="spin" color="primary" name="processing" />}
-      {!loading && typeof endIcon === 'string' && <Icon name={endIcon as IconName} color="dark" />}
+      {!loading && typeof endIcon === 'string' && <Icon name={endIcon} color="dark" />}
       {!loading && typeof endIcon !== 'string' && endIcon}
     </div>
   )

--- a/src/components/designSystem/Skeleton.tsx
+++ b/src/components/designSystem/Skeleton.tsx
@@ -1,8 +1,8 @@
 import { cva } from 'class-variance-authority'
-import { AvatarSize, avatarSizeStyles } from 'lago-design-system'
 
 import { tw } from '~/styles/utils'
 
+import { AvatarSize, avatarSizeStyles } from './Avatar'
 import { TypographyProps } from './Typography'
 
 import { ConditionalWrapper } from '../ConditionalWrapper'

--- a/src/components/designSystem/__tests__/Avatar.test.tsx
+++ b/src/components/designSystem/__tests__/Avatar.test.tsx
@@ -1,0 +1,255 @@
+import { cleanup, screen } from '@testing-library/react'
+
+import { render } from '~/test-utils'
+
+import { Avatar, AvatarBadge } from '../Avatar'
+
+describe('Avatar', () => {
+  afterEach(cleanup)
+
+  describe('User Variant', () => {
+    it('renders user avatar with identifier', () => {
+      const { container } = render(<Avatar variant="user" identifier="John Doe" />)
+
+      expect(container.firstChild).toBeInTheDocument()
+      expect(container.firstChild).toHaveAttribute('data-test', 'user/big')
+    })
+
+    it('displays initials from identifier', () => {
+      render(<Avatar variant="user" identifier="John Doe" />)
+
+      expect(screen.getByText('JO')).toBeInTheDocument()
+    })
+
+    it('displays custom initials when provided', () => {
+      render(<Avatar variant="user" identifier="John Doe" initials="JD" />)
+
+      expect(screen.getByText('JD')).toBeInTheDocument()
+    })
+
+    it('displays single initial for small size', () => {
+      render(<Avatar variant="user" identifier="John Doe" size="small" />)
+
+      expect(screen.getByText('J')).toBeInTheDocument()
+    })
+
+    it('displays single initial for intermediate size', () => {
+      render(<Avatar variant="user" identifier="John Doe" size="intermediate" />)
+
+      expect(screen.getByText('J')).toBeInTheDocument()
+    })
+
+    it('renders with rounded-full class for user variant', () => {
+      const { container } = render(<Avatar variant="user" identifier="John" />)
+
+      expect(container.firstChild).toHaveClass('rounded-full')
+    })
+
+    it('uppercases initials', () => {
+      render(<Avatar variant="user" identifier="john doe" />)
+
+      expect(screen.getByText('JO')).toBeInTheDocument()
+    })
+
+    it('removes non-alphanumeric characters from initials', () => {
+      render(<Avatar variant="user" identifier="@john-doe!" />)
+
+      expect(screen.getByText('JO')).toBeInTheDocument()
+    })
+  })
+
+  describe('Company Variant', () => {
+    it('renders company avatar with identifier', () => {
+      const { container } = render(<Avatar variant="company" identifier="Acme Corp" />)
+
+      expect(container.firstChild).toBeInTheDocument()
+      expect(container.firstChild).toHaveAttribute('data-test', 'company/big')
+    })
+
+    it('does not have rounded-full class for company variant', () => {
+      const { container } = render(<Avatar variant="company" identifier="Acme" />)
+
+      expect(container.firstChild).not.toHaveClass('rounded-full')
+    })
+  })
+
+  describe('Connector Variant', () => {
+    it('renders connector avatar with children', () => {
+      const { container } = render(
+        <Avatar variant="connector" size="big">
+          <svg data-testid="connector-icon" />
+        </Avatar>,
+      )
+
+      expect(container.firstChild).toBeInTheDocument()
+      expect(container.firstChild).toHaveAttribute('data-test', 'connector/big')
+      expect(container.querySelector('svg')).toBeInTheDocument()
+    })
+
+    it('renders connector-full variant with full-size SVG styling', () => {
+      const { container } = render(
+        <Avatar variant="connector-full" size="big">
+          <svg data-testid="connector-icon" />
+        </Avatar>,
+      )
+
+      expect(container.firstChild).toHaveAttribute('data-test', 'connector-full/big')
+    })
+  })
+
+  describe('Sizes', () => {
+    it.each(['tiny', 'small', 'intermediate', 'medium', 'big', 'large'] as const)(
+      'renders %s size correctly',
+      (size) => {
+        const { container } = render(<Avatar variant="user" identifier="Test" size={size} />)
+
+        expect(container.firstChild).toHaveAttribute('data-test', `user/${size}`)
+      },
+    )
+
+    it('defaults to big size', () => {
+      const { container } = render(<Avatar variant="user" identifier="Test" />)
+
+      expect(container.firstChild).toHaveAttribute('data-test', 'user/big')
+    })
+  })
+
+  describe('Custom className', () => {
+    it('applies custom className to user avatar', () => {
+      const { container } = render(
+        <Avatar variant="user" identifier="Test" className="custom-class" />,
+      )
+
+      expect(container.firstChild).toHaveClass('custom-class')
+    })
+
+    it('applies custom className to connector avatar', () => {
+      const { container } = render(
+        <Avatar variant="connector" className="custom-class">
+          <span>Icon</span>
+        </Avatar>,
+      )
+
+      expect(container.firstChild).toHaveClass('custom-class')
+    })
+  })
+
+  describe('Background Colors', () => {
+    it('applies background color based on identifier', () => {
+      const { container } = render(<Avatar variant="user" identifier="Test User" />)
+
+      // Should have one of the avatar background color classes
+      const element = container.firstChild as HTMLElement
+
+      expect(element.className).toMatch(/bg-avatar-/)
+    })
+
+    it('applies default background when no identifier', () => {
+      const { container } = render(<Avatar variant="company" identifier="" />)
+      const element = container.firstChild as HTMLElement
+
+      expect(element).toHaveClass('bg-grey-100')
+    })
+
+    it('generates consistent color for same identifier', () => {
+      const { container: container1, unmount } = render(
+        <Avatar variant="user" identifier="consistent" />,
+      )
+      const element1 = container1.firstChild as HTMLElement
+      const bgClass1 = element1.className.match(/bg-avatar-\w+/)?.[0]
+
+      unmount()
+
+      const { container: container2 } = render(<Avatar variant="user" identifier="consistent" />)
+      const element2 = container2.firstChild as HTMLElement
+      const bgClass2 = element2.className.match(/bg-avatar-\w+/)?.[0]
+
+      expect(bgClass1).toBe(bgClass2)
+    })
+  })
+
+  describe('Text Color', () => {
+    it('applies white text color when identifier is provided', () => {
+      const { container } = render(<Avatar variant="user" identifier="Test" />)
+
+      expect(container.firstChild).toHaveClass('text-white')
+    })
+
+    it('applies default text color when no identifier', () => {
+      const { container } = render(<Avatar variant="company" identifier="" />)
+
+      expect(container.firstChild).toHaveClass('text-grey-600')
+    })
+  })
+})
+
+describe('AvatarBadge', () => {
+  afterEach(cleanup)
+
+  it('renders with icon', () => {
+    const { container } = render(<AvatarBadge icon="checkmark" />)
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders with big size by default', () => {
+    const { container } = render(<AvatarBadge icon="checkmark" />)
+
+    expect(container.firstChild).toHaveClass('size-4')
+  })
+
+  it('renders with large size', () => {
+    const { container } = render(<AvatarBadge icon="checkmark" size="large" />)
+
+    expect(container.firstChild).toHaveClass('size-6')
+  })
+
+  describe('Colors', () => {
+    it.each([
+      ['primary', 'bg-blue-600'],
+      ['success', 'bg-green-600'],
+      ['error', 'bg-red-600'],
+      ['warning', 'bg-yellow-600'],
+      ['info', 'bg-purple-600'],
+      ['light', 'bg-white'],
+      ['black', 'bg-grey-700'],
+      ['dark', 'bg-grey-600'],
+      ['input', 'bg-grey-500'],
+      ['disabled', 'bg-grey-400'],
+      ['skeleton', 'bg-grey-100'],
+    ] as const)('applies %s color correctly', (color, expectedClass) => {
+      const { container } = render(<AvatarBadge icon="checkmark" color={color} />)
+
+      expect(container.firstChild).toHaveClass(expectedClass)
+    })
+  })
+
+  it('has rounded-full class', () => {
+    const { container } = render(<AvatarBadge icon="checkmark" />)
+
+    expect(container.firstChild).toHaveClass('rounded-full')
+  })
+
+  it('is positioned at bottom-right', () => {
+    const { container } = render(<AvatarBadge icon="checkmark" />)
+
+    expect(container.firstChild).toHaveClass('absolute', 'bottom-0', 'right-0')
+  })
+})
+
+describe('Avatar with AvatarBadge', () => {
+  afterEach(cleanup)
+
+  it('renders avatar with badge overlay', () => {
+    const { container } = render(
+      <Avatar variant="connector">
+        <AvatarBadge icon="checkmark" color="success" />
+      </Avatar>,
+    )
+
+    // Avatar should render
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/components/designSystem/__tests__/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/designSystem/__tests__/__snapshots__/Avatar.test.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Avatar with AvatarBadge renders avatar with badge overlay 1`] = `
+<div>
+  <div
+    class="relative flex items-center justify-center [&>img]:size-full [&>img]:rounded-[inherit] [&>img]:object-cover w-10 min-w-10 h-10 rounded-xl bg-grey-100 text-grey-600"
+    data-test="connector/big"
+  >
+    <div
+      class="absolute bottom-0 right-0 flex items-center justify-center rounded-full size-4 bg-green-600"
+    >
+      <svg
+        class="text-white size-2 min-w-2"
+        data-test="checkmark/xsmall"
+        fill="currentColor"
+        title="checkmark/xsmall"
+        viewBox="0 0 16 16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M5 14C5.19667 14.0002 5.39139 13.9609 5.5726 13.8844C5.75382 13.808 5.91786 13.696 6.055 13.555L15.7 3.71499C15.7952 3.62185 15.8709 3.51063 15.9226 3.38785C15.9743 3.26507 16.0009 3.1332 16.0009 2.99999C16.0009 2.86677 15.9743 2.73491 15.9226 2.61212C15.8709 2.48934 15.7952 2.37812 15.7 2.28499C15.6071 2.19201 15.4968 2.11825 15.3754 2.06793C15.254 2.0176 15.1239 1.9917 14.9925 1.9917C14.8611 1.9917 14.731 2.0176 14.6096 2.06793C14.4882 2.11825 14.3779 2.19201 14.285 2.28499L5 11.775L1.7 8.30499C1.51263 8.11874 1.25918 8.01419 0.994996 8.01419C0.73081 8.01419 0.477358 8.11874 0.289996 8.30499C0.19475 8.39812 0.119071 8.50934 0.0674035 8.63212C0.0157357 8.75491 -0.0108795 8.88678 -0.0108795 9.01999C-0.0108795 9.1532 0.0157357 9.28507 0.0674035 9.40785C0.119071 9.53063 0.19475 9.64186 0.289996 9.73499L3.94 13.56C4.22103 13.8414 4.60231 13.9996 5 14Z"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/designSystem/index.ts
+++ b/src/components/designSystem/index.ts
@@ -1,4 +1,5 @@
 export * from './Accordion'
+export * from './Avatar'
 export * from './AiBadge'
 export * from './Alert'
 export * from './Button'

--- a/src/components/layouts/DetailsPage.tsx
+++ b/src/components/layouts/DetailsPage.tsx
@@ -1,7 +1,7 @@
-import { Avatar, Icon, IconName } from 'lago-design-system'
+import { Icon, IconName } from 'lago-design-system'
 import { FC, PropsWithChildren, ReactNode } from 'react'
 
-import { Skeleton, Typography, TypographyProps } from '~/components/designSystem'
+import { Avatar, Skeleton, Typography, TypographyProps } from '~/components/designSystem'
 import { tw } from '~/styles/utils'
 
 const DetailsPageContainer: FC<PropsWithChildren<{ className?: string }>> = ({

--- a/src/components/layouts/Integrations.tsx
+++ b/src/components/layouts/Integrations.tsx
@@ -1,8 +1,8 @@
-import { Avatar, Icon, IconName } from 'lago-design-system'
+import { Icon, IconName } from 'lago-design-system'
 import { FC, PropsWithChildren } from 'react'
 import { Link } from 'react-router-dom'
 
-import { Chip, Skeleton, Typography } from '~/components/designSystem'
+import { Avatar, Chip, Skeleton, Typography } from '~/components/designSystem'
 import { tw } from '~/styles/utils'
 
 const IntegrationsContainer: FC<PropsWithChildren<{ className?: string }>> = ({

--- a/src/components/plans/details/PlanSubscriptionList.tsx
+++ b/src/components/plans/details/PlanSubscriptionList.tsx
@@ -1,9 +1,8 @@
 import { gql } from '@apollo/client'
-import { Avatar } from 'lago-design-system'
 import { generatePath } from 'react-router-dom'
 
 import { computeCustomerInitials } from '~/components/customers/utils'
-import { InfiniteScroll, Table, Typography } from '~/components/designSystem'
+import { Avatar, InfiniteScroll, Table, Typography } from '~/components/designSystem'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { CustomerSubscriptionDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { PLAN_SUBSCRIPTION_DETAILS_ROUTE } from '~/core/router/ObjectsRoutes'

--- a/src/components/settings/PreviewEmailLayout.tsx
+++ b/src/components/settings/PreviewEmailLayout.tsx
@@ -1,7 +1,6 @@
-import { Avatar } from 'lago-design-system'
 import { FC, PropsWithChildren, useRef } from 'react'
 
-import { Button, Skeleton, Tooltip, Typography } from '~/components/designSystem'
+import { Avatar, Button, Skeleton, Tooltip, Typography } from '~/components/designSystem'
 import { LocaleEnum } from '~/core/translations'
 import { PremiumIntegrationTypeEnum } from '~/generated/graphql'
 import { useContextualLocale } from '~/hooks/core/useContextualLocale'

--- a/src/components/settings/members/EditInviteRoleDialog.tsx
+++ b/src/components/settings/members/EditInviteRoleDialog.tsx
@@ -1,11 +1,10 @@
 import { gql } from '@apollo/client'
 import { Stack } from '@mui/material'
 import { useFormik } from 'formik'
-import { Avatar } from 'lago-design-system'
 import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { object, string } from 'yup'
 
-import { Button, Dialog, DialogRef, Typography } from '~/components/designSystem'
+import { Avatar, Button, Dialog, DialogRef, Typography } from '~/components/designSystem'
 import { addToast } from '~/core/apolloClient'
 import {
   InviteForEditRoleForDialogFragment,

--- a/src/components/settings/members/EditMemberRoleDialog.tsx
+++ b/src/components/settings/members/EditMemberRoleDialog.tsx
@@ -1,12 +1,11 @@
 import { gql } from '@apollo/client'
 import { Stack } from '@mui/material'
 import { useFormik } from 'formik'
-import { Avatar } from 'lago-design-system'
 import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { object, string } from 'yup'
 
-import { Alert, Button, Dialog, DialogRef, Typography } from '~/components/designSystem'
+import { Alert, Avatar, Button, Dialog, DialogRef, Typography } from '~/components/designSystem'
 import { addToast } from '~/core/apolloClient'
 import { HOME_ROUTE } from '~/core/router'
 import {

--- a/src/components/wallets/WalletDetailsDrawer.tsx
+++ b/src/components/wallets/WalletDetailsDrawer.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { Avatar, AvatarBadge, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import {
   FC,
   forwardRef,
@@ -14,6 +14,8 @@ import { generatePath, Link } from 'react-router-dom'
 
 import {
   Alert,
+  Avatar,
+  AvatarBadge,
   Button,
   Drawer,
   DrawerRef,

--- a/src/components/wallets/WalletTransactionListItem/ListItem.tsx
+++ b/src/components/wallets/WalletTransactionListItem/ListItem.tsx
@@ -1,7 +1,15 @@
-import { Avatar, AvatarBadge, Icon, IconName } from 'lago-design-system'
+import { Icon, IconName } from 'lago-design-system'
 import { FC } from 'react'
 
-import { Button, Popper, Tooltip, Typography, TypographyColor } from '~/components/designSystem'
+import {
+  Avatar,
+  AvatarBadge,
+  Button,
+  Popper,
+  Tooltip,
+  Typography,
+  TypographyColor,
+} from '~/components/designSystem'
 import { addToast } from '~/core/apolloClient'
 import { intlFormatDateTime } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'

--- a/src/layouts/MainNavLayout.tsx
+++ b/src/layouts/MainNavLayout.tsx
@@ -1,11 +1,12 @@
 import { ApolloError, gql, useApolloClient } from '@apollo/client'
 import { ClickAwayListener, Stack } from '@mui/material'
 import { captureException } from '@sentry/react'
-import { Avatar, ConditionalWrapper, Icon, IconName } from 'lago-design-system'
+import { ConditionalWrapper, Icon, IconName } from 'lago-design-system'
 import { useEffect, useRef, useState } from 'react'
 import { Location, Outlet, useLocation, useNavigate } from 'react-router-dom'
 
 import {
+  Avatar,
   Button,
   Popper,
   Skeleton,

--- a/src/pages/AddOnsList.tsx
+++ b/src/pages/AddOnsList.tsx
@@ -1,11 +1,12 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon, tw } from 'lago-design-system'
+import { Icon, tw } from 'lago-design-system'
 import { useRef } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 
 import { DeleteAddOnDialog, DeleteAddOnDialogRef } from '~/components/addOns/DeleteAddOnDialog'
 import {
   ActionItem,
+  Avatar,
   ButtonLink,
   InfiniteScroll,
   Table,

--- a/src/pages/BillableMetricsList.tsx
+++ b/src/pages/BillableMetricsList.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon, tw } from 'lago-design-system'
+import { Icon, tw } from 'lago-design-system'
 import { useRef } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 
@@ -7,7 +7,7 @@ import {
   DeleteBillableMetricDialog,
   DeleteBillableMetricDialogRef,
 } from '~/components/billableMetrics/DeleteBillableMetricDialog'
-import { ButtonLink, InfiniteScroll, Table, Typography } from '~/components/designSystem'
+import { Avatar, ButtonLink, InfiniteScroll, Table, Typography } from '~/components/designSystem'
 import { SearchInput } from '~/components/SearchInput'
 import { BillableMetricDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import {

--- a/src/pages/CouponsList.tsx
+++ b/src/pages/CouponsList.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon, tw } from 'lago-design-system'
+import { Icon, tw } from 'lago-design-system'
 import { useRef } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 
@@ -9,7 +9,14 @@ import {
   TerminateCouponDialog,
   TerminateCouponDialogRef,
 } from '~/components/coupons/TerminateCouponDialog'
-import { ButtonLink, InfiniteScroll, Status, Table, Typography } from '~/components/designSystem'
+import {
+  Avatar,
+  ButtonLink,
+  InfiniteScroll,
+  Status,
+  Table,
+  Typography,
+} from '~/components/designSystem'
 import { SearchInput } from '~/components/SearchInput'
 import { couponStatusMapping } from '~/core/constants/statusCouponMapping'
 import { CouponDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'

--- a/src/pages/CreateCoupon.tsx
+++ b/src/pages/CreateCoupon.tsx
@@ -1,6 +1,6 @@
 import { InputAdornment } from '@mui/material'
 import { useFormik } from 'formik'
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import isEqual from 'lodash/isEqual'
 import { DateTime } from 'luxon'
 import { useEffect, useRef, useState } from 'react'
@@ -18,6 +18,7 @@ import {
 import { CouponCodeSnippet } from '~/components/coupons/CouponCodeSnippet'
 import {
   Alert,
+  Avatar,
   Button,
   Card,
   Skeleton,

--- a/src/pages/CreateCreditNote.tsx
+++ b/src/pages/CreateCreditNote.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { useFormik } from 'formik'
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { generatePath, useNavigate, useParams } from 'react-router-dom'
 import { array, object, Schema, string } from 'yup'
@@ -16,6 +16,7 @@ import {
 } from '~/components/creditNote/utils'
 import {
   Alert,
+  Avatar,
   Button,
   Card,
   Skeleton,

--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -1,7 +1,6 @@
 import { gql } from '@apollo/client'
 import { InputAdornment } from '@mui/material'
 import { useFormik } from 'formik'
-import { Avatar } from 'lago-design-system'
 import _get from 'lodash/get'
 import { DateTime } from 'luxon'
 import { useCallback, useMemo, useRef, useState } from 'react'
@@ -10,6 +9,7 @@ import { array, number, object, string } from 'yup'
 
 import {
   Alert,
+  Avatar,
   Button,
   Card,
   GenericPlaceholder,

--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { Avatar } from 'lago-design-system'
 import { useRef } from 'react'
 import { generatePath, useNavigate, useParams } from 'react-router-dom'
 
@@ -22,6 +21,7 @@ import { CustomerSubscriptionsList } from '~/components/customers/overview/Custo
 import { CustomerUsage } from '~/components/customers/usage/CustomerUsage'
 import { computeCustomerInitials } from '~/components/customers/utils'
 import {
+  Avatar,
   Button,
   Chip,
   GenericPlaceholder,

--- a/src/pages/CustomerDraftInvoicesList.tsx
+++ b/src/pages/CustomerDraftInvoicesList.tsx
@@ -1,9 +1,9 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { CustomerInvoicesList } from '~/components/customers/CustomerInvoicesList'
-import { Button, Skeleton, Typography } from '~/components/designSystem'
+import { Avatar, Button, Skeleton, Typography } from '~/components/designSystem'
 import { SearchInput } from '~/components/SearchInput'
 import { CustomerDetailsTabsOptions } from '~/core/constants/tabsOptions'
 import { CUSTOMER_DETAILS_TAB_ROUTE } from '~/core/router'

--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -1,12 +1,13 @@
 import { gql } from '@apollo/client'
 import { Stack } from '@mui/material'
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { useCallback, useMemo, useRef } from 'react'
 import { generatePath, Outlet, useNavigate, useParams } from 'react-router-dom'
 
 import { createCreditNoteForInvoiceButtonProps } from '~/components/creditNote/utils'
 import {
   Alert,
+  Avatar,
   Button,
   GenericPlaceholder,
   NavigationTab,

--- a/src/pages/CustomerRequestOverduePayment/components/EmailPreview.tsx
+++ b/src/pages/CustomerRequestOverduePayment/components/EmailPreview.tsx
@@ -1,7 +1,6 @@
-import { Avatar } from 'lago-design-system'
 import { FC } from 'react'
 
-import { Card, Skeleton, Typography } from '~/components/designSystem'
+import { Avatar, Card, Skeleton, Typography } from '~/components/designSystem'
 import {
   DunningEmail,
   DunningEmailProps,

--- a/src/pages/CustomersList.tsx
+++ b/src/pages/CustomersList.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { Avatar } from 'lago-design-system'
 import { useMemo, useRef } from 'react'
 import { generatePath, useNavigate, useSearchParams } from 'react-router-dom'
 
@@ -8,7 +7,7 @@ import {
   DeleteCustomerDialogRef,
 } from '~/components/customers/DeleteCustomerDialog'
 import { computeCustomerInitials } from '~/components/customers/utils'
-import { Button, InfiniteScroll, Table, Typography } from '~/components/designSystem'
+import { Avatar, Button, InfiniteScroll, Table, Typography } from '~/components/designSystem'
 import {
   AvailableFiltersEnum,
   AvailableQuickFilters,

--- a/src/pages/PaymentDetails.tsx
+++ b/src/pages/PaymentDetails.tsx
@@ -1,10 +1,11 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon, IconName } from 'lago-design-system'
+import { Icon, IconName } from 'lago-design-system'
 import { ReactNode, useCallback } from 'react'
 import { generatePath, Link, useParams } from 'react-router-dom'
 
 import { ConditionalWrapper } from '~/components/ConditionalWrapper'
 import {
+  Avatar,
   Button,
   Popper,
   Skeleton,

--- a/src/pages/PlansList.tsx
+++ b/src/pages/PlansList.tsx
@@ -1,9 +1,10 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon, tw } from 'lago-design-system'
+import { Icon, tw } from 'lago-design-system'
 import { useRef } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 
 import {
+  Avatar,
   ButtonLink,
   GenericPlaceholderProps,
   InfiniteScroll,

--- a/src/pages/__devOnly/DesignSystem.tsx
+++ b/src/pages/__devOnly/DesignSystem.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-alert */
 import { Box, InputAdornment, Stack } from '@mui/material'
 import { useFormik } from 'formik'
-import { Avatar, AvatarBadge, Icon, IconName } from 'lago-design-system'
+import { Icon, IconName } from 'lago-design-system'
 import { useRef } from 'react'
 import { generatePath, Link } from 'react-router-dom'
 import { boolean, number, object, string } from 'yup'
@@ -10,6 +10,8 @@ import { AnalyticsStateProvider } from '~/components/analytics/AnalyticsStateCon
 import {
   Accordion,
   Alert,
+  Avatar,
+  AvatarBadge,
   Button,
   ButtonLink,
   ChargeTable,

--- a/src/pages/features/FeaturesList.tsx
+++ b/src/pages/features/FeaturesList.tsx
@@ -1,9 +1,16 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon, Typography } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { useMemo, useRef } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 
-import { ActionItem, Button, InfiniteScroll, Table } from '~/components/designSystem'
+import {
+  ActionItem,
+  Avatar,
+  Button,
+  InfiniteScroll,
+  Table,
+  Typography,
+} from '~/components/designSystem'
 import {
   DeleteFeatureDialog,
   DeleteFeatureDialogRef,

--- a/src/pages/settings/Authentication/Authentication.tsx
+++ b/src/pages/settings/Authentication/Authentication.tsx
@@ -1,9 +1,9 @@
 import { gql } from '@apollo/client'
-import { Avatar, ConditionalWrapper, Icon, Typography } from 'lago-design-system'
+import { ConditionalWrapper, Icon, Typography } from 'lago-design-system'
 import { useRef } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 
-import { Button, Chip, Popper, Selector, Tooltip } from '~/components/designSystem'
+import { Avatar, Button, Chip, Popper, Selector, Tooltip } from '~/components/designSystem'
 import { PageBannerHeaderWithBurgerMenu } from '~/components/layouts/CenteredPage'
 import {
   SettingsListItem,

--- a/src/pages/settings/BillingEntity/sections/BillingEntityEmailScenarios.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityEmailScenarios.tsx
@@ -1,8 +1,8 @@
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { useRef } from 'react'
 import { generatePath, useNavigate, useParams } from 'react-router-dom'
 
-import { Button, Table, TableColumn, Tooltip, Typography } from '~/components/designSystem'
+import { Avatar, Button, Table, TableColumn, Tooltip, Typography } from '~/components/designSystem'
 import { Switch } from '~/components/form'
 import {
   SettingsListItem,

--- a/src/pages/settings/BillingEntity/sections/BillingEntityEmailScenariosConfig.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityEmailScenariosConfig.tsx
@@ -1,8 +1,8 @@
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { Button, Skeleton, Tooltip, Typography } from '~/components/designSystem'
+import { Avatar, Button, Skeleton, Tooltip, Typography } from '~/components/designSystem'
 import { Switch } from '~/components/form'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { LanguageSettingsButton } from '~/components/settings/LanguageSettingsButton'

--- a/src/pages/settings/BillingEntity/sections/BillingEntityMain.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityMain.tsx
@@ -1,7 +1,7 @@
-import { Avatar, Icon, IconName, Typography } from 'lago-design-system'
+import { Icon, IconName } from 'lago-design-system'
 import { generatePath, useNavigate } from 'react-router-dom'
 
-import { Button, Tooltip } from '~/components/designSystem'
+import { Avatar, Button, Tooltip, Typography } from '~/components/designSystem'
 import { SettingsPaddedContainer, SettingsPageHeaderContainer } from '~/components/layouts/Settings'
 import {
   BILLING_ENTITY_DUNNING_CAMPAIGNS_ROUTE,

--- a/src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx
+++ b/src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx
@@ -1,8 +1,9 @@
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { useRef } from 'react'
 import { useParams } from 'react-router-dom'
 
 import {
+  Avatar,
   Button,
   ButtonLink,
   GenericPlaceholder,

--- a/src/pages/settings/BillingEntity/sections/general/InformationBlock.tsx
+++ b/src/pages/settings/BillingEntity/sections/general/InformationBlock.tsx
@@ -1,7 +1,6 @@
-import { Avatar } from 'lago-design-system'
 import { generatePath, useNavigate } from 'react-router-dom'
 
-import { Button, Typography } from '~/components/designSystem'
+import { Avatar, Button, Typography } from '~/components/designSystem'
 import {
   SettingsListItem,
   SettingsListItemHeader,

--- a/src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx
@@ -1,9 +1,16 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { useRef } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { Button, GenericPlaceholder, Table, Tooltip, Typography } from '~/components/designSystem'
+import {
+  Avatar,
+  Button,
+  GenericPlaceholder,
+  Table,
+  Tooltip,
+  Typography,
+} from '~/components/designSystem'
 import {
   SettingsListItem,
   SettingsListItemHeader,

--- a/src/pages/settings/Dunnings/Dunnings.tsx
+++ b/src/pages/settings/Dunnings/Dunnings.tsx
@@ -1,9 +1,10 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { useMemo, useRef } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 
 import {
+  Avatar,
   Button,
   ButtonLink,
   GenericPlaceholder,

--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -1,9 +1,8 @@
 import { gql } from '@apollo/client'
-import { Avatar } from 'lago-design-system'
 import { useRef } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 
-import { Alert, Chip, NavigationTab, Selector, Typography } from '~/components/designSystem'
+import { Alert, Avatar, Chip, NavigationTab, Selector, Typography } from '~/components/designSystem'
 import { PageBannerHeaderWithBurgerMenu } from '~/components/layouts/CenteredPage'
 import {
   SettingsListItem,

--- a/src/pages/settings/LagoTaxManagementIntegration.tsx
+++ b/src/pages/settings/LagoTaxManagementIntegration.tsx
@@ -1,9 +1,10 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon, tw } from 'lago-design-system'
+import { Icon, tw } from 'lago-design-system'
 import { FC, useRef } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 
 import {
+  Avatar,
   Button,
   ButtonLink,
   Chip,

--- a/src/pages/settings/Members.tsx
+++ b/src/pages/settings/Members.tsx
@@ -1,10 +1,10 @@
 import { gql } from '@apollo/client'
-import { Avatar } from 'lago-design-system'
 import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import {
   ActionItem,
+  Avatar,
   Button,
   Chip,
   InfiniteScroll,

--- a/src/pages/settings/MoneyhashIntegrationDetails.tsx
+++ b/src/pages/settings/MoneyhashIntegrationDetails.tsx
@@ -1,9 +1,17 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { useRef } from 'react'
 import { generatePath, useNavigate, useParams } from 'react-router-dom'
 
-import { Button, ButtonLink, Chip, Popper, Skeleton, Typography } from '~/components/designSystem'
+import {
+  Avatar,
+  Button,
+  ButtonLink,
+  Chip,
+  Popper,
+  Skeleton,
+  Typography,
+} from '~/components/designSystem'
 import {
   AddEditDeleteSuccessRedirectUrlDialog,
   AddEditDeleteSuccessRedirectUrlDialogRef,

--- a/src/pages/settings/TaxesSettings.tsx
+++ b/src/pages/settings/TaxesSettings.tsx
@@ -1,11 +1,12 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { useRef } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 
 import {
   ActionItem,
   Alert,
+  Avatar,
   Button,
   GenericPlaceholder,
   InfiniteScroll,

--- a/src/pages/settings/integrations/IntegrationItem/IntegrationItemsTable.tsx
+++ b/src/pages/settings/integrations/IntegrationItem/IntegrationItemsTable.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '@mui/material'
-import { Avatar, Icon, Typography } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 
-import { Skeleton, Status, Table, TableColumn } from '~/components/designSystem'
+import { Avatar, Skeleton, Status, Table, TableColumn, Typography } from '~/components/designSystem'
 import { VoidReturningFunction } from '~/core/types/voidReturningFunction'
 import { useGetBillingEntitiesQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'

--- a/src/pages/subscriptions/CreateSubscription.tsx
+++ b/src/pages/subscriptions/CreateSubscription.tsx
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 import { useMediaQuery } from '@mui/material'
 import { useFormik } from 'formik'
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { DateTime } from 'luxon'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
@@ -16,6 +16,7 @@ import { object, string } from 'yup'
 import { SubscriptionDatesOffsetHelperComponent } from '~/components/customers/subscriptions/SubscriptionDatesOffsetHelperComponent'
 import {
   Alert,
+  Avatar,
   Button,
   Card,
   Selector,

--- a/src/pages/subscriptions/SubscriptionDetails.tsx
+++ b/src/pages/subscriptions/SubscriptionDetails.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { Avatar, Icon } from 'lago-design-system'
+import { Icon } from 'lago-design-system'
 import { useMemo, useRef } from 'react'
 import { generatePath, useNavigate, useParams } from 'react-router-dom'
 
@@ -8,6 +8,7 @@ import {
   TerminateCustomerSubscriptionDialogRef,
 } from '~/components/customers/subscriptions/TerminateCustomerSubscriptionDialog'
 import {
+  Avatar,
   Button,
   ButtonLink,
   NavigationTab,


### PR DESCRIPTION
## Context

We decided to move back all of our components from the design-system package to our app

## Description

This PR moves back Avatar to the app and adds some much needed testing

<!-- Linear link -->
Fixes [ISSUE-1322](https://linear.app/getlago/issue/ISSUE-1322/avatar)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves `Avatar` (and `AvatarBadge`) from the design-system package into the app, adds tests, and updates imports/usages across the codebase.
> 
> - **Design System (app)**:
>   - Add local `src/components/designSystem/Avatar.tsx` (with `AvatarBadge`), exporting from `components/designSystem/index.ts`.
>   - Internal tweaks: use `codePointAt` for color hashing, `replaceAll` for initial sanitization, rely on `lago-design-system` `Icon`/`Typography`, and app `tw` util.
>   - Update `Selector` and `Skeleton` to consume local `Avatar` types and helpers.
> - **Tests**:
>   - Add comprehensive unit tests and snapshot for `Avatar`/`AvatarBadge` in `components/designSystem/__tests__/`.
> - **App-wide import updates**:
>   - Replace `Avatar` imports from `lago-design-system` with local `~/components/designSystem` across customers, invoices, payments, plans, settings, integrations, wallets, layouts, and dev pages.
> - **Design-system package**:
>   - Remove `Avatar` export from `packages/design-system/src/components/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 714955e3c58ee12ef6a252b770e150d6f7b51137. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->