### PR TITLE
chore: fix some linter warnings

### DIFF
--- a/src/components/designSystem/GenericPlaceholder.tsx
+++ b/src/components/designSystem/GenericPlaceholder.tsx
@@ -67,9 +67,10 @@ export const GenericPlaceholder = ({
         className={tw({
           'mb-5': hasButton,
         })}
+        html={typeof subtitle === 'string' ? subtitle : undefined}
         data-test={GENERIC_PLACEHOLDER_SUBTITLE_TEST_ID}
       >
-        {subtitle}
+        {typeof subtitle === 'string' ? undefined : subtitle}
       </Typography>
 
       {hasButton && (

--- a/src/components/designSystem/__tests__/AiBadge.test.tsx
+++ b/src/components/designSystem/__tests__/AiBadge.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable tailwindcss/no-custom-classname */
 import { cleanup, screen } from '@testing-library/react'
 
 import { render } from '~/test-utils'

--- a/src/components/designSystem/__tests__/Avatar.test.tsx
+++ b/src/components/designSystem/__tests__/Avatar.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable tailwindcss/no-custom-classname */
 import { cleanup, screen } from '@testing-library/react'
 
 import { render } from '~/test-utils'

--- a/src/components/designSystem/__tests__/Typography.test.tsx
+++ b/src/components/designSystem/__tests__/Typography.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable tailwindcss/no-custom-classname */
 import { cleanup, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 

--- a/src/components/designSystem/__tests__/__snapshots__/GenericPlaceholder.test.tsx.snap
+++ b/src/components/designSystem/__tests__/__snapshots__/GenericPlaceholder.test.tsx.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`GenericPlaceholder Snapshot Tests matches snapshot with HTML markup in string subtitle 1`] = `
+<div
+  class="mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3"
+  data-test="empty-state"
+>
+  <div
+    class="mb-1 [&>img]:size-35 [&>svg]:size-35"
+    data-test="generic-placeholder-image"
+  >
+    <img
+      alt="Test"
+      src="test.png"
+    />
+  </div>
+  <div
+    class="MuiTypography-root MuiTypography-body whitespace-pre-line css-11vl04s-MuiTypography-root"
+    data-test="generic-placeholder-subtitle"
+  >
+    Text with 
+    <strong>
+      bold
+    </strong>
+     and 
+    <em>
+      italic
+    </em>
+     markup
+  </div>
+</div>
+`;
+
 exports[`GenericPlaceholder Snapshot Tests matches snapshot with ReactNode subtitle 1`] = `
 <div
   class="mx-auto my-0 max-w-124 px-4 pb-4 pt-12 first:mb-3"
@@ -54,7 +85,9 @@ exports[`GenericPlaceholder Snapshot Tests matches snapshot with all props 1`] =
     class="MuiTypography-root MuiTypography-body whitespace-pre-line mb-5 css-11vl04s-MuiTypography-root"
     data-test="generic-placeholder-subtitle"
   >
-    Something went wrong
+    <span>
+      Something went wrong
+    </span>
   </div>
   <button
     class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-qynrhl-MuiButtonBase-root-MuiButton-root"
@@ -85,7 +118,9 @@ exports[`GenericPlaceholder Snapshot Tests matches snapshot with button 1`] = `
     class="MuiTypography-root MuiTypography-body whitespace-pre-line mb-5 css-11vl04s-MuiTypography-root"
     data-test="generic-placeholder-subtitle"
   >
-    Test subtitle
+    <span>
+      Test subtitle
+    </span>
   </div>
   <button
     class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-qynrhl-MuiButtonBase-root-MuiButton-root"
@@ -116,7 +151,9 @@ exports[`GenericPlaceholder Snapshot Tests matches snapshot with minimal props 1
     class="MuiTypography-root MuiTypography-body whitespace-pre-line css-11vl04s-MuiTypography-root"
     data-test="generic-placeholder-subtitle"
   >
-    Test subtitle
+    <span>
+      Test subtitle
+    </span>
   </div>
 </div>
 `;
@@ -139,7 +176,9 @@ exports[`GenericPlaceholder Snapshot Tests matches snapshot with noMargins 1`] =
     class="MuiTypography-root MuiTypography-body whitespace-pre-line css-11vl04s-MuiTypography-root"
     data-test="generic-placeholder-subtitle"
   >
-    Test subtitle
+    <span>
+      Test subtitle
+    </span>
   </div>
 </div>
 `;
@@ -168,7 +207,9 @@ exports[`GenericPlaceholder Snapshot Tests matches snapshot with title 1`] = `
     class="MuiTypography-root MuiTypography-body whitespace-pre-line css-11vl04s-MuiTypography-root"
     data-test="generic-placeholder-subtitle"
   >
-    Test subtitle
+    <span>
+      Test subtitle
+    </span>
   </div>
 </div>
 `;

--- a/src/components/invoices/utils/emptyStateMapping.ts
+++ b/src/components/invoices/utils/emptyStateMapping.ts
@@ -1,0 +1,151 @@
+import { GenericPlaceholderProps } from '~/components/designSystem'
+import {
+  isDraftUrlParams,
+  isOutstandingUrlParams,
+  isPaymentDisputeLostUrlParams,
+  isPaymentOverdueUrlParams,
+  isSucceededUrlParams,
+  isVoidedUrlParams,
+} from '~/components/designSystem/Filters'
+import { INVOICE_LIST_FILTER_PREFIX } from '~/core/constants/filters'
+import { INVOICE_SETTINGS_ROUTE } from '~/core/router'
+import { TranslateFunc } from '~/hooks/core/useInternationalization'
+
+export const URL_PARAMS_TYPE = {
+  succeeded: 'succeeded',
+  draft: 'draft',
+  outstanding: 'outstanding',
+  voided: 'voided',
+  paymentDisputeLost: 'paymentDisputeLost',
+  paymentOverdue: 'paymentOverdue',
+  default: 'default',
+} as const
+
+export type UrlParamsType = (typeof URL_PARAMS_TYPE)[keyof typeof URL_PARAMS_TYPE]
+
+type TranslationConfig = readonly [string, Record<string, string>?]
+
+type TranslationMap = Partial<Record<UrlParamsType, TranslationConfig>> & {
+  default: TranslationConfig
+}
+
+type TranslationKeysType = {
+  withSearchTerm: {
+    titles: TranslationMap
+    subtitle: TranslationConfig
+  }
+  withoutSearchTerm: {
+    titles: TranslationMap
+    subtitle: TranslationMap
+  }
+}
+
+const TRANSLATION_KEYS: TranslationKeysType = {
+  withSearchTerm: {
+    titles: {
+      succeeded: ['text_63c67d2913c20b8d7d05c44c'],
+      draft: ['text_63c67d2913c20b8d7d05c442'],
+      outstanding: ['text_63c67d8796db41749ada51ca'],
+      voided: ['text_65269cd46e7ec037a6823fd8'],
+      default: ['text_63c67d2913c20b8d7d05c43e'],
+    },
+    subtitle: ['text_66ab48ea4ed9cd01084c60b8'],
+  },
+  withoutSearchTerm: {
+    titles: {
+      succeeded: ['text_63b578e959c1366df5d14559'],
+      draft: ['text_63b578e959c1366df5d1455b'],
+      outstanding: ['text_63b578e959c1366df5d1456e'],
+      voided: ['text_65269cd46e7ec037a6823fd6'],
+      paymentDisputeLost: ['text_66141e30699a0631f0b2ec7f'],
+      paymentOverdue: ['text_666c5b12fea4aa1e1b26bf70'],
+      default: ['text_63b578e959c1366df5d14569'],
+    },
+    subtitle: {
+      succeeded: ['text_63b578e959c1366df5d1455f'],
+      draft: ['text_63b578e959c1366df5d14566', { link: INVOICE_SETTINGS_ROUTE }],
+      outstanding: ['text_63b578e959c1366df5d14570'],
+      voided: ['text_65269cd46e7ec037a6823fda'],
+      paymentDisputeLost: ['text_66141e30699a0631f0b2ec87'],
+      paymentOverdue: ['text_666c5b12fea4aa1e1b26bf73', { link: INVOICE_SETTINGS_ROUTE }],
+      default: ['text_63b578e959c1366df5d1456d'],
+    },
+  },
+} as const
+
+/**
+ * Method to determine the URL params type from the URL search params.
+ *
+ * @param searchParams - The URL search params to get the URL params type from.
+ * @returns The URL params type, based on URL_PARAMS_TYPE
+ */
+export const getUrlParamsType = (searchParams: URLSearchParams): UrlParamsType => {
+  if (isSucceededUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX })) {
+    return URL_PARAMS_TYPE.succeeded
+  }
+  if (isDraftUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX })) {
+    return URL_PARAMS_TYPE.draft
+  }
+  if (isOutstandingUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX })) {
+    return URL_PARAMS_TYPE.outstanding
+  }
+  if (isVoidedUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX })) {
+    return URL_PARAMS_TYPE.voided
+  }
+  if (isPaymentDisputeLostUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX })) {
+    return URL_PARAMS_TYPE.paymentDisputeLost
+  }
+  if (isPaymentOverdueUrlParams({ searchParams, prefix: INVOICE_LIST_FILTER_PREFIX })) {
+    return URL_PARAMS_TYPE.paymentOverdue
+  }
+
+  return URL_PARAMS_TYPE.default
+}
+
+/**
+ * Factory function to get empty state configuration based on URL params and search term
+ *
+ * @param urlParams - The URL search params to get the URL params type from.
+ * @param hasSearchTerm - Whether user is searching (affects which empty state to show)
+ * @param translate - Translation function from useInternationalization hook
+ * @returns Partial GenericPlaceholderProps with translated title and subtitle
+ */
+export const getEmptyStateConfig = ({
+  hasSearchTerm,
+  searchParams,
+  translate,
+}: {
+  hasSearchTerm: boolean
+  searchParams: URLSearchParams
+  translate: TranslateFunc
+}): Pick<GenericPlaceholderProps, 'title' | 'subtitle'> => {
+  const urlParamsType = getUrlParamsType(searchParams)
+
+  if (hasSearchTerm) {
+    const titleConfig =
+      TRANSLATION_KEYS.withSearchTerm.titles[urlParamsType] ||
+      TRANSLATION_KEYS.withSearchTerm.titles.default
+    const [titleKey, titleVariables = {}] = titleConfig
+
+    const subtitleConfig = TRANSLATION_KEYS.withSearchTerm.subtitle
+    const [subtitleKey, subtitleVariables = {}] = subtitleConfig
+
+    return {
+      title: translate(titleKey, titleVariables),
+      subtitle: translate(subtitleKey, subtitleVariables),
+    }
+  }
+
+  const [titleKey, titleVariables = {}] =
+    TRANSLATION_KEYS.withoutSearchTerm.titles[urlParamsType] ||
+    TRANSLATION_KEYS.withoutSearchTerm.titles.default
+
+  const [subtitleKey, subtitleVariables = {}] =
+    TRANSLATION_KEYS.withoutSearchTerm.subtitle[urlParamsType] ||
+    TRANSLATION_KEYS.withoutSearchTerm.subtitle.default
+
+  return {
+    title: translate(titleKey, titleVariables),
+    subtitle: translate(subtitleKey, subtitleVariables),
+  }
+}


### PR DESCRIPTION
Fixing some eslint warning we have in the app.

Decided to disable custom classNames warning on the whole file even tho sometimes it's only happening on one line.
Tests files sounds like a normal place to have this to me