### PR TITLE
fix(gha): Uses github runner merge build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
 
   merge:
     name: Merge Images
-    runs-on: lago-runner
+    runs-on: ubuntu-latest
     needs: [build-images]
     steps:
       - name: Download Digests


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the `merge` job in `.github/workflows/release.yml` to run on `ubuntu-latest` instead of a custom runner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aae089931f982dac7c5c65cd776fcbeda61d8c00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->