### PR TITLE
fix(customer-portal): top up with jpy

### DIFF
--- a/src/components/customerPortal/wallet/WalletPage.tsx
+++ b/src/components/customerPortal/wallet/WalletPage.tsx
@@ -86,7 +86,7 @@ const WalletPage = () => {
         variables: {
           input: {
             walletId: wallet?.id,
-            paidCredits: amount,
+            paidCredits: String(amount),
           },
         },
       })


### PR DESCRIPTION
## Context

Using the customer portal to top up a wallet using any non decimal currency (JPY for example), we had an issue

## Description

This PR
- cast the amount we send to back as String indiscriminately

<!-- Linear link -->
Fixes ISSUE-1849