### PR TITLE
fix(createInvoice): use billing entity taxes in tax fallback chain

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3778,6 +3778,8 @@ export enum EventTypeEnum {
   PlanCreated = 'plan_created',
   PlanDeleted = 'plan_deleted',
   PlanUpdated = 'plan_updated',
+  SubscriptionCanceled = 'subscription_canceled',
+  SubscriptionIncomplete = 'subscription_incomplete',
   SubscriptionStarted = 'subscription_started',
   SubscriptionTerminated = 'subscription_terminated',
   SubscriptionTerminationAlert = 'subscription_termination_alert',
@@ -8357,6 +8359,7 @@ export type SetAsDefaultInput = {
 export enum StatusTypeEnum {
   Active = 'active',
   Canceled = 'canceled',
+  Incomplete = 'incomplete',
   Pending = 'pending',
   Terminated = 'terminated'
 }
@@ -12822,6 +12825,13 @@ export type GetInfosForCreateInvoiceQueryVariables = Exact<{
 
 
 export type GetInfosForCreateInvoiceQuery = { __typename?: 'Query', customer?: { __typename?: 'Customer', id: string, externalId: string, addressLine1?: string | null, addressLine2?: string | null, city?: string | null, country?: CountryCode | null, currency?: CurrencyEnum | null, email?: string | null, name?: string | null, displayName: string, legalName?: string | null, legalNumber?: string | null, taxIdentificationNumber?: string | null, state?: string | null, zipcode?: string | null, accountType: CustomerAccountTypeEnum, billingEntity: { __typename?: 'BillingEntity', id: string, code: string }, taxes?: Array<{ __typename?: 'Tax', id: string, name: string, code: string, rate: number }> | null, anrokCustomer?: { __typename?: 'AnrokCustomer', id: string } | null, avalaraCustomer?: { __typename?: 'AvalaraCustomer', id: string } | null } | null, taxes: { __typename?: 'TaxCollection', collection: Array<{ __typename?: 'Tax', id: string, name: string, code: string, rate: number }> } };
+
+export type GetBillingEntityTaxesForCreateInvoiceQueryVariables = Exact<{
+  billingEntityId: Scalars['ID']['input'];
+}>;
+
+
+export type GetBillingEntityTaxesForCreateInvoiceQuery = { __typename?: 'Query', billingEntityTaxes: { __typename?: 'TaxCollection', collection: Array<{ __typename?: 'Tax', id: string, name: string, code: string, rate: number }> } };
 
 export type GetAddonListForInfoiceQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -32897,6 +32907,52 @@ export type GetInfosForCreateInvoiceQueryHookResult = ReturnType<typeof useGetIn
 export type GetInfosForCreateInvoiceLazyQueryHookResult = ReturnType<typeof useGetInfosForCreateInvoiceLazyQuery>;
 export type GetInfosForCreateInvoiceSuspenseQueryHookResult = ReturnType<typeof useGetInfosForCreateInvoiceSuspenseQuery>;
 export type GetInfosForCreateInvoiceQueryResult = Apollo.QueryResult<GetInfosForCreateInvoiceQuery, GetInfosForCreateInvoiceQueryVariables>;
+export const GetBillingEntityTaxesForCreateInvoiceDocument = gql`
+    query getBillingEntityTaxesForCreateInvoice($billingEntityId: ID!) {
+  billingEntityTaxes(billingEntityId: $billingEntityId) {
+    collection {
+      id
+      ...TaxInfosForCreateInvoice
+    }
+  }
+}
+    ${TaxInfosForCreateInvoiceFragmentDoc}`;
+
+/**
+ * __useGetBillingEntityTaxesForCreateInvoiceQuery__
+ *
+ * To run a query within a React component, call `useGetBillingEntityTaxesForCreateInvoiceQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetBillingEntityTaxesForCreateInvoiceQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetBillingEntityTaxesForCreateInvoiceQuery({
+ *   variables: {
+ *      billingEntityId: // value for 'billingEntityId'
+ *   },
+ * });
+ */
+export function useGetBillingEntityTaxesForCreateInvoiceQuery(baseOptions: Apollo.QueryHookOptions<GetBillingEntityTaxesForCreateInvoiceQuery, GetBillingEntityTaxesForCreateInvoiceQueryVariables> & ({ variables: GetBillingEntityTaxesForCreateInvoiceQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetBillingEntityTaxesForCreateInvoiceQuery, GetBillingEntityTaxesForCreateInvoiceQueryVariables>(GetBillingEntityTaxesForCreateInvoiceDocument, options);
+      }
+export function useGetBillingEntityTaxesForCreateInvoiceLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetBillingEntityTaxesForCreateInvoiceQuery, GetBillingEntityTaxesForCreateInvoiceQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetBillingEntityTaxesForCreateInvoiceQuery, GetBillingEntityTaxesForCreateInvoiceQueryVariables>(GetBillingEntityTaxesForCreateInvoiceDocument, options);
+        }
+// @ts-ignore
+export function useGetBillingEntityTaxesForCreateInvoiceSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetBillingEntityTaxesForCreateInvoiceQuery, GetBillingEntityTaxesForCreateInvoiceQueryVariables>): Apollo.UseSuspenseQueryResult<GetBillingEntityTaxesForCreateInvoiceQuery, GetBillingEntityTaxesForCreateInvoiceQueryVariables>;
+export function useGetBillingEntityTaxesForCreateInvoiceSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetBillingEntityTaxesForCreateInvoiceQuery, GetBillingEntityTaxesForCreateInvoiceQueryVariables>): Apollo.UseSuspenseQueryResult<GetBillingEntityTaxesForCreateInvoiceQuery | undefined, GetBillingEntityTaxesForCreateInvoiceQueryVariables>;
+export function useGetBillingEntityTaxesForCreateInvoiceSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetBillingEntityTaxesForCreateInvoiceQuery, GetBillingEntityTaxesForCreateInvoiceQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetBillingEntityTaxesForCreateInvoiceQuery, GetBillingEntityTaxesForCreateInvoiceQueryVariables>(GetBillingEntityTaxesForCreateInvoiceDocument, options);
+        }
+export type GetBillingEntityTaxesForCreateInvoiceQueryHookResult = ReturnType<typeof useGetBillingEntityTaxesForCreateInvoiceQuery>;
+export type GetBillingEntityTaxesForCreateInvoiceLazyQueryHookResult = ReturnType<typeof useGetBillingEntityTaxesForCreateInvoiceLazyQuery>;
+export type GetBillingEntityTaxesForCreateInvoiceSuspenseQueryHookResult = ReturnType<typeof useGetBillingEntityTaxesForCreateInvoiceSuspenseQuery>;
+export type GetBillingEntityTaxesForCreateInvoiceQueryResult = Apollo.QueryResult<GetBillingEntityTaxesForCreateInvoiceQuery, GetBillingEntityTaxesForCreateInvoiceQueryVariables>;
 export const GetAddonListForInfoiceDocument = gql`
     query getAddonListForInfoice($page: Int, $limit: Int, $searchTerm: String) {
   addOns(page: $page, limit: $limit, searchTerm: $searchTerm) {

--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -68,6 +68,7 @@ import {
   useFetchDraftInvoiceTaxesMutation,
   useGetAddonListForInfoiceLazyQuery,
   useGetBillingEntityQuery,
+  useGetBillingEntityTaxesForCreateInvoiceQuery,
   useGetInfosForCreateInvoiceQuery,
   useGetInvoiceFeesForCreateInvoiceQuery,
   useVoidInvoiceMutation,
@@ -80,6 +81,34 @@ import { usePermissionsInvoiceActions } from '~/hooks/usePermissionsInvoiceActio
 import ErrorImage from '~/public/images/maneki/error.svg'
 import { MenuPopper, PageHeader } from '~/styles'
 import { tw } from '~/styles/utils'
+
+export const computeHasTaxProvider = (
+  customer?: {
+    anrokCustomer?: { id: string } | null
+    avalaraCustomer?: { id: string } | null
+  } | null,
+): boolean => {
+  return !!customer?.anrokCustomer?.id || !!customer?.avalaraCustomer?.id
+}
+
+export const resolveCustomerApplicableTax = ({
+  hasTaxProvider,
+  customerTaxes,
+  billingEntityTaxes,
+  orgTaxes,
+}: {
+  hasTaxProvider: boolean
+  customerTaxes?: TaxInfosForCreateInvoiceFragment[] | null
+  billingEntityTaxes?: TaxInfosForCreateInvoiceFragment[] | null
+  orgTaxes?: TaxInfosForCreateInvoiceFragment[]
+}): TaxInfosForCreateInvoiceFragment[] | undefined => {
+  if (hasTaxProvider) return []
+  if (!!customerTaxes?.length) return customerTaxes
+
+  if (!!billingEntityTaxes?.length) return billingEntityTaxes
+
+  return orgTaxes
+}
 
 gql`
   fragment TaxInfosForCreateInvoice on Tax {
@@ -184,6 +213,15 @@ gql`
     }
 
     taxes(page: 1, limit: 1000, appliedToOrganization: true) {
+      collection {
+        id
+        ...TaxInfosForCreateInvoice
+      }
+    }
+  }
+
+  query getBillingEntityTaxesForCreateInvoice($billingEntityId: ID!) {
+    billingEntityTaxes(billingEntityId: $billingEntityId) {
       collection {
         id
         ...TaxInfosForCreateInvoice
@@ -299,10 +337,15 @@ const CreateInvoice = () => {
   })
 
   const billingEntity = billingEntityData?.billingEntity
-  const hasTaxProvider =
-    !!customer?.anrokCustomer?.id ||
-    !!customer?.avalaraCustomer?.id ||
-    !!billingEntity?.euTaxManagement
+
+  const { data: billingEntityTaxesData } = useGetBillingEntityTaxesForCreateInvoiceQuery({
+    variables: {
+      billingEntityId: billingEntity?.id as string,
+    },
+    skip: !billingEntity?.id,
+  })
+
+  const hasTaxProvider = computeHasTaxProvider(customer)
   const customerName = customer?.displayName
   const customerIsPartner = customer?.accountType === CustomerAccountTypeEnum.Partner
 
@@ -324,12 +367,21 @@ const CreateInvoice = () => {
     zipcode: customer?.zipcode,
   })
 
-  const customerApplicableTax = useMemo(() => {
-    if (hasTaxProvider) return []
-    if (!!customer?.taxes?.length) return customer?.taxes
-
-    return taxes?.collection
-  }, [customer?.taxes, hasTaxProvider, taxes?.collection])
+  const customerApplicableTax = useMemo(
+    () =>
+      resolveCustomerApplicableTax({
+        hasTaxProvider,
+        customerTaxes: customer?.taxes,
+        billingEntityTaxes: billingEntityTaxesData?.billingEntityTaxes?.collection,
+        orgTaxes: taxes?.collection,
+      }),
+    [
+      billingEntityTaxesData?.billingEntityTaxes?.collection,
+      customer?.taxes,
+      hasTaxProvider,
+      taxes?.collection,
+    ],
+  )
 
   const [getAddOns, { data: addOnData }] = useGetAddonListForInfoiceLazyQuery({
     variables: { limit: 20 },

--- a/src/pages/__tests__/CreateInvoice.test.tsx
+++ b/src/pages/__tests__/CreateInvoice.test.tsx
@@ -1,0 +1,215 @@
+import { TaxInfosForCreateInvoiceFragment } from '~/generated/graphql'
+
+import { computeHasTaxProvider, resolveCustomerApplicableTax } from '../CreateInvoice'
+
+// -- Test data --
+
+const orgTax: TaxInfosForCreateInvoiceFragment = {
+  id: 'org-tax-1',
+  name: 'Org VAT',
+  code: 'org_vat',
+  rate: 20,
+}
+const customerTax: TaxInfosForCreateInvoiceFragment = {
+  id: 'cust-tax-1',
+  name: 'Customer Tax',
+  code: 'cust_tax',
+  rate: 10,
+}
+const billingEntityTax: TaxInfosForCreateInvoiceFragment = {
+  id: 'be-tax-1',
+  name: 'BE Tax',
+  code: 'be_tax',
+  rate: 15,
+}
+
+// -- Tests --
+
+describe('CreateInvoice tax resolution logic', () => {
+  describe('computeHasTaxProvider', () => {
+    describe('GIVEN a customer with an Anrok integration', () => {
+      describe('WHEN computing hasTaxProvider', () => {
+        it('THEN should return true', () => {
+          const result = computeHasTaxProvider({
+            anrokCustomer: { id: 'anrok-1' },
+            avalaraCustomer: null,
+          })
+
+          expect(result).toBe(true)
+        })
+      })
+    })
+
+    describe('GIVEN a customer with an Avalara integration', () => {
+      describe('WHEN computing hasTaxProvider', () => {
+        it('THEN should return true', () => {
+          const result = computeHasTaxProvider({
+            anrokCustomer: null,
+            avalaraCustomer: { id: 'avalara-1' },
+          })
+
+          expect(result).toBe(true)
+        })
+      })
+    })
+
+    describe('GIVEN a customer with both Anrok and Avalara integrations', () => {
+      describe('WHEN computing hasTaxProvider', () => {
+        it('THEN should return true', () => {
+          const result = computeHasTaxProvider({
+            anrokCustomer: { id: 'anrok-1' },
+            avalaraCustomer: { id: 'avalara-1' },
+          })
+
+          expect(result).toBe(true)
+        })
+      })
+    })
+
+    describe('GIVEN a customer with no tax provider', () => {
+      describe('WHEN computing hasTaxProvider', () => {
+        it('THEN should return false', () => {
+          const result = computeHasTaxProvider({
+            anrokCustomer: null,
+            avalaraCustomer: null,
+          })
+
+          expect(result).toBe(false)
+        })
+      })
+    })
+
+    describe('GIVEN no customer data', () => {
+      describe('WHEN computing hasTaxProvider', () => {
+        it('THEN should return false', () => {
+          expect(computeHasTaxProvider(undefined)).toBe(false)
+          expect(computeHasTaxProvider(null)).toBe(false)
+        })
+      })
+    })
+  })
+
+  describe('resolveCustomerApplicableTax', () => {
+    describe('GIVEN the customer has a tax provider (Anrok or Avalara)', () => {
+      describe('WHEN resolving applicable taxes', () => {
+        it('THEN should return an empty array regardless of other taxes', () => {
+          const result = resolveCustomerApplicableTax({
+            hasTaxProvider: true,
+            customerTaxes: [customerTax],
+            billingEntityTaxes: [billingEntityTax],
+            orgTaxes: [orgTax],
+          })
+
+          expect(result).toEqual([])
+        })
+      })
+    })
+
+    describe('GIVEN no tax provider and the customer has taxes', () => {
+      describe('WHEN resolving applicable taxes', () => {
+        it('THEN should return customer taxes', () => {
+          const result = resolveCustomerApplicableTax({
+            hasTaxProvider: false,
+            customerTaxes: [customerTax],
+            billingEntityTaxes: [billingEntityTax],
+            orgTaxes: [orgTax],
+          })
+
+          expect(result).toEqual([customerTax])
+        })
+      })
+    })
+
+    describe('GIVEN no tax provider, no customer taxes, but billing entity has taxes', () => {
+      describe('WHEN resolving applicable taxes', () => {
+        it('THEN should return billing entity taxes', () => {
+          const result = resolveCustomerApplicableTax({
+            hasTaxProvider: false,
+            customerTaxes: null,
+            billingEntityTaxes: [billingEntityTax],
+            orgTaxes: [orgTax],
+          })
+
+          expect(result).toEqual([billingEntityTax])
+        })
+      })
+    })
+
+    describe('GIVEN no tax provider, no customer taxes, and empty billing entity taxes', () => {
+      describe('WHEN resolving applicable taxes', () => {
+        it('THEN should fall back to org-level taxes', () => {
+          const result = resolveCustomerApplicableTax({
+            hasTaxProvider: false,
+            customerTaxes: [],
+            billingEntityTaxes: [],
+            orgTaxes: [orgTax],
+          })
+
+          expect(result).toEqual([orgTax])
+        })
+      })
+    })
+
+    describe('GIVEN no tax provider, no customer taxes, and no billing entity taxes', () => {
+      describe('WHEN resolving applicable taxes', () => {
+        it('THEN should fall back to org-level taxes', () => {
+          const result = resolveCustomerApplicableTax({
+            hasTaxProvider: false,
+            customerTaxes: null,
+            billingEntityTaxes: null,
+            orgTaxes: [orgTax],
+          })
+
+          expect(result).toEqual([orgTax])
+        })
+      })
+    })
+
+    describe('GIVEN no tax provider and no taxes at any level', () => {
+      describe('WHEN resolving applicable taxes', () => {
+        it('THEN should return undefined', () => {
+          const result = resolveCustomerApplicableTax({
+            hasTaxProvider: false,
+            customerTaxes: null,
+            billingEntityTaxes: null,
+            orgTaxes: undefined,
+          })
+
+          expect(result).toBeUndefined()
+        })
+      })
+    })
+
+    describe('GIVEN customer taxes take precedence over billing entity taxes', () => {
+      describe('WHEN both customer and billing entity have taxes', () => {
+        it('THEN should return customer taxes, not billing entity taxes', () => {
+          const result = resolveCustomerApplicableTax({
+            hasTaxProvider: false,
+            customerTaxes: [customerTax],
+            billingEntityTaxes: [billingEntityTax],
+            orgTaxes: [orgTax],
+          })
+
+          expect(result).toEqual([customerTax])
+          expect(result).not.toEqual([billingEntityTax])
+        })
+      })
+    })
+
+    describe('GIVEN billing entity taxes take precedence over org taxes', () => {
+      describe('WHEN billing entity has taxes but customer does not', () => {
+        it('THEN should return billing entity taxes, not org taxes', () => {
+          const result = resolveCustomerApplicableTax({
+            hasTaxProvider: false,
+            customerTaxes: null,
+            billingEntityTaxes: [billingEntityTax],
+            orgTaxes: [orgTax],
+          })
+
+          expect(result).toEqual([billingEntityTax])
+          expect(result).not.toEqual([orgTax])
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description

Revert the `hasTaxProvider` approach from #3343 and instead fetch billing entity taxes directly. The previous fix added `euTaxManagement` to `hasTaxProvider`, which bypassed local tax resolution entirely. This restores the correct behavior by querying `billingEntityTaxes` and inserting them into the tax fallback chain between customer taxes and org-level taxes.

It does 
- remove `!!billingEntity?.euTaxManagement` from the `hasTaxProvider` logic
- returns `billingEntityTaxes` before `taxes?.collection` if present

Those two resolve the original bug (1757) and prevent (1810) to happen

<!-- Linear link -->
Fixes ISSUE-1757 ISSUE-1810