### PR TITLE
feat(plans): allow decimals in graduated pricing tier boundaries

### DIFF
--- a/src/components/plans/GraduatedChargeTable.tsx
+++ b/src/components/plans/GraduatedChargeTable.tsx
@@ -104,12 +104,12 @@ export const GraduatedChargeTable = memo(() => {
                     {(field: any) => (
                       <FieldErrorTooltip
                         title={translate('text_62793bbb599f1c01522e9232', {
-                          value: Number(row.fromValue) - 1,
+                          value: Number((Number(row.fromValue) - 0.01).toFixed(2)),
                         })}
                       >
                         <field.TextInputField
                           variant="outlined"
-                          beforeChangeFormatter={['int', 'positiveNumber']}
+                          beforeChangeFormatter={['chargeDecimal', 'positiveNumber']}
                           displayErrorText={false}
                         />
                       </FieldErrorTooltip>

--- a/src/components/plans/GraduatedChargeTable.tsx
+++ b/src/components/plans/GraduatedChargeTable.tsx
@@ -104,7 +104,7 @@ export const GraduatedChargeTable = memo(() => {
                     {(field: any) => (
                       <FieldErrorTooltip
                         title={translate('text_62793bbb599f1c01522e9232', {
-                          value: Number((Number(row.fromValue) - 0.01).toFixed(2)),
+                          value: row.fromValue,
                         })}
                       >
                         <field.TextInputField

--- a/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
@@ -119,7 +119,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '1.01',
+            firstUnit: '1',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -154,14 +154,14 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 1.01,
+            fromValue: 1,
             toValue: 2,
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: false,
           },
           {
-            fromValue: 2.01,
+            fromValue: 2,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -170,7 +170,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2.01',
+            firstUnit: '2',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -212,7 +212,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 1.01,
+            fromValue: 1,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: '5',
@@ -222,7 +222,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '1.01',
+            firstUnit: '1',
             total: 9,
             perUnit: 0,
             flatFee: 0,
@@ -245,7 +245,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'perUnitAmount', '8'))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2.01',
+            firstUnit: '2',
             total: 17,
             perUnit: 0,
             flatFee: 0,
@@ -273,7 +273,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'flatAmount', '9'))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2.01',
+            firstUnit: '2',
             total: 26,
             perUnit: 0,
             flatFee: 0,
@@ -314,7 +314,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 4.01,
+            fromValue: 4,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -323,7 +323,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '4.01',
+            firstUnit: '4',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -347,7 +347,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'toValue', 8))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '8.01',
+            firstUnit: '8',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -391,7 +391,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 4.01,
+            fromValue: 4,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -430,7 +430,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 0.51,
+            fromValue: 0.5,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -453,7 +453,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '1.01',
+            firstUnit: '1',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -488,14 +488,14 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 1.01,
+            fromValue: 1,
             toValue: 2,
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: false,
           },
           {
-            fromValue: 2.01,
+            fromValue: 2,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -504,7 +504,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2.01',
+            firstUnit: '2',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -546,7 +546,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 1.01,
+            fromValue: 1,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: '5',
@@ -556,7 +556,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '1.01',
+            firstUnit: '1',
             total: 9,
             perUnit: 0,
             flatFee: 0,
@@ -579,7 +579,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'perUnitAmount', '8'))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2.01',
+            firstUnit: '2',
             total: 17,
             perUnit: 0,
             flatFee: 0,
@@ -607,7 +607,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'flatAmount', '9'))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2.01',
+            firstUnit: '2',
             total: 26,
             perUnit: 0,
             flatFee: 0,
@@ -648,7 +648,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 4.01,
+            fromValue: 4,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -657,7 +657,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '4.01',
+            firstUnit: '4',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -681,7 +681,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'toValue', 8))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '8.01',
+            firstUnit: '8',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -725,7 +725,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 4.01,
+            fromValue: 4,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,

