### PR TITLE
feat(auth): add Entra ID SSO flows and settings parity

### DIFF
--- a/src/core/apolloClient/graphqlResolvers.tsx
+++ b/src/core/apolloClient/graphqlResolvers.tsx
@@ -51,6 +51,8 @@ export const typeDefs = gql`
     domain_not_configured
     okta_login_method_not_authorized
     okta_userinfo_error
+    entra_id_login_method_not_authorized
+    entra_id_userinfo_error
 
     # Anrok errors
     currencyCodeNotSupported

--- a/src/core/router/AuthRoutes.tsx
+++ b/src/core/router/AuthRoutes.tsx
@@ -16,10 +16,13 @@ const InvitationInit = lazyLoad(() => import('~/pages/InvitationInit'))
 const GoogleAuthCallback = lazyLoad(() => import('~/pages/auth/GoogleAuthCallback'))
 const LoginOkta = lazyLoad(() => import('~/pages/auth/LoginOkta'))
 const OktaAuthCallback = lazyLoad(() => import('~/pages/auth/OktaAuthCallback'))
+const LoginEntraId = lazyLoad(() => import('~/pages/auth/LoginEntraId'))
+const EntraIdAuthCallback = lazyLoad(() => import('~/pages/auth/EntraIdAuthCallback'))
 
 // ----------- Routes -----------
 export const LOGIN_ROUTE = '/login'
 export const LOGIN_OKTA = `${LOGIN_ROUTE}/okta`
+export const LOGIN_ENTRA_ID = `${LOGIN_ROUTE}/entra`
 export const FORGOT_PASSWORD_ROUTE = '/forgot-password'
 export const RESET_PASSWORD_ROUTE = '/reset-password/:token'
 export const SIGN_UP_ROUTE = '/sign-up'
@@ -27,6 +30,7 @@ export const INVITATION_ROUTE = '/invitation/:token'
 export const INVITATION_ROUTE_FORM = '/invitation/:token/form'
 export const GOOGLE_AUTH_CALLBACK = '/auth/google/callback'
 export const OKTA_AUTH_CALLBACK = '/auth/okta/callback'
+export const ENTRA_ID_AUTH_CALLBACK = '/auth/entra/callback'
 
 export const authRoutes: CustomRouteObject[] = [
   ...(!disableSignUp
@@ -49,6 +53,11 @@ export const authRoutes: CustomRouteObject[] = [
     onlyPublic: true,
   },
   {
+    path: LOGIN_ENTRA_ID,
+    element: <LoginEntraId />,
+    onlyPublic: true,
+  },
+  {
     path: FORGOT_PASSWORD_ROUTE,
     element: <ForgotPassword />,
     onlyPublic: true,
@@ -61,6 +70,11 @@ export const authRoutes: CustomRouteObject[] = [
   {
     path: OKTA_AUTH_CALLBACK,
     element: <OktaAuthCallback />,
+    onlyPublic: true,
+  },
+  {
+    path: ENTRA_ID_AUTH_CALLBACK,
+    element: <EntraIdAuthCallback />,
     onlyPublic: true,
   },
   {

--- a/src/core/router/SettingRoutes.tsx
+++ b/src/core/router/SettingRoutes.tsx
@@ -104,6 +104,9 @@ const RoleCreateEdit = lazyLoad(
 const OktaAuthenticationDetails = lazyLoad(
   () => import('~/pages/settings/teamAndSecurity/authentication/OktaAuthenticationDetails'),
 )
+const EntraIdAuthenticationDetails = lazyLoad(
+  () => import('~/pages/settings/teamAndSecurity/authentication/EntraIdAuthenticationDetails'),
+)
 
 // ----------- Routes -----------
 export const SETTINGS_ROUTE = '/settings'
@@ -165,6 +168,7 @@ export const ROLE_EDIT_ROUTE = `${ROOT_ROLES_ROUTE}/:roleId/edit`
 
 export const AUTHENTICATION_ROUTE = `${TEAM_AND_SECURITY_ROOT_ROUTE}/authentication`
 export const OKTA_AUTHENTICATION_ROUTE = `${AUTHENTICATION_ROUTE}/okta/:integrationId`
+export const ENTRA_ID_AUTHENTICATION_ROUTE = `${AUTHENTICATION_ROUTE}/entra-id/:integrationId`
 
 export const TEAM_AND_SECURITY_GROUP_ROUTE = `${TEAM_AND_SECURITY_ROOT_ROUTE}/:group`
 export const TEAM_AND_SECURITY_TAB_ROUTE = `${TEAM_AND_SECURITY_GROUP_ROUTE}/:tab`
@@ -246,6 +250,12 @@ export const settingRoutes: CustomRouteObject[] = [
         path: OKTA_AUTHENTICATION_ROUTE,
         private: true,
         element: <OktaAuthenticationDetails />,
+        permissions: ['organizationIntegrationsView', 'authenticationMethodsView'],
+      },
+      {
+        path: ENTRA_ID_AUTHENTICATION_ROUTE,
+        private: true,
+        element: <EntraIdAuthenticationDetails />,
         permissions: ['organizationIntegrationsView', 'authenticationMethodsView'],
       },
       {

--- a/src/pages/Invitation.tsx
+++ b/src/pages/Invitation.tsx
@@ -1,4 +1,4 @@
-import { gql, useApolloClient } from '@apollo/client'
+import { gql, useApolloClient, useMutation } from '@apollo/client'
 import Stack from '@mui/material/Stack'
 import { revalidateLogic, useStore } from '@tanstack/react-form'
 import { useEffect, useMemo } from 'react'
@@ -20,7 +20,6 @@ import {
   CurrentUserFragmentDoc,
   LagoApiError,
   useAcceptInviteMutation,
-  useFetchOktaAuthorizeUrlMutation,
   useGetinviteQuery,
   useGoogleAcceptInviteMutation,
   useOktaAcceptInviteMutation,
@@ -76,6 +75,18 @@ gql`
     }
   }
 
