### PR TITLE
feat(org-slug): Fix e2e test considering the new org slug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,34 @@
   import { useNavigate, Link, useLocation } from 'react-router-dom'
   ```
 
+## Cypress e2e tests
+
+- Authenticated navigation goes through `cy.visitApp(path)`, not `cy.visit(path)`.
+  `cy.visitApp` prepends `/${orgSlug}` captured by `cy.login()` / `cy.signup()`
+  so spec files write paths as they would look without the slug (e.g.
+  `cy.visitApp('/customers')` lands on `/${slug}/customers`).
+  ```typescript
+  // Correct — authenticated
+  cy.login().visitApp('/customers')
+  cy.visitApp('/settings/taxes')
+  // Correct — public paths pass through unchanged
+  cy.visit('/login')
+  cy.visit('/sign-up')
+  ```
+- For strict URL assertions use the slug-tolerant regex pattern instead of
+  `be.equal(baseUrl + '/path')`:
+  ```typescript
+  // Correct
+  cy.url().should('match', /\/[^/]+\/create\/plans$/)
+  // Wrong — `baseUrl + '/create/plans'` is never the full URL anymore
+  cy.url().should('be.equal', Cypress.config().baseUrl + '/create/plans')
+  ```
+- `cy.url().should('include', '/path')` continues to work — `/acme/customers`
+  still includes `/customers` — so existing `include` assertions need no changes.
+- Keep `cy.visit()` with slug-less paths only when the test is intentionally
+  probing legacy-URL behavior (e.g. testing the auth-guard redirect from a
+  slug-less path to `/login`). Always add an inline comment explaining why.
+
 ## Detailed Guidelines (read on demand)
 
 When working on these areas, read the relevant file first:

--- a/cypress/e2e/00-auth/t0-signup.cy.ts
+++ b/cypress/e2e/00-auth/t0-signup.cy.ts
@@ -17,7 +17,7 @@ describe('Sign up', () => {
     cy.get('input[name="password"]').type(userPassword)
     cy.get(`[data-test="${SIGNUP_SUBMIT_BUTTON_TEST_ID}"]`).click()
 
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/')
+    cy.url().should('match', /\/[^/]+\/(customers|analytics)/)
     cy.get('[data-test="side-nav-name"]').contains('Company name')
   })
 

--- a/cypress/e2e/00-auth/t10-login.cy.ts
+++ b/cypress/e2e/00-auth/t10-login.cy.ts
@@ -6,7 +6,8 @@ describe('Log in', () => {
     cy.get('input[name="email"]').type(userEmail)
     cy.get('input[name="password"]').type(userPassword)
     cy.get('[data-test="submit"]').click()
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/')
+
+    cy.url().should('match', /\/[^/]+\/(customers|analytics)/)
     cy.get('[data-test="incorrect-login-or-password-alert"]').should('not.exist')
   })
 

--- a/cypress/e2e/00-auth/t20-auth-redirect.cy.ts
+++ b/cypress/e2e/00-auth/t20-auth-redirect.cy.ts
@@ -30,7 +30,7 @@ describe('Authentication redirect flows', () => {
       cy.get('[data-test="side-nav-name"]').contains(testUser.org1Name)
 
       // 2. Navigate to a specific page (customers list)
-      cy.visit('/customers')
+      cy.visitApp('/customers')
       cy.url().should('include', '/customers')
 
       // 3. Logout
@@ -55,13 +55,17 @@ describe('Authentication redirect flows', () => {
       cy.url().should('include', Cypress.config().baseUrl)
 
       // 2. Navigate to a specific page (customers list)
-      cy.visit('/customers')
+      cy.visitApp('/customers')
       cy.url().should('include', '/customers')
 
       // 3. Logout
       cy.logout()
 
-      // 4. Try to access the plans page (should redirect to login with saved state)
+      // 4. Try to access the plans page (should redirect to login with saved state).
+      // Intentionally uses a slug-less path here: the auth guard fires before
+      // `OrganizationLayout` can resolve anything, saves `location.state.from`,
+      // and redirects to `/login`. After re-login, `Home.tsx` restores the
+      // saved path and prepends the current org slug.
       cy.visit('/plans')
       cy.url().should('include', '/login')
 
@@ -96,13 +100,15 @@ describe('Authentication redirect flows', () => {
       cy.login(testUser.email, testUser.password)
 
       // Navigate to a specific page
-      cy.visit('/settings/taxes')
+      cy.visitApp('/settings/taxes')
       cy.url().should('include', '/settings/taxes')
 
       // Simulate session expiration by clearing auth token
       cy.clearLocalStorage('authToken')
 
-      // Try to navigate to another protected page (should redirect to login)
+      // Try to navigate to another protected page (should redirect to login).
+      // Slug-less path is intentional: no valid session → auth guard catches
+      // this before slug resolution and redirects to `/login`.
       cy.visit('/customers')
       cy.url().should('include', '/login')
 
@@ -134,14 +140,15 @@ describe('Authentication redirect flows', () => {
       cy.login(testUser.email, testUser.password)
 
       // Navigate to page with query params
-      cy.visit('/customers?search=test&status=active')
+      cy.visitApp('/customers?search=test&status=active')
       cy.url().should('include', 'search=test')
       cy.url().should('include', 'status=active')
 
       // Logout
       cy.logout()
 
-      // Try to access the same page with query params
+      // Try to access the same page with query params (slug-less intentionally
+      // — logged out → auth guard redirects to `/login` with saved state).
       cy.visit('/customers?search=test&status=active')
       cy.url().should('include', '/login')
 

--- a/cypress/e2e/00-auth/t30-multi-org-redirect.cy.ts
+++ b/cypress/e2e/00-auth/t30-multi-org-redirect.cy.ts
@@ -111,7 +111,7 @@ describe('Multi-organization redirect flows', () => {
       cy.get('[data-test="side-nav-user-infos"]').click()
       cy.contains(testUsers.userA.org1Name).click()
       // 3. Create a customer in Org1
-      cy.visit('/customers')
+      cy.visitApp('/customers')
       cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="${CREATE_CUSTOMER_DATA_TEST}"]`, {
         timeout: 10000,
       }).click()
