### PR TITLE
fix(subscription): correct downgrade date and add pending sub alert

### DIFF
--- a/src/components/subscriptions/SubscriptionInformations.tsx
+++ b/src/components/subscriptions/SubscriptionInformations.tsx
@@ -28,11 +28,20 @@ gql`
     endingAt
     terminatedAt
     billingTime
+    downgradePlanDate
     nextSubscriptionAt
     nextSubscriptionType
     nextPlan {
       id
       name
+    }
+    previousPlan {
+      id
+      name
+    }
+    previousSubscription {
+      id
+      downgradePlanDate
     }
     customer {
       id
@@ -68,13 +77,44 @@ const SubscriptionEndOrTerminatedAt = ({
   return '-'
 }
 
-export const SubscriptionInformations = ({
+export const SubscriptionDowngradeAlert = ({
   subscription,
 }: {
   subscription?: SubscriptionForSubscriptionInformationsFragment | null
 }) => {
   const { translate } = useInternationalization()
   const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
+
+  let content: string | null = null
+
+  if (
+    subscription?.nextPlan?.id &&
+    subscription?.nextSubscriptionType === NextSubscriptionTypeEnum.Downgrade
+  ) {
+    content = translate('text_62681c60582e4f00aa82938a', {
+      planName: subscription.nextPlan.name,
+      dateStartNewPlan: intlFormatDateTimeOrgaTZ(subscription.downgradePlanDate).date,
+    })
+  } else if (subscription?.previousPlan?.id && subscription?.status === StatusTypeEnum.Pending) {
+    content = translate('text_1776951742342o96gqg8qg8j', {
+      planName: subscription.previousPlan.name,
+      dateStartNewPlan: intlFormatDateTimeOrgaTZ(
+        subscription.previousSubscription?.downgradePlanDate,
+      ).date,
+    })
+  }
+
+  if (!content) return null
+
+  return <Alert type="info">{content}</Alert>
+}
+
+export const SubscriptionInformations = ({
+  subscription,
+}: {
+  subscription?: SubscriptionForSubscriptionInformationsFragment | null
+}) => {
+  const { translate } = useInternationalization()
 
   const isCustomerDeleted = !!subscription?.customer?.deletedAt
 
@@ -91,15 +131,8 @@ export const SubscriptionInformations = ({
         {translate('text_6335e8900c69f8ebdfef5312')}
       </DetailsPage.SectionTitle>
       <div className="flex flex-col gap-4">
-        {!!subscription?.nextPlan?.id &&
-          subscription?.nextSubscriptionType === NextSubscriptionTypeEnum.Downgrade && (
-            <Alert type="info">
-              {translate('text_62681c60582e4f00aa82938a', {
-                planName: subscription?.nextPlan?.name,
-                dateStartNewPlan: intlFormatDateTimeOrgaTZ(subscription?.nextSubscriptionAt).date,
-              })}
-            </Alert>
-          )}
+        <SubscriptionDowngradeAlert subscription={subscription} />
+
         <DetailsPage.InfoGridItem
           label={translate('text_62d7f6178ec94cd09370e5fb')}
           value={<Status {...subscriptionStatusMapping(subscription?.status ?? undefined)} />}

--- a/src/components/subscriptions/__tests__/SubscriptionDowngradeAlert.test.tsx
+++ b/src/components/subscriptions/__tests__/SubscriptionDowngradeAlert.test.tsx
@@ -1,0 +1,148 @@
+import { screen } from '@testing-library/react'
+
+import {
+  NextSubscriptionTypeEnum,
+  StatusTypeEnum,
+  SubscriptionForSubscriptionInformationsFragment,
+} from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import { SubscriptionDowngradeAlert } from '../SubscriptionInformations'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  useOrganizationInfos: () => ({
+    intlFormatDateTimeOrgaTZ: (dateStr: string | null | undefined) => ({
+      date: `formatted-${dateStr}`,
+      time: '',
+      timezone: '',
+    }),
+  }),
+}))
+
+const baseSubscription = (
+  overrides: Partial<SubscriptionForSubscriptionInformationsFragment> = {},
+): SubscriptionForSubscriptionInformationsFragment =>
+  ({
+    id: 'sub-1',
+    externalId: 'ext-1',
+    status: StatusTypeEnum.Active,
+    subscriptionAt: '2026-01-01',
+    endingAt: null,
+    terminatedAt: null,
+    billingTime: null,
+    downgradePlanDate: null,
+    nextSubscriptionAt: null,
+    nextSubscriptionType: null,
+    nextPlan: null,
+    previousPlan: null,
+    previousSubscription: null,
+    customer: {
+      id: 'cust-1',
+      name: 'Acme',
+      displayName: 'Acme',
+      externalId: 'cust-ext-1',
+      deletedAt: null,
+    },
+    plan: { id: 'plan-1', name: 'Current', parent: null },
+    ...overrides,
+  }) as SubscriptionForSubscriptionInformationsFragment
+
+describe('SubscriptionDowngradeAlert', () => {
+  it('renders nothing when subscription is null', () => {
+    const { container } = render(<SubscriptionDowngradeAlert subscription={null} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when no downgrade conditions are met', () => {
+    const { container } = render(<SubscriptionDowngradeAlert subscription={baseSubscription()} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  describe('WHEN subscription has a pending downgrade (next plan)', () => {
+    it('renders the "downgrading to" alert with next plan name and downgrade date', () => {
+      const subscription = baseSubscription({
+        status: StatusTypeEnum.Active,
+        nextSubscriptionType: NextSubscriptionTypeEnum.Downgrade,
+        nextPlan: { id: 'plan-2', name: 'Lower plan' },
+        downgradePlanDate: '2026-05-22',
+      })
+
+      render(<SubscriptionDowngradeAlert subscription={subscription} />)
+
+      expect(screen.getByText('text_62681c60582e4f00aa82938a')).toBeInTheDocument()
+    })
+
+    it('renders nothing when nextSubscriptionType is not Downgrade', () => {
+      const subscription = baseSubscription({
+        nextSubscriptionType: NextSubscriptionTypeEnum.Upgrade,
+        nextPlan: { id: 'plan-2', name: 'Higher plan' },
+        downgradePlanDate: '2026-05-22',
+      })
+
+      const { container } = render(<SubscriptionDowngradeAlert subscription={subscription} />)
+
+      expect(container).toBeEmptyDOMElement()
+    })
+  })
+
+  describe('WHEN subscription is pending (incoming downgrade from previous plan)', () => {
+    it('renders the "downgrading from" alert with previous plan name and previous subscription downgrade date', () => {
+      const subscription = baseSubscription({
+        status: StatusTypeEnum.Pending,
+        previousPlan: { id: 'plan-0', name: 'Higher plan' },
+        previousSubscription: {
+          id: 'sub-0',
+          downgradePlanDate: '2026-05-22',
+        } as SubscriptionForSubscriptionInformationsFragment['previousSubscription'],
+      })
+
+      render(<SubscriptionDowngradeAlert subscription={subscription} />)
+
+      expect(screen.getByText('text_1776951742342o96gqg8qg8j')).toBeInTheDocument()
+    })
+
+    it('renders nothing when previousPlan exists but status is not Pending', () => {
+      const subscription = baseSubscription({
+        status: StatusTypeEnum.Active,
+        previousPlan: { id: 'plan-0', name: 'Higher plan' },
+        previousSubscription: {
+          id: 'sub-0',
+          downgradePlanDate: '2026-05-22',
+        } as SubscriptionForSubscriptionInformationsFragment['previousSubscription'],
+      })
+
+      const { container } = render(<SubscriptionDowngradeAlert subscription={subscription} />)
+
+      expect(container).toBeEmptyDOMElement()
+    })
+  })
+
+  describe('WHEN both conditions are met', () => {
+    it('prioritizes the "downgrading to" variant (next plan takes precedence)', () => {
+      const subscription = baseSubscription({
+        status: StatusTypeEnum.Pending,
+        nextSubscriptionType: NextSubscriptionTypeEnum.Downgrade,
+        nextPlan: { id: 'plan-2', name: 'Lower plan' },
+        downgradePlanDate: '2026-05-22',
+        previousPlan: { id: 'plan-0', name: 'Higher plan' },
+        previousSubscription: {
+          id: 'sub-0',
+          downgradePlanDate: '2026-04-22',
+        } as SubscriptionForSubscriptionInformationsFragment['previousSubscription'],
+      })
+
+      render(<SubscriptionDowngradeAlert subscription={subscription} />)
+
+      expect(screen.getByText('text_62681c60582e4f00aa82938a')).toBeInTheDocument()
+      expect(screen.queryByText('text_1776951742342o96gqg8qg8j')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -8410,6 +8410,7 @@ export type Subscription = {
   currentBillingPeriodEndingAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   currentBillingPeriodStartedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   customer: Customer;
+  downgradePlanDate?: Maybe<Scalars['ISO8601Date']['output']>;
   endingAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   externalId: Scalars['String']['output'];
   fees?: Maybe<Array<Fee>>;
@@ -8428,6 +8429,8 @@ export type Subscription = {
   paymentMethodType?: Maybe<PaymentMethodTypeEnum>;
   periodEndDate?: Maybe<Scalars['ISO8601Date']['output']>;
   plan: Plan;
+  previousPlan?: Maybe<Plan>;
+  previousSubscription?: Maybe<Subscription>;
   progressiveBillingDisabled?: Maybe<Scalars['Boolean']['output']>;
   selectedInvoiceCustomSections?: Maybe<Array<InvoiceCustomSection>>;
   skipInvoiceCustomSections?: Maybe<Scalars['Boolean']['output']>;
@@ -12192,7 +12195,7 @@ export type GetSubscriptionForDetailsOverviewQueryVariables = Exact<{
 }>;
 
 
-export type GetSubscriptionForDetailsOverviewQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, paymentMethodType?: PaymentMethodTypeEnum | null, skipInvoiceCustomSections?: boolean | null, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, terminatedAt?: any | null, billingTime?: BillingTimeEnum | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null }, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string, deletedAt?: any | null } } | null };
+export type GetSubscriptionForDetailsOverviewQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, paymentMethodType?: PaymentMethodTypeEnum | null, skipInvoiceCustomSections?: boolean | null, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, terminatedAt?: any | null, billingTime?: BillingTimeEnum | null, downgradePlanDate?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null }, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, previousPlan?: { __typename?: 'Plan', id: string, name: string } | null, previousSubscription?: { __typename?: 'Subscription', id: string, downgradePlanDate?: any | null } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string, deletedAt?: any | null } } | null };
 
 export type GetEntitlementsForSubscriptionDetailsQueryVariables = Exact<{
   subscriptionId: Scalars['ID']['input'];
@@ -12201,7 +12204,7 @@ export type GetEntitlementsForSubscriptionDetailsQueryVariables = Exact<{
 
 export type GetEntitlementsForSubscriptionDetailsQuery = { __typename?: 'Query', subscriptionEntitlements: { __typename?: 'SubscriptionEntitlementCollection', collection: Array<{ __typename?: 'SubscriptionEntitlement', code: string, name: string, privileges: Array<{ __typename?: 'SubscriptionEntitlementPrivilegeObject', code: string, name?: string | null, value?: string | null, valueType: PrivilegeValueTypeEnum, config: { __typename?: 'PrivilegeConfigObject', selectOptions?: Array<string> | null } }> }> } };
 
-export type SubscriptionForSubscriptionInformationsFragment = { __typename?: 'Subscription', id: string, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, terminatedAt?: any | null, billingTime?: BillingTimeEnum | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string, deletedAt?: any | null }, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null } };
+export type SubscriptionForSubscriptionInformationsFragment = { __typename?: 'Subscription', id: string, externalId: string, status?: StatusTypeEnum | null, subscriptionAt?: any | null, endingAt?: any | null, terminatedAt?: any | null, billingTime?: BillingTimeEnum | null, downgradePlanDate?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, previousPlan?: { __typename?: 'Plan', id: string, name: string } | null, previousSubscription?: { __typename?: 'Subscription', id: string, downgradePlanDate?: any | null } | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string, deletedAt?: any | null }, plan: { __typename?: 'Plan', id: string, name: string, parent?: { __typename?: 'Plan', id: string, name: string } | null } };
 
 export type ThresholdForRecurringThresholdsTableFragment = { __typename?: 'UsageThreshold', id: string, amountCents: any, thresholdDisplayName?: string | null };
 
@@ -16962,11 +16965,20 @@ export const SubscriptionForSubscriptionInformationsFragmentDoc = gql`
   endingAt
   terminatedAt
   billingTime