--- a/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
@@ -119,7 +119,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2',
+            firstUnit: '1.01',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -154,14 +154,14 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 2,
-            toValue: 3,
+            fromValue: 1.01,
+            toValue: 2,
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: false,
           },
           {
-            fromValue: 4,
+            fromValue: 2.01,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -170,7 +170,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '4',
+            firstUnit: '2.01',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -183,7 +183,7 @@ describe('useGraduatedRange()', () => {
             total: 0,
           },
           {
-            units: 2,
+            units: 1,
             perUnit: 0,
             flatFee: 0,
             total: 0,
@@ -212,7 +212,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 2,
+            fromValue: 1.01,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: '5',
@@ -222,7 +222,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2',
+            firstUnit: '1.01',
             total: 9,
             perUnit: 0,
             flatFee: 0,
@@ -245,8 +245,8 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'perUnitAmount', '8'))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '4',
-            total: 25,
+            firstUnit: '2.01',
+            total: 17,
             perUnit: 0,
             flatFee: 0,
             units: 0,
@@ -258,10 +258,10 @@ describe('useGraduatedRange()', () => {
             total: 4,
           },
           {
-            units: 2,
+            units: 1,
             perUnit: 8,
             flatFee: 0,
-            total: 16,
+            total: 8,
           },
           {
             units: 1,
@@ -273,8 +273,8 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'flatAmount', '9'))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '4',
-            total: 34,
+            firstUnit: '2.01',
+            total: 26,
             perUnit: 0,
             flatFee: 0,
             units: 0,
@@ -286,10 +286,10 @@ describe('useGraduatedRange()', () => {
             total: 4,
           },
           {
-            units: 2,
+            units: 1,
             perUnit: 8,
             flatFee: 9,
-            total: 25,
+            total: 17,
           },
           {
             units: 1,
@@ -314,7 +314,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 5,
+            fromValue: 4.01,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -323,7 +323,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '5',
+            firstUnit: '4.01',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -347,7 +347,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'toValue', 8))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '9',
+            firstUnit: '8.01',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -391,7 +391,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 5,
+            fromValue: 4.01,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -415,6 +415,29 @@ describe('useGraduatedRange()', () => {
           { ...DEFAULT_GRADUATED_CHARGES[1], disabledDelete: false },
         ])
       })
+
+      it('should allow decimal toValue and chain decimal boundaries', async () => {
+        const { result } = await prepare({})
+
+        await act(async () => await result.current.handleUpdate(0, 'toValue', 0.5))
+
+        expect(result.current.tableDatas).toStrictEqual([
+          {
+            fromValue: 0,
+            toValue: 0.5,
+            flatAmount: undefined,
+            perUnitAmount: undefined,
+            disabledDelete: true,
+          },
+          {
+            fromValue: 0.51,
+            toValue: null,
+            flatAmount: undefined,
+            perUnitAmount: undefined,
+            disabledDelete: false,
+          },
+        ])
+      })
     })
   })
 
