### PR TITLE
feat: Store superset filters in localStorage

### DIFF
--- a/src/core/constants/localStorageKeys.ts
+++ b/src/core/constants/localStorageKeys.ts
@@ -1,2 +1,3 @@
 export const ORGANIZATION_LS_KEY_ID = 'currentOrganization'
 export const REDIRECT_AFTER_LOGIN_LS_KEY = 'redirectAfterLogin'
+export const SUPERSET_FILTERS_LS_KEY_PREFIX = 'superset-filters-'

--- a/src/core/utils/__tests__/risonEncoder.test.ts
+++ b/src/core/utils/__tests__/risonEncoder.test.ts
@@ -1,0 +1,93 @@
+import { encodeRison } from '~/core/utils/risonEncoder'
+
+describe('encodeRison', () => {
+  it('encodes a string without special characters', () => {
+    expect(encodeRison('Currency')).toBe('Currency')
+  })
+
+  it('encodes a string with spaces using single quotes', () => {
+    expect(encodeRison('Last quarter')).toBe("'Last quarter'")
+  })
+
+  it('encodes a string containing a single quote', () => {
+    expect(encodeRison("it's")).toBe("'it!'s'")
+  })
+
+  it('encodes RISON keyword-like strings with quotes and escaped !', () => {
+    expect(encodeRison('!t')).toBe("'!!t'")
+    expect(encodeRison('!f')).toBe("'!!f'")
+    expect(encodeRison('!n')).toBe("'!!n'")
+  })
+
+  it('encodes an empty string with single quotes', () => {
+    expect(encodeRison('')).toBe("''")
+  })
+
+  it('encodes a number', () => {
+    expect(encodeRison(42)).toBe('42')
+    expect(encodeRison(3.14)).toBe('3.14')
+  })
+
+  it('encodes booleans', () => {
+    expect(encodeRison(true)).toBe('!t')
+    expect(encodeRison(false)).toBe('!f')
+  })
+
+  it('encodes null', () => {
+    expect(encodeRison(null)).toBe('!n')
+  })
+
+  it('encodes an empty array', () => {
+    expect(encodeRison([])).toBe('!()')
+  })
+
+  it('encodes an array of strings', () => {
+    expect(encodeRison(['EUR', 'USD'])).toBe('!(EUR,USD)')
+  })
+
+  it('encodes an empty object', () => {
+    expect(encodeRison({})).toBe('()')
+  })
+
+  it('encodes a simple object', () => {
+    expect(encodeRison({ label: 'Currency', value: 'EUR' })).toBe('(label:Currency,value:EUR)')
+  })
+
+  it('encodes a nested filter state object', () => {
+    const input = {
+      'NATIVE_FILTER-abc': {
+        filterState: {
+          value: ['EUR'],
+          excludeFilterValues: true,
+          label: 'Currency',
+        },
+      },
+    }
+
+    expect(encodeRison(input)).toBe(
+      '(NATIVE_FILTER-abc:(filterState:(value:!(EUR),excludeFilterValues:!t,label:Currency)))',
+    )
+  })
+
+  it('encodes a realistic multi-filter object', () => {
+    const input = {
+      'NATIVE_FILTER-oFKcx8PxGN0bMEs0162b': {
+        filterState: {
+          value: 'Last quarter',
+        },
+      },
+      'NATIVE_FILTER-60Cxt1g_5G-Phhv5JyBFR': {
+        filterState: {
+          value: ['Currency'],
+          excludeFilterValues: true,
+          label: 'Currency',
+        },
+      },
+    }
+
+    expect(encodeRison(input)).toBe(
+      "(NATIVE_FILTER-oFKcx8PxGN0bMEs0162b:(filterState:(value:'Last quarter'))" +
+        ',NATIVE_FILTER-60Cxt1g_5G-Phhv5JyBFR:(filterState:(value:!(Currency),excludeFilterValues:!t,label:Currency)))',
+    )
+  })
+})

