### PR TITLE
feat(org-slug): Phase 5/5 — Edit slug in organization settings

### DIFF
--- a/src/core/apolloClient/reactiveVars/__tests__/rewriteSlugInLocationHistory.test.ts
+++ b/src/core/apolloClient/reactiveVars/__tests__/rewriteSlugInLocationHistory.test.ts
@@ -1,0 +1,133 @@
+import type { Location } from 'react-router-dom'
+
+import { locationHistoryVar, rewriteSlugInLocationHistory } from '../locationHistoryVar'
+
+const createLocation = (pathname: string): Location => ({
+  pathname,
+  search: '',
+  hash: '',
+  state: null,
+  key: 'test-key',
+})
+
+describe('rewriteSlugInLocationHistory', () => {
+  beforeEach(() => {
+    locationHistoryVar([])
+  })
+
+  describe('GIVEN early-return conditions', () => {
+    describe('WHEN oldSlug is empty', () => {
+      it('THEN should not modify history', () => {
+        const history = [createLocation('/acme/settings')]
+
+        locationHistoryVar(history)
+        rewriteSlugInLocationHistory('', 'new-slug')
+
+        expect(locationHistoryVar()).toEqual(history)
+      })
+    })
+
+    describe('WHEN oldSlug equals newSlug', () => {
+      it('THEN should not modify history', () => {
+        const history = [createLocation('/acme/settings')]
+
+        locationHistoryVar(history)
+        rewriteSlugInLocationHistory('acme', 'acme')
+
+        expect(locationHistoryVar()).toEqual(history)
+      })
+    })
+  })
+
+  describe('GIVEN history entries with matching slug prefix', () => {
+    describe('WHEN pathname starts with /${oldSlug}/', () => {
+      it('THEN should rewrite the slug segment', () => {
+        locationHistoryVar([
+          createLocation('/acme/settings/general'),
+          createLocation('/acme/customers'),
+        ])
+
+        rewriteSlugInLocationHistory('acme', 'new-org')
+
+        const result = locationHistoryVar()
+
+        expect(result[0].pathname).toBe('/new-org/settings/general')
+        expect(result[1].pathname).toBe('/new-org/customers')
+      })
+    })
+
+    describe('WHEN pathname equals exactly /${oldSlug}', () => {
+      it('THEN should rewrite to /${newSlug}', () => {
+        locationHistoryVar([createLocation('/acme')])
+
+        rewriteSlugInLocationHistory('acme', 'new-org')
+
+        expect(locationHistoryVar()[0].pathname).toBe('/new-org')
+      })
+    })
+  })
+
+  describe('GIVEN history entries that do NOT match the slug', () => {
+    describe('WHEN pathname has a different prefix', () => {
+      it('THEN should leave them unchanged', () => {
+        locationHistoryVar([createLocation('/other-org/settings'), createLocation('/login')])
+
+        rewriteSlugInLocationHistory('acme', 'new-org')
+
+        const result = locationHistoryVar()
+
+        expect(result[0].pathname).toBe('/other-org/settings')
+        expect(result[1].pathname).toBe('/login')
+      })
+    })
+  })
+
+  describe('GIVEN a mix of matching and non-matching entries', () => {
+    describe('WHEN rewriting', () => {
+      it('THEN should only rewrite matching entries and preserve non-matching ones', () => {
+        locationHistoryVar([
+          createLocation('/acme/customers'),
+          createLocation('/login'),
+          createLocation('/acme/settings/taxes'),
+          createLocation('/other/dashboard'),
+        ])
+
+        rewriteSlugInLocationHistory('acme', 'new-org')
+
+        const result = locationHistoryVar()
+
+        expect(result.map((l) => l.pathname)).toEqual([
+          '/new-org/customers',
+          '/login',
+          '/new-org/settings/taxes',
+          '/other/dashboard',
+        ])
+      })
+    })
+  })
+
+  describe('GIVEN entries with extra properties', () => {
+    describe('WHEN rewriting', () => {
+      it('THEN should preserve search, hash, state, and key', () => {
+        const entry: Location = {
+          pathname: '/acme/customers',
+          search: '?page=2',
+          hash: '#section',
+          state: { from: 'test' },
+          key: 'abc123',
+        }
+
+        locationHistoryVar([entry])
+        rewriteSlugInLocationHistory('acme', 'new-org')
+
+        const result = locationHistoryVar()[0]
+
+        expect(result.pathname).toBe('/new-org/customers')
+        expect(result.search).toBe('?page=2')
+        expect(result.hash).toBe('#section')
+        expect(result.state).toEqual({ from: 'test' })
+        expect(result.key).toBe('abc123')
+      })
+    })
+  })
+})

