### PR TITLE
chore(cve): Fix CVE-2025-49796

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pnpm install --pnpmfile=./pnpmfile.docker.cjs
 COPY . .
 RUN pnpm install && pnpm build
 
-FROM nginx:1.27-alpine
+FROM nginx:1.28-alpine
 
 WORKDIR /usr/share/nginx/html
 


### PR DESCRIPTION
Fixes CVE-2025-49796

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a base image version bump for the runtime container; main potential impact is nginx behavior/compat changes when deploying the new image.
> 
> **Overview**
> Updates the runtime container base image from `nginx:1.27-alpine` to `nginx:1.28-alpine` (CVE remediation), leaving the build stage and nginx configuration/copy steps unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5086e41f904f0de9ae93e5ec41d1410bef2b69ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->