--- a/src/core/utils/__tests__/supersetFilters.test.ts
+++ b/src/core/utils/__tests__/supersetFilters.test.ts
@@ -1,0 +1,169 @@
+import { extractNativeFilters } from '~/core/utils/supersetFilters'
+
+describe('extractNativeFilters', () => {
+  describe('GIVEN an empty dataMask', () => {
+    describe('WHEN called with no entries', () => {
+      it('THEN should return an empty object', () => {
+        expect(extractNativeFilters({})).toEqual({})
+      })
+    })
+  })
+
+  describe('GIVEN entries without NATIVE_FILTER- prefix', () => {
+    describe('WHEN called with non-native filter keys', () => {
+      it('THEN should skip all entries', () => {
+        const dataMask = {
+          'OTHER_KEY-abc': { filterState: { value: 'EUR' } },
+          'SOME_FILTER-xyz': { filterState: { value: ['USD'] } },
+        }
+
+        expect(extractNativeFilters(dataMask)).toEqual({})
+      })
+    })
+  })
+
+  describe('GIVEN entries with missing filterState', () => {
+    describe('WHEN filterState is undefined', () => {
+      it('THEN should skip the entry', () => {
+        const dataMask = {
+          'NATIVE_FILTER-abc': {},
+        }
+
+        expect(extractNativeFilters(dataMask)).toEqual({})
+      })
+    })
+  })
+
+  describe('GIVEN entries with null or undefined values', () => {
+    describe('WHEN filterState.value is null', () => {
+      it('THEN should skip the entry', () => {
+        const dataMask = {
+          'NATIVE_FILTER-abc': { filterState: { value: null } },
+        }
+
+        expect(extractNativeFilters(dataMask)).toEqual({})
+      })
+    })
+
+    describe('WHEN filterState.value is undefined', () => {
+      it('THEN should skip the entry', () => {
+        const dataMask = {
+          'NATIVE_FILTER-abc': { filterState: { value: undefined } },
+        }
+
+        expect(extractNativeFilters(dataMask)).toEqual({})
+      })
+    })
+  })
+
+  describe('GIVEN entries with empty array values', () => {
+    describe('WHEN filterState.value is an empty array', () => {
+      it('THEN should skip the entry', () => {
+        const dataMask = {
+          'NATIVE_FILTER-abc': { filterState: { value: [] } },
+        }
+
+        expect(extractNativeFilters(dataMask)).toEqual({})
+      })
+    })
+  })
+
+  describe('GIVEN entries with valid filter values', () => {
+    describe('WHEN filterState.value is a non-empty array', () => {
+      it('THEN should include the entry', () => {
+        const dataMask = {
+          'NATIVE_FILTER-abc': { filterState: { value: ['EUR'] } },
+        }
+
+        expect(extractNativeFilters(dataMask)).toEqual({
+          'NATIVE_FILTER-abc': { filterState: { value: ['EUR'] } },
+        })
+      })
+    })
+
+    describe('WHEN filterState.value is a string', () => {
+      it('THEN should include the entry', () => {
+        const dataMask = {
+          'NATIVE_FILTER-abc': { filterState: { value: 'Last quarter' } },
+        }
+
+        expect(extractNativeFilters(dataMask)).toEqual({
+          'NATIVE_FILTER-abc': { filterState: { value: 'Last quarter' } },
+        })
+      })
+    })
+
+    describe('WHEN filterState.value is a number', () => {
+      it('THEN should include the entry', () => {
+        const dataMask = {
+          'NATIVE_FILTER-abc': { filterState: { value: 42 } },
+        }
+
+        expect(extractNativeFilters(dataMask)).toEqual({
+          'NATIVE_FILTER-abc': { filterState: { value: 42 } },
+        })
+      })
+    })
+
+    describe('WHEN filterState.value is a boolean', () => {
+      it('THEN should include the entry', () => {
+        const dataMask = {
+          'NATIVE_FILTER-abc': { filterState: { value: true } },
+        }
+
+        expect(extractNativeFilters(dataMask)).toEqual({
+          'NATIVE_FILTER-abc': { filterState: { value: true } },
+        })
+      })
+    })
+  })
+
+  describe('GIVEN a mix of valid and invalid entries', () => {
+    describe('WHEN dataMask contains multiple entries', () => {
+      it('THEN should only include valid native filter entries', () => {
+        const dataMask = {
+          'NATIVE_FILTER-valid1': { filterState: { value: ['EUR'], label: 'Currency' } },
+          'NATIVE_FILTER-nullVal': { filterState: { value: null } },
+          'NATIVE_FILTER-emptyArr': { filterState: { value: [] } },
+          'NATIVE_FILTER-valid2': { filterState: { value: 'Last quarter' } },
+          'OTHER_KEY-skip': { filterState: { value: 'something' } },
+          'NATIVE_FILTER-noState': {},
+        }
+
+        const result = extractNativeFilters(dataMask)
+
+        expect(Object.keys(result)).toHaveLength(2)
+        expect(result).toEqual({
+          'NATIVE_FILTER-valid1': { filterState: { value: ['EUR'], label: 'Currency' } },
+          'NATIVE_FILTER-valid2': { filterState: { value: 'Last quarter' } },
+        })
+      })
+    })
+  })
+
+  describe('GIVEN entries with extra filterState properties', () => {
+    describe('WHEN filterState has additional fields beyond value', () => {
+      it('THEN should preserve the full filterState object', () => {
+        const dataMask = {
+          'NATIVE_FILTER-abc': {
+            filterState: {
+              value: ['EUR'],
+              excludeFilterValues: true,
+              label: 'Currency',
+            },
+          },
+        }
+
+        expect(extractNativeFilters(dataMask)).toEqual({
+          'NATIVE_FILTER-abc': {
+            filterState: {
+              value: ['EUR'],
+              excludeFilterValues: true,
+              label: 'Currency',
+            },
+          },
+        })
+      })
+    })
+  })
+})

