### PR TITLE
feat(quotes): hide behind feature flag

### DIFF
--- a/src/core/router/QuotesRoutes.tsx
+++ b/src/core/router/QuotesRoutes.tsx
@@ -1,3 +1,5 @@
+import { FeatureFlagEnum } from '~/generated/graphql'
+
 import { CustomRouteObject } from './types'
 import { lazyLoad } from './utils'
 
@@ -18,12 +20,14 @@ export const quotesRoutes: CustomRouteObject[] = [
     private: true,
     element: <Quotes />,
     permissions: ['quotesView'],
+    featureFlag: FeatureFlagEnum.OrderForms,
   },
   {
     path: QUOTE_DETAILS_ROUTE,
     private: true,
     element: <QuoteDetails />,
     permissions: ['quotesView'],
+    featureFlag: FeatureFlagEnum.OrderForms,
   },
 ]
 
@@ -33,5 +37,6 @@ export const quotesCreationRoutes: CustomRouteObject[] = [
     private: true,
     element: <CreateQuote />,
     permissions: ['quotesCreate'],
+    featureFlag: FeatureFlagEnum.OrderForms,
   },
 ]

--- a/src/core/router/types.ts
+++ b/src/core/router/types.ts
@@ -1,5 +1,6 @@
 import type { RouteObject } from 'react-router-dom'
 
+import { FeatureFlagEnum } from '~/generated/graphql'
 import { TMembershipPermissions } from '~/hooks/usePermissions'
 
 export interface CustomRouteObject extends Omit<RouteObject, 'children' | 'path'> {
@@ -11,4 +12,5 @@ export interface CustomRouteObject extends Omit<RouteObject, 'children' | 'path'
   children?: CustomRouteObject[]
   permissions?: Array<keyof TMembershipPermissions> // AND logic (all must be true)
   permissionsOr?: Array<keyof TMembershipPermissions> // OR logic (at least one must be true)
+  featureFlag?: FeatureFlagEnum
 }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3843,6 +3843,7 @@ export enum FeatureFlagEnum {
   MultiCurrency = 'multi_currency',
   MultiplePaymentMethods = 'multiple_payment_methods',
   NonPersistableChargeCacheOptimization = 'non_persistable_charge_cache_optimization',
+  OrderForms = 'order_forms',
   PostgresEnrichedEvents = 'postgres_enriched_events',
   WalletTraceability = 'wallet_traceability'
 }

--- a/src/hooks/core/__tests__/useLocationHistory.test.ts
+++ b/src/hooks/core/__tests__/useLocationHistory.test.ts
@@ -2,12 +2,14 @@ import { act, renderHook } from '@testing-library/react'
 import type { Location } from 'react-router-dom'
 
 import { authTokenVar, locationHistoryVar } from '~/core/apolloClient'
+import { FeatureFlagEnum } from '~/generated/graphql'
 import { useLocationHistory } from '~/hooks/core/useLocationHistory'
 
 const mockNavigate = jest.fn()
 const mockGetItemFromLS = jest.fn()
 const mockHasPermissions = jest.fn()
 const mockHasPermissionsOr = jest.fn()
