### PR TITLE
chore: silent noisy sentry about signal abord

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -43,6 +43,11 @@ if (!!sentryDsn && appEnv !== AppEnvEnum.development) {
       // Generic script errors from extensions
       /^Script error\.?$/i,
       /^Javascript error: Script error\.? on line 0$/i,
+      // Apollo Client abort errors (user navigating away, component unmounting, etc.)
+      // Matches "signal aborted", "AbortError: signal aborted", etc.
+      /signal aborted/i,
+      // Also catch generic AbortError messages
+      'AbortError',
     ],
     // Deny URLs from browser extensions and other noise
     denyUrls: [


### PR DESCRIPTION
Those are noisy and should not be reported.

Happen when the user navigate while a query is in flight or component tis unmounted before receiving the result