### PR TITLE
bug: remove wrong condition on field 

### DIFF
--- a/src/pages/createCustomers/customerInformation/CustomerInformation.tsx
+++ b/src/pages/createCustomers/customerInformation/CustomerInformation.tsx
@@ -103,7 +103,6 @@ const CustomerInformation = withForm({
             <field.ComboBoxField
               label={translate('text_1726128938631ioz4orixel3')}
               placeholder={translate('text_17261289386318j0nhr1ms3t')}
-              disabled={isEdition && !customer?.canEditAttributes}
               PopperProps={{ displayInDialog: true }}
               data={customerTypeData}
             />

--- a/src/pages/createCustomers/customerInformation/__tests__/__snapshots__/CustomerInformation.test.tsx.snap
+++ b/src/pages/createCustomers/customerInformation/__tests__/__snapshots__/CustomerInformation.test.tsx.snap
@@ -1341,7 +1341,7 @@ exports[`CustomerInformation Integration Tests WHEN rendering the component THEN
           class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
         >
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd css-gt5rc1-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd css-gt5rc1-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-autocomplete="list"
@@ -1349,8 +1349,7 @@ exports[`CustomerInformation Integration Tests WHEN rendering the component THEN
               aria-invalid="false"
               autocapitalize="none"
               autocomplete="off"
-              class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled MuiInputBase-inputAdornedEnd css-1u6ndc-MuiInputBase-input-MuiOutlinedInput-input"
-              disabled=""
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd css-1u6ndc-MuiInputBase-input-MuiOutlinedInput-input"
               id=":rv:"
               name="customerType"
               placeholder="Search or select a customer type"
@@ -1363,10 +1362,9 @@ exports[`CustomerInformation Integration Tests WHEN rendering the component THEN
               class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
             >
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center MuiAutocomplete-clearIndicator hidden css-1w4ajx2-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center MuiAutocomplete-clearIndicator hidden css-1w4ajx2-MuiButtonBase-root-MuiButton-root"
                 data-test="button"
-                disabled=""
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 <svg


### PR DESCRIPTION
This should be editable all the time

BE does not check for this condition on this attribute


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the `customerType` combobox always editable by removing the `disabled={isEdition && !customer?.canEditAttributes}` condition.
> 
> - Enables interaction (input no longer has disabled classes; clear indicator button regains focusability)
> - Updates Jest snapshots in `CustomerInformation.test.tsx.snap` to reflect enabled state
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e35f88d91222b7c9f2d376b202d5036ea805014d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->