@@ -124,7 +124,12 @@ describe('Multi-organization redirect flows', () => {
         const customerIdMatch = org1CustomerUrl.match(/\/customer\/([^/]+)/)
         const org1CustomerId = customerIdMatch ? customerIdMatch[1] : null
         cy.log('Org1 Customer ID:', org1CustomerId)
-        // 4. logout, visit orga 1 url and login with customer in org2
+        // 4. logout, visit orga 1 url and login with customer in org2.
+        // Slug-less path is intentional: the test probes what happens when
+        // a logged-out user visits a legacy cross-org URL. Auth guard fires,
+        // saves state, redirects to login. After login as User B, Home.tsx
+        // cannot resolve a slug from `location.state.from` so falls to the
+        // permission-based default (Org2 home).
         cy.logout()
         cy.visit(`/customer/${org1CustomerId}`)
         cy.get('input[name="email"]').type(testUsers.userB.email)
@@ -145,7 +150,7 @@ describe('Multi-organization redirect flows', () => {
 
       // 2. Navigate to a deep page (e.g., customers/:id)
       // Create a customer to get a deep link
-      cy.visit('/customers')
+      cy.visitApp('/customers')
       cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="${CREATE_CUSTOMER_DATA_TEST}"]`, {
         timeout: 10000,
       }).click()
@@ -170,7 +175,7 @@ describe('Multi-organization redirect flows', () => {
       cy.login(testUsers.userA.email, testUsers.userA.password)
 
       // 2. Navigate to customers with query params
-      cy.visit('/customers?search=test&page=2')
+      cy.visitApp('/customers?search=test&page=2')
       cy.url().should('include', 'search=test')
       cy.url().should('include', 'page=2')
 

--- a/cypress/e2e/10-resources/t10-create-taxes.cy.ts
+++ b/cypress/e2e/10-resources/t10-create-taxes.cy.ts
@@ -11,7 +11,7 @@ describe.skip('Create taxes', () => {
   })
 
   it('should create taxes', () => {
-    cy.visit('/settings/taxes')
+    cy.visitApp('/settings/taxes')
     cy.url().should('include', '/settings/taxes')
 
     // Make sure no tax exists
@@ -38,7 +38,7 @@ describe.skip('Create taxes', () => {
   })
 
   it('should assign tax to organization', () => {
-    cy.visit('/settings/invoice')
+    cy.visitApp('/settings/invoice')
     cy.url().should('include', '/settings/invoice')
 
     // Make sure no tax are already assigned

--- a/cypress/e2e/10-resources/t20-create-customer.cy.ts
+++ b/cypress/e2e/10-resources/t20-create-customer.cy.ts
@@ -8,7 +8,7 @@ import { customerName } from '../../support/reusableConstants'
 
 describe('Create customer', () => {
   beforeEach(() => {
-    cy.login().visit('/customers')
+    cy.login().visitApp('/customers')
   })
 
   it('should create customer', () => {

--- a/cypress/e2e/10-resources/t30-create-bm.cy.ts
+++ b/cypress/e2e/10-resources/t30-create-bm.cy.ts
@@ -2,7 +2,7 @@ import { ACTIONS_BLOCK_TEST_ID } from '~/components/MainHeader/mainHeaderTestIds
 
 describe('Create billable metrics', () => {
   beforeEach(() => {
-    cy.login().visit('/billable-metrics')
+    cy.login().visitApp('/billable-metrics')
   })
 
   it('should create count billable metric', () => {
@@ -11,7 +11,7 @@ describe('Create billable metrics', () => {
     const bmCode = `bm_count_${randomId}`
 
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-bm"]`).click()
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
+    cy.url().should('match', /\/[^/]+\/create\/billable-metrics$/)
     cy.get('input[name="name"]').type(bmName)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('input[name="code"]').should('have.value', bmCode)
@@ -34,7 +34,7 @@ describe('Create billable metrics', () => {
     const bmCode = `bm_uniq_count_${randomId}`
 
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-bm"]`).click()
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
+    cy.url().should('match', /\/[^/]+\/create\/billable-metrics$/)
     cy.get('input[name="name"]').type(bmName)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('input[name="code"]').should('have.value', bmCode)
@@ -59,7 +59,7 @@ describe('Create billable metrics', () => {
     const bmCode = `bm_max_${randomId}`
 
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-bm"]`).click()
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
+    cy.url().should('match', /\/[^/]+\/create\/billable-metrics$/)
     cy.get('input[name="name"]').type(bmName)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('input[name="code"]').should('have.value', bmCode)
@@ -83,7 +83,7 @@ describe('Create billable metrics', () => {
     const bmCode = `bm_sum_${randomId}`
 
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-bm"]`).click()
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
+    cy.url().should('match', /\/[^/]+\/create\/billable-metrics$/)
     cy.get('input[name="name"]').type(bmName)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('input[name="code"]').should('have.value', bmCode)
@@ -107,7 +107,7 @@ describe('Create billable metrics', () => {
     const bmCode = `bm_recurring_count_${randomId}`
 
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-bm"]`).click()
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
+    cy.url().should('match', /\/[^/]+\/create\/billable-metrics$/)
     cy.get('input[name="name"]').type(bmName)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('input[name="code"]').should('have.value', bmCode)
@@ -130,7 +130,7 @@ describe('Create billable metrics', () => {
     const bmCode = `bm_weighted_sum_${randomId}`
 
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-bm"]`).click()
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
+    cy.url().should('match', /\/[^/]+\/create\/billable-metrics$/)
     cy.get('input[name="name"]').type(bmName)
     cy.get('[data-test="submit"]').should('be.disabled')
     cy.get('[data-test="recurring-switch"] [data-test="button-selector-true"]').click()
@@ -155,7 +155,7 @@ describe('Create billable metrics', () => {
     const bmCode = `bm_filtered_${randomId}`
 
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-bm"]`).click()
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/create/billable-metrics')
+    cy.url().should('match', /\/[^/]+\/create\/billable-metrics$/)
     cy.get('input[name="name"]').type(bmName)
     cy.get('input[name="code"]').should('have.value', bmCode)
     cy.get('input[name="aggregationType"]').click()

--- a/cypress/e2e/10-resources/t40-create-plan.cy.ts
+++ b/cypress/e2e/10-resources/t40-create-plan.cy.ts
@@ -20,7 +20,7 @@ const selectMeteredBillableMetric = (bmNameFragment: string) => {
 
 describe('Create plan', () => {
   beforeEach(() => {
-    cy.login().visit('/plans')
+    cy.login().visitApp('/plans')
   })
 
   it('should be able to create a minimal plan', () => {
@@ -31,7 +31,7 @@ describe('Create plan', () => {
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-plan"]`).click({
       force: true,
     })
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/create/plans')
+    cy.url().should('match', /\/[^/]+\/create\/plans$/)
     cy.get('input[name="name"]').type(planName)
     cy.get('input[name="code"]').should('have.value', planCode)
 
@@ -49,7 +49,7 @@ describe('Create plan', () => {
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-plan"]`).click({
       force: true,
     })
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/create/plans')
+    cy.url().should('match', /\/[^/]+\/create\/plans$/)
     cy.get('input[name="name"]').type(planName)
     cy.get('input[name="code"]').should('have.value', planCode)
     cy.get('[data-test="show-description"]').click({ force: true })
@@ -69,7 +69,7 @@ describe('Create plan', () => {
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-plan"]`).click({
       force: true,
     })
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/create/plans')
+    cy.url().should('match', /\/[^/]+\/create\/plans$/)
     cy.get('input[name="name"]').type(planWithChargesName)
     cy.get('[data-test="show-description"]').click({ force: true })
     cy.get('textarea[name="description"]').type('A plan with all charge types')

--- a/cypress/e2e/10-resources/t50-edit-plan.cy.ts
+++ b/cypress/e2e/10-resources/t50-edit-plan.cy.ts
@@ -10,7 +10,7 @@ describe('Edit plan', () => {
   })
 
   it('should be able to close the form without warning dialog when no data has changed', () => {
-    cy.visit('/plans')
+    cy.visitApp('/plans')
     cy.get(`[data-test="${planWithChargesName}"] [data-test="open-action-button"]`).click({
       force: true,
     })
@@ -22,7 +22,7 @@ describe('Edit plan', () => {
   })
 
   it('should be able to update plan code', () => {
-    cy.visit('/plans')
+    cy.visitApp('/plans')
     cy.get(`[data-test="${planWithChargesName}"] [data-test="open-action-button"]`).click({
       force: true,
     })
@@ -37,7 +37,7 @@ describe('Edit plan', () => {
   })
 
   it('should add plan to customer', () => {
-    cy.visit('/customers')
+    cy.visitApp('/customers')
     cy.get('[data-test="table-customers-list"] tr').contains(customerName).click()
     cy.get('[data-test="add-subscription"]').click()
 
@@ -51,7 +51,7 @@ describe('Edit plan', () => {
   })
 
   it('should not be able to update locked fields of a used plan', () => {
-    cy.visit('/plans')
+    cy.visitApp('/plans')
     cy.get(`[data-test="${planWithChargesName}"] [data-test="open-action-button"]`).click({
       force: true,
     })

--- a/cypress/e2e/10-resources/t60-coupons-create-edit-apply.cy.ts
+++ b/cypress/e2e/10-resources/t60-coupons-create-edit-apply.cy.ts
@@ -15,7 +15,7 @@ describe('Coupons', () => {
   })
 
   it('should be able create a coupon with plan limitation', () => {
-    cy.visit('/coupons')
+    cy.visitApp('/coupons')
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="add-coupon"]`).click()
     cy.get('input[name="name"]').type(couponName)
     cy.get('input[name="code"]').should('have.value', couponCode)
@@ -34,7 +34,7 @@ describe('Coupons', () => {
   })
 
   it('should be able to edit the same coupon', () => {
-    cy.visit('/coupons')
+    cy.visitApp('/coupons')
     cy.get(`[data-test="${couponName}"]`).click()
 
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="coupon-details-actions"]`).click()
@@ -55,7 +55,7 @@ describe('Coupons', () => {
   })
 
   it('should be able to apply the coupon to a customer', () => {
-    cy.visit('/customers')
+    cy.visitApp('/customers')
     cy.get('[data-test="table-customers-list"] tr', { timeout: 10000 })
       .contains(customerName)
       .click()
@@ -79,7 +79,7 @@ describe('Coupons', () => {
   })
 
   it('should not be able to apply the same coupon to a customer multiple time', () => {
-    cy.visit('/customers')
+    cy.visitApp('/customers')
     cy.get('[data-test="table-customers-list"] tr', { timeout: 10000 })
       .contains(customerName)
       .click()
@@ -92,7 +92,7 @@ describe('Coupons', () => {
   })
 
   it('should not be able to edit an applied coupon', () => {
-    cy.visit('/coupons')
+    cy.visitApp('/coupons')
     cy.get(`[data-test="${couponName}"]`).click()
 
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="coupon-details-actions"]`).click()

--- a/cypress/e2e/10-resources/t70-addon-create-edit.cy.ts
+++ b/cypress/e2e/10-resources/t70-addon-create-edit.cy.ts
@@ -16,9 +16,9 @@ describe('Add On', () => {
 
   it('should be able create an add on with all attributes filled', () => {
     // Navigation
-    cy.visit('/add-ons')
+    cy.visitApp('/add-ons')
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-addon-cta"]`).click()
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/create/add-on')
+    cy.url().should('match', /\/[^/]+\/create\/add-on$/)
 
     // Basic form infos
     cy.get('[data-test="submit"]').should('be.disabled')
@@ -40,7 +40,7 @@ describe('Add On', () => {
 
   it('should be able to edit the same coupon', () => {
     // Navigation
-    cy.visit('/add-ons')
+    cy.visitApp('/add-ons')
     cy.get(`[data-test="${addOnName}"]`).click()
 
     cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="addon-details-actions"]`).click()

--- a/cypress/e2e/t10-add-subscription.cy.ts
+++ b/cypress/e2e/t10-add-subscription.cy.ts
@@ -4,7 +4,7 @@ import { customerName } from '../support/reusableConstants'
 
 describe('Subscriptions', () => {
   beforeEach(() => {
-    cy.login().visit('/customers')
+    cy.login().visitApp('/customers')
     cy.get('[data-test="table-customers-list"] tr').contains(customerName).click()
   })
 

--- a/cypress/e2e/t20-invitations.cy.ts
+++ b/cypress/e2e/t20-invitations.cy.ts
@@ -6,7 +6,7 @@ describe('Invitations', () => {
   const inviteEmail = `test-invite-${Date.now()}@gmail.com`
 
   it('should be able to create an invitation', () => {
-    cy.visit('/settings/team-and-security/members')
+    cy.visitApp('/settings/team-and-security/members')
     cy.get(`[role="dialog"]`).should('not.exist')
     cy.get(`[data-test="create-invite-button"]`).click()
     cy.get(`[role="dialog"]`).should('exist')
@@ -20,7 +20,7 @@ describe('Invitations', () => {
   })
 
   it('invite link should have correct format', () => {
-    cy.visit('/settings/team-and-security/members/invitations')
+    cy.visitApp('/settings/team-and-security/members/invitations')
 
     cy.get('#table-members-setting-invitations-list-row-0')
       .first()
@@ -30,10 +30,7 @@ describe('Invitations', () => {
 
     cy.get('[data-test="copy-invite-link"]').click()
 
-    cy.url().should(
-      'be.equal',
-      Cypress.config().baseUrl + '/settings/team-and-security/members/invitations',
-    )
+    cy.url().should('match', /\/[^/]+\/settings\/team-and-security\/members\/invitations$/)
     cy.window().then((win) => {
       new Cypress.Promise((resolve, reject) =>
         win.navigator.clipboard.readText().then(resolve).catch(reject),

--- a/cypress/e2e/t30-create-one-off-invoice.cy.ts
+++ b/cypress/e2e/t30-create-one-off-invoice.cy.ts
@@ -11,7 +11,7 @@ describe.skip('Create one-off', () => {
   })
 
   it('should create a one-off invoice with correct amounts', () => {
-    cy.visit('/customers')
+    cy.visitApp('/customers')
     cy.get('[data-test="table-customers-list"] tr').contains(customerName).click({ force: true })
     cy.get('[data-test="customer-actions"]').click({ force: true })
     cy.get('[data-test="create-invoice-action"]').click({ force: true })
@@ -97,7 +97,7 @@ describe.skip('Create one-off', () => {
 
   describe('anti-regression', () => {
     it('should allow to edit the units and have an effect on totals', () => {
-      cy.visit('/customers')
+      cy.visitApp('/customers')
       cy.get('[data-test="table-customers-list"] tr').contains(customerName).click({ force: true })
       cy.get('[data-test="customer-actions"]').click({ force: true })
       cy.get('[data-test="create-invoice-action"]').click({ force: true })

--- a/cypress/e2e/t40-wallet-top-up.cy.ts
+++ b/cypress/e2e/t40-wallet-top-up.cy.ts
@@ -21,7 +21,7 @@ const walletCustomerExternalId = `wallet-customer-${randomId}`
 describe('Wallet Top-Up', () => {
   before(() => {
     // Create a customer and a wallet as prerequisites
-    cy.login().visit('/customers')
+    cy.login().visitApp('/customers')
 
     // Create customer
     cy.get(
@@ -58,7 +58,7 @@ describe('Wallet Top-Up', () => {
 
   it('should be able to create a prepaid credits top-up', () => {
     // Navigate to the customer
-    cy.visit('/customers')
+    cy.visitApp('/customers')
     cy.contains(walletCustomerName).click({ force: true })
 
     // Go to wallet tab
@@ -85,7 +85,7 @@ describe('Wallet Top-Up', () => {
 
   it('should be able to create a free credits top-up', () => {
     // Navigate to the customer
-    cy.visit('/customers')
+    cy.visitApp('/customers')
     cy.contains(walletCustomerName).click({ force: true })
 
     // Go to wallet tab

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -2,23 +2,27 @@
 // This example support/e2e.ts is processed and
 // loaded automatically before your test files.
 // ***********************************************************
+import { NEVER_SLUG_PREFIXES } from '~/core/router/slugPrefixes'
 import { SIGNUP_SUBMIT_BUTTON_TEST_ID } from '~/pages/auth/signUpTestIds'
 
 import { userEmail, userPassword } from './reusableConstants'
 
 /**
- * Public paths that live outside `/:organizationSlug` and must NOT be
- * prefixed with the org slug when navigating via `cy.visitApp()`.
- * Mirrors `NEVER_SLUG_PREFIXES` in `src/core/router/slugPrefixes.ts`
- * plus the auth routes (`/sign-up`, `/invitation`, `/password-reset`).
+ * Paths that pass through `cy.visitApp()` unchanged (no slug prepended).
+ *
+ * Extends the app's `NEVER_SLUG_PREFIXES` with auth entry pages that are
+ * reachable only from outside the app (signup, invitation, password reset)
+ * — those aren't in `NEVER_SLUG_PREFIXES` because the in-app wrappers
+ * (`useNavigate` / `<Link>`) never build `navigate('/sign-up')` calls, but
+ * Cypress tests do visit those pages directly.
+ *
+ * Importing `NEVER_SLUG_PREFIXES` from the source keeps the two lists in
+ * sync — any new public route added there is reflected here automatically.
  */
 const PUBLIC_PATHS = [
-  '/login',
+  ...NEVER_SLUG_PREFIXES,
   '/sign-up',
   '/invitation',
-  '/customer-portal',
-  '/forbidden',
-  '/404',
   '/password-reset',
   '/forgot-password',
 ]
@@ -31,9 +35,17 @@ const PUBLIC_PATHS = [
 const POST_AUTH_URL_RE = /\/[^/]+\/(customers|analytics)/
 
 /**
- * Extracts the org slug from the current URL and stores it in
- * `Cypress.env('orgSlug')` so `cy.visitApp()` can build slug-prefixed
- * paths in subsequent steps.
+ * Module-scoped org slug captured by `cy.login()` / `cy.signup()` and read
+ * by `cy.visitApp()`. Preferred over `Cypress.env('orgSlug', value)` because
+ * Cypress deprecated the 2-arg setter overload. Module-scoped state is
+ * fine here: Cypress loads this support file once per spec run, and tests
+ * that need a different slug re-login/signup (both re-capture).
+ */
+let capturedOrgSlug: string | undefined
+
+/**
+ * Extracts the org slug from the current URL and stores it for subsequent
+ * `cy.visitApp()` calls in the same spec.
  */
 const captureOrgSlugFromUrl = (): void => {
   cy.url()
@@ -42,7 +54,7 @@ const captureOrgSlugFromUrl = (): void => {
       const slug = new URL(url).pathname.split('/')[1]
 
       if (!slug) throw new Error(`Could not extract org slug from URL: ${url}`)
-      Cypress.env('orgSlug', slug)
+      capturedOrgSlug = slug
     })
 }
 
@@ -59,7 +71,7 @@ Cypress.Commands.add('logout', () => {
   cy.get('[data-test="side-nav-logout"]').click()
   cy.url().should('include', '/login')
   // Clear the captured slug — subsequent login/signup must re-capture it.
-  Cypress.env('orgSlug', undefined)
+  capturedOrgSlug = undefined
 })
 
 Cypress.Commands.add(
@@ -90,7 +102,7 @@ Cypress.Commands.add(
  * through unchanged.
  *
  * Requires `cy.login()` or `cy.signup()` to have been called first so
- * the slug is available in `Cypress.env('orgSlug')`.
+ * the slug is available.
  */
 Cypress.Commands.add('visitApp', (path: string) => {
   const isPublic = PUBLIC_PATHS.some((p) => path.startsWith(p))
@@ -99,9 +111,7 @@ Cypress.Commands.add('visitApp', (path: string) => {
     return cy.visit(path)
   }
 
-  const slug = Cypress.env('orgSlug')
-
-  if (!slug) {
+  if (!capturedOrgSlug) {
     throw new Error(
       `cy.visitApp('${path}') called without a captured org slug. Call cy.login() or cy.signup() first.`,
     )
@@ -109,7 +119,7 @@ Cypress.Commands.add('visitApp', (path: string) => {
 
   const normalized = path.startsWith('/') ? path : `/${path}`
 
-  return cy.visit(`/${slug}${normalized}`)
+  return cy.visit(`/${capturedOrgSlug}${normalized}`)
 })
 
 // https://docs.cypress.io/api/cypress-api/custom-commands#Overwrite-type-command

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,33 +1,65 @@
 // ***********************************************************
 // This example support/e2e.ts is processed and
 // loaded automatically before your test files.
-//
-// This is a great place to put global configuration and
-// behavior that modifies Cypress.
-//
-// You can change the location of this file or turn off
-// automatically serving support files with the
-// 'supportFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/configuration
 // ***********************************************************
 import { SIGNUP_SUBMIT_BUTTON_TEST_ID } from '~/pages/auth/signUpTestIds'
 
 import { userEmail, userPassword } from './reusableConstants'
+
+/**
+ * Public paths that live outside `/:organizationSlug` and must NOT be
+ * prefixed with the org slug when navigating via `cy.visitApp()`.
+ * Mirrors `NEVER_SLUG_PREFIXES` in `src/core/router/slugPrefixes.ts`
+ * plus the auth routes (`/sign-up`, `/invitation`, `/password-reset`).
+ */
+const PUBLIC_PATHS = [
+  '/login',
+  '/sign-up',
+  '/invitation',
+  '/customer-portal',
+  '/forbidden',
+  '/404',
+  '/password-reset',
+  '/forgot-password',
+]
+
+/**
+ * Regex matching the first authenticated URL after login/signup.
+ * `Home.tsx` redirects to `/${slug}/customers` or `/${slug}/analytics`
+ * depending on the user's permissions.
+ */
+const POST_AUTH_URL_RE = /\/[^/]+\/(customers|analytics)/
+
+/**
+ * Extracts the org slug from the current URL and stores it in
+ * `Cypress.env('orgSlug')` so `cy.visitApp()` can build slug-prefixed
+ * paths in subsequent steps.
+ */
+const captureOrgSlugFromUrl = (): void => {
+  cy.url()
+    .should('match', POST_AUTH_URL_RE)
+    .then((url) => {
+      const slug = new URL(url).pathname.split('/')[1]
+
+      if (!slug) throw new Error(`Could not extract org slug from URL: ${url}`)
+      Cypress.env('orgSlug', slug)
+    })
+}
 
 Cypress.Commands.add('login', (email = userEmail, password = userPassword) => {
   cy.visit('/login')
   cy.get('input[name="email"]').type(email)
   cy.get('input[name="password"]').type(password)
   cy.get('[data-test="submit"]').click()
-  cy.url().should('be.equal', Cypress.config().baseUrl + '/')
+  captureOrgSlugFromUrl()
 })
 
 Cypress.Commands.add('logout', () => {
   cy.get('[data-test="side-nav-user-infos"]').click()
   cy.get('[data-test="side-nav-logout"]').click()
   cy.url().should('include', '/login')
+  // Clear the captured slug — subsequent login/signup must re-capture it.
+  Cypress.env('orgSlug', undefined)
 })
 
 Cypress.Commands.add(
@@ -46,9 +78,39 @@ Cypress.Commands.add(
     cy.get('input[name="email"]').type(email)
     cy.get('input[name="password"]').type(password)
     cy.get(`[data-test="${SIGNUP_SUBMIT_BUTTON_TEST_ID}"]`).click()
-    cy.url().should('be.equal', Cypress.config().baseUrl + '/')
+    captureOrgSlugFromUrl()
   },
 )
+
+/**
+ * Slug-aware wrapper around `cy.visit()`. Prepends `/${orgSlug}` to any
+ * absolute authenticated path so spec files can keep writing
+ * `cy.visitApp('/customers')` while the actual navigation targets
+ * `/${slug}/customers`. Public paths (login/signup/invitation/…) pass
+ * through unchanged.
+ *
+ * Requires `cy.login()` or `cy.signup()` to have been called first so
+ * the slug is available in `Cypress.env('orgSlug')`.
+ */
+Cypress.Commands.add('visitApp', (path: string) => {
+  const isPublic = PUBLIC_PATHS.some((p) => path.startsWith(p))
+
+  if (isPublic) {
+    return cy.visit(path)
+  }
+
+  const slug = Cypress.env('orgSlug')
+
+  if (!slug) {
+    throw new Error(
+      `cy.visitApp('${path}') called without a captured org slug. Call cy.login() or cy.signup() first.`,
+    )
+  }
+
+  const normalized = path.startsWith('/') ? path : `/${path}`
+
+  return cy.visit(`/${slug}${normalized}`)
+})
 
 // https://docs.cypress.io/api/cypress-api/custom-commands#Overwrite-type-command
 // @ts-expect-error custom command
@@ -67,6 +129,3 @@ beforeEach(() => {
     },
   })
 })
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -4,21 +4,24 @@ declare namespace Cypress {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface Chainable<Subject> {
     /**
-     * Login user
+     * Login user. Captures the org slug from the post-login URL and stores
+     * it in `Cypress.env('orgSlug')` so subsequent `cy.visitApp()` calls
+     * work without manual setup.
      * @example
      * cy.login('usertest@lago.com', 'P@ssw0rd')
      */
     login(email?: string, password?: string): Chainable<unknown>
 
     /**
-     * Logout current user
+     * Logout current user. Clears the captured org slug so any subsequent
+     * `cy.visitApp()` call throws unless re-login/signup happens first.
      * @example
      * cy.logout()
      */
     logout(): Chainable<unknown>
 
     /**
-     * Signup user
+     * Signup user. Same slug-capture behavior as `cy.login()`.
      * @example
      * cy.signup({ organizationName: 'Lago', email: 'user@lago.com', password: 'P@ssw0rd' })
      */
@@ -31,6 +34,20 @@ declare namespace Cypress {
       email: string
       password: string
     }): Chainable<unknown>
+
+    /**
+     * Slug-aware `cy.visit()` wrapper. Prepends `/${orgSlug}` to
+     * authenticated paths; public paths (`/login`, `/sign-up`, `/invitation`,
+     * `/customer-portal`, `/forbidden`, `/404`, `/password-reset`,
+     * `/forgot-password`) pass through unchanged.
+     *
+     * Requires `cy.login()` or `cy.signup()` to have been called first.
+     *
+     * @example
+     * cy.visitApp('/customers')            // → /${slug}/customers
+     * cy.visitApp('/login')                // → /login (public, unchanged)
+     */
+    visitApp(path: string): Chainable<Cypress.AUTWindow>
   }
 
   interface Cypress {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -82,7 +82,10 @@ const Home = () => {
         const isLegacySegment = LEGACY_APP_PATH_SEGMENTS.has(savedSlug ?? '')
 
         if (isLegacySegment) {
-          return navigate(`/${slug}${savedLocation.pathname}`, { replace: true })
+          return navigate(
+            `/${slug}${savedLocation.pathname}${savedLocation.search || ''}${savedLocation.hash || ''}`,
+            { replace: true },
+          )
         }
       }
       // Unknown slug or unrecognized path — fall through to default navigation

--- a/src/pages/__tests__/Home.test.tsx
+++ b/src/pages/__tests__/Home.test.tsx
@@ -147,7 +147,7 @@ describe('Home', () => {
       })
     })
 
-    it('should prepend slug to legacy saved location (no slug in path)', async () => {
+    it('should prepend slug to legacy saved location and preserve search + hash', async () => {
       mockUseLocation.mockReturnValue({
         state: {
           from: savedLocationLegacy,
@@ -158,7 +158,7 @@ describe('Home', () => {
       renderHook(() => Home())
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith(`/${TEST_ORG_SLUG}/customers/123`, {
+        expect(mockNavigate).toHaveBeenCalledWith(`/${TEST_ORG_SLUG}/customers/123?tab=overview`, {
           replace: true,
         })
       })


### PR DESCRIPTION
## Context

All authenticated routes are now under `/:organizationSlug`, so URLs are `/${slug}/customers` instead of `/customers`. The Cypress suite was slug-unaware.

## Description

- `cy.login()` and `cy.signup()` now capture the org slug from the post-redirect URL into `Cypress.env('orgSlug')`. `cy.logout()` clears it.
- New `cy.visitApp(path)` command prepends `/${slug}` to authenticated paths; public paths (`/login`, `/sign-up`, `/invitation`, …) pass through.
- 15 spec files migrated: `cy.visit('/<auth-path>')` → `cy.visitApp(...)`, strict `be.equal(baseUrl + '/<path>')` → `match(/\/[^/]+\/<path>$/)`.
- `should('include', '/<path>')` left untouched — still matches because `'/acme/customers'` includes `'/customers'`.
- Intentionally-legacy `cy.visit()` calls kept with inline comments where tests probe slug-less URLs on purpose (auth-guard redirect, cross-org access protection).

<!-- Linear link -->
Fixes LAGO-1348