--- a/src/core/apolloClient/reactiveVars/locationHistoryVar.ts
+++ b/src/core/apolloClient/reactiveVars/locationHistoryVar.ts
@@ -23,3 +23,27 @@ export const addLocationToHistory = (location: Location) => {
 export const resetLocationHistoryVar = () => {
   locationHistoryVar([])
 }
+
+/**
+ * Rewrites the leading `/${oldSlug}` segment of every entry in
+ * `locationHistoryVar` with `/${newSlug}`. Used after an organization slug
+ * rename to avoid stale slug that leads to 404.
+ */
+export const rewriteSlugInLocationHistory = (oldSlug: string, newSlug: string) => {
+  if (!oldSlug || oldSlug === newSlug) return
+
+  const oldPrefix = `/${oldSlug}`
+  const previousHistory = locationHistoryVar()
+
+  const rewritten = previousHistory.map((location) => {
+    if (location.pathname === oldPrefix || location.pathname.startsWith(`${oldPrefix}/`)) {
+      return {
+        ...location,
+        pathname: `/${newSlug}${location.pathname.slice(oldPrefix.length)}`,
+      }
+    }
+    return location
+  })
+
+  locationHistoryVar(rewritten)
+}

--- a/src/core/router/SettingRoutes.tsx
+++ b/src/core/router/SettingRoutes.tsx
@@ -40,6 +40,9 @@ const CreateInvoiceCustomSection = lazyLoad(
 )
 
 const TaxesSettings = lazyLoad(() => import('~/pages/settings/TaxesSettings'))
+const OrganizationGeneralSettings = lazyLoad(
+  () => import('~/pages/settings/OrganizationGeneralSettings/OrganizationGeneralSettings'),
+)
 const Integrations = lazyLoad(() => import('~/pages/settings/Integrations'))
 
 const AnrokIntegrationDetails = lazyLoad(() => import('~/pages/settings/AnrokIntegrationDetails'))
@@ -109,6 +112,7 @@ const OktaAuthenticationDetails = lazyLoad(
 export const SETTINGS_ROUTE = '/settings'
 export const INVOICE_SETTINGS_ROUTE = `${SETTINGS_ROUTE}/invoice-sections`
 export const TAXES_SETTINGS_ROUTE = `${SETTINGS_ROUTE}/taxes`
+export const GENERAL_SETTINGS_ROUTE = `${SETTINGS_ROUTE}/general`
 export const ROOT_INTEGRATIONS_ROUTE = `${SETTINGS_ROUTE}/integrations`
 export const INTEGRATIONS_ROUTE = `${ROOT_INTEGRATIONS_ROUTE}/:integrationGroup`
 export const FULL_INTEGRATIONS_ROUTE = `${ROOT_INTEGRATIONS_ROUTE}/:integrationGroup/:tab`
@@ -235,6 +239,12 @@ export const settingRoutes: CustomRouteObject[] = [
         private: true,
         element: <TaxesSettings />,
         permissions: ['organizationTaxesView'],
+      },
+      {
+        path: [GENERAL_SETTINGS_ROUTE],
+        private: true,
+        element: <OrganizationGeneralSettings />,
+        permissions: ['organizationView'],
       },
       {
         path: INTEGRATIONS_ROUTE,

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -39,6 +39,20 @@ export type AcceptInviteInput = {
   token: Scalars['String']['input'];
 };
 
+export enum ActivationRuleStatusEnum {
+  Declined = 'declined',
+  Expired = 'expired',
+  Failed = 'failed',
+  Inactive = 'inactive',
+  NotApplicable = 'not_applicable',
+  Pending = 'pending',
+  Satisfied = 'satisfied'
+}
+
+export enum ActivationRuleTypeEnum {
+  Payment = 'payment'
+}
+
 /** Base activity log */
 export type ActivityLog = {
   __typename?: 'ActivityLog';
@@ -772,6 +786,11 @@ export type BillingEntityUpdateAppliedDunningCampaignInput = {
 export enum BillingTimeEnum {
   Anniversary = 'anniversary',
   Calendar = 'calendar'
+}
+
+export enum CancelationReasonEnum {
+  PaymentFailed = 'payment_failed',
+  Timeout = 'timeout'
 }
 
 export type CashfreeProvider = {
@@ -2110,6 +2129,7 @@ export type CreateSubscriptionChargeFilterInput = {
 
 /** Create Subscription input arguments */
 export type CreateSubscriptionInput = {
+  activationRules?: InputMaybe<Array<SubscriptionActivationRuleInput>>;
   billingTime: BillingTimeEnum;
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
@@ -3802,6 +3822,7 @@ export enum FeatureFlagEnum {
   MultiCurrency = 'multi_currency',
   MultiplePaymentMethods = 'multiple_payment_methods',
   NonPersistableChargeCacheOptimization = 'non_persistable_charge_cache_optimization',
+  PaymentGatedSubscriptions = 'payment_gated_subscriptions',
   PostgresEnrichedEvents = 'postgres_enriched_events',
   WalletTraceability = 'wallet_traceability'
 }
@@ -8378,8 +8399,11 @@ export type StripeProvider = {
 
 export type Subscription = {
   __typename?: 'Subscription';
+  activatedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  activationRules: Array<SubscriptionActivationRule>;
   activityLogs?: Maybe<Array<ActivityLog>>;
   billingTime?: Maybe<BillingTimeEnum>;
+  cancelationReason?: Maybe<CancelationReasonEnum>;
   canceledAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   charges?: Maybe<Array<Charge>>;
   createdAt: Scalars['ISO8601DateTime']['output'];
@@ -8413,6 +8437,23 @@ export type Subscription = {
   terminatedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   updatedAt: Scalars['ISO8601DateTime']['output'];
   usageThresholds: Array<UsageThreshold>;
+};
+
+export type SubscriptionActivationRule = {
+  __typename?: 'SubscriptionActivationRule';
+  createdAt: Scalars['ISO8601DateTime']['output'];
+  expiresAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  id: Scalars['ID']['output'];
+  status: ActivationRuleStatusEnum;
+  timeoutHours?: Maybe<Scalars['Int']['output']>;
+  type: ActivationRuleTypeEnum;
+  updatedAt: Scalars['ISO8601DateTime']['output'];
+};
+
+export type SubscriptionActivationRuleInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  timeoutHours?: InputMaybe<Scalars['Int']['input']>;
+  type: ActivationRuleTypeEnum;
 };
 
 /** SubscriptionCollection type */
@@ -9548,6 +9589,7 @@ export type UpdateSubscriptionFixedChargeInput = {
 
 /** Update Subscription input arguments */
 export type UpdateSubscriptionInput = {
+  activationRules?: InputMaybe<Array<SubscriptionActivationRuleInput>>;
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   endingAt?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
@@ -9946,7 +9988,7 @@ export type XeroIntegration = {
 export type UserIdentifierQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type UserIdentifierQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string, email?: string | null, premium: boolean, memberships: Array<{ __typename?: 'Membership', id: string, roles: Array<string>, organization: { __typename?: 'Organization', id: string, name: string, slug: string, logoUrl?: string | null, accessibleByCurrentSession: boolean }, permissions: { __typename?: 'Permissions', aiConversationsView: boolean, aiConversationsCreate: boolean, addonsCreate: boolean, addonsDelete: boolean, addonsUpdate: boolean, addonsView: boolean, analyticsView: boolean, auditLogsView: boolean, authenticationMethodsView: boolean, authenticationMethodsUpdate: boolean, billableMetricsCreate: boolean, billableMetricsDelete: boolean, billableMetricsUpdate: boolean, billableMetricsView: boolean, billingEntitiesView: boolean, billingEntitiesCreate: boolean, billingEntitiesUpdate: boolean, billingEntitiesDelete: boolean, couponsAttach: boolean, couponsCreate: boolean, couponsDelete: boolean, couponsDetach: boolean, couponsUpdate: boolean, couponsView: boolean, creditNotesCreate: boolean, creditNotesView: boolean, creditNotesVoid: boolean, creditNotesSend: boolean, customersCreate: boolean, customersDelete: boolean, customersUpdate: boolean, customersView: boolean, dataApiView: boolean, developersKeysManage: boolean, developersManage: boolean, dunningCampaignsCreate: boolean, dunningCampaignsUpdate: boolean, dunningCampaignsView: boolean, featuresCreate: boolean, featuresDelete: boolean, featuresUpdate: boolean, featuresView: boolean, invoiceCustomSectionsCreate: boolean, invoiceCustomSectionsUpdate: boolean, invoicesCreate: boolean, invoicesSend: boolean, invoicesUpdate: boolean, invoicesView: boolean, invoicesVoid: boolean, organizationEmailsUpdate: boolean, organizationEmailsView: boolean, organizationIntegrationsCreate: boolean, organizationIntegrationsDelete: boolean, organizationIntegrationsUpdate: boolean, organizationIntegrationsView: boolean, organizationInvoicesUpdate: boolean, organizationInvoicesView: boolean, organizationMembersCreate: boolean, organizationMembersDelete: boolean, organizationMembersUpdate: boolean, organizationMembersView: boolean, organizationTaxesUpdate: boolean, organizationTaxesView: boolean, organizationUpdate: boolean, organizationView: boolean, paymentsCreate: boolean, paymentsView: boolean, paymentReceiptsView: boolean, paymentReceiptsSend: boolean, plansCreate: boolean, plansDelete: boolean, plansUpdate: boolean, plansView: boolean, pricingUnitsCreate: boolean, pricingUnitsUpdate: boolean, pricingUnitsView: boolean, rolesCreate: boolean, rolesDelete: boolean, rolesUpdate: boolean, rolesView: boolean, securityLogsView: boolean, subscriptionsCreate: boolean, subscriptionsUpdate: boolean, subscriptionsView: boolean, walletsCreate: boolean, walletsTerminate: boolean, walletsTopUp: boolean, walletsUpdate: boolean } }> }, organization?: { __typename?: 'CurrentOrganization', id: string, name: string, logoUrl?: string | null, timezone?: TimezoneEnum | null, defaultCurrency: CurrencyEnum, featureFlags: Array<FeatureFlagEnum>, premiumIntegrations: Array<PremiumIntegrationTypeEnum>, canCreateBillingEntity: boolean, authenticationMethods: Array<AuthenticationMethodsEnum>, authenticatedMethod: AuthenticationMethodsEnum } | null };
+export type UserIdentifierQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string, email?: string | null, premium: boolean, memberships: Array<{ __typename?: 'Membership', id: string, roles: Array<string>, organization: { __typename?: 'Organization', id: string, name: string, slug: string, logoUrl?: string | null, accessibleByCurrentSession: boolean }, permissions: { __typename?: 'Permissions', aiConversationsView: boolean, aiConversationsCreate: boolean, addonsCreate: boolean, addonsDelete: boolean, addonsUpdate: boolean, addonsView: boolean, analyticsView: boolean, auditLogsView: boolean, authenticationMethodsView: boolean, authenticationMethodsUpdate: boolean, billableMetricsCreate: boolean, billableMetricsDelete: boolean, billableMetricsUpdate: boolean, billableMetricsView: boolean, billingEntitiesView: boolean, billingEntitiesCreate: boolean, billingEntitiesUpdate: boolean, billingEntitiesDelete: boolean, couponsAttach: boolean, couponsCreate: boolean, couponsDelete: boolean, couponsDetach: boolean, couponsUpdate: boolean, couponsView: boolean, creditNotesCreate: boolean, creditNotesView: boolean, creditNotesVoid: boolean, creditNotesSend: boolean, customersCreate: boolean, customersDelete: boolean, customersUpdate: boolean, customersView: boolean, dataApiView: boolean, developersKeysManage: boolean, developersManage: boolean, dunningCampaignsCreate: boolean, dunningCampaignsUpdate: boolean, dunningCampaignsView: boolean, featuresCreate: boolean, featuresDelete: boolean, featuresUpdate: boolean, featuresView: boolean, invoiceCustomSectionsCreate: boolean, invoiceCustomSectionsUpdate: boolean, invoicesCreate: boolean, invoicesSend: boolean, invoicesUpdate: boolean, invoicesView: boolean, invoicesVoid: boolean, organizationEmailsUpdate: boolean, organizationEmailsView: boolean, organizationIntegrationsCreate: boolean, organizationIntegrationsDelete: boolean, organizationIntegrationsUpdate: boolean, organizationIntegrationsView: boolean, organizationInvoicesUpdate: boolean, organizationInvoicesView: boolean, organizationMembersCreate: boolean, organizationMembersDelete: boolean, organizationMembersUpdate: boolean, organizationMembersView: boolean, organizationTaxesUpdate: boolean, organizationTaxesView: boolean, organizationUpdate: boolean, organizationView: boolean, paymentsCreate: boolean, paymentsView: boolean, paymentReceiptsView: boolean, paymentReceiptsSend: boolean, plansCreate: boolean, plansDelete: boolean, plansUpdate: boolean, plansView: boolean, pricingUnitsCreate: boolean, pricingUnitsUpdate: boolean, pricingUnitsView: boolean, rolesCreate: boolean, rolesDelete: boolean, rolesUpdate: boolean, rolesView: boolean, securityLogsView: boolean, subscriptionsCreate: boolean, subscriptionsUpdate: boolean, subscriptionsView: boolean, walletsCreate: boolean, walletsTerminate: boolean, walletsTopUp: boolean, walletsUpdate: boolean } }> }, organization?: { __typename?: 'CurrentOrganization', id: string, name: string, slug: string, logoUrl?: string | null, timezone?: TimezoneEnum | null, defaultCurrency: CurrencyEnum, featureFlags: Array<FeatureFlagEnum>, premiumIntegrations: Array<PremiumIntegrationTypeEnum>, canCreateBillingEntity: boolean, authenticationMethods: Array<AuthenticationMethodsEnum>, authenticatedMethod: AuthenticationMethodsEnum } | null };
 
 export type ActivityLogsTableDataFragment = { __typename?: 'ActivityLog', activityId: string, activityType: ActivityTypeEnum, activityObject?: any | null, loggedAt: any, externalCustomerId?: string | null, externalSubscriptionId?: string | null };
 
@@ -12650,12 +12692,12 @@ export type GetCustomerOverdueInvoicesReadyForPaymentProcessingQueryVariables = 
 
 export type GetCustomerOverdueInvoicesReadyForPaymentProcessingQuery = { __typename?: 'Query', invoices: { __typename?: 'InvoiceCollection', collection: Array<{ __typename?: 'Invoice', readyForPaymentProcessing: boolean }> } };
 
-export type MainOrganizationInfosFragment = { __typename?: 'CurrentOrganization', id: string, name: string, logoUrl?: string | null, timezone?: TimezoneEnum | null, defaultCurrency: CurrencyEnum, featureFlags: Array<FeatureFlagEnum>, premiumIntegrations: Array<PremiumIntegrationTypeEnum>, canCreateBillingEntity: boolean, authenticationMethods: Array<AuthenticationMethodsEnum>, authenticatedMethod: AuthenticationMethodsEnum };
+export type MainOrganizationInfosFragment = { __typename?: 'CurrentOrganization', id: string, name: string, slug: string, logoUrl?: string | null, timezone?: TimezoneEnum | null, defaultCurrency: CurrencyEnum, featureFlags: Array<FeatureFlagEnum>, premiumIntegrations: Array<PremiumIntegrationTypeEnum>, canCreateBillingEntity: boolean, authenticationMethods: Array<AuthenticationMethodsEnum>, authenticatedMethod: AuthenticationMethodsEnum };
 
 export type GetOrganizationInfosQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetOrganizationInfosQuery = { __typename?: 'Query', organization?: { __typename?: 'CurrentOrganization', id: string, name: string, logoUrl?: string | null, timezone?: TimezoneEnum | null, defaultCurrency: CurrencyEnum, featureFlags: Array<FeatureFlagEnum>, premiumIntegrations: Array<PremiumIntegrationTypeEnum>, canCreateBillingEntity: boolean, authenticationMethods: Array<AuthenticationMethodsEnum>, authenticatedMethod: AuthenticationMethodsEnum } | null };
+export type GetOrganizationInfosQuery = { __typename?: 'Query', organization?: { __typename?: 'CurrentOrganization', id: string, name: string, slug: string, logoUrl?: string | null, timezone?: TimezoneEnum | null, defaultCurrency: CurrencyEnum, featureFlags: Array<FeatureFlagEnum>, premiumIntegrations: Array<PremiumIntegrationTypeEnum>, canCreateBillingEntity: boolean, authenticationMethods: Array<AuthenticationMethodsEnum>, authenticatedMethod: AuthenticationMethodsEnum } | null };
 
 export type MembershipPermissionsFragment = { __typename?: 'Membership', id: string, permissions: { __typename?: 'Permissions', aiConversationsView: boolean, aiConversationsCreate: boolean, addonsCreate: boolean, addonsDelete: boolean, addonsUpdate: boolean, addonsView: boolean, analyticsView: boolean, auditLogsView: boolean, authenticationMethodsView: boolean, authenticationMethodsUpdate: boolean, billableMetricsCreate: boolean, billableMetricsDelete: boolean, billableMetricsUpdate: boolean, billableMetricsView: boolean, billingEntitiesView: boolean, billingEntitiesCreate: boolean, billingEntitiesUpdate: boolean, billingEntitiesDelete: boolean, couponsAttach: boolean, couponsCreate: boolean, couponsDelete: boolean, couponsDetach: boolean, couponsUpdate: boolean, couponsView: boolean, creditNotesCreate: boolean, creditNotesView: boolean, creditNotesVoid: boolean, creditNotesSend: boolean, customersCreate: boolean, customersDelete: boolean, customersUpdate: boolean, customersView: boolean, dataApiView: boolean, developersKeysManage: boolean, developersManage: boolean, dunningCampaignsCreate: boolean, dunningCampaignsUpdate: boolean, dunningCampaignsView: boolean, featuresCreate: boolean, featuresDelete: boolean, featuresUpdate: boolean, featuresView: boolean, invoiceCustomSectionsCreate: boolean, invoiceCustomSectionsUpdate: boolean, invoicesCreate: boolean, invoicesSend: boolean, invoicesUpdate: boolean, invoicesView: boolean, invoicesVoid: boolean, organizationEmailsUpdate: boolean, organizationEmailsView: boolean, organizationIntegrationsCreate: boolean, organizationIntegrationsDelete: boolean, organizationIntegrationsUpdate: boolean, organizationIntegrationsView: boolean, organizationInvoicesUpdate: boolean, organizationInvoicesView: boolean, organizationMembersCreate: boolean, organizationMembersDelete: boolean, organizationMembersUpdate: boolean, organizationMembersView: boolean, organizationTaxesUpdate: boolean, organizationTaxesView: boolean, organizationUpdate: boolean, organizationView: boolean, paymentsCreate: boolean, paymentsView: boolean, paymentReceiptsView: boolean, paymentReceiptsSend: boolean, plansCreate: boolean, plansDelete: boolean, plansUpdate: boolean, plansView: boolean, pricingUnitsCreate: boolean, pricingUnitsUpdate: boolean, pricingUnitsView: boolean, rolesCreate: boolean, rolesDelete: boolean, rolesUpdate: boolean, rolesView: boolean, securityLogsView: boolean, subscriptionsCreate: boolean, subscriptionsUpdate: boolean, subscriptionsView: boolean, walletsCreate: boolean, walletsTerminate: boolean, walletsTopUp: boolean, walletsUpdate: boolean } };
 
@@ -14157,6 +14199,13 @@ export type GetNetsuiteIntegrationsListQuery = { __typename?: 'Query', integrati
       | { __typename?: 'SalesforceIntegration' }
       | { __typename?: 'XeroIntegration' }
     > } | null };
+
+export type UpdateOrganizationSlugMutationVariables = Exact<{
+  input: UpdateOrganizationInput;
+}>;
+
+
+export type UpdateOrganizationSlugMutation = { __typename?: 'Mutation', updateOrganization?: { __typename?: 'CurrentOrganization', id: string, slug: string } | null };
 
 export type SalesforceIntegrationDetailsFragment = { __typename?: 'SalesforceIntegration', id: string, name: string, code: string, instanceId: string };
 
@@ -17556,6 +17605,7 @@ export const MainOrganizationInfosFragmentDoc = gql`
     fragment MainOrganizationInfos on CurrentOrganization {
   id
   name
+  slug
   logoUrl
   timezone
   defaultCurrency
@@ -38479,6 +38529,40 @@ export type GetNetsuiteIntegrationsListQueryHookResult = ReturnType<typeof useGe
 export type GetNetsuiteIntegrationsListLazyQueryHookResult = ReturnType<typeof useGetNetsuiteIntegrationsListLazyQuery>;
 export type GetNetsuiteIntegrationsListSuspenseQueryHookResult = ReturnType<typeof useGetNetsuiteIntegrationsListSuspenseQuery>;
 export type GetNetsuiteIntegrationsListQueryResult = Apollo.QueryResult<GetNetsuiteIntegrationsListQuery, GetNetsuiteIntegrationsListQueryVariables>;
+export const UpdateOrganizationSlugDocument = gql`
+    mutation updateOrganizationSlug($input: UpdateOrganizationInput!) {
+  updateOrganization(input: $input) {
+    id
+    slug
+  }
+}
+    `;
+export type UpdateOrganizationSlugMutationFn = Apollo.MutationFunction<UpdateOrganizationSlugMutation, UpdateOrganizationSlugMutationVariables>;
+
+/**
+ * __useUpdateOrganizationSlugMutation__
+ *
+ * To run a mutation, you first call `useUpdateOrganizationSlugMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateOrganizationSlugMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateOrganizationSlugMutation, { data, loading, error }] = useUpdateOrganizationSlugMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateOrganizationSlugMutation(baseOptions?: Apollo.MutationHookOptions<UpdateOrganizationSlugMutation, UpdateOrganizationSlugMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateOrganizationSlugMutation, UpdateOrganizationSlugMutationVariables>(UpdateOrganizationSlugDocument, options);
+      }
+export type UpdateOrganizationSlugMutationHookResult = ReturnType<typeof useUpdateOrganizationSlugMutation>;
+export type UpdateOrganizationSlugMutationResult = Apollo.MutationResult<UpdateOrganizationSlugMutation>;
+export type UpdateOrganizationSlugMutationOptions = Apollo.BaseMutationOptions<UpdateOrganizationSlugMutation, UpdateOrganizationSlugMutationVariables>;
 export const GetSalesforceIntegrationsDetailsDocument = gql`
     query getSalesforceIntegrationsDetails($id: ID!, $limit: Int, $integrationsType: [IntegrationTypeEnum!]) {
   integration(id: $id) {

--- a/src/hooks/useOrganizationInfos.ts
+++ b/src/hooks/useOrganizationInfos.ts
@@ -20,6 +20,7 @@ gql`
   fragment MainOrganizationInfos on CurrentOrganization {
     id
     name
+    slug
     logoUrl
     timezone
     defaultCurrency

--- a/src/layouts/SettingsNavLayout.tsx
+++ b/src/layouts/SettingsNavLayout.tsx
@@ -24,6 +24,7 @@ import {
   EDIT_PRICING_UNIT,
   FULL_INTEGRATIONS_ROUTE,
   FULL_INTEGRATIONS_ROUTE_ID,
+  GENERAL_SETTINGS_ROUTE,
   HOME_ROUTE,
   INTEGRATIONS_ROUTE,
   INVOICE_SETTINGS_ROUTE,
@@ -103,6 +104,12 @@ const generateTabs = ({
     link: TAXES_SETTINGS_ROUTE,
     match: [TAXES_SETTINGS_ROUTE],
     hidden: !hasPermissions(['organizationTaxesView']),
+  },
+  {
+    title: translate('text_1776867582729i8hvt0ot0wl'),
+    link: GENERAL_SETTINGS_ROUTE,
+    match: [GENERAL_SETTINGS_ROUTE],
+    hidden: !hasPermissions(['organizationView']),
   },
 ]
 

--- a/src/layouts/SettingsNavLayout.tsx
+++ b/src/layouts/SettingsNavLayout.tsx
@@ -65,6 +65,12 @@ const generateTabs = ({
   hasPermissions: (permissionsToCheck: Array<keyof TMembershipPermissions>) => boolean
 }) => [
   {
+    title: translate('text_1776867582729i8hvt0ot0wl'),
+    link: GENERAL_SETTINGS_ROUTE,
+    match: [GENERAL_SETTINGS_ROUTE],
+    hidden: !hasPermissions(['organizationView']),
+  },
+  {
     title: translate('text_62b1edddbf5f461ab9712733'),
     link: generatePath(INTEGRATIONS_ROUTE, {
       integrationGroup: IntegrationsTabsOptionsEnum.Lago,
@@ -104,12 +110,6 @@ const generateTabs = ({
     link: TAXES_SETTINGS_ROUTE,
     match: [TAXES_SETTINGS_ROUTE],
     hidden: !hasPermissions(['organizationTaxesView']),
-  },
-  {
-    title: translate('text_1776867582729i8hvt0ot0wl'),
-    link: GENERAL_SETTINGS_ROUTE,
-    match: [GENERAL_SETTINGS_ROUTE],
-    hidden: !hasPermissions(['organizationView']),
   },
 ]
 

--- a/src/pages/settings/OrganizationGeneralSettings/OrganizationGeneralSettings.tsx
+++ b/src/pages/settings/OrganizationGeneralSettings/OrganizationGeneralSettings.tsx
@@ -1,0 +1,78 @@
+import { Button } from '~/components/designSystem/Button'
+import { Typography } from '~/components/designSystem/Typography'
+import {
+  SettingsListItem,
+  SettingsListItemHeader,
+  SettingsListItemLoadingSkeleton,
+  SettingsListWrapper,
+  SettingsPaddedContainer,
+} from '~/components/layouts/Settings'
+import { MainHeader } from '~/components/MainHeader/MainHeader'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
+import { usePermissions } from '~/hooks/usePermissions'
+
+import { useEditOrganizationSlugDialog } from './dialogs/useEditOrganizationSlugDialog'
+
+const OrganizationGeneralSettings = () => {
+  const { translate } = useInternationalization()
+  const { hasPermissions } = usePermissions()
+  const { organization, loading } = useOrganizationInfos()
+  const { openEditOrganizationSlugDialog } = useEditOrganizationSlugDialog()
+
+  const canUpdate = hasPermissions(['organizationUpdate'])
+  const currentSlug = organization?.slug || ''
+
+  return (
+    <>
+      <MainHeader.Configure
+        entity={{
+          viewName: translate('text_1776867582729i8hvt0ot0wl'),
+          metadata: translate('text_1776867582729flunw00muqy'),
+        }}
+      />
+
+      <SettingsPaddedContainer>
+        <SettingsListWrapper>
+          {loading && <SettingsListItemLoadingSkeleton count={1} />}
+
+          {!loading && (
+            <SettingsListItem className="!pb-12 !shadow-b">
+              <SettingsListItemHeader
+                label={translate('text_1776867582729ra096lnt5hc')}
+                sublabel={translate('text_1776867582729aiet5qqthjk')}
+                action={
+                  canUpdate ? (
+                    <Button
+                      variant="inline"
+                      disabled={!currentSlug}
+                      onClick={() =>
+                        openEditOrganizationSlugDialog({
+                          currentSlug,
+                        })
+                      }
+                      data-test="edit-organization-slug-button"
+                    >
+                      {translate('text_1776867582730ouvncumhk7p')}
+                    </Button>
+                  ) : undefined
+                }
+              />
+
+              <Typography
+                variant="body"
+                color="grey700"
+                className="font-mono"
+                data-test="current-organization-slug"
+              >
+                {currentSlug ? `/${currentSlug}` : '—'}
+              </Typography>
+            </SettingsListItem>
+          )}
+        </SettingsListWrapper>
+      </SettingsPaddedContainer>
+    </>
+  )
+}
+
+export default OrganizationGeneralSettings

--- a/src/pages/settings/OrganizationGeneralSettings/OrganizationGeneralSettings.tsx
+++ b/src/pages/settings/OrganizationGeneralSettings/OrganizationGeneralSettings.tsx
@@ -1,7 +1,6 @@
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
 import {
-  SettingsListItem,
   SettingsListItemHeader,
   SettingsListItemLoadingSkeleton,
   SettingsListWrapper,
@@ -37,7 +36,7 @@ const OrganizationGeneralSettings = () => {
           {loading && <SettingsListItemLoadingSkeleton count={1} />}
 
           {!loading && (
-            <SettingsListItem className="!pb-12 !shadow-b">
+            <div className="flex flex-col gap-4 pb-12 shadow-b">
               <SettingsListItemHeader
                 label={translate('text_1776867582729ra096lnt5hc')}
                 sublabel={translate('text_1776867582729aiet5qqthjk')}
@@ -67,7 +66,7 @@ const OrganizationGeneralSettings = () => {
               >
                 {currentSlug ? `/${currentSlug}` : '—'}
               </Typography>
-            </SettingsListItem>
+            </div>
           )}
         </SettingsListWrapper>
       </SettingsPaddedContainer>

--- a/src/pages/settings/OrganizationGeneralSettings/__tests__/OrganizationGeneralSettings.test.tsx
+++ b/src/pages/settings/OrganizationGeneralSettings/__tests__/OrganizationGeneralSettings.test.tsx
@@ -1,0 +1,147 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { render } from '~/test-utils'
+
+import OrganizationGeneralSettings from '../OrganizationGeneralSettings'
+
+const mockMainHeaderConfigure = jest.fn()
+const mockHasPermissions = jest.fn()
+const mockOpenEditOrganizationSlugDialog = jest.fn()
+const mockUseOrganizationInfos = jest.fn()
+
+jest.mock('~/components/MainHeader/MainHeader', () => ({
+  MainHeader: {
+    Configure: (props: Record<string, unknown>) => {
+      mockMainHeaderConfigure(props)
+      return null
+    },
+  },
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+jest.mock('~/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasPermissions: mockHasPermissions }),
+}))
+
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  useOrganizationInfos: () => mockUseOrganizationInfos(),
+}))
+
+jest.mock('../dialogs/useEditOrganizationSlugDialog', () => ({
+  useEditOrganizationSlugDialog: () => ({
+    openEditOrganizationSlugDialog: mockOpenEditOrganizationSlugDialog,
+  }),
+}))
+
+describe('OrganizationGeneralSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockHasPermissions.mockReturnValue(true)
+    mockUseOrganizationInfos.mockReturnValue({
+      organization: { slug: 'acme' },
+      loading: false,
+    })
+  })
+
+  describe('GIVEN the page is loading', () => {
+    describe('WHEN loading is true', () => {
+      it('THEN should not display the slug content', () => {
+        mockUseOrganizationInfos.mockReturnValue({
+          organization: null,
+          loading: true,
+        })
+
+        render(<OrganizationGeneralSettings />)
+
+        expect(screen.queryByTestId('current-organization-slug')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('edit-organization-slug-button')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN the page is loaded with an organization slug', () => {
+    describe('WHEN the user has organizationUpdate permission', () => {
+      it('THEN should display the current slug', () => {
+        render(<OrganizationGeneralSettings />)
+
+        const slugElement = screen.getByTestId('current-organization-slug')
+
+        expect(slugElement).toHaveTextContent('/acme')
+      })
+
+      it('THEN should display the edit button', () => {
+        render(<OrganizationGeneralSettings />)
+
+        expect(screen.getByTestId('edit-organization-slug-button')).toBeInTheDocument()
+      })
+
+      it('THEN should enable the edit button', () => {
+        render(<OrganizationGeneralSettings />)
+
+        expect(screen.getByTestId('edit-organization-slug-button')).not.toBeDisabled()
+      })
+    })
+
+    describe('WHEN the user clicks the edit button', () => {
+      it('THEN should call openEditOrganizationSlugDialog with current slug', async () => {
+        const user = userEvent.setup()
+
+        render(<OrganizationGeneralSettings />)
+
+        await user.click(screen.getByTestId('edit-organization-slug-button'))
+
+        expect(mockOpenEditOrganizationSlugDialog).toHaveBeenCalledWith({
+          currentSlug: 'acme',
+        })
+      })
+    })
+
+    describe('WHEN the user does NOT have organizationUpdate permission', () => {
+      it('THEN should not display the edit button', () => {
+        mockHasPermissions.mockReturnValue(false)
+
+        render(<OrganizationGeneralSettings />)
+
+        expect(screen.queryByTestId('edit-organization-slug-button')).not.toBeInTheDocument()
+      })
+
+      it('THEN should still display the slug', () => {
+        mockHasPermissions.mockReturnValue(false)
+
+        render(<OrganizationGeneralSettings />)
+
+        expect(screen.getByTestId('current-organization-slug')).toHaveTextContent('/acme')
+      })
+    })
+  })
+
+  describe('GIVEN the organization has no slug', () => {
+    describe('WHEN slug is empty', () => {
+      it('THEN should display a dash placeholder', () => {
+        mockUseOrganizationInfos.mockReturnValue({
+          organization: { slug: '' },
+          loading: false,
+        })
+
+        render(<OrganizationGeneralSettings />)
+
+        expect(screen.getByTestId('current-organization-slug')).toHaveTextContent('—')
+      })
+
+      it('THEN should disable the edit button', () => {
+        mockUseOrganizationInfos.mockReturnValue({
+          organization: { slug: '' },
+          loading: false,
+        })
+
+        render(<OrganizationGeneralSettings />)
+
+        expect(screen.getByTestId('edit-organization-slug-button')).toBeDisabled()
+      })
+    })
+  })
+})

--- a/src/pages/settings/OrganizationGeneralSettings/dialogs/__tests__/useEditOrganizationSlugDialog.test.tsx
+++ b/src/pages/settings/OrganizationGeneralSettings/dialogs/__tests__/useEditOrganizationSlugDialog.test.tsx
@@ -1,0 +1,250 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { addToast } from '~/core/apolloClient'
+import { AllTheProviders } from '~/test-utils'
+
+import { useEditOrganizationSlugDialog } from '../useEditOrganizationSlugDialog'
+
+const mockFormDialogOpen = jest.fn()
+const mockNavigate = jest.fn()
+const mockUpdateOrganizationSlug = jest.fn()
+const mockRewriteSlugInLocationHistory = jest.fn()
+
+jest.mock('~/components/dialogs/FormDialog', () => ({
+  ...jest.requireActual('~/components/dialogs/FormDialog'),
+  useFormDialog: () => ({
+    open: mockFormDialogOpen,
+    close: jest.fn(),
+  }),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+jest.mock('~/core/router', () => ({
+  ...jest.requireActual('~/core/router'),
+  GENERAL_SETTINGS_ROUTE: '/settings/general',
+  useNavigate: () => mockNavigate,
+}))
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: jest.fn(),
+}))
+
+jest.mock('~/core/apolloClient/reactiveVars', () => ({
+  ...jest.requireActual('~/core/apolloClient/reactiveVars'),
+  rewriteSlugInLocationHistory: (...args: unknown[]) => mockRewriteSlugInLocationHistory(...args),
+}))
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useUpdateOrganizationSlugMutation: () => [mockUpdateOrganizationSlug],
+}))
+
+describe('useEditOrganizationSlugDialog', () => {
+  const customWrapper = ({ children }: { children: React.ReactNode }) =>
+    AllTheProviders({ children })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+  })
+
+  describe('GIVEN the hook is initialized', () => {
+    describe('WHEN rendered', () => {
+      it('THEN should return openEditOrganizationSlugDialog function', () => {
+        const { result } = renderHook(() => useEditOrganizationSlugDialog(), {
+          wrapper: customWrapper,
+        })
+
+        expect(typeof result.current.openEditOrganizationSlugDialog).toBe('function')
+      })
+    })
+  })
+
+  describe('GIVEN openEditOrganizationSlugDialog is called', () => {
+    describe('WHEN opening the dialog', () => {
+      it('THEN should call formDialog.open', () => {
+        const { result } = renderHook(() => useEditOrganizationSlugDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditOrganizationSlugDialog({ currentSlug: 'acme' })
+        })
+
+        expect(mockFormDialogOpen).toHaveBeenCalledTimes(1)
+      })
+
+      it('THEN should include closeOnError false', () => {
+        const { result } = renderHook(() => useEditOrganizationSlugDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditOrganizationSlugDialog({ currentSlug: 'acme' })
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs.closeOnError).toBe(false)
+      })
+
+      it.each([
+        ['title', 'string'],
+        ['description', 'string'],
+        ['children', 'object'],
+        ['mainAction', 'object'],
+      ])('THEN should include %s', (prop, expectedType) => {
+        const { result } = renderHook(() => useEditOrganizationSlugDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditOrganizationSlugDialog({ currentSlug: 'acme' })
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs[prop]).toBeDefined()
+        expect(typeof callArgs[prop]).toBe(expectedType)
+      })
+
+      it('THEN should include form with id and submit function', () => {
+        const { result } = renderHook(() => useEditOrganizationSlugDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditOrganizationSlugDialog({ currentSlug: 'acme' })
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs.form).toBeDefined()
+        expect(callArgs.form.id).toBe('form-edit-organization-slug')
+        expect(typeof callArgs.form.submit).toBe('function')
+      })
+    })
+  })
+
+  describe('GIVEN the dialog resolves with success', () => {
+    describe('WHEN mutation succeeds and dialog resolves', () => {
+      it('THEN should rewrite slug in location history', async () => {
+        mockUpdateOrganizationSlug.mockResolvedValue({
+          data: { updateOrganization: { id: 'org-1', slug: 'new-slug' } },
+          errors: undefined,
+        })
+
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useEditOrganizationSlugDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditOrganizationSlugDialog({ currentSlug: 'acme' })
+        })
+
+        expect(mockRewriteSlugInLocationHistory).toHaveBeenCalledWith('acme', 'new-slug')
+      })
+
+      it('THEN should navigate to the new slug settings route', async () => {
+        mockUpdateOrganizationSlug.mockResolvedValue({
+          data: { updateOrganization: { id: 'org-1', slug: 'new-slug' } },
+          errors: undefined,
+        })
+
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useEditOrganizationSlugDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditOrganizationSlugDialog({ currentSlug: 'acme' })
+        })
+
+        expect(mockNavigate).toHaveBeenCalledWith('/new-slug/settings/general', {
+          skipSlugPrepend: true,
+        })
+      })
+
+      it('THEN should show success toast', async () => {
+        mockUpdateOrganizationSlug.mockResolvedValue({
+          data: { updateOrganization: { id: 'org-1', slug: 'new-slug' } },
+          errors: undefined,
+        })
+
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useEditOrganizationSlugDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditOrganizationSlugDialog({ currentSlug: 'acme' })
+        })
+
+        expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+      })
+    })
+  })
+
+  describe('GIVEN the dialog resolves without success', () => {
+    describe('WHEN dialog is closed/cancelled', () => {
+      it('THEN should not navigate', async () => {
+        mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+
+        const { result } = renderHook(() => useEditOrganizationSlugDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditOrganizationSlugDialog({ currentSlug: 'acme' })
+        })
+
+        expect(mockNavigate).not.toHaveBeenCalled()
+      })
+
+      it('THEN should not show toast', async () => {
+        mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+
+        const { result } = renderHook(() => useEditOrganizationSlugDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditOrganizationSlugDialog({ currentSlug: 'acme' })
+        })
+
+        expect(addToast).not.toHaveBeenCalled()
+      })
+
+      it('THEN should not rewrite location history', async () => {
+        mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+
+        const { result } = renderHook(() => useEditOrganizationSlugDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditOrganizationSlugDialog({ currentSlug: 'acme' })
+        })
+
+        expect(mockRewriteSlugInLocationHistory).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/pages/settings/OrganizationGeneralSettings/dialogs/__tests__/validationSchema.test.ts
+++ b/src/pages/settings/OrganizationGeneralSettings/dialogs/__tests__/validationSchema.test.ts
@@ -1,0 +1,52 @@
+import {
+  editOrganizationSlugDefaultValues,
+  editOrganizationSlugValidationSchema,
+} from '../validationSchema'
+
+describe('editOrganizationSlugValidationSchema', () => {
+  describe('GIVEN valid slugs', () => {
+    it.each([
+      ['minimum length (3 chars)', 'abc'],
+      ['maximum length (40 chars)', 'a'.repeat(40)],
+      ['lowercase letters only', 'myorganization'],
+      ['numbers only', '123'],
+      ['letters and numbers', 'org123'],
+      ['with hyphens', 'my-org-name'],
+      ['starts with number', '1st-org'],
+      ['ends with number', 'org-1'],
+    ])('THEN should pass for %s', (_, slug) => {
+      const result = editOrganizationSlugValidationSchema.safeParse({ slug })
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('GIVEN invalid slugs', () => {
+    it.each([
+      ['too short (2 chars)', 'ab'],
+      ['too short (1 char)', 'a'],
+      ['empty string', ''],
+      ['too long (41 chars)', 'a'.repeat(41)],
+      ['starts with hyphen', '-my-org'],
+      ['ends with hyphen', 'my-org-'],
+      ['uppercase letters', 'MyOrg'],
+      ['contains spaces', 'my org'],
+      ['contains underscores', 'my_org'],
+      ['contains dots', 'my.org'],
+      ['contains special chars', 'my@org!'],
+      ['single hyphen only', '-'],
+    ])('THEN should fail for %s', (_, slug) => {
+      const result = editOrganizationSlugValidationSchema.safeParse({ slug })
+
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('GIVEN default values', () => {
+    describe('WHEN checking defaults', () => {
+      it('THEN should have empty slug', () => {
+        expect(editOrganizationSlugDefaultValues).toEqual({ slug: '' })
+      })
+    })
+  })
+})

--- a/src/pages/settings/OrganizationGeneralSettings/dialogs/useEditOrganizationSlugDialog.tsx
+++ b/src/pages/settings/OrganizationGeneralSettings/dialogs/useEditOrganizationSlugDialog.tsx
@@ -1,0 +1,210 @@
+import { gql } from '@apollo/client'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
+
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
+import { rewriteSlugInLocationHistory } from '~/core/apolloClient/reactiveVars'
+import { GENERAL_SETTINGS_ROUTE, useNavigate } from '~/core/router'
+import { LagoApiError, useUpdateOrganizationSlugMutation } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
+
+import {
+  editOrganizationSlugDefaultValues,
+  editOrganizationSlugValidationSchema,
+} from './validationSchema'
+
+gql`
+  mutation updateOrganizationSlug($input: UpdateOrganizationInput!) {
+    updateOrganization(input: $input) {
+      id
+      slug
+    }
+  }
+`
+
+const EDIT_ORGANIZATION_SLUG_FORM_ID = 'form-edit-organization-slug'
+
+type EditOrganizationSlugDialogData = {
+  currentSlug: string
+}
+
+export const useEditOrganizationSlugDialog = () => {
+  const formDialog = useFormDialog()
+  const { translate } = useInternationalization()
+  const navigate = useNavigate()
+
+  const dataRef = useRef<EditOrganizationSlugDialogData | null>(null)
+  const successRef = useRef<{ orgId: string; savedSlug: string } | null>(null)
+
+  const [updateOrganizationSlug] = useUpdateOrganizationSlugMutation({
+    // The mutation's return type is `CurrentOrganization`, which is a separate
+    // cache entry from the `Organization` that lives inside the current user's
+    // memberships. Apollo's auto-normalization only touches the returned type,
+    // so without this `update` the memberships would still carry the old slug
+    // and `OrganizationLayout` would render Error404 for the new URL until a
+    // full refetch landed — the race that caused the 404 flash on submit.
+    // Patching the `Organization:${id}` entry directly keeps the SPA flow
+    // (no hard reload, no cache clearing) while staying in sync instantly.
+    update(cache, { data }) {
+      if (!data?.updateOrganization?.id || !data.updateOrganization.slug) return
+
+      cache.modify({
+        id: cache.identify({
+          __typename: 'Organization',
+          id: data.updateOrganization.id,
+        }),
+        fields: {
+          slug: () => data.updateOrganization?.slug ?? '',
+        },
+      })
+    },
+  })
+
+  const form = useAppForm({
+    defaultValues: editOrganizationSlugDefaultValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: editOrganizationSlugValidationSchema,
+    },
+    onSubmit: async ({ value, formApi }) => {
+      const result = await updateOrganizationSlug({
+        variables: { input: { slug: value.slug } },
+        context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
+      })
+
+      const { errors, data } = result
+
+      if (hasDefinedGQLError('ValueAlreadyExist', errors, 'slug')) {
+        formApi.setErrorMap({
+          onDynamic: {
+            fields: {
+              slug: {
+                message: 'text_1776867582730tgxmf57unmt',
+                path: ['slug'],
+              },
+            },
+          },
+        })
+
+        return
+      }
+
+      if (errors?.length) {
+        formApi.setErrorMap({
+          onDynamic: {
+            fields: {
+              slug: {
+                message: 'text_1776867582730967zpytg618',
+                path: ['slug'],
+              },
+            },
+          },
+        })
+
+        return
+      }
+
+      const savedSlug = data?.updateOrganization?.slug
+      const orgId = data?.updateOrganization?.id
+
+      if (savedSlug && orgId) {
+        successRef.current = { orgId, savedSlug }
+      }
+    },
+  })
+
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = null
+    await form.handleSubmit()
+
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openEditOrganizationSlugDialog = (data: EditOrganizationSlugDialogData) => {
+    dataRef.current = data
+    form.reset()
+    form.setFieldValue('slug', data.currentSlug)
+
+    formDialog
+      .open({
+        title: translate('text_1776867582729jiym04jk1ax'),
+        description: translate('text_1776867582730aqe2kknmohd'),
+        children: (
+          <div className="flex flex-col gap-6 px-6 pb-2 pt-6">
+            <div className="flex items-center gap-3 overflow-hidden rounded-xl border border-grey-300 px-3 py-2">
+              <span className="font-mono shrink-0 rounded-md bg-grey-100 px-2 py-1 text-sm text-grey-700">
+                {translate('text_1776867582730qd932fynpjo')}
+              </span>
+              <form.Subscribe selector={(state) => state.values.slug}>
+                {(slugValue) => (
+                  <span className="font-mono truncate text-sm text-grey-700">
+                    {window.location.origin}
+                    {'/'}
+                    {slugValue}
+                  </span>
+                )}
+              </form.Subscribe>
+            </div>
+
+            <form.AppField name="slug">
+              {(field) => (
+                <field.TextInputField
+                  label={translate('text_1776867582729ra096lnt5hc')}
+                  placeholder={translate('text_1776867582730tl36ydvczz2')}
+                  beforeChangeFormatter={['lowercase', 'dashSeparator']}
+                  helperText={translate('text_1776867582730967zpytg618')}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        closeOnError: false,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>{translate('text_1776867582730tnsmp9njbz7')}</form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: EDIT_ORGANIZATION_SLUG_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'success' && successRef.current && dataRef.current) {
+          const { savedSlug } = successRef.current
+          const { currentSlug: oldSlug } = dataRef.current
+
+          // Keep `goBack(...)` consumers (e.g. "Back to app" in
+          // SettingsNavLayout) in sync with the new slug so they don't
+          // navigate to the pre-rename URL and land on Error404.
+          rewriteSlugInLocationHistory(oldSlug, savedSlug)
+
+          // The `update` callback on the mutation already patched the
+          // `Organization:${id}` cache entry with the new slug, so by the
+          // time OrganizationLayout re-renders under the new URL it finds
+          // the membership matching the new slug and renders normally.
+          navigate(`/${savedSlug}${GENERAL_SETTINGS_ROUTE}`, {
+            skipSlugPrepend: true,
+          })
+
+          addToast({
+            severity: 'success',
+            translateKey: 'text_17768675827302s9i3t87uhn',
+          })
+        }
+
+        form.reset()
+        dataRef.current = null
+        successRef.current = null
+      })
+  }
+
+  return { openEditOrganizationSlugDialog }
+}

--- a/src/pages/settings/OrganizationGeneralSettings/dialogs/validationSchema.ts
+++ b/src/pages/settings/OrganizationGeneralSettings/dialogs/validationSchema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod'
+
+const SLUG_FORMAT_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
+const SLUG_MIN_LENGTH = 3
+const SLUG_MAX_LENGTH = 40
+
+export const editOrganizationSlugValidationSchema = z.object({
+  slug: z.string().superRefine((value, ctx) => {
+    if (
+      value.length < SLUG_MIN_LENGTH ||
+      value.length > SLUG_MAX_LENGTH ||
+      !SLUG_FORMAT_REGEX.test(value)
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'text_1776867582730967zpytg618',
+      })
+    }
+  }),
+})
+
+export type EditOrganizationSlugFormValues = z.infer<typeof editOrganizationSlugValidationSchema>
+
+export const editOrganizationSlugDefaultValues: EditOrganizationSlugFormValues = {
+  slug: '',
+}

--- a/translations/base.json
+++ b/translations/base.json
@@ -4055,5 +4055,18 @@
   "text_17767988500524o9o9mr53rq": "{{emailUpdater}} assigned role {{rolesAdded}} to {{emailUpdated}}",
   "text_177679885005270syn8w6fh8": "{{emailUpdater}} removed role {{rolesDeleted}} from {{emailUpdated}}",
   "text_17767988500520plhs9f7tkm": "{{emailUpdater}} updated {{emailUpdated}}’s role to {{rolesAdded}} (previously {{rolesDeleted}})",
-  "text_1776863953533imjygk4dami": "The page you're looking for doesn't exist. Check the URL or head back to your homepage."
+  "text_1776863953533imjygk4dami": "The page you're looking for doesn't exist. Check the URL or head back to your homepage.",
+  "text_1776867582729i8hvt0ot0wl": "General",
+  "text_1776867582729flunw00muqy": "Define all settings that applies to this organization",
+  "text_1776867582729ra096lnt5hc": "Organization slug",
+  "text_1776867582729aiet5qqthjk": "Used as the identifier in your organization URLs.",
+  "text_1776867582729jiym04jk1ax": "Edit organization slug",
+  "text_1776867582730aqe2kknmohd": "Used as the identifier in your organization URLs. Changing it updates all organization URLs. Existing bookmarks, shared links, and integrations using the current URLs will stop working.",
+  "text_1776867582730tl36ydvczz2": "Type an organization slug",
+  "text_1776867582730967zpytg618": "Use 3–40 characters, with lowercase letters, numbers, or hyphens only. Start and end with a letter or number.",
+  "text_1776867582730tgxmf57unmt": "This slug is not available. Please choose a different one.",
+  "text_1776867582730qd932fynpjo": "Preview",
+  "text_1776867582730tnsmp9njbz7": "Save edits",
+  "text_17768675827302s9i3t87uhn": "Organization slug successfully edited",
+  "text_1776867582730ouvncumhk7p": "Edit"
 }


### PR DESCRIPTION
## Context

Final phase of the organization slug initiative: expose slug editing in a new "General" section under organization settings. BE already ships `updateOrganization(slug)`; the FE wires the UI, validation, and the in-app state propagation needed to keep the SPA in sync after a rename.

## Description

- New `/settings/general` route + "General" sidebar entry (last under "Your organization"), gated by `organizationView` / `organizationUpdate`.
- Slug block follows the `SettingsListWrapper` pattern, with inline edit button opening a NiceModal `FormDialog`.
- `useEditOrganizationSlugDialog` uses the new TanStack Form architecture (`useAppForm` + Zod) with schema + defaults extracted into a sibling `validationSchema.ts`, mirroring existing `*/validationSchema.ts`.
- `beforeChangeFormatter: ['lowercase', 'dashSeparator']` auto-normalizes input; single `superRefine` collapses length + format into one user-facing error. Backend `ValueAlreadyExist` on `slug` is mapped to an inline "not available" message via `formApi.setErrorMap`; expected 422s silenced from Sentry via `silentErrorCodes`.
- SPA stays consistent after rename via two targeted patches:
  - `cache.modify` on `Organization:${id}` inside the mutation's `update`, because `updateOrganization` returns `CurrentOrganization` (separate cache entity) and wouldn't update the membership-side `Organization` that `OrganizationLayout` reads to match URL slug.
  - New `rewriteSlugInLocationHistory` util rewrites the leading slug segment across `locationHistoryVar`, so `goBack(...)` ("Back to app" and siblings) doesn't point to a stale URL post-rename.
- `slug` added to `MainOrganizationInfos` fragment for the page render.

<!-- Linear link -->
Fixes LAGO-1347