### PR TITLE
refactor(dialogs): migrate SpendingMinimumOptionSection to usePremiumWarningDialog hook

### DIFF
--- a/src/components/plans/chargeAccordion/SpendingMinimumOptionSection.tsx
+++ b/src/components/plans/chargeAccordion/SpendingMinimumOptionSection.tsx
@@ -1,11 +1,11 @@
 import InputAdornment from '@mui/material/InputAdornment'
-import { RefObject, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { AmountInput } from '~/components/form'
 import { LocalUsageChargeInput } from '~/components/plans/types'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { FORM_TYPE_ENUM } from '~/core/constants/form'
 import { getCurrencySymbol } from '~/core/formats/intlFormatNumber'
 import { CurrencyEnum } from '~/generated/graphql'
@@ -19,7 +19,6 @@ export const SpendingMinimumOptionSection = ({
   chargePricingUnitShortName,
   currency,
   isPremium,
-  premiumWarningDialogRef,
   chargeIndex,
   handleUpdate,
   handleRemoveSpendingMinimum,
@@ -31,12 +30,12 @@ export const SpendingMinimumOptionSection = ({
   chargePricingUnitShortName: string | undefined
   currency: CurrencyEnum
   isPremium: boolean
-  premiumWarningDialogRef: RefObject<PremiumWarningDialogRef> | undefined
   chargeIndex: number
   handleUpdate: (name: string, value: unknown) => void
   handleRemoveSpendingMinimum: () => void
 }) => {
   const { translate } = useInternationalization()
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const [showSpendingMinimum, setShowSpendingMinimum] = useState(
     !!initialLocalCharge?.minAmountCents && Number(initialLocalCharge?.minAmountCents) > 0,
   )
@@ -63,7 +62,7 @@ export const SpendingMinimumOptionSection = ({
                 document.getElementById(`spending-minimum-input-${chargeIndex}`)?.focus()
               }, 0)
             } else {
-              premiumWarningDialogRef?.current?.openDialog()
+              openPremiumWarningDialog()
             }
           }}
         >

--- a/src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx
+++ b/src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx
@@ -793,7 +793,6 @@ export const UsageChargeDrawerContent = withForm({
                       chargePricingUnitShortName={chargePricingUnitShortName}
                       currency={currency}
                       isPremium={isPremium}
-                      premiumWarningDialogRef={premiumWarningDialogRef}
                       chargeIndex={editIndex}
                       handleUpdate={(name, value) => {
                         form.setFieldValue(


### PR DESCRIPTION
## Summary

- Migrates `SpendingMinimumOptionSection` from the deprecated imperative `PremiumWarningDialogRef` to the new hook-based `usePremiumWarningDialog` (from `~/components/dialogs/PremiumWarningDialog`).
- Drops the now-unused `premiumWarningDialogRef` prop being forwarded from `UsageChargeDrawerContent` to this section. Other `premiumWarningDialogRef` usages in that parent are intentionally left untouched to keep the change tightly scoped — they still serve sibling components and can be migrated in follow-up PRs.
- Clears 1 `no-restricted-imports` warning for `~/components/PremiumWarningDialog` (ESLint: 523 → 522 warnings).

## Test plan

- [x] `pnpm code:style` (lint + types + translations) — 0 errors
- [x] `pnpm jest src/components/plans/drawers/usageCharge/__tests__/UsageChargeDrawerContent.test.tsx` — 14/14 pass
- [ ] Manual check: in a plan's usage charge drawer, when the user is **not** premium, clicking "Add spending minimum" opens the premium warning dialog.
- [ ] Manual check: when the user **is** premium, the spending-minimum input appears and auto-focuses as before.