### PR TITLE
fix(combobox): Downgrade @tanstack/react-virtual to fix unmount error

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@nangohq/frontend": "0.69.22",
     "@sentry/react": "10.33.0",
     "@tanstack/react-form": "1.27.7",
-    "@tanstack/react-virtual": "3.13.18",
+    "@tanstack/react-virtual": "3.13.15",
     "ace-builds": "1.43.6",
     "actioncable": "5.2.8-1",
     "apollo-link-timeout": "4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: 1.27.7
         version: 1.27.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-virtual':
-        specifier: 3.13.18
-        version: 3.13.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 3.13.15
+        version: 3.13.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ace-builds:
         specifier: 1.43.6
         version: 1.43.6
@@ -3330,8 +3330,8 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/react-virtual@3.13.18':
-    resolution: {integrity: sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==}
+  '@tanstack/react-virtual@3.13.15':
+    resolution: {integrity: sha512-rlpmFOoIE1Xxuh7R8j6wZydit6Q+s4DY+WthsfDgDz7zP1HqDO1fmyP+9Msz3pD6fEN1riNUBBskk+k2yvznxQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3342,8 +3342,8 @@ packages:
   '@tanstack/store@0.8.0':
     resolution: {integrity: sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ==}
 
-  '@tanstack/virtual-core@3.13.18':
-    resolution: {integrity: sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==}
+  '@tanstack/virtual-core@3.13.15':
+    resolution: {integrity: sha512-8cG3acM2cSIm3h8WxboHARAhQAJbYUhvmadvnN8uz8aziDwrbYb9KiARni+uY2qrLh49ycn+poGoxvtIAKhjog==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -11933,9 +11933,9 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
 
-  '@tanstack/react-virtual@3.13.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@tanstack/react-virtual@3.13.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tanstack/virtual-core': 3.13.18
+      '@tanstack/virtual-core': 3.13.15
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -11943,7 +11943,7 @@ snapshots:
 
   '@tanstack/store@0.8.0': {}
 
-  '@tanstack/virtual-core@3.13.18': {}
+  '@tanstack/virtual-core@3.13.15': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,11 @@
   },
   "packageRules": [
     {
+      "matchPackageNames": ["@tanstack/react-virtual"],
+      "enabled": false,
+      "description": "Disabled due to regression in v3.13.16+ causing 'Cannot read properties of null (requestAnimationFrame)' on unmount for scrollToIndex."
+    },
+    {
       "matchDepNames": ["node"],
       "rangeStrategy": "bump"
     },


### PR DESCRIPTION
 ## Context

  Sentry reported a TypeError when interacting with virtualized ComboBox dropdowns:
  `Cannot read properties of null (reading 'requestAnimationFrame')`

  The error occurs when selecting an option triggers `scrollToIndex()` while the
  component unmounts. 

This is a regression in @tanstack/react-virtual, versions affected are between v3.13.16 and v3.13.18. This was introduced by renovate the 27th of Jan 2026 by this commit: https://github.com/getlago/lago-front/commit/f95197b894bb4bc072afd3ceeb857b62fdf77d66

  ## Description

  - Downgrade @tanstack/react-virtual from 3.13.18 to 3.13.15
  - Disable auto-updates for this package in renovate.json until upstream fix or a new version of @tanstack/react-virtual releses

Note: This may not be an intrinsic bug in the new library version. The error could
  be caused by the combination of the updated library with our specific usage pattern
  (MUI Autocomplete, React StrictMode, and other project dependencies). 

  I was unable to reproduce the issue in isolation with just @tanstack/react-virtual itself 
  and I could not open a issue to tanstack team. For now, the decision is to downgrade to the
  last known working version.

<!-- Linear link -->
Fixes ISSUE-1530