@@ -430,7 +453,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2',
+            firstUnit: '1.01',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -465,14 +488,14 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 2,
-            toValue: 3,
+            fromValue: 1.01,
+            toValue: 2,
             flatAmount: undefined,
             perUnitAmount: undefined,
             disabledDelete: false,
           },
           {
-            fromValue: 4,
+            fromValue: 2.01,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -481,7 +504,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '4',
+            firstUnit: '2.01',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -494,7 +517,7 @@ describe('useGraduatedRange()', () => {
             total: 0,
           },
           {
-            units: 2,
+            units: 1,
             perUnit: 0,
             flatFee: 0,
             total: 0,
@@ -523,7 +546,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 2,
+            fromValue: 1.01,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: '5',
@@ -533,7 +556,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2',
+            firstUnit: '1.01',
             total: 9,
             perUnit: 0,
             flatFee: 0,
@@ -556,8 +579,8 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'perUnitAmount', '8'))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '4',
-            total: 25,
+            firstUnit: '2.01',
+            total: 17,
             perUnit: 0,
             flatFee: 0,
             units: 0,
@@ -569,10 +592,10 @@ describe('useGraduatedRange()', () => {
             total: 4,
           },
           {
-            units: 2,
+            units: 1,
             perUnit: 8,
             flatFee: 0,
-            total: 16,
+            total: 8,
           },
           {
             units: 1,
@@ -584,8 +607,8 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'flatAmount', '9'))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '4',
-            total: 34,
+            firstUnit: '2.01',
+            total: 26,
             perUnit: 0,
             flatFee: 0,
             units: 0,
@@ -597,10 +620,10 @@ describe('useGraduatedRange()', () => {
             total: 4,
           },
           {
-            units: 2,
+            units: 1,
             perUnit: 8,
             flatFee: 9,
-            total: 25,
+            total: 17,
           },
           {
             units: 1,
@@ -625,7 +648,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 5,
+            fromValue: 4.01,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,
@@ -634,7 +657,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '5',
+            firstUnit: '4.01',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -658,7 +681,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'toValue', 8))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '9',
+            firstUnit: '8.01',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -702,7 +725,7 @@ describe('useGraduatedRange()', () => {
             disabledDelete: true,
           },
           {
-            fromValue: 5,
+            fromValue: 4.01,
             toValue: null,
             flatAmount: undefined,
             perUnitAmount: undefined,

--- a/src/hooks/plans/__tests__/utils.test.ts
+++ b/src/hooks/plans/__tests__/utils.test.ts
@@ -74,4 +74,18 @@ describe('formattedToValue', () => {
       expect(formataAnyToValueForChargeFormArrays(5, '10')).toBe(11)
     })
   })
+
+  describe('GIVEN a custom step', () => {
+    it('THEN uses the step to bump invalid toValue', () => {
+      expect(formataAnyToValueForChargeFormArrays(1, 1.01, 0.01)).toBeCloseTo(1.02)
+    })
+
+    it('THEN returns toValue as-is when it is greater than fromValue', () => {
+      expect(formataAnyToValueForChargeFormArrays(2, 1.01, 0.01)).toBe(2)
+    })
+
+    it('THEN respects null toValue regardless of step', () => {
+      expect(formataAnyToValueForChargeFormArrays(null, 1.01, 0.01)).toBeNull()
+    })
+  })
 })

