### PR TITLE
fix(gha): Uses github runner for amd64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         platform:
           - version: linux/amd64
-            runner: linux/amd64
+            runner: ubuntu-latest
           - version: linux/arm64
             runner: linux-arm64
     name: Build ${{ matrix.platform.version }} Image


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch amd64 image build to run on `ubuntu-latest` in `.github/workflows/release.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01613ac75b39138336b1660c2f1d90d7858e433a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->