### PR TITLE
fix(org slug): QA Phase - prepend org slug when navigating from the devtools panel

### DIFF
--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -5,6 +5,7 @@ import { Spinner } from '~/components/designSystem/Spinner'
 import { DEVTOOL_ROUTE } from '~/components/developers/devtoolsRoutes'
 import { drawerStack } from '~/components/drawers/drawerStack'
 import { CustomRouteObject, routes, useLocation, useNavigate } from '~/core/router'
+import { NEVER_SLUG_PREFIXES } from '~/core/router/slugPrefixes'
 import { useIsAuthenticated } from '~/hooks/auth/useIsAuthenticated'
 import { useLocationHistory } from '~/hooks/core/useLocationHistory'
 import { DEVTOOL_TAB_PARAMS, useDeveloperTool } from '~/hooks/useDeveloperTool'
@@ -93,14 +94,23 @@ export const RouteWrapper = () => {
     drawerStack.clearAll()
   }, [location])
 
-  // Listen for navigation requests from the MemoryRouter (devtools panel)
-  // This allows the devtools panel to navigate in the BrowserRouter without a page reload
+  // Bridge devtools MemoryRouter → BrowserRouter without a page reload.
+  // RouteWrapper sits outside `:organizationSlug`, so the slug-aware
+  // `useNavigate` wrapper has no slug to prepend. We derive it from the
+  // first segment of the current URL (authoritative per-tab) and pass
+  // `skipSlugPrepend: true`. Public paths are skipped via
+  // `NEVER_SLUG_PREFIXES`.
   useEffect(() => {
-    if (mainRouterUrl) {
-      navigate(mainRouterUrl)
-      setMainRouterUrl('')
-    }
-  }, [mainRouterUrl, navigate, setMainRouterUrl])
+    if (!mainRouterUrl) return
+
+    const firstSegment = location.pathname.split('/')[1] ?? ''
+    const onPublicPath = NEVER_SLUG_PREFIXES.some((prefix) => location.pathname.startsWith(prefix))
+    const slug = !onPublicPath && firstSegment ? firstSegment : undefined
+    const target = slug ? `/${slug}${mainRouterUrl}` : mainRouterUrl
+
+    navigate(target, { skipSlugPrepend: true })
+    setMainRouterUrl('')
+  }, [mainRouterUrl, location.pathname, navigate, setMainRouterUrl])
 
   const formattedRoutes = routesFormatter(routes, isAuthenticated)
 

--- a/src/components/__tests__/RouteWrapper.test.tsx
+++ b/src/components/__tests__/RouteWrapper.test.tsx
@@ -33,12 +33,16 @@ jest.mock('~/hooks/core/useLocationHistory', () => ({
   }),
 }))
 
+const TEST_SLUG = 'test-slug'
+
 jest.mock('~/core/router', () => ({
   routes: [],
   useNavigate: () => mockNavigate,
   useLocation: () => ({
-    pathname: '/',
-    strippedPathname: '/',
+    // First segment of `pathname` is treated as the active org slug by
+    // RouteWrapper's MemoryRouter→BrowserRouter bridge.
+    pathname: `/${TEST_SLUG}/api-keys`,
+    strippedPathname: '/api-keys',
     search: '',
     hash: '',
     state: null,
@@ -82,7 +86,9 @@ describe('RouteWrapper', () => {
           )
 
           await waitFor(() => {
-            expect(mockNavigate).toHaveBeenCalledWith('/api-keys/create')
+            expect(mockNavigate).toHaveBeenCalledWith(`/${TEST_SLUG}/api-keys/create`, {
+              skipSlugPrepend: true,
+            })
             expect(mockSetMainRouterUrl).toHaveBeenCalledWith('')
           })
         })
@@ -101,7 +107,9 @@ describe('RouteWrapper', () => {
           )
 
           await waitFor(() => {
-            expect(mockNavigate).toHaveBeenCalledWith('/webhook/123/edit')
+            expect(mockNavigate).toHaveBeenCalledWith(`/${TEST_SLUG}/webhook/123/edit`, {
+              skipSlugPrepend: true,
+            })
             expect(mockSetMainRouterUrl).toHaveBeenCalledWith('')
           })
         })
@@ -120,7 +128,9 @@ describe('RouteWrapper', () => {
           )
 
           await waitFor(() => {
-            expect(mockNavigate).toHaveBeenCalledWith('/api-keys/456/edit')
+            expect(mockNavigate).toHaveBeenCalledWith(`/${TEST_SLUG}/api-keys/456/edit`, {
+              skipSlugPrepend: true,
+            })
             expect(mockSetMainRouterUrl).toHaveBeenCalledWith('')
           })
         })

--- a/src/components/activityLogs/__tests__/utils.test.tsx
+++ b/src/components/activityLogs/__tests__/utils.test.tsx
@@ -1,5 +1,3 @@
-import { isValidElement, ReactElement } from 'react'
-
 import { AvailableFiltersEnum } from '~/components/designSystem/Filters'
 import {
   ActivityTypeEnum,
@@ -13,7 +11,6 @@ import {
 import {
   buildLinkToActivityLog,
   formatActivityType,
-  formatResourceObject,
   getResourceLink,
   isDeletedActivityType,
 } from '../utils'
@@ -273,32 +270,6 @@ describe('activityLogs utils', () => {
           },
         ),
       ).toBeNull()
-    })
-  })
-
-  describe('formatResourceObject', () => {
-    it('should return null when resource is null', () => {
-      expect(formatResourceObject(null)).toBeNull()
-    })
-
-    it('should return null when resource is undefined', () => {
-      expect(formatResourceObject(undefined)).toBeNull()
-    })
-
-    it('should return plain text when no onClick is provided', () => {
-      const resource = { id: 'plan-123', __typename: 'Plan' as const }
-
-      expect(formatResourceObject(resource)).toBe('plan-123')
-    })
-
-    it('should return a clickable Button wired to the provided onClick', () => {
-      const resource = { id: 'plan-123', __typename: 'Plan' as const }
-      const onClick = jest.fn()
-      const result = formatResourceObject(resource, onClick)
-
-      expect(isValidElement(result)).toBe(true)
-      ;(result as ReactElement).props.onClick()
-      expect(onClick).toHaveBeenCalledTimes(1)
     })
   })
   describe('buildLinkToActivityLog', () => {

--- a/src/components/activityLogs/__tests__/utils.test.tsx
+++ b/src/components/activityLogs/__tests__/utils.test.tsx
@@ -14,6 +14,7 @@ import {
   buildLinkToActivityLog,
   formatActivityType,
   formatResourceObject,
+  getResourceLink,
   isDeletedActivityType,
 } from '../utils'
 
@@ -125,214 +126,181 @@ describe('activityLogs utils', () => {
     })
   })
 
