### PR TITLE
fix(api key form): make "Alerts" key selected by default

### DIFF
--- a/src/pages/developers/ApiKeysForm.tsx
+++ b/src/pages/developers/ApiKeysForm.tsx
@@ -51,18 +51,13 @@ const canOnlyRead = (permission: ApiKeysPermissionsEnum) =>
   permission === ApiKeysPermissionsEnum.CustomerUsage ||
   permission === ApiKeysPermissionsEnum.SecurityLog
 
-const isDefaultUnchecked = (permission: ApiKeysPermissionsEnum) =>
-  permission === ApiKeysPermissionsEnum.Alert
-
 const DEFAULT_PERMISSIONS: Record<ApiKeysPermissionsEnum, string[]> = Object.values(
   ApiKeysPermissionsEnum,
 ).reduce(
   (acc, permission) => {
     let defaultValue: string[] = [READ_PERMISSION, WRITE_PERMISSION] // Default: both read and write
 
-    if (isDefaultUnchecked(permission)) {
-      defaultValue = [] // Keep empty array to have the permission uncheked on creation
-    } else if (canOnlyRead(permission)) {
+    if (canOnlyRead(permission)) {
       defaultValue = [READ_PERMISSION] // Read-only permissions
     }
 

--- a/src/pages/developers/__tests__/ApiKeysForm.test.tsx
+++ b/src/pages/developers/__tests__/ApiKeysForm.test.tsx
@@ -398,14 +398,28 @@ describe('ApiKeysForm', () => {
 
         expect(readHeaderCheckbox).toBeDefined()
 
-        // Default state: Alert permission has canRead=false, so not all are true (indeterminate)
-        // First click: sets all to true (since not all are currently true)
+        // Default state: all permissions have canRead=true, so header checkbox is checked
+        // First click: sets all to false (since all are currently true)
         await user.click(readHeaderCheckbox)
 
         await waitFor(() => {
           const rows = table.querySelectorAll('tbody tr')
 
-          // All rows should now have read checked (including Alert which was unchecked)
+          rows.forEach((row) => {
+            const rowReadCheckbox = row.querySelectorAll(
+              'input[type="checkbox"]',
+            )[0] as HTMLInputElement
+
+            expect(rowReadCheckbox.checked).toBe(false)
+          })
+        })
+
+        // Second click: now all are false, so sets all to true
+        await user.click(readHeaderCheckbox)
+
+        await waitFor(() => {
+          const rows = table.querySelectorAll('tbody tr')
+
           rows.forEach((row) => {
             const rowReadCheckbox = row.querySelectorAll(
               'input[type="checkbox"]',
@@ -413,18 +427,6 @@ describe('ApiKeysForm', () => {
 
             expect(rowReadCheckbox.checked).toBe(true)
           })
-        })
-
-        // Second click: now all are true, so sets all to false
-        await user.click(readHeaderCheckbox)
-
-        await waitFor(() => {
-          const rows = table.querySelectorAll('tbody tr')
-          const firstRowReadCheckbox = rows[0]?.querySelectorAll(
-            'input[type="checkbox"]',
-          )[0] as HTMLInputElement
-
-          expect(firstRowReadCheckbox.checked).toBe(false)
         })
       })
     })


### PR DESCRIPTION
## Context

When users land on Api Key form migration "Alerts"  was unchecked by default. We are now changing this behavior to have it consistent among other keys which are selected by default