### PR TITLE
fix(invoices): guard credit note views behind proper permissions

### DIFF
--- a/src/components/invoices/InvoiceCreditNoteList.tsx
+++ b/src/components/invoices/InvoiceCreditNoteList.tsx
@@ -19,6 +19,7 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { usePermissions } from '~/hooks/usePermissions'
 import ErrorImage from '~/public/images/maneki/error.svg'
 
 gql`
@@ -53,6 +54,8 @@ export const InvoiceCreditNoteList = () => {
   const { invoiceId, customerId } = useParams()
   const { translate } = useInternationalization()
   const { isPremium } = useCurrentUser()
+  const { hasPermissions } = usePermissions()
+  const canIssueCreditNote = hasPermissions(['creditNotesCreate'])
   const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
   const { data, loading, error, fetchMore, variables } = useGetInvoiceCreditNotesQuery({
     variables: { invoiceId: invoiceId as string, limit: 20 },
@@ -76,7 +79,7 @@ export const InvoiceCreditNoteList = () => {
       {(!loading || !!creditNotes?.length) && (
         <div className="flex h-18 items-center justify-between shadow-b">
           <Typography variant="subhead1">{translate('text_636bdef6565341dcb9cfb129')}</Typography>
-          {data?.invoice?.status !== InvoiceStatusTypeEnum.Draft && (
+          {data?.invoice?.status !== InvoiceStatusTypeEnum.Draft && canIssueCreditNote && (
             <>
               {data?.invoice?.status !== InvoiceStatusTypeEnum.Voided && (
                 <>

--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -612,7 +612,8 @@ const CustomerInvoiceDetails = () => {
         InvoiceStatusTypeEnum.Failed,
         InvoiceStatusTypeEnum.Pending,
       ].includes(status) &&
-      taxStatus !== InvoiceTaxStatusTypeEnum.Pending
+      taxStatus !== InvoiceTaxStatusTypeEnum.Pending &&
+      hasPermissions(['creditNotesView'])
     ) {
       tabs.push({
         title: translate('text_636bdef6565341dcb9cfb125'),

--- a/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
+++ b/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
@@ -546,9 +546,7 @@ describe('CustomerInvoiceDetails', () => {
 
   describe('GIVEN the user does not have auditLogsView permission', () => {
     beforeEach(() => {
-      mockHasPermissions.mockImplementation(
-        (perms: string[]) => !perms.includes('auditLogsView'),
-      )
+      mockHasPermissions.mockImplementation((perms: string[]) => !perms.includes('auditLogsView'))
     })
 
     describe('WHEN tabs are configured for a finalized invoice', () => {
@@ -563,9 +561,7 @@ describe('CustomerInvoiceDetails', () => {
 
   describe('GIVEN the user does not have creditNotesView permission', () => {
     beforeEach(() => {
-      mockHasPermissions.mockImplementation(
-        (perms: string[]) => !perms.includes('creditNotesView'),
-      )
+      mockHasPermissions.mockImplementation((perms: string[]) => !perms.includes('creditNotesView'))
     })
 
     describe('WHEN tabs are configured for a finalized invoice', () => {

--- a/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
+++ b/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
@@ -546,7 +546,9 @@ describe('CustomerInvoiceDetails', () => {
 
   describe('GIVEN the user does not have auditLogsView permission', () => {
     beforeEach(() => {
-      mockHasPermissions.mockReturnValue(false)
+      mockHasPermissions.mockImplementation(
+        (perms: string[]) => !perms.includes('auditLogsView'),
+      )
     })
 
     describe('WHEN tabs are configured for a finalized invoice', () => {
@@ -554,6 +556,23 @@ describe('CustomerInvoiceDetails', () => {
         render(<CustomerInvoiceDetails />)
 
         // Finalized without activity logs: overview + payments + credit notes = 3
+        expect(capturedConfig?.tabs).toHaveLength(3)
+      })
+    })
+  })
+
+  describe('GIVEN the user does not have creditNotesView permission', () => {
+    beforeEach(() => {
+      mockHasPermissions.mockImplementation(
+        (perms: string[]) => !perms.includes('creditNotesView'),
+      )
+    })
+
+    describe('WHEN tabs are configured for a finalized invoice', () => {
+      it('THEN should not include credit notes tab', () => {
+        render(<CustomerInvoiceDetails />)
+
+        // Finalized without credit notes: overview + payments + activity logs = 3
         expect(capturedConfig?.tabs).toHaveLength(3)
       })
     })


### PR DESCRIPTION
## Context

Credit Notes tab rendered for all users on the invoice details page, causing a forbidden error for roles without `credit_notes:view` (Pylon #5281). The "Issue a credit note" button next to Overview also ignored `credit_notes:create`.

## Description

- Added `creditNotesView` guard to the Credit Notes tab in `CustomerInvoiceDetails`, mirroring the existing `auditLogsView` pattern.
- Added `creditNotesCreate` guard to the "Issue a credit note" button in `InvoiceCreditNoteList`.
- Updated the `auditLogsView` test to use a selective mock and added a test for the new `creditNotesView` guard.

<!-- Linear link -->
Fixes ING-12