### PR TITLE
misc(form migration): Migrate EditCustomerInvoiceGracePeriodDialog from Formik to TanStack Form

### DIFF
--- a/.claude/skills/migrate-formik-to-tanstack/SKILL.md
+++ b/.claude/skills/migrate-formik-to-tanstack/SKILL.md
@@ -1106,6 +1106,85 @@ const hasLimits = limitPlansList.length > 0
 
 This reduces form state complexity and avoids synchronization issues between the flag and the actual data.
 
+### Pattern 11: `beforeChangeFormatter` Type Coercion (CRITICAL for numeric fields)
+
+The `TextInputField`'s `beforeChangeFormatter` with `'int'` uses `parseInt()` internally, which converts the value to a `number`. However, when the field is emptied, `formatValue` returns `''` (empty string) — **not** `NaN`. This means the field's runtime type is `number | ''`, not a pure `number` or `string`.
+
+**This has cascading implications for the Zod schema, `defaultValues`, and dirty checking.**
+
+**Schema — must accept both types:**
+
+```typescript
+// ❌ WRONG: z.number() rejects '' when field is emptied → runtime error
+// ❌ WRONG: z.string() rejects number from parseInt → runtime error
+// ❌ WRONG: z.coerce.number() coerces '' to 0 → hides "required" validation
+
+// ✅ CORRECT: accept both number and '' with union
+const schema = z.object({
+  gracePeriod: z
+    .union([z.number().max(365, { message: 'text_max_error' }), z.literal('')])
+    .refine((val) => val !== '', { message: 'text_required_error' }),
+})
+```
+
+**`defaultValues` — must match the runtime type:**
+
+```typescript
+const form = useAppForm({
+  defaultValues: {
+    // If the field has an existing value, use it; otherwise '' for empty/placeholder
+    gracePeriod: (existingValue ?? '') as number | '',
+  },
+})
+```
+
+**Why `''` instead of `0` for empty default:** If the original form showed `0` as a **placeholder** (field visually empty), use `''` as default — otherwise TanStack Form displays `0` as the field value. Use `0` as default only when `0` is the actual saved value.
+
+**Dirty check:** TanStack Form uses deep equality. If `defaultValues` is `''` (string) and the user types `5` (number from `parseInt`), dirty is `true`. If the user clears the field, it goes back to `''` and dirty is `false`. This works correctly as long as `defaultValues` type matches the runtime type.
+
+> **Reference**: See `EditCustomerInvoiceGracePeriodDialog.tsx` and `SubscriptionFeeDrawer.tsx` for real-world examples.
+
+### Pattern 12: Dialog Close After Submit (ref-based Dialog pattern)
+
+In legacy `<Dialog ref>` components, `closeDialog` is only available inside the `actions` render prop — not accessible from `onSubmit`. If you call `closeDialog()` after `await form.handleSubmit()`, it runs **unconditionally**, even when validation fails (because `handleSubmit` doesn't throw on validation failure — it simply doesn't call `onSubmit`).
+
+**Fix: use a `useRef` to bridge `closeDialog` into `onSubmit`:**
+
+```typescript
+const closeDialogRef = useRef<(() => void) | null>(null)
+
+const form = useAppForm({
+  // ...
+  onSubmit: async ({ value }) => {
+    await mutation({ variables: { input: { ...value } } })
+    // Only reached if validation passed AND mutation succeeded
+    closeDialogRef.current?.()
+  },
+})
+
+// In the actions render prop:
+<Button
+  onClick={async () => {
+    closeDialogRef.current = closeDialog
+    await form.handleSubmit()
+  }}
+>
+```
+
+**Why this works:** TanStack Form's `handleSubmit()` runs validation first. If validation fails, `onSubmit` is never called, so `closeDialogRef.current?.()` never executes and the dialog stays open with errors visible.
+
+> **Note**: This pattern is specific to the legacy `<Dialog ref>` system. The newer `useFormDialog` / NiceModal system handles this differently.
+
+### Pattern 13: Adding New Translation Keys
+
+**Never add translation keys manually to the JSON files.** Always use the project's npm script:
+
+```bash
+pnpm translations:add <count>
+```
+
+This generates unique keys with timestamps and random suffixes (e.g., `text_177583191144596sed2y63wo`). After generation, populate the empty values in `translations/base.json` with the actual text.
+
 ---
 
 ### Phase 4: Test Migration
