### PR TITLE
fix(ui): improve sparkles icon alignment in dunning campaigns premium banner

### DIFF
--- a/src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx
+++ b/src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx
@@ -125,13 +125,12 @@ const BillingEntityDunningCampaigns = () => {
                 {!hasAccessToFeature && (
                   <div className="flex items-center justify-between gap-4 rounded-lg bg-grey-100 px-6 py-4">
                     <div>
-                      <Typography
-                        className="flex items-center gap-2"
-                        variant="bodyHl"
-                        color="textSecondary"
-                      >
-                        {translate('text_1729263759370k8po52j4m2n')} <Icon name="sparkles" />
-                      </Typography>
+                      <div className="flex items-center gap-1">
+                        <Typography variant="bodyHl" color="textSecondary">
+                          {translate('text_1729263759370k8po52j4m2n')}
+                        </Typography>
+                        <Icon name="sparkles" />
+                      </div>
                       <Typography variant="caption">
                         {translate('text_1729263759370rhgayszv6yq')}
                       </Typography>


### PR DESCRIPTION
## 🎨 Fix: Improve sparkles icon alignment in Dunning Campaigns premium banner

### Description

Fixed the alignment of the sparkles icon in the Billing Entity Dunning Campaigns premium feature banner. The icon is now properly aligned next to the text using a flex container wrapper, consistent with other similar UI patterns in the codebase.

### Changes

- Wrapped Typography and Icon in a flex container with `gap-1` spacing
- Removed the flex class from Typography component that was causing layout issues
- Icon now sits cleanly beside the "Unlock Dunning campaigns" text

### Before & After

| Before | After |
|--------|-------|
| <img width="2234" height="1050" alt="Before" src="https://github.com/user-attachments/assets/eebba9be-8518-4f53-8bdd-a25bad8f3b88" /> | <img width="1674" height="922" alt="After" src="https://github.com/user-attachments/assets/d0f082c9-8f0d-4ec5-83a4-09dfcaa7c9b0" /> |


### Related Files

- `src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx`

### Type of Change

- [x] 🎨 UI - UI / design related changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **UI alignment fix for premium banner**
> 
> - In `BillingEntityDunningCampaigns.tsx`, wraps the label and `sparkles` `Icon` in a `div` with `flex` and `gap-1`, moving `Icon` out of `Typography` and removing flex classes from `Typography` to correct alignment.
> - Purely presentational change; no logic or data flow modifications.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af5a71c3cf9b607dadceb348b653fe1d066363f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->