### PR TITLE
refactor(analytics): migrate Invoices page to usePremiumWarningDialog hook

### DIFF
--- a/src/pages/analytics/Invoices.tsx
+++ b/src/pages/analytics/Invoices.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { Icon } from 'lago-design-system'
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
@@ -15,13 +15,13 @@ import InlineBarsChart from '~/components/designSystem/graphs/InlineBarsChart'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import {
   AnalyticsPeriodScopeEnum,
   TPeriodScopeTranslationLookupValue,
 } from '~/components/graphs/MonthSelectorDropdown'
 import { ChartWrapper } from '~/components/layouts/Charts'
 import { FullscreenPage } from '~/components/layouts/FullscreenPage'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { ANALYTICS_INVOICES_FILTER_PREFIX } from '~/core/constants/filters'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
@@ -183,7 +183,7 @@ const Invoices = () => {
   const { translate } = useInternationalization()
   const { organization, hasOrganizationPremiumAddon } = useOrganizationInfos()
   const [searchParams] = useSearchParams()
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const [hoveredBarId, setHoveredBarId] = useState<string | undefined>(undefined)
 
   const hasAccessToAnalyticsDashboardsFeature = hasOrganizationPremiumAddon(
@@ -301,7 +301,7 @@ const Invoices = () => {
                 onClick={(e) => {
                   if (!hasAccessToAnalyticsDashboardsFeature) {
                     e.stopPropagation()
-                    premiumWarningDialogRef.current?.openDialog()
+                    openPremiumWarningDialog()
                   } else {
                     onClick()
                   }
@@ -453,8 +453,6 @@ const Invoices = () => {
           </ChartWrapper>
         </>
       )}
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </FullscreenPage.Wrapper>
   )
 }


### PR DESCRIPTION
## Summary

Migrates the legacy ref-based `PremiumWarningDialog` to the new hook-based `usePremiumWarningDialog` in `src/pages/analytics/Invoices.tsx`. This is part of the ongoing dialog system migration away from the deprecated `~/components/PremiumWarningDialog` toward the new dialog management system in `~/components/dialogs`.

### Changes

- Removed import of the deprecated `PremiumWarningDialog` component and its `PremiumWarningDialogRef` type
- Replaced the `useRef<PremiumWarningDialogRef>` + JSX rendering pattern with the `usePremiumWarningDialog()` hook (the dialog is rendered globally via NiceModal registration)
- Replaced `premiumWarningDialogRef.current?.openDialog()` with `openPremiumWarningDialog()`
- Removed the now-unused `useRef` import from React

The change is intentionally scoped to a single file and a single dialog so it's easy to review and replicates the migration pattern documented in the `migrate-dialog` skill. Other consumers of the deprecated `PremiumWarningDialog` (54 remaining files) can be migrated incrementally with the same pattern.

### Verification

- `pnpm eslint src/pages/analytics/Invoices.tsx` — clean (no warnings, no errors)
- `pnpm tsc --noEmit` — clean
- The previously emitted `no-restricted-imports` warning for `~/components/PremiumWarningDialog` in this file is gone

## Test plan

- [ ] Open the Analytics → Invoices page as a non-premium user
- [ ] Click the filter button — confirm the premium warning dialog opens with the default title/description and a working `mailto:` link
- [ ] Close the dialog with the cancel button — confirm it closes correctly
- [ ] Sign in as a premium user — confirm the filter button opens the filters panel as before (dialog should not appear)

cc @ansmonjol

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013uhdJcTLT514KYV46UKRfq)_