### PR TITLE
misc(invoice-details): unify customer infos display

### DIFF
--- a/agents/testing-practices.md
+++ b/agents/testing-practices.md
@@ -160,3 +160,38 @@ describe('InvoiceDetailsTable', () => {
 - Refactoring the test ID only requires changing it in one place
 - TypeScript provides autocomplete and catches typos
 - No coupling with translation keys or hardcoded strings
+
+### Timezone Handling in Tests
+
+When testing components that display dates/times, **always enforce UTC timezone** to ensure consistent behavior across different environments (local development vs CI).
+
+**Why this matters**:
+- Local development machines may be in different timezones (e.g., UTC-3)
+- CI servers typically run in UTC
+- A date like `'2024-01-20T00:00:00Z'` (midnight UTC) will display as Jan 19 in timezones west of UTC
+
+**Pattern to follow**:
+
+```tsx
+import { Settings } from 'luxon'
+
+const originalDefaultZone = Settings.defaultZone
+
+describe('MyComponent', () => {
+  beforeAll(() => {
+    Settings.defaultZone = 'UTC'
+  })
+
+  afterAll(() => {
+    Settings.defaultZone = originalDefaultZone
+  })
+
+  // ... your tests
+})
+```
+
+**Key points**:
+- Store the original timezone before tests run
+- Set `Settings.defaultZone = 'UTC'` in `beforeAll` or `beforeEach`
+- Always restore the original timezone in `afterAll` or `afterEach` to avoid affecting other tests
+- This applies to any test involving date formatting, especially snapshot tests

--- a/src/components/invoices/InvoiceCustomerInfos.tsx
+++ b/src/components/invoices/InvoiceCustomerInfos.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { Box, Stack } from '@mui/material'
 import { Icon } from 'lago-design-system'
 import { DateTime } from 'luxon'
 import { memo } from 'react'
@@ -17,6 +16,8 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useFormatterDateHelper } from '~/hooks/helpers/useFormatterDateHelper'
+
+import { DetailsPage } from '../layouts/DetailsPage'
 
 gql`
   fragment InvoiceForInvoiceInfos on Invoice {
@@ -55,12 +56,6 @@ gql`
   }
 `
 
-const InfoLine = ({ children }: { children: React.ReactNode }) => (
-  <div className="mb-2 flex items-baseline gap-2 first-child:mt-1 first-child:min-w-35 last-child:w-full">
-    {children}
-  </div>
-)
-
 interface InvoiceCustomerInfosProps {
   invoice?: InvoiceForInvoiceInfosFragment | null
 }
@@ -83,171 +78,139 @@ export const InvoiceCustomerInfos = memo(({ invoice }: InvoiceCustomerInfosProps
   })
 
   return (
-    <section className="grid grid-cols-1 gap-0 py-6 shadow-b md:grid-cols-2">
-      <div className="pr-8">
-        {customer && customerName && (
-          <InfoLine>
-            <Typography variant="caption" color="grey600" noWrap>
-              {translate(
+    <DetailsPage.Overview
+      leftColumn={
+        <>
+          {!!customer && !!customerName && (
+            <DetailsPage.OverviewLine
+              title={translate(
                 customerIsPartner
                   ? 'text_17385950520558ttf6sv58s0'
                   : 'text_634687079be251fdb43833cb',
               )}
-            </Typography>
-            <ConditionalWrapper
-              condition={!!customer.deletedAt}
-              validWrapper={(children) => <>{children}</>}
-              invalidWrapper={(children) => (
-                <Link
-                  className="*:text-blue-600"
-                  to={generatePath(CUSTOMER_DETAILS_ROUTE, {
-                    customerId: customer.id,
-                  })}
+              value={
+                <ConditionalWrapper
+                  condition={!!customer.deletedAt}
+                  validWrapper={(children) => <>{children}</>}
+                  invalidWrapper={(children) => (
+                    <Link
+                      className="*:text-blue-600"
+                      to={generatePath(CUSTOMER_DETAILS_ROUTE, {
+                        customerId: customer.id,
+                      })}
+                    >
+                      {children}
+                    </Link>
+                  )}
                 >
-                  {children}
-                </Link>
-              )}
-            >
-              <Typography variant="body" color="grey700" forceBreak>
-                {customerName}
-              </Typography>
-            </ConditionalWrapper>
-          </InfoLine>
-        )}
-        {customer?.legalName && (
-          <InfoLine>
-            <Typography variant="caption" color="grey600" noWrap>
-              {translate('text_634687079be251fdb43833d7')}
-            </Typography>
-            <Typography variant="body" color="grey700" forceBreak>
-              {customer?.legalName}
-            </Typography>
-          </InfoLine>
-        )}
-        {customer?.legalNumber && (
-          <InfoLine>
-            <Typography variant="caption" color="grey600" noWrap>
-              {translate('text_647ddd5220412a009bfd36f4')}
-            </Typography>
-            <Typography variant="body" color="grey700" forceBreak>
-              {customer?.legalNumber}
-            </Typography>
-          </InfoLine>
-        )}
-        {customer?.email && (
-          <InfoLine>
-            <Typography variant="caption" color="grey600" noWrap>
-              {translate('text_634687079be251fdb43833e3')}
-            </Typography>
-            <Typography variant="body" color="grey700" forceBreak>
-              {customer?.email.split(',').join(', ')}
-            </Typography>
-          </InfoLine>
-        )}
-        {!!formattedAddress && (
-          <InfoLine>
-            <Typography variant="caption" color="grey600" noWrap>
-              {translate('text_634687079be251fdb43833ef')}
-            </Typography>
-            <div>
-              <Typography variant="body" color="grey700">
-                {formattedAddress}
-              </Typography>
-            </div>
-          </InfoLine>
-        )}
-      </div>
-      <div>
-        {customer?.taxIdentificationNumber && (
-          <InfoLine>
-            <Typography variant="caption" color="grey600" noWrap>
-              {translate('text_648053ee819b60364c675cf1')}
-            </Typography>
-            <Typography variant="body" color="grey700">
-              {customer?.taxIdentificationNumber}
-            </Typography>
-          </InfoLine>
-        )}
-        {invoice?.number && (
-          <InfoLine>
-            <Typography variant="caption" color="grey600" noWrap>
-              {translate('text_634687079be251fdb43833fb')}
-            </Typography>
-            <Typography variant="body" color="grey700">
-              {invoice?.number}
-            </Typography>
-          </InfoLine>
-        )}
-        {invoice?.issuingDate && (
-          <InfoLine>
-            <Typography variant="caption" color="grey600" noWrap>
-              {translate('text_634687079be251fdb4383407')}
-            </Typography>
-            <Typography variant="body" color="grey700">
-              {formattedDateWithTimezone(invoice.issuingDate, customer?.applicableTimezone)}
-            </Typography>
-          </InfoLine>
-        )}
-        {invoice?.paymentDueDate && (
-          <InfoLine>
-            <Typography variant="caption" color="grey600" noWrap>
-              {translate('text_666c5d227d073444e90be894')}
-            </Typography>
-            <Stack alignItems="baseline" flexDirection="row" flexWrap="wrap" columnGap={3}>
-              <Typography variant="body" color="grey700">
-                {formattedDateWithTimezone(invoice.paymentDueDate, customer?.applicableTimezone)}
-              </Typography>
-              {invoice?.paymentOverdue && <Status type={StatusType.danger} label="overdue" />}
-            </Stack>
-          </InfoLine>
-        )}
-        <InfoLine>
-          <Typography variant="caption" color="grey600" noWrap>
-            {translate('text_65269b6afe1fda4ad9bf672b')}
-          </Typography>
-          <Typography variant="body" color="grey700">
-            {invoice?.status && <Status {...invoiceStatusMapping({ status: invoice.status })} />}
-          </Typography>
-        </InfoLine>
-        <InfoLine>
-          <Typography variant="caption" color="grey600" noWrap>
-            {translate('text_63eba8c65a6c8043feee2a0f')}
-          </Typography>
-          <Typography variant="body" color="grey700">
-            {invoice?.status === InvoiceStatusTypeEnum.Finalized ? (
-              <Status
-                {...paymentStatusMapping({
-                  status: invoice.status,
-                  paymentStatus: invoice.paymentStatus,
-                  totalPaidAmountCents: invoice.totalPaidAmountCents,
-                  totalDueAmountCents: invoice.totalDueAmountCents,
-                })}
-              />
-            ) : (
-              <Typography variant="body" color="grey700">
-                -
-              </Typography>
-            )}
-          </Typography>
-        </InfoLine>
-        {!!invoice?.paymentDisputeLostAt && (
-          <InfoLine>
-            <Typography variant="caption" color="grey600" noWrap>
-              {translate('text_66141e30699a0631f0b2ed32')}
-            </Typography>
-
-            <Typography variant="body" color="textSecondary">
-              <Box marginRight={1} display="inline" sx={{ verticalAlign: 'middle' }}>
-                <Icon name="warning-filled" color="warning" />
-              </Box>
-              {translate('text_66141e30699a0631f0b2ed2c', {
-                date: DateTime.fromISO(invoice?.paymentDisputeLostAt).toFormat('LLL. dd, yyyy'),
-              })}
-            </Typography>
-          </InfoLine>
-        )}
-      </div>
-    </section>
+                  {customerName}
+                </ConditionalWrapper>
+              }
+            />
+          )}
+          {!!customer?.legalName && (
+            <DetailsPage.OverviewLine
+              title={translate('text_634687079be251fdb43833d7')}
+              value={customer?.legalName}
+            />
+          )}
+          {!!customer?.legalNumber && (
+            <DetailsPage.OverviewLine
+              title={translate('text_647ddd5220412a009bfd36f4')}
+              value={customer?.legalNumber}
+            />
+          )}
+          {!!customer?.email && (
+            <DetailsPage.OverviewLine
+              title={translate('text_634687079be251fdb43833e3')}
+              value={customer?.email.split(',').join(', ')}
+            />
+          )}
+          {!!formattedAddress && (
+            <DetailsPage.OverviewLine
+              title={translate('text_634687079be251fdb43833ef')}
+              value={formattedAddress}
+            />
+          )}
+        </>
+      }
+      rightColumn={
+        <>
+          {customer?.taxIdentificationNumber && (
+            <DetailsPage.OverviewLine
+              title={translate('text_648053ee819b60364c675cf1')}
+              value={customer?.taxIdentificationNumber}
+            />
+          )}
+          {invoice?.number && (
+            <DetailsPage.OverviewLine
+              title={translate('text_634687079be251fdb43833fb')}
+              value={invoice?.number}
+            />
+          )}
+          {invoice?.issuingDate && (
+            <DetailsPage.OverviewLine
+              title={translate('text_634687079be251fdb4383407')}
+              value={formattedDateWithTimezone(invoice.issuingDate, customer?.applicableTimezone)}
+            />
+          )}
+          {invoice?.paymentDueDate && (
+            <DetailsPage.OverviewLine
+              title={translate('text_666c5d227d073444e90be894')}
+              value={
+                <div className="flex flex-wrap items-baseline gap-3">
+                  <Typography variant="body" color="grey700">
+                    {formattedDateWithTimezone(
+                      invoice.paymentDueDate,
+                      customer?.applicableTimezone,
+                    )}
+                  </Typography>
+                  {invoice?.paymentOverdue && <Status type={StatusType.danger} label="overdue" />}
+                </div>
+              }
+            />
+          )}
+          {!!invoice?.status && (
+            <DetailsPage.OverviewLine
+              title={translate('text_65269b6afe1fda4ad9bf672b')}
+              value={<Status {...invoiceStatusMapping({ status: invoice.status })} />}
+            />
+          )}
+          <DetailsPage.OverviewLine
+            title={translate('text_63eba8c65a6c8043feee2a0f')}
+            value={
+              invoice?.status === InvoiceStatusTypeEnum.Finalized ? (
+                <Status
+                  {...paymentStatusMapping({
+                    status: invoice.status,
+                    paymentStatus: invoice.paymentStatus,
+                    totalPaidAmountCents: invoice.totalPaidAmountCents,
+                    totalDueAmountCents: invoice.totalDueAmountCents,
+                  })}
+                />
+              ) : (
+                <Typography variant="body" color="grey700">
+                  -
+                </Typography>
+              )
+            }
+          />
+          {!!invoice?.paymentDisputeLostAt && (
+            <DetailsPage.OverviewLine
+              title={translate('text_66141e30699a0631f0b2ed32')}
+              value={
+                <div className="flex flex-wrap items-center gap-2">
+                  <Icon name="warning-filled" color="warning" />
+                  {translate('text_66141e30699a0631f0b2ed2c', {
+                    date: DateTime.fromISO(invoice?.paymentDisputeLostAt).toFormat('LLL. dd, yyyy'),
+                  })}
+                </div>
+              }
+            />
+          )}
+        </>
+      }
+    />
   )
 })
 

--- a/src/components/invoices/__tests__/InvoiceCustomerInfos.test.tsx
+++ b/src/components/invoices/__tests__/InvoiceCustomerInfos.test.tsx
@@ -1,0 +1,379 @@
+import { screen } from '@testing-library/react'
+import { Settings } from 'luxon'
+
+import { InvoiceCustomerInfos } from '~/components/invoices/InvoiceCustomerInfos'
+import {
+  CountryCode,
+  CustomerAccountTypeEnum,
+  InvoiceForInvoiceInfosFragment,
+  InvoicePaymentStatusTypeEnum,
+  InvoiceStatusTypeEnum,
+  TimezoneEnum,
+} from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+const originalDefaultZone = Settings.defaultZone
+
+describe('InvoiceCustomerInfos', () => {
+  beforeAll(() => {
+    Settings.defaultZone = 'UTC'
+  })
+
+  afterAll(() => {
+    Settings.defaultZone = originalDefaultZone
+  })
+
+  const createMockInvoice = (
+    overrides?: Partial<InvoiceForInvoiceInfosFragment>,
+  ): InvoiceForInvoiceInfosFragment => ({
+    number: 'INV-001',
+    issuingDate: '2024-01-15',
+    paymentDueDate: '2024-02-15',
+    paymentOverdue: false,
+    status: InvoiceStatusTypeEnum.Finalized,
+    totalPaidAmountCents: '0',
+    totalDueAmountCents: '10000',
+    paymentStatus: InvoicePaymentStatusTypeEnum.Pending,
+    paymentDisputeLostAt: null,
+    taxProviderVoidable: false,
+    errorDetails: [],
+    customer: {
+      id: 'customer-1',
+      name: 'Acme Inc',
+      displayName: 'Acme Corporation',
+      legalNumber: 'LN-123456',
+      legalName: 'Acme Corporation Legal',
+      taxIdentificationNumber: 'TAX-789',
+      email: 'billing@acme.com',
+      addressLine1: '123 Main Street',
+      addressLine2: 'Suite 100',
+      state: 'California',
+      country: CountryCode.Us,
+      city: 'San Francisco',
+      zipcode: '94102',
+      applicableTimezone: TimezoneEnum.TzAmericaLosAngeles,
+      deletedAt: null,
+      accountType: CustomerAccountTypeEnum.Customer,
+    },
+    ...overrides,
+  })
+
+  describe('rendering', () => {
+    it('should render invoice with full customer information', () => {
+      const mockInvoice = createMockInvoice()
+
+      render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      // Customer info
+      expect(screen.getByText('Acme Corporation')).toBeInTheDocument()
+      expect(screen.getByText('Acme Corporation Legal')).toBeInTheDocument()
+      expect(screen.getByText('LN-123456')).toBeInTheDocument()
+      expect(screen.getByText('billing@acme.com')).toBeInTheDocument()
+      expect(screen.getByText('TAX-789')).toBeInTheDocument()
+
+      // Invoice info
+      expect(screen.getByText('INV-001')).toBeInTheDocument()
+    })
+
+    it('should render invoice with minimal customer information', () => {
+      const mockInvoice = createMockInvoice({
+        customer: {
+          id: 'customer-2',
+          name: null,
+          displayName: 'Simple Customer',
+          legalNumber: null,
+          legalName: null,
+          taxIdentificationNumber: null,
+          email: null,
+          addressLine1: null,
+          addressLine2: null,
+          state: null,
+          country: null,
+          city: null,
+          zipcode: null,
+          applicableTimezone: TimezoneEnum.TzUtc,
+          deletedAt: null,
+          accountType: CustomerAccountTypeEnum.Customer,
+        },
+      })
+
+      render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(screen.getByText('Simple Customer')).toBeInTheDocument()
+      expect(screen.queryByText('LN-123456')).not.toBeInTheDocument()
+    })
+
+    it('should render partner customer label', () => {
+      const mockInvoice = createMockInvoice({
+        customer: {
+          id: 'partner-1',
+          name: 'Partner Company',
+          displayName: 'Partner Company Display',
+          legalNumber: null,
+          legalName: null,
+          taxIdentificationNumber: null,
+          email: null,
+          addressLine1: null,
+          addressLine2: null,
+          state: null,
+          country: null,
+          city: null,
+          zipcode: null,
+          applicableTimezone: TimezoneEnum.TzUtc,
+          deletedAt: null,
+          accountType: CustomerAccountTypeEnum.Partner,
+        },
+      })
+
+      render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(screen.getByText('Partner Company Display')).toBeInTheDocument()
+    })
+
+    it('should not render customer link when customer is deleted', () => {
+      const mockInvoice = createMockInvoice({
+        customer: {
+          id: 'deleted-customer',
+          name: 'Deleted Customer',
+          displayName: 'Deleted Customer Display',
+          legalNumber: null,
+          legalName: null,
+          taxIdentificationNumber: null,
+          email: null,
+          addressLine1: null,
+          addressLine2: null,
+          state: null,
+          country: null,
+          city: null,
+          zipcode: null,
+          applicableTimezone: TimezoneEnum.TzUtc,
+          deletedAt: '2024-01-01T00:00:00Z',
+          accountType: CustomerAccountTypeEnum.Customer,
+        },
+      })
+
+      render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(screen.getByText('Deleted Customer Display')).toBeInTheDocument()
+      // The customer name should not be a link
+      expect(
+        screen.queryByRole('link', { name: 'Deleted Customer Display' }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('should render customer link when customer is not deleted', () => {
+      const mockInvoice = createMockInvoice()
+
+      render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(screen.getByRole('link', { name: 'Acme Corporation' })).toBeInTheDocument()
+    })
+
+    it('should render overdue status when payment is overdue', () => {
+      const mockInvoice = createMockInvoice({
+        paymentOverdue: true,
+      })
+
+      render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(screen.getByText('Overdue')).toBeInTheDocument()
+    })
+
+    it('should render payment dispute lost information', () => {
+      const mockInvoice = createMockInvoice({
+        paymentDisputeLostAt: '2024-01-20T00:00:00Z',
+      })
+
+      render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      // Check that the dispute info is rendered (date may vary due to timezone)
+      expect(screen.getByText(/Dispute lost on/)).toBeInTheDocument()
+    })
+
+    it('should render dash for payment status when invoice is draft', () => {
+      const mockInvoice = createMockInvoice({
+        status: InvoiceStatusTypeEnum.Draft,
+      })
+
+      render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(screen.getByText('-')).toBeInTheDocument()
+    })
+
+    it('should format multiple emails with comma and space', () => {
+      const mockInvoice = createMockInvoice({
+        customer: {
+          id: 'customer-multi-email',
+          name: 'Multi Email Customer',
+          displayName: 'Multi Email Customer',
+          legalNumber: null,
+          legalName: null,
+          taxIdentificationNumber: null,
+          email: 'email1@test.com,email2@test.com,email3@test.com',
+          addressLine1: null,
+          addressLine2: null,
+          state: null,
+          country: null,
+          city: null,
+          zipcode: null,
+          applicableTimezone: TimezoneEnum.TzUtc,
+          deletedAt: null,
+          accountType: CustomerAccountTypeEnum.Customer,
+        },
+      })
+
+      render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(
+        screen.getByText('email1@test.com, email2@test.com, email3@test.com'),
+      ).toBeInTheDocument()
+    })
+
+    it('should handle null invoice gracefully', () => {
+      const { container } = render(<InvoiceCustomerInfos invoice={null} />)
+
+      expect(container).toBeInTheDocument()
+    })
+
+    it('should handle undefined invoice gracefully', () => {
+      const { container } = render(<InvoiceCustomerInfos invoice={undefined} />)
+
+      expect(container).toBeInTheDocument()
+    })
+  })
+
+  describe('Snapshot Tests', () => {
+    it('should match snapshot for invoice with full customer information', () => {
+      const mockInvoice = createMockInvoice()
+
+      const { container } = render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(container).toMatchSnapshot()
+    })
+
+    it('should match snapshot for invoice with minimal customer information', () => {
+      const mockInvoice = createMockInvoice({
+        number: 'INV-MINIMAL',
+        customer: {
+          id: 'customer-minimal',
+          name: null,
+          displayName: 'Minimal Customer',
+          legalNumber: null,
+          legalName: null,
+          taxIdentificationNumber: null,
+          email: null,
+          addressLine1: null,
+          addressLine2: null,
+          state: null,
+          country: null,
+          city: null,
+          zipcode: null,
+          applicableTimezone: TimezoneEnum.TzUtc,
+          deletedAt: null,
+          accountType: CustomerAccountTypeEnum.Customer,
+        },
+      })
+
+      const { container } = render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(container).toMatchSnapshot()
+    })
+
+    it('should match snapshot for partner customer', () => {
+      const mockInvoice = createMockInvoice({
+        number: 'INV-PARTNER',
+        customer: {
+          id: 'partner-customer',
+          name: 'Partner Corp',
+          displayName: 'Partner Corporation',
+          legalNumber: 'PARTNER-001',
+          legalName: 'Partner Corp Legal',
+          taxIdentificationNumber: 'PARTNER-TAX',
+          email: 'partner@example.com',
+          addressLine1: '456 Partner Ave',
+          addressLine2: null,
+          state: 'New York',
+          country: CountryCode.Us,
+          city: 'New York City',
+          zipcode: '10001',
+          applicableTimezone: TimezoneEnum.TzAmericaNewYork,
+          deletedAt: null,
+          accountType: CustomerAccountTypeEnum.Partner,
+        },
+      })
+
+      const { container } = render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(container).toMatchSnapshot()
+    })
+
+    it('should match snapshot for deleted customer', () => {
+      const mockInvoice = createMockInvoice({
+        number: 'INV-DELETED',
+        customer: {
+          id: 'deleted-customer',
+          name: 'Deleted Corp',
+          displayName: 'Deleted Corporation',
+          legalNumber: null,
+          legalName: null,
+          taxIdentificationNumber: null,
+          email: 'deleted@example.com',
+          addressLine1: null,
+          addressLine2: null,
+          state: null,
+          country: null,
+          city: null,
+          zipcode: null,
+          applicableTimezone: TimezoneEnum.TzUtc,
+          deletedAt: '2024-01-01T00:00:00Z',
+          accountType: CustomerAccountTypeEnum.Customer,
+        },
+      })
+
+      const { container } = render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(container).toMatchSnapshot()
+    })
+
+    it('should match snapshot for overdue invoice', () => {
+      const mockInvoice = createMockInvoice({
+        number: 'INV-OVERDUE',
+        paymentOverdue: true,
+        paymentDueDate: '2024-01-01',
+      })
+
+      const { container } = render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(container).toMatchSnapshot()
+    })
+
+    it('should match snapshot for draft invoice', () => {
+      const mockInvoice = createMockInvoice({
+        number: 'INV-DRAFT',
+        status: InvoiceStatusTypeEnum.Draft,
+        paymentStatus: InvoicePaymentStatusTypeEnum.Pending,
+      })
+
+      const { container } = render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(container).toMatchSnapshot()
+    })
+
+    it('should match snapshot for invoice with payment dispute lost', () => {
+      const mockInvoice = createMockInvoice({
+        number: 'INV-DISPUTE',
+        paymentDisputeLostAt: '2024-01-20T00:00:00Z',
+      })
+
+      const { container } = render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+
+      expect(container).toMatchSnapshot()
+    })
+
+    it('should match snapshot for null invoice', () => {
+      const { container } = render(<InvoiceCustomerInfos invoice={null} />)
+
+      expect(container).toMatchSnapshot()
+    })
+  })
+})

--- a/src/components/invoices/__tests__/__snapshots__/InvoiceCustomerInfos.test.tsx.snap
+++ b/src/components/invoices/__tests__/__snapshots__/InvoiceCustomerInfos.test.tsx.snap
@@ -1,0 +1,1387 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`InvoiceCustomerInfos Snapshot Tests should match snapshot for deleted customer 1`] = `
+<div>
+  <div
+    class="flex flex-row gap-8 py-6"
+  >
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Customer name
+        </div>
+        Deleted Corporation
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Email
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          deleted@example.com
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          INV-DELETED
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Issuing date
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          Jan 15, 2024 UTC±0:00
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Due date
+        </div>
+        <div
+          class="flex flex-wrap items-baseline gap-3"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+            data-test="body"
+          >
+            Feb 15, 2024 UTC±0:00
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-green-100 outline-green-200"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Finalized
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Payment status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-grey-100 outline-grey-400"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Pending
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InvoiceCustomerInfos Snapshot Tests should match snapshot for draft invoice 1`] = `
+<div>
+  <div
+    class="flex flex-row gap-8 py-6"
+  >
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Customer name
+        </div>
+        <a
+          class="*:text-blue-600"
+          href="/customer/customer-1"
+        >
+          Acme Corporation
+        </a>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Legal name
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          Acme Corporation Legal
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Legal number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          LN-123456
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Email
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          billing@acme.com
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Address
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          123 Main Street
+Suite 100
+San Francisco, CA 94102
+United States of America
+
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Tax ID number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          TAX-789
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          INV-DRAFT
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Issuing date
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          Jan 15, 2024 UTC-8:00
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Due date
+        </div>
+        <div
+          class="flex flex-wrap items-baseline gap-3"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+            data-test="body"
+          >
+            Feb 15, 2024 UTC-8:00
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-white outline-grey-400"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Draft
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Payment status
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          -
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InvoiceCustomerInfos Snapshot Tests should match snapshot for invoice with full customer information 1`] = `
+<div>
+  <div
+    class="flex flex-row gap-8 py-6"
+  >
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Customer name
+        </div>
+        <a
+          class="*:text-blue-600"
+          href="/customer/customer-1"
+        >
+          Acme Corporation
+        </a>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Legal name
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          Acme Corporation Legal
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Legal number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          LN-123456
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Email
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          billing@acme.com
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Address
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          123 Main Street
+Suite 100
+San Francisco, CA 94102
+United States of America
+
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Tax ID number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          TAX-789
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          INV-001
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Issuing date
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          Jan 15, 2024 UTC-8:00
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Due date
+        </div>
+        <div
+          class="flex flex-wrap items-baseline gap-3"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+            data-test="body"
+          >
+            Feb 15, 2024 UTC-8:00
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-green-100 outline-green-200"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Finalized
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Payment status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-grey-100 outline-grey-400"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Pending
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InvoiceCustomerInfos Snapshot Tests should match snapshot for invoice with minimal customer information 1`] = `
+<div>
+  <div
+    class="flex flex-row gap-8 py-6"
+  >
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Customer name
+        </div>
+        <a
+          class="*:text-blue-600"
+          href="/customer/customer-minimal"
+        >
+          Minimal Customer
+        </a>
+      </div>
+    </div>
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          INV-MINIMAL
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Issuing date
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          Jan 15, 2024 UTC±0:00
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Due date
+        </div>
+        <div
+          class="flex flex-wrap items-baseline gap-3"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+            data-test="body"
+          >
+            Feb 15, 2024 UTC±0:00
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-green-100 outline-green-200"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Finalized
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Payment status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-grey-100 outline-grey-400"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Pending
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InvoiceCustomerInfos Snapshot Tests should match snapshot for invoice with payment dispute lost 1`] = `
+<div>
+  <div
+    class="flex flex-row gap-8 py-6"
+  >
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Customer name
+        </div>
+        <a
+          class="*:text-blue-600"
+          href="/customer/customer-1"
+        >
+          Acme Corporation
+        </a>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Legal name
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          Acme Corporation Legal
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Legal number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          LN-123456
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Email
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          billing@acme.com
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Address
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          123 Main Street
+Suite 100
+San Francisco, CA 94102
+United States of America
+
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Tax ID number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          TAX-789
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          INV-DISPUTE
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Issuing date
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          Jan 15, 2024 UTC-8:00
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Due date
+        </div>
+        <div
+          class="flex flex-wrap items-baseline gap-3"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+            data-test="body"
+          >
+            Feb 15, 2024 UTC-8:00
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-green-100 outline-green-200"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Finalized
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Payment status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-grey-100 outline-grey-400"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Pending
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Disputed
+        </div>
+        <div
+          class="flex flex-wrap items-center gap-2"
+        >
+          <svg
+            class="text-yellow-600 size-4 min-w-4"
+            data-test="warning-filled/medium"
+            fill="currentColor"
+            title="warning-filled/medium"
+            viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M15.71 11.97L9.71 1.96999C9.53231 1.67384 9.28095 1.42874 8.98041 1.25857C8.67986 1.0884 8.34037 0.998962 7.995 0.998962C7.64962 0.998962 7.31013 1.0884 7.00959 1.25857C6.70905 1.42874 6.45769 1.67384 6.28 1.96999L0.28 11.97C0.0974291 12.2739 -0.00109149 12.6208 -0.005472 12.9753C-0.00985251 13.3298 0.0800645 13.679 0.25507 13.9873C0.430076 14.2956 0.68388 14.5519 0.990491 14.7298C1.2971 14.9077 1.6455 15.001 2 15H14C14.3537 14.9992 14.7008 14.9047 15.006 14.726C15.3112 14.5474 15.5636 14.291 15.7374 13.983C15.9112 13.675 16.0002 13.3264 15.9954 12.9728C15.9906 12.6192 15.8921 12.2731 15.71 11.97ZM8 13C7.80222 13 7.60888 12.9413 7.44443 12.8315C7.27998 12.7216 7.15181 12.5654 7.07612 12.3827C7.00043 12.2 6.98063 11.9989 7.01921 11.8049C7.0578 11.6109 7.15304 11.4327 7.29289 11.2929C7.43275 11.153 7.61093 11.0578 7.80491 11.0192C7.99889 10.9806 8.19996 11.0004 8.38268 11.0761C8.56541 11.1518 8.72159 11.28 8.83147 11.4444C8.94135 11.6089 9 11.8022 9 12C9 12.2652 8.89464 12.5196 8.70711 12.7071C8.51957 12.8946 8.26522 13 8 13ZM9 9C9 9.26521 8.89464 9.51957 8.70711 9.7071C8.51957 9.89464 8.26522 10 8 10C7.73478 10 7.48043 9.89464 7.29289 9.7071C7.10536 9.51957 7 9.26521 7 9V4.99999C7 4.73478 7.10536 4.48042 7.29289 4.29289C7.48043 4.10535 7.73478 3.99999 8 3.99999C8.26522 3.99999 8.51957 4.10535 8.70711 4.29289C8.89464 4.48042 9 4.73478 9 4.99999V9Z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          Dispute lost on Jan. 20, 2024
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InvoiceCustomerInfos Snapshot Tests should match snapshot for null invoice 1`] = `
+<div>
+  <div
+    class="flex flex-row gap-8 py-6"
+  >
+    <div
+      class="flex flex-1 flex-col gap-2"
+    />
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Payment status
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          -
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InvoiceCustomerInfos Snapshot Tests should match snapshot for overdue invoice 1`] = `
+<div>
+  <div
+    class="flex flex-row gap-8 py-6"
+  >
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Customer name
+        </div>
+        <a
+          class="*:text-blue-600"
+          href="/customer/customer-1"
+        >
+          Acme Corporation
+        </a>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Legal name
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          Acme Corporation Legal
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Legal number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          LN-123456
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Email
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          billing@acme.com
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Address
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          123 Main Street
+Suite 100
+San Francisco, CA 94102
+United States of America
+
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Tax ID number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          TAX-789
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          INV-OVERDUE
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Issuing date
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          Jan 15, 2024 UTC-8:00
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Due date
+        </div>
+        <div
+          class="flex flex-wrap items-baseline gap-3"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+            data-test="body"
+          >
+            Jan 1, 2024 UTC-8:00
+          </div>
+          <div
+            class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-red-100 outline-red-200"
+            data-test="status"
+          >
+            <div
+              class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+              data-test="captionHl"
+            >
+              Overdue
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-green-100 outline-green-200"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Finalized
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Payment status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-grey-100 outline-grey-400"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Pending
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InvoiceCustomerInfos Snapshot Tests should match snapshot for partner customer 1`] = `
+<div>
+  <div
+    class="flex flex-row gap-8 py-6"
+  >
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Partner name
+        </div>
+        <a
+          class="*:text-blue-600"
+          href="/customer/partner-customer"
+        >
+          Partner Corporation
+        </a>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Legal name
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          Partner Corp Legal
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Legal number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          PARTNER-001
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Email
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          partner@example.com
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Address
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          456 Partner Ave
+New York City, NY 10001
+United States of America
+
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex flex-1 flex-col gap-2"
+    >
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Tax ID number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          PARTNER-TAX
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice number
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          INV-PARTNER
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Issuing date
+        </div>
+        <div
+          class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+          data-test="body"
+        >
+          Jan 15, 2024 UTC-5:00
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Due date
+        </div>
+        <div
+          class="flex flex-wrap items-baseline gap-3"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-body whitespace-pre-line css-hash-MuiTypography-root
+            data-test="body"
+          >
+            Feb 15, 2024 UTC-5:00
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Invoice status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-green-100 outline-green-200"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Finalized
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-start gap-2"
+      >
+        <div
+          class=MuiTypography-root MuiTypography-caption MuiTypography-noWrap min-w-35 css-hash-MuiTypography-root
+          data-test="caption"
+        >
+          Payment status
+        </div>
+        <div
+          class="flex h-fit min-h-8 w-fit items-center gap-2 rounded-lg px-2 outline outline-1 -outline-offset-1 bg-grey-100 outline-grey-400"
+          data-test="status"
+        >
+          <div
+            class=MuiTypography-root MuiTypography-captionHl MuiTypography-noWrap css-hash-MuiTypography-root
+            data-test="captionHl"
+          >
+            Pending
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Context

On top of invoice details, you have several pieces of information, including the customer ones. 

It happened that the link sending to the customer view was showing on the full line instead of taking the size of the context. I realized we had a unified way, usually, to display this information using a layout component. 

## Description

This pull request uses this new layout component and at the same time adds a test with a snapshot to make sure it doesn't change in the future. 

<!-- Linear link -->
Fixes ISSUE-1375