### PR TITLE
refactor(auth): Replace localStorage redirect with router state for post-login navigation

### DIFF
--- a/cypress/e2e/00-auth/t20-auth-redirect.cy.ts
+++ b/cypress/e2e/00-auth/t20-auth-redirect.cy.ts
@@ -1,0 +1,167 @@
+// Note: some login are done manually without using cy.login command
+// to preserve the router state needed for redirect testing
+// otherwise, cy.login breaks the redirection logic as it manually navigate to /login route
+
+// Use unique credentials for this test to avoid conflicts with other tests
+const testUser = {
+  email: 'auth-redirect-test@lago.com',
+  email2: 'auth-redirect-test2@lago.com',
+  password: 'AuthR3dir3ct!',
+  org1Name: 'Auth Test Org Primary',
+  org2Name: 'Auth Test Org Secondary',
+}
+
+describe('Authentication redirect flows', () => {
+  beforeEach(() => {
+    // Clean up any existing session before each test
+    cy.clearLocalStorage()
+    cy.clearCookies()
+  })
+
+  describe('Basic redirect after logout', () => {
+    it('should redirect to intended destination after logout and login', () => {
+      // 1. Create new organization
+      cy.signup({
+        organizationName: testUser.org1Name,
+        email: testUser.email,
+        password: testUser.password,
+      })
+      cy.url().should('include', Cypress.config().baseUrl)
+      cy.get('[data-test="side-nav-name"]').contains(testUser.org1Name)
+
+      // 2. Navigate to a specific page (customers list)
+      cy.visit('/customers')
+      cy.url().should('include', '/customers')
+
+      // 3. Logout
+      cy.logout()
+      // 4. Login again
+      cy.get('input[name="email"]').type(testUser.email)
+      cy.get('input[name="password"]').type(testUser.password)
+      cy.get('[data-test="submit"]').click()
+
+      // 5. Should be redirected back to /customers (not default home)
+      cy.url().should('include', '/customers')
+      cy.url().should('not.equal', Cypress.config().baseUrl + '/')
+    })
+
+    it('should redirect to new intended destination after logout and login', () => {
+      // 1. Create new organization
+      cy.signup({
+        organizationName: testUser.org2Name,
+        email: testUser.email2,
+        password: testUser.password,
+      })
+      cy.url().should('include', Cypress.config().baseUrl)
+
+      // 2. Navigate to a specific page (customers list)
+      cy.visit('/customers')
+      cy.url().should('include', '/customers')
+
+      // 3. Logout
+      cy.logout()
+
+      // 4. Try to access the plans page (should redirect to login with saved state)
+      cy.visit('/plans')
+      cy.url().should('include', '/login')
+
+      // 5. Login again
+      cy.get('input[name="email"]').type(testUser.email2)
+      cy.get('input[name="password"]').type(testUser.password)
+      cy.get('[data-test="submit"]').click()
+
+      // 6. Should be redirected to /plans (not default home nor /customers)
+      cy.url().should('include', '/plans')
+      cy.url().should('not.equal', Cypress.config().baseUrl + '/')
+    })
+
+    it('should redirect to default home if accessing root path after logout', () => {
+      // Login
+      cy.login(testUser.email, testUser.password)
+
+      // Logout
+      cy.logout()
+
+      // We should be on login page now, so login again
+      cy.login(testUser.email, testUser.password)
+
+      // Should go to default home (based on permissions)
+      cy.url().should('match', /\/(analytics)/)
+    })
+  })
+
+  describe('Session expiration redirect', () => {
+    it('should redirect back after session expiration and re-login', () => {
+      // Login
+      cy.login(testUser.email, testUser.password)
+
+      // Navigate to a specific page
+      cy.visit('/settings/taxes')
+      cy.url().should('include', '/settings/taxes')
+
+      // Simulate session expiration by clearing auth token
+      cy.clearLocalStorage('authToken')
+
+      // Try to navigate to another protected page (should redirect to login)
+      cy.visit('/customers')
+      cy.url().should('include', '/login')
+
+      // Login again
+      cy.get('input[name="email"]').type(testUser.email)
+      cy.get('input[name="password"]').type(testUser.password)
+      cy.get('[data-test="submit"]').click()
+
+      // Should be redirected to /customers (the page we tried to access)
+      cy.url().should('include', '/customers')
+    })
+  })
+
+  describe('Edge cases and corner scenarios', () => {
+    it('should handle navigation to public pages while authenticated', () => {
+      // Login
+      cy.login(testUser.email, testUser.password)
+
+      // Try to access login page while authenticated
+      cy.visit('/login')
+
+      // Should be redirected to home, not stay on login
+      cy.url().should('not.include', '/login')
+      cy.url().should('match', /\/(analytics|customers)/)
+    })
+
+    it('should preserve query parameters in redirect', () => {
+      // Login
+      cy.login(testUser.email, testUser.password)
+
+      // Navigate to page with query params
+      cy.visit('/customers?search=test&status=active')
+      cy.url().should('include', 'search=test')
+      cy.url().should('include', 'status=active')
+
+      // Logout
+      cy.logout()
+
+      // Try to access the same page with query params
+      cy.visit('/customers?search=test&status=active')
+      cy.url().should('include', '/login')
+
+      // Login
+      cy.get('input[name="email"]').type(testUser.email)
+      cy.get('input[name="password"]').type(testUser.password)
+      cy.get('[data-test="submit"]').click()
+
+      // Should preserve query parameters in redirect
+      cy.url().should('include', '/customers')
+      cy.url().should('include', 'search=test')
+      cy.url().should('include', 'status=active')
+    })
+  })
+
+  // Cleanup after all tests in this file
+  after(() => {
+    // Note: In a real scenario, you might want to delete the test organizations
+    // via API calls to keep the test database clean
+    cy.clearCookies()
+    cy.clearLocalStorage()
+  })
+})

