### PR TITLE
feat(order-forms): display order forms list

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -14198,6 +14198,7 @@ export type GetOrderFormsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   status?: InputMaybe<Array<OrderFormStatusEnum> | OrderFormStatusEnum>;
+  quoteNumber?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
 }>;
 
 
@@ -38562,8 +38563,13 @@ export type UpdateCustomerCurrencyForQuoteMutationHookResult = ReturnType<typeof
 export type UpdateCustomerCurrencyForQuoteMutationResult = Apollo.MutationResult<UpdateCustomerCurrencyForQuoteMutation>;
 export type UpdateCustomerCurrencyForQuoteMutationOptions = Apollo.BaseMutationOptions<UpdateCustomerCurrencyForQuoteMutation, UpdateCustomerCurrencyForQuoteMutationVariables>;
 export const GetOrderFormsDocument = gql`
-    query getOrderForms($page: Int, $limit: Int, $status: [OrderFormStatusEnum!]) {
-  orderForms(page: $page, limit: $limit, status: $status) {
+    query getOrderForms($page: Int, $limit: Int, $status: [OrderFormStatusEnum!], $quoteNumber: [String!]) {
+  orderForms(
+    page: $page
+    limit: $limit
+    status: $status
+    quoteNumber: $quoteNumber
+  ) {
     metadata {
       currentPage
       totalPages
@@ -38591,6 +38597,7 @@ export const GetOrderFormsDocument = gql`
  *      page: // value for 'page'
  *      limit: // value for 'limit'
  *      status: // value for 'status'
+ *      quoteNumber: // value for 'quoteNumber'
  *   },
  * });
  */

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -14192,6 +14192,17 @@ export type UpdateCustomerCurrencyForQuoteMutationVariables = Exact<{
 
 export type UpdateCustomerCurrencyForQuoteMutation = { __typename?: 'Mutation', updateCustomer?: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null } | null };
 
