### PR TITLE
chore(test): reduce noise on test output

### DIFF
--- a/jest-setup-early.ts
+++ b/jest-setup-early.ts
@@ -1,0 +1,57 @@
+/**
+ * Early Jest Setup - Runs before any test imports
+ *
+ * This file configures console suppression BEFORE any libraries are imported,
+ * so we can intercept warnings from libraries that cache console references.
+ */
+
+/**
+ * Patterns to suppress in test console output.
+ * Each pattern is an array of strings that must ALL be present in the message.
+ */
+const SUPPRESSED_PATTERNS: string[][] = [
+  // Apollo Client 4.0 deprecation warnings
+  ['MockedProvider', 'addTypename', 'deprecated'],
+  ['InMemoryCache', 'addTypename', 'deprecated'],
+  ['useLazyQuery', 'variables', 'deprecated'],
+  ['cache.diff', 'canonizeResults', 'deprecated'],
+  ['ApolloLink', 'onError', 'deprecated'],
+
+  // React Router v7 future flag warnings
+  ['React Router Future Flag Warning', 'v7_startTransition'],
+  ['React Router Future Flag Warning', 'v7_relativeSplatPath'],
+
+  // GraphQL fragment duplicate warnings (test environment artifact)
+  ['Warning: fragment with name', 'already exists'],
+
+  // React act() warnings - often false positives in async tests
+  // May need more checking on this one to avoid missing real warnings
+  ['not wrapped in act'],
+]
+
+/**
+ * Check if console args should be suppressed based on known noise patterns.
+ *
+ * Note: Console messages may come as printf-style format strings with multiple args,
+ * e.g., console.warn("[%s]: `%s` is deprecated", "InMemoryCache", "addTypename")
+ * So we need to check ALL arguments, not just the first one.
+ */
+function shouldSuppressWarning(args: unknown[]): boolean {
+  const fullMessage = args.map(String).join(' ')
+  return SUPPRESSED_PATTERNS.some((pattern) => pattern.every((term) => fullMessage.includes(term)))
+}
+
+// Store original methods before any library can cache them
+const originalWarn = console.warn.bind(console)
+const originalError = console.error.bind(console)
+
+// Replace console methods
+console.warn = (...args: unknown[]) => {
+  if (shouldSuppressWarning(args)) return
+  originalWarn(...args)
+}
+
+console.error = (...args: unknown[]) => {
+  if (shouldSuppressWarning(args)) return
+  originalError(...args)
+}

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,1 +1,2 @@
+// Console suppression is handled in jest-setup-early.ts (runs before imports)
 import '@testing-library/jest-dom'

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -45,6 +45,8 @@ export default {
 
   testEnvironment: 'jsdom',
 
+  // Load early setup for console suppression (runs before test framework and imports)
+  setupFiles: ['./jest-setup-early.ts'],
   // Load setup files before test execution
   setupFilesAfterEnv: ['./jest-setup.ts'],
 


### PR DESCRIPTION
## Context

While trying to read which tests where not passing on the github actions, I had some issues where the output was not rendering because of how long it was

## Description

Tasked Claude to come up with a solution and this one seems clever enough

<!-- Linear link -->
Fixes LAGO-XXX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an early Jest setup to intercept and suppress known noisy console warnings/errors and wires it into Jest config.
> 
> - **Testing / Infra**:
>   - **Early console suppression** in `jest-setup-early.ts`:
>     - Overrides `console.warn`/`console.error` to drop messages matching known noise patterns (Apollo deprecations, React Router v7 future flags, GraphQL fragment duplicates, React `act()` warnings).
>   - **Jest config** (`jest.config.ts`):
>     - Adds `setupFiles: ['./jest-setup-early.ts']` to ensure suppression runs before framework/imports.
>     - Keeps `setupFilesAfterEnv: ['./jest-setup.ts']` (now only includes `@testing-library/jest-dom`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68211b711a8421e4e2eab2c28a54354ae4d4f101. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->