### PR TITLE
refactor(billing-entity): migrate PremiumWarningDialog to hook-based dialog

### DIFF
--- a/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
@@ -6,6 +6,7 @@ import { Button } from '~/components/designSystem/Button'
 import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder'
 import { ShowMoreText } from '~/components/designSystem/ShowMoreText'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import {
   SettingsListItem,
   SettingsListItemHeader,
@@ -14,7 +15,6 @@ import {
   SettingsPaddedContainer,
 } from '~/components/layouts/Settings'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import {
   EditBillingEntityDocumentLocaleDialog,
   EditBillingEntityDocumentLocaleDialogRef,
@@ -148,7 +148,7 @@ const BillingEntityInvoiceSettings = () => {
   const editNetPaymentTermDialogRef = useRef<EditNetPaymentTermDialogRef>(null)
   const editFinalizeZeroAmountInvoiceDialogRef =
     useRef<EditFinalizeZeroAmountInvoiceDialogRef>(null)
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const premiumWarningDialog = usePremiumWarningDialog()
 
   const { data, error, loading } = useGetBillingEntitySettingsQuery({
     variables: {
@@ -253,7 +253,7 @@ const BillingEntityInvoiceSettings = () => {
           onClick={() => {
             isPremium
               ? editGracePeriodDialogRef?.current?.openDialog()
-              : premiumWarningDialogRef.current?.openDialog()
+              : premiumWarningDialog.open()
           }}
         >
           {translate('text_637f819eff19cd55a56d55e4')}
@@ -466,8 +466,6 @@ const BillingEntityInvoiceSettings = () => {
       {items.map((item) => (
         <div key={`billing-entity-invoice-settings-dialog-${item.id}`}>{item.dialog}</div>
       ))}
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </>
   )
 }


### PR DESCRIPTION
## Summary

Migrate the deprecated ref-based `PremiumWarningDialog` to the new hook-based dialog management system in `BillingEntityInvoiceSettings.tsx`.

## Changes

- Replaced the `PremiumWarningDialog` import from `~/components/PremiumWarningDialog` with `usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`.
- Removed the `useRef<PremiumWarningDialogRef>` and the inline `<PremiumWarningDialog ref={...} />` JSX; the dialog is now rendered centrally via NiceModal.
- Updated the grace period button click handler to call `premiumWarningDialog.open()` instead of `premiumWarningDialogRef.current?.openDialog()`.

## Scope

Scope was intentionally limited to the `PremiumWarningDialog` migration, as instructed. The file still imports several other deprecated dialogs (Edit* dialogs for default currency, document locale, grace period, invoice numbering, template, etc.) — these each wrap their own forms/mutations and are meaningful migrations on their own; they are out of scope here.

## Test plan

- [ ] Navigate to Settings → Billing Entity → Invoice Settings as a non-premium user.
- [ ] Click "Edit" on the "Grace period" item → Premium warning dialog should open.
- [ ] Verify the dialog title, description, "Cancel" button and "Contact us" mailto link behave as before.
- [ ] As a premium user, verify clicking "Edit" still opens the grace period edit dialog (no regression).

Co-authored-by: Alexandre Monjol <ansmonjol@users.noreply.github.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCY1e455Rmbpfg1zQVaKW6)_