### PR TITLE
bug: prevent showing skip rule button if no rule is defined

### DIFF
--- a/cypress/e2e/00-auth/t30-multi-org-redirect.cy.ts
+++ b/cypress/e2e/00-auth/t30-multi-org-redirect.cy.ts
@@ -1,3 +1,8 @@
+import {
+  CREATE_CUSTOMER_DATA_TEST,
+  SUBMIT_CUSTOMER_DATA_TEST,
+} from '~/components/customers/utils/dataTestConstants'
+
 // Note: some login are done manually without using cy.login command
 // to preserve the router state needed for redirect testing
 // otherwise, cy.login breaks the redirection logic as it manually navigate to /login route
@@ -103,10 +108,10 @@ describe('Multi-organization redirect flows', () => {
       cy.contains(testUsers.userA.org1Name).click()
       // 3. Create a customer in Org1
       cy.visit('/customers')
-      cy.get('[data-test="create-customer"]', { timeout: 10000 }).click()
+      cy.get(`[data-test="${CREATE_CUSTOMER_DATA_TEST}"]`, { timeout: 10000 }).click()
       cy.get('input[name="name"]').type('Customer Org1 Multi-Org Test')
       cy.get('input[name="externalId"]').type(`customer-org1-${Date.now()}`)
-      cy.get('[data-test="submit-customer"]').click()
+      cy.get(`[data-test="${SUBMIT_CUSTOMER_DATA_TEST}"]`).click()
       cy.url().should('include', '/customer/')
       // Save the customer URL from Org1
       cy.url().then((org1CustomerUrl) => {
@@ -135,10 +140,10 @@ describe('Multi-organization redirect flows', () => {
       // 2. Navigate to a deep page (e.g., customers/:id)
       // Create a customer to get a deep link
       cy.visit('/customers')
-      cy.get('[data-test="create-customer"]', { timeout: 10000 }).click()
+      cy.get(`[data-test="${CREATE_CUSTOMER_DATA_TEST}"]`, { timeout: 10000 }).click()
       cy.get('input[name="name"]').type('Customer for Org Switch Test')
       cy.get('input[name="externalId"]').type(`customer-org-switch-${Date.now()}`)
-      cy.get('[data-test="submit-customer"]').click()
+      cy.get(`[data-test="${SUBMIT_CUSTOMER_DATA_TEST}"]`).click()
       cy.url().should('include', '/customer/')
 
       const urlToAvoidAfterLogin = cy.url()

--- a/cypress/e2e/10-resources/t20-create-customer.cy.ts
+++ b/cypress/e2e/10-resources/t20-create-customer.cy.ts
@@ -1,3 +1,8 @@
+import {
+  CREATE_CUSTOMER_DATA_TEST,
+  SUBMIT_CUSTOMER_DATA_TEST,
+} from '~/components/customers/utils/dataTestConstants'
+
 import { customerName } from '../../support/reusableConstants'
 
 describe('Create customer', () => {
@@ -6,16 +11,16 @@ describe('Create customer', () => {
   })
 
   it('should create customer', () => {
-    cy.get('[data-test="create-customer"]').click()
+    cy.get(`[data-test="${CREATE_CUSTOMER_DATA_TEST}"]`).click()
     cy.url().should('include', '/customer/create')
 
-    cy.get('[data-test="submit-customer"]').should('be.disabled')
+    cy.get(`[data-test="${SUBMIT_CUSTOMER_DATA_TEST}"]`).should('be.disabled')
 
     cy.get('input[name="externalId"]').type('id-george-de-la-jungle')
 
     cy.get('input[name="name"]').should('exist').type(customerName)
 
-    cy.get('[data-test="submit-customer"]').click()
+    cy.get(`[data-test="${SUBMIT_CUSTOMER_DATA_TEST}"]`).click()
 
     cy.url().should('include', '/customer/')
 
@@ -28,11 +33,11 @@ describe('Create customer', () => {
       const randomNumber = Math.round(Math.random() * 1000)
       const randomId = `Customer ${randomNumber}`
 
-      cy.get('[data-test="create-customer"]').click()
+      cy.get(`[data-test="${CREATE_CUSTOMER_DATA_TEST}"]`).click()
       cy.get('input[name="name"]').type(randomId)
-      cy.get('[data-test="submit-customer"]').should('be.disabled')
+      cy.get(`[data-test="${SUBMIT_CUSTOMER_DATA_TEST}"]`).should('be.disabled')
       cy.get('input[name="externalId"]').type(randomId)
-      cy.get('[data-test="submit-customer"]').click()
+      cy.get(`[data-test="${SUBMIT_CUSTOMER_DATA_TEST}"]`).click()
       cy.url().should('include', '/customer/')
       cy.contains(randomId).should('exist')
 

--- a/cypress/e2e/10-resources/t80-wallet-topup-limits.cy.ts
+++ b/cypress/e2e/10-resources/t80-wallet-topup-limits.cy.ts
@@ -1,0 +1,307 @@
+import {
+  CREATE_CUSTOMER_DATA_TEST,
+  SUBMIT_CUSTOMER_DATA_TEST,
+} from '~/components/customers/utils/dataTestConstants'
+import {
+  ADD_MIN_MAX_AMOUNT_DATA_TEST,
+  ADD_MIN_TOPUP_OPTION_DATA_TEST,
+  CREATE_WALLET_DATA_TEST,
+  IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST,
+  INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST,
+  RECURRING_IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST,
+  RECURRING_INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST,
+  SUBMIT_WALLET_DATA_TEST,
+  WALLET_ACTIONS_DATA_TEST,
+  WALLET_TOPUP_BUTTON_DATA_TEST,
+} from '~/components/wallets/utils/dataTestConstants'
+
+describe('Wallet Top-Up Limits Switch Visibility', () => {
+  const randomId = `wallet-test-${Math.round(Math.random() * 100000)}`
+  const walletName = 'Test Wallet'
+  const customerName = 'Customer wallet top-up limits'
+
+  beforeEach(() => {
+    cy.login()
+  })
+
+  describe('Scenario 1: Wallet Creation WITHOUT min/max limits', () => {
+    it('should NOT show ignorePaidTopUpLimits switch when no limits are set', () => {
+      // Create a customer first
+      cy.visit('/customers')
+      cy.get(`[data-test="${CREATE_CUSTOMER_DATA_TEST}"]`).click()
+      cy.get('input[name="externalId"]').type(`${randomId}-no-limits`)
+      cy.get('input[name="name"]').type(`${customerName} - No Limits`)
+      cy.get(`[data-test="${SUBMIT_CUSTOMER_DATA_TEST}"]`).click()
+      cy.url().should('include', '/customer/')
+
+      // Navigate to create wallet
+      cy.get('button[role="tab"]').contains('Wallet').click()
+      cy.get(`[data-test="${CREATE_WALLET_DATA_TEST}"]`).click()
+      cy.url().should('include', '/customer/')
+      cy.url().should('include', '/wallet/create')
+
+      // Fill wallet form WITHOUT min/max limits
+      cy.get('input[name="name"]').type(`${walletName} No Limits`)
+      cy.get('input[name="rateAmount"]').clear().type('1')
+
+      // Test one-time top-up section
+      cy.get('input[name="paidCredits"]').type('50')
+
+      // Should see invoiceRequiresSuccessfulPayment switch
+      cy.get(`[data-test="${INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}"]`).should(
+        'exist',
+      )
+
+      // Should NOT see ignorePaidTopUpLimits switch
+      cy.get(`[data-test="${IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST}"]`).should('not.exist')
+
+      // Clear the paid credits
+      cy.get('input[name="paidCredits"]').clear()
+
+      // Both switches should disappear
+      cy.get(`[data-test="${INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}"]`).should(
+        'not.exist',
+      )
+    })
+
+    it('should NOT show ignorePaidTopUpLimits switch in recurring rule when no limits are set', () => {
+      // Navigate back to the same form
+      cy.visit('/customers')
+      cy.intercept('POST', '/graphql').as('searchCustomers')
+      cy.get('div[data-test="search-customers"] input').type(`${randomId}-no-limits`)
+      cy.wait('@searchCustomers')
+      cy.get('table tbody tr', { timeout: 10000 }).should('have.length', 1)
+      cy.get('table tbody tr').first().click()
+      cy.get('button[role="tab"]', { timeout: 10000 }).contains('Wallet').click()
+      cy.get(`[data-test="${CREATE_WALLET_DATA_TEST}"]`).click()
+
+      // Fill wallet form WITHOUT min/max limits
+      cy.get('input[name="name"]').type(`${walletName} No Limits Recurring`)
+      cy.get('input[name="rateAmount"]').clear().type('1')
+
+      // Add recurring rule
+      cy.contains('button', 'Add a recurring top-up rule').click()
+
+      // Select Fixed amount method
+      cy.get('input[name="recurringTransactionRules.0.paidCredits"]').type('100')
+
+      // Should see invoiceRequiresSuccessfulPayment switch
+      cy.get(
+        `[data-test="${RECURRING_INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}"]`,
+      ).should('exist')
+
+      // Should NOT see ignorePaidTopUpLimits switch for recurring rule
+      cy.get(`[data-test="${RECURRING_IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST}"]`).should(
+        'not.exist',
+      )
+
+      // Clear the paid credits
+      cy.get('input[name="recurringTransactionRules.0.paidCredits"]').clear()
+
+      // Both switches should disappear
+      cy.get(
+        `[data-test="${RECURRING_INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}"]`,
+      ).should('not.exist')
+    })
+  })
+
+  describe('Scenario 2: Wallet Creation WITH min/max limits', () => {
+    it('should show BOTH switches when limits are set', () => {
+      // Create a customer
+      cy.visit('/customers')
+      cy.get(`[data-test="${CREATE_CUSTOMER_DATA_TEST}"]`).click()
+      cy.get('input[name="externalId"]').type(`${randomId}-with-limits`)
+      cy.get('input[name="name"]').type(`${customerName} - With Limits`)
+      cy.get(`[data-test="${SUBMIT_CUSTOMER_DATA_TEST}"]`).click()
+      cy.url().should('include', '/customer/')
+
+      // Navigate to create wallet
+      cy.get('button[role="tab"]', { timeout: 10000 }).contains('Wallet').click()
+      cy.get(`[data-test="${CREATE_WALLET_DATA_TEST}"]`).click()
+
+      // Fill wallet form WITH min/max limits
+      cy.get('input[name="name"]').type(`${walletName} With Limits`)
+      cy.get('input[name="rateAmount"]').clear().type('1')
+
+      // Set minimum per transaction
+      cy.get(`[data-test="${ADD_MIN_MAX_AMOUNT_DATA_TEST}"]`).click()
+      cy.get(`[data-test="${ADD_MIN_TOPUP_OPTION_DATA_TEST}"]`).click()
+      cy.get('input[name="paidTopUpMinAmountCents"]').type('10')
+
+      // Test one-time top-up section
+      cy.get('input[name="paidCredits"]').type('50')
+
+      // Should see BOTH switches
+      cy.get(`[data-test="${INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}"]`).should(
+        'exist',
+      )
+      cy.get(`[data-test="${IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST}"]`).should('exist')
+
+      // Clear the paid credits
+      cy.get('input[name="paidCredits"]').clear()
+
+      // Both switches should disappear
+      cy.get(`[data-test="${INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}"]`).should(
+        'not.exist',
+      )
+      cy.get(`[data-test="${IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST}"]`).should('not.exist')
+    })
+
+    it('should show BOTH switches in recurring rule when limits are set', () => {
+      // Navigate back to the same form
+      cy.visit('/customers')
+      cy.intercept('POST', '/graphql').as('searchCustomers')
+      cy.get('div[data-test="search-customers"] input').type(`${randomId}-with-limits`)
+      cy.wait('@searchCustomers')
+      // A bit of a hack here, as after the search the table contain 3 items (loading) then only one (the result)
+      cy.get('table tbody tr', { timeout: 10000 }).should('have.length', 1)
+      cy.get('table tbody tr').first().click()
+      cy.get('button[role="tab"]', { timeout: 10000 }).contains('Wallet').click()
+      cy.get(`[data-test="${CREATE_WALLET_DATA_TEST}"]`).click()
+
+      // Fill wallet form WITH min/max limits
+      cy.get('input[name="name"]').type(`${walletName} With Limits Recurring`)
+      cy.get('input[name="rateAmount"]').clear().type('1')
+
+      // Set minimum per transaction
+      cy.get(`[data-test="${ADD_MIN_MAX_AMOUNT_DATA_TEST}"]`).click()
+      cy.get(`[data-test="${ADD_MIN_TOPUP_OPTION_DATA_TEST}"]`).click()
+      cy.get('input[name="paidTopUpMinAmountCents"]').type('10')
+
+      // Add recurring rule
+      cy.contains('button', 'Add a recurring top-up rule').click()
+
+      // Select Fixed amount method and enter paid credits
+      cy.get('input[name="recurringTransactionRules.0.paidCredits"]').type('100')
+
+      // Should see BOTH switches
+      cy.get(
+        `[data-test="${RECURRING_INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}"]`,
+      ).should('exist')
+      cy.get(`[data-test="${RECURRING_IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST}"]`).should('exist')
+
+      // Clear the paid credits
+      cy.get('input[name="recurringTransactionRules.0.paidCredits"]').clear()
+
+      // Both switches should disappear
+      cy.get(
+        `[data-test="${RECURRING_INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}"]`,
+      ).should('not.exist')
+      cy.get(`[data-test="${RECURRING_IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST}"]`).should(
+        'not.exist',
+      )
+    })
+  })
+
+  describe('Scenario 3: Top-Up Form for Wallet WITHOUT min/max limits', () => {
+    it('should NOT show ignorePaidTopUpLimits switch in top-up form', () => {
+      let customerId: string
+
+      // Create customer and wallet WITHOUT limits
+      cy.visit('/customers')
+      cy.get(`[data-test="${CREATE_CUSTOMER_DATA_TEST}"]`).click()
+      cy.get('input[name="externalId"]').type(`${randomId}-topup-no-limits`)
+      cy.get('input[name="name"]').type(`${customerName} - TopUp No Limits`)
+      cy.get(`[data-test="${SUBMIT_CUSTOMER_DATA_TEST}"]`).click()
+
+      // Save customer ID from URL
+      cy.url().then((url) => {
+        customerId = url.split('/customer/')[1].split('/')[0]
+      })
+
+      // Create wallet WITHOUT limits
+      cy.get('button[role="tab"]', { timeout: 10000 }).contains('Wallet').click()
+      cy.get(`[data-test="${CREATE_WALLET_DATA_TEST}"]`).click()
+      cy.get('input[name="name"]').type(`${walletName} For TopUp No Limits`)
+      cy.get('input[name="rateAmount"]').clear().type('1')
+      cy.get(`[data-test="${SUBMIT_WALLET_DATA_TEST}"]`).click()
+
+      // make sure we're on the correct page
+      cy.url().should('include', '/wallet/')
+
+      // Click on the wallet actions button
+      cy.get(`[data-test="${WALLET_ACTIONS_DATA_TEST}"]`, { timeout: 10000 }).click()
+
+      // Click top-up button
+      cy.get(`[data-test="${WALLET_TOPUP_BUTTON_DATA_TEST}"]`).click()
+      cy.url().should('include', '/wallet/')
+      cy.url().should('include', '/top-up')
+
+      // Enter credits to purchase
+      cy.get('input[name="paidCredits"]').type('50')
+
+      // Should see invoiceRequiresSuccessfulPayment switch
+      cy.get(`[data-test="${INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}"]`).should(
+        'exist',
+      )
+
+      // Should NOT see ignorePaidTopUpLimits switch
+      cy.get(`[data-test="${IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST}"]`).should('not.exist')
+
+      // Clear the paid credits
+      cy.get('input[name="paidCredits"]').clear()
+
+      // Switch should disappear
+      cy.get(`[data-test="${INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}"]`).should(
+        'not.exist',
+      )
+    })
+  })
+
+  describe('Scenario 4: Top-Up Form for Wallet WITH min/max limits', () => {
+    it('should show BOTH switches in top-up form', () => {
+      let customerId: string
+      // Create customer and wallet WITH limits
+      cy.visit('/customers')
+      cy.get(`[data-test="${CREATE_CUSTOMER_DATA_TEST}"]`).click()
+      cy.get('input[name="externalId"]').type(`${randomId}-topup-with-limits`)
+      cy.get('input[name="name"]').type(`${customerName} - TopUp With Limits`)
+      cy.get(`[data-test="${SUBMIT_CUSTOMER_DATA_TEST}"]`).click()
+
+      // Save customer ID from URL
+      cy.url().then((url) => {
+        customerId = url.split('/customer/')[1].split('/')[0]
+      })
+
+      // Create wallet WITH limits
+      cy.get('button[role="tab"]', { timeout: 10000 }).contains('Wallet').click()
+      cy.get(`[data-test="${CREATE_WALLET_DATA_TEST}"]`).click()
+      cy.get('input[name="name"]').type(`${walletName} For TopUp With Limits`)
+      cy.get('input[name="rateAmount"]').clear().type('1')
+      cy.get(`[data-test="${ADD_MIN_MAX_AMOUNT_DATA_TEST}"]`).click()
+      cy.get(`[data-test="${ADD_MIN_TOPUP_OPTION_DATA_TEST}"]`).click()
+      cy.get('input[name="paidTopUpMinAmountCents"]').type('10')
+      cy.get(`[data-test="${SUBMIT_WALLET_DATA_TEST}"]`).click()
+
+      // make sure we're on the correct page
+      cy.url().should('include', '/wallet/')
+
+      // Click on the wallet actions button
+      cy.get(`[data-test="${WALLET_ACTIONS_DATA_TEST}"]`, { timeout: 10000 }).click()
+
+      // Click top-up button
+      cy.get(`[data-test="${WALLET_TOPUP_BUTTON_DATA_TEST}"]`).should('be.visible')
+      cy.get(`[data-test="${WALLET_TOPUP_BUTTON_DATA_TEST}"]`, { timeout: 10000 }).click()
+      cy.url().should('include', '/wallet/')
+      cy.url().should('include', '/top-up')
+
+      // Enter credits to purchase
+      cy.get('input[name="paidCredits"]').type('50')
+
+      // Should see BOTH switches
+      cy.get(`[data-test="${INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}"]`).should(
+        'exist',
+      )
+      cy.get(`[data-test="${IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST}"]`).should('exist')
+
+      // Clear the paid credits
+      cy.get('input[name="paidCredits"]').clear()
+
+      // Both switches should disappear
+      cy.get(`[data-test="${INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}"]`).should(
+        'not.exist',
+      )
+      cy.get(`[data-test="${IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST}"]`).should('not.exist')
+    })
+  })
+})

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "noEmit": true,
     "sourceMap": false,
-    "types": ["cypress"]
+    "types": ["cypress"],
+    "baseUrl": "../src",
+    "paths": {
+      "~/*": ["*"]
+    }
   },
   "exclude": ["node_modules"]
 }

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -11,13 +11,21 @@ interface SearchInputProps {
   onChange: ReturnType<UseDebouncedSearch>['debouncedSearch']
   placeholder?: string
   disabled?: boolean
+  'data-test'?: string
 }
 
-export const SearchInput = ({ className, onChange, placeholder, disabled }: SearchInputProps) => {
+export const SearchInput = ({
+  className,
+  onChange,
+  placeholder,
+  disabled,
+  ...props
+}: SearchInputProps) => {
   const [localValue, setLocalValue] = useState<string>('')
 
   return (
     <TextInput
+      cleanable
       className={tw('max-w-60 [&_input]:h-10 [&_input]:!pl-3', className)}
       placeholder={placeholder}
       value={localValue}
@@ -29,7 +37,7 @@ export const SearchInput = ({ className, onChange, placeholder, disabled }: Sear
       InputProps={{
         startAdornment: <Icon className="ml-4" name="magnifying-glass" />,
       }}
-      cleanable
+      {...props}
     />
   )
 }

--- a/src/components/customers/utils/dataTestConstants.ts
+++ b/src/components/customers/utils/dataTestConstants.ts
@@ -1,0 +1,7 @@
+// Data test constants for customer components and e2e tests
+
+// CustomersList
+export const CREATE_CUSTOMER_DATA_TEST = 'create-customer'
+
+// CreateCustomer
+export const SUBMIT_CUSTOMER_DATA_TEST = 'submit-customer'

--- a/src/components/designSystem/NavigationTab.tsx
+++ b/src/components/designSystem/NavigationTab.tsx
@@ -25,6 +25,7 @@ type NavigationTabProps = {
     disabled?: boolean
     hidden?: boolean
     component?: ReactNode
+    dataTest?: string
   }[]
   children?: ReactNode
   onChange?: (index: number) => void
@@ -153,6 +154,7 @@ export const NavigationTab = ({
                     disableFocusRipple
                     disableRipple
                     role="tab"
+                    component="button"
                     className="relative my-2 h-9 justify-between gap-1 overflow-visible rounded-xl p-2 text-grey-600 no-underline [min-height:unset] [min-width:unset] first:-ml-2 last:-mr-2 hover:bg-grey-100 hover:text-grey-700"
                     disabled={loading || tab.disabled}
                     icon={!!tab.icon ? <Icon name={tab.icon} /> : undefined}
@@ -176,6 +178,7 @@ export const NavigationTab = ({
                       onClickActionLookup[managedBy]()
                     }}
                     {...a11yProps(tabIndex)}
+                    data-test={tab.dataTest || undefined}
                   />
                 )
               })

--- a/src/components/form/Switch/Switch.tsx
+++ b/src/components/form/Switch/Switch.tsx
@@ -21,6 +21,7 @@ export interface SwitchProps {
   labelPosition?: LabelPosition
   onChange?: (value: boolean, e: MouseEvent<HTMLDivElement>) => Promise<unknown> | void
   className?: string
+  'data-test'?: string
 }
 
 const switchVariants = cva(
@@ -75,6 +76,7 @@ export const Switch = ({
   labelPosition = LabelPositionEnum.right,
   onChange,
   className,
+  'data-test': dataTest,
   ...props
 }: SwitchProps) => {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -102,6 +104,7 @@ export const Switch = ({
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events
     <div
+      data-test={dataTest}
       className={tw(
         'h-[initial] p-0',
         'flex items-center',

--- a/src/components/wallets/CustomerWalletList.tsx
+++ b/src/components/wallets/CustomerWalletList.tsx
@@ -11,6 +11,7 @@ import {
 } from '~/components/designSystem'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { CREATE_WALLET_DATA_TEST } from '~/components/wallets/utils/dataTestConstants'
 import { WalletAccordion, WalletAccordionSkeleton } from '~/components/wallets/WalletAccordion'
 import { CREATE_WALLET_ROUTE } from '~/core/router'
 import {
@@ -110,6 +111,7 @@ export const CustomerWalletsList = ({ customerId, customerTimezone }: CustomerWa
                       }),
                     )
                   }
+                  data-test={CREATE_WALLET_DATA_TEST}
                 >
                   {translate('text_62d175066d2dbf1d50bc9382')}
                 </Button>

--- a/src/components/wallets/WalletAccordion.tsx
+++ b/src/components/wallets/WalletAccordion.tsx
@@ -24,6 +24,10 @@ import {
   TerminateCustomerWalletDialog,
   TerminateCustomerWalletDialogRef,
 } from '~/components/wallets/TerminateCustomerWalletDialog'
+import {
+  WALLET_ACTIONS_DATA_TEST,
+  WALLET_TOPUP_BUTTON_DATA_TEST,
+} from '~/components/wallets/utils/dataTestConstants'
 import { VoidWalletDialog, VoidWalletDialogRef } from '~/components/wallets/VoidWalletDialog'
 import { WalletTransactionList } from '~/components/wallets/WalletTransactionList'
 import { WalletTransactionListItem } from '~/components/wallets/WalletTransactionListItem'
@@ -208,6 +212,7 @@ export const WalletAccordion: FC<WalletAccordionProps> = ({
                           e.stopPropagation()
                           onClick()
                         }}
+                        data-test={WALLET_ACTIONS_DATA_TEST}
                       />
                     </Tooltip>
                   )}
@@ -229,6 +234,7 @@ export const WalletAccordion: FC<WalletAccordionProps> = ({
                           )
                           closePopper()
                         }}
+                        data-test={WALLET_TOPUP_BUTTON_DATA_TEST}
                       >
                         {translate('text_1741253143637fb7iatyka9w')}
                       </Button>

--- a/src/components/wallets/WalletTransactionListItem/ListItem.tsx
+++ b/src/components/wallets/WalletTransactionListItem/ListItem.tsx
@@ -10,6 +10,11 @@ import {
   Typography,
   TypographyColor,
 } from '~/components/designSystem'
+import {
+  TRANSACTION_AMOUNT_DATA_TEST,
+  TRANSACTION_CREDITS_DATA_TEST,
+  TRANSACTION_LABEL_DATA_TEST,
+} from '~/components/wallets/utils/dataTestConstants'
 import { addToast } from '~/core/apolloClient'
 import { intlFormatDateTime } from '~/core/timezone'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
@@ -100,7 +105,7 @@ export const ListItem: FC<ListItemProps> = ({
               noWrap
               variant="bodyHl"
               color={isPending || isFailed ? 'grey500' : labelColor}
-              data-test="transaction-label"
+              data-test={TRANSACTION_LABEL_DATA_TEST}
             >
               {label}
             </Typography>
@@ -117,12 +122,17 @@ export const ListItem: FC<ListItemProps> = ({
               variant="bodyHl"
               color={isPending || isFailed ? 'grey500' : creditsColor}
               blur={isBlurry}
-              data-test="credits"
+              data-test={TRANSACTION_CREDITS_DATA_TEST}
               className={tw(isFailed && 'line-through')}
             >
               {credits}
             </Typography>
-            <Typography variant="caption" color="grey600" blur={isBlurry} data-test="amount">
+            <Typography
+              variant="caption"
+              color="grey600"
+              blur={isBlurry}
+              data-test={TRANSACTION_AMOUNT_DATA_TEST}
+            >
               {amount}
             </Typography>
           </div>

--- a/src/components/wallets/utils/dataTestConstants.ts
+++ b/src/components/wallets/utils/dataTestConstants.ts
@@ -1,0 +1,38 @@
+// Data test constants for wallet components and e2e tests
+
+// CustomerWalletList
+export const CREATE_WALLET_DATA_TEST = 'create-wallet'
+
+// WalletAccordion
+export const WALLET_ACTIONS_DATA_TEST = 'wallet-actions'
+export const WALLET_TOPUP_BUTTON_DATA_TEST = 'wallet-topup-button'
+
+// WalletTransactionListItem
+export const TRANSACTION_LABEL_DATA_TEST = 'transaction-label'
+export const TRANSACTION_CREDITS_DATA_TEST = 'credits'
+export const TRANSACTION_AMOUNT_DATA_TEST = 'amount'
+
+// CreateWallet & CreateWalletTopUp - Common
+export const SUBMIT_WALLET_DATA_TEST = 'submit-wallet'
+export const CLOSE_CREATE_WALLET_BUTTON_DATA_TEST = 'close-create-wallet-button'
+export const CLOSE_CREATE_TOPUP_BUTTON_DATA_TEST = 'close-create-topup-button'
+export const ADD_METADATA_DATA_TEST = 'add-metadata'
+
+// TopUpSection & CreateWalletTopUp - Top-up settings
+export const IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST = 'ignore-paid-topup-limits-switch'
+export const INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST =
+  'invoice-requires-successful-payment-switch'
+export const RECURRING_IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST =
+  'recurring-ignore-paid-topup-limits-switch'
+export const RECURRING_INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST =
+  'recurring-invoice-requires-successful-payment-switch'
+export const SHOW_RECURRING_EXPIRATION_AT_DATA_TEST = 'show-recurring-expiration-at'
+
+// SettingsSection
+export const SHOW_EXPIRATION_AT_DATA_TEST = 'show-expiration-at'
+export const ADD_MIN_MAX_AMOUNT_DATA_TEST = 'add-min-max-amount'
+export const ADD_MIN_TOPUP_OPTION_DATA_TEST = 'add-min-topup-option'
+export const ADD_MAX_TOPUP_OPTION_DATA_TEST = 'add-max-topup-option'
+
+// ScopeSection
+export const SHOW_LIMIT_INPUT_DATA_TEST = 'show-limit-input'

--- a/src/pages/CreateCustomer.tsx
+++ b/src/pages/CreateCustomer.tsx
@@ -11,6 +11,7 @@ import {
   LocalCustomerMetadata,
   MetadataAccordion,
 } from '~/components/customers/createCustomer/MetadataAccordion'
+import { SUBMIT_CUSTOMER_DATA_TEST } from '~/components/customers/utils/dataTestConstants'
 import {
   Button,
   DrawerRef,
@@ -368,7 +369,7 @@ const CreateCustomer = () => {
           loading={formikProps.isSubmitting}
           disabled={!formikProps.isValid || !formikProps.dirty}
           onClick={formikProps.submitForm}
-          data-test="submit-customer"
+          data-test={SUBMIT_CUSTOMER_DATA_TEST}
         >
           {isEdition
             ? translate('text_17295436903260tlyb1gp1i7')

--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -406,6 +406,7 @@ const CustomerDetails = () => {
                           customerTimezone={safeTimezone}
                         />
                       ),
+                      dataTest: 'wallet-tab',
                     },
                     {
                       title: translate('text_6553885df387fd0097fd7384'),

--- a/src/pages/CustomersList.tsx
+++ b/src/pages/CustomersList.tsx
@@ -7,6 +7,7 @@ import {
   DeleteCustomerDialogRef,
 } from '~/components/customers/DeleteCustomerDialog'
 import { computeCustomerInitials } from '~/components/customers/utils'
+import { CREATE_CUSTOMER_DATA_TEST } from '~/components/customers/utils/dataTestConstants'
 import { Avatar, Button, InfiniteScroll, Table, Typography } from '~/components/designSystem'
 import {
   AvailableFiltersEnum,
@@ -142,9 +143,13 @@ const CustomersList = () => {
           <SearchInput
             onChange={debouncedSearch}
             placeholder={translate('text_63befc65efcd9374da45b801')}
+            data-test="search-customers"
           />
           {hasPermissions(['customersCreate']) && (
-            <Button data-test="create-customer" onClick={() => navigate(CREATE_CUSTOMER_ROUTE)}>
+            <Button
+              data-test={CREATE_CUSTOMER_DATA_TEST}
+              onClick={() => navigate(CREATE_CUSTOMER_ROUTE)}
+            >
               {translate('text_1734452833961s338w0x3b4s')}
             </Button>
           )}

--- a/src/pages/wallet/CreateWallet.tsx
+++ b/src/pages/wallet/CreateWallet.tsx
@@ -7,6 +7,10 @@ import { generatePath, useNavigate, useParams } from 'react-router-dom'
 import { Button, Typography, WarningDialog, WarningDialogRef } from '~/components/designSystem'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import {
+  CLOSE_CREATE_WALLET_BUTTON_DATA_TEST,
+  SUBMIT_WALLET_DATA_TEST,
+} from '~/components/wallets/utils/dataTestConstants'
 import { addToast } from '~/core/apolloClient'
 import { FORM_TYPE_ENUM } from '~/core/constants/form'
 import { CustomerDetailsTabsOptions } from '~/core/constants/tabsOptions'
@@ -406,7 +410,7 @@ const CreateWallet = () => {
             variant="quaternary"
             icon="close"
             onClick={onAbort}
-            data-test="close-create-wallet-button"
+            data-test={CLOSE_CREATE_WALLET_BUTTON_DATA_TEST}
           />
         </CenteredPage.Header>
 
@@ -461,7 +465,7 @@ const CreateWallet = () => {
             variant="primary"
             disabled={!formikProps.isValid}
             onClick={formikProps.submitForm}
-            data-test="submit-wallet"
+            data-test={SUBMIT_WALLET_DATA_TEST}
           >
             {translate(
               formType === FORM_TYPE_ENUM.edition

--- a/src/pages/wallet/CreateWalletTopUp.tsx
+++ b/src/pages/wallet/CreateWalletTopUp.tsx
@@ -16,6 +16,13 @@ import {
 } from '~/components/designSystem'
 import { AmountInputField, SwitchField, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
+import {
+  ADD_METADATA_DATA_TEST,
+  CLOSE_CREATE_TOPUP_BUTTON_DATA_TEST,
+  IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST,
+  INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST,
+  SUBMIT_WALLET_DATA_TEST,
+} from '~/components/wallets/utils/dataTestConstants'
 import { addToast } from '~/core/apolloClient'
 import { CustomerDetailsTabsOptions } from '~/core/constants/tabsOptions'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -271,7 +278,7 @@ const CreateWalletTopUp = () => {
             variant="quaternary"
             icon="close"
             onClick={onAbort}
-            data-test="close-create-topup-button"
+            data-test={CLOSE_CREATE_TOPUP_BUTTON_DATA_TEST}
           />
         </CenteredPage.Header>
 
@@ -395,6 +402,7 @@ const CreateWalletTopUp = () => {
                       name={'ignorePaidTopUpLimits'}
                       formikProps={formikProps}
                       label={translate('text_17587075291282to3nmogezj')}
+                      data-test={IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST}
                     />
                   )}
 
@@ -403,6 +411,7 @@ const CreateWalletTopUp = () => {
                     formikProps={formikProps}
                     label={translate('text_66a8aed1c3e07b277ec3990d')}
                     subLabel={translate('text_66a8aed1c3e07b277ec3990f')}
+                    data-test={INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}
                   />
                 </>
               )}
@@ -554,7 +563,7 @@ const CreateWalletTopUp = () => {
                         { key: '', value: '' },
                       ])
                     }
-                    data-test="add-metadata"
+                    data-test={ADD_METADATA_DATA_TEST}
                   >
                     {translate('text_63fcc3218d35b9377840f5bb')}
                   </Button>
@@ -573,7 +582,7 @@ const CreateWalletTopUp = () => {
             variant="primary"
             disabled={!formikProps.isValid || !formikProps.dirty}
             onClick={formikProps.submitForm}
-            data-test="submit-wallet"
+            data-test={SUBMIT_WALLET_DATA_TEST}
           >
             {translate('text_1741103892833yi7redcuhoc')}
           </Button>

--- a/src/pages/wallet/components/ScopeSection.tsx
+++ b/src/pages/wallet/components/ScopeSection.tsx
@@ -4,6 +4,7 @@ import { FC, useEffect, useMemo, useState } from 'react'
 
 import { Alert, Button, Chip, Tooltip, Typography } from '~/components/designSystem'
 import { ComboBox, ComboboxItem } from '~/components/form'
+import { SHOW_LIMIT_INPUT_DATA_TEST } from '~/components/wallets/utils/dataTestConstants'
 import {
   MUI_INPUT_BASE_ROOT_CLASSNAME,
   SEARCH_APPLIES_TO_BILLABLE_METRIC_CLASSNAME,
@@ -220,7 +221,7 @@ export const ScopeSection: FC<ScopeSectionProps> = ({ formikProps }) => {
                 selector: `.${SEARCH_APPLIES_TO_FEE_TYPE_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
               })
             }}
-            data-test="show-limit-input"
+            data-test={SHOW_LIMIT_INPUT_DATA_TEST}
           >
             {translate('text_1748442650797pz30j2eeiv4')}
           </Button>

--- a/src/pages/wallet/components/SettingsSection.tsx
+++ b/src/pages/wallet/components/SettingsSection.tsx
@@ -11,6 +11,12 @@ import {
   TextInput,
   TextInputField,
 } from '~/components/form'
+import {
+  ADD_MAX_TOPUP_OPTION_DATA_TEST,
+  ADD_MIN_MAX_AMOUNT_DATA_TEST,
+  ADD_MIN_TOPUP_OPTION_DATA_TEST,
+  SHOW_EXPIRATION_AT_DATA_TEST,
+} from '~/components/wallets/utils/dataTestConstants'
 import { dateErrorCodes, FORM_TYPE_ENUM } from '~/core/constants/form'
 import { getCurrencySymbol } from '~/core/formats/intlFormatNumber'
 import { CurrencyEnum, GetCustomerInfosForWalletFormQuery } from '~/generated/graphql'
@@ -161,7 +167,7 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
             startIcon="plus"
             variant="inline"
             onClick={() => setShowExpirationDate(true)}
-            data-test="show-expiration-at"
+            data-test={SHOW_EXPIRATION_AT_DATA_TEST}
           >
             {translate('text_6560809c38fb9de88d8a517e')}
           </Button>
@@ -255,7 +261,7 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
               startIcon="plus"
               endIcon="chevron-down-filled"
               variant="inline"
-              data-test="add-min-max-amount"
+              data-test={ADD_MIN_MAX_AMOUNT_DATA_TEST}
               disabled={showMinTopUp && showMaxTopUp}
             >
               {translate('text_17582856866461p9g3nsnrgc')}
@@ -273,6 +279,7 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
                     closePopper()
                   }}
                   disabled={showMinTopUp}
+                  data-test={ADD_MIN_TOPUP_OPTION_DATA_TEST}
                 >
                   {translate('text_1758285847805xn6hdyurz3e')}
                 </Button>
@@ -283,6 +290,7 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
                     closePopper()
                   }}
                   disabled={showMaxTopUp}
+                  data-test={ADD_MAX_TOPUP_OPTION_DATA_TEST}
                 >
                   {translate('text_1758285847805k1uohu4vrov')}
                 </Button>

--- a/src/pages/wallet/components/TopUpSection.tsx
+++ b/src/pages/wallet/components/TopUpSection.tsx
@@ -17,6 +17,14 @@ import {
 } from '~/components/form'
 import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { getWordingForWalletCreationAlert } from '~/components/wallets/utils'
+import {
+  ADD_METADATA_DATA_TEST,
+  IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST,
+  INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST,
+  RECURRING_IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST,
+  RECURRING_INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST,
+  SHOW_RECURRING_EXPIRATION_AT_DATA_TEST,
+} from '~/components/wallets/utils/dataTestConstants'
 import { dateErrorCodes, FORM_TYPE_ENUM, getIntervalTranslationKey } from '~/core/constants/form'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { intlFormatDateTime } from '~/core/timezone'
@@ -190,6 +198,7 @@ export const TopUpSection: FC<TopUpSectionProps> = ({
                     name={'ignorePaidTopUpLimitsOnCreation'}
                     formikProps={formikProps}
                     label={translate('text_17587075291282to3nmogezj')}
+                    data-test={IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST}
                   />
                 )}
 
@@ -198,6 +207,7 @@ export const TopUpSection: FC<TopUpSectionProps> = ({
                   formikProps={formikProps}
                   label={translate('text_66a8aed1c3e07b277ec3990d')}
                   subLabel={translate('text_66a8aed1c3e07b277ec3990f')}
+                  data-test={INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}
                 />
               </>
             )}
@@ -348,6 +358,7 @@ export const TopUpSection: FC<TopUpSectionProps> = ({
                           }
                           label={translate('text_1758285686646ty4gyil56oi')}
                           subLabel={translate('text_1758285686647hxpjldry342')}
+                          data-test={RECURRING_IGNORE_PAID_TOPUP_LIMITS_SWITCH_DATA_TEST}
                         />
                       )}
 
@@ -366,6 +377,7 @@ export const TopUpSection: FC<TopUpSectionProps> = ({
                         }
                         label={translate('text_66a8aed1c3e07b277ec3990d')}
                         subLabel={translate('text_66a8aed1c3e07b277ec3990f')}
+                        data-test={RECURRING_INVOICE_REQUIRES_SUCCESSFUL_PAYMENT_SWITCH_DATA_TEST}
                       />
                     </>
                   )}
@@ -590,7 +602,7 @@ export const TopUpSection: FC<TopUpSectionProps> = ({
                   onClick={() =>
                     formikProps.setFieldValue('recurringTransactionRules.0.expirationAt', '')
                   }
-                  data-test="show-recurring-expiration-at"
+                  data-test={SHOW_RECURRING_EXPIRATION_AT_DATA_TEST}
                 >
                   {translate('text_6560809c38fb9de88d8a517e')}
                 </Button>
@@ -710,7 +722,7 @@ export const TopUpSection: FC<TopUpSectionProps> = ({
                     metadatas,
                   )
                 }}
-                data-test="add-metadata"
+                data-test={ADD_METADATA_DATA_TEST}
               >
                 {translate('text_63fcc3218d35b9377840f5bb')}
               </Button>


### PR DESCRIPTION
## Context

When setting top-up min or max limits, you can choose to bypass the rules.

In the UI, it shows a ON/OFF switch to enable or not this rule.

However it's visible in some cases that does not makes sense

## Description

This PR ensure the bypass switch is only visible if a min or max rule have been defined.

It's currently flaky as it does not check for all possible values, such as empty string (when you enter a min/max value then reset the input)

<!-- Linear link -->
Fixes ISSUE-1312