### PR TITLE
fix(payments): stop lazy-loading provider SVGs in PaymentProviderChip

### DIFF
--- a/src/components/PaymentProviderChip.tsx
+++ b/src/components/PaymentProviderChip.tsx
@@ -1,20 +1,18 @@
 import type { TypographyProps as MuiTypographyProps } from '@mui/material/Typography'
 import { Icon } from 'lago-design-system'
-import { FC, lazy, Suspense } from 'react'
+import { FC } from 'react'
 
 import { Avatar } from '~/components/designSystem/Avatar'
 import { Typography, TypographyColor } from '~/components/designSystem/Typography'
 import { ProviderTypeEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import Adyen from '~/public/images/adyen.svg'
+import Cashfree from '~/public/images/cashfree.svg'
+import Flutterwave from '~/public/images/flutterwave.svg'
+import Gocardless from '~/public/images/gocardless.svg'
+import Moneyhash from '~/public/images/moneyhash.svg'
+import Stripe from '~/public/images/stripe.svg'
 import { tw } from '~/styles/utils'
-
-// Lazy load payment provider icons to avoid loading all SVGs on every page
-const Adyen = lazy(() => import('~/public/images/adyen.svg'))
-const Cashfree = lazy(() => import('~/public/images/cashfree.svg'))
-const Flutterwave = lazy(() => import('~/public/images/flutterwave.svg'))
-const Gocardless = lazy(() => import('~/public/images/gocardless.svg'))
-const Moneyhash = lazy(() => import('~/public/images/moneyhash.svg'))
-const Stripe = lazy(() => import('~/public/images/stripe.svg'))
 
 interface PaymentProviderChipProps {
   paymentProvider?: ProviderTypeEnum | 'manual' | 'manual_long'
@@ -44,7 +42,7 @@ const ProviderIcon: FC<{ provider: ProviderTypeEnum }> = ({ provider }) => {
     [ProviderTypeEnum.Moneyhash]: <Moneyhash />,
   }
 
-  return <Suspense fallback={null}>{icons[provider]}</Suspense>
+  return icons[provider]
 }
 
 export const PaymentProviderChip: FC<PaymentProviderChipProps> = ({


### PR DESCRIPTION
## Summary

- Each `lazy(() => import('…svg'))` in `PaymentProviderChip` was emitted by Vite as its own hashed chunk (e.g. `stripe.DkPTC1ok.js`). After a deploy, users with a stale tab would trigger `TypeError: Failed to fetch dynamically imported module` when the old chunk was no longer on the CDN — tripping the ErrorBoundary on pages that render the chip (notably `/customer/:id/information`).
- The provider logos are 1–3 KB each and `vite-plugin-svgr` already compiles SVGs as React components, so importing them directly (like `CustomerIntegrationRows.tsx` already does for Anrok / Avalara / Hubspot / …) is simpler, matches convention, and removes the stale-chunk failure mode entirely.
- Dropped the now-unnecessary `Suspense` wrapper inside `ProviderIcon`.

See Sentry issue [FRONT-EU-9D](https://lago-eu.sentry.io/issues/FRONT-EU-9D) for the original error.
