### PR TITLE
feat(integrations): move Lago EU Tax Management to Built by community…

### DIFF
--- a/src/components/settings/integrations/AddLagoTaxManagementDialog.tsx
+++ b/src/components/settings/integrations/AddLagoTaxManagementDialog.tsx
@@ -127,7 +127,7 @@ export const AddLagoTaxManagementDialog = forwardRef<
 
       navigate(
         generatePath(TAX_MANAGEMENT_INTEGRATION_ROUTE, {
-          integrationGroup: IntegrationsTabsOptionsEnum.Lago,
+          integrationGroup: IntegrationsTabsOptionsEnum.Community,
         }),
       )
 

--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -525,36 +525,6 @@ const Integrations = () => {
                       />
                       <Selector
                         fullWidth
-                        title={translate('text_657078c28394d6b1ae1b9713')}
-                        subtitle={translate('text_657078c28394d6b1ae1b971f')}
-                        icon={
-                          <Avatar size="big" variant="connector-full">
-                            {<LagoTaxManagement />}
-                          </Avatar>
-                        }
-                        endContent={getEndContent({
-                          showConnectedBadge: hasTaxManagement,
-                        })}
-                        hoverActions={getHoverActions(
-                          hasTaxManagement,
-                          generatePath(TAX_MANAGEMENT_INTEGRATION_ROUTE, {
-                            integrationGroup: IntegrationsTabsOptionsEnum.Lago,
-                          }),
-                        )}
-                        onClick={() => {
-                          if (hasTaxManagement) {
-                            navigate(
-                              generatePath(TAX_MANAGEMENT_INTEGRATION_ROUTE, {
-                                integrationGroup: IntegrationsTabsOptionsEnum.Lago,
-                              }),
-                            )
-                          } else {
-                            addLagoTaxManagementDialog.current?.openDialog()
-                          }
-                        }}
-                      />
-                      <Selector
-                        fullWidth
                         title={translate('text_661ff6e56ef7e1b7c542b239')}
                         subtitle={translate('text_661ff6e56ef7e1b7c542b245')}
                         endContent={getEndContent({
@@ -783,33 +753,6 @@ const Integrations = () => {
                         }}
                       />
                       <Selector
-                        title={translate('text_1733427981129n3wxjui0bex')}
-                        subtitle={translate('text_634ea0ecc6147de10ddb6631')}
-                        icon={
-                          <Avatar size="big" variant="connector-full">
-                            <Moneyhash />
-                          </Avatar>
-                        }
-                        endContent={getEndContent({
-                          showConnectedBadge: hasMoneyhashIntegration,
-                        })}
-                        hoverActions={getHoverActions(
-                          hasMoneyhashIntegration,
-                          MONEYHASH_INTEGRATION_ROUTE,
-                        )}
-                        onClick={() => {
-                          if (hasMoneyhashIntegration) {
-                            navigate(MONEYHASH_INTEGRATION_ROUTE)
-                          } else {
-                            const element = document.activeElement as HTMLElement
-
-                            element.blur && element.blur()
-                            addMoneyhashDialogRef.current?.openDialog()
-                          }
-                        }}
-                        fullWidth
-                      />
-                      <Selector
                         title={translate('text_1749724395108m0swrna0zt4')}
                         subtitle={translate('text_634ea0ecc6147de10ddb6631')}
                         icon={
@@ -832,6 +775,63 @@ const Integrations = () => {
 
                             element.blur && element.blur()
                             addFlutterwaveDialogRef.current?.openDialog()
+                          }
+                        }}
+                        fullWidth
+                      />
+                      <Selector
+                        fullWidth
+                        title={translate('text_657078c28394d6b1ae1b9713')}
+                        subtitle={translate('text_657078c28394d6b1ae1b971f')}
+                        icon={
+                          <Avatar size="big" variant="connector-full">
+                            {<LagoTaxManagement />}
+                          </Avatar>
+                        }
+                        endContent={getEndContent({
+                          showConnectedBadge: hasTaxManagement,
+                        })}
+                        hoverActions={getHoverActions(
+                          hasTaxManagement,
+                          generatePath(TAX_MANAGEMENT_INTEGRATION_ROUTE, {
+                            integrationGroup: IntegrationsTabsOptionsEnum.Community,
+                          }),
+                        )}
+                        onClick={() => {
+                          if (hasTaxManagement) {
+                            navigate(
+                              generatePath(TAX_MANAGEMENT_INTEGRATION_ROUTE, {
+                                integrationGroup: IntegrationsTabsOptionsEnum.Community,
+                              }),
+                            )
+                          } else {
+                            addLagoTaxManagementDialog.current?.openDialog()
+                          }
+                        }}
+                      />
+                      <Selector
+                        title={translate('text_1733427981129n3wxjui0bex')}
+                        subtitle={translate('text_634ea0ecc6147de10ddb6631')}
+                        icon={
+                          <Avatar size="big" variant="connector-full">
+                            <Moneyhash />
+                          </Avatar>
+                        }
+                        endContent={getEndContent({
+                          showConnectedBadge: hasMoneyhashIntegration,
+                        })}
+                        hoverActions={getHoverActions(
+                          hasMoneyhashIntegration,
+                          MONEYHASH_INTEGRATION_ROUTE,
+                        )}
+                        onClick={() => {
+                          if (hasMoneyhashIntegration) {
+                            navigate(MONEYHASH_INTEGRATION_ROUTE)
+                          } else {
+                            const element = document.activeElement as HTMLElement
+
+                            element.blur && element.blur()
+                            addMoneyhashDialogRef.current?.openDialog()
                           }
                         }}
                         fullWidth

--- a/src/pages/settings/LagoTaxManagementIntegration.tsx
+++ b/src/pages/settings/LagoTaxManagementIntegration.tsx
@@ -109,7 +109,7 @@ const LagoTaxManagementIntegration = () => {
 
     navigate(
       generatePath(INTEGRATIONS_ROUTE, {
-        integrationGroup: IntegrationsTabsOptionsEnum.Lago,
+        integrationGroup: IntegrationsTabsOptionsEnum.Community,
       }),
     )
 
@@ -132,7 +132,7 @@ const LagoTaxManagementIntegration = () => {
           {
             label: translate('text_62b1edddbf5f461ab9712750'),
             path: generatePath(INTEGRATIONS_ROUTE, {
-              integrationGroup: IntegrationsTabsOptionsEnum.Lago,
+              integrationGroup: IntegrationsTabsOptionsEnum.Community,
             }),
           },
         ]}


### PR DESCRIPTION
## Summary
- Move the Lago EU Tax Management integration from the "Built by Lago" tab to the "Built by community" tab in Settings > Integrations
- Sort all community integrations alphabetically: Airbyte, Cashfree, Flutterwave, Lago EU Tax Management, Moneyhash
- Update navigation references (breadcrumb, dialog redirect, back-navigation) to point to the Community tab

## Test plan
- [x] All 15 related test suites pass (54 tests)
- [x] Pre-commit hooks pass (lint, types, translations)
- [x] Verify "Lago EU Tax Management" no longer appears in "Built by Lago" tab
- [x] Verify it appears in "Built by community" tab in alphabetical order
- [ ] Click into the integration detail page — breadcrumb links back to Community tab
- [ ] Add EU tax management via dialog — redirects to Community tab after submission

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation change that re-categorizes the Lago EU Tax Management integration and updates redirects/breadcrumbs; main risk is broken routing if `integrationGroup` mismatches expected tab state.
> 
> **Overview**
> Moves **Lago EU Tax Management** out of the *Built by Lago* integrations list and into the *Built by community* tab, keeping the community list sorted alphabetically (and reordering Flutterwave/Moneyhash accordingly).
> 
> Updates all related navigation targets (detail page breadcrumb/back navigation and the add/update dialog post-submit redirect) to use `IntegrationsTabsOptionsEnum.Community` when routing to `TAX_MANAGEMENT_INTEGRATION_ROUTE`/`INTEGRATIONS_ROUTE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a24faef013070d8e696b74b429b28fd21e9df5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->