### PR TITLE
fix(invitation): use correct email validation

### DIFF
--- a/src/formValidation/zodCustoms.ts
+++ b/src/formValidation/zodCustoms.ts
@@ -47,3 +47,8 @@ export const zodOneOfPermissions = z.string().refine((value) => {
 
   return allPermissions.includes(value as PermissionName)
 })
+
+export const zodRequiredEmail = z
+  .string()
+  .min(1, { message: 'text_620bc4d4269a55014d493f3d' })
+  .refine((val) => EMAIL_REGEX.test(val), 'text_620bc4d4269a55014d493fc3')

--- a/src/pages/settings/members/dialogs/CreateInviteDialog.tsx
+++ b/src/pages/settings/members/dialogs/CreateInviteDialog.tsx
@@ -15,6 +15,7 @@ import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { scrollToFirstInputError } from '~/core/form/scrollToFirstInputError'
 import { INVITATION_ROUTE } from '~/core/router'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
+import { zodRequiredEmail } from '~/formValidation/zodCustoms'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm } from '~/hooks/forms/useAppform'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
@@ -50,7 +51,7 @@ export const CreateInviteDialog = forwardRef<DialogRef>((_, ref) => {
   }
 
   const validationSchema = z.object({
-    email: z.email('text_620bc4d4269a55014d493fc3'),
+    email: zodRequiredEmail,
     role: z.string().min(1, 'text_1768219065391kkeiaebav23'),
   })
 

--- a/translations/base.json
+++ b/translations/base.json
@@ -3787,5 +3787,6 @@
   "text_1768572142437iellff897qo": "Create a new charge",
   "text_1768572142437tyh61d8ed6t": "Update a charge",
   "text_1768572142437ch7vfimm1ts": "Delete a charge",
-  "text_1768993189751mlil3uubnse": "Use the unused amount to reduce this invoice's amount due."
+  "text_1768993189751mlil3uubnse": "Use the unused amount to reduce this invoice's amount due.",
+  "text_620bc4d4269a55014d493f3d": "Email is required"
 }


### PR DESCRIPTION
## Context

We were no longer using our old email regex validation on create invite

## Description

Uses some code from #2987 to use the correct email validation

<!-- Linear link -->
Fixes [ISSUE-1422](https://linear.app/getlago/issue/ISSUE-1422/invitation-some-emails-are-not-longer-authorized)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes invite email validation using our shared regex and required check.
> 
> - Adds `zodRequiredEmail` in `zodCustoms.ts` (required + `EMAIL_REGEX`)
> - Replaces `z.email` with `zodRequiredEmail` in `CreateInviteDialog`
> - Adds i18n key `text_620bc4d4269a55014d493f3d` ("Email is required")
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0851281f017ecca6602fa4faa09abc8524a480fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->