### PR TITLE
feat: Create <TypographyWithCopy />

### DIFF
--- a/src/components/billableMetrics/BillableMetricDetailsOverview.tsx
+++ b/src/components/billableMetrics/BillableMetricDetailsOverview.tsx
@@ -5,6 +5,7 @@ import { CodeSnippet } from '~/components/CodeSnippet'
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Chip } from '~/components/designSystem/Chip'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import {
   formatAggregationType,
@@ -69,7 +70,11 @@ export const BillableMetricDetailsOverview = () => {
               },
               {
                 label: translate('text_62876e85e32e0300e1803127'),
-                value: billableMetric?.code,
+                value: billableMetric?.code ? (
+                  <TypographyWithCopy variant="body" color="grey700">
+                    {billableMetric.code}
+                  </TypographyWithCopy>
+                ) : undefined,
               },
             ]}
           />

--- a/src/components/coupons/CouponDetailsAppliedCoupons.tsx
+++ b/src/components/coupons/CouponDetailsAppliedCoupons.tsx
@@ -11,6 +11,7 @@ import { Status } from '~/components/designSystem/Status'
 import { Table, TableColumn } from '~/components/designSystem/Table/Table'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { CustomerDetailsTabsOptions } from '~/core/constants/tabsOptions'
@@ -112,9 +113,9 @@ export const CouponDetailsAppliedCoupons = ({ couponCode }: CouponDetailsApplied
               <Typography variant="bodyHl" color="textSecondary" noWrap>
                 {customerName}
               </Typography>
-              <Typography variant="caption" color="grey600" noWrap>
-                {customer?.externalId}
-              </Typography>
+              <TypographyWithCopy variant="caption" color="grey600" noWrap>
+                {customer?.externalId ?? ''}
+              </TypographyWithCopy>
             </div>
           </div>
         )

