### PR TITLE
misc: allow to submit form with keyboard

### DIFF
--- a/src/components/form/ButtonSelector/TabButton.tsx
+++ b/src/components/form/ButtonSelector/TabButton.tsx
@@ -34,6 +34,7 @@ export const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>(
     return (
       <button
         {...props}
+        type="button"
         ref={ref}
         className={tw(
           'transition-250 flex min-h-10 items-center justify-center rounded-xl px-3 py-[6px] font-sans outline-none transition-colors ease-in',

--- a/src/hooks/plans/usePlanForm.tsx
+++ b/src/hooks/plans/usePlanForm.tsx
@@ -379,6 +379,8 @@ export const usePlanForm = ({
   }, [errorCode, form])
 
   // Clear code error when the code field value changes
+  const codeValue = useStore(form.store, (s) => s.values.code)
+
   useEffect(() => {
     if (errorCode === FORM_ERRORS_ENUM.existingCode) {
       form.setFieldMeta('code', (meta) => ({
@@ -387,7 +389,7 @@ export const usePlanForm = ({
       }))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form.state.values.code])
+  }, [codeValue])
 
   // Auto-reset billChargesMonthly when conditions aren't met
   const charges = useStore(form.store, (s) => s.values.charges)

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -233,7 +233,13 @@ const CreatePlan = () => {
       currency={amountCurrency || CurrencyEnum.Usd}
       interval={interval || PlanInterval.Monthly}
     >
-      <form className="contents">
+      <form
+        className="contents"
+        onSubmit={(e) => {
+          e.preventDefault()
+          handleFormSubmit()
+        }}
+      >
         <CenteredPage.Wrapper>
           <CenteredPage.Header>
             <Typography variant="bodyHl" color="textSecondary" noWrap>

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -210,6 +210,20 @@ const CreatePlan = () => {
     return planCloseRedirection()
   }, [isDirty, planCloseRedirection])
 
+  const handleFormSubmit = useCallback(() => {
+    if (plan?.hasOverriddenPlans && isEdition) {
+      return impactOverridenSubscriptionsDialogRef.current?.openDialog({
+        onSave: async (cascadeUpdates) => {
+          form.setFieldValue('cascadeUpdates', cascadeUpdates)
+
+          return form.handleSubmit()
+        },
+      })
+    }
+
+    return form.handleSubmit()
+  }, [form, plan?.hasOverriddenPlans, isEdition])
+
   const pageTitle = isEdition
     ? translate('text_625fd165963a7b00c8f59767')
     : translate('text_624453d52e945301380e4988')
@@ -219,121 +233,116 @@ const CreatePlan = () => {
       currency={amountCurrency || CurrencyEnum.Usd}
       interval={interval || PlanInterval.Monthly}
     >
-      <CenteredPage.Wrapper>
-        <CenteredPage.Header>
-          <Typography variant="bodyHl" color="textSecondary" noWrap>
-            {pageTitle}
-          </Typography>
-          <Button
-            variant="quaternary"
-            icon="close"
-            onClick={onLeave}
-            data-test="close-create-plan-button"
-          />
-        </CenteredPage.Header>
+      <form className="contents">
+        <CenteredPage.Wrapper>
+          <CenteredPage.Header>
+            <Typography variant="bodyHl" color="textSecondary" noWrap>
+              {pageTitle}
+            </Typography>
+            <Button
+              variant="quaternary"
+              icon="close"
+              onClick={onLeave}
+              data-test="close-create-plan-button"
+            />
+          </CenteredPage.Header>
 
-        <CenteredPage.Container className="gap-20">
-          {loading && <FormLoadingSkeleton id="create-plan" />}
-          {!loading && (
-            <>
-              <CenteredPage.SectionWrapper>
-                <CenteredPage.PageTitle
-                  title={pageTitle}
-                  description={translate('text_1770063200028ww5znt6yree')}
-                />
+          <CenteredPage.Container className="gap-20">
+            {loading && <FormLoadingSkeleton id="create-plan" />}
+            {!loading && (
+              <>
+                <CenteredPage.SectionWrapper>
+                  <CenteredPage.PageTitle
+                    title={pageTitle}
+                    description={translate('text_1770063200028ww5znt6yree')}
+                  />
 
-                <PlanSettingsSection form={form} canBeEdited={canBeEdited} isEdition={isEdition} />
-              </CenteredPage.SectionWrapper>
-
-              <CenteredPage.SectionWrapper>
-                <CenteredPage.PageTitle
-                  title={translate('text_6661fc17337de3591e29e3e7')}
-                  description={translate('text_6661fc17337de3591e29e3e9')}
-                />
-
-                <CenteredPage.SubsectionWrapper>
-                  <SubscriptionFeeSection
+                  <PlanSettingsSection
                     form={form}
                     canBeEdited={canBeEdited}
                     isEdition={isEdition}
                   />
+                </CenteredPage.SectionWrapper>
 
-                  <FixedChargesSection
-                    form={form}
-                    alreadyExistingFixedChargesIds={alreadyExistingFixedChargesIds}
-                    canBeEdited={canBeEdited}
-                    isEdition={isEdition}
+                <CenteredPage.SectionWrapper>
+                  <CenteredPage.PageTitle
+                    title={translate('text_6661fc17337de3591e29e3e7')}
+                    description={translate('text_6661fc17337de3591e29e3e9')}
                   />
 
-                  <UsageChargesSection
-                    form={form}
-                    canBeEdited={canBeEdited}
-                    isEdition={isEdition}
-                    premiumWarningDialogRef={premiumWarningDialogRef}
-                    alreadyExistingCharges={plan?.charges as LocalUsageChargeInput[]}
+                  <CenteredPage.SubsectionWrapper>
+                    <SubscriptionFeeSection
+                      form={form}
+                      canBeEdited={canBeEdited}
+                      isEdition={isEdition}
+                    />
+
+                    <FixedChargesSection
+                      form={form}
+                      alreadyExistingFixedChargesIds={alreadyExistingFixedChargesIds}
+                      canBeEdited={canBeEdited}
+                      isEdition={isEdition}
+                    />
+
+                    <UsageChargesSection
+                      form={form}
+                      canBeEdited={canBeEdited}
+                      isEdition={isEdition}
+                      premiumWarningDialogRef={premiumWarningDialogRef}
+                      alreadyExistingCharges={plan?.charges as LocalUsageChargeInput[]}
+                    />
+                  </CenteredPage.SubsectionWrapper>
+                </CenteredPage.SectionWrapper>
+
+                <CenteredPage.SectionWrapper>
+                  <CenteredPage.PageTitle
+                    title={translate('text_6661fc17337de3591e29e44d')}
+                    description={translate('text_6667029c1051a60107146e35')}
                   />
-                </CenteredPage.SubsectionWrapper>
-              </CenteredPage.SectionWrapper>
 
-              <CenteredPage.SectionWrapper>
-                <CenteredPage.PageTitle
-                  title={translate('text_6661fc17337de3591e29e44d')}
-                  description={translate('text_6667029c1051a60107146e35')}
-                />
+                  <CenteredPage.SubsectionWrapper>
+                    <ProgressiveBillingSection form={form} />
 
-                <CenteredPage.SubsectionWrapper>
-                  <ProgressiveBillingSection form={form} />
+                    <CommitmentsSection form={form} />
 
-                  <CommitmentsSection form={form} />
+                    <FeatureEntitlementSection form={form} isEdition={isEdition} />
+                  </CenteredPage.SubsectionWrapper>
+                </CenteredPage.SectionWrapper>
+              </>
+            )}
+          </CenteredPage.Container>
 
-                  <FeatureEntitlementSection form={form} isEdition={isEdition} />
-                </CenteredPage.SubsectionWrapper>
-              </CenteredPage.SectionWrapper>
-            </>
+          {(!loading || plan) && (
+            <CenteredPage.StickyFooter>
+              <Button variant="quaternary" onClick={onLeave}>
+                {translate('text_6411e6b530cb47007488b027')}
+              </Button>
+              <form.Subscribe
+                selector={(s) => ({
+                  canSubmit: s.canSubmit,
+                  isSubmitting: s.isSubmitting,
+                })}
+              >
+                {({ canSubmit, isSubmitting }) => (
+                  <Button
+                    type="submit"
+                    disabled={!canSubmit || (isEdition && !isDirty)}
+                    loading={isSubmitting}
+                    onClick={() => handleFormSubmit()}
+                    data-test="submit"
+                  >
+                    {translate(
+                      type === FORM_TYPE_ENUM.edition
+                        ? 'text_6661fc17337de3591e29e461'
+                        : 'text_6661ffe746c680007e2df0e2',
+                    )}
+                  </Button>
+                )}
+              </form.Subscribe>
+            </CenteredPage.StickyFooter>
           )}
-        </CenteredPage.Container>
-
-        {(!loading || plan) && (
-          <CenteredPage.StickyFooter>
-            <Button variant="quaternary" onClick={onLeave}>
-              {translate('text_6411e6b530cb47007488b027')}
-            </Button>
-            <form.Subscribe
-              selector={(s) => ({
-                canSubmit: s.canSubmit,
-                isSubmitting: s.isSubmitting,
-              })}
-            >
-              {({ canSubmit, isSubmitting }) => (
-                <Button
-                  disabled={!canSubmit || (isEdition && !isDirty)}
-                  loading={isSubmitting}
-                  onClick={() => {
-                    if (plan?.hasOverriddenPlans && isEdition) {
-                      return impactOverridenSubscriptionsDialogRef.current?.openDialog({
-                        onSave: async (cascadeUpdates) => {
-                          form.setFieldValue('cascadeUpdates', cascadeUpdates)
-
-                          return form.handleSubmit()
-                        },
-                      })
-                    }
-
-                    return form.handleSubmit()
-                  }}
-                  data-test="submit"
-                >
-                  {translate(
-                    type === FORM_TYPE_ENUM.edition
-                      ? 'text_6661fc17337de3591e29e461'
-                      : 'text_6661ffe746c680007e2df0e2',
-                  )}
-                </Button>
-              )}
-            </form.Subscribe>
-          </CenteredPage.StickyFooter>
-        )}
-      </CenteredPage.Wrapper>
+        </CenteredPage.Wrapper>
+      </form>
 
       <WarningDialog
         ref={warningDialogRef}

--- a/src/pages/__tests__/CreatePlan.test.tsx
+++ b/src/pages/__tests__/CreatePlan.test.tsx
@@ -56,7 +56,9 @@ jest.mock('~/components/plans/PlanSettingsSection', () => {
     PlanSettingsSection: (props: Record<string, unknown>) => {
       capturedPlanSettingsProps = props
 
-      return React.createElement('div', { 'data-test': 'plan-settings-section-mock' })
+      return React.createElement('div', { 'data-test': 'plan-settings-section-mock' }, [
+        React.createElement('input', { key: 'name', 'data-test': 'mock-plan-name-input' }),
+      ])
     },
   }
 })
@@ -288,14 +290,29 @@ describe('CreatePlan', () => {
   // handleMinimumCommitmentSave and handleEntitlementDrawerSave are now internal to the section components.
   // Their behavior is tested in CommitmentsSection.test.tsx and FeatureEntitlementSection.test.tsx.
 
-  describe('GIVEN the submit button', () => {
-    describe('WHEN clicked in creation mode', () => {
-      it('THEN should call submitForm', async () => {
+  describe('GIVEN the form submission', () => {
+    describe('WHEN the submit button is clicked', () => {
+      it('THEN should call handleSubmit', async () => {
         const user = userEvent.setup()
 
         render(<CreatePlan />)
 
         await user.click(screen.getByTestId('submit'))
+
+        expect(mockHandleSubmit).toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN Enter is pressed in an input field', () => {
+      it('THEN should submit the form', async () => {
+        const user = userEvent.setup()
+
+        render(<CreatePlan />)
+
+        const input = screen.getByTestId('mock-plan-name-input')
+
+        await user.click(input)
+        await user.keyboard('{Enter}')
 
         expect(mockHandleSubmit).toHaveBeenCalled()
       })

--- a/src/pages/subscriptions/__tests__/CreateSubscription.test.tsx
+++ b/src/pages/subscriptions/__tests__/CreateSubscription.test.tsx
@@ -115,7 +115,9 @@ const mockSubscriptionForm = {
         <input data-test={`field-${props.label}`} />
       ),
       ComboBoxField: (props: Record<string, unknown>) => (
-        <div data-test={`combobox-${props.label}`}>combobox</div>
+        <div data-test={`combobox-${props.label}`}>
+          <input data-test={`combobox-input-${props.label}`} />
+        </div>
       ),
       ButtonSelectorField: (props: Record<string, unknown>) => (
         <div data-test={`selector-${props.label}`}>selector</div>
@@ -200,7 +202,6 @@ jest.mock('~/generated/graphql', () => {
 
 jest.mock('~/components/designSystem/WarningDialog', () => ({
   WarningDialog: () => <div data-test="warning-dialog" />,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ...((): any => {
     // Capture ref via mock
     const actual = jest.requireActual('react')
@@ -286,6 +287,24 @@ describe('CreateSubscription', () => {
     Router.useParams.mockReturnValue({ customerId: 'customer-1' })
   })
 
+  describe('GIVEN form submission via Enter key', () => {
+    describe('WHEN Enter is pressed in an input field', () => {
+      it('THEN should submit the form', async () => {
+        mockPlanFormIsDirty = true
+        const user = userEvent.setup()
+
+        renderCreateSubscription()
+
+        const input = screen.getByTestId('combobox-input-text_625434c7bb2cb40124c81a29')
+
+        await user.click(input)
+        await user.keyboard('{Enter}')
+
+        expect(mockSubscriptionForm.handleSubmit).toHaveBeenCalled()
+      })
+    })
+  })
+
   describe('GIVEN the submit button reactive state', () => {
     describe('WHEN planFormCanSubmit is false', () => {
       it('THEN the submit button should be disabled', () => {
@@ -328,9 +347,11 @@ describe('CreateSubscription', () => {
       it('THEN should not navigate away (warning dialog should intercept)', async () => {
         mockPlanFormIsDirty = true
         const user = userEvent.setup()
+
         renderCreateSubscription()
 
         const closeButton = screen.getByTestId('close-create-subscription-button')
+
         await user.click(closeButton)
 
         // Should NOT navigate away when form is dirty
@@ -342,9 +363,11 @@ describe('CreateSubscription', () => {
       it('THEN should navigate away on close click', async () => {
         mockPlanFormIsDirty = false
         const user = userEvent.setup()
+
         renderCreateSubscription()
 
         const closeButton = screen.getByTestId('close-create-subscription-button')
+
         await user.click(closeButton)
 
         expect(testMockNavigateFn).toHaveBeenCalled()


### PR DESCRIPTION
## Context

The plan form cannot be submitted if you press enter focussing one of the elements of the form.

## Description

This pull request allows the user that presses Enter to submit the form. 

It also fixed a bug that prevented form re-submission after the backend returned the "code already exists" error. 

<!-- Linear link -->
Fixes LAGO-1364 