### PR TITLE
feat: Redirect back to the previous route after logging in with google

### DIFF
--- a/src/components/auth/GoogleAuthButton.tsx
+++ b/src/components/auth/GoogleAuthButton.tsx
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 import { Stack } from '@mui/material'
 import { useEffect, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useLocation, useSearchParams } from 'react-router-dom'
 
 import { Alert, Button, Typography } from '~/components/designSystem'
 import { hasDefinedGQLError } from '~/core/apolloClient'
@@ -81,6 +81,10 @@ const GoogleAuthButton = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const location = useLocation()
+
+  const previousLocation = location.state?.from?.pathname
+
   return (
     <Stack spacing={8}>
       {!!errorCode && !hideAlert && (
@@ -126,6 +130,7 @@ const GoogleAuthButton = ({
               stateType: 'object',
               values: {
                 mode,
+                redirectPath: previousLocation,
                 ...(!!invitationToken && { invitationToken }),
               },
             })

--- a/src/pages/auth/GoogleAuthCallback.tsx
+++ b/src/pages/auth/GoogleAuthCallback.tsx
@@ -28,6 +28,7 @@ const GoogleAuthCallback = () => {
   const state = JSON.parse(searchParams.get('state') || '{}')
   const invitationToken = state.invitationToken || ''
   const mode = state.mode as GoogleAuthModeEnum
+  const redirectPath = state.redirectPath
 
   if (!code) {
     navigate(LOGIN_ROUTE)
@@ -60,6 +61,12 @@ const GoogleAuthCallback = () => {
           }
         } else if (!!res.data?.googleLoginUser) {
           await onLogIn(client, res.data?.googleLoginUser?.token)
+
+          if (redirectPath) {
+            navigate({
+              pathname: redirectPath,
+            })
+          }
         }
       } else if (mode === 'signup') {
         navigate({


### PR DESCRIPTION
## Context

After a login with user/pass the users would be redirected to the previous route they've visited. This wasn't applied for Google logins.

## Description

Include previous route in the google sign in state => redirect after google goes to /callback.

<!-- Linear link -->
Fixes ISSUE-1374

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements return-to-previous-route behavior for Google auth.
> 
> - In `GoogleAuthButton.tsx`, capture previous route via `useLocation()` (`location.state?.from?.pathname`) and include it as `redirectPath` in the Google OAuth `state` payload when building the auth URL.
> - In `GoogleAuthCallback.tsx`, parse `redirectPath` from `state` and, after successful `googleLoginUser` and `onLogIn`, `navigate` to that path (fallback remains existing error handling and signup/invite flows).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a19803c22576f495c44bff233419266f7f3709b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->