+  mutation entraIdAuthorize($input: EntraIdAuthorizeInput!) {
+    entraIdAuthorize(input: $input) {
+      url
+    }
+  }
+
+  mutation entraIdAcceptInvite($input: EntraIdAcceptInviteInput!) {
+    entraIdAcceptInvite(input: $input) {
+      token
+    }
+  }
+
   ${CurrentUserFragmentDoc}
 `
 
@@ -89,6 +100,8 @@ const Invitation = () => {
   const googleCode = searchParams.get('code') || ''
   const oktaCode = searchParams.get('oktaCode') || ''
   const oktaState = searchParams.get('oktaState') || ''
+  const entraIdCode = searchParams.get('entraIdCode') || ''
+  const entraIdState = searchParams.get('entraIdState') || ''
 
   const { data, error, loading } = useGetinviteQuery({
     context: { silentErrorCodes: [LagoApiError.InviteNotFound, LagoApiError.NotFound] },
@@ -116,10 +129,28 @@ const Invitation = () => {
     },
   })
 
+  const [fetchOktaAuthorizeUrl, { error: oktaAuthorizeUrlError, loading: oktaAuthorizeUrlLoading }] =
+    useMutation<{ oktaAuthorize?: { url?: string } }>(gql`
+      mutation fetchOktaAuthorizeUrl($input: OktaAuthorizeInput!) {
+        oktaAuthorize(input: $input) {
+          url
+        }
+      }
+    `, {
+      context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
+      fetchPolicy: 'network-only',
+    })
+
   const [
-    fetchOktaAuthorizeUrl,
-    { error: oktaAuthorizeUrlError, loading: oktaAuthorizeUrlLoading },
-  ] = useFetchOktaAuthorizeUrlMutation({
+    fetchEntraIdAuthorizeUrl,
+    { error: entraIdAuthorizeUrlError, loading: entraIdAuthorizeUrlLoading },
+  ] = useMutation<{ entraIdAuthorize?: { url?: string } }>(gql`
+    mutation fetchEntraIdAuthorizeUrl($input: EntraIdAuthorizeInput!) {
+      entraIdAuthorize(input: $input) {
+        url
+      }
+    }
+  `, {
     context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
     fetchPolicy: 'network-only',
   })
@@ -130,6 +161,22 @@ const Invitation = () => {
       onCompleted: async (res) => {
         if (!!res?.oktaAcceptInvite) {
           await onLogIn(client, res?.oktaAcceptInvite.token)
+        }
+      },
+    })
+
+  const [entraIdAcceptInvite, { error: entraIdAcceptInviteError, loading: entraIdAcceptInviteLoading }] =
+    useMutation<{ entraIdAcceptInvite?: { token?: string } }>(gql`
+      mutation entraIdAcceptInvite($input: EntraIdAcceptInviteInput!) {
+        entraIdAcceptInvite(input: $input) {
+          token
+        }
+      }
+    `, {
+      context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
+      onCompleted: async (res) => {
+        if (!!res?.entraIdAcceptInvite) {
+          await onLogIn(client, res?.entraIdAcceptInvite.token)
         }
       },
     })
@@ -176,6 +223,26 @@ const Invitation = () => {
     }
   }
 
+  const onEntraIdLogin = async () => {
+    const { data: entraIdAuthorizeData } = await fetchEntraIdAuthorizeUrl({
+      variables: {
+        input: {
+          email: email || '',
+        },
+      },
+    })
+
+    if (entraIdAuthorizeData?.entraIdAuthorize?.url) {
+      window.location.href = addValuesToUrlState({
+        url: entraIdAuthorizeData.entraIdAuthorize.url,
+        values: {
+          invitationToken: token || '',
+        },
+        stateType: 'string',
+      })
+    }
+  }
+
   useEffect(() => {
     if (!!googleCode && !!token) {
       googleAcceptInvite({
@@ -205,12 +272,29 @@ const Invitation = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [oktaCode, oktaState, token])
 
+  useEffect(() => {
+    if (!!entraIdCode && !!entraIdState && !!token) {
+      entraIdAcceptInvite({
+        variables: {
+          input: {
+            code: entraIdCode,
+            state: entraIdState,
+            inviteToken: token || '',
+          },
+        },
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entraIdCode, entraIdState, token])
+
   const errorTranslation: string | undefined = useMemo(() => {
     if (
       !acceptInviteError &&
       !googleAcceptInviteError &&
       !oktaAcceptInviteError &&
-      !oktaAuthorizeUrlError
+      !oktaAuthorizeUrlError &&
+      !entraIdAcceptInviteError &&
+      !entraIdAuthorizeUrlError
     )
       return
 
@@ -244,6 +328,18 @@ const Invitation = () => {
       })
     }
 
+    if (hasDefinedGQLError('DomainNotConfigured', entraIdAuthorizeUrlError)) {
+      return translate('text_664c90c9b2b6c2012aa50bd1')
+    }
+
+    if (hasDefinedGQLError('EntraIdUserinfoError', entraIdAcceptInviteError)) {
+      return 'Unable to validate your Entra ID profile email.'
+    }
+
+    if (hasDefinedGQLError('LoginMethodNotAuthorized', entraIdAcceptInviteError)) {
+      return translate('text_17521583805554mlsol8fld6', { method: 'Entra ID' })
+    }
+
     if (hasDefinedGQLError('LoginMethodNotAuthorized', googleAcceptInviteError)) {
       return translate('text_17521583805554mlsol8fld6', {
         method: translate('text_1752158380555upqjf6cxtq9'),
@@ -259,7 +355,14 @@ const Invitation = () => {
     return
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [acceptInviteError, googleAcceptInviteError, oktaAcceptInviteError, oktaAuthorizeUrlError])
+  }, [
+    acceptInviteError,
+    googleAcceptInviteError,
+    oktaAcceptInviteError,
+    oktaAuthorizeUrlError,
+    entraIdAcceptInviteError,
+    entraIdAuthorizeUrlError,
+  ])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -330,6 +433,16 @@ const Invitation = () => {
                   loading={oktaAuthorizeUrlLoading || oktaAcceptInviteLoading}
                 >
                   {translate('text_664c90c9b2b6c2012aa50bd5')}
+                </Button>
+                <Button
+                  fullWidth
+                  startIcon="key"
+                  size="large"
+                  variant="tertiary"
+                  onClick={() => onEntraIdLogin()}
+                  loading={entraIdAuthorizeUrlLoading || entraIdAcceptInviteLoading}
+                >
+                  Continue with Entra ID
                 </Button>
               </Stack>
 

--- a/src/pages/Invitation.tsx
+++ b/src/pages/Invitation.tsx
@@ -1,4 +1,4 @@
-import { gql, useApolloClient, useMutation } from '@apollo/client'
+import { ApolloError, gql, useApolloClient, useMutation } from '@apollo/client'
 import Stack from '@mui/material/Stack'
 import { revalidateLogic, useStore } from '@tanstack/react-form'
 import { useEffect, useMemo } from 'react'
@@ -11,7 +11,7 @@ import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Typography } from '~/components/designSystem/Typography'
 import { PasswordValidationHints } from '~/components/form/PasswordValidationHints/PasswordValidationHints'
 import { TextInput } from '~/components/form/TextInput'
-import { hasDefinedGQLError, onLogIn } from '~/core/apolloClient'
+import { hasDefinedGQLError, LagoGQLError, onLogIn } from '~/core/apolloClient'
 import { DOCUMENTATION_ENV_VARS } from '~/core/constants/externalUrls'
 import { LOGIN_ROUTE } from '~/core/router'
 import { addValuesToUrlState } from '~/core/utils/urlUtils'
@@ -38,6 +38,7 @@ import {
 export const INVITATION_FORM_ID = 'invitation-form'
 export const INVITATION_ERROR_ALERT_TEST_ID = 'invitation-error-alert'
 export const INVITATION_SUBMIT_BUTTON_TEST_ID = 'submit-button'
+const ENTRA_ID_USERINFO_GRAPHQL_ERROR = 'EntraIdUserinfoError'
 
 gql`
   query getinvite($token: String!) {
@@ -102,6 +103,13 @@ const Invitation = () => {
   const oktaState = searchParams.get('oktaState') || ''
   const entraIdCode = searchParams.get('entraIdCode') || ''
   const entraIdState = searchParams.get('entraIdState') || ''
+  const hasGraphQLErrorCode = (code: string, error: ApolloError | undefined) => {
+    if (!error?.graphQLErrors?.length) return false
+
+    return error.graphQLErrors.some(
+      (graphQLError) => (graphQLError.extensions as LagoGQLError['extensions'])?.code === code,
+    )
+  }
 
   const { data, error, loading } = useGetinviteQuery({
     context: { silentErrorCodes: [LagoApiError.InviteNotFound, LagoApiError.NotFound] },
@@ -114,8 +122,10 @@ const Invitation = () => {
     useAcceptInviteMutation({
       context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
       onCompleted: async (res) => {
-        if (!!res?.acceptInvite) {
-          await onLogIn(client, res?.acceptInvite.token)
+        const loginToken = res?.acceptInvite?.token
+
+        if (!!res?.acceptInvite && !!loginToken) {
+          await onLogIn(client, loginToken)
         }
       },
     })
@@ -123,8 +133,10 @@ const Invitation = () => {
   const [googleAcceptInvite, { error: googleAcceptInviteError }] = useGoogleAcceptInviteMutation({
     context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
     onCompleted: async (res) => {
-      if (!!res?.googleAcceptInvite) {
-        await onLogIn(client, res?.googleAcceptInvite.token)
+      const loginToken = res?.googleAcceptInvite?.token
+
+      if (!!res?.googleAcceptInvite && !!loginToken) {
+        await onLogIn(client, loginToken)
       }
     },
   })
@@ -159,8 +171,10 @@ const Invitation = () => {
     useOktaAcceptInviteMutation({
       context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
       onCompleted: async (res) => {
-        if (!!res?.oktaAcceptInvite) {
-          await onLogIn(client, res?.oktaAcceptInvite.token)
+        const loginToken = res?.oktaAcceptInvite?.token
+
+        if (!!res?.oktaAcceptInvite && !!loginToken) {
+          await onLogIn(client, loginToken)
         }
       },
     })
@@ -175,8 +189,10 @@ const Invitation = () => {
     `, {
       context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
       onCompleted: async (res) => {
-        if (!!res?.entraIdAcceptInvite) {
-          await onLogIn(client, res?.entraIdAcceptInvite.token)
+        const loginToken = res?.entraIdAcceptInvite?.token
+
+        if (!!res?.entraIdAcceptInvite && !!loginToken) {
+          await onLogIn(client, loginToken)
         }
       },
     })
@@ -332,7 +348,7 @@ const Invitation = () => {
       return translate('text_664c90c9b2b6c2012aa50bd1')
     }
 
-    if (hasDefinedGQLError('EntraIdUserinfoError', entraIdAcceptInviteError)) {
+    if (hasGraphQLErrorCode(ENTRA_ID_USERINFO_GRAPHQL_ERROR, entraIdAcceptInviteError)) {
       return 'Unable to validate your Entra ID profile email.'
     }
 

--- a/src/pages/Invitation.tsx
+++ b/src/pages/Invitation.tsx
@@ -141,31 +141,39 @@ const Invitation = () => {
     },
   })
 
-  const [fetchOktaAuthorizeUrl, { error: oktaAuthorizeUrlError, loading: oktaAuthorizeUrlLoading }] =
-    useMutation<{ oktaAuthorize?: { url?: string } }>(gql`
+  const [
+    fetchOktaAuthorizeUrl,
+    { error: oktaAuthorizeUrlError, loading: oktaAuthorizeUrlLoading },
+  ] = useMutation<{ oktaAuthorize?: { url?: string } }>(
+    gql`
       mutation fetchOktaAuthorizeUrl($input: OktaAuthorizeInput!) {
         oktaAuthorize(input: $input) {
           url
         }
       }
-    `, {
+    `,
+    {
       context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
       fetchPolicy: 'network-only',
-    })
+    },
+  )
 
   const [
     fetchEntraIdAuthorizeUrl,
     { error: entraIdAuthorizeUrlError, loading: entraIdAuthorizeUrlLoading },
-  ] = useMutation<{ entraIdAuthorize?: { url?: string } }>(gql`
-    mutation fetchEntraIdAuthorizeUrl($input: EntraIdAuthorizeInput!) {
-      entraIdAuthorize(input: $input) {
-        url
+  ] = useMutation<{ entraIdAuthorize?: { url?: string } }>(
+    gql`
+      mutation fetchEntraIdAuthorizeUrl($input: EntraIdAuthorizeInput!) {
+        entraIdAuthorize(input: $input) {
+          url
+        }
       }
-    }
-  `, {
-    context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
-    fetchPolicy: 'network-only',
-  })
+    `,
+    {
+      context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
+      fetchPolicy: 'network-only',
+    },
+  )
 
   const [oktaAcceptInvite, { error: oktaAcceptInviteError, loading: oktaAcceptInviteLoading }] =
     useOktaAcceptInviteMutation({
@@ -179,14 +187,18 @@ const Invitation = () => {
       },
     })
 
-  const [entraIdAcceptInvite, { error: entraIdAcceptInviteError, loading: entraIdAcceptInviteLoading }] =
-    useMutation<{ entraIdAcceptInvite?: { token?: string } }>(gql`
+  const [
+    entraIdAcceptInvite,
+    { error: entraIdAcceptInviteError, loading: entraIdAcceptInviteLoading },
+  ] = useMutation<{ entraIdAcceptInvite?: { token?: string } }>(
+    gql`
       mutation entraIdAcceptInvite($input: EntraIdAcceptInviteInput!) {
         entraIdAcceptInvite(input: $input) {
           token
         }
       }
-    `, {
+    `,
+    {
       context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
       onCompleted: async (res) => {
         const loginToken = res?.entraIdAcceptInvite?.token
@@ -195,7 +207,8 @@ const Invitation = () => {
           await onLogIn(client, loginToken)
         }
       },
-    })
+    },
+  )
 
   const form = useAppForm({
     defaultValues: invitationDefaultValues,

--- a/src/pages/auth/EntraIdAuthCallback.tsx
+++ b/src/pages/auth/EntraIdAuthCallback.tsx
@@ -29,16 +29,19 @@ const EntraIdAuthCallback = () => {
   const client = useApolloClient()
   const [entraIdLoginUser] = useMutation<{
     entraIdLogin?: { token?: string }
-  }>(gql`
-    mutation entraIdLoginUser($input: EntraIdLoginInput!) {
-      entraIdLogin(input: $input) {
-        token
+  }>(
+    gql`
+      mutation entraIdLoginUser($input: EntraIdLoginInput!) {
+        entraIdLogin(input: $input) {
+          token
+        }
       }
-    }
-  `, {
-    context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
-    fetchPolicy: 'network-only',
-  })
+    `,
+    {
+      context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
+      fetchPolicy: 'network-only',
+    },
+  )
 
   const [searchParams] = useSearchParams()
   const code = searchParams.get('code') || ''

--- a/src/pages/auth/EntraIdAuthCallback.tsx
+++ b/src/pages/auth/EntraIdAuthCallback.tsx
@@ -1,0 +1,111 @@
+import { gql, useApolloClient, useMutation } from '@apollo/client'
+import { Icon } from 'lago-design-system'
+import { useEffect } from 'react'
+import { generatePath, useNavigate, useSearchParams } from 'react-router-dom'
+
+import {
+  getItemFromLS,
+  hasDefinedGQLError,
+  LagoGQLError,
+  onLogIn,
+  removeItemFromLS,
+} from '~/core/apolloClient'
+import { REDIRECT_AFTER_LOGIN_LS_KEY } from '~/core/constants/localStorageKeys'
+import { INVITATION_ROUTE_FORM, LOGIN_ENTRA_ID, LOGIN_ROUTE } from '~/core/router'
+import { LagoApiError } from '~/generated/graphql'
+
+const ENTRA_ID_USERINFO_ERROR = 'entra_id_userinfo_error'
+const ENTRA_ID_LOGIN_METHOD_NOT_AUTHORIZED = 'entra_id_login_method_not_authorized'
+
+const EntraIdAuthCallback = () => {
+  const navigate = useNavigate()
+  const client = useApolloClient()
+  const [entraIdLoginUser] = useMutation<{
+    entraIdLogin?: { token?: string }
+  }>(gql`
+    mutation entraIdLoginUser($input: EntraIdLoginInput!) {
+      entraIdLogin(input: $input) {
+        token
+      }
+    }
+  `, {
+    context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
+    fetchPolicy: 'network-only',
+  })
+
+  const [searchParams] = useSearchParams()
+  const code = searchParams.get('code') || ''
+  const state = JSON.parse(searchParams.get('state') || '{}')
+
+  const entraIdState = state.state || ''
+  const invitationToken = state.invitationToken || undefined
+
+  if (!code) {
+    navigate(LOGIN_ROUTE)
+  }
+
+  useEffect(() => {
+    const callback = async () => {
+      if (invitationToken) {
+        return navigate({
+          pathname: generatePath(INVITATION_ROUTE_FORM, {
+            token: invitationToken as string,
+          }),
+          search: `?entraIdCode=${code}&entraIdState=${entraIdState}`,
+        })
+      }
+
+      const res = await entraIdLoginUser({ variables: { input: { code, state: entraIdState } } })
+
+      if (res.errors) {
+        if (hasDefinedGQLError('EntraIdUserinfoError', res.errors)) {
+          return navigate({
+            pathname: LOGIN_ENTRA_ID,
+            search: `?lago_error_code=${ENTRA_ID_USERINFO_ERROR}`,
+          })
+        }
+
+        if (hasDefinedGQLError('LoginMethodNotAuthorized', res.errors)) {
+          return navigate({
+            pathname: LOGIN_ROUTE,
+            search: `?lago_error_code=${ENTRA_ID_LOGIN_METHOD_NOT_AUTHORIZED}`,
+          })
+        }
+
+        return navigate({
+          pathname: LOGIN_ROUTE,
+          search: `?lago_error_code=${
+            (res.errors[0].extensions as LagoGQLError['extensions']).code
+          }`,
+        })
+      }
+
+      if (!res.data?.entraIdLogin) {
+        return
+      }
+
+      // Read redirect path from localStorage (set by LoginEntraId before Entra ID redirect)
+      const redirectPath = getItemFromLS(REDIRECT_AFTER_LOGIN_LS_KEY)
+
+      await onLogIn(client, res.data?.entraIdLogin?.token)
+
+      removeItemFromLS(REDIRECT_AFTER_LOGIN_LS_KEY)
+
+      if (redirectPath) {
+        navigate({ pathname: redirectPath })
+      }
+    }
+
+    callback()
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div className="m-auto flex h-40 w-full items-center justify-center">
+      <Icon name="processing" color="info" size="large" animation="spin" />
+    </div>
+  )
+}
+
+export default EntraIdAuthCallback

--- a/src/pages/auth/EntraIdAuthCallback.tsx
+++ b/src/pages/auth/EntraIdAuthCallback.tsx
@@ -16,6 +16,13 @@ import { LagoApiError } from '~/generated/graphql'
 
 const ENTRA_ID_USERINFO_ERROR = 'entra_id_userinfo_error'
 const ENTRA_ID_LOGIN_METHOD_NOT_AUTHORIZED = 'entra_id_login_method_not_authorized'
+const ENTRA_ID_USERINFO_GRAPHQL_ERROR = 'EntraIdUserinfoError'
+
+const hasGraphQLErrorCode = (code: string, errors: readonly LagoGQLError[] | undefined) => {
+  if (!errors?.length) return false
+
+  return errors.some((error) => (error.extensions as LagoGQLError['extensions'])?.code === code)
+}
 
 const EntraIdAuthCallback = () => {
   const navigate = useNavigate()
@@ -58,7 +65,7 @@ const EntraIdAuthCallback = () => {
       const res = await entraIdLoginUser({ variables: { input: { code, state: entraIdState } } })
 
       if (res.errors) {
-        if (hasDefinedGQLError('EntraIdUserinfoError', res.errors)) {
+        if (hasGraphQLErrorCode(ENTRA_ID_USERINFO_GRAPHQL_ERROR, res.errors as LagoGQLError[])) {
           return navigate({
             pathname: LOGIN_ENTRA_ID,
             search: `?lago_error_code=${ENTRA_ID_USERINFO_ERROR}`,
@@ -87,7 +94,13 @@ const EntraIdAuthCallback = () => {
       // Read redirect path from localStorage (set by LoginEntraId before Entra ID redirect)
       const redirectPath = getItemFromLS(REDIRECT_AFTER_LOGIN_LS_KEY)
 
-      await onLogIn(client, res.data?.entraIdLogin?.token)
+      const loginToken = res.data?.entraIdLogin?.token
+
+      if (!loginToken) {
+        return navigate(LOGIN_ROUTE)
+      }
+
+      await onLogIn(client, loginToken)
 
       removeItemFromLS(REDIRECT_AFTER_LOGIN_LS_KEY)
 

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -12,7 +12,7 @@ import { Typography } from '~/components/designSystem/Typography'
 import { TextInputField } from '~/components/form'
 import { envGlobalVar, hasDefinedGQLError, onLogIn } from '~/core/apolloClient'
 import { authenticationMethodsMapping } from '~/core/constants/authenticationMethodsMapping'
-import { FORGOT_PASSWORD_ROUTE, LOGIN_OKTA, SIGN_UP_ROUTE } from '~/core/router'
+import { FORGOT_PASSWORD_ROUTE, LOGIN_ENTRA_ID, LOGIN_OKTA, SIGN_UP_ROUTE } from '~/core/router'
 import { AuthenticationMethodsEnum, LagoApiError, useLoginUserMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useShortcuts } from '~/hooks/ui/useShortcuts'
@@ -21,6 +21,7 @@ import { useIframeConfig } from '~/hooks/useIframeConfig'
 import { Card, Page, StyledLogo } from '~/styles/auth'
 
 const { disableSignUp } = envGlobalVar()
+const ENTRA_ID_LOGIN_METHOD_NOT_AUTHORIZED = 'entra_id_login_method_not_authorized'
 
 gql`
   mutation loginUser($input: LoginUserInput!) {
@@ -37,7 +38,7 @@ const Login = () => {
   const navigate = useNavigate()
   const { closePanel: closeDevTool } = useDeveloperTool()
   const client = useApolloClient()
-  const [authMethodError, setAuthMethodError] = useState<AuthenticationMethodsEnum>()
+  const [authMethodError, setAuthMethodError] = useState<AuthenticationMethodsEnum | 'entra_id'>()
   const [searchParams] = useSearchParams()
 
   const lagoErrorCode = searchParams.get('lago_error_code')
@@ -47,6 +48,8 @@ const Login = () => {
     // Google login method is handled in GoogleAuthButton
     if (lagoErrorCode === LagoApiError.OktaLoginMethodNotAuthorized) {
       setAuthMethodError(AuthenticationMethodsEnum.Okta)
+    } else if (lagoErrorCode === ENTRA_ID_LOGIN_METHOD_NOT_AUTHORIZED) {
+      setAuthMethodError('entra_id')
     }
   }, [lagoErrorCode])
 
@@ -124,7 +127,10 @@ const Login = () => {
           {authMethodError && (
             <Alert data-test="login-method-not-authorized-alert" type="danger">
               {translate('text_17521583805554mlsol8fld6', {
-                method: translate(authenticationMethodsMapping[authMethodError]),
+                method:
+                  authMethodError === 'entra_id'
+                    ? 'Entra ID'
+                    : translate(authenticationMethodsMapping[authMethodError]),
               })}
             </Alert>
           )}
@@ -145,6 +151,15 @@ const Login = () => {
                   onClick={() => navigate(LOGIN_OKTA, { state: location.state })}
                 >
                   {translate('text_664c90c9b2b6c2012aa50bce')}
+                </Button>
+                <Button
+                  fullWidth
+                  startIcon="key"
+                  size="large"
+                  variant="tertiary"
+                  onClick={() => navigate(LOGIN_ENTRA_ID, { state: location.state })}
+                >
+                  Log in with Entra ID
                 </Button>
               </Stack>
 

--- a/src/pages/auth/LoginEntraId.tsx
+++ b/src/pages/auth/LoginEntraId.tsx
@@ -41,18 +41,22 @@ const LoginEntraId = () => {
 
   const lagoErrorCode = searchParams.get('lago_error_code')
 
-  const [fetchEntraIdAuthorizeUrl, { error: fetchEntraIdAuthorizeUrlError, loading }] = useMutation<{
-    entraIdAuthorize?: { url?: string }
-  }>(gql`
-    mutation fetchEntraIdAuthorizeUrl($input: EntraIdAuthorizeInput!) {
-      entraIdAuthorize(input: $input) {
-        url
-      }
-    }
-  `, {
-    context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
-    fetchPolicy: 'network-only',
-  })
+  const [fetchEntraIdAuthorizeUrl, { error: fetchEntraIdAuthorizeUrlError, loading }] =
+    useMutation<{
+      entraIdAuthorize?: { url?: string }
+    }>(
+      gql`
+        mutation fetchEntraIdAuthorizeUrl($input: EntraIdAuthorizeInput!) {
+          entraIdAuthorize(input: $input) {
+            url
+          }
+        }
+      `,
+      {
+        context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
+        fetchPolicy: 'network-only',
+      },
+    )
 
   useEffect(() => {
     if (lagoErrorCode) {

--- a/src/pages/auth/LoginEntraId.tsx
+++ b/src/pages/auth/LoginEntraId.tsx
@@ -1,0 +1,187 @@
+import { gql, useMutation } from '@apollo/client'
+import Stack from '@mui/material/Stack'
+import { useFormik } from 'formik'
+import { useEffect, useState } from 'react'
+import { useLocation, useSearchParams } from 'react-router-dom'
+import { object, string } from 'yup'
+
+import { Alert } from '~/components/designSystem/Alert'
+import { Button } from '~/components/designSystem/Button'
+import { Typography } from '~/components/designSystem/Typography'
+import { TextInputField } from '~/components/form'
+import { hasDefinedGQLError, setItemFromLS } from '~/core/apolloClient'
+import { REDIRECT_AFTER_LOGIN_LS_KEY } from '~/core/constants/localStorageKeys'
+import { LOGIN_ROUTE } from '~/core/router'
+import { addValuesToUrlState } from '~/core/utils/urlUtils'
+import { LagoApiError } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useShortcuts } from '~/hooks/ui/useShortcuts'
+import { Card, Page, StyledLogo } from '~/styles/auth'
+
+const ENTRA_ID_USERINFO_ERROR = 'entra_id_userinfo_error'
+
+const getErrorKey = (code: string): string => {
+  switch (code) {
+    case ENTRA_ID_USERINFO_ERROR:
+      return 'text_664c98989d08a3f733357f73'
+    case LagoApiError.DomainNotConfigured:
+      return 'text_664c90c9b2b6c2012aa50bd6'
+    default:
+      return 'text_62b31e1f6a5b8b1b745ece48'
+  }
+}
+
+const LoginEntraId = () => {
+  const { translate } = useInternationalization()
+  const location = useLocation()
+  const [searchParams] = useSearchParams()
+  const previousLocation = (location.state as { from?: Location } | null)?.from?.pathname
+  const [errorAlert, setErrorAlert] = useState<string>()
+  const [errorField, setErrorField] = useState<string>()
+
+  const lagoErrorCode = searchParams.get('lago_error_code')
+
+  const [fetchEntraIdAuthorizeUrl, { error: fetchEntraIdAuthorizeUrlError, loading }] = useMutation<{
+    entraIdAuthorize?: { url?: string }
+  }>(gql`
+    mutation fetchEntraIdAuthorizeUrl($input: EntraIdAuthorizeInput!) {
+      entraIdAuthorize(input: $input) {
+        url
+      }
+    }
+  `, {
+    context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
+    fetchPolicy: 'network-only',
+  })
+
+  useEffect(() => {
+    if (lagoErrorCode) {
+      setErrorAlert(lagoErrorCode)
+
+      // Remove the error code from the URL, so it disappears on page reload
+      history.replaceState({}, '', window.location.pathname)
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (!fetchEntraIdAuthorizeUrlError) return
+
+    if (hasDefinedGQLError('DomainNotConfigured', fetchEntraIdAuthorizeUrlError)) {
+      setErrorField(LagoApiError.DomainNotConfigured)
+      return
+    }
+
+    setErrorAlert(LagoApiError.UnprocessableEntity)
+  }, [fetchEntraIdAuthorizeUrlError])
+
+  const formikProps = useFormik({
+    initialValues: {
+      email: '',
+    },
+    validationSchema: object().shape({
+      email: string()
+        .email('text_620bc4d4269a55014d493fc3')
+        .required('text_620bc4d4269a55014d493f98'),
+    }),
+    validateOnChange: false,
+    validateOnBlur: false,
+    onSubmit: async (values) => {
+      const { data } = await fetchEntraIdAuthorizeUrl({
+        variables: {
+          input: {
+            email: values.email,
+          },
+        },
+      })
+
+      if (!data?.entraIdAuthorize?.url) return
+
+      setErrorField(undefined)
+      setErrorAlert(undefined)
+
+      if (previousLocation) {
+        setItemFromLS(REDIRECT_AFTER_LOGIN_LS_KEY, previousLocation)
+      }
+
+      window.location.href = addValuesToUrlState({
+        url: data.entraIdAuthorize.url,
+        stateType: 'string',
+        values: {},
+      })
+    },
+  })
+
+  useShortcuts([
+    {
+      keys: ['Enter'],
+      action: formikProps.submitForm,
+    },
+  ])
+
+  const getEmailFieldError = (): string | undefined => {
+    if (formikProps.touched.email && formikProps.errors.email) {
+      return formikProps.errors.email
+    }
+
+    if (errorField) {
+      return translate(getErrorKey(errorField))
+    }
+
+    return undefined
+  }
+
+  return (
+    <Page>
+      <Card>
+        <StyledLogo height={24} />
+
+        <Stack spacing={8}>
+          <Stack spacing={3}>
+            <Typography variant="headline">Log in with Entra ID</Typography>
+            <Typography>Enter your work email to continue with Microsoft Entra ID.</Typography>
+          </Stack>
+
+          {/* This error is displayed in the input */}
+          {!!errorAlert && (
+            <Alert type="danger" data-test="login-entra-id-error-alert">
+              <Typography color="textSecondary">{translate(getErrorKey(errorAlert))}</Typography>
+            </Alert>
+          )}
+
+          <TextInputField
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            name="email"
+            beforeChangeFormatter={['lowercase']}
+            formikProps={formikProps}
+            label={translate('text_62ab2d0396dd6b0361614d60')}
+            placeholder={translate('text_62a99ba2af7535cefacab4bf')}
+            error={getEmailFieldError()}
+          />
+
+          <Button
+            data-test="submit"
+            fullWidth
+            size="large"
+            onClick={formikProps.submitForm}
+            loading={formikProps.isSubmitting || loading}
+          >
+            {translate('text_620bc4d4269a55014d493f6d')}
+          </Button>
+
+          <Typography
+            className="mx-auto text-center"
+            variant="caption"
+            html={translate('text_664c90c9b2b6c2012aa50bda', {
+              linkLogin: LOGIN_ROUTE,
+            })}
+          />
+        </Stack>
+      </Card>
+    </Page>
+  )
+}
+
+export default LoginEntraId

--- a/src/pages/settings/teamAndSecurity/authentication/Authentication.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/Authentication.tsx
@@ -31,8 +31,8 @@ import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import Okta from '~/public/images/okta.svg'
 import { MenuPopper } from '~/styles'
 
-import { useAddOktaDialog } from './dialogs/AddOktaDialog'
 import { useAddEntraIdDialog } from './dialogs/AddEntraIdDialog'
+import { useAddOktaDialog } from './dialogs/AddOktaDialog'
 import { useDeleteEntraIdIntegrationDialog } from './dialogs/DeleteEntraIdIntegrationDialog'
 import { useDeleteOktaIntegrationDialog } from './dialogs/DeleteOktaIntegrationDialog'
 import { useUpdateLoginMethodDialog } from './dialogs/UpdateLoginMethodDialog'
@@ -217,29 +217,27 @@ const Authentication = () => {
                 {translate('text_657078c28394d6b1ae1b9789')}
               </Button>
             )}
-          {method === ENTRA_ID_METHOD &&
-            shouldSeeEntraIdIntegration &&
-            !entraIdIntegration?.id && (
-              <Button
-                size="small"
-                startIcon="link"
-                variant="primary"
-                loading={authIntegrationLoading}
-                onClick={() => {
-                  if (!shouldSeeEntraIdIntegration) {
-                    return premiumWarningDialog.open()
-                  }
+          {method === ENTRA_ID_METHOD && shouldSeeEntraIdIntegration && !entraIdIntegration?.id && (
+            <Button
+              size="small"
+              startIcon="link"
+              variant="primary"
+              loading={authIntegrationLoading}
+              onClick={() => {
+                if (!shouldSeeEntraIdIntegration) {
+                  return premiumWarningDialog.open()
+                }
 
-                  return openAddEntraIdDialog({
-                    integration: entraIdIntegration,
-                    callback: (id) =>
-                      navigate(generatePath(ENTRA_ID_AUTHENTICATION_ROUTE, { integrationId: id })),
-                  })
-                }}
-              >
-                {translate('text_657078c28394d6b1ae1b9789')}
-              </Button>
-            )}
+                return openAddEntraIdDialog({
+                  integration: entraIdIntegration,
+                  callback: (id) =>
+                    navigate(generatePath(ENTRA_ID_AUTHENTICATION_ROUTE, { integrationId: id })),
+                })
+              }}
+            >
+              {translate('text_657078c28394d6b1ae1b9789')}
+            </Button>
+          )}
 
           {isPopperVisible && (
             <Popper

--- a/src/pages/settings/teamAndSecurity/authentication/Authentication.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/Authentication.tsx
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql, useQuery } from '@apollo/client'
 import { ConditionalWrapper, Icon } from 'lago-design-system'
 import { generatePath, useNavigate } from 'react-router-dom'
 
@@ -16,14 +16,10 @@ import {
   SettingsListWrapper,
   SettingsWithTabsPaddedContainer,
 } from '~/components/layouts/Settings'
-import { OKTA_AUTHENTICATION_ROUTE } from '~/core/router'
+import { ENTRA_ID_AUTHENTICATION_ROUTE, OKTA_AUTHENTICATION_ROUTE } from '~/core/router'
 import {
-  AddOktaIntegrationDialogFragmentDoc,
   AuthenticationMethodsEnum,
-  DeleteOktaIntegrationDialogFragmentDoc,
-  OktaIntegration,
   PremiumIntegrationTypeEnum,
-  useGetAuthIntegrationsQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
@@ -32,25 +28,65 @@ import Okta from '~/public/images/okta.svg'
 import { MenuPopper } from '~/styles'
 
 import { useAddOktaDialog } from './dialogs/AddOktaDialog'
+import { useAddEntraIdDialog } from './dialogs/AddEntraIdDialog'
+import { useDeleteEntraIdIntegrationDialog } from './dialogs/DeleteEntraIdIntegrationDialog'
 import { useDeleteOktaIntegrationDialog } from './dialogs/DeleteOktaIntegrationDialog'
 import { useUpdateLoginMethodDialog } from './dialogs/UpdateLoginMethodDialog'
 
-gql`
+const GET_AUTH_INTEGRATIONS = gql`
   query GetAuthIntegrations($limit: Int!) {
     integrations(limit: $limit) {
       collection {
         ... on OktaIntegration {
           id
-          ...AddOktaIntegrationDialog
-          ...DeleteOktaIntegrationDialog
+          domain
+          host
+          clientId
+          clientSecret
+          organizationName
+        }
+        ... on EntraIdIntegration {
+          id
+          domain
+          host
+          clientId
+          clientSecret
+          tenantId
         }
       }
     }
-
-    ${AddOktaIntegrationDialogFragmentDoc}
-    ${DeleteOktaIntegrationDialogFragmentDoc}
   }
 `
+
+type OktaIntegration = {
+  __typename: 'OktaIntegration'
+  id: string
+  domain?: string | null
+  host?: string | null
+  clientId?: string | null
+  clientSecret?: string | null
+  organizationName?: string | null
+}
+
+type EntraIdIntegration = {
+  __typename: 'EntraIdIntegration'
+  id: string
+  domain?: string | null
+  host?: string | null
+  clientId?: string | null
+  clientSecret?: string | null
+  tenantId?: string | null
+}
+
+type GetAuthIntegrationsResult = {
+  integrations?: {
+    collection: Array<OktaIntegration | EntraIdIntegration>
+  } | null
+}
+
+const ENTRA_ID_METHOD = 'entra_id' as const
+type OrganizationAuthenticationMethod = AuthenticationMethodsEnum | typeof ENTRA_ID_METHOD
+const ENTRA_ID_PREMIUM_INTEGRATION = 'entra_id' as unknown as PremiumIntegrationTypeEnum
 
 const Authentication = () => {
   const { isPremium } = useCurrentUser()
@@ -64,38 +100,55 @@ const Authentication = () => {
 
   const premiumWarningDialog = usePremiumWarningDialog()
   const { openAddOktaDialog } = useAddOktaDialog()
+  const { openAddEntraIdDialog } = useAddEntraIdDialog()
   const { openDeleteOktaIntegrationDialog } = useDeleteOktaIntegrationDialog()
+  const { openDeleteEntraIdIntegrationDialog } = useDeleteEntraIdIntegrationDialog()
   const { openUpdateLoginMethodDialog } = useUpdateLoginMethodDialog()
 
   const { data: authIntegrationsData, loading: authIntegrationsLoading } =
-    useGetAuthIntegrationsQuery({ variables: { limit: 10 } })
+    useQuery<GetAuthIntegrationsResult>(GET_AUTH_INTEGRATIONS, { variables: { limit: 10 } })
 
   const hasAccessToOktaPremiumIntegration = !!premiumIntegrations?.includes(
     PremiumIntegrationTypeEnum.Okta,
+  )
+  const hasAccessToEntraIdPremiumIntegration = !!premiumIntegrations?.includes(
+    ENTRA_ID_PREMIUM_INTEGRATION,
   )
 
   const oktaIntegration = authIntegrationsData?.integrations?.collection.find(
     (integration) => integration.__typename === 'OktaIntegration',
   ) as OktaIntegration | undefined
+  const entraIdIntegration = authIntegrationsData?.integrations?.collection.find(
+    (integration) => integration.__typename === 'EntraIdIntegration',
+  ) as EntraIdIntegration | undefined
 
   const shouldSeeOktaIntegration = hasAccessToOktaPremiumIntegration && isPremium
+  const shouldSeeEntraIdIntegration = hasAccessToEntraIdPremiumIntegration && isPremium
 
   const getEndContent = ({
     type,
     method,
   }: {
     type: 'enabled' | 'disabled'
-    method: AuthenticationMethodsEnum
+    method: OrganizationAuthenticationMethod
   }) => {
     let isPopperVisible = true
     let icon = undefined
+    const organizationAuthenticationMethods = (authenticationMethods || []) as string[]
     const isUniqueAuthenticationMethodEnabled =
-      authenticationMethods?.length === 1 && authenticationMethods?.includes(method)
+      organizationAuthenticationMethods.length === 1 &&
+      organizationAuthenticationMethods.includes(method)
 
     if (method === AuthenticationMethodsEnum.Okta && !shouldSeeOktaIntegration) {
       isPopperVisible = false
       icon = <Icon name="sparkles" size="medium" />
     } else if (method === AuthenticationMethodsEnum.Okta && !oktaIntegration?.id) {
+      isPopperVisible = false
+      icon = undefined
+    } else if (method === ENTRA_ID_METHOD && !shouldSeeEntraIdIntegration) {
+      isPopperVisible = false
+      icon = <Icon name="sparkles" size="medium" />
+    } else if (method === ENTRA_ID_METHOD && !entraIdIntegration?.id) {
       isPopperVisible = false
       icon = undefined
     } else if (type === 'enabled') {
@@ -120,7 +173,11 @@ const Authentication = () => {
 
     return (
       <ConditionalWrapper
-        condition={isUniqueAuthenticationMethodEnabled && method !== AuthenticationMethodsEnum.Okta}
+        condition={
+          isUniqueAuthenticationMethodEnabled &&
+          method !== AuthenticationMethodsEnum.Okta &&
+          method !== ENTRA_ID_METHOD
+        }
         validWrapper={(children) => (
           <Tooltip title={translate('text_1752158016615ah5wceoz1ed')} placement="top">
             {children}
@@ -148,6 +205,29 @@ const Authentication = () => {
                     integration: oktaIntegration,
                     callback: (id) =>
                       navigate(generatePath(OKTA_AUTHENTICATION_ROUTE, { integrationId: id })),
+                  })
+                }}
+              >
+                {translate('text_657078c28394d6b1ae1b9789')}
+              </Button>
+            )}
+          {method === ENTRA_ID_METHOD &&
+            shouldSeeEntraIdIntegration &&
+            !entraIdIntegration?.id && (
+              <Button
+                size="small"
+                startIcon="link"
+                variant="primary"
+                loading={authIntegrationsLoading}
+                onClick={() => {
+                  if (!shouldSeeEntraIdIntegration) {
+                    return premiumWarningDialog.open()
+                  }
+
+                  return openAddEntraIdDialog({
+                    integration: entraIdIntegration,
+                    callback: (id) =>
+                      navigate(generatePath(ENTRA_ID_AUTHENTICATION_ROUTE, { integrationId: id })),
                   })
                 }}
               >
@@ -263,6 +343,60 @@ const Authentication = () => {
                       </ConditionalWrapper>
                     </>
                   )}
+                  {method === ENTRA_ID_METHOD && entraIdIntegration?.id && (
+                    <>
+                      <Button
+                        startIcon="pen"
+                        variant="quaternary"
+                        align="left"
+                        loading={authIntegrationsLoading}
+                        onClick={(e) => {
+                          e.stopPropagation()
+
+                          openAddEntraIdDialog({
+                            integration: entraIdIntegration,
+                            callback: () => {
+                              refetchOrganizationInfos()
+                            },
+                          })
+                        }}
+                      >
+                        {translate('text_664c8fa719b5e7ad81c86018')}
+                      </Button>
+                      <ConditionalWrapper
+                        condition={isUniqueAuthenticationMethodEnabled}
+                        validWrapper={(children) => (
+                          <Tooltip
+                            title={translate('text_1752158016615ah5wceoz1ed')}
+                            placement="bottom"
+                          >
+                            {children}
+                          </Tooltip>
+                        )}
+                        invalidWrapper={(children) => <>{children}</>}
+                      >
+                        <Button
+                          startIcon="trash"
+                          variant="quaternary"
+                          align="left"
+                          loading={authIntegrationsLoading}
+                          disabled={isUniqueAuthenticationMethodEnabled}
+                          onClick={(e) => {
+                            e.stopPropagation()
+
+                            openDeleteEntraIdIntegrationDialog({
+                              integration: entraIdIntegration,
+                              callback: () => {
+                                refetchOrganizationInfos()
+                              },
+                            })
+                          }}
+                        >
+                          {translate('text_17522481192202remk2eytrr')}
+                        </Button>
+                      </ConditionalWrapper>
+                    </>
+                  )}
                 </MenuPopper>
               )}
             </Popper>
@@ -312,6 +446,40 @@ const Authentication = () => {
                   ? 'enabled'
                   : 'disabled',
                 method: AuthenticationMethodsEnum.GoogleOauth,
+              })}
+            />
+            <Selector
+              title="Microsoft Entra ID"
+              subtitle="Enterprise SSO via Microsoft identity platform."
+              icon={
+                <Avatar size="big" variant="connector">
+                  <Icon name="key" color="black" />
+                </Avatar>
+              }
+              onClick={() => {
+                if (!shouldSeeEntraIdIntegration) {
+                  return premiumWarningDialog.open()
+                }
+
+                if (entraIdIntegration?.id) {
+                  return navigate(
+                    generatePath(ENTRA_ID_AUTHENTICATION_ROUTE, {
+                      integrationId: entraIdIntegration.id,
+                    }),
+                  )
+                }
+
+                return openAddEntraIdDialog({
+                  integration: entraIdIntegration,
+                  callback: (id) =>
+                    navigate(generatePath(ENTRA_ID_AUTHENTICATION_ROUTE, { integrationId: id })),
+                })
+              }}
+              endContent={getEndContent({
+                method: ENTRA_ID_METHOD,
+                type: (authenticationMethods as string[] | undefined)?.includes(ENTRA_ID_METHOD)
+                  ? 'enabled'
+                  : 'disabled',
               })}
             />
 

--- a/src/pages/settings/teamAndSecurity/authentication/Authentication.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/Authentication.tsx
@@ -63,11 +63,11 @@ type OktaIntegration = {
   __typename: 'OktaIntegration'
   id: string
   name: string
-  domain?: string | null
+  domain: string
   host?: string | null
   clientId?: string | null
   clientSecret?: string | null
-  organizationName?: string | null
+  organizationName: string
 }
 
 type EntraIdIntegration = {

--- a/src/pages/settings/teamAndSecurity/authentication/Authentication.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/Authentication.tsx
@@ -39,6 +39,7 @@ const GET_AUTH_INTEGRATIONS = gql`
       collection {
         ... on OktaIntegration {
           id
+          name
           domain
           host
           clientId
@@ -61,6 +62,7 @@ const GET_AUTH_INTEGRATIONS = gql`
 type OktaIntegration = {
   __typename: 'OktaIntegration'
   id: string
+  name: string
   domain?: string | null
   host?: string | null
   clientId?: string | null

--- a/src/pages/settings/teamAndSecurity/authentication/Authentication.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/Authentication.tsx
@@ -18,8 +18,12 @@ import {
 } from '~/components/layouts/Settings'
 import { ENTRA_ID_AUTHENTICATION_ROUTE, OKTA_AUTHENTICATION_ROUTE } from '~/core/router'
 import {
+  AddOktaIntegrationDialogFragmentDoc,
   AuthenticationMethodsEnum,
+  DeleteOktaIntegrationDialogFragmentDoc,
+  OktaIntegration,
   PremiumIntegrationTypeEnum,
+  useGetAuthIntegrationsQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
@@ -33,19 +37,27 @@ import { useDeleteEntraIdIntegrationDialog } from './dialogs/DeleteEntraIdIntegr
 import { useDeleteOktaIntegrationDialog } from './dialogs/DeleteOktaIntegrationDialog'
 import { useUpdateLoginMethodDialog } from './dialogs/UpdateLoginMethodDialog'
 
-const GET_AUTH_INTEGRATIONS = gql`
+gql`
   query GetAuthIntegrations($limit: Int!) {
     integrations(limit: $limit) {
       collection {
         ... on OktaIntegration {
           id
-          name
-          domain
-          host
-          clientId
-          clientSecret
-          organizationName
+          ...AddOktaIntegrationDialog
+          ...DeleteOktaIntegrationDialog
         }
+      }
+    }
+
+    ${AddOktaIntegrationDialogFragmentDoc}
+    ${DeleteOktaIntegrationDialogFragmentDoc}
+  }
+`
+
+const GET_ENTRA_ID_INTEGRATIONS = gql`
+  query GetEntraIdIntegrations($limit: Int!) {
+    integrations(limit: $limit) {
+      collection {
         ... on EntraIdIntegration {
           id
           domain
@@ -59,17 +71,6 @@ const GET_AUTH_INTEGRATIONS = gql`
   }
 `
 
-type OktaIntegration = {
-  __typename: 'OktaIntegration'
-  id: string
-  name: string
-  domain: string
-  host?: string | null
-  clientId?: string | null
-  clientSecret?: string | null
-  organizationName: string
-}
-
 type EntraIdIntegration = {
   __typename: 'EntraIdIntegration'
   id: string
@@ -82,7 +83,7 @@ type EntraIdIntegration = {
 
 type GetAuthIntegrationsResult = {
   integrations?: {
-    collection: Array<OktaIntegration | EntraIdIntegration>
+    collection: Array<EntraIdIntegration>
   } | null
 }
 
@@ -108,7 +109,9 @@ const Authentication = () => {
   const { openUpdateLoginMethodDialog } = useUpdateLoginMethodDialog()
 
   const { data: authIntegrationsData, loading: authIntegrationsLoading } =
-    useQuery<GetAuthIntegrationsResult>(GET_AUTH_INTEGRATIONS, { variables: { limit: 10 } })
+    useGetAuthIntegrationsQuery({ variables: { limit: 10 } })
+  const { data: entraIdIntegrationsData, loading: entraIdIntegrationsLoading } =
+    useQuery<GetAuthIntegrationsResult>(GET_ENTRA_ID_INTEGRATIONS, { variables: { limit: 10 } })
 
   const hasAccessToOktaPremiumIntegration = !!premiumIntegrations?.includes(
     PremiumIntegrationTypeEnum.Okta,
@@ -120,12 +123,13 @@ const Authentication = () => {
   const oktaIntegration = authIntegrationsData?.integrations?.collection.find(
     (integration) => integration.__typename === 'OktaIntegration',
   ) as OktaIntegration | undefined
-  const entraIdIntegration = authIntegrationsData?.integrations?.collection.find(
+  const entraIdIntegration = entraIdIntegrationsData?.integrations?.collection.find(
     (integration) => integration.__typename === 'EntraIdIntegration',
   ) as EntraIdIntegration | undefined
 
   const shouldSeeOktaIntegration = hasAccessToOktaPremiumIntegration && isPremium
   const shouldSeeEntraIdIntegration = hasAccessToEntraIdPremiumIntegration && isPremium
+  const authIntegrationLoading = authIntegrationsLoading || entraIdIntegrationsLoading
 
   const getEndContent = ({
     type,
@@ -197,7 +201,7 @@ const Authentication = () => {
                 size="small"
                 startIcon="link"
                 variant="primary"
-                loading={authIntegrationsLoading}
+                loading={authIntegrationLoading}
                 onClick={() => {
                   if (!shouldSeeOktaIntegration) {
                     return premiumWarningDialog.open()
@@ -220,7 +224,7 @@ const Authentication = () => {
                 size="small"
                 startIcon="link"
                 variant="primary"
-                loading={authIntegrationsLoading}
+                loading={authIntegrationLoading}
                 onClick={() => {
                   if (!shouldSeeEntraIdIntegration) {
                     return premiumWarningDialog.open()
@@ -297,7 +301,7 @@ const Authentication = () => {
                         startIcon="pen"
                         variant="quaternary"
                         align="left"
-                        loading={authIntegrationsLoading}
+                        loading={authIntegrationLoading}
                         onClick={(e) => {
                           e.stopPropagation()
 
@@ -327,7 +331,7 @@ const Authentication = () => {
                           startIcon="trash"
                           variant="quaternary"
                           align="left"
-                          loading={authIntegrationsLoading}
+                          loading={authIntegrationLoading}
                           disabled={isUniqueAuthenticationMethodEnabled}
                           onClick={(e) => {
                             e.stopPropagation()
@@ -351,7 +355,7 @@ const Authentication = () => {
                         startIcon="pen"
                         variant="quaternary"
                         align="left"
-                        loading={authIntegrationsLoading}
+                        loading={authIntegrationLoading}
                         onClick={(e) => {
                           e.stopPropagation()
 
@@ -381,7 +385,7 @@ const Authentication = () => {
                           startIcon="trash"
                           variant="quaternary"
                           align="left"
-                          loading={authIntegrationsLoading}
+                          loading={authIntegrationLoading}
                           disabled={isUniqueAuthenticationMethodEnabled}
                           onClick={(e) => {
                             e.stopPropagation()

--- a/src/pages/settings/teamAndSecurity/authentication/EntraIdAuthenticationDetails.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/EntraIdAuthenticationDetails.tsx
@@ -53,28 +53,31 @@ const EntraIdAuthenticationDetails = () => {
   const { openAddEntraIdDialog } = useAddEntraIdDialog()
   const { openDeleteEntraIdIntegrationDialog } = useDeleteEntraIdIntegrationDialog()
 
-  const { data, loading, refetch } = useQuery<{ integration?: EntraIdIntegration | null }>(gql`
-    query GetEntraIdIntegration($id: ID) {
-      integration(id: $id) {
-        ... on EntraIdIntegration {
-          id
-          clientId
-          clientSecret
-          code
-          tenantId
-          domain
-          name
-          host
+  const { data, loading, refetch } = useQuery<{ integration?: EntraIdIntegration | null }>(
+    gql`
+      query GetEntraIdIntegration($id: ID) {
+        integration(id: $id) {
+          ... on EntraIdIntegration {
+            id
+            clientId
+            clientSecret
+            code
+            tenantId
+            domain
+            name
+            host
+          }
         }
       }
-    }
-  `, {
-    variables: { id: integrationId },
-    skip: !integrationId,
-    context: {
-      silentErrorCodes: [LagoApiError.NotFound],
+    `,
+    {
+      variables: { id: integrationId },
+      skip: !integrationId,
+      context: {
+        silentErrorCodes: [LagoApiError.NotFound],
+      },
     },
-  })
+  )
 
   const integration = data?.integration || null
 
@@ -176,11 +179,31 @@ const EntraIdAuthenticationDetails = () => {
             ))
           ) : (
             <>
-              <IntegrationsPage.DetailsItem icon="globe" label="Email domain" value={integration.domain} />
-              <IntegrationsPage.DetailsItem icon="globe" label="Host" value={integration.host || 'N/A'} />
-              <IntegrationsPage.DetailsItem icon="text" label="Tenant ID" value={integration.tenantId || 'N/A'} />
-              <IntegrationsPage.DetailsItem icon="key" label="Client ID" value={integration.clientId || 'N/A'} />
-              <IntegrationsPage.DetailsItem icon="key" label="Client secret" value={integration.clientSecret || 'N/A'} />
+              <IntegrationsPage.DetailsItem
+                icon="globe"
+                label="Email domain"
+                value={integration.domain}
+              />
+              <IntegrationsPage.DetailsItem
+                icon="globe"
+                label="Host"
+                value={integration.host || 'N/A'}
+              />
+              <IntegrationsPage.DetailsItem
+                icon="text"
+                label="Tenant ID"
+                value={integration.tenantId || 'N/A'}
+              />
+              <IntegrationsPage.DetailsItem
+                icon="key"
+                label="Client ID"
+                value={integration.clientId || 'N/A'}
+              />
+              <IntegrationsPage.DetailsItem
+                icon="key"
+                label="Client secret"
+                value={integration.clientSecret || 'N/A'}
+              />
             </>
           )}
         </section>

--- a/src/pages/settings/teamAndSecurity/authentication/EntraIdAuthenticationDetails.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/EntraIdAuthenticationDetails.tsx
@@ -1,0 +1,192 @@
+import { gql, useQuery } from '@apollo/client'
+import { Icon } from 'lago-design-system'
+import { useNavigate, useParams } from 'react-router-dom'
+
+import { Button } from '~/components/designSystem/Button'
+import { StatusType } from '~/components/designSystem/Status'
+import { IntegrationsPage } from '~/components/layouts/Integrations'
+import { MainHeader } from '~/components/MainHeader/MainHeader'
+import { AUTHENTICATION_ROUTE } from '~/core/router'
+import { AuthenticationMethodsEnum, LagoApiError } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
+
+import { useAddEntraIdDialog } from './dialogs/AddEntraIdDialog'
+import { useDeleteEntraIdIntegrationDialog } from './dialogs/DeleteEntraIdIntegrationDialog'
+
+gql`
+  query GetEntraIdIntegration($id: ID) {
+    integration(id: $id) {
+      ... on EntraIdIntegration {
+        id
+        clientId
+        clientSecret
+        code
+        tenantId
+        domain
+        name
+        host
+      }
+    }
+  }
+`
+
+type EntraIdIntegration = {
+  id: string
+  clientId?: string | null
+  clientSecret?: string | null
+  code: string
+  tenantId?: string | null
+  domain: string
+  name: string
+  host?: string | null
+}
+
+const ENTRA_ID_METHOD = 'entra_id' as AuthenticationMethodsEnum
+
+const EntraIdAuthenticationDetails = () => {
+  const { translate } = useInternationalization()
+  const { integrationId } = useParams()
+  const { organization } = useOrganizationInfos()
+  const navigate = useNavigate()
+
+  const { openAddEntraIdDialog } = useAddEntraIdDialog()
+  const { openDeleteEntraIdIntegrationDialog } = useDeleteEntraIdIntegrationDialog()
+
+  const { data, loading, refetch } = useQuery<{ integration?: EntraIdIntegration | null }>(gql`
+    query GetEntraIdIntegration($id: ID) {
+      integration(id: $id) {
+        ... on EntraIdIntegration {
+          id
+          clientId
+          clientSecret
+          code
+          tenantId
+          domain
+          name
+          host
+        }
+      }
+    }
+  `, {
+    variables: { id: integrationId },
+    skip: !integrationId,
+    context: {
+      silentErrorCodes: [LagoApiError.NotFound],
+    },
+  })
+
+  const integration = data?.integration || null
+
+  const hasOtherAuthenticationMethodsThanEntraId = organization?.authenticationMethods.some(
+    (method) => method !== ENTRA_ID_METHOD,
+  )
+
+  const onDeleteCallback = () => {
+    navigate(AUTHENTICATION_ROUTE)
+  }
+
+  const onEditCallback = () => {
+    refetch()
+  }
+
+  if (!integration) {
+    navigate(AUTHENTICATION_ROUTE)
+    return null
+  }
+
+  return (
+    <>
+      <MainHeader.Configure
+        breadcrumb={[
+          {
+            label: translate('text_664c732c264d7eed1c74fd96'),
+            path: AUTHENTICATION_ROUTE,
+          },
+        ]}
+        entity={{
+          viewName: 'Entra ID',
+          viewNameLoading: loading,
+          metadata: 'Microsoft Entra ID',
+          metadataLoading: loading,
+          icon: <Icon name="key" size="medium" />,
+          badges: [
+            {
+              label: translate('text_62b1edddbf5f461ab971270d'),
+              type: StatusType.default,
+            },
+          ],
+        }}
+        actions={{
+          items: [
+            {
+              type: 'dropdown',
+              label: translate('text_626162c62f790600f850b6fe'),
+              items: [
+                {
+                  label: translate('text_664c732c264d7eed1c74fdaa'),
+                  onClick: (closePopper) => {
+                    closePopper()
+                    openAddEntraIdDialog({
+                      integration,
+                      callback: onEditCallback,
+                      deleteCallback: onDeleteCallback,
+                    })
+                  },
+                },
+                {
+                  label: translate('text_664c732c264d7eed1c74fdb0'),
+                  onClick: (closePopper) => {
+                    closePopper()
+                    openDeleteEntraIdIntegrationDialog({
+                      integration,
+                      callback: onDeleteCallback,
+                    })
+                  },
+                  disabled: !hasOtherAuthenticationMethodsThanEntraId,
+                },
+              ],
+            },
+          ],
+          loading,
+        }}
+      />
+
+      <IntegrationsPage.Container>
+        <section>
+          <IntegrationsPage.Headline label={translate('text_664c732c264d7eed1c74fdc5')}>
+            <Button
+              variant="inline"
+              disabled={loading}
+              onClick={() =>
+                openAddEntraIdDialog({
+                  integration,
+                  callback: onEditCallback,
+                  deleteCallback: onDeleteCallback,
+                })
+              }
+            >
+              {translate('text_62b1edddbf5f461ab9712787')}
+            </Button>
+          </IntegrationsPage.Headline>
+
+          {loading ? (
+            [0, 1, 2, 3].map((i) => (
+              <IntegrationsPage.ItemSkeleton key={`item-skeleton-item-${i}`} />
+            ))
+          ) : (
+            <>
+              <IntegrationsPage.DetailsItem icon="globe" label="Email domain" value={integration.domain} />
+              <IntegrationsPage.DetailsItem icon="globe" label="Host" value={integration.host || 'N/A'} />
+              <IntegrationsPage.DetailsItem icon="text" label="Tenant ID" value={integration.tenantId || 'N/A'} />
+              <IntegrationsPage.DetailsItem icon="key" label="Client ID" value={integration.clientId || 'N/A'} />
+              <IntegrationsPage.DetailsItem icon="key" label="Client secret" value={integration.clientSecret || 'N/A'} />
+            </>
+          )}
+        </section>
+      </IntegrationsPage.Container>
+    </>
+  )
+}
+
+export default EntraIdAuthenticationDetails

--- a/src/pages/settings/teamAndSecurity/authentication/__tests__/Authentication.test.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/__tests__/Authentication.test.tsx
@@ -232,8 +232,8 @@ describe('Authentication', () => {
 
     const selectorButtons = screen.getAllByRole('button').filter((el) => el.tagName === 'DIV')
 
-    // Click the Okta selector (3rd one)
-    await user.click(selectorButtons[2])
+    // Click the Okta selector (4th one, after Entra ID)
+    await user.click(selectorButtons[3])
 
     await waitFor(() => {
       expect(testMockNavigateFn).toHaveBeenCalled()

--- a/src/pages/settings/teamAndSecurity/authentication/dialogs/AddEntraIdDialog.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/dialogs/AddEntraIdDialog.tsx
@@ -211,12 +211,18 @@ export const useAddEntraIdDialog = () => {
             </form.AppField>
             <form.AppField name="tenantId">
               {(field) => (
-                <field.TextInputField label="Tenant ID" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" />
+                <field.TextInputField
+                  label="Tenant ID"
+                  placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                />
               )}
             </form.AppField>
             <form.AppField name="clientId">
               {(field) => (
-                <field.TextInputField label="Client ID" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" />
+                <field.TextInputField
+                  label="Client ID"
+                  placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                />
               )}
             </form.AppField>
             <form.AppField name="clientSecret">
@@ -230,7 +236,9 @@ export const useAddEntraIdDialog = () => {
         mainAction: (
           <form.AppForm>
             <form.SubmitButton dataTest="add-entra-id-dialog-submit-button">
-              {translate(isEdition ? 'text_664c732c264d7eed1c74fdaa' : 'text_664c732c264d7eed1c74fdcb')}
+              {translate(
+                isEdition ? 'text_664c732c264d7eed1c74fdaa' : 'text_664c732c264d7eed1c74fdcb',
+              )}
             </form.SubmitButton>
           </form.AppForm>
         ),

--- a/src/pages/settings/teamAndSecurity/authentication/dialogs/AddEntraIdDialog.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/dialogs/AddEntraIdDialog.tsx
@@ -1,0 +1,277 @@
+import { gql, useMutation } from '@apollo/client'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
+import { z } from 'zod'
+
+import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { addToast } from '~/core/apolloClient'
+import { zodDomain, zodOptionalHost } from '~/formValidation/zodCustoms'
+import { AuthenticationMethodsEnum } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
+
+gql`
+  mutation createEntraIdIntegration($input: CreateEntraIdIntegrationInput!) {
+    createEntraIdIntegration(input: $input) {
+      id
+    }
+  }
+
+  mutation updateEntraIdIntegration($input: UpdateEntraIdIntegrationInput!) {
+    updateEntraIdIntegration(input: $input) {
+      id
+    }
+  }
+
+  mutation DestroyIntegration($input: DestroyIntegrationInput!) {
+    destroyIntegration(input: $input) {
+      id
+    }
+  }
+`
+
+type EntraIdIntegrationForm = {
+  id: string
+  domain?: string | null
+  host?: string | null
+  clientId?: string | null
+  clientSecret?: string | null
+  tenantId?: string | null
+}
+
+type OpenAddEntraIdDialogData = {
+  integration?: EntraIdIntegrationForm
+  callback?: (id: string) => void
+  deleteCallback?: () => void
+}
+
+type EntraIdInput = {
+  domain: string
+  host: string
+  clientId: string
+  clientSecret: string
+  tenantId: string
+}
+
+const defaultFormValues: EntraIdInput = {
+  domain: '',
+  host: '',
+  clientId: '',
+  clientSecret: '',
+  tenantId: '',
+}
+
+const validationSchema = z.object({
+  domain: zodDomain,
+  host: zodOptionalHost,
+  clientId: z.string().min(1),
+  clientSecret: z.string().min(1),
+  tenantId: z.string().min(1),
+})
+
+const ENTRA_ID_METHOD = 'entra_id' as AuthenticationMethodsEnum
+
+export const useAddEntraIdDialog = () => {
+  const formDialogOpeningDialog = useFormDialogOpeningDialog()
+  const { translate } = useInternationalization()
+  const { organization } = useOrganizationInfos()
+
+  const dataRef = useRef<OpenAddEntraIdDialogData | null>(null)
+  const successRef = useRef(false)
+
+  const [createIntegration] = useMutation<{ createEntraIdIntegration?: { id: string } }>(gql`
+    mutation createEntraIdIntegration($input: CreateEntraIdIntegrationInput!) {
+      createEntraIdIntegration(input: $input) {
+        id
+      }
+    }
+  `)
+
+  const [updateIntegration] = useMutation<{ updateEntraIdIntegration?: { id: string } }>(gql`
+    mutation updateEntraIdIntegration($input: UpdateEntraIdIntegrationInput!) {
+      updateEntraIdIntegration(input: $input) {
+        id
+      }
+    }
+  `)
+
+  const [deleteIntegration] = useMutation<{ destroyIntegration?: { id: string } }>(gql`
+    mutation DestroyIntegration($input: DestroyIntegrationInput!) {
+      destroyIntegration(input: $input) {
+        id
+      }
+    }
+  `)
+
+  const form = useAppForm({
+    defaultValues: defaultFormValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: validationSchema,
+    },
+    onSubmit: async ({ value }) => {
+      const integration = dataRef.current?.integration
+
+      if (integration) {
+        const res = await updateIntegration({
+          variables: {
+            input: {
+              id: integration.id,
+              domain: value.domain,
+              host: value.host,
+              clientId: value.clientId,
+              clientSecret: value.clientSecret,
+              tenantId: value.tenantId,
+            },
+          },
+        })
+
+        if (res.data?.updateEntraIdIntegration?.id) {
+          successRef.current = true
+          dataRef.current?.callback?.(res.data.updateEntraIdIntegration.id)
+          addToast({ severity: 'success', message: 'Entra ID integration updated' })
+        }
+      } else {
+        const res = await createIntegration({
+          variables: {
+            input: {
+              domain: value.domain,
+              host: value.host,
+              clientId: value.clientId,
+              clientSecret: value.clientSecret,
+              tenantId: value.tenantId,
+            },
+          },
+        })
+
+        if (res.data?.createEntraIdIntegration?.id) {
+          successRef.current = true
+          dataRef.current?.callback?.(res.data.createEntraIdIntegration.id)
+          addToast({ severity: 'success', message: 'Entra ID integration created' })
+        }
+      }
+    },
+  })
+
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
+
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openAddEntraIdDialog = (data?: OpenAddEntraIdDialogData) => {
+    dataRef.current = data ?? null
+    const integration = data?.integration
+    const isEdition = !!integration
+
+    const hasOtherAuthenticationMethodsThanEntraId = organization?.authenticationMethods.some(
+      (method) => method !== ENTRA_ID_METHOD,
+    )
+
+    form.reset()
+    if (integration) {
+      form.setFieldValue('domain', integration.domain || '')
+      form.setFieldValue('host', integration.host || '')
+      form.setFieldValue('clientId', integration.clientId || '')
+      form.setFieldValue('clientSecret', integration.clientSecret || '')
+      form.setFieldValue('tenantId', integration.tenantId || '')
+    }
+
+    formDialogOpeningDialog
+      .open({
+        title: isEdition ? 'Edit Entra ID integration' : 'Add Entra ID integration',
+        description: 'Configure Microsoft Entra ID SSO settings.',
+        children: (
+          <div className="flex flex-col gap-6 p-8">
+            <form.AppField name="domain">
+              {(field) => (
+                <field.TextInputField
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus
+                  label="Email domain"
+                  placeholder="example.com"
+                  helperText="Only users from this email domain can use this SSO provider."
+                />
+              )}
+            </form.AppField>
+            <form.AppField name="host">
+              {(field) => (
+                <field.TextInputField
+                  label="Host (optional)"
+                  placeholder="login.microsoftonline.com"
+                />
+              )}
+            </form.AppField>
+            <form.AppField name="tenantId">
+              {(field) => (
+                <field.TextInputField label="Tenant ID" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" />
+              )}
+            </form.AppField>
+            <form.AppField name="clientId">
+              {(field) => (
+                <field.TextInputField label="Client ID" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" />
+              )}
+            </form.AppField>
+            <form.AppField name="clientSecret">
+              {(field) => (
+                <field.TextInputField label="Client secret" placeholder="Client secret value" />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        closeOnError: false,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton dataTest="add-entra-id-dialog-submit-button">
+              {translate(isEdition ? 'text_664c732c264d7eed1c74fdaa' : 'text_664c732c264d7eed1c74fdcb')}
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: 'form-add-entra-id-integration',
+          submit: handleSubmit,
+        },
+        canOpenDialog:
+          isEdition && !!data?.deleteCallback && !!hasOtherAuthenticationMethodsThanEntraId,
+        openDialogText: translate('text_65845f35d7d69c3ab4793dad'),
+        otherDialogProps: {
+          title: translate('text_664c900d2d312a01546bd84b'),
+          description: translate('text_664c900d2d312a01546bd84c'),
+          colorVariant: 'danger',
+          actionText: translate('text_645d071272418a14c1c76a81'),
+          onAction: async () => {
+            const result = await deleteIntegration({
+              variables: {
+                input: {
+                  id: integration?.id ?? '',
+                },
+              },
+              update(cache) {
+                cache.evict({ id: `EntraIdIntegration:${integration?.id}` })
+              },
+            })
+
+            if (result.data?.destroyIntegration) {
+              data?.deleteCallback?.()
+              addToast({ message: 'Entra ID integration deleted', severity: 'success' })
+            }
+          },
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close' || response.reason === 'open-other-dialog') {
+          form.reset()
+          dataRef.current = null
+        }
+      })
+  }
+
+  return { openAddEntraIdDialog }
+}

--- a/src/pages/settings/teamAndSecurity/authentication/dialogs/DeleteEntraIdIntegrationDialog.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/dialogs/DeleteEntraIdIntegrationDialog.tsx
@@ -1,0 +1,70 @@
+import { gql, useMutation } from '@apollo/client'
+
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
+import { addToast } from '~/core/apolloClient'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+gql`
+  mutation DestroyIntegration($input: DestroyIntegrationInput!) {
+    destroyIntegration(input: $input) {
+      id
+    }
+  }
+`
+
+type EntraIdIntegrationLite = {
+  id: string
+  name?: string | null
+}
+
+type DeleteEntraIdIntegrationDialogData = {
+  integration: EntraIdIntegrationLite | undefined
+  callback?: () => void
+}
+
+export const useDeleteEntraIdIntegrationDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+
+  const [deleteIntegration] = useMutation<{ destroyIntegration?: { id: string } }>(gql`
+    mutation DestroyIntegration($input: DestroyIntegrationInput!) {
+      destroyIntegration(input: $input) {
+        id
+      }
+    }
+  `)
+
+  const openDeleteEntraIdIntegrationDialog = (data: DeleteEntraIdIntegrationDialogData) => {
+    centralizedDialog.open({
+      title: translate('text_664c900d2d312a01546bd84b'),
+      description: translate('text_664c900d2d312a01546bd84c'),
+      colorVariant: 'danger',
+      actionText: translate('text_645d071272418a14c1c76a81'),
+      onAction: async () => {
+        const result = await deleteIntegration({
+          variables: {
+            input: {
+              id: data.integration?.id ?? '',
+            },
+          },
+          update(cache) {
+            cache.evict({ id: `EntraIdIntegration:${data.integration?.id}` })
+          },
+        })
+
+        if (result.data?.destroyIntegration) {
+          data.callback?.()
+
+          addToast({
+            message: translate('text_664c732c264d7eed1c74fdb4', {
+              integration: 'Entra ID',
+            }),
+            severity: 'success',
+          })
+        }
+      },
+    })
+  }
+
+  return { openDeleteEntraIdIntegrationDialog }
+}

--- a/src/pages/settings/teamAndSecurity/authentication/dialogs/UpdateLoginMethodDialog.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/dialogs/UpdateLoginMethodDialog.tsx
@@ -1,16 +1,13 @@
-import { gql } from '@apollo/client'
+import { gql, useMutation } from '@apollo/client'
 
 import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import { authenticationMethodsMapping } from '~/core/constants/authenticationMethodsMapping'
-import {
-  AuthenticationMethodsEnum,
-  useUpdateOrganizationAuthenticationMethodsMutation,
-} from '~/generated/graphql'
+import { AuthenticationMethodsEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
-gql`
+const UPDATE_ORGANIZATION_AUTH_METHODS = gql`
   mutation updateOrganizationAuthenticationMethods($input: UpdateOrganizationInput!) {
     updateOrganization(input: $input) {
       id
@@ -19,8 +16,18 @@ gql`
   }
 `
 
+type UpdateOrganizationAuthenticationMethodsResult = {
+  updateOrganization?: {
+    id: string
+    authenticationMethods?: string[] | null
+  } | null
+}
+
+const ENTRA_ID_METHOD = 'entra_id' as const
+type OrganizationAuthenticationMethod = AuthenticationMethodsEnum | typeof ENTRA_ID_METHOD
+
 type UpdateLoginMethodDialogData = {
-  method: AuthenticationMethodsEnum
+  method: OrganizationAuthenticationMethod
   type: 'enable' | 'disable'
 }
 
@@ -30,22 +37,27 @@ export const useUpdateLoginMethodDialog = () => {
   const { organization, refetchOrganizationInfos } = useOrganizationInfos()
 
   const [updateOrganizationAuthenticationMethods] =
-    useUpdateOrganizationAuthenticationMethodsMutation()
+    useMutation<UpdateOrganizationAuthenticationMethodsResult>(UPDATE_ORGANIZATION_AUTH_METHODS)
 
   const openUpdateLoginMethodDialog = (data: UpdateLoginMethodDialogData) => {
     const isDanger = data.type === 'disable'
-    const methodLabel = translate(authenticationMethodsMapping[data.method])
+    const methodLabel =
+      data.method === ENTRA_ID_METHOD
+        ? 'Entra ID'
+        : translate(authenticationMethodsMapping[data.method])
 
     const getNewAuthMethods = () => {
+      const currentAuthenticationMethods = (organization?.authenticationMethods || []) as string[]
+
       if (data.type === 'disable') {
-        return organization?.authenticationMethods?.filter((method) => method !== data.method) || []
+        return currentAuthenticationMethods.filter((method) => method !== data.method)
       }
 
       if (data.type === 'enable') {
-        return [...(organization?.authenticationMethods || []), data.method]
+        return [...currentAuthenticationMethods, data.method]
       }
 
-      return []
+      return currentAuthenticationMethods
     }
 
     centralizedDialog.open({
@@ -71,9 +83,7 @@ export const useUpdateLoginMethodDialog = () => {
         })
 
         if (result.data?.updateOrganization) {
-          const isEnabled = result.data.updateOrganization.authenticationMethods?.includes(
-            data.method,
-          )
+          const isEnabled = result.data.updateOrganization.authenticationMethods?.includes(data.method)
 
           addToast({
             message: translate(

--- a/src/pages/settings/teamAndSecurity/authentication/dialogs/UpdateLoginMethodDialog.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/dialogs/UpdateLoginMethodDialog.tsx
@@ -83,7 +83,9 @@ export const useUpdateLoginMethodDialog = () => {
         })
 
         if (result.data?.updateOrganization) {
-          const isEnabled = result.data.updateOrganization.authenticationMethods?.includes(data.method)
+          const isEnabled = result.data.updateOrganization.authenticationMethods?.includes(
+            data.method,
+          )
 
           addToast({
             message: translate(


### PR DESCRIPTION
## Summary\n- add Entra login and callback pages/routes\n- add Entra invitation flow support\n- add authentication settings parity: create/update/delete + details route\n- include QA-driven typing and test compatibility fixes\n\n## Validation\n- pnpm types: pass\n- targeted tests for auth/invitation/settings: pass\n\n## Notes\n- Depends on companion backend PR in lago-api: codex/entra-id-e2e\n- Built by Codex for team review; no changes to main until merge.