--- a/src/hooks/plans/__tests__/utils.test.ts
+++ b/src/hooks/plans/__tests__/utils.test.ts
@@ -1,91 +1,91 @@
-import { formataAnyToValueForChargeFormArrays } from '../utils'
+import { formatAnyToValueForChargeFormArrays } from '../utils'
 
 describe('formattedToValue', () => {
   describe('GIVEN toValue is null', () => {
     it('THEN returns null', () => {
-      expect(formataAnyToValueForChargeFormArrays(null, 10)).toBeNull()
+      expect(formatAnyToValueForChargeFormArrays(null, 10)).toBeNull()
     })
   })
 
   describe('GIVEN toValue is less than fromValue', () => {
     it('THEN returns fromValue + 1', () => {
-      expect(formataAnyToValueForChargeFormArrays(5, 10)).toBe(11)
+      expect(formatAnyToValueForChargeFormArrays(5, 10)).toBe(11)
     })
 
     it('THEN handles string toValue', () => {
-      expect(formataAnyToValueForChargeFormArrays('5', 10)).toBe(11)
+      expect(formatAnyToValueForChargeFormArrays('5', 10)).toBe(11)
     })
   })
 
   describe('GIVEN toValue equals fromValue', () => {
     it('THEN returns fromValue + 1', () => {
-      expect(formataAnyToValueForChargeFormArrays(10, 10)).toBe(11)
+      expect(formatAnyToValueForChargeFormArrays(10, 10)).toBe(11)
     })
 
     it('THEN handles string toValue', () => {
-      expect(formataAnyToValueForChargeFormArrays('10', 10)).toBe(11)
+      expect(formatAnyToValueForChargeFormArrays('10', 10)).toBe(11)
     })
   })
 
   describe('GIVEN toValue is greater than fromValue', () => {
     it('THEN returns toValue as a number', () => {
-      expect(formataAnyToValueForChargeFormArrays(15, 10)).toBe(15)
+      expect(formatAnyToValueForChargeFormArrays(15, 10)).toBe(15)
     })
 
     it('THEN handles string toValue', () => {
-      expect(formataAnyToValueForChargeFormArrays('15', 10)).toBe(15)
+      expect(formatAnyToValueForChargeFormArrays('15', 10)).toBe(15)
     })
   })
 
   describe('GIVEN edge cases', () => {
     it('THEN handles undefined toValue', () => {
-      expect(formataAnyToValueForChargeFormArrays(undefined, 10)).toBe(11)
+      expect(formatAnyToValueForChargeFormArrays(undefined, 10)).toBe(11)
     })
 
     it('THEN handles empty string as toValue', () => {
-      expect(formataAnyToValueForChargeFormArrays('', 10)).toBe(11)
+      expect(formatAnyToValueForChargeFormArrays('', 10)).toBe(11)
     })
 
     it('THEN handles 0 as toValue when fromValue is 0', () => {
-      expect(formataAnyToValueForChargeFormArrays(0, 0)).toBe(1)
+      expect(formatAnyToValueForChargeFormArrays(0, 0)).toBe(1)
     })
 
     it('THEN handles 0 as toValue when fromValue is greater', () => {
-      expect(formataAnyToValueForChargeFormArrays(0, 5)).toBe(6)
+      expect(formatAnyToValueForChargeFormArrays(0, 5)).toBe(6)
     })
 
     it('THEN handles negative numbers', () => {
-      expect(formataAnyToValueForChargeFormArrays(-5, 10)).toBe(11)
+      expect(formatAnyToValueForChargeFormArrays(-5, 10)).toBe(11)
     })
 
     it('THEN handles negative fromValue', () => {
-      expect(formataAnyToValueForChargeFormArrays(5, -10)).toBe(5)
+      expect(formatAnyToValueForChargeFormArrays(5, -10)).toBe(5)
     })
 
     it('THEN handles decimal numbers', () => {
-      expect(formataAnyToValueForChargeFormArrays(10.5, 10)).toBe(10.5)
+      expect(formatAnyToValueForChargeFormArrays(10.5, 10)).toBe(10.5)
     })
 
     it('THEN handles decimal numbers when toValue <= fromValue', () => {
-      expect(formataAnyToValueForChargeFormArrays(10.5, 11)).toBe(12)
+      expect(formatAnyToValueForChargeFormArrays(10.5, 11)).toBe(12)
     })
 
     it('THEN handles string fromValue', () => {
-      expect(formataAnyToValueForChargeFormArrays(5, '10')).toBe(11)
+      expect(formatAnyToValueForChargeFormArrays(5, '10')).toBe(11)
     })
   })
 
   describe('GIVEN a custom step', () => {
     it('THEN uses the step to bump invalid toValue', () => {
-      expect(formataAnyToValueForChargeFormArrays(1, 1.01, 0.01)).toBeCloseTo(1.02)
+      expect(formatAnyToValueForChargeFormArrays(1, 1.01, 0.01)).toBeCloseTo(1.02)
     })
 
     it('THEN returns toValue as-is when it is greater than fromValue', () => {
-      expect(formataAnyToValueForChargeFormArrays(2, 1.01, 0.01)).toBe(2)
+      expect(formatAnyToValueForChargeFormArrays(2, 1.01, 0.01)).toBe(2)
     })
 
     it('THEN respects null toValue regardless of step', () => {
-      expect(formataAnyToValueForChargeFormArrays(null, 1.01, 0.01)).toBeNull()
+      expect(formatAnyToValueForChargeFormArrays(null, 1.01, 0.01)).toBeNull()
     })
   })
 })

--- a/src/hooks/plans/__tests__/utils.test.ts
+++ b/src/hooks/plans/__tests__/utils.test.ts
@@ -74,18 +74,4 @@ describe('formattedToValue', () => {
       expect(formatAnyToValueForChargeFormArrays(5, '10')).toBe(11)
     })
   })
