### PR TITLE
bug(subscription) better display when customer is deleted

### DIFF
--- a/src/components/subscriptions/SubscriptionInformations.tsx
+++ b/src/components/subscriptions/SubscriptionInformations.tsx
@@ -35,6 +35,7 @@ gql`
       name
       displayName
       externalId
+      deletedAt
     }
     plan {
       id
@@ -71,7 +72,14 @@ export const SubscriptionInformations = ({
   const { translate } = useInternationalization()
   const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
 
-  const customerName = subscription?.customer?.displayName
+  const isCustomerDeleted = !!subscription?.customer?.deletedAt
+
+  const customerNameForDispay = [
+    subscription?.customer?.displayName || subscription?.customer?.externalId,
+    isCustomerDeleted ? translate('text_1764874328964clrgkmh7i9h') : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   return (
     <section>
@@ -98,7 +106,7 @@ export const SubscriptionInformations = ({
               label: translate('text_65201c5a175a4b0238abf29a'),
               value: (
                 <ConditionalWrapper
-                  condition={!!subscription?.customer?.id}
+                  condition={!!subscription?.customer?.id && !isCustomerDeleted}
                   validWrapper={(children) => (
                     <Link
                       to={generatePath(CUSTOMER_DETAILS_ROUTE, {
@@ -110,7 +118,7 @@ export const SubscriptionInformations = ({
                   )}
                   invalidWrapper={(children) => <>{children}</>}
                 >
-                  {customerName}
+                  {customerNameForDispay}
                 </ConditionalWrapper>
               ),
             },

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -11271,7 +11271,7 @@ export type GetSubscriptionForDetailsOverviewQueryVariables = Exact<{
 }>;
 
 
-export type GetSubscriptionForDetailsOverviewQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, paymentMethodType?: PaymentMethodTypeEnum | null, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, terminatedAt?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null }, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string } } | null };
+export type GetSubscriptionForDetailsOverviewQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, paymentMethodType?: PaymentMethodTypeEnum | null, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, terminatedAt?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null }, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string, deletedAt?: any | null } } | null };
 
 export type GetEntitlementsForSubscriptionDetailsQueryVariables = Exact<{
   subscriptionId: Scalars['ID']['input'];
@@ -11280,7 +11280,7 @@ export type GetEntitlementsForSubscriptionDetailsQueryVariables = Exact<{
 
 export type GetEntitlementsForSubscriptionDetailsQuery = { __typename?: 'Query', subscriptionEntitlements: { __typename?: 'SubscriptionEntitlementCollection', collection: Array<{ __typename?: 'SubscriptionEntitlement', code: string, name: string, privileges: Array<{ __typename?: 'SubscriptionEntitlementPrivilegeObject', code: string, name?: string | null, value?: string | null, valueType: PrivilegeValueTypeEnum, config: { __typename?: 'PrivilegeConfigObject', selectOptions?: Array<string> | null } }> }> } };
 
-export type SubscriptionForSubscriptionInformationsFragment = { __typename?: 'Subscription', id: string, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, terminatedAt?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string }, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null } };
+export type SubscriptionForSubscriptionInformationsFragment = { __typename?: 'Subscription', id: string, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, terminatedAt?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string, deletedAt?: any | null }, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null } };
 
 export type SubscriptionUsageLifetimeGraphForLifetimeGraphFragment = { __typename?: 'Subscription', id: string, status?: StatusTypeEnum | null, lifetimeUsage?: { __typename?: 'SubscriptionLifetimeUsage', lastThresholdAmountCents?: any | null, nextThresholdAmountCents?: any | null, totalUsageAmountCents: any, totalUsageFromDatetime: any, totalUsageToDatetime: any } | null, customer: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null, applicableTimezone: TimezoneEnum }, plan: { __typename?: 'Plan', id: string } };
 
@@ -15614,6 +15614,7 @@ export const SubscriptionForSubscriptionInformationsFragmentDoc = gql`
     name
     displayName
     externalId
+    deletedAt
   }
   plan {
     id

--- a/translations/base.json
+++ b/translations/base.json
@@ -3561,5 +3561,6 @@
   "text_1764327933607yodbve95igk": "Edit behavior",
   "text_1764327933607nrezuuiheuc": "subscription",
   "text_176432831893806loy6xo6qt": "No payment methods available",
-  "text_176433192749240fjx4tced9": "Search and select a payment method"
+  "text_176433192749240fjx4tced9": "Search and select a payment method",
+  "text_1764874328964clrgkmh7i9h": "(deleted)"
 }


### PR DESCRIPTION
## Context

If a customer has no display name and is deleted, we display the "Customer" label but no data is displayed.

## Description

This PR does
- make sure we display a data even if the customer has no name (external_id)
- add a (deleted) label if the customer is indeed deleted

Spotted while testing some scenarios