+export type OrderFormListItemFragment = { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, customer: { __typename?: 'Customer', id: string, name?: string | null } };
+
+export type GetOrderFormsQueryVariables = Exact<{
+  page?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  status?: InputMaybe<Array<OrderFormStatusEnum> | OrderFormStatusEnum>;
+}>;
+
+
+export type GetOrderFormsQuery = { __typename?: 'Query', orderForms: { __typename?: 'OrderFormCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, customer: { __typename?: 'Customer', id: string, name?: string | null } }> } };
+
 export type QuoteDetailItemFragment = { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, currency?: CurrencyEnum | null, netPaymentTerm?: number | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number } }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, content?: string | null, currency?: string | null, startDate?: any | null, endDate?: any | null, billingItems?: any | null, createdAt: any } };
 
 export type GetQuoteQueryVariables = Exact<{
@@ -19857,6 +19868,18 @@ export const FeatureForFeaturesListFragmentDoc = gql`
   code
   createdAt
   subscriptionsCount
+}
+    `;
+export const OrderFormListItemFragmentDoc = gql`
+    fragment OrderFormListItem on OrderForm {
+  id
+  number
+  status
+  createdAt
+  customer {
+    id
+    name
+  }
 }
     `;
 export const QuoteDetailItemFragmentDoc = gql`
@@ -38530,6 +38553,58 @@ export function useUpdateCustomerCurrencyForQuoteMutation(baseOptions?: Apollo.M
 export type UpdateCustomerCurrencyForQuoteMutationHookResult = ReturnType<typeof useUpdateCustomerCurrencyForQuoteMutation>;
 export type UpdateCustomerCurrencyForQuoteMutationResult = Apollo.MutationResult<UpdateCustomerCurrencyForQuoteMutation>;
 export type UpdateCustomerCurrencyForQuoteMutationOptions = Apollo.BaseMutationOptions<UpdateCustomerCurrencyForQuoteMutation, UpdateCustomerCurrencyForQuoteMutationVariables>;
+export const GetOrderFormsDocument = gql`
+    query getOrderForms($page: Int, $limit: Int, $status: [OrderFormStatusEnum!]) {
+  orderForms(page: $page, limit: $limit, status: $status) {
+    metadata {
+      currentPage
+      totalPages
+      totalCount
+    }
+    collection {
+      ...OrderFormListItem
+    }
+  }
+}
+    ${OrderFormListItemFragmentDoc}`;
+
+/**
+ * __useGetOrderFormsQuery__
+ *
+ * To run a query within a React component, call `useGetOrderFormsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetOrderFormsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetOrderFormsQuery({
+ *   variables: {
+ *      page: // value for 'page'
+ *      limit: // value for 'limit'
+ *      status: // value for 'status'
+ *   },
+ * });
+ */
+export function useGetOrderFormsQuery(baseOptions?: Apollo.QueryHookOptions<GetOrderFormsQuery, GetOrderFormsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetOrderFormsQuery, GetOrderFormsQueryVariables>(GetOrderFormsDocument, options);
+      }
+export function useGetOrderFormsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetOrderFormsQuery, GetOrderFormsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetOrderFormsQuery, GetOrderFormsQueryVariables>(GetOrderFormsDocument, options);
+        }
+// @ts-ignore
+export function useGetOrderFormsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetOrderFormsQuery, GetOrderFormsQueryVariables>): Apollo.UseSuspenseQueryResult<GetOrderFormsQuery, GetOrderFormsQueryVariables>;
+export function useGetOrderFormsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetOrderFormsQuery, GetOrderFormsQueryVariables>): Apollo.UseSuspenseQueryResult<GetOrderFormsQuery | undefined, GetOrderFormsQueryVariables>;
+export function useGetOrderFormsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetOrderFormsQuery, GetOrderFormsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetOrderFormsQuery, GetOrderFormsQueryVariables>(GetOrderFormsDocument, options);
+        }
+export type GetOrderFormsQueryHookResult = ReturnType<typeof useGetOrderFormsQuery>;
+export type GetOrderFormsLazyQueryHookResult = ReturnType<typeof useGetOrderFormsLazyQuery>;
+export type GetOrderFormsSuspenseQueryHookResult = ReturnType<typeof useGetOrderFormsSuspenseQuery>;
+export type GetOrderFormsQueryResult = Apollo.QueryResult<GetOrderFormsQuery, GetOrderFormsQueryVariables>;
 export const GetQuoteDocument = gql`
     query getQuote($id: ID!) {
   quote(id: $id) {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -14192,7 +14192,7 @@ export type UpdateCustomerCurrencyForQuoteMutationVariables = Exact<{
 
 export type UpdateCustomerCurrencyForQuoteMutation = { __typename?: 'Mutation', updateCustomer?: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null } | null };
 
-export type OrderFormListItemFragment = { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, customer: { __typename?: 'Customer', id: string, name?: string | null } };
+export type OrderFormListItemFragment = { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, customer: { __typename?: 'Customer', id: string, name?: string | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number } } };
 
 export type GetOrderFormsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -14201,7 +14201,7 @@ export type GetOrderFormsQueryVariables = Exact<{
 }>;
 
 
-export type GetOrderFormsQuery = { __typename?: 'Query', orderForms: { __typename?: 'OrderFormCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, customer: { __typename?: 'Customer', id: string, name?: string | null } }> } };
+export type GetOrderFormsQuery = { __typename?: 'Query', orderForms: { __typename?: 'OrderFormCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, customer: { __typename?: 'Customer', id: string, name?: string | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number } } }> } };
 
 export type QuoteDetailItemFragment = { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, currency?: CurrencyEnum | null, netPaymentTerm?: number | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number } }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, content?: string | null, currency?: string | null, startDate?: any | null, endDate?: any | null, billingItems?: any | null, createdAt: any } };
 
@@ -19879,6 +19879,14 @@ export const OrderFormListItemFragmentDoc = gql`
   customer {
     id
     name
+  }
+  quote {
+    id
+    number
+    currentVersion {
+      id
+      version
+    }
   }
 }
     `;

--- a/src/pages/quotes/OrderFormsList.tsx
+++ b/src/pages/quotes/OrderFormsList.tsx
@@ -1,16 +1,66 @@
-import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder'
+import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
+import { Table, TableColumn } from '~/components/designSystem/Table/Table'
+import { Typography } from '~/components/designSystem/Typography'
+import { DetailsPage } from '~/components/layouts/DetailsPage'
+import { OrderFormListItemFragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import EmptyImage from '~/public/images/maneki/empty.svg'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
+
+import { createOrderFormsPaginationHandler } from './common/orderFormsPaginationHandler'
+import { orderFormCreatedAtColumn, orderFormStatusColumn } from './common/orderFormTableColumns'
+import { useOrderForms } from './hooks/useOrderForms'
 
 const OrderFormsList = (): JSX.Element => {
   const { translate } = useInternationalization()
+  const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
+  const { orderForms, loading, error, fetchMore, metadata } = useOrderForms()
+
+  const columns: Array<TableColumn<OrderFormListItemFragment>> = [
+    {
+      key: 'number',
+      title: translate('text_1775746196826pyjlfqx3anr'),
+      minWidth: 160,
+      maxSpace: true,
+      content: ({ number }) => (
+        <Typography variant="bodyHl" noWrap>
+          {number}
+        </Typography>
+      ),
+    },
+    {
+      key: 'customer.name',
+      title: translate('text_65201c5a175a4b0238abf29a'),
+      maxSpace: true,
+      minWidth: 160,
+      content: ({ customer }) => (
+        <Typography color="grey600" noWrap>
+          {customer.name}
+        </Typography>
+      ),
+    },
+    orderFormStatusColumn(translate),
+    orderFormCreatedAtColumn(translate, 'text_624efab67eb2570101d117e3', intlFormatDateTimeOrgaTZ),
+  ]
 
   return (
-    <GenericPlaceholder
-      title={translate('text_17757461968258p4ij8g74zp')}
-      subtitle={translate('text_1775746196826qogq3id888u')}
-      image={<EmptyImage width="136" height="104" />}
-    />
+    <DetailsPage.Container>
+      <InfiniteScroll onBottom={createOrderFormsPaginationHandler(metadata, loading, fetchMore)}>
+        <Table
+          name="order-forms-list"
+          data={orderForms}
+          isLoading={loading}
+          hasError={!!error}
+          containerSize={0}
+          columns={columns}
+          placeholder={{
+            emptyState: {
+              title: translate('text_1776697938480e54yje9i5aa'),
+              subtitle: translate('text_17766979384803pz48gknynl'),
+            },
+          }}
+        />
+      </InfiniteScroll>
+    </DetailsPage.Container>
   )
 }
 

--- a/src/pages/quotes/OrderFormsList.tsx
+++ b/src/pages/quotes/OrderFormsList.tsx
@@ -7,7 +7,11 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
 import { createOrderFormsPaginationHandler } from './common/orderFormsPaginationHandler'
-import { orderFormCreatedAtColumn, orderFormStatusColumn } from './common/orderFormTableColumns'
+import {
+  orderFormCreatedAtColumn,
+  orderFormSourceQuoteColumn,
+  orderFormStatusColumn,
+} from './common/orderFormTableColumns'
 import { useOrderForms } from './hooks/useOrderForms'
 
 const OrderFormsList = (): JSX.Element => {
@@ -38,6 +42,7 @@ const OrderFormsList = (): JSX.Element => {
         </Typography>
       ),
     },
+    orderFormSourceQuoteColumn(translate),
     orderFormStatusColumn(translate),
     orderFormCreatedAtColumn(translate, 'text_624efab67eb2570101d117e3', intlFormatDateTimeOrgaTZ),
   ]

--- a/src/pages/quotes/OrderFormsList.tsx
+++ b/src/pages/quotes/OrderFormsList.tsx
@@ -14,10 +14,16 @@ import {
 } from './common/orderFormTableColumns'
 import { useOrderForms } from './hooks/useOrderForms'
 
-const OrderFormsList = (): JSX.Element => {
+interface OrderFormsListProps {
+  quoteNumber?: string
+}
+
+const OrderFormsList = ({ quoteNumber }: OrderFormsListProps): JSX.Element => {
   const { translate } = useInternationalization()
   const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
-  const { orderForms, loading, error, fetchMore, metadata } = useOrderForms()
+  const { orderForms, loading, error, fetchMore, metadata } = useOrderForms(
+    quoteNumber ? { quoteNumber: [quoteNumber] } : undefined,
+  )
 
   const columns: Array<TableColumn<OrderFormListItemFragment>> = [
     {

--- a/src/pages/quotes/QuoteDetails.tsx
+++ b/src/pages/quotes/QuoteDetails.tsx
@@ -90,7 +90,7 @@ const QuoteDetails = (): JSX.Element => {
               quoteId: quoteId as string,
               tab: QuoteDetailsTabsOptionsEnum.orderForms,
             }),
-            content: <OrderFormsList />,
+            content: <OrderFormsList quoteNumber={quote?.number} />,
           },
           {
             title: translate('text_1747314141347qq6rasuxisl'),

--- a/src/pages/quotes/__tests__/OrderFormsList.test.tsx
+++ b/src/pages/quotes/__tests__/OrderFormsList.test.tsx
@@ -1,13 +1,20 @@
 import { screen } from '@testing-library/react'
 
-import {
-  GENERIC_PLACEHOLDER_SUBTITLE_TEST_ID,
-  GENERIC_PLACEHOLDER_TEST_ID,
-  GENERIC_PLACEHOLDER_TITLE_TEST_ID,
-} from '~/components/designSystem/GenericPlaceholder'
+import { OrderFormStatusEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
+import { useOrderForms } from '../hooks/useOrderForms'
 import OrderFormsList from '../OrderFormsList'
+
+const mockIntersectionObserver = jest.fn()
+
+mockIntersectionObserver.mockReturnValue({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+})
+
+globalThis.IntersectionObserver = mockIntersectionObserver
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({
@@ -15,29 +22,120 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
   }),
 }))
 
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  useOrganizationInfos: () => ({
+    intlFormatDateTimeOrgaTZ: (date: string) => ({
+      date: new Date(date).toLocaleDateString('en-US'),
+    }),
+  }),
+}))
+
+jest.mock('../hooks/useOrderForms', () => ({
+  useOrderForms: jest.fn(),
+}))
+
+const mockUseOrderForms = useOrderForms as jest.MockedFunction<typeof useOrderForms>
+
+const mockOrderForms = [
+  {
+    id: 'of-1',
+    number: 'OF-2026-0001',
+    status: OrderFormStatusEnum.Generated,
+    createdAt: '2026-04-10T10:00:00Z',
+    customer: { id: 'customer-001', name: 'Acme Corp' },
+  },
+  {
+    id: 'of-2',
+    number: 'OF-2026-0002',
+    status: OrderFormStatusEnum.Signed,
+    createdAt: '2026-04-11T14:00:00Z',
+    customer: { id: 'customer-002', name: 'Globex Inc' },
+  },
+  {
+    id: 'of-3',
+    number: 'OF-2026-0003',
+    status: OrderFormStatusEnum.Voided,
+    createdAt: '2026-04-12T08:00:00Z',
+    customer: { id: 'customer-003', name: 'Wayne Enterprises' },
+  },
+]
+
 describe('OrderFormsList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseOrderForms.mockReturnValue({
+      orderForms: mockOrderForms,
+      loading: false,
+      error: undefined,
+      fetchMore: jest.fn(),
+      metadata: { currentPage: 1, totalPages: 1, totalCount: 3 },
+    })
+  })
+
   describe('GIVEN the component is rendered', () => {
-    describe('WHEN in default state', () => {
-      it('THEN should render the empty state placeholder', () => {
+    describe('WHEN order forms are loaded', () => {
+      it('THEN should render the table with rows', () => {
         render(<OrderFormsList />)
 
-        expect(screen.getByTestId(GENERIC_PLACEHOLDER_TEST_ID)).toBeInTheDocument()
+        expect(screen.getByTestId('table-row-0')).toBeInTheDocument()
+        expect(screen.getByTestId('table-row-1')).toBeInTheDocument()
+        expect(screen.getByTestId('table-row-2')).toBeInTheDocument()
       })
 
-      it('THEN should display the correct title in the placeholder', () => {
+      it('THEN should display order form numbers', () => {
         render(<OrderFormsList />)
 
-        expect(screen.getByTestId(GENERIC_PLACEHOLDER_TITLE_TEST_ID)).toHaveTextContent(
-          'text_17757461968258p4ij8g74zp',
-        )
+        expect(screen.getByText('OF-2026-0001')).toBeInTheDocument()
+        expect(screen.getByText('OF-2026-0002')).toBeInTheDocument()
+        expect(screen.getByText('OF-2026-0003')).toBeInTheDocument()
       })
 
-      it('THEN should display the correct subtitle in the placeholder', () => {
+      it('THEN should display customer names', () => {
         render(<OrderFormsList />)
 
-        expect(screen.getByTestId(GENERIC_PLACEHOLDER_SUBTITLE_TEST_ID)).toHaveTextContent(
-          'text_1775746196826qogq3id888u',
-        )
+        expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+        expect(screen.getByText('Globex Inc')).toBeInTheDocument()
+        expect(screen.getByText('Wayne Enterprises')).toBeInTheDocument()
+      })
+
+      it('THEN should display status badges', () => {
+        render(<OrderFormsList />)
+
+        const statusBadges = screen.getAllByTestId('status')
+
+        expect(statusBadges).toHaveLength(3)
+      })
+    })
+
+    describe('WHEN order forms are loading', () => {
+      it('THEN should show the table in loading state', () => {
+        mockUseOrderForms.mockReturnValue({
+          orderForms: [],
+          loading: true,
+          error: undefined,
+          fetchMore: jest.fn(),
+          metadata: undefined,
+        })
+
+        render(<OrderFormsList />)
+
+        expect(screen.getByTestId('table-order-forms-list')).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN there are no order forms', () => {
+      it('THEN should show empty state', () => {
+        mockUseOrderForms.mockReturnValue({
+          orderForms: [],
+          loading: false,
+          error: undefined,
+          fetchMore: jest.fn(),
+          metadata: undefined,
+        })
+
+        render(<OrderFormsList />)
+
+        expect(screen.queryByTestId('table-row-0')).not.toBeInTheDocument()
       })
     })
   })

--- a/src/pages/quotes/__tests__/OrderFormsList.test.tsx
+++ b/src/pages/quotes/__tests__/OrderFormsList.test.tsx
@@ -43,6 +43,7 @@ const mockOrderForms = [
     status: OrderFormStatusEnum.Generated,
     createdAt: '2026-04-10T10:00:00Z',
     customer: { id: 'customer-001', name: 'Acme Corp' },
+    quote: { id: 'q-1', number: 'QUO-001', currentVersion: { id: 'qv-1', version: 1 } },
   },
   {
     id: 'of-2',
@@ -50,6 +51,7 @@ const mockOrderForms = [
     status: OrderFormStatusEnum.Signed,
     createdAt: '2026-04-11T14:00:00Z',
     customer: { id: 'customer-002', name: 'Globex Inc' },
+    quote: { id: 'q-2', number: 'QUO-002', currentVersion: { id: 'qv-2', version: 3 } },
   },
   {
     id: 'of-3',
@@ -57,6 +59,7 @@ const mockOrderForms = [
     status: OrderFormStatusEnum.Voided,
     createdAt: '2026-04-12T08:00:00Z',
     customer: { id: 'customer-003', name: 'Wayne Enterprises' },
+    quote: { id: 'q-3', number: 'QUO-003', currentVersion: { id: 'qv-3', version: 2 } },
   },
 ]
 

--- a/src/pages/quotes/common/__tests__/getOrderFormStatusMapping.test.ts
+++ b/src/pages/quotes/common/__tests__/getOrderFormStatusMapping.test.ts
@@ -1,0 +1,68 @@
+import { StatusType } from '~/components/designSystem/Status'
+import { OrderFormStatusEnum } from '~/generated/graphql'
+
+import { getOrderFormStatusMapping } from '../getOrderFormStatusMapping'
+
+describe('getOrderFormStatusMapping', () => {
+  const mockTranslate = jest.fn((key: string) => key)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN a generated status', () => {
+    it('THEN should return warning type', () => {
+      const result = getOrderFormStatusMapping(OrderFormStatusEnum.Generated, mockTranslate)
+
+      expect(result.type).toBe(StatusType.warning)
+    })
+
+    it('THEN should call translate for the label', () => {
+      getOrderFormStatusMapping(OrderFormStatusEnum.Generated, mockTranslate)
+
+      expect(mockTranslate).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('GIVEN a signed status', () => {
+    it('THEN should return success type', () => {
+      const result = getOrderFormStatusMapping(OrderFormStatusEnum.Signed, mockTranslate)
+
+      expect(result.type).toBe(StatusType.success)
+    })
+
+    it('THEN should call translate for the label', () => {
+      getOrderFormStatusMapping(OrderFormStatusEnum.Signed, mockTranslate)
+
+      expect(mockTranslate).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('GIVEN a voided status', () => {
+    it('THEN should return disabled type', () => {
+      const result = getOrderFormStatusMapping(OrderFormStatusEnum.Voided, mockTranslate)
+
+      expect(result.type).toBe(StatusType.disabled)
+    })
+
+    it('THEN should call translate for the label', () => {
+      getOrderFormStatusMapping(OrderFormStatusEnum.Voided, mockTranslate)
+
+      expect(mockTranslate).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('GIVEN an expired status', () => {
+    it('THEN should return disabled type', () => {
+      const result = getOrderFormStatusMapping(OrderFormStatusEnum.Expired, mockTranslate)
+
+      expect(result.type).toBe(StatusType.disabled)
+    })
+
+    it('THEN should call translate for the label', () => {
+      getOrderFormStatusMapping(OrderFormStatusEnum.Expired, mockTranslate)
+
+      expect(mockTranslate).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/pages/quotes/common/__tests__/orderFormTableColumns.test.tsx
+++ b/src/pages/quotes/common/__tests__/orderFormTableColumns.test.tsx
@@ -1,0 +1,124 @@
+import { screen } from '@testing-library/react'
+
+import { OrderFormStatusEnum } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import { orderFormCreatedAtColumn, orderFormStatusColumn } from '../orderFormTableColumns'
+
+describe('orderFormStatusColumn', () => {
+  const mockTranslate = jest.fn((key: string) => key)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN the column config is created', () => {
+    it('THEN should return a column with key "status"', () => {
+      const column = orderFormStatusColumn(mockTranslate)
+
+      expect(column.key).toBe('status')
+    })
+
+    it('THEN should have minWidth of 100', () => {
+      const column = orderFormStatusColumn(mockTranslate)
+
+      expect(column.minWidth).toBe(100)
+    })
+
+    describe('WHEN rendering content for a generated order form', () => {
+      it('THEN should render a Status component with warning type', () => {
+        const column = orderFormStatusColumn(mockTranslate)
+        const content = column.content({
+          id: 'of-1',
+          number: 'OF-001',
+          status: OrderFormStatusEnum.Generated,
+          createdAt: '2026-04-10T10:00:00Z',
+          customer: { id: 'c-1', name: 'Test Customer' },
+        })
+
+        render(<>{content}</>)
+
+        const statusEl = screen.getByTestId('status')
+
+        expect(statusEl).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN rendering content for each status', () => {
+      it.each([
+        [OrderFormStatusEnum.Generated],
+        [OrderFormStatusEnum.Signed],
+        [OrderFormStatusEnum.Voided],
+        [OrderFormStatusEnum.Expired],
+      ])('THEN should render a status badge for %s', (status) => {
+        const column = orderFormStatusColumn(mockTranslate)
+        const content = column.content({
+          id: 'of-1',
+          number: 'OF-001',
+          status,
+          createdAt: '2026-04-10T10:00:00Z',
+          customer: { id: 'c-1', name: 'Test Customer' },
+        })
+
+        render(<>{content}</>)
+
+        expect(screen.getByTestId('status')).toBeInTheDocument()
+      })
+    })
+  })
+})
+
+describe('orderFormCreatedAtColumn', () => {
+  const mockTranslate = jest.fn((key: string) => key)
+  const mockIntlFormatDateTimeOrgaTZ = jest.fn((date: string) => ({
+    date: new Date(date).toLocaleDateString('en-US'),
+  }))
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN the column config is created', () => {
+    it('THEN should return a column with key "createdAt"', () => {
+      const column = orderFormCreatedAtColumn(
+        mockTranslate,
+        'text_titleKey',
+        mockIntlFormatDateTimeOrgaTZ,
+      )
+
+      expect(column.key).toBe('createdAt')
+    })
+
+    it('THEN should have minWidth of 120', () => {
+      const column = orderFormCreatedAtColumn(
+        mockTranslate,
+        'text_titleKey',
+        mockIntlFormatDateTimeOrgaTZ,
+      )
+
+      expect(column.minWidth).toBe(120)
+    })
+
+    describe('WHEN rendering content with a date', () => {
+      it('THEN should format and display the date', () => {
+        const column = orderFormCreatedAtColumn(
+          mockTranslate,
+          'text_titleKey',
+          mockIntlFormatDateTimeOrgaTZ,
+        )
+        const content = column.content({
+          id: 'of-1',
+          number: 'OF-001',
+          status: OrderFormStatusEnum.Generated,
+          createdAt: '2026-04-10T10:00:00Z',
+          customer: { id: 'c-1', name: 'Test Customer' },
+        })
+
+        render(<>{content}</>)
+
+        expect(mockIntlFormatDateTimeOrgaTZ).toHaveBeenCalledWith('2026-04-10T10:00:00Z')
+        expect(screen.getByText('4/10/2026')).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/pages/quotes/common/__tests__/orderFormTableColumns.test.tsx
+++ b/src/pages/quotes/common/__tests__/orderFormTableColumns.test.tsx
@@ -34,6 +34,7 @@ describe('orderFormStatusColumn', () => {
           status: OrderFormStatusEnum.Generated,
           createdAt: '2026-04-10T10:00:00Z',
           customer: { id: 'c-1', name: 'Test Customer' },
+          quote: { id: 'q-1', number: 'QUO-001', currentVersion: { id: 'qv-1', version: 1 } },
         })
 
         render(<>{content}</>)
@@ -58,6 +59,7 @@ describe('orderFormStatusColumn', () => {
           status,
           createdAt: '2026-04-10T10:00:00Z',
           customer: { id: 'c-1', name: 'Test Customer' },
+          quote: { id: 'q-1', number: 'QUO-001', currentVersion: { id: 'qv-1', version: 1 } },
         })
 
         render(<>{content}</>)
@@ -112,6 +114,7 @@ describe('orderFormCreatedAtColumn', () => {
           status: OrderFormStatusEnum.Generated,
           createdAt: '2026-04-10T10:00:00Z',
           customer: { id: 'c-1', name: 'Test Customer' },
+          quote: { id: 'q-1', number: 'QUO-001', currentVersion: { id: 'qv-1', version: 1 } },
         })
 
         render(<>{content}</>)

--- a/src/pages/quotes/common/__tests__/orderFormsPaginationHandler.test.ts
+++ b/src/pages/quotes/common/__tests__/orderFormsPaginationHandler.test.ts
@@ -1,0 +1,83 @@
+import { createOrderFormsPaginationHandler } from '../orderFormsPaginationHandler'
+
+describe('createOrderFormsPaginationHandler', () => {
+  const mockFetchMore = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN there are more pages to load', () => {
+    describe('WHEN the handler is called and not loading', () => {
+      it('THEN should call fetchMore with the next page', () => {
+        const handler = createOrderFormsPaginationHandler(
+          { currentPage: 1, totalPages: 3, totalCount: 60 },
+          false,
+          mockFetchMore,
+        )
+
+        handler()
+
+        expect(mockFetchMore).toHaveBeenCalledWith({
+          variables: { page: 2 },
+        })
+      })
+    })
+
+    describe('WHEN currently loading', () => {
+      it('THEN should not call fetchMore', () => {
+        const handler = createOrderFormsPaginationHandler(
+          { currentPage: 1, totalPages: 3, totalCount: 60 },
+          true,
+          mockFetchMore,
+        )
+
+        handler()
+
+        expect(mockFetchMore).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN the current page is the last page', () => {
+    describe('WHEN the handler is called', () => {
+      it('THEN should not call fetchMore', () => {
+        const handler = createOrderFormsPaginationHandler(
+          { currentPage: 3, totalPages: 3, totalCount: 60 },
+          false,
+          mockFetchMore,
+        )
+
+        handler()
+
+        expect(mockFetchMore).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN metadata is undefined', () => {
+    describe('WHEN the handler is called', () => {
+      it('THEN should not call fetchMore', () => {
+        const handler = createOrderFormsPaginationHandler(undefined, false, mockFetchMore)
+
+        handler()
+
+        expect(mockFetchMore).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN fetchMore is undefined', () => {
+    describe('WHEN the handler is called', () => {
+      it('THEN should not throw', () => {
+        const handler = createOrderFormsPaginationHandler(
+          { currentPage: 1, totalPages: 3, totalCount: 60 },
+          false,
+          undefined,
+        )
+
+        expect(() => handler()).not.toThrow()
+      })
+    })
+  })
+})

--- a/src/pages/quotes/common/getOrderFormStatusMapping.ts
+++ b/src/pages/quotes/common/getOrderFormStatusMapping.ts
@@ -1,0 +1,20 @@
+import { StatusProps, StatusType } from '~/components/designSystem/Status'
+import { OrderFormStatusEnum } from '~/generated/graphql'
+
+export const getOrderFormStatusMapping = (
+  status: OrderFormStatusEnum,
+  translate: (key: string) => string,
+): Pick<StatusProps, 'type' | 'label'> => {
+  switch (status) {
+    case OrderFormStatusEnum.Generated:
+      return { type: StatusType.warning, label: translate('text_17766979384805q6wx9it6wa') }
+    case OrderFormStatusEnum.Signed:
+      return { type: StatusType.success, label: translate('text_1776697938480b1fi7wqtzyi') }
+    case OrderFormStatusEnum.Voided:
+      return { type: StatusType.disabled, label: translate('text_1776697938480hzc1xsmmpez') }
+    case OrderFormStatusEnum.Expired:
+      return { type: StatusType.disabled, label: translate('text_1776697938480ap28ussl837') }
+    default:
+      return { type: StatusType.outline, label: status }
+  }
+}

--- a/src/pages/quotes/common/orderFormTableColumns.tsx
+++ b/src/pages/quotes/common/orderFormTableColumns.tsx
@@ -1,0 +1,29 @@
+import { Status } from '~/components/designSystem/Status'
+import { TableColumn } from '~/components/designSystem/Table/Table'
+import { Typography } from '~/components/designSystem/Typography'
+import { OrderFormListItemFragment } from '~/generated/graphql'
+import { TranslateFunc } from '~/hooks/core/useInternationalization'
+
+import { getOrderFormStatusMapping } from './getOrderFormStatusMapping'
+
+export const orderFormStatusColumn = (
+  translate: TranslateFunc,
+): TableColumn<OrderFormListItemFragment> => ({
+  key: 'status',
+  title: translate('text_63ac86d797f728a87b2f9fa7'),
+  minWidth: 100,
+  content: ({ status }) => <Status {...getOrderFormStatusMapping(status, translate)} />,
+})
+
+export const orderFormCreatedAtColumn = (
+  translate: TranslateFunc,
+  titleKey: string,
+  intlFormatDateTimeOrgaTZ: (date: string) => { date: string },
+): TableColumn<OrderFormListItemFragment> => ({
+  key: 'createdAt',
+  title: translate(titleKey),
+  minWidth: 120,
+  content: ({ createdAt }) => (
+    <Typography color="grey600">{intlFormatDateTimeOrgaTZ(createdAt).date}</Typography>
+  ),
+})

--- a/src/pages/quotes/common/orderFormTableColumns.tsx
+++ b/src/pages/quotes/common/orderFormTableColumns.tsx
@@ -1,10 +1,34 @@
+import { generatePath } from 'react-router-dom'
+
 import { Status } from '~/components/designSystem/Status'
 import { TableColumn } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
+import { QuoteDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
+import { Link, QUOTE_DETAILS_ROUTE } from '~/core/router'
 import { OrderFormListItemFragment } from '~/generated/graphql'
 import { TranslateFunc } from '~/hooks/core/useInternationalization'
 
 import { getOrderFormStatusMapping } from './getOrderFormStatusMapping'
+
+export const orderFormSourceQuoteColumn = (
+  translate: TranslateFunc,
+): TableColumn<OrderFormListItemFragment> => ({
+  key: 'quote.number',
+  title: translate('text_1779695273381h7tmhdzrv48'),
+  minWidth: 160,
+  content: ({ quote }) => (
+    <Typography color="info600" noWrap>
+      <Link
+        to={generatePath(QUOTE_DETAILS_ROUTE, {
+          quoteId: quote.id,
+          tab: QuoteDetailsTabsOptionsEnum.overview,
+        })}
+      >
+        {quote.number} - v{quote.currentVersion.version}
+      </Link>
+    </Typography>
+  ),
+})
 
 export const orderFormStatusColumn = (
   translate: TranslateFunc,

--- a/src/pages/quotes/common/orderFormsPaginationHandler.ts
+++ b/src/pages/quotes/common/orderFormsPaginationHandler.ts
@@ -1,0 +1,23 @@
+import { FetchMoreQueryOptions, OperationVariables } from '@apollo/client'
+
+import { GetOrderFormsQuery } from '~/generated/graphql'
+
+export const createOrderFormsPaginationHandler = (
+  metadata: GetOrderFormsQuery['orderForms']['metadata'] | undefined,
+  loading: boolean,
+  fetchMore:
+    | ((
+        fetchMoreOptions: FetchMoreQueryOptions<OperationVariables, GetOrderFormsQuery>,
+      ) => Promise<unknown>)
+    | undefined,
+) => {
+  return () => {
+    const { currentPage = 0, totalPages = 0 } = metadata || {}
+
+    currentPage < totalPages &&
+      !loading &&
+      fetchMore?.({
+        variables: { page: currentPage + 1 },
+      })
+  }
+}

--- a/src/pages/quotes/hooks/__tests__/useOrderForms.test.ts
+++ b/src/pages/quotes/hooks/__tests__/useOrderForms.test.ts
@@ -1,0 +1,106 @@
+import { renderHook } from '@testing-library/react'
+
+import { useGetOrderFormsQuery } from '~/generated/graphql'
+
+import { useOrderForms } from '../useOrderForms'
+
+jest.mock('~/generated/graphql', () => ({
+  useGetOrderFormsQuery: jest.fn(),
+}))
+
+const mockUseGetOrderFormsQuery = useGetOrderFormsQuery as jest.Mock
+
+describe('useOrderForms', () => {
+  const mockFetchMore = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseGetOrderFormsQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+      fetchMore: mockFetchMore,
+    })
+  })
+
+  describe('GIVEN the hook is rendered', () => {
+    it('THEN should pass limit of 20 as default', () => {
+      renderHook(() => useOrderForms())
+
+      expect(mockUseGetOrderFormsQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: expect.objectContaining({ limit: 20 }),
+        }),
+      )
+    })
+  })
+
+  describe('GIVEN custom variables are provided', () => {
+    it('THEN should merge them with defaults', () => {
+      renderHook(() => useOrderForms({ status: ['generated' as never] }))
+
+      expect(mockUseGetOrderFormsQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            limit: 20,
+            status: ['generated'],
+          }),
+        }),
+      )
+    })
+  })
+
+  describe('GIVEN the query returns data', () => {
+    it('THEN should return the order forms collection', () => {
+      const mockOrderForms = [
+        { id: 'of-1', number: 'OF-001' },
+        { id: 'of-2', number: 'OF-002' },
+      ]
+
+      mockUseGetOrderFormsQuery.mockReturnValue({
+        data: {
+          orderForms: {
+            collection: mockOrderForms,
+            metadata: { currentPage: 1, totalPages: 2, totalCount: 10 },
+          },
+        },
+        loading: false,
+        error: undefined,
+        fetchMore: mockFetchMore,
+      })
+
+      const { result } = renderHook(() => useOrderForms())
+
+      expect(result.current.orderForms).toEqual(mockOrderForms)
+      expect(result.current.metadata).toEqual({
+        currentPage: 1,
+        totalPages: 2,
+        totalCount: 10,
+      })
+    })
+  })
+
+  describe('GIVEN the query has no data yet', () => {
+    it('THEN should return an empty array for order forms', () => {
+      const { result } = renderHook(() => useOrderForms())
+
+      expect(result.current.orderForms).toEqual([])
+      expect(result.current.metadata).toBeUndefined()
+    })
+  })
+
+  describe('GIVEN the query is loading', () => {
+    it('THEN should return loading true', () => {
+      mockUseGetOrderFormsQuery.mockReturnValue({
+        data: undefined,
+        loading: true,
+        error: undefined,
+        fetchMore: mockFetchMore,
+      })
+
+      const { result } = renderHook(() => useOrderForms())
+
+      expect(result.current.loading).toBe(true)
+    })
+  })
+})

--- a/src/pages/quotes/hooks/useOrderForms.ts
+++ b/src/pages/quotes/hooks/useOrderForms.ts
@@ -1,0 +1,68 @@
+import { FetchMoreQueryOptions, gql, OperationVariables } from '@apollo/client'
+
+import {
+  GetOrderFormsQuery,
+  GetOrderFormsQueryVariables,
+  OrderFormListItemFragment,
+  useGetOrderFormsQuery,
+} from '~/generated/graphql'
+
+gql`
+  fragment OrderFormListItem on OrderForm {
+    id
+    number
+    status
+    createdAt
+    customer {
+      id
+      name
+    }
+  }
+
+  query getOrderForms($page: Int, $limit: Int, $status: [OrderFormStatusEnum!]) {
+    orderForms(page: $page, limit: $limit, status: $status) {
+      metadata {
+        currentPage
+        totalPages
+        totalCount
+      }
+      collection {
+        ...OrderFormListItem
+      }
+    }
+  }
+`
+
+interface UseOrderFormsReturn {
+  orderForms: OrderFormListItemFragment[]
+  metadata: GetOrderFormsQuery['orderForms']['metadata'] | undefined
+  loading: boolean
+  error: Error | undefined
+  fetchMore:
+    | ((
+        fetchMoreOptions: FetchMoreQueryOptions<OperationVariables, GetOrderFormsQuery>,
+      ) => Promise<unknown>)
+    | undefined
+}
+
+export const useOrderForms = (
+  variables?: Omit<GetOrderFormsQueryVariables, 'limit' | 'page'>,
+): UseOrderFormsReturn => {
+  const { data, loading, error, fetchMore } = useGetOrderFormsQuery({
+    variables: {
+      limit: 20,
+      ...variables,
+    },
+    notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'network-only',
+    nextFetchPolicy: 'network-only',
+  })
+
+  return {
+    orderForms: data?.orderForms?.collection || [],
+    metadata: data?.orderForms?.metadata,
+    loading,
+    error,
+    fetchMore,
+  }
+}

--- a/src/pages/quotes/hooks/useOrderForms.ts
+++ b/src/pages/quotes/hooks/useOrderForms.ts
@@ -17,6 +17,14 @@ gql`
       id
       name
     }
