### PR TITLE
chore: combobox chevron should also receive disabled props

### DIFF
--- a/src/components/form/ComboBox/ComboBoxInput.tsx
+++ b/src/components/form/ComboBox/ComboBoxInput.tsx
@@ -88,6 +88,7 @@ export const ComboBoxInput = ({
                 variant="quaternary"
                 size="small"
                 icon="chevron-up-down"
+                disabled={restParams.disabled}
                 onClick={restParams.disabled ? undefined : () => inputProps.onMouseDown()}
               />
             )}

--- a/src/components/form/ComboBox/__tests__/ComboBoxInput.test.tsx
+++ b/src/components/form/ComboBox/__tests__/ComboBoxInput.test.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react'
+
+import { ComboBoxInput } from '../ComboBoxInput'
+import { ComboBoxInputProps } from '../types'
+
+const buildProps = (disabled: boolean): ComboBoxInputProps => ({
+  params: {
+    id: 'test-combobox',
+    inputProps: {
+      onChange: jest.fn(),
+      onMouseDown: jest.fn(),
+      value: '',
+    },
+    InputProps: {
+      ref: null,
+      className: '',
+      startAdornment: undefined,
+      endAdornment: undefined,
+    },
+    disabled,
+    fullWidth: true,
+    size: 'small' as const,
+  } as ComboBoxInputProps['params'],
+  name: 'test',
+  placeholder: 'Select',
+  hasValueSelected: false,
+})
+
+describe('ComboBoxInput', () => {
+  describe('GIVEN the chevron button', () => {
+    it('WHEN the combobox is disabled THEN the chevron button should be disabled', () => {
+      const { container } = render(<ComboBoxInput {...buildProps(true)} />)
+
+      const chevronButton = container.querySelector(
+        '.MuiInputAdornment-positionEnd button:last-of-type',
+      ) as HTMLButtonElement
+
+      expect(chevronButton).toBeDisabled()
+    })
+
+    it('WHEN the combobox is not disabled THEN the chevron button should not be disabled', () => {
+      const { container } = render(<ComboBoxInput {...buildProps(false)} />)
+
+      const chevronButton = container.querySelector(
+        '.MuiInputAdornment-positionEnd button:last-of-type',
+      ) as HTMLButtonElement
+
+      expect(chevronButton).not.toBeDisabled()
+    })
+  })
+})

