### PR TITLE
fix(GenericPlaceholder): Fix placeholder image/svg default size

### DIFF
--- a/src/components/designSystem/GenericPlaceholder.tsx
+++ b/src/components/designSystem/GenericPlaceholder.tsx
@@ -37,7 +37,7 @@ export const GenericPlaceholder = ({
   return (
     <div
       className={tw(
-        'mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3 [&>img]:size-10 [&>svg]:mb-5',
+        'mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3',
         {
           'm-0': noMargins,
           'p-0': noMargins,
@@ -47,7 +47,13 @@ export const GenericPlaceholder = ({
       data-test={GENERIC_PLACEHOLDER_TEST_ID}
       {...props}
     >
-      <div data-test={GENERIC_PLACEHOLDER_IMAGE_TEST_ID}>{image}</div>
+      <div
+        className="mb-1 [&>img]:size-35 [&>svg]:size-35"
+        data-test={GENERIC_PLACEHOLDER_IMAGE_TEST_ID}
+      >
+        {image}
+      </div>
+
       {title && (
         <Typography
           className="mb-3"

--- a/src/components/designSystem/__tests__/__snapshots__/GenericPlaceholder.test.tsx.snap
+++ b/src/components/designSystem/__tests__/__snapshots__/GenericPlaceholder.test.tsx.snap
@@ -2,10 +2,11 @@
 
 exports[`GenericPlaceholder Snapshot Tests matches snapshot with ReactNode subtitle 1`] = `
 <div
-  class="mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3 [&>img]:size-10 [&>svg]:mb-5"
+  class="mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3"
   data-test="empty-state"
 >
   <div
+    class="mb-1 [&>img]:size-35 [&>svg]:size-35"
     data-test="generic-placeholder-image"
   >
     <img
@@ -32,10 +33,11 @@ exports[`GenericPlaceholder Snapshot Tests matches snapshot with ReactNode subti
 
 exports[`GenericPlaceholder Snapshot Tests matches snapshot with all props 1`] = `
 <div
-  class="mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3 [&>img]:size-10 [&>svg]:mb-5 custom-class"
+  class="mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3 custom-class"
   data-test="empty-state"
 >
   <div
+    class="mb-1 [&>img]:size-35 [&>svg]:size-35"
     data-test="generic-placeholder-image"
   >
     <svg
@@ -67,10 +69,11 @@ exports[`GenericPlaceholder Snapshot Tests matches snapshot with all props 1`] =
 
 exports[`GenericPlaceholder Snapshot Tests matches snapshot with button 1`] = `
 <div
-  class="mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3 [&>img]:size-10 [&>svg]:mb-5"
+  class="mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3"
   data-test="empty-state"
 >
   <div
+    class="mb-1 [&>img]:size-35 [&>svg]:size-35"
     data-test="generic-placeholder-image"
   >
     <img
@@ -97,10 +100,11 @@ exports[`GenericPlaceholder Snapshot Tests matches snapshot with button 1`] = `
 
 exports[`GenericPlaceholder Snapshot Tests matches snapshot with minimal props 1`] = `
 <div
-  class="mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3 [&>img]:size-10 [&>svg]:mb-5"
+  class="mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3"
   data-test="empty-state"
 >
   <div
+    class="mb-1 [&>img]:size-35 [&>svg]:size-35"
     data-test="generic-placeholder-image"
   >
     <img
@@ -119,10 +123,11 @@ exports[`GenericPlaceholder Snapshot Tests matches snapshot with minimal props 1
 
 exports[`GenericPlaceholder Snapshot Tests matches snapshot with noMargins 1`] = `
 <div
-  class="max-w-124 first:mb-3 [&>img]:size-10 [&>svg]:mb-5 m-0 p-0"
+  class="max-w-124 first:mb-3 m-0 p-0"
   data-test="empty-state"
 >
   <div
+    class="mb-1 [&>img]:size-35 [&>svg]:size-35"
     data-test="generic-placeholder-image"
   >
     <img
@@ -141,10 +146,11 @@ exports[`GenericPlaceholder Snapshot Tests matches snapshot with noMargins 1`] =
 
 exports[`GenericPlaceholder Snapshot Tests matches snapshot with title 1`] = `
 <div
-  class="mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3 [&>img]:size-10 [&>svg]:mb-5"
+  class="mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3"
   data-test="empty-state"
 >
   <div
+    class="mb-1 [&>img]:size-35 [&>svg]:size-35"
     data-test="generic-placeholder-image"
   >
     <img


### PR DESCRIPTION
## Context

Wrapping the image prop in a div broke sizing because the parent CSS selector [&>img]:size-10 only targeted direct children.

## Description

Fixed image sizing in GenericPlaceholder by:
- Removing [&>svg]:mb-5 from the parent container
- Updating the wrapper div to use mb-1 for spacing
- Changing image size from size-10 (40px) to size-35 (140px) to match actual image dimensions
- Applying sizing via [&>img]:size-35 and [&>svg]:size-35 on the wrapper div

Images and SVGs are now properly constrained regardless of their intrinsic dimensions.

<!-- Linear link -->
Fixes ISSUE-1328