### PR TITLE
fix: include EU tax management in hasTaxProvider check for invoice pr…

### DIFF
--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -299,7 +299,10 @@ const CreateInvoice = () => {
   })
 
   const billingEntity = billingEntityData?.billingEntity
-  const hasTaxProvider = !!customer?.anrokCustomer?.id || !!customer?.avalaraCustomer?.id
+  const hasTaxProvider =
+    !!customer?.anrokCustomer?.id ||
+    !!customer?.avalaraCustomer?.id ||
+    !!billingEntity?.euTaxManagement
   const customerName = customer?.displayName
   const customerIsPartner = customer?.accountType === CustomerAccountTypeEnum.Partner
 


### PR DESCRIPTION
## Description

For customers under a billing entity with EU tax management enabled, the one-off invoice preview was missing taxes. The hasTaxProvider flag only checked for Anrok/Avalara, causing the fallback to an org-scoped tax query that returned nothing useful in mixed orgs.

Adding billingEntity.euTaxManagement to the check routes EU tax customers through the fetchDraftInvoiceTaxes mutation path, which correctly computes taxes server-side.

<!-- Linear link -->
Fixes ISSUE-1757