### PR TITLE
chore(*): fix strange scrolling on body

### DIFF
--- a/packages/design-system/src/style.css
+++ b/packages/design-system/src/style.css
@@ -6,7 +6,7 @@
   html,
   body,
   #root {
-    @apply m-0 h-full w-full overflow-auto p-0;
+    @apply m-0 h-full w-full overflow-hidden p-0;
   }
 
   body {


### PR DESCRIPTION
## Context

On some cases, we have a strange scroll possible on our body which shouldn't be possible since we manage all heights inside a wrapper

## Description

Add an overflow hidden to our #root wrapper so that it doesn't scroll once the scrollable element have done it's full scroll

<!-- Linear link -->
Fixes [ISSUE-1410](https://linear.app/getlago/issue/ISSUE-1410/vertical-scroll-on-the-whole-container)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Prevent unintended page scrolling**
> 
> - In `style.css`, updates base styles for `html`, `body`, and `#root` to use `overflow-hidden` (was `overflow-auto`) to avoid whole-page scroll when inner containers handle their own scrolling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32d2582b1460447e980869f041163bc52a3c953d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->