+const mockHasFeatureFlag = jest.fn()
 
 const FALLBACK_URL = '/fallback'
 const MOCK_HISTORY_VAR = [
@@ -56,6 +58,12 @@ jest.mock('~/hooks/usePermissions', () => ({
   }),
 }))
 
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  useOrganizationInfos: () => ({
+    hasFeatureFlag: mockHasFeatureFlag,
+  }),
+}))
+
 jest.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({
     isPremium: true,
@@ -79,11 +87,13 @@ describe('useLocationHistory()', () => {
     mockGetItemFromLS.mockClear()
     mockHasPermissions.mockClear()
     mockHasPermissionsOr.mockClear()
+    mockHasFeatureFlag.mockClear()
     authTokenVar(undefined)
 
     // Default to true for backwards compatibility with existing tests
     mockHasPermissions.mockReturnValue(true)
     mockHasPermissionsOr.mockReturnValue(true)
+    mockHasFeatureFlag.mockReturnValue(true)
   })
 
   describe('onRouteEnter()', () => {
@@ -515,6 +525,90 @@ describe('useLocationHistory()', () => {
 
         expect(mockHasPermissions).not.toHaveBeenCalled()
         expect(mockHasPermissionsOr).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('feature flag gating', () => {
+      beforeEach(() => {
+        authTokenVar('test-token')
+      })
+
+      it('should redirect to home when feature flag is not active', () => {
+        mockHasFeatureFlag.mockReturnValue(false)
+
+        const { result } = renderHook(() => useLocationHistory())
+
+        act(() => {
+          result.current.onRouteEnter(
+            {
+              private: true,
+              permissions: ['quotesView'],
+              featureFlag: FeatureFlagEnum.OrderForms,
+            },
+            mockLocation,
+          )
+        })
+
+        expect(mockHasFeatureFlag).toHaveBeenCalledWith(FeatureFlagEnum.OrderForms)
+        expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+      })
+
+      it('should allow access when feature flag is active', () => {
+        mockHasFeatureFlag.mockReturnValue(true)
+
+        const { result } = renderHook(() => useLocationHistory())
+
+        act(() => {
+          result.current.onRouteEnter(
+            {
+              private: true,
+              permissions: ['quotesView'],
+              featureFlag: FeatureFlagEnum.OrderForms,
+            },
+            mockLocation,
+          )
+        })
+
+        expect(mockHasFeatureFlag).toHaveBeenCalledWith(FeatureFlagEnum.OrderForms)
+        expect(mockNavigate).not.toHaveBeenCalledWith('/', { replace: true })
+      })
+
+      it('should not check feature flag when no featureFlag field is specified', () => {
+        const { result } = renderHook(() => useLocationHistory())
+
+        act(() => {
+          result.current.onRouteEnter(
+            {
+              private: true,
+              permissions: ['customersView'],
+            },
+            mockLocation,
+          )
+        })
+
+        expect(mockHasFeatureFlag).not.toHaveBeenCalled()
+      })
+
+      it('should check permissions before feature flag', () => {
+        mockHasPermissions.mockReturnValue(false)
+        mockHasFeatureFlag.mockReturnValue(false)
+
+        const { result } = renderHook(() => useLocationHistory())
+
+        act(() => {
+          result.current.onRouteEnter(
+            {
+              private: true,
+              permissions: ['quotesView'],
+              featureFlag: FeatureFlagEnum.OrderForms,
+            },
+            mockLocation,
+          )
+        })
+
+        // Should redirect to forbidden (permission check), not home (feature flag check)
+        expect(mockNavigate).toHaveBeenCalledWith('/forbidden')
+        expect(mockNavigate).not.toHaveBeenCalledWith('/', { replace: true })
       })
     })
 

--- a/src/hooks/core/useLocationHistory.ts
+++ b/src/hooks/core/useLocationHistory.ts
@@ -9,6 +9,7 @@ import {
 import { ORGANIZATION_LS_KEY_ID } from '~/core/constants/localStorageKeys'
 import { CustomRouteObject, FORBIDDEN_ROUTE, HOME_ROUTE, LOGIN_ROUTE } from '~/core/router'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { TMembershipPermissions, usePermissions } from '~/hooks/usePermissions'
 
 type GoBack = (
@@ -84,6 +85,7 @@ export const useLocationHistory: UseLocationHistoryReturn = () => {
   const navigate = useNavigate()
   const { loading: isCurrentUserLoading } = useCurrentUser()
   const { hasPermissions, hasPermissionsOr } = usePermissions()
+  const { hasFeatureFlag } = useOrganizationInfos()
   const goBack: GoBack = (fallback, options) => {
     const { previous, remainingHistory } = getPreviousLocation(options || {})
 
@@ -132,6 +134,12 @@ export const useLocationHistory: UseLocationHistoryReturn = () => {
            * Redirect to forbidden page
            */
           navigate(FORBIDDEN_ROUTE)
+        } else if (routeConfig.featureFlag && !hasFeatureFlag(routeConfig.featureFlag)) {
+          /**
+           * In case of navigation to a route gated by a feature flag that is not active
+           * Redirect to home page
+           */
+          navigate(HOME_ROUTE, { replace: true })
         } else if (!routeConfig?.children && !routeConfig.onlyPublic) {
           /**
            * We add the current location to the history only if :

--- a/src/layouts/MainNavLayout/MainNavMenuSections.tsx
+++ b/src/layouts/MainNavLayout/MainNavMenuSections.tsx
@@ -32,7 +32,9 @@ import {
   SUBSCRIPTIONS_ROUTE,
   WALLET_DETAILS_ROUTE,
 } from '~/core/router'
+import { FeatureFlagEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { usePermissions } from '~/hooks/usePermissions'
 import { NavLayout } from '~/layouts/NavLayout'
 import { BadgeAI } from '~/pages/forecasts/Forecasts'
@@ -53,6 +55,7 @@ interface MainNavMenuSectionsProps {
 export const MainNavMenuSections = ({ isLoading, onItemClick }: MainNavMenuSectionsProps) => {
   const { translate } = useInternationalization()
   const { hasPermissions } = usePermissions()
+  const { hasFeatureFlag } = useOrganizationInfos()
 
   const getReportsTabs = (): NavTab[] => [
     {
@@ -135,7 +138,7 @@ export const MainNavMenuSections = ({ isLoading, onItemClick }: MainNavMenuSecti
       link: QUOTES_LIST_ROUTE,
       canBeClickedOnActive: true,
       match: [QUOTES_LIST_ROUTE, QUOTES_TAB_ROUTE, QUOTE_DETAILS_ROUTE],
-      hidden: !hasPermissions(['quotesView']),
+      hidden: !hasPermissions(['quotesView']) || !hasFeatureFlag(FeatureFlagEnum.OrderForms),
     },
     {
       title: translate('text_6250304370f0f700a8fdc28d'),

--- a/src/layouts/MainNavLayout/__tests__/MainNavLayout.test.tsx
+++ b/src/layouts/MainNavLayout/__tests__/MainNavLayout.test.tsx
@@ -108,6 +108,7 @@ describe('MainNavLayout', () => {
       organization: defaultOrganization,
       loading: false,
       refetchOrganizationInfos: mockRefetchOrganizationInfos,
+      hasFeatureFlag: jest.fn(() => false),
     })
 
     mockUseSideNavInfosQuery.mockReturnValue({
@@ -134,6 +135,7 @@ describe('MainNavLayout', () => {
         organization: undefined,
         loading: true,
         refetchOrganizationInfos: mockRefetchOrganizationInfos,
+        hasFeatureFlag: jest.fn(() => false),
       })
 
       render(<MainNavLayout />)

--- a/src/layouts/MainNavLayout/__tests__/MainNavMenuSections.test.tsx
+++ b/src/layouts/MainNavLayout/__tests__/MainNavMenuSections.test.tsx
@@ -11,10 +11,17 @@ import {
 } from '../MainNavMenuSections'
 
 const mockHasPermissions = jest.fn()
+const mockHasFeatureFlag = jest.fn()
 
 jest.mock('~/hooks/usePermissions', () => ({
   usePermissions: () => ({
     hasPermissions: mockHasPermissions,
+  }),
+}))
+
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  useOrganizationInfos: () => ({
+    hasFeatureFlag: mockHasFeatureFlag,
   }),
 }))
 
@@ -39,6 +46,7 @@ describe('MainNavMenuSections', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockHasPermissions.mockReturnValue(true)
+    mockHasFeatureFlag.mockReturnValue(true)
   })
 
   describe('Test ID constants', () => {
@@ -212,6 +220,31 @@ describe('MainNavMenuSections', () => {
       expect(mockHasPermissions).toHaveBeenCalledWith(['quotesView'])
       expect(mockHasPermissions).toHaveBeenCalledWith(['subscriptionsView'])
       expect(mockHasPermissions).toHaveBeenCalledWith(['invoicesView'])
+    })
+  })
+
+  describe('Feature flag gating', () => {
+    it('hides quotes nav item when order_forms feature flag is off', () => {
+      mockHasFeatureFlag.mockReturnValue(false)
+
+      // Allow all billing permissions except quotes will be hidden by feature flag
+      mockHasPermissions.mockImplementation((permissions: string[]) => {
+        const billingPermissions = [
+          'customersView',
+          'quotesView',
+          'subscriptionsView',
+          'invoicesView',
+          'paymentsView',
+          'creditNotesView',
+        ]
+
+        return billingPermissions.some((p) => permissions.includes(p))
+      })
+
+      render(<MainNavMenuSections {...defaultProps} />)
+
+      // Billing section should still render (other billing tabs are visible)
+      expect(screen.getByTestId(MAIN_NAV_BILLING_SECTION_TEST_ID)).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Context

We want to be able to merge on main more easily our quotes features without creating issues

## Description

This PR
- adds an optional featureFlag check on routes
- hide a nav button behind a feature flag
- updates the tests

<!-- Linear link -->
Fixes [LAGO-1423](https://linear.app/getlago/issue/LAGO-1423/quotes-hide-nav-and-page-access-behind-feature-flag)