### PR TITLE
lint: allow to defined a type as any in tests

### DIFF
--- a/packages/configs/eslint.config.mjs
+++ b/packages/configs/eslint.config.mjs
@@ -118,5 +118,11 @@ export default [
       'import/order': 'off',
     },
   },
+  {
+    files: ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}', '**/__tests__/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
   pluginPrettier,
 ]

--- a/src/components/designSystem/__tests__/Button.test.tsx
+++ b/src/components/designSystem/__tests__/Button.test.tsx
@@ -8,8 +8,7 @@ import { Button } from '../Button'
 async function prepare({
   children,
   props,
-}: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-{ children?: React.ReactNode; props?: Record<string, any> } = {}) {
+}: { children?: React.ReactNode; props?: Record<string, any> } = {}) {
   await act(() =>
     render(
       <Button

--- a/src/components/designSystem/__tests__/ButtonLink.test.tsx
+++ b/src/components/designSystem/__tests__/ButtonLink.test.tsx
@@ -13,7 +13,6 @@ async function prepare(
     to,
   }: {
     children?: React.ReactNode
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     props?: Record<string, any>
     type: ButtonLinkBaseProps['type']
     to: string

--- a/src/components/designSystem/__tests__/Popper.test.tsx
+++ b/src/components/designSystem/__tests__/Popper.test.tsx
@@ -13,7 +13,6 @@ async function prepare({
 }: {
   children?: React.ReactNode
   opener?: React.ReactElement
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   props?: Record<string, any>
 } = {}) {
   await act(() =>

--- a/src/components/designSystem/__tests__/Table.test.tsx
+++ b/src/components/designSystem/__tests__/Table.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { act, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 

--- a/src/components/invoices/__tests__/InvoicesList.test.tsx
+++ b/src/components/invoices/__tests__/InvoicesList.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ApolloError } from '@apollo/client'
 import { act, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/src/core/apolloClient/__tests__/cacheHelpers.test.ts
+++ b/src/core/apolloClient/__tests__/cacheHelpers.test.ts
@@ -4,11 +4,7 @@ import { createPaginatedFieldPolicy, mergePaginatedCollection } from '../cacheHe
 
 // Type helper to extract the keyArgs function from a field policy
 type KeyArgsFunction = NonNullable<
-  Extract<
-    ReturnType<typeof createPaginatedFieldPolicy>['keyArgs'],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (...args: any[]) => any
-  >
+  Extract<ReturnType<typeof createPaginatedFieldPolicy>['keyArgs'], (...args: any[]) => any>
 >
 
 // Mock context for testing keyArgs functions - matches the actual signature


### PR DESCRIPTION
## Context

There is no real objective behind forcing the typing within the tests. It is actually very needed in some cases to test special cases that are supposedly not happening. 

## Description

This pull request ensures that the linter rule to prevent the typing of any is not enabled in test files. 