+    quote {
+      id
+      number
+      currentVersion {
+        id
+        version
+      }
+    }
   }
 
   query getOrderForms($page: Int, $limit: Int, $status: [OrderFormStatusEnum!]) {

--- a/src/pages/quotes/hooks/useOrderForms.ts
+++ b/src/pages/quotes/hooks/useOrderForms.ts
@@ -27,8 +27,13 @@ gql`
     }
   }
 
-  query getOrderForms($page: Int, $limit: Int, $status: [OrderFormStatusEnum!]) {
-    orderForms(page: $page, limit: $limit, status: $status) {
+  query getOrderForms(
+    $page: Int
+    $limit: Int
+    $status: [OrderFormStatusEnum!]
+    $quoteNumber: [String!]
+  ) {
+    orderForms(page: $page, limit: $limit, status: $status, quoteNumber: $quoteNumber) {
       metadata {
         currentPage
         totalPages

--- a/src/pages/settings/teamAndSecurity/roles/common/permissionsConst.ts
+++ b/src/pages/settings/teamAndSecurity/roles/common/permissionsConst.ts
@@ -234,9 +234,6 @@ export const permissionDescriptionMapping: Partial<Record<PermissionName, string
   InvoicesView: 'text_17660475818496eb8mnaygrc',
   InvoicesVoid: 'text_1766047581850xfdxud1g9ic',
 
-  // Order Forms
-  OrderFormsView: 'text_1779698186588yty6aq2wonz',
-
   // Organization
   OrganizationView: 'text_1766047581850c4xikdtb4v6',
   OrganizationUpdate: 'text_1766047581850ru00srfppl3',

--- a/src/pages/settings/teamAndSecurity/roles/common/permissionsConst.ts
+++ b/src/pages/settings/teamAndSecurity/roles/common/permissionsConst.ts
@@ -234,6 +234,9 @@ export const permissionDescriptionMapping: Partial<Record<PermissionName, string
   InvoicesView: 'text_17660475818496eb8mnaygrc',
   InvoicesVoid: 'text_1766047581850xfdxud1g9ic',
 
+  // Order Forms
+  OrderFormsView: 'text_1779698186588yty6aq2wonz',
+
   // Organization
   OrganizationView: 'text_1766047581850c4xikdtb4v6',
   OrganizationUpdate: 'text_1766047581850ru00srfppl3',

--- a/translations/base.json
+++ b/translations/base.json
@@ -4255,5 +4255,6 @@
   "text_1776697938480ap28ussl837": "Expired",
   "text_1776697938480e54yje9i5aa": "No order forms yet",
   "text_17766979384803pz48gknynl": "Order forms will appear here once they are created from quotes.",
-  "text_1779695273381h7tmhdzrv48": "Source quote"
+  "text_1779695273381h7tmhdzrv48": "Source quote",
+  "text_1779698186588yty6aq2wonz": "View order forms"
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -4255,6 +4255,5 @@
   "text_1776697938480ap28ussl837": "Expired",
   "text_1776697938480e54yje9i5aa": "No order forms yet",
   "text_17766979384803pz48gknynl": "Order forms will appear here once they are created from quotes.",
-  "text_1779695273381h7tmhdzrv48": "Source quote",
-  "text_1779698186588yty6aq2wonz": "View order forms"
+  "text_1779695273381h7tmhdzrv48": "Source quote"
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -4084,7 +4084,6 @@
   "text_17757391860814p20fr87x9g": "Quotes",
   "text_177573918608169w9wthupaz": "Quotes will appear here once created.",
   "text_17757461968258p4ij8g74zp": "Order forms",
-  "text_1775746196826qogq3id888u": "Order forms will appear here once created.",
   "text_1775746196826pyjlfqx3anr": "Quote number",
   "text_1775747115932pql5mtb30dc": "Version",
   "text_1775747115932x8ryaymh8ej": "Type",

--- a/translations/base.json
+++ b/translations/base.json
@@ -4254,5 +4254,6 @@
   "text_1776697938480hzc1xsmmpez": "Voided",
   "text_1776697938480ap28ussl837": "Expired",
   "text_1776697938480e54yje9i5aa": "No order forms yet",
-  "text_17766979384803pz48gknynl": "Order forms will appear here once they are created from quotes."
+  "text_17766979384803pz48gknynl": "Order forms will appear here once they are created from quotes.",
+  "text_1779695273381h7tmhdzrv48": "Source quote"
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -4249,5 +4249,11 @@
   "text_17791906642738j2tip131uw": "This value is already used",
   "text_1779790016087nsol47cwuwg": "Filters",
   "text_1780503765268ttscgcx6yo7": "Edit invoicing & payments",
-  "text_1780512470285ql6s1rc7wjr": "Lifetime"
+  "text_1780512470285ql6s1rc7wjr": "Lifetime",
+  "text_17766979384805q6wx9it6wa": "Generated",
+  "text_1776697938480b1fi7wqtzyi": "Signed",
+  "text_1776697938480hzc1xsmmpez": "Voided",
+  "text_1776697938480ap28ussl837": "Expired",
+  "text_1776697938480e54yje9i5aa": "No order forms yet",
+  "text_17766979384803pz48gknynl": "Order forms will appear here once they are created from quotes."
 }


### PR DESCRIPTION
## Context

We want to be able to display order forms in the list

## Description

This PR displays order form list

<!-- Linear link -->
Fixes [LAGO-1424](https://linear.app/getlago/issue/LAGO-1424/order-forms-display-order-forms-list)
Fixes LAGO-1426