@@ -1177,6 +1256,9 @@ The `/make-tests` skill will automatically:
 - [ ] Add `formApi.setErrorMap` for server-side errors
 - [ ] Migrate dialogs with forms to independent TanStack forms (Pattern 9)
 - [ ] Derive boolean state from form values instead of separate flags (Pattern 10)
+- [ ] Handle `beforeChangeFormatter` type coercion in schema — use `z.union([z.number(), z.literal('')])` for numeric fields (Pattern 11)
+- [ ] Use `closeDialogRef` pattern for legacy `<Dialog ref>` forms (Pattern 12)
+- [ ] Add new translation keys via `pnpm translations:add`, never manually (Pattern 13)
 
 ### Phase 3: Verification
 
@@ -1231,6 +1313,13 @@ The `/make-tests` skill will automatically:
 12. **Form dirty state incorrect with mappers**: Ensure mapper output structure exactly matches `defaultValues` structure
 13. **Side-effect on field change not working**: Use `listeners={{ onChange }}` on `form.AppField` instead of `useStore` + `useEffect`
 14. **Dialog form state leaking to parent**: Dialogs should use their own `useAppForm` instance, not share the parent form. Communicate via callbacks and `useRef`
+
+### Numeric Field & Dialog Issues
+
+15. **`beforeChangeFormatter: ['int']` causes Zod type error**: The formatter converts input to `number` via `parseInt`, but empty field returns `''`. Use `z.union([z.number(), z.literal('')])` in the schema, and `as number | ''` on `defaultValues`. See Pattern 11.
+16. **Field shows `0` instead of placeholder**: If `defaultValues` is `0`, the field displays `0` as a value. Use `''` as default when the original form showed `0` as placeholder (visually empty field). See Pattern 11.
+17. **Dialog closes even when validation fails**: `closeDialog()` after `await form.handleSubmit()` runs unconditionally because `handleSubmit` doesn't throw on validation failure. Use the `closeDialogRef` pattern (Pattern 12) to call `closeDialog` only from inside `onSubmit`.
+18. **Translation keys added manually cause inconsistent IDs**: Always use `pnpm translations:add <count>` to generate keys. See Pattern 13.
 
 ## Usage
 