+  downgradePlanDate
   nextSubscriptionAt
   nextSubscriptionType
   nextPlan {
     id
     name
+  }
+  previousPlan {
+    id
+    name
+  }
+  previousSubscription {
+    id
+    downgradePlanDate
   }
   customer {
     id

--- a/translations/base.json
+++ b/translations/base.json
@@ -4056,5 +4056,6 @@
   "text_17767988500520plhs9f7tkm": "{{emailUpdater}} updated {{emailUpdated}}’s role to {{rolesAdded}} (previously {{rolesDeleted}})",
   "text_1776883338722o7e5us2iq7h": "Anniversary",
   "text_177688333872224m25xpq3m2": "Calendar",
-  "text_1775559630554ourrtpgddty": "Copied to clipboard"
+  "text_1775559630554ourrtpgddty": "Copied to clipboard",
+  "text_1776951742342o96gqg8qg8j": "Downgrading from {{planName}} on {{dateStartNewPlan}}"
 }


### PR DESCRIPTION
## Context

Fixes [ISSUE-1845 — Wrong downgrade date displayed when downgrade is pending](https://linear.app/getlago/issue/ISSUE-1845/wrong-downgrade-date-displayed-when-downgrade-is-pending).

Depends on: https://github.com/getlago/lago-api/pull/5399 (new GraphQL fields on `Subscription`).

## Problem

On a subscription with a pending downgrade, the active subscription details page displayed the wrong effective date, e.g.:

> Downgrading to `lower_2` on **April 22, 2026**

April 22 is the day the subscription *started* (and the day the downgrade was scheduled). The downgrade actually takes effect on **May 22, 2026** (end of the current billing period + 1 day), which is already what the REST API returns as `downgrade_plan_date`.

The UI was reading `nextSubscriptionAt`, which the back-end resolves from the pending sub's `subscription_at` (the scheduling date), so the displayed date was off.

Additionally, the **pending** subscription view had no indication of when it would activate, so there was no way to see the incoming effective date from that side.

## Changes

- Extend `SubscriptionForSubscriptionInformations` fragment to query `downgradePlanDate`, `previousPlan { id name }` and `previousSubscription { id downgradePlanDate }` (all new fields exposed by the companion API PR).
- Fix the existing `"Downgrading to {planName} on {date}"` alert on the active-sub view to read `downgradePlanDate` instead of `nextSubscriptionAt`.
- Add a symmetric `"Downgrading from {planName} on {date}"` alert on the pending-sub view, using `previousPlan.name` and `previousSubscription.downgradePlanDate`. This addresses Anais' follow-up request in the ticket comments (no way to see when a pending sub activates).
- Regenerate `src/generated/graphql.tsx` via `pnpm codegen` against the updated API schema.
- Add the new translation key `text_1776951742342o96gqg8qg8j` via `pnpm translations:add`.
