### PR TITLE
build(sentry): Different approach to upload sourcemaps onto Sentry

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -74,11 +74,20 @@ export default defineConfig(({ mode }) => {
         authToken: sentryAuthToken,
         release: {
           name: appVersion,
+          // Use release-based source map instead of Debug IDs
+          // This is needed because Debug ID injection is not working correctly
+          // with this build setup. The legacy method matches source maps by
+          // release name + file path instead of Debug IDs.
+          // Docs: https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/vite/
+          uploadLegacySourcemaps: {
+            paths: ['./dist'],
+            urlPrefix: '~/',
+          },
         },
-        // Upload source maps
         sourcemaps: {
-          assets: './dist/**',
+          disable: true,
         },
+        debug: true,
         telemetry: false,
       }),
     )


### PR DESCRIPTION
## Context

Sourcemaps do not seem to be captured properly by Sentry and therefore we are trying a different approach