### PR TITLE
misc: increase wallet limit to 6

### DIFF
--- a/src/components/wallets/CustomerWalletList.tsx
+++ b/src/components/wallets/CustomerWalletList.tsx
@@ -25,7 +25,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { usePermissions } from '~/hooks/usePermissions'
 import ErrorImage from '~/public/images/maneki/error.svg'
 
-const ACTIVE_WALLET_COUNT_LIMIT = 5
+const ACTIVE_WALLET_COUNT_LIMIT = 6
 
 gql`
   fragment CustomerWallet on Wallet {


### PR DESCRIPTION
## Context

We have a fixed limit for the number of wallets you can create

## Description

This PR increases the limit to be 6 active wallets