### PR TITLE
refactor(plans): move bill-monthly switches to plan settings

### DIFF
--- a/src/components/plans/PlanSettingsSection.tsx
+++ b/src/components/plans/PlanSettingsSection.tsx
@@ -16,6 +16,8 @@ import { CurrencyEnum, PlanInterval, TaxForPlanSettingsSectionFragment } from '~
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { PlanFormType } from '~/hooks/plans/usePlanForm'
 
+export const PLAN_SETTINGS_REMOVE_DESCRIPTION_TEST_ID = 'remove-description'
+
 gql`
   fragment TaxForPlanSettingsSection on Tax {
     id
@@ -79,8 +81,6 @@ type PlanSettingsSectionProps = {
   isEdition?: boolean
 }
 
-export const PLAN_SETTINGS_REMOVE_DESCRIPTION_TEST_ID = 'remove-description'
-
 export const PlanSettingsSection = ({
   form,
   canBeEdited,
@@ -90,6 +90,9 @@ export const PlanSettingsSection = ({
 }: PlanSettingsSectionProps) => {
   const { translate } = useInternationalization()
   const description = useStore(form.store, (s) => s.values.description)
+  const planInterval = useStore(form.store, (s) => s.values.interval)
+  const hasAnyFixedCharge = useStore(form.store, (s) => !!s.values.fixedCharges.length)
+  const hasAnyUsageCharge = useStore(form.store, (s) => !!s.values.charges.length)
   const [shouldDisplayDescription, setShouldDisplayDescription] = useState(!!description)
 
   const handleHideDescription = () => {
@@ -101,6 +104,9 @@ export const PlanSettingsSection = ({
     label: translate(getIntervalTranslationKey[interval]),
     value: interval,
   }))
+  const canApplyChargesMonthly = [PlanInterval.Semiannual, PlanInterval.Yearly].includes(
+    planInterval,
+  )
 
   return (
     <CenteredPage.PageSection>
@@ -168,6 +174,34 @@ export const PlanSettingsSection = ({
           />
         )}
       </form.AppField>
+
+      {canApplyChargesMonthly && (
+        <>
+          {hasAnyFixedCharge && (
+            <form.AppField name="billFixedChargesMonthly">
+              {(field) => (
+                <field.SwitchField
+                  label={translate('text_1760729707268reew4lqsqof')}
+                  subLabel={translate('text_1760729707268ge00k7a7e84')}
+                  disabled={isInSubscriptionForm || (isEdition && !canBeEdited)}
+                />
+              )}
+            </form.AppField>
+          )}
+
+          {hasAnyUsageCharge && (
+            <form.AppField name="billChargesMonthly">
+              {(field) => (
+                <field.SwitchField
+                  label={translate('text_62a30bc79dae432fb055330b')}
+                  subLabel={translate('text_64358e074a3b7500714f256c')}
+                  disabled={isInSubscriptionForm || (isEdition && !canBeEdited)}
+                />
+              )}
+            </form.AppField>
+          )}
+        </>
+      )}
 
       <form.AppField name="amountCurrency">
         {(field) => (

--- a/src/components/plans/UsageChargesSection.tsx
+++ b/src/components/plans/UsageChargesSection.tsx
@@ -119,8 +119,6 @@ export const UsageChargesSection = ({
     return null
   }
 
-  const canApplyChargesMonthly = isAnnual
-
   const renderChargeSelector = (charge: LocalUsageChargeInput, i: number) => {
     const isNew = !alreadyExistingCharges?.find((chargeFetched) => chargeFetched?.id === charge.id)
     const alreadyUsedChargeAlertMessage =
@@ -203,25 +201,11 @@ export const UsageChargesSection = ({
         />
 
         {!!hasAnyCharge && (
-          <>
-            {canApplyChargesMonthly && (
-              <form.AppField name="billChargesMonthly">
-                {(field) => (
-                  <field.SwitchField
-                    label={translate('text_62a30bc79dae432fb055330b')}
-                    subLabel={translate('text_64358e074a3b7500714f256c')}
-                    disabled={isInSubscriptionForm || (isEdition && !canBeEdited)}
-                  />
-                )}
-              </form.AppField>
-            )}
-
-            <div className="flex flex-col gap-4">
-              {charges.map((charge, i) => {
-                return renderChargeSelector(charge, i)
-              })}
-            </div>
-          </>
+          <div className="flex flex-col gap-4">
+            {charges.map((charge, i) => {
+              return renderChargeSelector(charge, i)
+            })}
+          </div>
         )}
 
         {/* Single add button at the bottom */}

--- a/src/components/plans/__tests__/PlanSettingsSection.test.tsx
+++ b/src/components/plans/__tests__/PlanSettingsSection.test.tsx
@@ -2,16 +2,16 @@ import { act, cleanup, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { FORM_TYPE_ENUM } from '~/core/constants/form'
-import { CurrencyEnum, PlanInterval } from '~/generated/graphql'
+import { ChargeModelEnum, CurrencyEnum, PlanInterval } from '~/generated/graphql'
 import { useAppForm } from '~/hooks/forms/useAppform'
 import { PlanFormType } from '~/hooks/plans/usePlanForm'
 import { render } from '~/test-utils'
 
 import {
   PLAN_SETTINGS_REMOVE_DESCRIPTION_TEST_ID,
-  PlanSettingsFormValues,
   PlanSettingsSection,
 } from '../PlanSettingsSection'
+import { LocalFixedChargeInput, LocalUsageChargeInput, PlanFormInput } from '../types'
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({
@@ -40,18 +40,59 @@ jest.mock('~/components/taxes/TaxesSelectorSection', () => ({
   ),
 }))
 
-const DEFAULT_INITIAL_VALUES: PlanSettingsFormValues = {
+type TestFormValues = Pick<
+  PlanFormInput,
+  | 'name'
+  | 'code'
+  | 'description'
+  | 'interval'
+  | 'amountCurrency'
+  | 'taxes'
+  | 'fixedCharges'
+  | 'charges'
+  | 'billChargesMonthly'
+  | 'billFixedChargesMonthly'
+>
+
+const DEFAULT_INITIAL_VALUES: TestFormValues = {
   name: '',
   code: '',
   description: '',
   interval: PlanInterval.Monthly,
   amountCurrency: CurrencyEnum.Usd,
   taxes: [],
+  fixedCharges: [],
+  charges: [],
+  billChargesMonthly: false,
+  billFixedChargesMonthly: false,
 }
+
+const createMockFixedCharge = (): LocalFixedChargeInput =>
+  ({
+    id: 'fixed-charge-1',
+    chargeModel: ChargeModelEnum.Standard,
+    invoiceDisplayName: 'Fixed Charge',
+    payInAdvance: false,
+    prorated: false,
+    properties: { amount: '50' },
+    addOn: { id: 'addon-1', name: 'Setup Fee', code: 'setup_fee' },
+    taxes: [],
+  }) as unknown as LocalFixedChargeInput
+
+const createMockUsageCharge = (): LocalUsageChargeInput =>
+  ({
+    id: 'charge-1',
+    chargeModel: ChargeModelEnum.Standard,
+    invoiceDisplayName: 'Test Charge',
+    payInAdvance: false,
+    prorated: false,
+    properties: { amount: '10' },
+    taxes: [],
+  }) as unknown as LocalUsageChargeInput
 
 const PlanSettingsSectionWrapper = (
   props: Partial<Omit<React.ComponentProps<typeof PlanSettingsSection>, 'form'>> & {
-    defaultValues?: PlanSettingsFormValues
+    defaultValues?: TestFormValues
   },
 ) => {
   const { defaultValues, ...rest } = props
@@ -263,12 +304,12 @@ describe('PlanSettingsSection', () => {
           render(
             <PlanSettingsSectionWrapper
               defaultValues={{
+                ...DEFAULT_INITIAL_VALUES,
                 name: 'Test Plan',
                 code: 'test_plan',
                 description: 'A test plan',
                 interval: PlanInterval.Yearly,
                 amountCurrency: CurrencyEnum.Eur,
-                taxes: [],
               }}
             />,
           ),
@@ -303,6 +344,147 @@ describe('PlanSettingsSection', () => {
         ) as HTMLInputElement
 
         expect(currencyInput).toBeDisabled()
+      })
+    })
+  })
+
+  describe('GIVEN the bill-monthly switches', () => {
+    describe('WHEN the plan interval is Monthly', () => {
+      it('THEN should not display any bill-monthly switch even with charges', async () => {
+        await act(() =>
+          render(
+            <PlanSettingsSectionWrapper
+              defaultValues={{
+                ...DEFAULT_INITIAL_VALUES,
+                interval: PlanInterval.Monthly,
+                fixedCharges: [createMockFixedCharge()],
+                charges: [createMockUsageCharge()],
+              }}
+            />,
+          ),
+        )
+
+        expect(screen.queryByLabelText('billFixedChargesMonthly')).not.toBeInTheDocument()
+        expect(screen.queryByLabelText('billChargesMonthly')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the plan interval is Yearly with no charges', () => {
+      it('THEN should not display any bill-monthly switch', async () => {
+        await act(() =>
+          render(
+            <PlanSettingsSectionWrapper
+              defaultValues={{
+                ...DEFAULT_INITIAL_VALUES,
+                interval: PlanInterval.Yearly,
+              }}
+            />,
+          ),
+        )
+
+        expect(screen.queryByLabelText('billFixedChargesMonthly')).not.toBeInTheDocument()
+        expect(screen.queryByLabelText('billChargesMonthly')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the plan interval is Yearly with fixed charges only', () => {
+      it('THEN should display only the billFixedChargesMonthly switch', async () => {
+        await act(() =>
+          render(
+            <PlanSettingsSectionWrapper
+              defaultValues={{
+                ...DEFAULT_INITIAL_VALUES,
+                interval: PlanInterval.Yearly,
+                fixedCharges: [createMockFixedCharge()],
+              }}
+            />,
+          ),
+        )
+
+        expect(screen.getByLabelText('billFixedChargesMonthly')).toBeInTheDocument()
+        expect(screen.queryByLabelText('billChargesMonthly')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the plan interval is Yearly with usage charges only', () => {
+      it('THEN should display only the billChargesMonthly switch', async () => {
+        await act(() =>
+          render(
+            <PlanSettingsSectionWrapper
+              defaultValues={{
+                ...DEFAULT_INITIAL_VALUES,
+                interval: PlanInterval.Yearly,
+                charges: [createMockUsageCharge()],
+              }}
+            />,
+          ),
+        )
+
+        expect(screen.getByLabelText('billChargesMonthly')).toBeInTheDocument()
+        expect(screen.queryByLabelText('billFixedChargesMonthly')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the plan interval is Semiannual with both charge types', () => {
+      it('THEN should display both bill-monthly switches', async () => {
+        await act(() =>
+          render(
+            <PlanSettingsSectionWrapper
+              defaultValues={{
+                ...DEFAULT_INITIAL_VALUES,
+                interval: PlanInterval.Semiannual,
+                fixedCharges: [createMockFixedCharge()],
+                charges: [createMockUsageCharge()],
+              }}
+            />,
+          ),
+        )
+
+        expect(screen.getByLabelText('billFixedChargesMonthly')).toBeInTheDocument()
+        expect(screen.getByLabelText('billChargesMonthly')).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN isInSubscriptionForm is true with annual interval and charges', () => {
+      it('THEN should render the switches as disabled', async () => {
+        await act(() =>
+          render(
+            <PlanSettingsSectionWrapper
+              isInSubscriptionForm
+              defaultValues={{
+                ...DEFAULT_INITIAL_VALUES,
+                interval: PlanInterval.Yearly,
+                fixedCharges: [createMockFixedCharge()],
+                charges: [createMockUsageCharge()],
+              }}
+            />,
+          ),
+        )
+
+        expect(screen.getByLabelText('billFixedChargesMonthly')).toBeDisabled()
+        expect(screen.getByLabelText('billChargesMonthly')).toBeDisabled()
+      })
+    })
+
+    describe('WHEN isEdition is true and canBeEdited is false', () => {
+      it('THEN should render the switches as disabled', async () => {
+        await act(() =>
+          render(
+            <PlanSettingsSectionWrapper
+              isEdition
+              canBeEdited={false}
+              defaultValues={{
+                ...DEFAULT_INITIAL_VALUES,
+                interval: PlanInterval.Yearly,
+                fixedCharges: [createMockFixedCharge()],
+                charges: [createMockUsageCharge()],
+              }}
+            />,
+          ),
+        )
+
+        expect(screen.getByLabelText('billFixedChargesMonthly')).toBeDisabled()
+        expect(screen.getByLabelText('billChargesMonthly')).toBeDisabled()
       })
     })
   })

--- a/src/components/plans/__tests__/UsageChargesSection.test.tsx
+++ b/src/components/plans/__tests__/UsageChargesSection.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { createRef } from 'react'
 
 import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
-import { AggregationTypeEnum, ChargeModelEnum, PlanInterval } from '~/generated/graphql'
+import { AggregationTypeEnum, ChargeModelEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 import { createMockPlanForm } from '~/test-utils/createMockPlanForm'
 
@@ -241,31 +241,6 @@ describe('UsageChargesSection', () => {
           initialCharge: undefined,
           isUsedInSubscription: false,
         })
-      })
-    })
-  })
-
-  describe('GIVEN the plan interval is yearly', () => {
-    describe('WHEN the component renders with charges', () => {
-      it('THEN should display the bill charges monthly switch', () => {
-        const charge = createMockCharge()
-        const form = createForm({
-          charges: [charge],
-          interval: PlanInterval.Yearly,
-        })
-
-        render(
-          <UsageChargesSection
-            form={form}
-            isEdition={false}
-            premiumWarningDialogRef={premiumWarningDialogRef}
-          />,
-        )
-
-        // The Switch component renders an input with aria-label={name}
-        const switchEl = screen.getByLabelText('billChargesMonthly') as HTMLInputElement
-
-        expect(switchEl).toBeInTheDocument()
       })
     })
   })

--- a/src/components/plans/form/FixedChargesSection.tsx
+++ b/src/components/plans/form/FixedChargesSection.tsx
@@ -137,8 +137,6 @@ export const FixedChargesSection = ({
     return null
   }
 
-  const canApplyChargesMonthly = isAnnual
-
   return (
     <>
       <CenteredPage.PageSection>
@@ -146,18 +144,6 @@ export const FixedChargesSection = ({
           title={translate('text_176072970726728iw4tc8ucl')}
           description={translate('text_1760729707268c05r06ip8vg')}
         />
-
-        {!!hasAnyFixedCharge && canApplyChargesMonthly && (
-          <form.AppField name="billFixedChargesMonthly">
-            {(field) => (
-              <field.SwitchField
-                label={translate('text_1760729707268reew4lqsqof')}
-                subLabel={translate('text_1760729707268ge00k7a7e84')}
-                disabled={isInSubscriptionForm || (isEdition && !canBeEdited)}
-              />
-            )}
-          </form.AppField>
-        )}
 
         {(!!fixedCharges?.length || !isInSubscriptionForm) && (
           <div className="flex flex-col gap-6">

--- a/src/components/plans/form/__tests__/FixedChargesSection.test.tsx
+++ b/src/components/plans/form/__tests__/FixedChargesSection.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { ChargeModelEnum, PlanInterval } from '~/generated/graphql'
+import { ChargeModelEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 import { createMockPlanForm } from '~/test-utils/createMockPlanForm'
 
@@ -176,25 +176,6 @@ describe('FixedChargesSection', () => {
           alreadyUsedChargeAlertMessage: undefined,
           isUsedInSubscription: false,
         })
-      })
-    })
-  })
-
-  describe('GIVEN the plan interval is yearly', () => {
-    describe('WHEN the component renders with fixed charges', () => {
-      it('THEN should display the bill fixed charges monthly switch', () => {
-        const fixedCharge = createMockFixedCharge()
-        const form = createForm({
-          fixedCharges: [fixedCharge],
-          interval: PlanInterval.Yearly,
-        })
-
-        render(<FixedChargesSection form={form} alreadyExistingFixedChargesIds={[]} />)
-
-        // The Switch component renders an input with aria-label={name}
-        const switchEl = screen.getByLabelText('billFixedChargesMonthly') as HTMLInputElement
-
-        expect(switchEl).toBeInTheDocument()
       })
     })
   })

--- a/translations/base.json
+++ b/translations/base.json
@@ -917,7 +917,7 @@
   "text_6661fc17337de3591e29e3c9": "Explain the goal of this plan",
   "text_6661fc17337de3591e29e3cd": "Unique identifier to identify the plan through API.",
   "text_6661fc17337de3591e29e3d1": "Billing period interval",
-  "text_6661fc17337de3591e29e3d3": "Frequency at which the subscription recurs.",
+  "text_6661fc17337de3591e29e3d3": "Frequency at which the subscription fee recurs.",
   "text_6661fc17337de3591e29e3e7": "Pricing definition",
   "text_6661fc17337de3591e29e3e9": "A plan can include fixed and usage-based charges. Add them here and set your pricing and invoicing rules.",
   "text_6661fc17337de3591e29e403": "Period during which the plan is free before billing starts. Applies to the subscription fee only.",


### PR DESCRIPTION
## Summary
- Move `billFixedChargesMonthly` and `billChargesMonthly` switches out of `FixedChargesSection` / `UsageChargesSection` and render them together in `PlanSettingsSection`, just below the billing-interval selector. Both toggles now share a single, predictable home next to the field that controls their visibility (annual intervals only).
- Each switch is rendered conditionally: `billFixedChargesMonthly` only when the plan has fixed charges, `billChargesMonthly` only when it has usage charges — so the settings panel doesn't grow noisy for plans that don't use a given charge type.
- Minor copy tweak: "Frequency at which the subscription recurs." → "Frequency at which the subscription fee recurs." to better reflect what the interval controls now that charge cadence is disambiguated by the adjacent switches.

No behavior change on save — the switches still drive the same form fields and the existing auto-reset logic in `usePlanForm` still clears them when conditions aren't met.
