### PR TITLE
bug(create-customer): prevent header to overflow

### DIFF
--- a/src/pages/createCustomers/CreateCustomer.tsx
+++ b/src/pages/createCustomers/CreateCustomer.tsx
@@ -132,7 +132,11 @@ const CreateCustomer = () => {
 
   return (
     <CenteredPage.Wrapper>
-      <form id="create-customer" className="flex min-h-full flex-col" onSubmit={handleSubmit}>
+      <form
+        id="create-customer"
+        className="flex size-full min-h-full flex-col overflow-auto"
+        onSubmit={handleSubmit}
+      >
         <CenteredPage.Header>
           <Typography variant="bodyHl" color="textSecondary" noWrap>
             {isEdition

--- a/src/pages/createCustomers/__tests__/__snapshots__/CreateCustomer.test.tsx.snap
+++ b/src/pages/createCustomers/__tests__/__snapshots__/CreateCustomer.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`CreateCustomer Integration Tests WHEN checking on expanded features THE
     class="flex size-full min-h-full flex-col overflow-auto bg-white"
   >
     <form
-      class="flex min-h-full flex-col"
+      class="flex size-full min-h-full flex-col overflow-auto"
       id="create-customer"
     >
       <header
@@ -2203,7 +2203,7 @@ exports[`CreateCustomer Integration Tests WHEN checking on expanded features THE
     class="flex size-full min-h-full flex-col overflow-auto bg-white"
   >
     <form
-      class="flex min-h-full flex-col"
+      class="flex size-full min-h-full flex-col overflow-auto"
       id="create-customer"
     >
       <header
@@ -3224,7 +3224,7 @@ exports[`CreateCustomer Integration Tests WHEN checking on expanded features THE
     class="flex size-full min-h-full flex-col overflow-auto bg-white"
   >
     <form
-      class="flex min-h-full flex-col"
+      class="flex size-full min-h-full flex-col overflow-auto"
       id="create-customer"
     >
       <header
@@ -4245,7 +4245,7 @@ exports[`CreateCustomer Integration Tests WHEN checking on expanded features THE
     class="flex size-full min-h-full flex-col overflow-auto bg-white"
   >
     <form
-      class="flex min-h-full flex-col"
+      class="flex size-full min-h-full flex-col overflow-auto"
       id="create-customer"
     >
       <header
@@ -5263,7 +5263,7 @@ exports[`CreateCustomer Integration Tests WHEN checking on expanded features THE
     class="flex size-full min-h-full flex-col overflow-auto bg-white"
   >
     <form
-      class="flex min-h-full flex-col"
+      class="flex size-full min-h-full flex-col overflow-auto"
       id="create-customer"
     >
       <header
@@ -6230,7 +6230,7 @@ exports[`CreateCustomer Integration Tests WHEN rendering the component THEN shou
     class="flex size-full min-h-full flex-col overflow-auto bg-white"
   >
     <form
-      class="flex min-h-full flex-col"
+      class="flex size-full min-h-full flex-col overflow-auto"
       id="create-customer"
     >
       <header


### PR DESCRIPTION
## Context

We recently changed the structure of the create customer form and we broke the fixed header within this form. 

It's mostly due to a class not being fully updated within this new form wrapper. 

## Description

This pull request makes sure that the class is correct and that the snapshot reflects these class changes. 

<!-- Linear link -->
Fixes ISSUE-1396