--- a/src/pages/createCustomers/__tests__/__snapshots__/CreateCustomer.test.tsx.snap
+++ b/src/pages/createCustomers/__tests__/__snapshots__/CreateCustomer.test.tsx.snap
@@ -640,9 +640,10 @@ exports[`CreateCustomer Integration Tests WHEN checking on expanded features THE
                         </svg>
                       </button>
                       <button
-                        class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
+                        class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
                         data-test="button"
-                        tabindex="0"
+                        disabled=""
+                        tabindex="-1"
                         type="button"
                       >
                         <svg
@@ -2838,9 +2839,10 @@ exports[`CreateCustomer Integration Tests WHEN checking on expanded features THE
                         </svg>
                       </button>
                       <button
-                        class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
+                        class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
                         data-test="button"
-                        tabindex="0"
+                        disabled=""
+                        tabindex="-1"
                         type="button"
                       >
                         <svg
@@ -3860,9 +3862,10 @@ exports[`CreateCustomer Integration Tests WHEN checking on expanded features THE
                         </svg>
                       </button>
                       <button
-                        class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
+                        class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
                         data-test="button"
-                        tabindex="0"
+                        disabled=""
+                        tabindex="-1"
                         type="button"
                       >
                         <svg
@@ -4882,9 +4885,10 @@ exports[`CreateCustomer Integration Tests WHEN checking on expanded features THE
                         </svg>
                       </button>
                       <button
-                        class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
+                        class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
                         data-test="button"
-                        tabindex="0"
+                        disabled=""
+                        tabindex="-1"
                         type="button"
                       >
                         <svg
@@ -5901,9 +5905,10 @@ exports[`CreateCustomer Integration Tests WHEN checking on expanded features THE
                         </svg>
                       </button>
                       <button
-                        class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
+                        class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
                         data-test="button"
-                        tabindex="0"
+                        disabled=""
+                        tabindex="-1"
                         type="button"
                       >
                         <svg
@@ -6869,9 +6874,10 @@ exports[`CreateCustomer Integration Tests WHEN rendering the component THEN shou
                         </svg>
                       </button>
                       <button
-                        class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
+                        class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
                         data-test="button"
-                        tabindex="0"
+                        disabled=""
+                        tabindex="-1"
                         type="button"
                       >
                         <svg

--- a/src/pages/createCustomers/customerInformation/__tests__/CustomerInformation.test.tsx
+++ b/src/pages/createCustomers/customerInformation/__tests__/CustomerInformation.test.tsx
@@ -85,7 +85,9 @@ describe('CustomerInformation Integration Tests', () => {
       const user = userEvent.setup()
       const rendered = render(<TestCustomerInformationWrapper isEdition={true} />)
 
-      const accordionButton = screen.getAllByRole('button')[0]
+      const accordionButton = screen
+        .getAllByRole('button')
+        .find((btn) => !btn.hasAttribute('disabled')) as HTMLElement
 
       await user.click(accordionButton)
       await waitFor(() => {
@@ -98,7 +100,9 @@ describe('CustomerInformation Integration Tests', () => {
       const rendered = render(
         <TestCustomerInformationWrapper customer={mockCustomer} isEdition={true} />,
       )
-      const accordionButton = screen.getAllByRole('button')[0]
+      const accordionButton = screen
+        .getAllByRole('button')
+        .find((btn) => !btn.hasAttribute('disabled')) as HTMLElement
 
       await user.click(accordionButton)
       await waitFor(() => {

--- a/src/pages/createCustomers/customerInformation/__tests__/__snapshots__/CustomerInformation.test.tsx.snap
+++ b/src/pages/createCustomers/customerInformation/__tests__/__snapshots__/CustomerInformation.test.tsx.snap
@@ -500,9 +500,10 @@ exports[`CustomerInformation Integration Tests WHEN rendering the component THEN
                 </svg>
               </button>
               <button
-                class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
+                class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
                 data-test="button"
-                tabindex="0"
+                disabled=""
+                tabindex="-1"
                 type="button"
               >
                 <svg
@@ -1117,9 +1118,10 @@ exports[`CustomerInformation Integration Tests WHEN rendering the component THEN
                 </svg>
               </button>
               <button
-                class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
+                class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
                 data-test="button"
-                tabindex="0"
+                disabled=""
+                tabindex="-1"
                 type="button"
               >
                 <svg
@@ -1302,9 +1304,10 @@ exports[`CustomerInformation Integration Tests WHEN rendering the component THEN
               class=MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-hash-MuiInputAdornment-root
             >
               <button
-                class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
+                class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
                 data-test="button"
-                tabindex="0"
+                disabled=""
+                tabindex="-1"
                 type="button"
               >
                 <svg
@@ -1717,9 +1720,10 @@ exports[`CustomerInformation Integration Tests WHEN rendering the component THEN
                 </svg>
               </button>
               <button
-                class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
+                class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
                 data-test="button"
-                tabindex="0"
+                disabled=""
+                tabindex="-1"
                 type="button"
               >
                 <svg

--- a/src/pages/createCustomers/externalAppsAccordion/crmProvidersAccordion/__tests__/__snapshots__/HubspotCrmProviderContent.test.tsx.snap
+++ b/src/pages/createCustomers/externalAppsAccordion/crmProvidersAccordion/__tests__/__snapshots__/HubspotCrmProviderContent.test.tsx.snap
@@ -315,9 +315,10 @@ exports[`HubspotCrmProviderContent Integration Tests WHEN rendering the componen
             class=MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-hash-MuiInputAdornment-root
           >
             <button
-              class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
+              class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation button-icon-only min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center css-hash-MuiButtonBase-root-MuiButton-root
               data-test="button"
-              tabindex="0"
+              disabled=""
+              tabindex="-1"
               type="button"
             >
               <svg


### PR DESCRIPTION
Minor fix, noticed that while navigating using TAB, the chevron of disabled combobox was selectable.

It's now fixed