### PR TITLE
perf(docker): move APP_VERSION below pnpm install to stop cache-busting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
 FROM node:24.14.1-alpine AS build
 
-ARG SENTRY_DSN
-ARG SENTRY_ORG
-ARG SENTRY_FRONT_PROJECT
-ARG SENTRY_AUTH_TOKEN
-ARG APP_VERSION
-
-ENV APP_VERSION=$APP_VERSION
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 WORKDIR /app
@@ -16,6 +9,16 @@ RUN apk add python3 build-base && corepack enable && corepack prepare pnpm@lates
 COPY package.json pnpm-lock.yaml pnpmfile.docker.cjs ./
 RUN pnpm install --pnpmfile=./pnpmfile.docker.cjs
 COPY . .
+
+# Build-time ARGs declared late so they don't invalidate the install layers above
+# when APP_VERSION (or any Sentry arg) changes between builds.
+ARG SENTRY_DSN
+ARG SENTRY_ORG
+ARG SENTRY_FRONT_PROJECT
+ARG SENTRY_AUTH_TOKEN
+ARG APP_VERSION
+ENV APP_VERSION=$APP_VERSION
+
 RUN pnpm install && pnpm build
 
 FROM nginx:1.28-alpine


### PR DESCRIPTION
## Summary

Single-file change to `Dockerfile`. Moves the `ARG APP_VERSION`/`ARG SENTRY_*` block and the `ENV APP_VERSION=$APP_VERSION` line from the top of the `build` stage to just before the final `RUN pnpm install && pnpm build`.

## Why

`APP_VERSION` is a different value on every release build (commit sha / release tag). When it lives at the top of the stage, `ENV APP_VERSION=$APP_VERSION` invalidates every layer below it — including `apk add`, `COPY package.json`, and the first `pnpm install`. The net effect: **`pnpm install` never gets cached across release builds**, even when no dependency actually changed.

Moving the block below `COPY . .` means only the final `pnpm build` step depends on `APP_VERSION`. All install and copy layers above it stay cached across `APP_VERSION` changes.

## Measured impact

Scenario: rebuild the image with a different `--build-arg APP_VERSION=…` but otherwise identical source/deps (i.e. the common "release tag bump" CI case). Measured on Darwin/arm64 + OrbStack, rebuilding against the previous build's cache.

| | Wall-clock | What re-ran |
|---|--:|---|
| before this change | **113s** | `apk add` + first `pnpm install` + `COPY . .` + second `pnpm install` + `pnpm build` |
| after this change  | **81s**  | only second `pnpm install` + `pnpm build` |
| saving | **−32s (−28%)** | |

CI runner numbers will differ in absolute terms but the ratio holds — the saved work is a full `pnpm install` pass plus the `COPY . .` step.

## Out of scope — follow-up

A second PR (`perf/docker-multistage-refactor`, stacked on this one) reworks the build stage into a proper `deps`/`build`/`runtime` multi-stage pipeline, adds a BuildKit cache mount on the pnpm store, drops `pnpmfile.docker.cjs`, and bundles hygiene items (pinned pnpm, HEALTHCHECK, broader `apk upgrade`). That PR will show the full cumulative benchmark.