### PR TITLE
misc: add drawer focus trap and logic

### DIFF
--- a/src/components/designSystem/Chip.tsx
+++ b/src/components/designSystem/Chip.tsx
@@ -52,6 +52,7 @@ export const Chip = ({
   return (
     <MuiChip
       {...chipProps}
+      tabIndex={onDelete ? -1 : undefined}
       className={tw(
         {
           'chip--error': !!error,

--- a/src/components/drawers/BaseDrawer.tsx
+++ b/src/components/drawers/BaseDrawer.tsx
@@ -13,6 +13,7 @@ import {
 import { drawerStack } from './drawerStack'
 import { FormDrawerProps } from './types'
 import { useDrawerStack } from './useDrawerStack'
+import { useFocusTrap } from './useFocusTrap'
 
 type DrawerState = 'unmounted' | 'mounting' | 'open' | 'closing'
 
@@ -55,10 +56,18 @@ export const BaseDrawer = ({
 }: BaseDrawerProps) => {
   const [state, setState] = useState<DrawerState>('unmounted')
   const paperRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
   const exitedRef = useRef(false)
 
   const isInStack = state === 'mounting' || state === 'open'
   const { depthFromTop, isTopmost, isBottommost, zIndex } = useDrawerStack(isInStack)
+
+  const { handleOpening, handleEntered, handleClosing } = useFocusTrap({
+    containerRef: paperRef,
+    isActive: state === 'open' && isTopmost,
+    onEntered,
+    closeButtonRef,
+  })
 
   const handleExit = useCallback(() => {
     if (exitedRef.current) return
@@ -72,16 +81,18 @@ export const BaseDrawer = ({
     if (isOpen) {
       if (state === 'unmounted') {
         exitedRef.current = false
+        handleOpening()
         setState('mounting')
       }
     } else {
       if (state === 'open') {
+        handleClosing()
         setState('closing')
       } else if (state === 'mounting') {
         handleExit()
       }
     }
-  }, [isOpen, state, handleExit])
+  }, [isOpen, state, handleExit, handleOpening, handleClosing])
 
   // Trigger enter animation after mount (double-rAF for reliable CSS transition)
   useEffect(() => {
@@ -127,10 +138,10 @@ export const BaseDrawer = ({
         handleExit()
       } else if (state === 'open' && !enteredFiredRef.current) {
         enteredFiredRef.current = true
-        onEntered?.()
+        handleEntered()
       }
     },
-    [state, handleExit, onEntered],
+    [state, handleExit, handleEntered],
   )
 
   // Close this drawer when clearAll is called (e.g. on browser navigation)
@@ -262,6 +273,7 @@ export const BaseDrawer = ({
             title
           )}
           <Button
+            ref={closeButtonRef}
             icon="close"
             variant="quaternary"
             onClick={onClose}

--- a/src/components/drawers/__tests__/BaseDrawer.test.tsx
+++ b/src/components/drawers/__tests__/BaseDrawer.test.tsx
@@ -6,8 +6,10 @@ import { render } from '~/test-utils'
 import {
   BASE_DRAWER_ACTIONS_TEST_ID,
   BASE_DRAWER_BACKDROP_TEST_ID,
+  BASE_DRAWER_CLOSE_BUTTON_TEST_ID,
   BASE_DRAWER_CONTENT_TEST_ID,
   BASE_DRAWER_HEADER_TEST_ID,
+  BASE_DRAWER_PAPER_TEST_ID,
   BASE_DRAWER_TEST_ID,
   BaseDrawer,
   BaseDrawerProps,
@@ -204,6 +206,251 @@ describe('BaseDrawer', () => {
 
         await waitFor(() => {
           expect(onExited).toHaveBeenCalled()
+        })
+      })
+    })
+  })
+
+  describe('GIVEN focus management', () => {
+    const fireTransitionEnd = () => {
+      const paper = screen.getByTestId(BASE_DRAWER_PAPER_TEST_ID)
+
+      act(() => {
+        const event = new Event('transitionend', { bubbles: true })
+
+        Object.defineProperty(event, 'propertyName', { value: 'transform' })
+        Object.defineProperty(event, 'target', { value: paper })
+        paper.dispatchEvent(event)
+      })
+    }
+
+    describe('WHEN the drawer opens without onEntered', () => {
+      it('THEN should focus the close button as fallback', async () => {
+        render(<BaseDrawer {...defaultProps} />)
+
+        fireTransitionEnd()
+
+        await waitFor(() => {
+          const closeButton = screen.getByTestId(BASE_DRAWER_CLOSE_BUTTON_TEST_ID)
+
+          expect(closeButton).toHaveFocus()
+        })
+      })
+    })
+
+    describe('WHEN the drawer opens with onEntered that moves focus inside', () => {
+      it('THEN should NOT override the focus set by onEntered', async () => {
+        const onEntered = () => {
+          const input = document.querySelector('[data-test="custom-input"]') as HTMLElement
+
+          input?.focus()
+        }
+
+        render(
+          <BaseDrawer {...defaultProps} onEntered={onEntered}>
+            <input data-test="custom-input" />
+          </BaseDrawer>,
+        )
+
+        fireTransitionEnd()
+
+        await waitFor(() => {
+          const input = screen.getByTestId('custom-input')
+
+          expect(input).toHaveFocus()
+        })
+      })
+    })
+
+    describe('WHEN the drawer opens with onEntered that does NOT move focus', () => {
+      it('THEN should focus the close button as fallback', async () => {
+        const onEntered = jest.fn() // no-op, does not move focus
+
+        render(<BaseDrawer {...defaultProps} onEntered={onEntered} />)
+
+        fireTransitionEnd()
+
+        await waitFor(() => {
+          expect(onEntered).toHaveBeenCalled()
+
+          const closeButton = screen.getByTestId(BASE_DRAWER_CLOSE_BUTTON_TEST_ID)
+
+          expect(closeButton).toHaveFocus()
+        })
+      })
+    })
+
+    describe('WHEN Tab is pressed at the last focusable element', () => {
+      it('THEN should wrap focus to the first focusable element', async () => {
+        const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+
+        render(
+          <BaseDrawer {...defaultProps} actions={<button data-test="save-button">Save</button>}>
+            <input data-test="input-field" />
+          </BaseDrawer>,
+        )
+
+        fireTransitionEnd()
+
+        // Focus the last focusable element (Save button in actions)
+        const saveButton = screen.getByTestId('save-button')
+
+        act(() => {
+          saveButton.focus()
+        })
+
+        await user.tab()
+
+        // Should wrap to the close button (first focusable element)
+        const closeButton = screen.getByTestId(BASE_DRAWER_CLOSE_BUTTON_TEST_ID)
+
+        expect(closeButton).toHaveFocus()
+      })
+    })
+
+    describe('WHEN Shift+Tab is pressed at the first focusable element', () => {
+      it('THEN should wrap focus to the last focusable element', async () => {
+        const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+
+        render(
+          <BaseDrawer {...defaultProps} actions={<button data-test="save-button">Save</button>}>
+            <input data-test="input-field" />
+          </BaseDrawer>,
+        )
+
+        fireTransitionEnd()
+
+        // Focus the close button (first focusable element)
+        const closeButton = screen.getByTestId(BASE_DRAWER_CLOSE_BUTTON_TEST_ID)
+
+        act(() => {
+          closeButton.focus()
+        })
+
+        await user.tab({ shift: true })
+
+        // Should wrap to the save button (last focusable element)
+        const saveButton = screen.getByTestId('save-button')
+
+        expect(saveButton).toHaveFocus()
+      })
+    })
+
+    describe('WHEN two drawers are stacked', () => {
+      it('THEN the topmost drawer should receive focus, not the one below', async () => {
+        const onCloseFirst = jest.fn()
+        const onCloseSecond = jest.fn()
+
+        const { rerender } = render(
+          <>
+            <BaseDrawer isOpen={true} title="First Drawer" onClose={onCloseFirst}>
+              <input data-test="first-drawer-input" />
+            </BaseDrawer>
+            <BaseDrawer isOpen={false} title="Second Drawer" onClose={onCloseSecond}>
+              <input data-test="second-drawer-input" />
+            </BaseDrawer>
+          </>,
+        )
+
+        // Fire transitionEnd for first drawer
+        const papers = screen.getAllByTestId(BASE_DRAWER_PAPER_TEST_ID)
+
+        act(() => {
+          const event = new Event('transitionend', { bubbles: true })
+
+          Object.defineProperty(event, 'propertyName', { value: 'transform' })
+          Object.defineProperty(event, 'target', { value: papers[0] })
+          papers[0].dispatchEvent(event)
+        })
+
+        // First drawer's close button should have focus
+        const closeButtons = screen.getAllByTestId(BASE_DRAWER_CLOSE_BUTTON_TEST_ID)
+
+        await waitFor(() => {
+          expect(closeButtons[0]).toHaveFocus()
+        })
+
+        // Now open the second drawer on top
+        rerender(
+          <>
+            <BaseDrawer isOpen={true} title="First Drawer" onClose={onCloseFirst}>
+              <input data-test="first-drawer-input" />
+            </BaseDrawer>
+            <BaseDrawer isOpen={true} title="Second Drawer" onClose={onCloseSecond}>
+              <input data-test="second-drawer-input" />
+            </BaseDrawer>
+          </>,
+        )
+
+        // Fire transitionEnd for second drawer
+        const updatedPapers = screen.getAllByTestId(BASE_DRAWER_PAPER_TEST_ID)
+
+        act(() => {
+          const event = new Event('transitionend', { bubbles: true })
+
+          Object.defineProperty(event, 'propertyName', { value: 'transform' })
+          Object.defineProperty(event, 'target', { value: updatedPapers[1] })
+          updatedPapers[1].dispatchEvent(event)
+        })
+
+        // Second drawer's close button should now have focus (topmost)
+        const updatedCloseButtons = screen.getAllByTestId(BASE_DRAWER_CLOSE_BUTTON_TEST_ID)
+
+        await waitFor(() => {
+          expect(updatedCloseButtons[1]).toHaveFocus()
+        })
+      })
+    })
+
+    describe('WHEN the drawer closes', () => {
+      it('THEN should restore focus to the element that was focused before opening', async () => {
+        // Render with drawer closed first, focus the trigger, then open
+        const { rerender } = render(
+          <>
+            <button data-test="trigger-button">Open drawer</button>
+            <BaseDrawer {...defaultProps} isOpen={false} />
+          </>,
+        )
+
+        const triggerButton = screen.getByTestId('trigger-button')
+
+        act(() => {
+          triggerButton.focus()
+        })
+
+        expect(triggerButton).toHaveFocus()
+
+        // Open the drawer
+        rerender(
+          <>
+            <button data-test="trigger-button">Open drawer</button>
+            <BaseDrawer {...defaultProps} isOpen={true} />
+          </>,
+        )
+
+        fireTransitionEnd()
+
+        // Verify focus moved into the drawer
+        const closeButton = screen.getByTestId(BASE_DRAWER_CLOSE_BUTTON_TEST_ID)
+
+        await waitFor(() => {
+          expect(closeButton).toHaveFocus()
+        })
+
+        // Close the drawer
+        rerender(
+          <>
+            <button data-test="trigger-button">Open drawer</button>
+            <BaseDrawer {...defaultProps} isOpen={false} />
+          </>,
+        )
+
+        act(() => {
+          jest.advanceTimersByTime(500)
+        })
+
+        await waitFor(() => {
+          expect(triggerButton).toHaveFocus()
         })
       })
     })

--- a/src/components/drawers/__tests__/useFocusTrap.test.ts
+++ b/src/components/drawers/__tests__/useFocusTrap.test.ts
@@ -1,0 +1,395 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { FOCUSABLE_SELECTOR, useFocusTrap } from '../useFocusTrap'
+
+let container: HTMLDivElement
+let closeButton: HTMLButtonElement
+
+beforeEach(() => {
+  container = document.createElement('div')
+  closeButton = document.createElement('button')
+  closeButton.textContent = 'Close'
+  container.appendChild(closeButton)
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  document.body.removeChild(container)
+})
+
+const createDefaultParams = (overrides?: Partial<Parameters<typeof useFocusTrap>[0]>) => ({
+  containerRef: { current: container },
+  isActive: false,
+  onEntered: undefined as (() => void) | undefined,
+  closeButtonRef: { current: closeButton },
+  ...overrides,
+})
+
+describe('useFocusTrap', () => {
+  describe('FOCUSABLE_SELECTOR', () => {
+    it('should match standard focusable elements', () => {
+      const elements = [
+        Object.assign(document.createElement('a'), { href: '#' }),
+        document.createElement('button'),
+        document.createElement('input'),
+        document.createElement('select'),
+        document.createElement('textarea'),
+      ]
+
+      elements.forEach((el) => container.appendChild(el))
+
+      const matched = container.querySelectorAll(FOCUSABLE_SELECTOR)
+
+      // close button + 5 elements
+      expect(matched).toHaveLength(6)
+    })
+
+    it('should NOT match disabled elements', () => {
+      const disabledButton = document.createElement('button')
+
+      disabledButton.disabled = true
+      container.appendChild(disabledButton)
+
+      const disabledInput = document.createElement('input')
+
+      disabledInput.disabled = true
+      container.appendChild(disabledInput)
+
+      const matched = container.querySelectorAll(FOCUSABLE_SELECTOR)
+
+      // Only the close button
+      expect(matched).toHaveLength(1)
+    })
+
+    it('should NOT match elements with tabindex="-1"', () => {
+      const div = document.createElement('div')
+
+      div.setAttribute('tabindex', '-1')
+      container.appendChild(div)
+
+      const matched = container.querySelectorAll(FOCUSABLE_SELECTOR)
+
+      expect(matched).toHaveLength(1)
+    })
+  })
+
+  describe('handleOpening', () => {
+    it('should capture document.activeElement as the trigger element', () => {
+      const trigger = document.createElement('button')
+
+      trigger.textContent = 'Trigger'
+      document.body.appendChild(trigger)
+      trigger.focus()
+
+      expect(document.activeElement).toBe(trigger)
+
+      const { result } = renderHook(() => useFocusTrap(createDefaultParams()))
+
+      act(() => {
+        result.current.handleOpening()
+      })
+
+      // Verify capture by closing — focus should restore to trigger
+      act(() => {
+        result.current.handleClosing()
+      })
+
+      expect(document.activeElement).toBe(trigger)
+
+      document.body.removeChild(trigger)
+    })
+
+    it('should overwrite the previously captured trigger on subsequent calls', () => {
+      const firstTrigger = document.createElement('button')
+
+      firstTrigger.textContent = 'First'
+      document.body.appendChild(firstTrigger)
+
+      const secondTrigger = document.createElement('button')
+
+      secondTrigger.textContent = 'Second'
+      document.body.appendChild(secondTrigger)
+
+      const { result } = renderHook(() => useFocusTrap(createDefaultParams()))
+
+      firstTrigger.focus()
+
+      act(() => {
+        result.current.handleOpening()
+      })
+
+      secondTrigger.focus()
+
+      act(() => {
+        result.current.handleOpening()
+      })
+
+      act(() => {
+        result.current.handleClosing()
+      })
+
+      expect(document.activeElement).toBe(secondTrigger)
+
+      document.body.removeChild(firstTrigger)
+      document.body.removeChild(secondTrigger)
+    })
+  })
+
+  describe('handleEntered', () => {
+    it('should call onEntered callback', () => {
+      const onEntered = jest.fn()
+      const { result } = renderHook(() => useFocusTrap(createDefaultParams({ onEntered })))
+
+      act(() => {
+        result.current.handleEntered()
+      })
+
+      expect(onEntered).toHaveBeenCalledTimes(1)
+    })
+
+    it('should focus the close button when onEntered does not move focus inside', async () => {
+      const onEntered = jest.fn()
+      const { result } = renderHook(() => useFocusTrap(createDefaultParams({ onEntered })))
+
+      act(() => {
+        result.current.handleEntered()
+      })
+
+      // queueMicrotask needs to flush
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(document.activeElement).toBe(closeButton)
+    })
+
+    it('should focus the close button when no onEntered is provided', async () => {
+      const { result } = renderHook(() =>
+        useFocusTrap(createDefaultParams({ onEntered: undefined })),
+      )
+
+      act(() => {
+        result.current.handleEntered()
+      })
+
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(document.activeElement).toBe(closeButton)
+    })
+
+    it('should NOT override focus when onEntered moves focus inside the container', async () => {
+      const input = document.createElement('input')
+
+      container.appendChild(input)
+
+      const onEntered = () => {
+        input.focus()
+      }
+
+      const { result } = renderHook(() => useFocusTrap(createDefaultParams({ onEntered })))
+
+      act(() => {
+        result.current.handleEntered()
+      })
+
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(document.activeElement).toBe(input)
+    })
+  })
+
+  describe('handleClosing', () => {
+    it('should restore focus to the captured trigger element', () => {
+      const trigger = document.createElement('button')
+
+      trigger.textContent = 'Trigger'
+      document.body.appendChild(trigger)
+      trigger.focus()
+
+      const { result } = renderHook(() => useFocusTrap(createDefaultParams()))
+
+      act(() => {
+        result.current.handleOpening()
+      })
+
+      // Move focus elsewhere
+      closeButton.focus()
+
+      act(() => {
+        result.current.handleClosing()
+      })
+
+      expect(document.activeElement).toBe(trigger)
+
+      document.body.removeChild(trigger)
+    })
+
+    it('should not throw when trigger element has been removed from DOM', () => {
+      const trigger = document.createElement('button')
+
+      document.body.appendChild(trigger)
+      trigger.focus()
+
+      const { result } = renderHook(() => useFocusTrap(createDefaultParams()))
+
+      act(() => {
+        result.current.handleOpening()
+      })
+
+      // Remove trigger from DOM before closing
+      document.body.removeChild(trigger)
+
+      expect(() => {
+        act(() => {
+          result.current.handleClosing()
+        })
+      }).not.toThrow()
+    })
+
+    it('should clear the trigger reference after restoring', () => {
+      const trigger = document.createElement('button')
+
+      document.body.appendChild(trigger)
+      trigger.focus()
+
+      const { result } = renderHook(() => useFocusTrap(createDefaultParams()))
+
+      act(() => {
+        result.current.handleOpening()
+      })
+
+      act(() => {
+        result.current.handleClosing()
+      })
+
+      expect(document.activeElement).toBe(trigger)
+
+      // Move focus elsewhere, then call handleClosing again — should do nothing
+      closeButton.focus()
+
+      act(() => {
+        result.current.handleClosing()
+      })
+
+      // Focus stays on close button (no trigger to restore to)
+      expect(document.activeElement).toBe(closeButton)
+
+      document.body.removeChild(trigger)
+    })
+  })
+
+  describe('focus trapping (Tab/Shift+Tab)', () => {
+    let input: HTMLInputElement
+    let saveButton: HTMLButtonElement
+
+    beforeEach(() => {
+      input = document.createElement('input')
+      saveButton = document.createElement('button')
+      saveButton.textContent = 'Save'
+      container.appendChild(input)
+      container.appendChild(saveButton)
+    })
+
+    const dispatchTab = (shiftKey = false) => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'Tab',
+        shiftKey,
+        bubbles: true,
+        cancelable: true,
+      })
+
+      document.dispatchEvent(event)
+
+      return event
+    }
+
+    it('should wrap focus from last to first element on Tab', () => {
+      renderHook(() => useFocusTrap(createDefaultParams({ isActive: true })))
+
+      // Focus the last element
+      saveButton.focus()
+
+      const event = dispatchTab()
+
+      expect(event.defaultPrevented).toBe(true)
+      expect(document.activeElement).toBe(closeButton)
+    })
+
+    it('should wrap focus from first to last element on Shift+Tab', () => {
+      renderHook(() => useFocusTrap(createDefaultParams({ isActive: true })))
+
+      // Focus the first element
+      closeButton.focus()
+
+      const event = dispatchTab(true)
+
+      expect(event.defaultPrevented).toBe(true)
+      expect(document.activeElement).toBe(saveButton)
+    })
+
+    it('should NOT intercept Tab when focus is on a middle element', () => {
+      renderHook(() => useFocusTrap(createDefaultParams({ isActive: true })))
+
+      // Focus the middle element
+      input.focus()
+
+      const event = dispatchTab()
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+
+    it('should NOT trap focus when isActive is false', () => {
+      renderHook(() => useFocusTrap(createDefaultParams({ isActive: false })))
+
+      saveButton.focus()
+
+      const event = dispatchTab()
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+
+    it('should deactivate trapping when isActive changes from true to false', () => {
+      const { rerender } = renderHook(
+        ({ isActive }) => useFocusTrap(createDefaultParams({ isActive })),
+        { initialProps: { isActive: true } },
+      )
+
+      saveButton.focus()
+
+      let event = dispatchTab()
+
+      expect(event.defaultPrevented).toBe(true)
+
+      // Deactivate
+      rerender({ isActive: false })
+
+      saveButton.focus()
+
+      event = dispatchTab()
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+
+    it('should reactivate trapping when isActive returns to true', () => {
+      const { rerender } = renderHook(
+        ({ isActive }) => useFocusTrap(createDefaultParams({ isActive })),
+        { initialProps: { isActive: true } },
+      )
+
+      // Deactivate then reactivate
+      rerender({ isActive: false })
+      rerender({ isActive: true })
+
+      saveButton.focus()
+
+      const event = dispatchTab()
+
+      expect(event.defaultPrevented).toBe(true)
+      expect(document.activeElement).toBe(closeButton)
+    })
+  })
+})

--- a/src/components/drawers/useFocusTrap.ts
+++ b/src/components/drawers/useFocusTrap.ts
@@ -1,0 +1,98 @@
+import { RefObject, useCallback, useEffect, useRef } from 'react'
+
+export const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not(:disabled)',
+  'input:not(:disabled)',
+  'select:not(:disabled)',
+  'textarea:not(:disabled)',
+  '[tabindex]:not([tabindex="-1"]):not(:disabled)',
+].join(', ')
+
+type UseFocusTrapParams = {
+  containerRef: RefObject<HTMLDivElement | null>
+  /** Whether focus trapping is active (typically: state === 'open' && isTopmost) */
+  isActive: boolean
+  onEntered?: () => void
+  closeButtonRef: RefObject<HTMLButtonElement | null>
+}
+
+export const useFocusTrap = ({
+  containerRef,
+  isActive,
+  onEntered,
+  closeButtonRef,
+}: UseFocusTrapParams) => {
+  const triggerElementRef = useRef<Element | null>(null)
+  const onEnteredRef = useRef(onEntered)
+
+  onEnteredRef.current = onEntered
+
+  // Tab trapping — only reactive effect, attaches/detaches keydown listener
+  useEffect(() => {
+    if (!isActive) return
+
+    const container = containerRef.current
+
+    if (!container) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return
+
+      const focusableElements = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+
+      if (focusableElements.length === 0) return
+
+      const first = focusableElements[0]
+      const last = focusableElements[focusableElements.length - 1]
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isActive, containerRef])
+
+  /** Call when the drawer starts opening (mounting). Captures the trigger element for later restoration. */
+  const handleOpening = useCallback(() => {
+    triggerElementRef.current = document.activeElement
+  }, [])
+
+  /** Call after the drawer enter transition completes. Runs onEntered, then falls back to focusing the close button. */
+  const handleEntered = useCallback(() => {
+    onEnteredRef.current?.()
+
+    queueMicrotask(() => {
+      const container = containerRef.current
+
+      if (!container) return
+      if (container.contains(document.activeElement)) return
+
+      closeButtonRef.current?.focus()
+    })
+  }, [containerRef, closeButtonRef])
+
+  /** Call when the drawer starts closing. Restores focus to the trigger element. */
+  const handleClosing = useCallback(() => {
+    const trigger = triggerElementRef.current
+
+    if (
+      trigger &&
+      document.contains(trigger) &&
+      typeof (trigger as HTMLElement).focus === 'function'
+    ) {
+      ;(trigger as HTMLElement).focus()
+    }
+
+    triggerElementRef.current = null
+  }, [])
+
+  return { handleOpening, handleEntered, handleClosing }
+}

--- a/src/components/taxes/__tests__/__snapshots__/TaxesSelectorSection.test.tsx.snap
+++ b/src/components/taxes/__tests__/__snapshots__/TaxesSelectorSection.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`TaxesSelectorSection Snapshots renders with taxes 1`] = `
         class=MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-deletable MuiChip-deletableColorDefault MuiChip-outlinedDefault css-hash-MuiButtonBase-root-MuiChip-root
         data-test="tax-chip-tax-1"
         role="button"
-        tabindex="0"
+        tabindex="-1"
       >
         <svg
           class="text-grey-600 size-3 min-w-3 MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDark !m-0"
@@ -82,7 +82,7 @@ exports[`TaxesSelectorSection Snapshots renders with taxes 1`] = `
         class=MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-deletable MuiChip-deletableColorDefault MuiChip-outlinedDefault css-hash-MuiButtonBase-root-MuiChip-root
         data-test="tax-chip-tax-2"
         role="button"
-        tabindex="0"
+        tabindex="-1"
       >
         <svg
           class="text-grey-600 size-3 min-w-3 MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDark !m-0"
@@ -288,7 +288,7 @@ exports[`TaxesSelectorSection Snapshots renders with title, description and taxe
         class=MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-deletable MuiChip-deletableColorDefault MuiChip-outlinedDefault css-hash-MuiButtonBase-root-MuiChip-root
         data-test="tax-chip-tax-1"
         role="button"
-        tabindex="0"
+        tabindex="-1"
       >
         <svg
           class="text-grey-600 size-3 min-w-3 MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDark !m-0"
@@ -346,7 +346,7 @@ exports[`TaxesSelectorSection Snapshots renders with title, description and taxe
         class=MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-deletable MuiChip-deletableColorDefault MuiChip-outlinedDefault css-hash-MuiButtonBase-root-MuiChip-root
         data-test="tax-chip-tax-2"
         role="button"
-        tabindex="0"
+        tabindex="-1"
       >
         <svg
           class="text-grey-600 size-3 min-w-3 MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDark !m-0"


### PR DESCRIPTION
## Summary

When opening a drawer in edit mode (e.g., clicking on an existing charge in the plan form), no element receives focus. The window focus stays outside the drawer, which breaks keyboard navigation and screen reader accessibility. In create mode, individual drawers manually focus a specific input via `onEntered`, but in edit mode this callback is intentionally skipped, leaving focus nowhere.

## Description 
Adding a `useFocusTrap` hook integrated into `BaseDrawer` that provides WAI-ARIA compliant focus management for all drawers automatically:

- **Initial focus fallback**: When a drawer opens and no `onEntered` callback moves focus inside (or when no `onEntered` is provided at all), the close button receives focus as a default. Drawers that already set focus to a specific element (like a combobox in create mode) are completely unaffected. The fallback only kicks in when nothing else claimed focus.
- **Focus trapping**: Tab/Shift+Tab now cycles within the open drawer instead of escaping to the background page. Only the topmost drawer traps focus when multiple drawers are stacked.
- **Focus restoration**: When a drawer closes, focus returns to the element that was focused before the drawer opened (typically the button/selector that triggered it).
- **Chip wrong focus**: When the MUI chip is passed an `onDelete`, they make the chip element focusable to allow user to press DELETE on it and fire the appropriate action. In our case we render a dedicated close component and this lead to have 2 focusable elements performing the same action. Decided to remove the focus on the MUI chip itself letting only the close button being focusable.

**What's preserved:** All existing `onEntered` overrides (FixedChargeDrawer, UsageChargeDrawer, FeatureEntitlementDrawer, ProgressiveBillingDrawer, etc.) continue to work exactly as before. The hook calls `onEntered` first, then checks if focus landed inside the drawer, if it did, the fallback is skipped.

**Design:** The hook is event-driven, not effect-driven. BaseDrawer calls `handleOpening()`, `handleEntered()`, and `handleClosing()` at explicit points in its state machine. The only reactive effect is the Tab keydown listener (attach/detach based on `isActive`).


Fixes LAGO-1363