--- a/src/core/utils/featureFlags.ts
+++ b/src/core/utils/featureFlags.ts
@@ -1,6 +1,7 @@
 // You can list your features such as FTR_ENABLED = 'ftr_enabled'
 export enum FeatureFlags {
   FTR_ENABLED = 'ftr_enabled',
+  SUPERSET_PERSISTENT_FILTERS = 'superset_persistent_filters',
 }
 
 const FF_KEY = 'featureFlags'

--- a/src/core/utils/risonEncoder.ts
+++ b/src/core/utils/risonEncoder.ts
@@ -1,0 +1,31 @@
+const SAFE_STRING_RE = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/
+const RISON_KEYWORDS = new Set(['!t', '!f', '!n'])
+
+export function encodeRison(value: unknown): string {
+  if (value === null) return '!n'
+  if (value === undefined) return '!n'
+
+  switch (typeof value) {
+    case 'boolean':
+      return value ? '!t' : '!f'
+    case 'number':
+      return String(value)
+    case 'string':
+      if (value === '') return "''"
+      if (SAFE_STRING_RE.test(value) && !RISON_KEYWORDS.has(value)) return value
+      return "'" + value.replace(/!/g, '!!').replace(/'/g, "!'") + "'"
+    case 'object':
+      if (Array.isArray(value)) {
+        return '!(' + value.map(encodeRison).join(',') + ')'
+      }
+      return (
+        '(' +
+        Object.entries(value as Record<string, unknown>)
+          .map(([k, v]) => k + ':' + encodeRison(v))
+          .join(',') +
+        ')'
+      )
+    default:
+      return "''"
+  }
+}

--- a/src/core/utils/supersetFilters.ts
+++ b/src/core/utils/supersetFilters.ts
@@ -1,0 +1,25 @@
+import { isNil } from 'lodash'
+
+type DataMaskEntry = {
+  filterState?: Record<string, unknown>
+}
+
+type NativeFilters = Record<string, { filterState: Record<string, unknown> }>
+
+export function extractNativeFilters(dataMask: Record<string, unknown>): NativeFilters {
+  return Object.entries(dataMask).reduce<NativeFilters>((acc, [key, entry]) => {
+    const filterState = (entry as DataMaskEntry)?.filterState
+    const val = filterState?.value
+
+    if (
+      key.startsWith('NATIVE_FILTER-') &&
+      filterState &&
+      !isNil(val) &&
+      !(Array.isArray(val) && val.length === 0)
+    ) {
+      acc[key] = { filterState }
+    }
+
+    return acc
+  }, {})
+}

--- a/src/pages/dashboards/Dashboards.tsx
+++ b/src/pages/dashboards/Dashboards.tsx
@@ -10,6 +10,7 @@ import {
   ORGANIZATION_LS_KEY_ID,
   SUPERSET_FILTERS_LS_KEY_PREFIX,
 } from '~/core/constants/localStorageKeys'
+import { FeatureFlags, isFeatureFlagActive } from '~/core/utils/featureFlags'
 import { encodeRison } from '~/core/utils/risonEncoder'
 import { extractNativeFilters } from '~/core/utils/supersetFilters'
 import { useSupersetDashboardsQuery } from '~/generated/graphql'
@@ -55,16 +56,19 @@ const Dashboards = () => {
 
     let embedded: null | EmbeddedDashboard = null
 
+    const persistFilters = isFeatureFlagActive(FeatureFlags.SUPERSET_PERSISTENT_FILTERS)
     const orgId = getItemFromLS(ORGANIZATION_LS_KEY_ID) || ''
     const filtersLsKey = `${SUPERSET_FILTERS_LS_KEY_PREFIX}${orgId}`
 
-    const debouncedSaveFilters = debounce((dataMask: Record<string, unknown>) => {
-      const filters = extractNativeFilters(dataMask)
+    const debouncedSaveFilters = persistFilters
+      ? debounce((dataMask: Record<string, unknown>) => {
+          const filters = extractNativeFilters(dataMask)
 
-      if (Object.keys(filters).length > 0) {
-        setItemFromLS(filtersLsKey, filters)
-      }
-    }, 500)
+          if (Object.keys(filters).length > 0) {
+            setItemFromLS(filtersLsKey, filters)
+          }
+        }, 500)
+      : null
 
     const mount = async () => {
       const mountPoint = document.getElementById('superset')
@@ -73,9 +77,14 @@ const Dashboards = () => {
         return
       }
 
-      const savedFilters = getItemFromLS(filtersLsKey)
-      const hasFilters = savedFilters && Object.keys(savedFilters).length > 0
-      const urlParams = hasFilters ? { native_filters: encodeRison(savedFilters) } : undefined
+      let urlParams: Record<string, string> | undefined
+
+      if (persistFilters) {
+        const savedFilters = getItemFromLS(filtersLsKey)
+        const hasFilters = savedFilters && Object.keys(savedFilters).length > 0
+
+        urlParams = hasFilters ? { native_filters: encodeRison(savedFilters) } : undefined
+      }
 
       embedded = await embedDashboard({
         id: dashboard.embeddedId,
@@ -84,7 +93,7 @@ const Dashboards = () => {
         fetchGuestToken: async () => dashboard?.guestToken,
         dashboardUiConfig: {
           hideTitle: true,
-          emitDataMasks: true,
+          emitDataMasks: persistFilters,
           filters: {
             expanded: true,
           },
@@ -93,7 +102,9 @@ const Dashboards = () => {
         iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox'],
       })
 
-      embedded.observeDataMask(debouncedSaveFilters)
+      if (debouncedSaveFilters) {
+        embedded.observeDataMask(debouncedSaveFilters)
+      }
 
       dashboardRef.current = dashboard.id
     }
@@ -101,7 +112,7 @@ const Dashboards = () => {
     mount()
 
     return () => {
-      debouncedSaveFilters.cancel()
+      debouncedSaveFilters?.cancel()
       embedded?.unmount()
       dashboardRef.current = ''
     }

--- a/src/pages/dashboards/Dashboards.tsx
+++ b/src/pages/dashboards/Dashboards.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useRef } from 'react'
 
 import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder'
 import { Typography } from '~/components/designSystem/Typography'
-import { envGlobalVar, getItemFromLS, setItemFromLS } from '~/core/apolloClient'
+import { envGlobalVar, getItemFromLS, removeItemFromLS, setItemFromLS } from '~/core/apolloClient'
 import {
   ORGANIZATION_LS_KEY_ID,
   SUPERSET_FILTERS_LS_KEY_PREFIX,
@@ -66,6 +66,8 @@ const Dashboards = () => {
 
           if (Object.keys(filters).length > 0) {
             setItemFromLS(filtersLsKey, filters)
+          } else {
+            removeItemFromLS(filtersLsKey)
           }
         }, 500)
       : null

--- a/src/pages/dashboards/Dashboards.tsx
+++ b/src/pages/dashboards/Dashboards.tsx
@@ -4,7 +4,12 @@ import { useEffect, useMemo, useRef } from 'react'
 
 import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder'
 import { Typography } from '~/components/designSystem/Typography'
-import { envGlobalVar, getItemFromLS } from '~/core/apolloClient'
+import { envGlobalVar, getItemFromLS, setItemFromLS } from '~/core/apolloClient'
+import {
+  ORGANIZATION_LS_KEY_ID,
+  SUPERSET_FILTERS_LS_KEY_PREFIX,
+} from '~/core/constants/localStorageKeys'
+import { encodeRison } from '~/core/utils/risonEncoder'
 import { useSupersetDashboardsQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import '~/main.css'
@@ -47,6 +52,7 @@ const Dashboards = () => {
     }
 
     let embedded: null | EmbeddedDashboard = null
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
     const mount = async () => {
       const mountPoint = document.getElementById('superset')
@@ -55,6 +61,12 @@ const Dashboards = () => {
         return
       }
 
+      const orgId = getItemFromLS(ORGANIZATION_LS_KEY_ID) || ''
+      const filtersLsKey = SUPERSET_FILTERS_LS_KEY_PREFIX + orgId + '-' + dashboard.embeddedId
+      const savedFilters = getItemFromLS(filtersLsKey)
+      const hasFilters = savedFilters && Object.keys(savedFilters).length > 0
+      const urlParams = hasFilters ? { native_filters: encodeRison(savedFilters) } : undefined
+
       embedded = await embedDashboard({
         id: dashboard.embeddedId,
         supersetDomain: lagoSupersetUrl,
@@ -62,11 +74,37 @@ const Dashboards = () => {
         fetchGuestToken: async () => dashboard?.guestToken,
         dashboardUiConfig: {
           hideTitle: true,
+          emitDataMasks: true,
           filters: {
             expanded: true,
           },
+          ...(urlParams && { urlParams }),
         },
         iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox'],
+      })
+
+      embedded.observeDataMask((dataMask) => {
+        if (debounceTimer) clearTimeout(debounceTimer)
+        debounceTimer = setTimeout(() => {
+          const filters: Record<string, { filterState: Record<string, unknown> }> = {}
+
+          for (const [key, entry] of Object.entries(dataMask)) {
+            if (!key.startsWith('NATIVE_FILTER-')) continue
+
+            const filterState = (entry as { filterState?: Record<string, unknown> })?.filterState
+            if (!filterState) continue
+
+            const val = filterState.value
+            if (val === null || val === undefined) continue
+            if (Array.isArray(val) && val.length === 0) continue
+
+            filters[key] = { filterState }
+          }
+
+          if (Object.keys(filters).length > 0) {
+            setItemFromLS(filtersLsKey, filters)
+          }
+        }, 500)
       })
 
       dashboardRef.current = dashboard.id
@@ -75,6 +113,7 @@ const Dashboards = () => {
     mount()
 
     return () => {
+      if (debounceTimer) clearTimeout(debounceTimer)
       embedded?.unmount()
       dashboardRef.current = ''
     }

--- a/src/pages/dashboards/Dashboards.tsx
+++ b/src/pages/dashboards/Dashboards.tsx
@@ -1,5 +1,6 @@
 import { gql } from '@apollo/client'
 import { embedDashboard, EmbeddedDashboard } from '@superset-ui/embedded-sdk'
+import { debounce } from 'lodash'
 import { useEffect, useMemo, useRef } from 'react'
 
 import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder'
@@ -10,6 +11,7 @@ import {
   SUPERSET_FILTERS_LS_KEY_PREFIX,
 } from '~/core/constants/localStorageKeys'
 import { encodeRison } from '~/core/utils/risonEncoder'
+import { extractNativeFilters } from '~/core/utils/supersetFilters'
 import { useSupersetDashboardsQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import '~/main.css'
@@ -52,7 +54,17 @@ const Dashboards = () => {
     }
 
     let embedded: null | EmbeddedDashboard = null
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+    const orgId = getItemFromLS(ORGANIZATION_LS_KEY_ID) || ''
+    const filtersLsKey = `${SUPERSET_FILTERS_LS_KEY_PREFIX}${orgId}`
+
+    const debouncedSaveFilters = debounce((dataMask: Record<string, unknown>) => {
+      const filters = extractNativeFilters(dataMask)
+
+      if (Object.keys(filters).length > 0) {
+        setItemFromLS(filtersLsKey, filters)
+      }
+    }, 500)
 
     const mount = async () => {
       const mountPoint = document.getElementById('superset')
@@ -61,8 +73,6 @@ const Dashboards = () => {
         return
       }
 
-      const orgId = getItemFromLS(ORGANIZATION_LS_KEY_ID) || ''
-      const filtersLsKey = SUPERSET_FILTERS_LS_KEY_PREFIX + orgId + '-' + dashboard.embeddedId
       const savedFilters = getItemFromLS(filtersLsKey)
       const hasFilters = savedFilters && Object.keys(savedFilters).length > 0
       const urlParams = hasFilters ? { native_filters: encodeRison(savedFilters) } : undefined
@@ -83,29 +93,7 @@ const Dashboards = () => {
         iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox'],
       })
 
-      embedded.observeDataMask((dataMask) => {
-        if (debounceTimer) clearTimeout(debounceTimer)
-        debounceTimer = setTimeout(() => {
-          const filters: Record<string, { filterState: Record<string, unknown> }> = {}
-
-          for (const [key, entry] of Object.entries(dataMask)) {
-            if (!key.startsWith('NATIVE_FILTER-')) continue
-
-            const filterState = (entry as { filterState?: Record<string, unknown> })?.filterState
-            if (!filterState) continue
-
-            const val = filterState.value
-            if (val === null || val === undefined) continue
-            if (Array.isArray(val) && val.length === 0) continue
-
-            filters[key] = { filterState }
-          }
-
-          if (Object.keys(filters).length > 0) {
-            setItemFromLS(filtersLsKey, filters)
-          }
-        }, 500)
-      })
+      embedded.observeDataMask(debouncedSaveFilters)
 
       dashboardRef.current = dashboard.id
     }
@@ -113,7 +101,7 @@ const Dashboards = () => {
     mount()
 
     return () => {
-      if (debounceTimer) clearTimeout(debounceTimer)
+      debouncedSaveFilters.cancel()
       embedded?.unmount()
       dashboardRef.current = ''
     }


### PR DESCRIPTION
### Context

Superset embedded dashboards lose user-selected filters on page refresh. When a user selects a filter (e.g., Currency: EUR), refreshing the page resets all filters to their defaults, forcing users to reapply them every time.

### Description

Persist Superset dashboard filter selections in `localStorage` so they survive page refresh.

**How it works:**
- When a user changes filters, the `observeDataMask` callback (debounced 500ms) saves the active native filter state to `localStorage`
- On next page load, saved filters are RISON-encoded and passed to the Superset embedded SDK via the `native_filters` URL parameter
- Only `NATIVE_FILTER-*` entries with non-empty values are stored — chart cross-filters and empty filter states are excluded
- Storage is scoped per organization and dashboard (`superset-filters-{orgId}`) to prevent filter leakage between users or dashboards
- This is hidden behind a frontend feature flag (run `localStorage.setItem('featureFlags', JSON.stringify(['superset_persistent_filters']))` to enable it)

**Key decisions:**
- Inline RISON encoder (~25 lines) instead of adding an unmaintained `rison` npm package
- Filters with cleared values are removed from storage, so the dashboard's defaults apply on reload
- No cleanup of orphan localStorage keys — old entries expire naturally if a dashboard's `embeddedId` changes

<!-- Linear link -->
Fixes LAGO-1787