--- a/cypress/e2e/00-auth/t30-multi-org-redirect.cy.ts
+++ b/cypress/e2e/00-auth/t30-multi-org-redirect.cy.ts
@@ -1,0 +1,182 @@
+// Note: some login are done manually without using cy.login command
+// to preserve the router state needed for redirect testing
+// otherwise, cy.login breaks the redirection logic as it manually navigate to /login route
+
+// Use unique credentials to avoid conflicts with other tests
+const testUsers = {
+  userA: {
+    email: 'multi-orga-user-a+3@lago.com',
+    password: 'Multi0rgT3st!',
+    org1Name: 'Multi Org Test - Organization A',
+  },
+  userB: {
+    email: 'multi-orga-user-b+3@lago.com',
+    password: 'Multi0rgT3st!',
+    org2Name: 'Multi Org Test - Organization B',
+  },
+}
+
+describe('Multi-organization redirect flows', () => {
+  let invitationUrl = ''
+
+  // Setup: Create two organizations and make User A a member of both
+  before(() => {
+    // 1. User A creates Org1
+    cy.signup({
+      organizationName: testUsers.userA.org1Name,
+      email: testUsers.userA.email,
+      password: testUsers.userA.password,
+    })
+
+    // Logout User A
+    cy.logout()
+
+    // 2. User B creates Org2
+    cy.signup({
+      organizationName: testUsers.userB.org2Name,
+      email: testUsers.userB.email,
+      password: testUsers.userB.password,
+    })
+
+    // Wait for session to be fully established
+    cy.url().should('eq', `${Cypress.config().baseUrl}/`)
+    // Ensure the user is authenticated by checking for the side nav
+    cy.get('[data-test="side-nav-user-infos"]', { timeout: 10000 }).should('be.visible')
+
+    // 3. User B invites User A to Org2 as admin
+    // Navigate to settings using UI to ensure session is maintained
+    cy.get('[data-test="side-nav-user-infos"]').click()
+    cy.contains('Settings').click()
+    cy.url().should('include', '/settings')
+
+    // Navigate to members tab
+    cy.contains('Members').click()
+    cy.url().should('include', '/settings/members')
+    // Wait for the page to load
+    cy.get('[data-test="create-invite-button"]', { timeout: 10000 }).should('be.visible')
+    cy.get('[data-test="create-invite-button"]').click()
+    cy.get('input[name="email"]').type(testUsers.userA.email)
+    cy.get('[data-test="submit-invite-button"]').click()
+
+    // Wait for invitation to be created and get the URL from the UI
+    cy.get('[data-test="invitation-url"]', { timeout: 10000 })
+      .should('be.visible')
+      .then(($link) => {
+        // Get the href attribute which contains the full URL
+        invitationUrl = $link.attr('href') || $link.text().trim()
+        cy.log('Invitation URL captured:', invitationUrl)
+
+        // Force a full page navigation by visiting the URL
+        // This will clear the session and disconnect User B
+        cy.visit(invitationUrl, { failOnStatusCode: false })
+      })
+
+    // 5. User A accepts the invitation to Org2 - enter the same password to avoid DB issues
+    cy.url().should('include', '/invitation/')
+    cy.get('input[name="password"]', { timeout: 10000 }).should('be.visible')
+    cy.get('input[name="password"]').type(testUsers.userA.password)
+    cy.get('[data-test="submit-button"]').click()
+
+    // User A should now have access to both organizations
+    cy.url().should('match', /\/(analytics|customers)/)
+    // Ensure the orga switcher shows two organizations
+    cy.get('[data-test="side-nav-user-infos"]').click()
+    cy.contains(testUsers.userA.org1Name).should('exist')
+    cy.contains(testUsers.userB.org2Name).should('exist')
+
+    // Logout to prepare for actual tests - doing it manually as the orga switcher is already open
+    cy.get('[data-test="side-nav-logout"]').click()
+  })
+
+  beforeEach(() => {
+    // Clean session before each test
+    cy.clearCookies()
+    cy.clearLocalStorage()
+  })
+
+  describe('Cross-organization redirect protection', () => {
+    it('should NOT redirect to Org1 resource when logged into Org2', () => {
+      // 1. Login as User A (will land in one of the orgs)
+      cy.login(testUsers.userA.email, testUsers.userA.password)
+      // 2. Ensure we're in Org1 by clicking on orga 1
+      cy.get('[data-test="side-nav-user-infos"]').click()
+      cy.contains(testUsers.userA.org1Name).click()
+      // 3. Create a customer in Org1
+      cy.visit('/customers')
+      cy.get('[data-test="create-customer"]', { timeout: 10000 }).click()
+      cy.get('input[name="name"]').type('Customer Org1 Multi-Org Test')
+      cy.get('input[name="externalId"]').type(`customer-org1-${Date.now()}`)
+      cy.get('[data-test="submit-customer"]').click()
+      cy.url().should('include', '/customer/')
+      // Save the customer URL from Org1
+      cy.url().then((org1CustomerUrl) => {
+        const customerIdMatch = org1CustomerUrl.match(/\/customer\/([^/]+)/)
+        const org1CustomerId = customerIdMatch ? customerIdMatch[1] : null
+        cy.log('Org1 Customer ID:', org1CustomerId)
+        // 4. logout, visit orga 1 url and login with customer in org2
+        cy.logout()
+        cy.visit(`/customer/${org1CustomerId}`)
+        cy.get('input[name="email"]').type(testUsers.userB.email)
+        cy.get('input[name="password"]').type(testUsers.userB.password)
+        cy.get('[data-test="submit"]').click()
+        // 5. Verify we're now in Org2 on home page (not the Org1 customer page)
+        cy.url().should('not.include', `/customer/${org1CustomerId}`)
+        cy.url().should('match', /\/(analytics|customers)/)
+        cy.get('[data-test="side-nav-user-infos"]').should('contain', testUsers.userB.org2Name)
+      })
+    })
+  })
+
+  describe('Organization switching redirect behavior', () => {
+    it('should redirect to home when switching orgs from deep page', () => {
+      // 1. Login as User A
+      cy.login(testUsers.userA.email, testUsers.userA.password)
+
+      // 2. Navigate to a deep page (e.g., customers/:id)
+      // Create a customer to get a deep link
+      cy.visit('/customers')
+      cy.get('[data-test="create-customer"]', { timeout: 10000 }).click()
+      cy.get('input[name="name"]').type('Customer for Org Switch Test')
+      cy.get('input[name="externalId"]').type(`customer-org-switch-${Date.now()}`)
+      cy.get('[data-test="submit-customer"]').click()
+      cy.url().should('include', '/customer/')
+
+      const urlToAvoidAfterLogin = cy.url()
+
+      // 3. switch organizations
+      cy.get('[data-test="side-nav-user-infos"]', { timeout: 10000 }).click()
+      cy.contains(testUsers.userB.org2Name).click()
+
+      // Make sure we're on home page of Org2 (not the deep link)
+      cy.url().should('match', /\/(analytics|customers)/)
+      cy.url().should('not.equal', urlToAvoidAfterLogin)
+    })
+
+    it('should preserve query params after logout', () => {
+      // 1. Login as User A
+      cy.login(testUsers.userA.email, testUsers.userA.password)
+
+      // 2. Navigate to customers with query params
+      cy.visit('/customers?search=test&page=2')
+      cy.url().should('include', 'search=test')
+      cy.url().should('include', 'page=2')
+
+      // 3. logout
+      cy.logout()
+      // 4. Login again
+      cy.get('input[name="email"]').type(testUsers.userA.email)
+      cy.get('input[name="password"]').type(testUsers.userA.password)
+      cy.get('[data-test="submit"]').click()
+
+      // 5. Should preserve query params after login
+      cy.url().should('include', 'search=test')
+      cy.url().should('include', 'page=2')
+    })
+  })
+
+  // Cleanup after all tests
+  after(() => {
+    cy.clearCookies()
+    cy.clearLocalStorage()
+  })
+})

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -13,6 +13,8 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 // Import commands.js using ES2015 syntax:
+import cypress from 'cypress'
+
 import { userEmail, userPassword } from './reusableConstants'
 
 Cypress.Commands.add('login', (email = userEmail, password = userPassword) => {
@@ -22,6 +24,32 @@ Cypress.Commands.add('login', (email = userEmail, password = userPassword) => {
   cy.get('[data-test="submit"]').click()
   cy.url().should('be.equal', Cypress.config().baseUrl + '/')
 })
+
+Cypress.Commands.add('logout', () => {
+  cy.get('[data-test="side-nav-user-infos"]').click()
+  cy.get('[data-test="side-nav-logout"]').click()
+  cy.url().should('include', '/login')
+})
+
+Cypress.Commands.add(
+  'signup',
+  ({
+    organizationName,
+    email,
+    password,
+  }: {
+    organizationName: string
+    email: string
+    password: string
+  }) => {
+    cy.visit('sign-up')
+    cy.get('input[name="organizationName"]').type(organizationName)
+    cy.get('input[name="email"]').type(email)
+    cy.get('input[name="password"]').type(password)
+    cy.get('[data-test="submit-button"]').click()
+    cy.url().should('be.equal', Cypress.config().baseUrl + '/')
+  },
+)
 
 // https://docs.cypress.io/api/cypress-api/custom-commands#Overwrite-type-command
 // @ts-expect-error custom command

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -9,6 +9,28 @@ declare namespace Cypress {
      * cy.login('usertest@lago.com', 'P@ssw0rd')
      */
     login(email?: string, password?: string): Chainable<unknown>
+
+    /**
+     * Logout current user
+     * @example
+     * cy.logout()
+     */
+    logout(): Chainable<unknown>
+
+    /**
+     * Signup user
+     * @example
+     * cy.signup({ organizationName: 'Lago', email: 'user@lago.com', password: 'P@ssw0rd' })
+     */
+    signup({
+      organizationName,
+      email,
+      password,
+    }: {
+      organizationName: string
+      email: string
+      password: string
+    }): Chainable<unknown>
   }
 
   interface Cypress {

--- a/src/components/settings/members/CreateInviteDialog.tsx
+++ b/src/components/settings/members/CreateInviteDialog.tsx
@@ -212,7 +212,12 @@ export const CreateInviteDialog = forwardRef<DialogRef>((_, ref) => {
               <Typography className="w-35 shrink-0" variant="caption" color="grey600">
                 {translate('text_63208c701ce25db781407475')}
               </Typography>
-              <Typography className="line-break-anywhere" variant="body" color="grey700">
+              <Typography
+                className="line-break-anywhere"
+                variant="body"
+                color="grey700"
+                data-test="invitation-url"
+              >
                 {invitationUrl}
               </Typography>
             </div>

--- a/src/core/apolloClient/cacheUtils.ts
+++ b/src/core/apolloClient/cacheUtils.ts
@@ -1,9 +1,6 @@
 import { ApolloClient, ApolloQueryResult, gql } from '@apollo/client'
 
-import {
-  LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY,
-  ORGANIZATION_LS_KEY_ID,
-} from '~/core/constants/localStorageKeys'
+import { ORGANIZATION_LS_KEY_ID } from '~/core/constants/localStorageKeys'
 import {
   CurrentUserFragmentDoc,
   GetCurrentUserInfosForLoginQuery,
@@ -130,9 +127,6 @@ export const onLogIn = async (client: ApolloClient<object>, token: string) => {
       } else {
         removeItemFromLS(ORGANIZATION_LS_KEY_ID)
       }
-    } else {
-      // If no organization have been found, any redirection logic should be prevented later
-      removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
     }
 
     // If still no organization, take the first one that is accessible by the current session
@@ -174,7 +168,6 @@ export const switchCurrentOrganization = async (
   setItemFromLS(ORGANIZATION_LS_KEY_ID, organizationId)
 
   // 4. Clear other org-specific state
-  removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
   removeItemFromLS(DEVTOOL_AUTO_SAVE_KEY)
 }
 

--- a/src/core/constants/localStorageKeys.ts
+++ b/src/core/constants/localStorageKeys.ts
@@ -1,2 +1,1 @@
-export const LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY = 'lastPrivateVisitedRoute'
 export const ORGANIZATION_LS_KEY_ID = 'currentOrganization'

--- a/src/hooks/core/useLocationHistory.ts
+++ b/src/hooks/core/useLocationHistory.ts
@@ -5,13 +5,8 @@ import {
   authTokenVar,
   getItemFromLS,
   locationHistoryVar,
-  removeItemFromLS,
-  setItemFromLS,
 } from '~/core/apolloClient'
-import {
-  LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY,
-  ORGANIZATION_LS_KEY_ID,
-} from '~/core/constants/localStorageKeys'
+import { ORGANIZATION_LS_KEY_ID } from '~/core/constants/localStorageKeys'
 import { CustomRouteObject, FORBIDDEN_ROUTE, HOME_ROUTE, LOGIN_ROUTE } from '~/core/router'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { usePermissions } from '~/hooks/usePermissions'
@@ -68,12 +63,6 @@ export const useLocationHistory: UseLocationHistoryReturn = () => {
   const goBack: GoBack = (fallback, options) => {
     const { previous, remainingHistory } = getPreviousLocation(options || {})
 
-    if (fallback === HOME_ROUTE) {
-      // Make sure the LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY is not set
-      // Otherwise, the back redirection will not always work in Home page
-      removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
-    }
-
     if (options?.state) {
       navigate(previous || fallback, { state: options.state })
     } else {
@@ -91,23 +80,20 @@ export const useLocationHistory: UseLocationHistoryReturn = () => {
       if (routeConfig.onlyPublic && isAuthenticated) {
         /**
          * In case of navigation to a only public route while authenticated
-         * Go back to previously visited page in app or fallback to the home
+         * Redirect to home, preserving any saved location state from login flow
          */
-        navigate(HOME_ROUTE)
+        navigate(HOME_ROUTE, { state: location.state, replace: true })
       } else if (routeConfig.private && !isAuthenticated) {
         /**
          * In case of navigation to a private route while NOT authenticated
-         * Redirect to login and add the route the user tried to visit in the history
+         * Redirect to login and store the intended destination in router state
          */
-        navigate({
-          pathname: LOGIN_ROUTE,
-          search: location.search,
-        })
-
-        // If user is kicked out or logs out, we save manually the last private route visited to redirect after login
-        setItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY, {
-          location,
-          organizationId: getItemFromLS(ORGANIZATION_LS_KEY_ID),
+        navigate(LOGIN_ROUTE, {
+          state: {
+            from: location,
+            orgId: getItemFromLS(ORGANIZATION_LS_KEY_ID),
+          },
+          replace: true,
         })
       } else if (
         isAuthenticated &&
@@ -123,16 +109,6 @@ export const useLocationHistory: UseLocationHistoryReturn = () => {
       } else if (!routeConfig?.children && !routeConfig.onlyPublic) {
         // In the invitation for page, once users are logged in, we redirect them to the home page
         if (routeConfig.invitation && isAuthenticated) {
-          // We have a special case for the invitation route, we don't want to be redirected to any potential last visited page.
-          // If user follows an invitation, we remove this info from the local storage before the redirection happens.
-          const lastPrivateVisitedRouteWhileNotConnected: Location = getItemFromLS(
-            LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY,
-          )
-
-          if (lastPrivateVisitedRouteWhileNotConnected) {
-            removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
-          }
-
           // We can then safely redirect to the home page.
           navigate(HOME_ROUTE)
         }

--- a/src/layouts/MainNavLayout.tsx
+++ b/src/layouts/MainNavLayout.tsx
@@ -200,7 +200,7 @@ const MainNavLayout = () => {
               opener={
                 <Button
                   className="max-w-[calc(240px-theme(space.8))] text-left *:first:mr-2"
-                  data-test="side-nav-name"
+                  data-test="side-nav-user-infos"
                   variant="quaternary"
                   size="small"
                   disabled={isLoading}
@@ -227,7 +227,12 @@ const MainNavLayout = () => {
                           initials={(organization?.name ?? 'Lago')[0]}
                         />
                       )}
-                      <Typography variant="caption" color="textSecondary" noWrap>
+                      <Typography
+                        noWrap
+                        color="textSecondary"
+                        data-test="side-nav-name"
+                        variant="caption"
+                      >
                         {organization?.name}
                       </Typography>
                     </>
@@ -323,6 +328,7 @@ const MainNavLayout = () => {
                       align="left"
                       size="small"
                       startIcon="logout"
+                      data-test="side-nav-logout"
                       onClick={async () => await logOut(client, true)}
                     >
                       {translate('text_623b497ad05b960101be3444')}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,12 +1,9 @@
 import { useEffect } from 'react'
-import { generatePath, useNavigate } from 'react-router-dom'
+import { generatePath, useLocation, useNavigate } from 'react-router-dom'
 
 import { Spinner } from '~/components/designSystem'
-import { getItemFromLS, removeItemFromLS } from '~/core/apolloClient'
-import {
-  LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY,
-  ORGANIZATION_LS_KEY_ID,
-} from '~/core/constants/localStorageKeys'
+import { getItemFromLS } from '~/core/apolloClient'
+import { ORGANIZATION_LS_KEY_ID } from '~/core/constants/localStorageKeys'
 import { NewAnalyticsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { ANALYTIC_ROUTE, ANALYTIC_TABS_ROUTE, CUSTOMERS_LIST_ROUTE } from '~/core/router'
 import { PremiumIntegrationTypeEnum } from '~/generated/graphql'
@@ -16,6 +13,7 @@ import { usePermissions } from '~/hooks/usePermissions'
 
 const Home = () => {
   const navigate = useNavigate()
+  const location = useLocation()
   const { loading: isUserLoading, currentMembership } = useCurrentUser()
   const { hasPermissions } = usePermissions()
   const { hasOrganizationPremiumAddon, loading: isOrganizationLoading } = useOrganizationInfos()
@@ -26,26 +24,26 @@ const Home = () => {
   useEffect(() => {
     // Make sure user permissions are loaded before performing redirection
     if (!isUserLoading && !isOrganizationLoading && !!currentMembership) {
-      const lastPrivateVisitedRouteWhileNotConnected:
-        | { location: Location; organizationId: string }
-        | undefined = getItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
+      // Check if there's a saved location from login redirect in router state
+      const routerState = location.state as
+        | { from?: Location; orgId?: string | null }
+        | null
+        | undefined
+      const savedLocation = routerState?.from
+      const savedOrgId = routerState?.orgId
 
-      if (
-        !!lastPrivateVisitedRouteWhileNotConnected &&
-        !!lastPrivateVisitedRouteWhileNotConnected?.organizationId &&
-        lastPrivateVisitedRouteWhileNotConnected?.location?.pathname !== '/'
-      ) {
+      if (savedLocation && savedLocation.pathname !== '/') {
         const currentOrganizationId = getItemFromLS(ORGANIZATION_LS_KEY_ID)
 
-        if (lastPrivateVisitedRouteWhileNotConnected.organizationId === currentOrganizationId) {
-          // Return navigation to prevent later ones to be performed
-          return navigate(lastPrivateVisitedRouteWhileNotConnected.location, { replace: true })
+        // Only redirect if the organization matches (or was null when saved)
+        if (!savedOrgId || savedOrgId === currentOrganizationId) {
+          // Return navigation to prevent later default redirections from executing
+          return navigate(savedLocation, { replace: true })
         }
-
-        // This is a temp value for redirection, should be removed if it does not match the current organization
-        removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
+        // Org mismatch - fall through to default navigation
       }
 
+      // Default home navigation based on permissions
       if (hasPermissions(['analyticsView']) && !hasAccessToAnalyticsDashboardsFeature) {
         navigate(ANALYTIC_ROUTE, { replace: true })
       } else if (hasPermissions(['dataApiView']) && hasAccessToAnalyticsDashboardsFeature) {
@@ -66,6 +64,7 @@ const Home = () => {
     hasPermissions,
     hasAccessToAnalyticsDashboardsFeature,
     navigate,
+    location.state,
   ])
 
   return <Spinner />

--- a/src/pages/Invitation.tsx
+++ b/src/pages/Invitation.tsx
@@ -8,9 +8,8 @@ import { object, string } from 'yup'
 import GoogleAuthButton from '~/components/auth/GoogleAuthButton'
 import { Alert, Button, Skeleton, Typography } from '~/components/designSystem'
 import { TextInput } from '~/components/form'
-import { hasDefinedGQLError, onLogIn, removeItemFromLS } from '~/core/apolloClient'
+import { hasDefinedGQLError, onLogIn } from '~/core/apolloClient'
 import { DOCUMENTATION_ENV_VARS } from '~/core/constants/externalUrls'
-import { LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY } from '~/core/constants/localStorageKeys'
 import { LOGIN_ROUTE } from '~/core/router'
 import { addValuesToUrlState } from '~/core/utils/urlUtils'
 import {
@@ -161,9 +160,6 @@ const Invitation = () => {
 
   const onInvitation = async () => {
     const { password } = formFields
-
-    // make sure no previous visited route is saved in the LS
-    removeItemFromLS(LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY)
 
     await acceptInvite({
       variables: {

--- a/src/pages/__tests__/Home.test.tsx
+++ b/src/pages/__tests__/Home.test.tsx
@@ -1,0 +1,185 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import type { Location } from 'react-router-dom'
+
+import { PremiumIntegrationTypeEnum } from '~/generated/graphql'
+
+// Import Home component after all mocks are set up
+
+import Home from '../Home'
+
+const mockNavigate = jest.fn()
+const mockUseLocation = jest.fn()
+const mockGetItemFromLS = jest.fn()
+const mockHasPermissions = jest.fn()
+const mockHasOrganizationPremiumAddon = jest.fn()
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockUseLocation(),
+  generatePath: jest.fn((route, params) => {
+    return route.replace(':tab', params.tab)
+  }),
+}))
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  getItemFromLS: (key: string) => mockGetItemFromLS(key),
+}))
+
+jest.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    loading: false,
+    currentMembership: { id: 'membership-1' },
+  }),
+}))
+
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  useOrganizationInfos: () => ({
+    loading: false,
+    hasOrganizationPremiumAddon: mockHasOrganizationPremiumAddon,
+  }),
+}))
+
+jest.mock('~/hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    hasPermissions: mockHasPermissions,
+  }),
+}))
+
+describe('Home', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+    mockGetItemFromLS.mockClear()
+    mockHasPermissions.mockClear()
+    mockHasOrganizationPremiumAddon.mockClear()
+    mockUseLocation.mockReturnValue({ state: null })
+  })
+
+  describe('redirect from login with saved location', () => {
+    const savedLocation: Location = {
+      pathname: '/customers/123',
+      search: '?tab=overview',
+      hash: '',
+      state: null,
+      key: 'saved-key',
+    }
+
+    it('should redirect to saved location when orgId matches', async () => {
+      mockUseLocation.mockReturnValue({
+        state: {
+          from: savedLocation,
+          orgId: 'org-a',
+        },
+      })
+      mockGetItemFromLS.mockReturnValue('org-a')
+
+      renderHook(() => Home())
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(savedLocation, { replace: true })
+      })
+    })
+
+    it('should redirect to saved location when orgId is null (first login)', async () => {
+      mockUseLocation.mockReturnValue({
+        state: {
+          from: savedLocation,
+          orgId: null,
+        },
+      })
+      mockGetItemFromLS.mockReturnValue('org-a')
+
+      renderHook(() => Home())
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(savedLocation, { replace: true })
+      })
+    })
+
+    it('should NOT redirect to saved location when orgId does not match', async () => {
+      mockUseLocation.mockReturnValue({
+        state: {
+          from: savedLocation,
+          orgId: 'org-a',
+        },
+      })
+      mockGetItemFromLS.mockReturnValue('org-b')
+      mockHasPermissions.mockReturnValue(false)
+      mockHasOrganizationPremiumAddon.mockReturnValue(false)
+
+      renderHook(() => Home())
+
+      await waitFor(() => {
+        // Should fall through to default navigation (customers list)
+        expect(mockNavigate).toHaveBeenCalledWith('/customers', { replace: true })
+        expect(mockNavigate).not.toHaveBeenCalledWith(savedLocation, { replace: true })
+      })
+    })
+
+    it('should ignore saved location with root pathname', async () => {
+      const rootLocation = { ...savedLocation, pathname: '/' }
+
+      mockUseLocation.mockReturnValue({
+        state: {
+          from: rootLocation,
+          orgId: 'org-a',
+        },
+      })
+      mockGetItemFromLS.mockReturnValue('org-a')
+      mockHasPermissions.mockReturnValue(false)
+      mockHasOrganizationPremiumAddon.mockReturnValue(false)
+
+      renderHook(() => Home())
+
+      await waitFor(() => {
+        // Should fall through to default navigation
+        expect(mockNavigate).toHaveBeenCalledWith('/customers', { replace: true })
+        expect(mockNavigate).not.toHaveBeenCalledWith(rootLocation, { replace: true })
+      })
+    })
+  })
+
+  describe('default navigation', () => {
+    beforeEach(() => {
+      mockUseLocation.mockReturnValue({ state: null })
+    })
+
+    it('should redirect to analytics when user has analyticsView and no dashboard feature', async () => {
+      mockHasPermissions.mockReturnValue(true)
+      mockHasOrganizationPremiumAddon.mockReturnValue(false)
+
+      renderHook(() => Home())
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/analytics', { replace: true })
+      })
+    })
+
+    it('should redirect to analytics dashboards when user has dataApiView and dashboard feature', async () => {
+      mockHasPermissions.mockImplementation((perms: string[]) => {
+        return perms.includes('dataApiView')
+      })
+      mockHasOrganizationPremiumAddon.mockImplementation((addon: PremiumIntegrationTypeEnum) => {
+        return addon === PremiumIntegrationTypeEnum.AnalyticsDashboards
+      })
+
+      renderHook(() => Home())
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/analytics/revenue-streams', { replace: true })
+      })
+    })
+
+    it('should redirect to customers list when user has no special permissions', async () => {
+      mockHasPermissions.mockReturnValue(false)
+      mockHasOrganizationPremiumAddon.mockReturnValue(false)
+
+      renderHook(() => Home())
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/customers', { replace: true })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Context

The current redirect mechanism after logout/session expiration uses localStorage `lastPrivateVisitedRoute` to store where users should be redirected after logging back in. This approach has several issues:

- Manual cleanup scattered across codebase: Multiple `removeItemFromLS()` calls needed in different flows (logout, org switch, invitation acceptance) that must be maintained carefully
- Cross-organization vulnerabilities: Users can be redirected to resources from Organization A after logging into Organization B, causing 404/403 errors and generating Sentry alerts
- Stale data persistence: `localStorage` values can persist indefinitely, surviving tab closes, refreshes, and even browser restarts, leading to unexpected redirects days later
- Missing state context: Only stores the location and organization id, with no validation before redirect
- Brittle maintenance: Adding new auth entry/exit points requires remembering to manually update `localStorage` cleanup logic

## Description

This PR replaces the `localStorage`-based approach with React Router's built-in location state for managing post-login redirects:

How it works:
1. When redirecting unauthenticated users to login, store the intended destination + current orgId in router state
2. After successful login, validate that the user's new organization matches the saved orgId
3. Only redirect to the saved location if the organization matches; otherwise fall back to default home navigation
4. Router state is automatically cleaned up on navigation - no manual management needed

Benefits:
- ✅ Self-cleaning: Router state is automatically cleared on navigation - no scattered cleanup calls
- ✅ Organization-safe: Validates orgId before redirect, preventing cross-org access attempts and Sentry errors
- ✅ Robust: Route guards still validate permissions after redirect - layered security
- ✅ Maintainable: No manual state management - new auth flows work automatically
- ✅ Ephemeral by design: State only lives for the current session/flow, no stale data issues

Files changed:
- `useLocationHistory.ts`: Store redirect info in router state instead of localStorage; preserve state through auth redirects
- `Home.tsx`: Validate orgId before restoring saved location from router state
- Removed: All localStorage cleanup calls from Invitation.tsx, cacheUtils.ts, and the `LAST_PRIVATE_VISITED_ROUTE_WHILE_NOT_CONNECTED_LS_KEY` constant
- Added comprehensive test coverage for the new redirect validation logic


Fixes ISSUE-1331