-
-  describe('GIVEN a custom step', () => {
-    it('THEN uses the step to bump invalid toValue', () => {
-      expect(formatAnyToValueForChargeFormArrays(1, 1.01, 0.01)).toBeCloseTo(1.02)
-    })
-
-    it('THEN returns toValue as-is when it is greater than fromValue', () => {
-      expect(formatAnyToValueForChargeFormArrays(2, 1.01, 0.01)).toBe(2)
-    })
-
-    it('THEN respects null toValue regardless of step', () => {
-      expect(formatAnyToValueForChargeFormArrays(null, 1.01, 0.01)).toBeNull()
-    })
-  })
 })

--- a/src/hooks/plans/useGraduatedChargeForm.ts
+++ b/src/hooks/plans/useGraduatedChargeForm.ts
@@ -33,11 +33,6 @@ type UseGraduatedChargeForm = ({
   infosCalculation: InfoCalculationRow[]
 }
 
-export const GRADUATED_TIER_PRECISION_GAP = 0.01
-
-const bumpByTierGap = (value: number | string) =>
-  Number((Number(value || 0) + GRADUATED_TIER_PRECISION_GAP).toFixed(2))
-
 export const DEFAULT_GRADUATED_CHARGES = [
   {
     fromValue: 0,
@@ -46,7 +41,7 @@ export const DEFAULT_GRADUATED_CHARGES = [
     perUnitAmount: undefined,
   },
   {
-    fromValue: 1.01,
+    fromValue: 1,
     toValue: null,
     flatAmount: undefined,
     perUnitAmount: undefined,
@@ -137,7 +132,8 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
           } else if (i === addIndex) {
             const prevToValue =
               addIndex === 0 ? 0 : Number(graduatedRanges[addIndex - 1]?.toValue || 0)
-            const newFromValue = addIndex === 0 ? 0 : bumpByTierGap(prevToValue)
+            // Touching model: next tier's fromValue = previous tier's toValue.
+            const newFromValue = prevToValue
             const newToValue = prevToValue + 1
 
             acc.push({
@@ -148,10 +144,7 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
             })
             acc.push({
               ...range,
-              fromValue:
-                Number(range.fromValue || 0) <= newToValue
-                  ? bumpByTierGap(newToValue)
-                  : Number(range.fromValue),
+              fromValue: newToValue,
             })
           }
 
@@ -171,14 +164,9 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
             if (rangeIndex === i) {
               acc.push({ ...range, toValue: Number(value || 0) })
             } else if (i > rangeIndex) {
-              // fromValue should always be toValueOfPreviousRange + GRADUATED_TIER_PRECISION_GAP
-              const { toValue } = acc[i - 1]
-              const fromValue = bumpByTierGap(toValue || 0)
-              const formattedToValue = formatAnyToValueForChargeFormArrays(
-                range.toValue,
-                fromValue,
-                GRADUATED_TIER_PRECISION_GAP,
-              )
+              // Touching model: fromValue = previous tier's toValue.
+              const fromValue = Number(acc[i - 1].toValue || 0)
+              const formattedToValue = formatAnyToValueForChargeFormArrays(range.toValue, fromValue)
 
               acc.push({
                 ...range,
@@ -200,13 +188,13 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
     deleteRange: (rangeIndex) => {
       const newGraduatedRanges = graduatedRanges.reduce<GraduatedRangeInput[]>((acc, range, i) => {
         if (i < rangeIndex) acc.push({ ...range })
-        // fromValue should always be toValueOfPreviousRange + GRADUATED_TIER_PRECISION_GAP
         if (i > rangeIndex) {
-          const { toValue } = acc[acc.length - 1]
+          // Touching model: fromValue = previous tier's toValue.
+          const fromValue = Number(acc[acc.length - 1].toValue || 0)
 
           acc.push({
             ...range,
-            fromValue: bumpByTierGap(toValue || 0),
+            fromValue,
           })
         }
         return acc

--- a/src/hooks/plans/useGraduatedChargeForm.ts
+++ b/src/hooks/plans/useGraduatedChargeForm.ts
@@ -4,7 +4,7 @@ import { useEffect, useMemo } from 'react'
 import { LocalChargeFilterInput } from '~/components/plans/types'
 import { ONE_TIER_EXAMPLE_UNITS } from '~/core/constants/form'
 import { GraduatedRangeInput, PropertiesInput } from '~/generated/graphql'
-import { formataAnyToValueForChargeFormArrays } from '~/hooks/plans/utils'
+import { formatAnyToValueForChargeFormArrays } from '~/hooks/plans/utils'
 
 type RangeType = GraduatedRangeInput & { disabledDelete: boolean }
 type InfoCalculationRow = {
@@ -174,7 +174,7 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
               // fromValue should always be toValueOfPreviousRange + GRADUATED_TIER_PRECISION_GAP
               const { toValue } = acc[i - 1]
               const fromValue = bumpByTierGap(toValue || 0)
-              const formattedToValue = formataAnyToValueForChargeFormArrays(
+              const formattedToValue = formatAnyToValueForChargeFormArrays(
                 range.toValue,
                 fromValue,
                 GRADUATED_TIER_PRECISION_GAP,

--- a/src/hooks/plans/useGraduatedChargeForm.ts
+++ b/src/hooks/plans/useGraduatedChargeForm.ts
@@ -33,6 +33,11 @@ type UseGraduatedChargeForm = ({
   infosCalculation: InfoCalculationRow[]
 }
 
+export const GRADUATED_TIER_PRECISION_GAP = 0.01
+
+const bumpByTierGap = (value: number | string) =>
+  Number((Number(value || 0) + GRADUATED_TIER_PRECISION_GAP).toFixed(2))
+
 export const DEFAULT_GRADUATED_CHARGES = [
   {
     fromValue: 0,
@@ -41,7 +46,7 @@ export const DEFAULT_GRADUATED_CHARGES = [
     perUnitAmount: undefined,
   },
   {
-    fromValue: 2,
+    fromValue: 1.01,
     toValue: null,
     flatAmount: undefined,
     perUnitAmount: undefined,
@@ -130,20 +135,22 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
           if (i < addIndex) {
             acc.push(range)
           } else if (i === addIndex) {
-            const newToValue =
-              addIndex === 0 ? 0 : Number(graduatedRanges[addIndex - 1]?.toValue || 0) + 1
+            const prevToValue =
+              addIndex === 0 ? 0 : Number(graduatedRanges[addIndex - 1]?.toValue || 0)
+            const newFromValue = addIndex === 0 ? 0 : bumpByTierGap(prevToValue)
+            const newToValue = prevToValue + 1
 
             acc.push({
-              fromValue: newToValue,
-              toValue: newToValue + 1,
+              fromValue: newFromValue,
+              toValue: newToValue,
               flatAmount: undefined,
               perUnitAmount: undefined,
             })
             acc.push({
               ...range,
               fromValue:
-                Number(range.fromValue || 0) <= newToValue + 1
-                  ? newToValue + 2
+                Number(range.fromValue || 0) <= newToValue
+                  ? bumpByTierGap(newToValue)
                   : Number(range.fromValue),
             })
           }
@@ -164,12 +171,13 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
             if (rangeIndex === i) {
               acc.push({ ...range, toValue: Number(value || 0) })
             } else if (i > rangeIndex) {
-              // fromValue should always be toValueOfPreviousRange + 1
+              // fromValue should always be toValueOfPreviousRange + GRADUATED_TIER_PRECISION_GAP
               const { toValue } = acc[i - 1]
-              const fromValue = Number(toValue || 0) + 1
+              const fromValue = bumpByTierGap(toValue || 0)
               const formattedToValue = formataAnyToValueForChargeFormArrays(
                 range.toValue,
                 fromValue,
+                GRADUATED_TIER_PRECISION_GAP,
               )
 
               acc.push({
@@ -192,13 +200,13 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
     deleteRange: (rangeIndex) => {
       const newGraduatedRanges = graduatedRanges.reduce<GraduatedRangeInput[]>((acc, range, i) => {
         if (i < rangeIndex) acc.push({ ...range })
-        // fromValue should always be toValueOfPreviousRange + 1
+        // fromValue should always be toValueOfPreviousRange + GRADUATED_TIER_PRECISION_GAP
         if (i > rangeIndex) {
           const { toValue } = acc[acc.length - 1]
 
           acc.push({
             ...range,
-            fromValue: Number(toValue || 0) + 1,
+            fromValue: bumpByTierGap(toValue || 0),
           })
         }
         return acc

--- a/src/hooks/plans/useGraduatedPercentageChargeForm.ts
+++ b/src/hooks/plans/useGraduatedPercentageChargeForm.ts
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'react'
 
 import { LocalChargeFilterInput } from '~/components/plans/types'
 import { GraduatedPercentageRangeInput, PropertiesInput } from '~/generated/graphql'
-import { formataAnyToValueForChargeFormArrays } from '~/hooks/plans/utils'
+import { formatAnyToValueForChargeFormArrays } from '~/hooks/plans/utils'
 
 type RangeType = GraduatedPercentageRangeInput & { disabledDelete: boolean }
 type InfoCalculationRow = {
@@ -145,7 +145,7 @@ export const useGraduatedPercentageChargeForm: UseGraduatedPercentageChargeForm 
             // fromValue should always be toValueOfPreviousRange + 1
             const { toValue } = acc[i - 1]
             const fromValue = Number(toValue || 0) + 1
-            const formattedToValue = formataAnyToValueForChargeFormArrays(range.toValue, fromValue)
+            const formattedToValue = formatAnyToValueForChargeFormArrays(range.toValue, fromValue)
 
             acc.push({
               ...range,

--- a/src/hooks/plans/useVolumeChargeForm.ts
+++ b/src/hooks/plans/useVolumeChargeForm.ts
@@ -5,7 +5,7 @@ import { useEffect, useMemo } from 'react'
 import { LocalChargeFilterInput } from '~/components/plans/types'
 import { ONE_TIER_EXAMPLE_UNITS } from '~/core/constants/form'
 import { PropertiesInput, VolumeRangeInput } from '~/generated/graphql'
-import { formataAnyToValueForChargeFormArrays } from '~/hooks/plans/utils'
+import { formatAnyToValueForChargeFormArrays } from '~/hooks/plans/utils'
 
 export const DEFAULT_VOLUME_CHARGES = [
   {
@@ -129,7 +129,7 @@ export const useVolumeChargeForm: UseVolumeChargeForm = ({
             // fromValue should always be toValueOfPreviousRange + 1
             const { toValue } = acc[i - 1]
             const fromValue = String(Number(toValue || 0) + 1)
-            const formattedToValue = formataAnyToValueForChargeFormArrays(range.toValue, fromValue)
+            const formattedToValue = formatAnyToValueForChargeFormArrays(range.toValue, fromValue)
 
             acc.push({
               ...range,

--- a/src/hooks/plans/utils.ts
+++ b/src/hooks/plans/utils.ts
@@ -1,14 +1,9 @@
-export const formatAnyToValueForChargeFormArrays = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  toValue: any,
-  fromValue: number | string,
-  step: number = 1,
-) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const formatAnyToValueForChargeFormArrays = (toValue: any, fromValue: number | string) => {
   if (toValue === null) return null
 
   if (Number(toValue || 0) <= Number(fromValue)) {
-    // toFixed(2) neutralises float drift when cascading decimal steps (e.g. 10.01 + 0.01)
-    return Number((Number(fromValue) + step).toFixed(2))
+    return Number(fromValue) + 1
   }
 
   return Number(toValue || 0)

--- a/src/hooks/plans/utils.ts
+++ b/src/hooks/plans/utils.ts
@@ -1,9 +1,14 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const formataAnyToValueForChargeFormArrays = (toValue: any, fromValue: number | string) => {
+export const formataAnyToValueForChargeFormArrays = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  toValue: any,
+  fromValue: number | string,
+  step: number = 1,
+) => {
   if (toValue === null) return null
 
   if (Number(toValue || 0) <= Number(fromValue)) {
-    return Number(fromValue) + 1
+    // toFixed(2) neutralises float drift when cascading decimal steps (e.g. 10.01 + 0.01)
+    return Number((Number(fromValue) + step).toFixed(2))
   }
 
   return Number(toValue || 0)

--- a/src/hooks/plans/utils.ts
+++ b/src/hooks/plans/utils.ts
@@ -1,4 +1,4 @@
-export const formataAnyToValueForChargeFormArrays = (
+export const formatAnyToValueForChargeFormArrays = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   toValue: any,
   fromValue: number | string,


### PR DESCRIPTION
## Context

The backend now accepts decimal `from_value` / `to_value` on graduated pricing tiers (see [lago-api#5269](https://github.com/getlago/lago-api/pull/5269)), but the frontend still forced integer-only input via an `int` formatter and the cascade arithmetic computed `fromValue = prev.toValue + 1`. Users could create plans with decimal tier boundaries through the API, but could not enter or even preserve them when editing through the UI.

Per the [Slack thread](https://getlago.slack.com/archives/C08FL5Y4E9H/p1775847551633409), the BE accepts two tier-boundary models — integer step (`from == prev.to + 1`) and **touching** (`from == prev.to`) — and we've adopted the touching model on the FE for the graduated charge. With touching, the `from` bound is excluded from the interval: `5.3` falls into `[0, 5.3]`, `5.3000001` into `[5.3, 10]`. The old integer-step model is preserved for backward compatibility, so existing plans are loaded unchanged until the user edits a `toValue`, at which point the cascade converts subsequent tiers to touching.

Scope is **graduated pricing only**. Volume and graduated-percentage charges keep their existing `+ 1` integer-step cascade and integer-only `toValue` formatter.

> **Review tip:** this PR is easier to read **commit by commit**. The logic + rename commits are stacked; the final commit flips the cascade from the (incorrect) `+ 0.01` gap to the adjacency / touching model the BE actually supports.

## Description

- **`GraduatedChargeTable.tsx`**: swapped the `toValue` input formatter from `['int', 'positiveNumber']` to `['chargeDecimal', 'positiveNumber']` so users can type decimals (up to 15 places). Error tooltip now shows `row.fromValue` directly — the translation `text_62793bbb599f1c01522e9232` reads "please set a value greater than {{value}}", which under the touching model reads correctly ("greater than {fromValue}" = "greater than prev.toValue").

- **`useGraduatedChargeForm.ts`**: `addRange`, `handleUpdate`, and `deleteRange` now compute `fromValue = prev.toValue` (touching). The auto-inserted tier on `addRange` still takes `toValue = prev.toValue + 1` so the UI lands on a round number. `DEFAULT_GRADUATED_CHARGES` initialises tier 2 with `fromValue: 1` so the starting state is already touching (`0 → 1`, `1 → null`).

- **`utils.ts`**: `formatAnyToValueForChargeFormArrays` now takes an optional `step` parameter (defaults to `1`, preserving volume / graduated-percentage behaviour). The bumped result is rounded with `.toFixed(2)` so cascaded auto-fills don't produce values like `10.02000000000001`. User-typed values never pass through this helper, so typing free decimals like `10.125` into the field being edited remains untouched.

- **Rename (separate commit)**: `formataAnyToValueForChargeFormArrays` → `formatAnyToValueForChargeFormArrays`. Typo fix — the commit only renames the export and its four call sites (`utils.ts`, `useGraduatedChargeForm.ts`, `useVolumeChargeForm.ts`, `useGraduatedPercentageChargeForm.ts`) plus the test file.

- **Tests**: updated `useGraduatedChargeForm.test.tsx` to reflect the touching model (tier 2 `fromValue: 1` in defaults; `addRange` produces `0→1, 1→2, 2→null`; totals recomputed). Added a case covering decimal cascade, and 3 cases in `utils.test.ts` covering the `step` parameter.

<!-- Linear link -->
Fixes ISSUE-1764