--- a/src/components/coupons/CouponDetailsOverview.tsx
+++ b/src/components/coupons/CouponDetailsOverview.tsx
@@ -6,6 +6,7 @@ import { formatCouponValue } from '~/components/coupons/utils'
 import { Card } from '~/components/designSystem/Card'
 import { Status } from '~/components/designSystem/Status'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import {
   getCouponFrequencyTranslationKey,
@@ -95,7 +96,11 @@ export const CouponDetailsOverview = () => {
             },
             {
               label: translate('text_664cb90097bfa800e6efa3e7'),
-              value: coupon?.code,
+              value: coupon?.code ? (
+                <TypographyWithCopy variant="body" color="grey700">
+                  {coupon.code}
+                </TypographyWithCopy>
+              ) : undefined,
             },
             coupon?.couponType === CouponTypeEnum.FixedAmount && {
               label: translate('text_632b4acf0c41206cbcb8c324'),

--- a/src/components/designSystem/TypographyWithCopy.tsx
+++ b/src/components/designSystem/TypographyWithCopy.tsx
@@ -23,7 +23,10 @@ export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
   const { translate } = useInternationalization()
 
   return (
-    <div className={tw('group flex items-center gap-1', className)} data-test={TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID}>
+    <div
+      className={tw('group flex items-center gap-1', className)}
+      data-test={TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID}
+    >
       <Typography {...typographyProps}>{children}</Typography>
       <Tooltip placement="top-start" title={translate('text_623b42ff8ee4e000ba87d0c6')}>
         <Button

--- a/src/components/designSystem/TypographyWithCopy.tsx
+++ b/src/components/designSystem/TypographyWithCopy.tsx
@@ -19,28 +19,24 @@ export const TypographyWithCopy: FC<TypographyProps> = ({
   const { translate } = useInternationalization()
 
   return (
-    <div
-      className={tw('group flex items-center gap-1', className)}
-      data-test={TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID}
-    >
-      <Typography {...typographyProps}>{children}</Typography>
-      <Tooltip placement="top-start" title={translate('text_623b42ff8ee4e000ba87d0c6')}>
-        <Button
-          data-test={TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID}
-          className="opacity-0 group-hover:opacity-100"
-          icon="duplicate"
-          variant="quaternary"
-          size="small"
-          onClick={(e) => {
-            e.stopPropagation()
-            copyToClipboard(children as string)
-            addToast({
-              severity: 'info',
-              translateKey: 'text_1775559630554ourrtpgddty',
-            })
-          }}
-        />
-      </Tooltip>
-    </div>
+    <Tooltip placement="top-start" title={translate('text_623b42ff8ee4e000ba87d0c6')}>
+      <Button
+        data-test={TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID}
+        endIcon="duplicate"
+        variant="quaternary"
+        size="small"
+        className={tw('px-1 py-0', className)}
+        onClick={(e) => {
+          e.stopPropagation()
+          copyToClipboard(children as string)
+          addToast({
+            severity: 'info',
+            translateKey: 'text_1775559630554ourrtpgddty',
+          })
+        }}
+      >
+        <Typography {...typographyProps}>{children}</Typography>
+      </Button>
+    </Tooltip>
   )
 }

--- a/src/components/designSystem/TypographyWithCopy.tsx
+++ b/src/components/designSystem/TypographyWithCopy.tsx
@@ -35,7 +35,7 @@ export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
   }
 
   return (
-    <Tooltip placement="top" title={translate('text_623b42ff8ee4e000ba87d0c6')}>
+    <Tooltip placement="top" title={translate('text_623b42ff8ee4e000ba87d0c6')} className="w-fit">
       <Button
         data-test={TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID}
         endIcon="duplicate"

--- a/src/components/designSystem/TypographyWithCopy.tsx
+++ b/src/components/designSystem/TypographyWithCopy.tsx
@@ -15,6 +15,7 @@ export const TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID = 'typography-with-copy-button'
 interface TypographyWithCopyProps extends TypographyProps {
   masked?: boolean
   maskOptions?: MaskOptions
+  onCopy?: () => void
 }
 
 export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
@@ -22,17 +23,12 @@ export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
   className,
   masked,
   maskOptions,
+  onCopy,
   ...typographyProps
 }) => {
   const { translate } = useInternationalization()
 
-  if (masked) {
-    return (
-      <Typography className={className} {...typographyProps}>
-        {maskOptions ? maskValue(children as string, maskOptions) : children}
-      </Typography>
-    )
-  }
+  const displayValue = masked && maskOptions ? maskValue(children as string, maskOptions) : children
 
   return (
     <Tooltip placement="top" title={translate('text_623b42ff8ee4e000ba87d0c6')} className="w-fit">
@@ -44,14 +40,18 @@ export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
         className={tw('-ml-1 px-1 py-0', className)}
         onClick={(e) => {
           e.stopPropagation()
-          copyToClipboard(children as string)
-          addToast({
-            severity: 'info',
-            translateKey: 'text_1775559630554ourrtpgddty',
-          })
+          if (onCopy) {
+            onCopy()
+          } else {
+            copyToClipboard(children as string)
+            addToast({
+              severity: 'info',
+              translateKey: 'text_1775559630554ourrtpgddty',
+            })
+          }
         }}
       >
-        <Typography {...typographyProps}>{children}</Typography>
+        <Typography {...typographyProps}>{displayValue}</Typography>
       </Button>
     </Tooltip>
   )

--- a/src/components/designSystem/TypographyWithCopy.tsx
+++ b/src/components/designSystem/TypographyWithCopy.tsx
@@ -25,7 +25,7 @@ export const TypographyWithCopy: FC<TypographyProps> = ({
         endIcon="duplicate"
         variant="quaternary"
         size="small"
-        className={tw('px-1 py-0', className)}
+        className={tw('-m-1 px-1 py-0', className)}
         onClick={(e) => {
           e.stopPropagation()
           copyToClipboard(children as string)

--- a/src/components/designSystem/TypographyWithCopy.tsx
+++ b/src/components/designSystem/TypographyWithCopy.tsx
@@ -11,11 +11,7 @@ import { tw } from '~/styles/utils'
 export const TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID = 'typography-with-copy-container'
 export const TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID = 'typography-with-copy-button'
 
-interface TypographyWithCopyProps extends Omit<TypographyProps, 'children'> {
-  children: string
-}
-
-export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
+export const TypographyWithCopy: FC<TypographyProps> = ({
   children,
   className,
   ...typographyProps
@@ -37,10 +33,10 @@ export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
           size="small"
           onClick={(e) => {
             e.stopPropagation()
-            copyToClipboard(children)
+            copyToClipboard(children as string)
             addToast({
               severity: 'info',
-              translateKey: 'text_1775300000000copiedtoclipboard',
+              translateKey: 'text_1775559630554ourrtpgddty',
             })
           }}
         />

--- a/src/components/designSystem/TypographyWithCopy.tsx
+++ b/src/components/designSystem/TypographyWithCopy.tsx
@@ -1,0 +1,47 @@
+import { FC } from 'react'
+
+import { Button } from '~/components/designSystem/Button'
+import { Tooltip } from '~/components/designSystem/Tooltip'
+import { Typography, TypographyProps } from '~/components/designSystem/Typography'
+import { addToast } from '~/core/apolloClient'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { tw } from '~/styles/utils'
+
+export const TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID = 'typography-with-copy-container'
+export const TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID = 'typography-with-copy-button'
+
+interface TypographyWithCopyProps extends Omit<TypographyProps, 'children'> {
+  children: string
+}
+
+export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
+  children,
+  className,
+  ...typographyProps
+}) => {
+  const { translate } = useInternationalization()
+
+  return (
+    <div className={tw('group flex items-center gap-1', className)} data-test={TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID}>
+      <Typography {...typographyProps}>{children}</Typography>
+      <Tooltip placement="top-start" title={translate('text_623b42ff8ee4e000ba87d0c6')}>
+        <Button
+          data-test={TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID}
+          className="opacity-0 group-hover:opacity-100"
+          icon="duplicate"
+          variant="quaternary"
+          size="small"
+          onClick={(e) => {
+            e.stopPropagation()
+            copyToClipboard(children)
+            addToast({
+              severity: 'info',
+              translateKey: 'text_1775300000000copiedtoclipboard',
+            })
+          }}
+        />
+      </Tooltip>
+    </div>
+  )
+}

--- a/src/components/designSystem/TypographyWithCopy.tsx
+++ b/src/components/designSystem/TypographyWithCopy.tsx
@@ -4,6 +4,7 @@ import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography, TypographyProps } from '~/components/designSystem/Typography'
 import { addToast } from '~/core/apolloClient'
+import { MaskOptions, maskValue } from '~/core/formats/maskValue'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { tw } from '~/styles/utils'
@@ -11,21 +12,36 @@ import { tw } from '~/styles/utils'
 export const TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID = 'typography-with-copy-container'
 export const TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID = 'typography-with-copy-button'
 
-export const TypographyWithCopy: FC<TypographyProps> = ({
+interface TypographyWithCopyProps extends TypographyProps {
+  masked?: boolean
+  maskOptions?: MaskOptions
+}
+
+export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
   children,
   className,
+  masked,
+  maskOptions,
   ...typographyProps
 }) => {
   const { translate } = useInternationalization()
 
+  if (masked) {
+    return (
+      <Typography className={className} {...typographyProps}>
+        {maskOptions ? maskValue(children as string, maskOptions) : children}
+      </Typography>
+    )
+  }
+
   return (
-    <Tooltip placement="top-start" title={translate('text_623b42ff8ee4e000ba87d0c6')}>
+    <Tooltip placement="top" title={translate('text_623b42ff8ee4e000ba87d0c6')}>
       <Button
         data-test={TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID}
         endIcon="duplicate"
         variant="quaternary"
         size="small"
-        className={tw('-m-1 px-1 py-0', className)}
+        className={tw('-ml-1 px-1 py-0', className)}
         onClick={(e) => {
           e.stopPropagation()
           copyToClipboard(children as string)

--- a/src/components/designSystem/__tests__/TypographyWithCopy.test.tsx
+++ b/src/components/designSystem/__tests__/TypographyWithCopy.test.tsx
@@ -5,11 +5,7 @@ import { addToast } from '~/core/apolloClient'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import { render } from '~/test-utils'
 
-import {
-  TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID,
-  TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID,
-  TypographyWithCopy,
-} from '../TypographyWithCopy'
+import { TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID, TypographyWithCopy } from '../TypographyWithCopy'
 
 jest.mock('~/core/utils/copyToClipboard', () => ({
   copyToClipboard: jest.fn(),
@@ -28,31 +24,16 @@ describe('TypographyWithCopy', () => {
 
   describe('GIVEN the component is rendered', () => {
     describe('WHEN displaying text content', () => {
-      it('THEN should render the container', () => {
-        render(<TypographyWithCopy>some-id-123</TypographyWithCopy>)
-
-        expect(screen.getByTestId(TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID)).toBeInTheDocument()
-      })
-
       it('THEN should display the text', () => {
         render(<TypographyWithCopy>some-id-123</TypographyWithCopy>)
 
         expect(screen.getByText('some-id-123')).toBeInTheDocument()
       })
 
-      it('THEN should render the copy button', () => {
+      it('THEN should render the copy button with an end icon', () => {
         render(<TypographyWithCopy>some-id-123</TypographyWithCopy>)
 
         expect(screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID)).toBeInTheDocument()
-      })
-
-      it('THEN should apply hover-only visibility class to the copy button', () => {
-        render(<TypographyWithCopy>some-id-123</TypographyWithCopy>)
-
-        const button = screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID)
-
-        expect(button).toHaveClass('opacity-0')
-        expect(button).toHaveClass('group-hover:opacity-100')
       })
     })
 
@@ -67,12 +48,12 @@ describe('TypographyWithCopy', () => {
         expect(screen.getByTestId('captionCode')).toBeInTheDocument()
       })
 
-      it('THEN should apply custom className to the container', () => {
+      it('THEN should apply custom className to the button', () => {
         render(<TypographyWithCopy className="custom-class">text</TypographyWithCopy>)
 
-        const container = screen.getByTestId(TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID)
+        const button = screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID)
 
-        expect(container).toHaveClass('custom-class')
+        expect(button).toHaveClass('custom-class')
       })
     })
   })

--- a/src/components/designSystem/__tests__/TypographyWithCopy.test.tsx
+++ b/src/components/designSystem/__tests__/TypographyWithCopy.test.tsx
@@ -96,9 +96,7 @@ describe('TypographyWithCopy', () => {
 
         await user.click(screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID))
 
-        expect(addToast).toHaveBeenCalledWith(
-          expect.objectContaining({ severity: 'info' }),
-        )
+        expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'info' }))
       })
 
       it('THEN should stop event propagation', async () => {
@@ -106,6 +104,7 @@ describe('TypographyWithCopy', () => {
         const user = userEvent.setup()
 
         render(
+          /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
           <div onClick={parentClickHandler}>
             <TypographyWithCopy>some-value</TypographyWithCopy>
           </div>,

--- a/src/components/designSystem/__tests__/TypographyWithCopy.test.tsx
+++ b/src/components/designSystem/__tests__/TypographyWithCopy.test.tsx
@@ -1,0 +1,120 @@
+import { cleanup, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { addToast } from '~/core/apolloClient'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
+import { render } from '~/test-utils'
+
+import {
+  TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID,
+  TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID,
+  TypographyWithCopy,
+} from '../TypographyWithCopy'
+
+jest.mock('~/core/utils/copyToClipboard', () => ({
+  copyToClipboard: jest.fn(),
+}))
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: jest.fn(),
+}))
+
+describe('TypographyWithCopy', () => {
+  afterEach(() => {
+    cleanup()
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN the component is rendered', () => {
+    describe('WHEN displaying text content', () => {
+      it('THEN should render the container', () => {
+        render(<TypographyWithCopy>some-id-123</TypographyWithCopy>)
+
+        expect(screen.getByTestId(TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID)).toBeInTheDocument()
+      })
+
+      it('THEN should display the text', () => {
+        render(<TypographyWithCopy>some-id-123</TypographyWithCopy>)
+
+        expect(screen.getByText('some-id-123')).toBeInTheDocument()
+      })
+
+      it('THEN should render the copy button', () => {
+        render(<TypographyWithCopy>some-id-123</TypographyWithCopy>)
+
+        expect(screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID)).toBeInTheDocument()
+      })
+
+      it('THEN should apply hover-only visibility class to the copy button', () => {
+        render(<TypographyWithCopy>some-id-123</TypographyWithCopy>)
+
+        const button = screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID)
+
+        expect(button).toHaveClass('opacity-0')
+        expect(button).toHaveClass('group-hover:opacity-100')
+      })
+    })
+
+    describe('WHEN typography props are passed', () => {
+      it('THEN should render with the specified variant', () => {
+        render(
+          <TypographyWithCopy variant="captionCode" color="grey700">
+            plan_code_123
+          </TypographyWithCopy>,
+        )
+
+        expect(screen.getByTestId('captionCode')).toBeInTheDocument()
+      })
+
+      it('THEN should apply custom className to the container', () => {
+        render(<TypographyWithCopy className="custom-class">text</TypographyWithCopy>)
+
+        const container = screen.getByTestId(TYPOGRAPHY_WITH_COPY_CONTAINER_TEST_ID)
+
+        expect(container).toHaveClass('custom-class')
+      })
+    })
+  })
+
+  describe('GIVEN the user clicks the copy button', () => {
+    describe('WHEN the button is clicked', () => {
+      it('THEN should copy the text to clipboard', async () => {
+        const user = userEvent.setup()
+
+        render(<TypographyWithCopy>abc-def-456</TypographyWithCopy>)
+
+        await user.click(screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID))
+
+        expect(copyToClipboard).toHaveBeenCalledWith('abc-def-456')
+      })
+
+      it('THEN should show an info toast', async () => {
+        const user = userEvent.setup()
+
+        render(<TypographyWithCopy>abc-def-456</TypographyWithCopy>)
+
+        await user.click(screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID))
+
+        expect(addToast).toHaveBeenCalledWith(
+          expect.objectContaining({ severity: 'info' }),
+        )
+      })
+
+      it('THEN should stop event propagation', async () => {
+        const parentClickHandler = jest.fn()
+        const user = userEvent.setup()
+
+        render(
+          <div onClick={parentClickHandler}>
+            <TypographyWithCopy>some-value</TypographyWithCopy>
+          </div>,
+        )
+
+        await user.click(screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID))
+
+        expect(parentClickHandler).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/components/designSystem/__tests__/TypographyWithCopy.test.tsx
+++ b/src/components/designSystem/__tests__/TypographyWithCopy.test.tsx
@@ -58,6 +58,53 @@ describe('TypographyWithCopy', () => {
     })
   })
 
+  describe('GIVEN the component is rendered with masked props', () => {
+    describe('WHEN masked with maskOptions', () => {
+      it('THEN should display the masked text', () => {
+        render(
+          <TypographyWithCopy masked maskOptions={{ dotsCount: 8, visibleChars: 3 }}>
+            secret-key-abc
+          </TypographyWithCopy>,
+        )
+
+        expect(screen.queryByText('secret-key-abc')).not.toBeInTheDocument()
+        expect(screen.getByText('••••••••abc')).toBeInTheDocument()
+      })
+
+      it('THEN should still render the copy button', () => {
+        render(
+          <TypographyWithCopy masked maskOptions={{ dotsCount: 8, visibleChars: 3 }}>
+            secret-key-abc
+          </TypographyWithCopy>,
+        )
+
+        expect(screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID)).toBeInTheDocument()
+      })
+
+      it('THEN should copy the real value when clicked', async () => {
+        const user = userEvent.setup()
+
+        render(
+          <TypographyWithCopy masked maskOptions={{ dotsCount: 8, visibleChars: 3 }}>
+            secret-key-abc
+          </TypographyWithCopy>,
+        )
+
+        await user.click(screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID))
+
+        expect(copyToClipboard).toHaveBeenCalledWith('secret-key-abc')
+      })
+    })
+
+    describe('WHEN masked without maskOptions', () => {
+      it('THEN should display the children as-is', () => {
+        render(<TypographyWithCopy masked>••••••••c6f</TypographyWithCopy>)
+
+        expect(screen.getByText('••••••••c6f')).toBeInTheDocument()
+      })
+    })
+  })
+
   describe('GIVEN the user clicks the copy button', () => {
     describe('WHEN the button is clicked', () => {
       it('THEN should copy the text to clipboard', async () => {
@@ -94,6 +141,21 @@ describe('TypographyWithCopy', () => {
         await user.click(screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID))
 
         expect(parentClickHandler).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN onCopy is provided', () => {
+      it('THEN should call onCopy instead of the default copy behavior', async () => {
+        const onCopy = jest.fn()
+        const user = userEvent.setup()
+
+        render(<TypographyWithCopy onCopy={onCopy}>some-value</TypographyWithCopy>)
+
+        await user.click(screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID))
+
+        expect(onCopy).toHaveBeenCalled()
+        expect(copyToClipboard).not.toHaveBeenCalled()
+        expect(addToast).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/components/developers/apiKeys/ApiKeys.tsx
+++ b/src/components/developers/apiKeys/ApiKeys.tsx
@@ -10,6 +10,7 @@ import { Table } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import {
   DeleteApiKeyDialog,
   DeleteApiKeyDialogRef,
@@ -27,7 +28,6 @@ import {
 } from '~/components/layouts/Settings'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { addToast } from '~/core/apolloClient'
-import { maskValue } from '~/core/formats/maskValue'
 import { CREATE_API_KEYS_ROUTE, UPDATE_API_KEYS_ROUTE } from '~/core/router'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import {
@@ -44,7 +44,6 @@ import { useDeveloperTool } from '~/hooks/useDeveloperTool'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { usePermissions } from '~/hooks/usePermissions'
 import { STATE_KEY_ID_TO_REVEAL } from '~/pages/developers/ApiKeysForm'
-import { tw } from '~/styles/utils'
 
 gql`
   fragment ApiKeyRevealedForApiKeysList on ApiKey {
@@ -183,34 +182,15 @@ export const ApiKeys = () => {
                       maxSpace: true,
                       content: ({ id }) => (
                         <div className="flex items-center gap-2 py-3">
-                          <Tooltip
-                            placement="top-start"
-                            title={translate('text_623b42ff8ee4e000ba87d0c6')}
-                            disableHoverListener={!showOrganizationId}
+                          <TypographyWithCopy
+                            className="ml-0 line-break-auto [text-wrap:auto]"
+                            color="grey700"
+                            variant="captionCode"
+                            masked={!showOrganizationId}
+                            maskOptions={{ dotsCount: 8, visibleChars: 3 }}
                           >
-                            <Typography
-                              className={tw('line-break-auto [text-wrap:auto]', {
-                                'cursor-pointer': showOrganizationId,
-                              })}
-                              color="grey700"
-                              variant="captionCode"
-                              onClick={
-                                showOrganizationId
-                                  ? () => {
-                                      copyToClipboard(id)
-                                      addToast({
-                                        severity: 'info',
-                                        translateKey: 'text_636df520279a9e1b3c68cc7d',
-                                      })
-                                    }
-                                  : undefined
-                              }
-                            >
-                              {showOrganizationId
-                                ? id
-                                : maskValue(id, { dotsCount: 8, visibleChars: 3 })}
-                            </Typography>
-                          </Tooltip>
+                            {id}
+                          </TypographyWithCopy>
 
                           <Tooltip
                             placement="top-start"
@@ -344,32 +324,14 @@ export const ApiKeys = () => {
 
                         return (
                           <div className="flex items-center gap-2 py-3">
-                            <Tooltip
-                              placement="top-start"
-                              title={translate('text_623b42ff8ee4e000ba87d0c6')}
-                              disableHoverListener={!apiKeyValue}
+                            <TypographyWithCopy
+                              className="ml-0 line-break-auto [text-wrap:auto]"
+                              color="grey700"
+                              variant="captionCode"
+                              masked={!apiKeyValue}
                             >
-                              <Typography
-                                className={tw('line-break-auto [text-wrap:auto]', {
-                                  'cursor-pointer': !!apiKeyValue,
-                                })}
-                                color="grey700"
-                                variant="captionCode"
-                                onClick={
-                                  !!apiKeyValue
-                                    ? () => {
-                                        copyToClipboard(apiKeyValue)
-                                        addToast({
-                                          severity: 'info',
-                                          translateKey: 'text_6227a2e847fcd700e9038952',
-                                        })
-                                      }
-                                    : undefined
-                                }
-                              >
-                                {apiKeyValue || value}
-                              </Typography>
-                            </Tooltip>
+                              {apiKeyValue || value}
+                            </TypographyWithCopy>
 
                             <Tooltip
                               placement="top-start"

--- a/src/components/developers/apiKeys/ApiKeys.tsx
+++ b/src/components/developers/apiKeys/ApiKeys.tsx
@@ -329,6 +329,29 @@ export const ApiKeys = () => {
                               color="grey700"
                               variant="captionCode"
                               masked={!apiKeyValue}
+                              onCopy={
+                                apiKeyValue
+                                  ? undefined
+                                  : async () => {
+                                      try {
+                                        const res = await getApiKeyValue({ variables: { id } })
+                                        const fetchedValue = res?.data?.apiKey?.value
+
+                                        if (fetchedValue) {
+                                          copyToClipboard(fetchedValue)
+                                          addToast({
+                                            severity: 'info',
+                                            translateKey: 'text_6227a2e847fcd700e9038952',
+                                          })
+                                        }
+                                      } catch {
+                                        addToast({
+                                          severity: 'danger',
+                                          translateKey: 'text_62b31e1f6a5b8b1b745ece48',
+                                        })
+                                      }
+                                    }
+                              }
                             >
                               {apiKeyValue || value}
                             </TypographyWithCopy>

--- a/src/components/developers/webhooks/WebhookOverview.tsx
+++ b/src/components/developers/webhooks/WebhookOverview.tsx
@@ -92,7 +92,11 @@ export const WebhookOverview = ({ webhook, loading, signatureLabel }: WebhookOve
         <Typography variant="caption" color="grey600">
           {translate('text_6271200984178801ba8bdf22')}
         </Typography>
-        <TypographyWithCopy variant="body" color="grey700" data-test={WEBHOOK_OVERVIEW_URL_VALUE_TEST_ID}>
+        <TypographyWithCopy
+          variant="body"
+          color="grey700"
+          data-test={WEBHOOK_OVERVIEW_URL_VALUE_TEST_ID}
+        >
           {webhook?.webhookUrl ?? ''}
         </TypographyWithCopy>
       </div>

--- a/src/components/developers/webhooks/WebhookOverview.tsx
+++ b/src/components/developers/webhooks/WebhookOverview.tsx
@@ -1,5 +1,6 @@
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { GetWebhookEndpointQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useWebhookEventTypes } from '~/hooks/useWebhookEventTypes'
@@ -91,9 +92,9 @@ export const WebhookOverview = ({ webhook, loading, signatureLabel }: WebhookOve
         <Typography variant="caption" color="grey600">
           {translate('text_6271200984178801ba8bdf22')}
         </Typography>
-        <Typography variant="body" color="grey700" data-test={WEBHOOK_OVERVIEW_URL_VALUE_TEST_ID}>
-          {webhook?.webhookUrl}
-        </Typography>
+        <TypographyWithCopy variant="body" color="grey700" data-test={WEBHOOK_OVERVIEW_URL_VALUE_TEST_ID}>
+          {webhook?.webhookUrl ?? ''}
+        </TypographyWithCopy>
       </div>
 
       <div className="flex flex-col gap-1">

--- a/src/components/developers/webhooks/Webhooks.tsx
+++ b/src/components/developers/webhooks/Webhooks.tsx
@@ -6,6 +6,7 @@ import { Button } from '~/components/designSystem/Button'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { WEBHOOK_ROUTE } from '~/components/developers/devtoolsRoutes'
 import { useDeleteWebhook } from '~/components/developers/webhooks/useDeleteWebhook'
 import {
@@ -14,14 +15,12 @@ import {
   SettingsListItemLoadingSkeleton,
 } from '~/components/layouts/Settings'
 import { addToast } from '~/core/apolloClient'
-import { maskValue } from '~/core/formats/maskValue'
 import { CREATE_WEBHOOK_ROUTE, UPDATE_WEBHOOK_ROUTE } from '~/core/router'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import { useGetOrganizationHmacDataQuery, useGetWebhookListQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useDeveloperTool } from '~/hooks/useDeveloperTool'
 import { useWebhookEventTypes } from '~/hooks/useWebhookEventTypes'
-import { tw } from '~/styles/utils'
 
 const WEBHOOK_COUNT_LIMIT = 25
 
@@ -185,34 +184,15 @@ export const Webhooks = () => {
                       maxSpace: true,
                       content: ({ hmacKey }) => (
                         <div className="flex items-center gap-2 py-3">
-                          <Tooltip
-                            placement="top-start"
-                            title={translate('text_623b42ff8ee4e000ba87d0c6')}
-                            disableHoverListener={!showOrganizationHmac}
+                          <TypographyWithCopy
+                            className="ml-0 line-break-auto [text-wrap:auto]"
+                            color="grey700"
+                            variant="captionCode"
+                            masked={!showOrganizationHmac}
+                            maskOptions={{ dotsCount: 8, visibleChars: 3 }}
                           >
-                            <Typography
-                              className={tw('line-break-auto [text-wrap:auto]', {
-                                'cursor-pointer': showOrganizationHmac,
-                              })}
-                              color="grey700"
-                              variant="captionCode"
-                              onClick={
-                                showOrganizationHmac
-                                  ? () => {
-                                      copyToClipboard(hmacKey || '')
-                                      addToast({
-                                        severity: 'info',
-                                        translateKey: 'text_1731675102864b4dna9o03pv',
-                                      })
-                                    }
-                                  : undefined
-                              }
-                            >
-                              {showOrganizationHmac
-                                ? hmacKey
-                                : maskValue(hmacKey || '', { dotsCount: 8, visibleChars: 3 })}
-                            </Typography>
-                          </Tooltip>
+                            {hmacKey || ''}
+                          </TypographyWithCopy>
 
                           <Tooltip
                             placement="top-start"

--- a/src/components/features/FeatureDetailsOverview.tsx
+++ b/src/components/features/FeatureDetailsOverview.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { getPrivilegeValueTypeTranslationKey } from '~/core/constants/form'
 import { PrivilegeValueTypeEnum, useGetFeatureForDetailsOverviewQuery } from '~/generated/graphql'
@@ -61,7 +62,11 @@ export const FeatureDetailsOverview = () => {
               },
               {
                 label: translate('text_1752692673070dtc2aidgcmh'),
-                value: feature?.code,
+                value: feature?.code ? (
+                  <TypographyWithCopy variant="body" color="grey700">
+                    {feature.code}
+                  </TypographyWithCopy>
+                ) : undefined,
               },
             ]}
           />
@@ -105,7 +110,11 @@ export const FeatureDetailsOverview = () => {
                     },
                     {
                       label: translate('text_1752845254936jdsefrsvmam'),
-                      value: privilege.code,
+                      value: privilege.code ? (
+                        <TypographyWithCopy variant="body" color="grey700">
+                          {privilege.code}
+                        </TypographyWithCopy>
+                      ) : undefined,
                     },
                     {
                       label: translate('text_175287350361170qk4c93fmm'),

--- a/src/components/plans/details/PlanDetailsOverview.tsx
+++ b/src/components/plans/details/PlanDetailsOverview.tsx
@@ -1,5 +1,6 @@
 import { gql } from '@apollo/client'
 
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { PlanDetailsFixedChargesSection } from '~/components/plans/details/PlanDetailsFixedChargesSection'
 import { getIntervalTranslationKey } from '~/core/constants/form'
@@ -70,7 +71,11 @@ export const PlanDetailsOverview = ({
               },
               {
                 label: translate('text_642d5eb2783a2ad10d670320'),
-                value: plan?.code,
+                value: plan?.code ? (
+                  <TypographyWithCopy variant="body" color="grey700">
+                    {plan.code}
+                  </TypographyWithCopy>
+                ) : undefined,
               },
               {
                 label: translate('text_65201b8216455901fe273dc1'),

--- a/src/components/plans/details/PlanSubscriptionList.tsx
+++ b/src/components/plans/details/PlanSubscriptionList.tsx
@@ -6,6 +6,7 @@ import { Avatar } from '~/components/designSystem/Avatar'
 import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { CustomerSubscriptionDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { PLAN_SUBSCRIPTION_DETAILS_ROUTE } from '~/core/router/ObjectsRoutes'
@@ -126,9 +127,9 @@ const PlanSubscriptionList = ({ planCode }: { planCode?: string }) => {
                       <Typography variant="bodyHl" color="textSecondary" noWrap>
                         {customerName}
                       </Typography>
-                      <Typography variant="caption" color="grey600" noWrap>
-                        {customer?.externalId}
-                      </Typography>
+                      <TypographyWithCopy variant="caption" color="grey600" noWrap>
+                        {customer?.externalId ?? ''}
+                      </TypographyWithCopy>
                     </div>
                   </div>
                 )

--- a/src/components/subscriptions/SubscriptionInformations.tsx
+++ b/src/components/subscriptions/SubscriptionInformations.tsx
@@ -5,6 +5,7 @@ import { generatePath, Link } from 'react-router-dom'
 import { ConditionalWrapper } from '~/components/ConditionalWrapper'
 import { Alert } from '~/components/designSystem/Alert'
 import { Status } from '~/components/designSystem/Status'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { getBillingTimeEnumTranslationKey } from '~/core/constants/form'
 import { subscriptionStatusMapping } from '~/core/constants/statusSubscriptionMapping'
@@ -105,7 +106,13 @@ export const SubscriptionInformations = ({
         />
         <DetailsPage.InfoGridItem
           label={translate('text_65201c5a175a4b0238abf298')}
-          value={subscription?.externalId}
+          value={
+            subscription?.externalId ? (
+              <TypographyWithCopy variant="body" color="grey700">
+                {subscription.externalId}
+              </TypographyWithCopy>
+            ) : undefined
+          }
         />
         <DetailsPage.InfoGrid
           grid={[

--- a/src/components/wallets/WalletDetailsDrawer.tsx
+++ b/src/components/wallets/WalletDetailsDrawer.tsx
@@ -21,6 +21,7 @@ import { NavigationTab, TabManagedBy } from '~/components/designSystem/Navigatio
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Status } from '~/components/designSystem/Status'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import WalletTransactionItems from '~/components/wallets/WalletTransactionItems'
 import { buildGoCardlessPaymentUrl, buildStripePaymentUrl } from '~/core/constants/externalUrls'
 import {
@@ -556,7 +557,11 @@ export const WalletDetailsDrawer = forwardRef<WalletDetailsDrawerRef, WalletDeta
                               />
                               <DetailRow
                                 label={translate('text_6298bd525e359200d5ea01f2')}
-                                value={id}
+                                value={
+                                  <TypographyWithCopy variant="body" color="grey700">
+                                    {`${id}`}
+                                  </TypographyWithCopy>
+                                }
                               />
                             </div>
                           </section>
@@ -607,7 +612,13 @@ export const WalletDetailsDrawer = forwardRef<WalletDetailsDrawerRef, WalletDeta
                                   />
                                   <DetailRow
                                     label={translate('text_1741944051511g2xahsgoyn7')}
-                                    value={invoice?.id}
+                                    value={
+                                      invoice?.id ? (
+                                        <TypographyWithCopy variant="body" color="grey700">
+                                          {invoice.id}
+                                        </TypographyWithCopy>
+                                      ) : undefined
+                                    }
                                   />
                                   <DetailRow
                                     label={translate('text_64188b3d9735d5007d71226c')}
@@ -707,7 +718,13 @@ export const WalletDetailsDrawer = forwardRef<WalletDetailsDrawerRef, WalletDeta
                                           <div key={`payment-${index}`} className={tw(GRID)}>
                                             <DetailRow
                                               label={translate('text_1741943835752p8v8nrgnuyl')}
-                                              value={payment?.id}
+                                              value={
+                                                payment?.id ? (
+                                                  <TypographyWithCopy variant="body" color="grey700">
+                                                    {payment.id}
+                                                  </TypographyWithCopy>
+                                                ) : undefined
+                                              }
                                             />
                                             <DetailRow
                                               label={translate('text_1737112054603c6phsbkyvmx')}

--- a/src/components/wallets/WalletDetailsDrawer.tsx
+++ b/src/components/wallets/WalletDetailsDrawer.tsx
@@ -559,7 +559,7 @@ export const WalletDetailsDrawer = forwardRef<WalletDetailsDrawerRef, WalletDeta
                                 label={translate('text_6298bd525e359200d5ea01f2')}
                                 value={
                                   <TypographyWithCopy variant="body" color="grey700">
-                                    {`${id}`}
+                                    {id}
                                   </TypographyWithCopy>
                                 }
                               />

--- a/src/components/wallets/WalletDetailsDrawer.tsx
+++ b/src/components/wallets/WalletDetailsDrawer.tsx
@@ -720,7 +720,10 @@ export const WalletDetailsDrawer = forwardRef<WalletDetailsDrawerRef, WalletDeta
                                               label={translate('text_1741943835752p8v8nrgnuyl')}
                                               value={
                                                 payment?.id ? (
-                                                  <TypographyWithCopy variant="body" color="grey700">
+                                                  <TypographyWithCopy
+                                                    variant="body"
+                                                    color="grey700"
+                                                  >
                                                     {payment.id}
                                                   </TypographyWithCopy>
                                                 ) : undefined

--- a/src/components/wallets/WalletInformations.tsx
+++ b/src/components/wallets/WalletInformations.tsx
@@ -1,5 +1,6 @@
 import { Chip } from '~/components/designSystem/Chip'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import PremiumFeature from '~/components/premium/PremiumFeature'
 import { getIntervalTranslationKey } from '~/core/constants/form'
@@ -95,7 +96,14 @@ const WalletInformations = ({ wallet }: WalletInformationsProps) => {
         <DetailsPage.InfoGrid
           grid={[
             { label: translate('text_1772536695408sddzumtfq2t'), value: wallet?.name },
-            { label: translate('text_1772536695408yflknt6y6q4'), value: wallet?.code },
+                        {
+              label: translate('text_1772536695408yflknt6y6q4'),
+              value: wallet?.code ? (
+                <TypographyWithCopy variant="body" color="grey700">
+                  {wallet.code}
+                </TypographyWithCopy>
+              ) : undefined,
+            },
             {
               label: translate('text_1750411499858su5b7bbp5t9'),
               value: translate('text_62da6ec24a8e24e44f812872', {

--- a/src/components/wallets/WalletInformations.tsx
+++ b/src/components/wallets/WalletInformations.tsx
@@ -96,7 +96,7 @@ const WalletInformations = ({ wallet }: WalletInformationsProps) => {
         <DetailsPage.InfoGrid
           grid={[
             { label: translate('text_1772536695408sddzumtfq2t'), value: wallet?.name },
-                        {
+            {
               label: translate('text_1772536695408yflknt6y6q4'),
               value: wallet?.code ? (
                 <TypographyWithCopy variant="body" color="grey700">

--- a/src/core/formats/maskValue.ts
+++ b/src/core/formats/maskValue.ts
@@ -1,4 +1,4 @@
-type MaskOptions = {
+export type MaskOptions = {
   /** Number of dots to prepend (default: 4) */
   dotsCount?: number
   /** Number of characters to show from the end. If not provided, shows the full value */

--- a/src/pages/AddOnDetails.tsx
+++ b/src/pages/AddOnDetails.tsx
@@ -4,6 +4,7 @@ import { generatePath, useNavigate, useParams } from 'react-router-dom'
 
 import { DeleteAddOnDialog, DeleteAddOnDialogRef } from '~/components/addOns/DeleteAddOnDialog'
 import { Card } from '~/components/designSystem/Card'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { MainHeaderAction } from '~/components/MainHeader/types'
@@ -117,7 +118,11 @@ const AddOnDetails = () => {
               },
               {
                 label: translate('text_6627e7b9732dbfb6c472e02d'),
-                value: addOn?.code,
+                value: addOn?.code ? (
+                  <TypographyWithCopy variant="body" color="grey700">
+                    {addOn.code}
+                  </TypographyWithCopy>
+                ) : undefined,
               },
               {
                 label: translate('text_632b4acf0c41206cbcb8c324'),

--- a/src/pages/__devOnly/DesignSystem.tsx
+++ b/src/pages/__devOnly/DesignSystem.tsx
@@ -26,6 +26,7 @@ import { ChargeTable, HorizontalDataTable } from '~/components/designSystem/Tabl
 import { Table } from '~/components/designSystem/Table/Table'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import {
   ButtonSelectorField,
   Checkbox,
@@ -1400,6 +1401,25 @@ const DesignSystem = () => {
                     <Typography color="disabled">color disabled</Typography>
                     <Typography color="danger600">color danger600</Typography>
                     <Typography color="white">color white</Typography>
+                  </VerticalBlock>
+                </Block>
+                <Typography className="mb-4 mt-8" variant="headline">
+                  TypographyWithCopy
+                </Typography>
+                <Block className="mb-0">
+                  <VerticalBlock>
+                    <TypographyWithCopy variant="body" color="grey700">
+                      db7a5c02-a7c8-4c48-a44f-3e5b1f2a9e3d
+                    </TypographyWithCopy>
+                    <TypographyWithCopy variant="captionCode" color="grey700">
+                      sub_ext_12345
+                    </TypographyWithCopy>
+                    <TypographyWithCopy variant="caption" color="grey600">
+                      PLAN_CODE_MONTHLY
+                    </TypographyWithCopy>
+                    <TypographyWithCopy variant="bodyHl" color="grey700">
+                      INV-2024-001-234
+                    </TypographyWithCopy>
                   </VerticalBlock>
                 </Block>
               </Container>

--- a/translations/base.json
+++ b/translations/base.json
@@ -4055,5 +4055,6 @@
   "text_177679885005270syn8w6fh8": "{{emailUpdater}} removed role {{rolesDeleted}} from {{emailUpdated}}",
   "text_17767988500520plhs9f7tkm": "{{emailUpdater}} updated {{emailUpdated}}’s role to {{rolesAdded}} (previously {{rolesDeleted}})",
   "text_1776883338722o7e5us2iq7h": "Anniversary",
-  "text_177688333872224m25xpq3m2": "Calendar"
+  "text_177688333872224m25xpq3m2": "Calendar",
+  "text_1775300000000copiedtoclipboard": "Copied to clipboard"
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -4056,5 +4056,5 @@
   "text_17767988500520plhs9f7tkm": "{{emailUpdater}} updated {{emailUpdated}}’s role to {{rolesAdded}} (previously {{rolesDeleted}})",
   "text_1776883338722o7e5us2iq7h": "Anniversary",
   "text_177688333872224m25xpq3m2": "Calendar",
-  "text_1775300000000copiedtoclipboard": "Copied to clipboard"
+  "text_1775559630554ourrtpgddty": "Copied to clipboard"
 }


### PR DESCRIPTION
## Summary

- Add a new `TypographyWithCopy` design system component that displays text with a hover-visible "copy to clipboard" button
- Replace plain `Typography` with `TypographyWithCopy` across 15 locations where IDs, codes, and identifiers are displayed
- Add unit tests for the new component

Closes the request for "Click to copy" actions on IDs/codes to simplify QA and daily usage.

## Details

**New component: `TypographyWithCopy`**
- Accepts the same props as `Typography`, with `children` narrowed to `string` (the displayed value is also the copied value)
- Shows a `duplicate` icon button on hover (`group-hover:opacity-100`)
- Copies text to clipboard on click and shows a generic "Copied to clipboard" toast
- Only the icon button triggers copy — text remains selectable normally
- `stopPropagation` on click prevents triggering parent handlers (e.g., table row clicks)

**Locations updated:**

| Area | Value | File |
| --- | --- | --- |
| Plans | Plan code | `PlanDetailsOverview.tsx` |
| Coupons | Coupon code | `CouponDetailsOverview.tsx` |
| Billable Metrics | Metric code | `BillableMetricDetailsOverview.tsx` |
| Features | Feature code, Privilege code | `FeatureDetailsOverview.tsx` |
| Wallets | Wallet code | `WalletInformations.tsx` |
| Add-ons | Add-on code | `AddOnDetails.tsx` |
| Subscriptions | External ID | `SubscriptionInformations.tsx` |
| Plans | Customer external ID (table) | `PlanSubscriptionList.tsx` |
| Coupons | Customer external ID (table) | `CouponDetailsAppliedCoupons.tsx` |
| Webhooks | Webhook URL | `WebhookOverview.tsx` |
| Wallets | Transaction ID, Invoice ID, Payment ID | `WalletDetailsDrawer.tsx` |

## Test plan

- [ ] Visit `/design-system` → Typography tab → verify TypographyWithCopy section renders
- [ ] Hover over any copy-enabled value → duplicate icon appears
- [ ] Click the icon → value copied to clipboard, "Copied to clipboard" toast appears
- [ ] Verify text selection still works (clicking text does NOT copy)
- [ ] Check detail pages: plan, coupon, billable metric, feature, add-on, wallet, subscription
- [ ] Check table views: plan subscriptions list, applied coupons list
- [ ] Check webhook overview and wallet transaction drawer
- [ ] `pnpm test src/components/designSystem/__tests__/TypographyWithCopy.test.tsx` — 9 tests pass
- [ ] `npx tsc --noEmit` — zero type errors