### PR TITLE
test(members): fix flaky CreateInviteDialog test

### DIFF
--- a/src/pages/settings/teamAndSecurity/members/dialogs/__tests__/CreateInviteDialog.test.tsx
+++ b/src/pages/settings/teamAndSecurity/members/dialogs/__tests__/CreateInviteDialog.test.tsx
@@ -150,6 +150,10 @@ describe('CreateInviteDialog', () => {
   afterEach(() => {
     cleanup()
     jest.clearAllMocks()
+    // NiceModal keeps open modals in module-level state that survives cleanup().
+    // Purge them so leaked dialogs from one test don't bleed into the next.
+    NiceModal.remove(FORM_DIALOG_NAME)
+    NiceModal.remove(CENTRALIZED_DIALOG_NAME)
   })
 
   describe('Opening', () => {


### PR DESCRIPTION
NiceModal keeps open modals in module-level state that survives React Testing Library's cleanup(). Dialogs left open by one test leaked into the next, occasionally pushing the suite past Jest's 5s per-test timeout under CI load.

Purge FORM_DIALOG_NAME and CENTRALIZED_DIALOG_NAME via NiceModal.remove() in afterEach so no cross-test state bleeds.