### PR TITLE
fix: missmatch between actions and route permissions

### DIFF
--- a/src/pages/BillableMetricsList.tsx
+++ b/src/pages/BillableMetricsList.tsx
@@ -214,9 +214,11 @@ const BillableMetricsList = () => {
               : {
                   title: translate('text_623b53fea66c76017eaebb70'),
                   subtitle: translate('text_623b53fea66c76017eaebb78'),
-                  buttonTitle: translate('text_623b53fea66c76017eaebb7c'),
-                  buttonAction: () => navigate(CREATE_BILLABLE_METRIC_ROUTE),
-                  buttonVariant: 'primary',
+                  ...(hasPermissions(['billableMetricsCreate']) && {
+                    buttonTitle: translate('text_623b53fea66c76017eaebb7c'),
+                    buttonAction: () => navigate(CREATE_BILLABLE_METRIC_ROUTE),
+                    buttonVariant: 'primary',
+                  }),
                 },
           }}
         />

--- a/src/pages/features/FeaturesList.tsx
+++ b/src/pages/features/FeaturesList.tsx
@@ -100,12 +100,14 @@ const FeaturesList = () => {
         : {
             title: translate('text_1752692673070vvbkvtj8pbx'),
             subtitle: translate('text_17526926730702mizvc3o8vm'),
-            buttonTitle: translate('text_17526926730703ysbxa2g5fj'),
-            buttonAction: () => navigate(CREATE_FEATURE_ROUTE),
-            buttonVariant: 'primary' as const,
+            ...(hasPermissions(['featuresCreate']) && {
+              buttonTitle: translate('text_17526926730703ysbxa2g5fj'),
+              buttonAction: () => navigate(CREATE_FEATURE_ROUTE),
+              buttonVariant: 'primary' as const,
+            }),
           },
     }),
-    [featuresVariables?.searchTerm, translate, navigate],
+    [featuresVariables?.searchTerm, translate, hasPermissions, navigate],
   )
 
   const featuresTotalCount = featuresData?.features?.metadata?.totalCount

--- a/src/pages/settings/Dunnings/Dunnings.tsx
+++ b/src/pages/settings/Dunnings/Dunnings.tsx
@@ -30,6 +30,7 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
+import { usePermissions } from '~/hooks/usePermissions'
 import ErrorImage from '~/public/images/maneki/error.svg'
 
 gql`
@@ -66,6 +67,7 @@ gql`
 
 const Dunnings = () => {
   const { translate } = useInternationalization()
+  const { hasPermissions } = usePermissions()
   const navigate = useNavigate()
   const deleteCampaignDialogRef = useRef<DeleteCampaignDialogRef>(null)
 
@@ -124,7 +126,7 @@ const Dunnings = () => {
                     hasAccessToFeature ? (
                       <Button
                         variant="inline"
-                        disabled={loading}
+                        disabled={loading || !hasPermissions(['dunningCampaignsCreate'])}
                         onClick={() => {
                           navigate(CREATE_DUNNING_ROUTE)
                         }}
@@ -217,6 +219,7 @@ const Dunnings = () => {
                               {
                                 startIcon: 'pen',
                                 title: translate('text_17321873136602nzwuvcycbr'),
+                                disabled: !hasPermissions(['dunningCampaignsUpdate']),
                                 onAction: () => {
                                   navigate(
                                     generatePath(UPDATE_DUNNING_ROUTE, {
@@ -228,6 +231,7 @@ const Dunnings = () => {
                               {
                                 startIcon: 'trash',
                                 title: translate('text_1732187313660we30lb9kg57'),
+                                disabled: !hasPermissions(['dunningCampaignsDelete']),
                                 onAction: () => {
                                   deleteCampaignDialogRef.current?.openDialog(campaign)
                                 },

--- a/src/pages/settings/Invoices/InvoiceSections.tsx
+++ b/src/pages/settings/Invoices/InvoiceSections.tsx
@@ -72,8 +72,8 @@ const InvoiceSections = () => {
   const navigate = useNavigate()
   const deleteCustomSectionDialogRef = useRef<DeleteCustomSectionDialogRef>(null)
 
-  const canEditInvoiceSettings = hasPermissions(['organizationInvoicesUpdate'])
-  const canEditOrCreatePricingUnits = hasPermissions(['pricingUnitsCreate', 'pricingUnitsUpdate'])
+  const canCreatePricingUnits = hasPermissions(['pricingUnitsCreate'])
+  const canEditPricingUnits = hasPermissions(['pricingUnitsUpdate'])
   const canViewPricingUnits = hasPermissions(['pricingUnitsView'])
 
   const {
@@ -121,7 +121,7 @@ const InvoiceSections = () => {
                 action={
                   <Button
                     variant="inline"
-                    disabled={!canEditOrCreatePricingUnits}
+                    disabled={!canCreatePricingUnits}
                     onClick={() => navigate(CREATE_PRICING_UNIT)}
                   >
                     {translate('text_1742230191029lznwj3y41nb')}
@@ -171,10 +171,14 @@ const InvoiceSections = () => {
                       },
                     ]}
                     actionColumnTooltip={() => translate('text_63e51ef4985f0ebd75c212fc')}
-                    onRowActionLink={({ id }) =>
-                      generatePath(EDIT_PRICING_UNIT, {
-                        pricingUnitId: id,
-                      })
+                    onRowActionLink={
+                      canEditPricingUnits
+                        ? ({ id }) => {
+                            return generatePath(EDIT_PRICING_UNIT, {
+                              pricingUnitId: id,
+                            })
+                          }
+                        : undefined
                     }
                     actionColumn={({ id }) => [
                       {
@@ -202,7 +206,7 @@ const InvoiceSections = () => {
               action={
                 <Button
                   variant="inline"
-                  disabled={!canEditInvoiceSettings}
+                  disabled={!hasPermissions(['invoiceCustomSectionsCreate'])}
                   onClick={() => navigate(CREATE_INVOICE_CUSTOM_SECTION)}
                 >
                   {translate('text_1742230191029lznwj3y41nb')}
@@ -246,6 +250,7 @@ const InvoiceSections = () => {
                     {
                       startIcon: 'pen',
                       title: translate('text_1732638001460kne05vskb7e'),
+                      disabled: !hasPermissions(['invoiceCustomSectionsUpdate']),
                       onAction: () =>
                         navigate(
                           generatePath(EDIT_INVOICE_CUSTOM_SECTION, { sectionId: section.id }),


### PR DESCRIPTION
## Description

Several pages allowed users to click navigation buttons that led to a Forbidden error page because the UI permission checks didn't match the route-level `permissionsOr` guards.

The fix aligns each button/action with the exact permission it gates:

- **InvoiceSections**: custom section create button checked `organizationInvoicesUpdate` instead of `invoiceCustomSectionsCreate`; edit/row actions had no permission check at all. Pricing unit create button checked both `pricingUnitsCreate` AND `pricingUnitsUpdate` instead of just `pricingUnitsCreate`.
- **Dunnings**: create button and edit/delete table actions had zero permission checks despite the route requiring `dunningCampaignsCreate` / `dunningCampaignsUpdate`.
- **FeaturesList**: empty state create button navigated to a `featuresCreate`-guarded route without checking the permission.
- **BillableMetricsList**: same pattern, empty state create button had no `billableMetricsCreate` check.
