### PR TITLE
bug: handle 404 error when navigating back to deleted alert

### DIFF
--- a/translations/base.json
+++ b/translations/base.json
@@ -3642,5 +3642,6 @@
   "text_1766162519559r3f2pkqdp79": "Add for future invoices (max: {{max}})",
   "text_1766162940956q60f79xxr11": "Allocated so far",
   "text_1766162940956fzxpt25f23k": "Remaining to allocate",
-  "text_17661418227616cvcuga1x7m": "Optional"
+  "text_17661418227616cvcuga1x7m": "Optional",
+  "text_1737477631498hwm4np3kbnd": "This alert no longer exists"
 }

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -3160,5 +3160,6 @@
   "text_1755599398258ce1ilgc5swg": "Desbloqueie o uso projetado para que os clientes possam ver o uso esperado no final de cada período e planejar os custos futuros.",
   "text_1755599398258mj61iwjhhfk": "Solicitar acesso ao uso projetado",
   "text_1755599398258w59pin31rfe": "Olá, gostaria de acessar seu complemento de uso projetado. \n\nEntre em contato se precisar de mais informações!",
-  "text_1756372772688ov7fcui4x30": "por semestre"
+  "text_1756372772688ov7fcui4x30": "por semestre",
+  "text_1737477631498hwm4np3kbnd": "Este alerta não existe mais"
 }


### PR DESCRIPTION
When a user edits an alert, saves it, then deletes it from the list, pressing the browser back button would land on the edit form with a 404 error since the alert no longer exists.

This fix:
- Silences the NotFound error in the alert query to prevent global error handling
- Detects the NotFound error and redirects to the alerts list with an info toast
- Uses history replace to prevent the back button from returning to the deleted alert page

Fixes ISSUE-1352