### PR TITLE
bug: show connected badge if salesforce is connected

### DIFF
--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -534,6 +534,7 @@ const Integrations = () => {
                           </Avatar>
                         }
                         endIcon={getEndIcon({
+                          showConnectedBadge: hasSalesforceIntegration,
                           showSparkles: !hasAccessToSalesforcePremiumIntegration,
                         })}
                         onClick={() => {


### PR DESCRIPTION
When Salesforce is connected to Lago we should show a "Connected" badge.

we already have the info is a salesforce connection exists, just need to pass this info down to the helper that takes care of displaying the bage.