### PR TITLE
refactor(dialogs): migrate TimezoneBlock to usePremiumWarningDialog hook

### DIFF
--- a/src/pages/settings/BillingEntity/sections/general/TimezoneBlock.tsx
+++ b/src/pages/settings/BillingEntity/sections/general/TimezoneBlock.tsx
@@ -2,8 +2,8 @@ import { useRef } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { SettingsListItem, SettingsListItemHeader } from '~/components/layouts/Settings'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { getTimezoneConfig } from '~/core/timezone'
 import { BillingEntity, TimezoneEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -27,7 +27,7 @@ const TimezoneBlock = ({ billingEntity }: TimezoneBlockProps) => {
   const timezoneConfig = getTimezoneConfig(timezone)
 
   const editTimezoneDialogRef = useRef<EditBillingEntityTimezoneDialogRef>(null)
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const premiumWarningDialog = usePremiumWarningDialog()
 
   return (
     <SettingsListItem>
@@ -43,7 +43,7 @@ const TimezoneBlock = ({ billingEntity }: TimezoneBlockProps) => {
                 onClick={() => {
                   isPremium
                     ? editTimezoneDialogRef?.current?.openDialog()
-                    : premiumWarningDialogRef.current?.openDialog()
+                    : premiumWarningDialog.open()
                 }}
               >
                 {translate('text_638906e7b4f1a919cb61d0f2')}
@@ -61,7 +61,6 @@ const TimezoneBlock = ({ billingEntity }: TimezoneBlockProps) => {
       </Typography>
 
       <EditBillingEntityTimezoneDialog ref={editTimezoneDialogRef} id={id} timezone={timezone} />
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </SettingsListItem>
   )
 }


### PR DESCRIPTION
## Summary

Replace the deprecated ref-based `PremiumWarningDialog` with the hook-based `usePremiumWarningDialog` in `TimezoneBlock.tsx` to align with the new dialog management system and silence the `no-restricted-imports` ESLint warning for `~/components/PremiumWarningDialog` in this file.

### Changes
- Remove imports of `PremiumWarningDialog` and `PremiumWarningDialogRef` from the deprecated `~/components/PremiumWarningDialog`.
- Import `usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog` (new dialog system).
- Replace the `useRef<PremiumWarningDialogRef>` + `<PremiumWarningDialog ref={...} />` pattern with the hook and call `premiumWarningDialog.open()` directly.

### Scope
Intentionally limited to the premium warning dialog in this file. The file also renders `EditBillingEntityTimezoneDialog`, which is a Formik-based ref dialog — migrating it is out of scope here (it requires a Formik → TanStack Form migration in addition to the dialog migration).

## Test plan
- [ ] As a non-premium user, visit the Billing Entity settings page and click "Edit timezone" — the premium warning dialog should open with the default title/description and a mailto CTA.
- [ ] As a premium user, clicking "Edit timezone" should open the `EditBillingEntityTimezoneDialog` instead (unchanged behavior).
- [ ] `pnpm code:style` shows no `no-restricted-imports` warning for `~/components/PremiumWarningDialog` in `TimezoneBlock.tsx`.

https://claude.ai/code/session_01EGHmxxBrQxLUz8w56HwaG2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGHmxxBrQxLUz8w56HwaG2)_