-  describe('formatResourceObject', () => {
+  describe('getResourceLink', () => {
     it('should return null when resource is null', () => {
-      const result = formatResourceObject(null, {
-        resourceType: 'Invoice',
-        activityType: ActivityTypeEnum.InvoiceGenerated,
-      })
-
-      expect(result).toBeNull()
+      expect(
+        getResourceLink(null, {
+          resourceType: 'Invoice',
+          activityType: ActivityTypeEnum.InvoiceGenerated,
+        }),
+      ).toBeNull()
     })
 
     it('should return null when resource is undefined', () => {
-      const result = formatResourceObject(undefined, {
-        resourceType: 'Invoice',
-        activityType: ActivityTypeEnum.InvoiceGenerated,
-      })
-
-      expect(result).toBeNull()
+      expect(
+        getResourceLink(undefined, {
+          resourceType: 'Invoice',
+          activityType: ActivityTypeEnum.InvoiceGenerated,
+        }),
+      ).toBeNull()
     })
 
-    it('should return plain text for deleted resources', () => {
-      const resource = {
-        id: 'coupon-123',
-        __typename: 'Coupon' as const,
-      }
-      const result = formatResourceObject(resource, {
-        resourceType: 'Coupon',
-        activityType: ActivityTypeEnum.CouponDeleted,
-      })
-
-      expect(result).toBe('coupon-123')
+    it('should return null for deleted resources', () => {
+      expect(
+        getResourceLink(
+          { id: 'coupon-123', __typename: 'Coupon' as const },
+          { resourceType: 'Coupon', activityType: ActivityTypeEnum.CouponDeleted },
+        ),
+      ).toBeNull()
     })
 
-    it('should return link for BillableMetric resource', () => {
-      const resource = {
-        id: 'metric-123',
-        __typename: 'BillableMetric' as const,
-      }
-      const result = formatResourceObject(resource, {
-        resourceType: 'BillableMetric',
-        activityType: ActivityTypeEnum.BillableMetricCreated,
-      })
-
-      expect(result).not.toBeNull()
-      expect(isValidElement(result)).toBe(true)
-      expect((result as ReactElement).type).toBe('a')
-      expect((result as ReactElement).props.href).toContain('metric-123')
+    it('should return null when activityType is not provided', () => {
+      expect(
+        getResourceLink({ id: 'invoice-123', __typename: 'Invoice' as const } as Invoice, {
+          resourceType: 'Invoice',
+        }),
+      ).toBeNull()
     })
 
-    it('should return link for BillingEntity resource', () => {
-      const resource: BillingEntity = {
-        id: 'entity-123',
-        code: 'entity-code',
-        __typename: 'BillingEntity' as const,
-      } as BillingEntity
-      const result = formatResourceObject(resource, {
-        resourceType: 'BillingEntity',
-        activityType: ActivityTypeEnum.BillingEntitiesCreated,
-      })
+    it('should return path for BillableMetric', () => {
+      const link = getResourceLink(
+        { id: 'metric-123', __typename: 'BillableMetric' as const },
+        { resourceType: 'BillableMetric', activityType: ActivityTypeEnum.BillableMetricCreated },
+      )
 
-      expect(result).not.toBeNull()
-      expect(isValidElement(result)).toBe(true)
-      expect((result as ReactElement).type).toBe('a')
-      expect((result as ReactElement).props.href).toContain('entity-code')
+      expect(link).toContain('metric-123')
     })
 
-    it('should return link for Coupon resource', () => {
-      const resource = {
-        id: 'coupon-123',
-        __typename: 'Coupon' as const,
-      }
-      const result = formatResourceObject(resource, {
-        resourceType: 'Coupon',
-        activityType: ActivityTypeEnum.CouponCreated,
-      })
+    it('should return path for BillingEntity using its code', () => {
+      const link = getResourceLink(
+        {
+          id: 'entity-123',
+          code: 'entity-code',
+          __typename: 'BillingEntity' as const,
+        } as BillingEntity,
+        { resourceType: 'BillingEntity', activityType: ActivityTypeEnum.BillingEntitiesCreated },
+      )
 
-      expect(result).not.toBeNull()
-      expect(isValidElement(result)).toBe(true)
-      expect((result as ReactElement).type).toBe('a')
-      expect((result as ReactElement).props.href).toContain('coupon-123')
+      expect(link).toContain('entity-code')
     })
 
-    it('should return link for CreditNote resource with customer and invoice', () => {
-      const resource: CreditNote = {
-        id: 'credit-note-123',
-        customer: { id: 'customer-123' },
-        invoice: { id: 'invoice-123' },
-        __typename: 'CreditNote' as const,
-      } as CreditNote
-      const result = formatResourceObject(resource, {
-        resourceType: 'CreditNote',
-        activityType: ActivityTypeEnum.CreditNoteCreated,
-      })
+    it('should return path for Coupon', () => {
+      const link = getResourceLink(
+        { id: 'coupon-123', __typename: 'Coupon' as const },
+        { resourceType: 'Coupon', activityType: ActivityTypeEnum.CouponCreated },
+      )
 
-      expect(result).not.toBeNull()
-      expect(isValidElement(result)).toBe(true)
-      expect((result as ReactElement).type).toBe('a')
-      expect((result as ReactElement).props.href).toContain('customer-123')
-      expect((result as ReactElement).props.href).toContain('invoice-123')
-      expect((result as ReactElement).props.href).toContain('credit-note-123')
+      expect(link).toContain('coupon-123')
     })
 
-    it('should return plain text for CreditNote without customer or invoice', () => {
-      const resource: CreditNote = {
-        id: 'credit-note-123',
-        __typename: 'CreditNote' as const,
-      } as CreditNote
-      const result = formatResourceObject(resource, {
-        resourceType: 'CreditNote',
-        activityType: ActivityTypeEnum.CreditNoteCreated,
-      })
+    it('should return path for CreditNote when both customer and invoice are present', () => {
+      const link = getResourceLink(
+        {
+          id: 'credit-note-123',
+          customer: { id: 'customer-123' },
+          invoice: { id: 'invoice-123' },
+          __typename: 'CreditNote' as const,
+        } as CreditNote,
+        { resourceType: 'CreditNote', activityType: ActivityTypeEnum.CreditNoteCreated },
+      )
 
-      expect(result).toBe('credit-note-123')
+      expect(link).toContain('customer-123')
+      expect(link).toContain('invoice-123')
+      expect(link).toContain('credit-note-123')
     })
 
-    it('should return link for Invoice resource', () => {
-      const resource: Invoice = {
-        id: 'invoice-123',
-        customer: { id: 'customer-123' },
-        __typename: 'Invoice' as const,
-      } as Invoice
-      const result = formatResourceObject(resource, {
-        resourceType: 'Invoice',
-        activityType: ActivityTypeEnum.InvoiceGenerated,
-      })
+    it('should return null for CreditNote without customer or invoice', () => {
+      const link = getResourceLink(
+        { id: 'credit-note-123', __typename: 'CreditNote' as const } as CreditNote,
+        { resourceType: 'CreditNote', activityType: ActivityTypeEnum.CreditNoteCreated },
+      )
 
-      expect(result).not.toBeNull()
-      expect(isValidElement(result)).toBe(true)
-      expect((result as ReactElement).type).toBe('a')
-      expect((result as ReactElement).props.href).toContain('customer-123')
-      expect((result as ReactElement).props.href).toContain('invoice-123')
+      expect(link).toBeNull()
     })
 
-    it('should return link for Feature resource', () => {
-      const resource = {
-        id: 'feature-123',
-        __typename: 'FeatureObject' as const,
-      }
-      const result = formatResourceObject(resource, {
-        resourceType: 'Feature',
-        activityType: ActivityTypeEnum.FeatureCreated,
-      })
+    it('should return path for Invoice', () => {
+      const link = getResourceLink(
+        {
+          id: 'invoice-123',
+          customer: { id: 'customer-123' },
+          __typename: 'Invoice' as const,
+        } as Invoice,
+        { resourceType: 'Invoice', activityType: ActivityTypeEnum.InvoiceGenerated },
+      )
 
-      expect(result).not.toBeNull()
-      expect(isValidElement(result)).toBe(true)
-      expect((result as ReactElement).type).toBe('a')
-      expect((result as ReactElement).props.href).toContain('feature-123')
+      expect(link).toContain('customer-123')
+      expect(link).toContain('invoice-123')
     })
 
-    it('should return link for Plan resource', () => {
-      const resource = {
-        id: 'plan-123',
-        __typename: 'Plan' as const,
-      }
-      const result = formatResourceObject(resource, {
-        resourceType: 'Plan',
-        activityType: ActivityTypeEnum.PlanCreated,
-      })
+    it('should return path for Feature', () => {
+      const link = getResourceLink(
+        { id: 'feature-123', __typename: 'FeatureObject' as const },
+        { resourceType: 'Feature', activityType: ActivityTypeEnum.FeatureCreated },
+      )
 
-      expect(result).not.toBeNull()
-      expect(isValidElement(result)).toBe(true)
-      expect((result as ReactElement).type).toBe('a')
-      expect((result as ReactElement).props.href).toContain('plan-123')
+      expect(link).toContain('feature-123')
     })
 
-    it('should return link for Wallet resource', () => {
-      const resource = {
-        id: 'wallet-123',
-        walletCustomer: { id: 'customer-123' },
-        __typename: 'Wallet' as const,
-      } as unknown as Wallet
-      const result = formatResourceObject(resource, {
-        resourceType: 'Wallet',
-        activityType: ActivityTypeEnum.WalletCreated,
-      })
+    it('should return path for Plan', () => {
+      const link = getResourceLink(
+        { id: 'plan-123', __typename: 'Plan' as const },
+        { resourceType: 'Plan', activityType: ActivityTypeEnum.PlanCreated },
+      )
 
-      expect(result).not.toBeNull()
-      expect(isValidElement(result)).toBe(true)
-      expect((result as ReactElement).type).toBe('a')
-      expect((result as ReactElement).props.href).toContain('customer-123')
+      expect(link).toContain('plan-123')
     })
 
-    it('should return plain text for unsupported resource types', () => {
-      const resource = {
-        id: 'subscription-123',
-        __typename: 'Subscription' as const,
-      }
-      const result = formatResourceObject(resource, {
-        resourceType: 'Subscription' as keyof typeof ResourceTypeEnum,
-        activityType: ActivityTypeEnum.SubscriptionStarted,
-      })
+    it("should return path for Wallet using its customer's id", () => {
+      const link = getResourceLink(
+        {
+          id: 'wallet-123',
+          walletCustomer: { id: 'customer-123' },
+          __typename: 'Wallet' as const,
+        } as unknown as Wallet,
+        { resourceType: 'Wallet', activityType: ActivityTypeEnum.WalletCreated },
+      )
 
-      expect(result).toBe('subscription-123')
+      expect(link).toContain('customer-123')
     })
 
-    it('should return plain text when activityType is not provided', () => {
-      const resource = {
-        id: 'invoice-123',
-        customer: { id: 'customer-123' },
-        __typename: 'Invoice' as const,
-      } as unknown as Invoice
-      const result = formatResourceObject(resource, {
-        resourceType: 'Invoice',
-      })
-
-      expect(result).toBe('invoice-123')
+    it('should return null for unsupported resource types', () => {
+      expect(
+        getResourceLink(
+          { id: 'subscription-123', __typename: 'Subscription' as const },
+          {
+            resourceType: 'Subscription' as keyof typeof ResourceTypeEnum,
+            activityType: ActivityTypeEnum.SubscriptionStarted,
+          },
+        ),
+      ).toBeNull()
     })
   })
 
+  describe('formatResourceObject', () => {
+    it('should return null when resource is null', () => {
+      expect(formatResourceObject(null)).toBeNull()
+    })
+
+    it('should return null when resource is undefined', () => {
+      expect(formatResourceObject(undefined)).toBeNull()
+    })
+
+    it('should return plain text when no onClick is provided', () => {
+      const resource = { id: 'plan-123', __typename: 'Plan' as const }
+
+      expect(formatResourceObject(resource)).toBe('plan-123')
+    })
+
+    it('should return a clickable Button wired to the provided onClick', () => {
+      const resource = { id: 'plan-123', __typename: 'Plan' as const }
+      const onClick = jest.fn()
+      const result = formatResourceObject(resource, onClick)
+
+      expect(isValidElement(result)).toBe(true)
+      ;(result as ReactElement).props.onClick()
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+  })
   describe('buildLinkToActivityLog', () => {
     it('should build link with default activityIds filter', () => {
       const result = buildLinkToActivityLog('log-123')

--- a/src/components/activityLogs/utils.ts
+++ b/src/components/activityLogs/utils.ts
@@ -1,6 +1,5 @@
 import { generatePath } from 'react-router-dom'
 
-import { Button } from '~/components/designSystem/Button'
 import { AvailableFiltersEnum, setFilterValue } from '~/components/designSystem/Filters'
 import { ACTIVITY_LOG_ROUTE } from '~/components/developers/devtoolsRoutes'
 import { ACTIVITY_LOG_FILTER_PREFIX } from '~/core/constants/filters'
@@ -137,26 +136,6 @@ export function getResourceLink(
     default:
       return null
   }
-}
-
-/**
- * Renders a resource as a clickable Button when an `onClick` is provided
- * (caller is responsible for the bridge to the main BrowserRouter), or as
- * plain text otherwise.
- */
-export function formatResourceObject(
-  resource: ActivityLogDetailsFragment['resource'],
-  onClick?: () => void,
-) {
-  if (!resource) return null
-
-  return onClick ? (
-    <Button variant="inline" onClick={onClick}>
-      {resource.id}
-    </Button>
-  ) : (
-    resource.id
-  )
 }
 
 export function buildLinkToActivityLog(activityId: string, filter?: AvailableFiltersEnum): string {

--- a/src/components/activityLogs/utils.tsx
+++ b/src/components/activityLogs/utils.tsx
@@ -1,5 +1,6 @@
 import { generatePath } from 'react-router-dom'
 
+import { Button } from '~/components/designSystem/Button'
 import { AvailableFiltersEnum, setFilterValue } from '~/components/designSystem/Filters'
 import { ACTIVITY_LOG_ROUTE } from '~/components/developers/devtoolsRoutes'
 import { ACTIVITY_LOG_FILTER_PREFIX } from '~/core/constants/filters'
@@ -68,7 +69,12 @@ export function isDeletedActivityType(activityType: ActivityTypeEnum) {
   return activityType.endsWith('deleted')
 }
 
-export function formatResourceObject(
+/**
+ * Pure mapping from an activity-log resource to the main-app path of its
+ * detail page. Returns `null` when the resource has been deleted, when the
+ * activityType is missing, or when the resource type is not linkable.
+ */
+export function getResourceLink(
   resource: ActivityLogDetailsFragment['resource'],
   {
     resourceType,
@@ -77,77 +83,76 @@ export function formatResourceObject(
     resourceType?: keyof typeof ResourceTypeEnum
     activityType?: ActivityTypeEnum
   },
+): string | null {
+  if (!resource || !activityType || isDeletedActivityType(activityType)) return null
+
+  switch (resourceType) {
+    case 'BillableMetric':
+      return generatePath(BILLABLE_METRIC_DETAILS_ROUTE, {
+        billableMetricId: resource.id,
+        tab: BillableMetricDetailsTabsOptionsEnum.overview,
+      })
+    case 'BillingEntity':
+      return generatePath(BILLING_ENTITY_ROUTE, {
+        billingEntityCode: (resource as BillingEntity).code,
+      })
+    case 'Coupon':
+      return generatePath(COUPON_DETAILS_ROUTE, {
+        couponId: resource.id,
+        tab: CouponDetailsTabsOptionsEnum.overview,
+      })
+    case 'CreditNote':
+      if (!(resource as CreditNote).customer?.id || !(resource as CreditNote).invoice?.id) {
+        return null
+      }
+      return generatePath(CUSTOMER_INVOICE_CREDIT_NOTE_DETAILS_ROUTE, {
+        customerId: (resource as CreditNote).customer?.id,
+        invoiceId: (resource as CreditNote).invoice?.id as string | null,
+        creditNoteId: resource.id,
+      })
+    case 'Invoice':
+      return generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
+        customerId: (resource as Invoice).customer?.id,
+        invoiceId: resource.id,
+        tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
+      })
+    case 'Feature':
+      return generatePath(FEATURE_DETAILS_ROUTE, {
+        featureId: resource.id,
+        tab: FeatureDetailsTabsOptionsEnum.overview,
+      })
+    case 'Plan':
+      return generatePath(PLAN_DETAILS_ROUTE, {
+        planId: resource.id,
+        tab: PlanDetailsTabsOptionsEnum.overview,
+      })
+    case 'Wallet':
+      return generatePath(CUSTOMER_DETAILS_TAB_ROUTE, {
+        // @ts-expect-error - walletCustomer is not typed in the graphql schema
+        customerId: (resource as Wallet).walletCustomer?.id,
+        tab: CustomerDetailsTabsOptions.wallet,
+      })
+    // Other resources are not linkable because they require more params in their URL
+    default:
+      return null
+  }
+}
+
+/**
+ * Renders a resource as a clickable Button when an `onClick` is provided
+ * (caller is responsible for the bridge to the main BrowserRouter), or as
+ * plain text otherwise.
+ */
+export function formatResourceObject(
+  resource: ActivityLogDetailsFragment['resource'],
+  onClick?: () => void,
 ) {
   if (!resource) return null
 
-  let link = null
-
-  // Deleted resources are not linkable
-  if (activityType && !isDeletedActivityType(activityType)) {
-    // Generate link to resource details page for those which are linkable
-    switch (resourceType) {
-      case 'BillableMetric':
-        link = generatePath(BILLABLE_METRIC_DETAILS_ROUTE, {
-          billableMetricId: resource.id,
-          tab: BillableMetricDetailsTabsOptionsEnum.overview,
-        })
-        break
-      case 'BillingEntity':
-        link = generatePath(BILLING_ENTITY_ROUTE, {
-          billingEntityCode: (resource as BillingEntity).code,
-        })
-        break
-      case 'Coupon':
-        link = generatePath(COUPON_DETAILS_ROUTE, {
-          couponId: resource.id,
-          tab: CouponDetailsTabsOptionsEnum.overview,
-        })
-        break
-      case 'CreditNote':
-        if ((resource as CreditNote).customer?.id && (resource as CreditNote).invoice?.id) {
-          link = generatePath(CUSTOMER_INVOICE_CREDIT_NOTE_DETAILS_ROUTE, {
-            customerId: (resource as CreditNote).customer?.id,
-            invoiceId: (resource as CreditNote).invoice?.id as string | null,
-            creditNoteId: resource.id,
-          })
-        }
-        break
-      case 'Invoice':
-        link = generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
-          customerId: (resource as Invoice).customer?.id,
-          invoiceId: resource.id,
-          tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
-        })
-        break
-      case 'Feature':
-        link = generatePath(FEATURE_DETAILS_ROUTE, {
-          featureId: resource.id,
-          tab: FeatureDetailsTabsOptionsEnum.overview,
-        })
-        break
-      case 'Plan':
-        link = generatePath(PLAN_DETAILS_ROUTE, {
-          planId: resource.id,
-          tab: PlanDetailsTabsOptionsEnum.overview,
-        })
-        break
-      case 'Wallet':
-        link = generatePath(CUSTOMER_DETAILS_TAB_ROUTE, {
-          // @ts-expect-error - walletCustomer is not typed in the graphql schema
-          customerId: (resource as Wallet).walletCustomer?.id,
-          tab: CustomerDetailsTabsOptions.wallet,
-        })
-        break
-      // Other resources are not linkable because they require more params in their URL
-      default:
-        break
-    }
-  }
-
-  return link ? (
-    <a href={link} className="visited:text-blue">
+  return onClick ? (
+    <Button variant="inline" onClick={onClick}>
       {resource.id}
-    </a>
+    </Button>
   ) : (
     resource.id
   )

--- a/src/components/activityLogs/utils.tsx
+++ b/src/components/activityLogs/utils.tsx
@@ -84,7 +84,8 @@ export function getResourceLink(
     activityType?: ActivityTypeEnum
   },
 ): string | null {
-  if (!resource || !activityType || isDeletedActivityType(activityType)) return null
+  if (!resource) return null
+  if (!activityType || isDeletedActivityType(activityType)) return null
 
   switch (resourceType) {
     case 'BillableMetric':

--- a/src/components/developers/activityLogs/ActivityLogDetails.tsx
+++ b/src/components/developers/activityLogs/ActivityLogDetails.tsx
@@ -4,7 +4,6 @@ import { generatePath, useParams } from 'react-router-dom'
 
 import {
   formatActivityType,
-  formatResourceObject,
   getResourceLink,
   isDeletedActivityType,
 } from '~/components/activityLogs/utils'
@@ -141,6 +140,27 @@ export const ActivityLogDetails = ({ goBack }: { goBack: () => void }) => {
     closePanel()
   }
 
+  const renderResourceCell = () => {
+    if (!resource?.__typename) return '-'
+
+    const link = getResourceLink(resource, {
+      resourceType: remapResourceTypeNames(resource.__typename),
+      activityType,
+    })
+
+    if (!link) return resource.id
+
+    return (
+      <Button
+        data-test={ACTIVITY_LOG_DETAILS_RESOURCE_LINK_TEST_ID}
+        variant="inline"
+        onClick={() => handleResourceNavigate(link)}
+      >
+        {resource.id}
+      </Button>
+    )
+  }
+
   const { data, loading } = useGetSingleActivityLogQuery({
     variables: { id: logId || '' },
     skip: !logId,
@@ -240,22 +260,7 @@ export const ActivityLogDetails = ({ goBack }: { goBack: () => void }) => {
                 translate('text_1732895022171f9vnwh5gm3q'),
                 resource?.__typename ? getResourceType(resource.__typename) : '-',
               ],
-              [
-                translate('text_1747666154075y3lcupj1zdd'),
-                resource?.__typename
-                  ? (() => {
-                      const link = getResourceLink(resource, {
-                        resourceType: remapResourceTypeNames(resource.__typename),
-                        activityType,
-                      })
-
-                      return formatResourceObject(
-                        resource,
-                        link ? () => handleResourceNavigate(link) : undefined,
-                      )
-                    })()
-                  : '-',
-              ],
+              [translate('text_1747666154075y3lcupj1zdd'), renderResourceCell()],
               [
                 translate('text_1748873734056eva3rfvpkoi'),
                 customerData?.customer?.id ? (

--- a/src/components/developers/activityLogs/ActivityLogDetails.tsx
+++ b/src/components/developers/activityLogs/ActivityLogDetails.tsx
@@ -5,6 +5,7 @@ import { generatePath, useParams } from 'react-router-dom'
 import {
   formatActivityType,
   formatResourceObject,
+  getResourceLink,
   isDeletedActivityType,
 } from '~/components/activityLogs/utils'
 import { CodeSnippet } from '~/components/CodeSnippet'
@@ -24,6 +25,7 @@ import {
 import { useActivityLogsInformation } from '~/hooks/activityLogs/useActivityLogsInformation'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useFormatterDateHelper } from '~/hooks/helpers/useFormatterDateHelper'
+import { useDeveloperTool } from '~/hooks/useDeveloperTool'
 
 const remapResourceTypeNames = (resourceType: string): keyof typeof ResourceTypeEnum => {
   if (resourceType === 'FeatureObject') return 'Feature'
@@ -124,6 +126,12 @@ export const ActivityLogDetails = ({ goBack }: { goBack: () => void }) => {
   const { translate } = useInternationalization()
   const { formattedDateTimeWithSecondsOrgaTZ } = useFormatterDateHelper()
   const { getActivityDescription, getResourceType } = useActivityLogsInformation()
+  const { setMainRouterUrl, closePanel } = useDeveloperTool()
+
+  const handleResourceNavigate = (path: string) => {
+    setMainRouterUrl(path)
+    closePanel()
+  }
 
   const { data, loading } = useGetSingleActivityLogQuery({
     variables: { id: logId || '' },
@@ -226,23 +234,34 @@ export const ActivityLogDetails = ({ goBack }: { goBack: () => void }) => {
               [
                 translate('text_1747666154075y3lcupj1zdd'),
                 resource?.__typename
-                  ? formatResourceObject(resource, {
-                      resourceType: remapResourceTypeNames(resource.__typename),
-                      activityType,
-                    })
+                  ? (() => {
+                      const link = getResourceLink(resource, {
+                        resourceType: remapResourceTypeNames(resource.__typename),
+                        activityType,
+                      })
+
+                      return formatResourceObject(
+                        resource,
+                        link ? () => handleResourceNavigate(link) : undefined,
+                      )
+                    })()
                   : '-',
               ],
               [
                 translate('text_1748873734056eva3rfvpkoi'),
                 customerData?.customer?.id ? (
-                  <a
-                    className="visited:text-blue"
-                    href={generatePath(CUSTOMER_DETAILS_ROUTE, {
-                      customerId: customerData.customer.id,
-                    })}
+                  <Button
+                    variant="inline"
+                    onClick={() =>
+                      handleResourceNavigate(
+                        generatePath(CUSTOMER_DETAILS_ROUTE, {
+                          customerId: customerData.customer?.id ?? '',
+                        }),
+                      )
+                    }
                   >
                     {externalCustomerId}
-                  </a>
+                  </Button>
                 ) : (
                   (externalCustomerId ?? '-')
                 ),
@@ -250,16 +269,20 @@ export const ActivityLogDetails = ({ goBack }: { goBack: () => void }) => {
               [
                 translate('text_1748873758144pfwdvafs9pv'),
                 subscriptionData?.subscription?.id && customerData?.customer?.id ? (
-                  <a
-                    className="visited:text-blue"
-                    href={generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
-                      tab: CustomerSubscriptionDetailsTabsOptionsEnum.overview,
-                      customerId: customerData?.customer?.id ?? '',
-                      subscriptionId: subscriptionData?.subscription?.id ?? '',
-                    })}
+                  <Button
+                    variant="inline"
+                    onClick={() =>
+                      handleResourceNavigate(
+                        generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
+                          tab: CustomerSubscriptionDetailsTabsOptionsEnum.overview,
+                          customerId: customerData?.customer?.id ?? '',
+                          subscriptionId: subscriptionData?.subscription?.id ?? '',
+                        }),
+                      )
+                    }
                   >
                     {externalSubscriptionId}
-                  </a>
+                  </Button>
                 ) : (
                   (externalSubscriptionId ?? '-')
                 ),

--- a/src/components/developers/activityLogs/ActivityLogDetails.tsx
+++ b/src/components/developers/activityLogs/ActivityLogDetails.tsx
@@ -27,6 +27,14 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useFormatterDateHelper } from '~/hooks/helpers/useFormatterDateHelper'
 import { useDeveloperTool } from '~/hooks/useDeveloperTool'
 
+export const ACTIVITY_LOG_DETAILS_LOADING_TEST_ID = 'activity-log-details-loading'
+export const ACTIVITY_LOG_DETAILS_CONTENT_TEST_ID = 'activity-log-details-content'
+export const ACTIVITY_LOG_DETAILS_CLOSE_BUTTON_TEST_ID = 'activity-log-details-close-button'
+export const ACTIVITY_LOG_DETAILS_RESOURCE_LINK_TEST_ID = 'activity-log-details-resource-link'
+export const ACTIVITY_LOG_DETAILS_CUSTOMER_LINK_TEST_ID = 'activity-log-details-customer-link'
+export const ACTIVITY_LOG_DETAILS_SUBSCRIPTION_LINK_TEST_ID =
+  'activity-log-details-subscription-link'
+
 const remapResourceTypeNames = (resourceType: string): keyof typeof ResourceTypeEnum => {
   if (resourceType === 'FeatureObject') return 'Feature'
   return resourceType as keyof typeof ResourceTypeEnum
@@ -192,7 +200,7 @@ export const ActivityLogDetails = ({ goBack }: { goBack: () => void }) => {
       </Typography>
 
       {loading && (
-        <div className="flex flex-col gap-4 p-4">
+        <div data-test={ACTIVITY_LOG_DETAILS_LOADING_TEST_ID} className="flex flex-col gap-4 p-4">
           <Skeleton variant="text" textVariant="subhead1" className="w-40" />
           <div className="grid grid-cols-[140px,_1fr] items-baseline gap-x-8 gap-y-3">
             {[...Array(3)].map((_, index) => (
@@ -206,13 +214,14 @@ export const ActivityLogDetails = ({ goBack }: { goBack: () => void }) => {
       )}
 
       {!loading && (
-        <div className="flex flex-col gap-12 p-4">
+        <div data-test={ACTIVITY_LOG_DETAILS_CONTENT_TEST_ID} className="flex flex-col gap-12 p-4">
           <div className="grid grid-cols-[140px,_1fr] items-baseline gap-3 not-last:pb-12 not-last:shadow-b">
             <div className="col-span-2 flex items-center justify-between">
               <Typography variant="subhead1" color="grey700">
                 {translate('text_63ebba5f5160e26242c48bd2')}
               </Typography>
               <Button
+                data-test={ACTIVITY_LOG_DETAILS_CLOSE_BUTTON_TEST_ID}
                 icon="close"
                 variant="quaternary"
                 size="small"
@@ -251,6 +260,7 @@ export const ActivityLogDetails = ({ goBack }: { goBack: () => void }) => {
                 translate('text_1748873734056eva3rfvpkoi'),
                 customerData?.customer?.id ? (
                   <Button
+                    data-test={ACTIVITY_LOG_DETAILS_CUSTOMER_LINK_TEST_ID}
                     variant="inline"
                     onClick={() =>
                       handleResourceNavigate(
@@ -270,6 +280,7 @@ export const ActivityLogDetails = ({ goBack }: { goBack: () => void }) => {
                 translate('text_1748873758144pfwdvafs9pv'),
                 subscriptionData?.subscription?.id && customerData?.customer?.id ? (
                   <Button
+                    data-test={ACTIVITY_LOG_DETAILS_SUBSCRIPTION_LINK_TEST_ID}
                     variant="inline"
                     onClick={() =>
                       handleResourceNavigate(

--- a/src/components/developers/activityLogs/__tests__/ActivityLogDetails.test.tsx
+++ b/src/components/developers/activityLogs/__tests__/ActivityLogDetails.test.tsx
@@ -1,0 +1,276 @@
+import { render as rtlRender, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import {
+  GetCustomerIdForActivityLogDetailsDocument,
+  GetSingleActivityLogDocument,
+  GetSubscriptionIdForActivityLogDetailsDocument,
+} from '~/generated/graphql'
+import { AllTheProviders, TestMocksType } from '~/test-utils'
+
+import {
+  ACTIVITY_LOG_DETAILS_CLOSE_BUTTON_TEST_ID,
+  ACTIVITY_LOG_DETAILS_CONTENT_TEST_ID,
+  ACTIVITY_LOG_DETAILS_CUSTOMER_LINK_TEST_ID,
+  ACTIVITY_LOG_DETAILS_LOADING_TEST_ID,
+  ACTIVITY_LOG_DETAILS_SUBSCRIPTION_LINK_TEST_ID,
+  ActivityLogDetails,
+} from '../ActivityLogDetails'
+
+const mockSetMainRouterUrl = jest.fn()
+const mockClosePanel = jest.fn()
+
+jest.mock('~/hooks/useDeveloperTool', () => ({
+  DEVTOOL_TAB_PARAMS: 'devtool-tab',
+  useDeveloperTool: () => ({
+    setMainRouterUrl: mockSetMainRouterUrl,
+    closePanel: mockClosePanel,
+    mainRouterUrl: '',
+  }),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('~/hooks/helpers/useFormatterDateHelper', () => ({
+  useFormatterDateHelper: () => ({
+    formattedDateTimeWithSecondsOrgaTZ: (date: string) => date,
+  }),
+}))
+
+jest.mock('~/hooks/activityLogs/useActivityLogsInformation', () => ({
+  useActivityLogsInformation: () => ({
+    getActivityDescription: () => 'Test activity description',
+    getResourceType: (typename: string) => typename,
+  }),
+}))
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ logId: 'test-log-id' }),
+}))
+
+const mockActivityLog = {
+  __typename: 'ActivityLog' as const,
+  activityId: 'activity-123',
+  activityType: 'plan_created',
+  activitySource: 'api',
+  activityObject: { name: 'Test Plan' },
+  activityObjectChanges: { name: ['Old', 'New'] },
+  loggedAt: '2026-04-20T10:00:00Z',
+  userEmail: 'user@test.com',
+  externalSubscriptionId: 'ext-sub-123',
+  externalCustomerId: 'ext-cust-123',
+  apiKey: { __typename: 'SanitizedApiKey' as const, value: 'key-value', name: 'Test Key' },
+  resource: {
+    __typename: 'Plan' as const,
+    id: 'plan-456',
+  },
+}
+
+const buildActivityLogMock = (overrides: Partial<typeof mockActivityLog> = {}): TestMocksType => [
+  {
+    request: {
+      query: GetSingleActivityLogDocument,
+      variables: { id: 'test-log-id' },
+    },
+    result: {
+      data: {
+        activityLog: {
+          ...mockActivityLog,
+          ...overrides,
+        },
+      },
+    },
+  },
+]
+
+const buildCustomerMock = (customerId: string | null = 'customer-internal-123'): TestMocksType => [
+  {
+    request: {
+      query: GetCustomerIdForActivityLogDetailsDocument,
+      variables: { externalId: 'ext-cust-123' },
+    },
+    result: {
+      data: {
+        customer: customerId ? { __typename: 'Customer' as const, id: customerId } : null,
+      },
+    },
+  },
+]
+
+const buildSubscriptionMock = (
+  subscriptionId: string | null = 'subscription-internal-123',
+): TestMocksType => [
+  {
+    request: {
+      query: GetSubscriptionIdForActivityLogDetailsDocument,
+      variables: { externalId: 'ext-sub-123' },
+    },
+    result: {
+      data: {
+        subscription: subscriptionId
+          ? { __typename: 'Subscription' as const, id: subscriptionId }
+          : null,
+      },
+    },
+  },
+]
+
+const renderComponent = (mocks: TestMocksType = []) =>
+  rtlRender(
+    <AllTheProviders mocks={mocks} forceTypenames>
+      <ActivityLogDetails goBack={mockGoBack} />
+    </AllTheProviders>,
+  )
+
+const mockGoBack = jest.fn()
+
+describe('ActivityLogDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('GIVEN the data is loading', () => {
+    describe('WHEN the component renders', () => {
+      it('THEN should display loading skeletons', () => {
+        renderComponent([])
+
+        expect(screen.getByTestId(ACTIVITY_LOG_DETAILS_LOADING_TEST_ID)).toBeInTheDocument()
+        expect(screen.queryByTestId(ACTIVITY_LOG_DETAILS_CONTENT_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN the data has loaded', () => {
+    describe('WHEN the component renders with activity log data', () => {
+      it('THEN should display content and not loading state', async () => {
+        renderComponent([
+          ...buildActivityLogMock(),
+          ...buildCustomerMock(),
+          ...buildSubscriptionMock(),
+        ])
+
+        await waitFor(() => {
+          expect(screen.getByTestId(ACTIVITY_LOG_DETAILS_CONTENT_TEST_ID)).toBeInTheDocument()
+        })
+
+        expect(screen.queryByTestId(ACTIVITY_LOG_DETAILS_LOADING_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the close button is clicked', () => {
+      it('THEN should call goBack', async () => {
+        const user = userEvent.setup()
+
+        renderComponent([
+          ...buildActivityLogMock(),
+          ...buildCustomerMock(),
+          ...buildSubscriptionMock(),
+        ])
+
+        await waitFor(() => {
+          expect(screen.getByTestId(ACTIVITY_LOG_DETAILS_CONTENT_TEST_ID)).toBeInTheDocument()
+        })
+
+        const closeButton = screen.getByTestId(ACTIVITY_LOG_DETAILS_CLOSE_BUTTON_TEST_ID)
+        await user.click(closeButton)
+
+        expect(mockGoBack).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('WHEN the customer link button is clicked', () => {
+      it('THEN should call setMainRouterUrl and closePanel', async () => {
+        const user = userEvent.setup()
+
+        renderComponent([
+          ...buildActivityLogMock(),
+          ...buildCustomerMock('customer-internal-123'),
+          ...buildSubscriptionMock(),
+        ])
+
+        await waitFor(() => {
+          expect(screen.getByTestId(ACTIVITY_LOG_DETAILS_CUSTOMER_LINK_TEST_ID)).toBeInTheDocument()
+        })
+
+        const customerLink = screen.getByTestId(ACTIVITY_LOG_DETAILS_CUSTOMER_LINK_TEST_ID)
+        await user.click(customerLink)
+
+        expect(mockSetMainRouterUrl).toHaveBeenCalledWith(
+          expect.stringContaining('customer-internal-123'),
+        )
+        expect(mockClosePanel).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('WHEN the subscription link button is clicked', () => {
+      it('THEN should call setMainRouterUrl and closePanel', async () => {
+        const user = userEvent.setup()
+
+        renderComponent([
+          ...buildActivityLogMock(),
+          ...buildCustomerMock('customer-internal-123'),
+          ...buildSubscriptionMock('subscription-internal-123'),
+        ])
+
+        await waitFor(() => {
+          expect(
+            screen.getByTestId(ACTIVITY_LOG_DETAILS_SUBSCRIPTION_LINK_TEST_ID),
+          ).toBeInTheDocument()
+        })
+
+        const subscriptionLink = screen.getByTestId(ACTIVITY_LOG_DETAILS_SUBSCRIPTION_LINK_TEST_ID)
+        await user.click(subscriptionLink)
+
+        expect(mockSetMainRouterUrl).toHaveBeenCalledWith(
+          expect.stringContaining('subscription-internal-123'),
+        )
+        expect(mockClosePanel).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('WHEN customer data is not available', () => {
+      it('THEN should not display the customer link button', async () => {
+        renderComponent([
+          ...buildActivityLogMock(),
+          ...buildCustomerMock(null),
+          ...buildSubscriptionMock(),
+        ])
+
+        await waitFor(() => {
+          expect(screen.getByTestId(ACTIVITY_LOG_DETAILS_CONTENT_TEST_ID)).toBeInTheDocument()
+        })
+
+        expect(
+          screen.queryByTestId(ACTIVITY_LOG_DETAILS_CUSTOMER_LINK_TEST_ID),
+        ).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN subscription data is not available', () => {
+      it('THEN should not display the subscription link button', async () => {
+        renderComponent([
+          ...buildActivityLogMock(),
+          ...buildCustomerMock(),
+          ...buildSubscriptionMock(null),
+        ])
+
+        await waitFor(() => {
+          expect(screen.getByTestId(ACTIVITY_LOG_DETAILS_CONTENT_TEST_ID)).toBeInTheDocument()
+        })
+
+        expect(
+          screen.queryByTestId(ACTIVITY_LOG_DETAILS_SUBSCRIPTION_LINK_TEST_ID),
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Context
Clicking resource links / action buttons in the devtools panel
(API keys, webhooks, activity logs) navigated to slug-less paths
and 404'd under the post-Phase-2 `/:organizationSlug/...` router.

## Description
- `RouteWrapper`: in the MemoryRouter → BrowserRouter bridge, derive
  the slug from the first segment of the current URL and pass it
  with `skipSlugPrepend: true`.
- `activityLogs/utils.tsx`: split into a pure `getResourceLink`
  (path mapping) + a thin `formatResourceObject(resource, onClick?)`
  renderer.
- `ActivityLogDetails`: replace raw `<a href>` with `<Button variant="inline">`
  wired to the existing `setMainRouterUrl + closePanel` bridge.