--- a/.cursor/rules/migrate-formik-to-tanstack.mdc
+++ b/.cursor/rules/migrate-formik-to-tanstack.mdc
@@ -799,6 +799,59 @@ const limitPlansList = useStore(form.store, (state) => state.values.limitPlansLi
 const hasLimits = limitPlansList.length > 0
 ```
 
+### Pattern 10: `beforeChangeFormatter` Type Coercion (CRITICAL for numeric fields)
+
+`TextInputField`'s `beforeChangeFormatter` with `'int'` uses `parseInt()` → returns `number`. Empty field returns `''` (string). Runtime type is `number | ''`.
+
+```typescript
+// ❌ WRONG: z.number() rejects '' / z.string() rejects number / z.coerce.number() coerces '' to 0
+
+// ✅ CORRECT:
+const schema = z.object({
+  gracePeriod: z
+    .union([z.number().max(365, { message: 'text_max_error' }), z.literal('')])
+    .refine((val) => val !== '', { message: 'text_required_error' }),
+})
+
+// defaultValues must match runtime type:
+defaultValues: { gracePeriod: (existingValue ?? '') as number | '' }
+```
+
+**Why `''` instead of `0` for empty default:** If the original form showed `0` as placeholder (visually empty), use `''`. Use `0` only when `0` is the actual saved value.
+
+> **Reference**: `EditCustomerInvoiceGracePeriodDialog.tsx`, `SubscriptionFeeDrawer.tsx`
+
+### Pattern 11: Dialog Close After Submit (ref-based Dialog pattern)
+
+In legacy `<Dialog ref>` components, `closeDialog()` after `await form.handleSubmit()` runs **unconditionally** — `handleSubmit` doesn't throw on validation failure. Use `useRef` to call `closeDialog` only from inside `onSubmit`:
+
+```typescript
+const closeDialogRef = useRef<(() => void) | null>(null)
+
+const form = useAppForm({
+  onSubmit: async ({ value }) => {
+    await mutation({ variables: { input: { ...value } } })
+    closeDialogRef.current?.()  // Only reached if validation + mutation succeeded
+  },
+})
+
+// In actions render prop:
+<Button onClick={async () => {
+  closeDialogRef.current = closeDialog
+  await form.handleSubmit()
+}} />
+```
+
+### Pattern 12: Adding New Translation Keys
+
+**Never add translation keys manually.** Always use:
+
+```bash
+pnpm translations:add <count>
+```
+
+Then populate the empty values in `translations/base.json`.
+
 ---
 
 ---
@@ -854,3 +907,9 @@ The `/make-tests` skill will:
 12. **Form dirty state incorrect with mappers**: Ensure mapper output structure exactly matches `defaultValues` structure
 13. **Side-effect on field change not working**: Use `listeners={{ onChange }}` on `form.AppField` instead of `useStore` + `useEffect`
 14. **Dialog form state leaking to parent**: Dialogs should use their own `useAppForm` instance, not share the parent form. Communicate via callbacks and `useRef`
+
+### Numeric Field & Dialog Issues
+15. **`beforeChangeFormatter: ['int']` causes Zod type error**: The formatter converts input to `number` via `parseInt`, but empty field returns `''`. Use `z.union([z.number(), z.literal('')])` in the schema, and `as number | ''` on `defaultValues`. See Pattern 10.
+16. **Field shows `0` instead of placeholder**: If `defaultValues` is `0`, the field displays `0` as a value. Use `''` as default when the original form showed `0` as placeholder. See Pattern 10.
+17. **Dialog closes even when validation fails**: `closeDialog()` after `await form.handleSubmit()` runs unconditionally. Use the `closeDialogRef` pattern (Pattern 11).
+18. **Translation keys added manually cause inconsistent IDs**: Always use `pnpm translations:add <count>`. See Pattern 12.

--- a/src/components/customers/EditCustomerInvoiceGracePeriodDialog.tsx
+++ b/src/components/customers/EditCustomerInvoiceGracePeriodDialog.tsx
@@ -1,19 +1,16 @@
 import { gql } from '@apollo/client'
 import InputAdornment from '@mui/material/InputAdornment'
-import { useFormik } from 'formik'
-import { forwardRef } from 'react'
+import { revalidateLogic, useStore } from '@tanstack/react-form'
+import { forwardRef, useRef } from 'react'
 import { useParams } from 'react-router-dom'
-import { number, object } from 'yup'
+import { z } from 'zod'
 
 import { Button } from '~/components/designSystem/Button'
 import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { TextInputField } from '~/components/form'
 import { addToast } from '~/core/apolloClient'
-import {
-  UpdateCustomerInput,
-  useUpdateCustomerInvoiceGracePeriodMutation,
-} from '~/generated/graphql'
+import { useUpdateCustomerInvoiceGracePeriodMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 gql`
   fragment EditCustomerInvoiceGracePeriod on Customer {
@@ -29,6 +26,12 @@ gql`
   }
 `
 
+const editCustomerInvoiceGracePeriodValidationSchema = z.object({
+  invoiceGracePeriod: z
+    .union([z.number().max(365, { message: 'text_63bed78ae69de9cad5c348e4' }), z.literal('')])
+    .refine((val) => val !== '', { message: 'text_177583191144596sed2y63wo' }),
+})
+
 export type EditCustomerInvoiceGracePeriodDialogRef = DialogRef
 
 interface EditCustomerInvoiceGracePeriodDialogProps {
@@ -41,6 +44,7 @@ export const EditCustomerInvoiceGracePeriodDialog = forwardRef<
 >(({ invoiceGracePeriod }: EditCustomerInvoiceGracePeriodDialogProps, ref) => {
   const { customerId } = useParams()
   const { translate } = useInternationalization()
+  const closeDialogRef = useRef<(() => void) | null>(null)
   const [updateCustomerInvoiceGracePeriod] = useUpdateCustomerInvoiceGracePeriodMutation({
     onCompleted(res) {
       if (res?.updateCustomerInvoiceGracePeriod) {
@@ -51,33 +55,37 @@ export const EditCustomerInvoiceGracePeriodDialog = forwardRef<
       }
     },
   })
-  const formikProps = useFormik<Pick<UpdateCustomerInput, 'invoiceGracePeriod'>>({
-    initialValues: {
-      invoiceGracePeriod: invoiceGracePeriod ?? 0,
+
+  const form = useAppForm({
+    defaultValues: {
+      invoiceGracePeriod: (invoiceGracePeriod ?? '') as number | '',
     },
-    validationSchema: object().shape({
-      invoiceGracePeriod: number().required('').max(365, 'text_63bed78ae69de9cad5c348e4'),
-    }),
-    enableReinitialize: true,
-    validateOnMount: true,
-    onSubmit: async (values) => {
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: editCustomerInvoiceGracePeriodValidationSchema,
+    },
+    onSubmit: async ({ value }) => {
       await updateCustomerInvoiceGracePeriod({
         variables: {
           input: {
             id: customerId || '',
-            ...values,
+            invoiceGracePeriod: Number(value.invoiceGracePeriod) || 0,
           },
         },
       })
+      closeDialogRef.current?.()
     },
   })
+
+  const isDirty = useStore(form.store, (state) => state.isDirty)
+  const canSubmit = useStore(form.store, (state) => state.canSubmit)
 
   return (
     <Dialog
       ref={ref}
       title={translate('text_638dff9779fb99299bee90b0')}
       description={translate('text_638dff9779fb99299bee90b4')}
-      onClose={() => formikProps.resetForm()}
+      onClose={() => form.reset()}
       actions={({ closeDialog }) => (
         <>
           <Button variant="quaternary" onClick={closeDialog}>
@@ -85,10 +93,10 @@ export const EditCustomerInvoiceGracePeriodDialog = forwardRef<
           </Button>
           <Button
             variant="primary"
-            disabled={!formikProps.isValid || !formikProps.dirty}
+            disabled={!canSubmit || !isDirty}
             onClick={async () => {
-              await formikProps.submitForm()
-              closeDialog()
+              closeDialogRef.current = closeDialog
+              await form.handleSubmit()
             }}
           >
             {translate('text_638dff9779fb99299bee90cc')}
@@ -97,20 +105,22 @@ export const EditCustomerInvoiceGracePeriodDialog = forwardRef<
       )}
     >
       <div className="mb-8">
-        <TextInputField
-          name="invoiceGracePeriod"
-          beforeChangeFormatter={['positiveNumber', 'int']}
-          label={translate('text_638dff9779fb99299bee90bc')}
-          placeholder={translate('text_638dff9779fb99299bee90c0')}
-          formikProps={formikProps}
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                {translate('text_638dff9779fb99299bee90c4')}
-              </InputAdornment>
-            ),
-          }}
-        />
+        <form.AppField name="invoiceGracePeriod">
+          {(field) => (
+            <field.TextInputField
+              beforeChangeFormatter={['positiveNumber', 'int']}
+              label={translate('text_638dff9779fb99299bee90bc')}
+              placeholder={translate('text_638dff9779fb99299bee90c0')}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    {translate('text_638dff9779fb99299bee90c4')}
+                  </InputAdornment>
+                ),
+              }}
+            />
+          )}
+        </form.AppField>
       </div>
     </Dialog>
   )

--- a/src/components/customers/__tests__/EditCustomerInvoiceGracePeriodDialog.test.tsx
+++ b/src/components/customers/__tests__/EditCustomerInvoiceGracePeriodDialog.test.tsx
@@ -56,240 +56,288 @@ describe('EditCustomerInvoiceGracePeriodDialog', () => {
     jest.clearAllMocks()
   })
 
-  describe('Rendering', () => {
-    it('renders the dialog with correct title and description', async () => {
-      await prepare()
+  describe('GIVEN the dialog is opened', () => {
+    describe('WHEN rendered with default props', () => {
+      it('THEN should display the dialog title and description', async () => {
+        await prepare()
 
-      expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
-      expect(screen.getByTestId('dialog-description')).toBeInTheDocument()
-    })
-
-    it('renders the input field with the initial grace period value', async () => {
-      await prepare({ invoiceGracePeriod: 10 })
-
-      const input = screen.getByRole('textbox')
-
-      expect(input).toHaveValue('10')
-    })
-
-    it('renders with default value of 0 when invoiceGracePeriod is null', async () => {
-      await prepare({ invoiceGracePeriod: null })
-
-      const input = screen.getByRole('textbox')
-
-      expect(input).toHaveValue('0')
-    })
-
-    it('renders with default value of 0 when invoiceGracePeriod is undefined', async () => {
-      const ref = createRef<EditCustomerInvoiceGracePeriodDialogRef>()
-
-      await act(() =>
-        render(<EditCustomerInvoiceGracePeriodDialog ref={ref} invoiceGracePeriod={undefined} />),
-      )
-
-      await act(() => {
-        ref.current?.openDialog()
+        expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
+        expect(screen.getByTestId('dialog-description')).toBeInTheDocument()
       })
 
-      const input = screen.getByRole('textbox')
+      it('THEN should render cancel and submit buttons', async () => {
+        await prepare()
 
-      expect(input).toHaveValue('0')
+        const buttons = screen.getAllByRole('button')
+
+        expect(buttons).toHaveLength(2)
+      })
     })
 
-    it('renders cancel and submit buttons', async () => {
-      await prepare()
+    describe('WHEN invoiceGracePeriod has a value', () => {
+      it('THEN should display the grace period value in the input', async () => {
+        await prepare({ invoiceGracePeriod: 10 })
 
-      const buttons = screen.getAllByRole('button')
+        const input = screen.getByRole('textbox')
 
-      expect(buttons).toHaveLength(2)
+        expect(input).toHaveValue('10')
+      })
+    })
+
+    describe('WHEN invoiceGracePeriod is null', () => {
+      it('THEN should display an empty input (placeholder shown)', async () => {
+        await prepare({ invoiceGracePeriod: null })
+
+        const input = screen.getByRole('textbox')
+
+        expect(input).toHaveValue('')
+      })
+    })
+
+    describe('WHEN invoiceGracePeriod is undefined', () => {
+      it('THEN should display an empty input (placeholder shown)', async () => {
+        const ref = createRef<EditCustomerInvoiceGracePeriodDialogRef>()
+
+        await act(() =>
+          render(<EditCustomerInvoiceGracePeriodDialog ref={ref} invoiceGracePeriod={undefined} />),
+        )
+
+        await act(() => {
+          ref.current?.openDialog()
+        })
+
+        const input = screen.getByRole('textbox')
+
+        expect(input).toHaveValue('')
+      })
     })
   })
 
-  describe('Form Validation', () => {
-    it('disables submit button when form is pristine', async () => {
-      await prepare()
+  describe('GIVEN the form validation', () => {
+    describe('WHEN the form is pristine', () => {
+      it('THEN should disable the submit button', async () => {
+        await prepare()
 
-      const buttons = screen.getAllByRole('button')
-      const submitButton = buttons[1]
+        const buttons = screen.getAllByRole('button')
+        const submitButton = buttons[1]
 
-      expect(submitButton).toBeDisabled()
-    })
-
-    it('enables submit button when form value changes and is valid', async () => {
-      const user = userEvent.setup()
-
-      await prepare({ invoiceGracePeriod: 5 })
-
-      const input = screen.getByRole('textbox')
-
-      await user.clear(input)
-      await user.type(input, '10')
-
-      const buttons = screen.getAllByRole('button')
-      const submitButton = buttons[1]
-
-      await waitFor(() => {
-        expect(submitButton).not.toBeDisabled()
-      })
-    })
-
-    it('shows error when grace period exceeds 365 days', async () => {
-      const user = userEvent.setup()
-
-      await prepare({ invoiceGracePeriod: 5 })
-
-      const input = screen.getByRole('textbox')
-
-      await user.clear(input)
-      await user.type(input, '400')
-
-      const buttons = screen.getAllByRole('button')
-      const submitButton = buttons[1]
-
-      await waitFor(() => {
         expect(submitButton).toBeDisabled()
       })
     })
-  })
 
-  describe('Form Submission', () => {
-    it('calls mutation with correct variables on submit', async () => {
-      const user = userEvent.setup()
-      const mutationMock = {
-        request: {
-          query: UpdateCustomerInvoiceGracePeriodDocument,
-          variables: {
-            input: {
-              id: CUSTOMER_ID,
-              invoiceGracePeriod: 15,
-            },
-          },
-        },
-        result: {
-          data: {
-            updateCustomerInvoiceGracePeriod: {
-              id: CUSTOMER_ID,
-              invoiceGracePeriod: 15,
-            },
-          },
-        },
-      }
+    describe('WHEN the user changes the value to a valid number', () => {
+      it('THEN should enable the submit button', async () => {
+        const user = userEvent.setup()
 
-      await prepare({ invoiceGracePeriod: 5, mocks: [mutationMock] })
+        await prepare({ invoiceGracePeriod: 5 })
 
-      const input = screen.getByRole('textbox')
+        const input = screen.getByRole('textbox')
 
-      await user.clear(input)
-      await user.type(input, '15')
+        await user.clear(input)
+        await user.type(input, '10')
 
-      const buttons = screen.getAllByRole('button')
-      const submitButton = buttons[1]
+        const buttons = screen.getAllByRole('button')
+        const submitButton = buttons[1]
 
-      await user.click(submitButton)
+        await waitFor(() => {
+          expect(submitButton).not.toBeDisabled()
+        })
+      })
+    })
 
-      await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith({
-          severity: 'success',
-          translateKey: 'text_638dff9779fb99299bee914a',
+    describe('WHEN the grace period exceeds 365 days', () => {
+      it('THEN should keep the submit button disabled', async () => {
+        const user = userEvent.setup()
+
+        await prepare({ invoiceGracePeriod: 5 })
+
+        const input = screen.getByRole('textbox')
+
+        await user.clear(input)
+        await user.type(input, '400')
+
+        // Trigger validation by clicking submit
+        const buttons = screen.getAllByRole('button')
+        const submitButton = buttons[1]
+
+        await user.click(submitButton)
+
+        await waitFor(() => {
+          expect(submitButton).toBeDisabled()
+        })
+      })
+    })
+
+    describe('WHEN the field is cleared (empty)', () => {
+      it('THEN should disable the submit button due to required validation', async () => {
+        const user = userEvent.setup()
+
+        await prepare({ invoiceGracePeriod: 5 })
+
+        const input = screen.getByRole('textbox')
+
+        await user.clear(input)
+
+        // Trigger validation by clicking submit
+        const buttons = screen.getAllByRole('button')
+        const submitButton = buttons[1]
+
+        await user.click(submitButton)
+
+        await waitFor(() => {
+          expect(submitButton).toBeDisabled()
         })
       })
     })
   })
 
-  describe('Dialog Actions', () => {
-    it('closes dialog when cancel button is clicked', async () => {
-      const user = userEvent.setup()
+  describe('GIVEN the form submission', () => {
+    describe('WHEN the user submits a valid grace period', () => {
+      it('THEN should call the mutation with correct variables and show success toast', async () => {
+        const user = userEvent.setup()
+        const mutationMock = {
+          request: {
+            query: UpdateCustomerInvoiceGracePeriodDocument,
+            variables: {
+              input: {
+                id: CUSTOMER_ID,
+                invoiceGracePeriod: 15,
+              },
+            },
+          },
+          result: {
+            data: {
+              updateCustomerInvoiceGracePeriod: {
+                id: CUSTOMER_ID,
+                invoiceGracePeriod: 15,
+              },
+            },
+          },
+        }
 
-      await prepare()
+        await prepare({ invoiceGracePeriod: 5, mocks: [mutationMock] })
 
-      expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
+        const input = screen.getByRole('textbox')
 
-      const buttons = screen.getAllByRole('button')
-      const cancelButton = buttons[0]
+        await user.clear(input)
+        await user.type(input, '15')
 
-      await user.click(cancelButton)
+        const buttons = screen.getAllByRole('button')
+        const submitButton = buttons[1]
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('dialog-title')).not.toBeInTheDocument()
-      })
-    })
+        await user.click(submitButton)
 
-    it('resets form when dialog is closed', async () => {
-      const user = userEvent.setup()
-      const ref = createRef<DialogRef>()
-
-      await act(() =>
-        render(<EditCustomerInvoiceGracePeriodDialog ref={ref} invoiceGracePeriod={5} />),
-      )
-
-      // Open dialog
-      await act(() => {
-        ref.current?.openDialog()
-      })
-
-      const input = screen.getByRole('textbox')
-
-      // Change value
-      await user.clear(input)
-      await user.type(input, '20')
-      expect(input).toHaveValue('20')
-
-      // Close dialog
-      const buttons = screen.getAllByRole('button')
-      const cancelButton = buttons[0]
-
-      await user.click(cancelButton)
-
-      // Reopen dialog
-      await act(() => {
-        ref.current?.openDialog()
-      })
-
-      // Value should be reset to initial
-      await waitFor(() => {
-        expect(screen.getByRole('textbox')).toHaveValue('5')
+        await waitFor(() => {
+          expect(mockAddToast).toHaveBeenCalledWith(
+            expect.objectContaining({ severity: 'success' }),
+          )
+        })
       })
     })
   })
 
-  describe('Dialog Ref', () => {
-    it('exposes openDialog method via ref', async () => {
-      const ref = createRef<DialogRef>()
+  describe('GIVEN the dialog actions', () => {
+    describe('WHEN the cancel button is clicked', () => {
+      it('THEN should close the dialog', async () => {
+        const user = userEvent.setup()
 
-      await act(() =>
-        render(<EditCustomerInvoiceGracePeriodDialog ref={ref} invoiceGracePeriod={5} />),
-      )
+        await prepare()
 
-      expect(screen.queryByTestId('dialog-title')).not.toBeInTheDocument()
-
-      await act(() => {
-        ref.current?.openDialog()
-      })
-
-      await waitFor(() => {
         expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
+
+        const buttons = screen.getAllByRole('button')
+        const cancelButton = buttons[0]
+
+        await user.click(cancelButton)
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('dialog-title')).not.toBeInTheDocument()
+        })
       })
     })
 
-    it('exposes closeDialog method via ref', async () => {
-      const ref = createRef<DialogRef>()
+    describe('WHEN the dialog is closed and reopened', () => {
+      it('THEN should reset the form to its initial value', async () => {
+        const user = userEvent.setup()
+        const ref = createRef<DialogRef>()
 
-      await act(() =>
-        render(<EditCustomerInvoiceGracePeriodDialog ref={ref} invoiceGracePeriod={5} />),
-      )
+        await act(() =>
+          render(<EditCustomerInvoiceGracePeriodDialog ref={ref} invoiceGracePeriod={5} />),
+        )
 
-      await act(() => {
-        ref.current?.openDialog()
+        // Open dialog
+        await act(() => {
+          ref.current?.openDialog()
+        })
+
+        const input = screen.getByRole('textbox')
+
+        // Change value
+        await user.clear(input)
+        await user.type(input, '20')
+        expect(input).toHaveValue('20')
+
+        // Close dialog
+        const buttons = screen.getAllByRole('button')
+        const cancelButton = buttons[0]
+
+        await user.click(cancelButton)
+
+        // Reopen dialog
+        await act(() => {
+          ref.current?.openDialog()
+        })
+
+        // Value should be reset to initial
+        await waitFor(() => {
+          expect(screen.getByRole('textbox')).toHaveValue('5')
+        })
       })
+    })
+  })
 
-      expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
+  describe('GIVEN the dialog ref API', () => {
+    describe('WHEN openDialog is called', () => {
+      it('THEN should show the dialog', async () => {
+        const ref = createRef<DialogRef>()
 
-      await act(() => {
-        ref.current?.closeDialog()
-      })
+        await act(() =>
+          render(<EditCustomerInvoiceGracePeriodDialog ref={ref} invoiceGracePeriod={5} />),
+        )
 
-      await waitFor(() => {
         expect(screen.queryByTestId('dialog-title')).not.toBeInTheDocument()
+
+        await act(() => {
+          ref.current?.openDialog()
+        })
+
+        await waitFor(() => {
+          expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
+        })
+      })
+    })
+
+    describe('WHEN closeDialog is called', () => {
+      it('THEN should hide the dialog', async () => {
+        const ref = createRef<DialogRef>()
+
+        await act(() =>
+          render(<EditCustomerInvoiceGracePeriodDialog ref={ref} invoiceGracePeriod={5} />),
+        )
+
+        await act(() => {
+          ref.current?.openDialog()
+        })
+
+        expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
+
+        await act(() => {
+          ref.current?.closeDialog()
+        })
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('dialog-title')).not.toBeInTheDocument()
+        })
       })
     })
   })

--- a/translations/base.json
+++ b/translations/base.json
@@ -3994,5 +3994,6 @@
   "text_1775225915210r5vkxkn0mvx": "Add minimum commitment",
   "text_1775225915210g1crmnurgor": "Add entitlement",
   "text_1775225915210s2oemt3bl21": "Add progressive billing",
-  "text_17756567905528w3193xcurh": "Lifetime"
+  "text_17756567905528w3193xcurh": "Lifetime",
+  "text_177583191144596sed2y63wo": "Grace period is required"
 }


### PR DESCRIPTION
  ## Context

  The EditCustomerInvoiceGracePeriodDialog still used Formik (useFormik + Yup validation).
  This migration aligns it with the project's ongoing move to TanStack Form.

  ## Description

  - Replace `useFormik` with `useAppForm` and Yup schema with Zod validation
  - Use `z.union([z.number(), z.literal('')])` to handle `beforeChangeFormatter: ['int']` which produces `number` at runtime but `''` when the field is emptied
  - Default value is `''` (not `0`) so the placeholder "0" is shown when no grace period is set
  - Use `closeDialogRef` pattern to prevent dialog from closing on validation failure (`handleSubmit` doesn't throw — it skips `onSubmit`)
  - Add `canSubmit` and `isDirty` via `useStore` for reactive button disabled state
  - Add translation key for "Grace period is required" via `pnpm translations:add`
  - Document new patterns (11-13) and common issues (15-18) in both Claude and Cursor migration skills

<!-- Linear link -->
Fixes ISSUE-1472