### PR TITLE
bug(creditNote): Fix refund amount initialization in credit note form

### DIFF
--- a/src/components/creditNote/useCreditNoteFormCalculation.ts
+++ b/src/components/creditNote/useCreditNoteFormCalculation.ts
@@ -209,8 +209,10 @@ export const useCreditNoteFormCalculation = ({
 
     // Initialize the refund field if possible
     if (canRefund) {
-      formikProps.setFieldValue('payBack.1.type', CreditTypeEnum.refund)
-      formikProps.setFieldValue('payBack.1.value', undefined)
+      formikProps.setFieldValue('payBack.1', {
+        type: CreditTypeEnum.refund,
+        value: undefined,
+      })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -230,7 +232,10 @@ export const useCreditNoteFormCalculation = ({
     )
 
     if (canRefund) {
-      formikProps.setFieldValue('payBack.1.value', undefined)
+      formikProps.setFieldValue('payBack.1', {
+        type: CreditTypeEnum.refund,
+        value: undefined,
+      })
     }
 
     setPayBackValidation(


### PR DESCRIPTION
## Context

After the UI redesign refactoring (PR #2887), credit notes were being created with refundAmountCents = 0 regardless of user input, causing no_voidable_amount errors when voiding.

## Description

Initialize payBack[1].type to CreditTypeEnum.refund in the second useEffect when canRefund becomes true, since the hook now runs before invoice is loaded.

<!-- Linear link -->
Fixes ISSUE-1382