### PR TITLE
perf(build): cut shiki chunks from sentry upload + drop debug noise

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -94,7 +94,6 @@ export default defineConfig(({ mode }) => {
         sourcemaps: {
           disable: true,
         },
-        debug: true,
         telemetry: false,
       }),
     )

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,6 +89,13 @@ export default defineConfig(({ mode }) => {
           uploadLegacySourcemaps: {
             paths: ['./dist'],
             urlPrefix: '~/',
+            // Skip Shiki language and theme grammar chunks. They're regex
+            // tokenizer data, not application code — runtime errors don't
+            // originate inside them, so symbolicating them in Sentry has
+            // no practical value. Each language is its own dynamic-import
+            // chunk (see chunkFileNames below); ignoring this glob removes
+            // ~150 .js + .js.map upload pairs per build.
+            ignore: ['./dist/assets/shiki-lang-*', './dist/assets/shiki-theme-*'],
           },
         },
         sourcemaps: {
@@ -195,9 +202,32 @@ export default defineConfig(({ mode }) => {
       target: 'esnext',
       rollupOptions: {
         output: {
-          chunkFileNames: 'assets/[name].[hash].js',
+          // Prefix Shiki language/theme chunks with `shiki-lang-` /
+          // `shiki-theme-` so the Sentry uploader can ignore them via a
+          // single glob (see `uploadLegacySourcemaps.ignore` above). This
+          // does NOT change runtime behavior — chunks remain individually
+          // code-split and lazy-loaded, only the output filename changes.
+          chunkFileNames: (chunkInfo) => {
+            const id = chunkInfo.facadeModuleId || ''
+            if (/[\\/]shiki[\\/](?:dist[\\/])?langs[\\/]/.test(id) || /@shikijs[\\/]langs[\\/]/.test(id)) {
+              return 'assets/shiki-lang-[name].[hash].js'
+            }
+            if (/[\\/]shiki[\\/](?:dist[\\/])?themes[\\/]/.test(id) || /@shikijs[\\/]themes[\\/]/.test(id)) {
+              return 'assets/shiki-theme-[name].[hash].js'
+            }
+            return 'assets/[name].[hash].js'
+          },
           entryFileNames: 'assets/[name].[hash].js',
-          sourcemapFileNames: 'assets/[name].[hash].js.map',
+          sourcemapFileNames: (chunkInfo) => {
+            const id = chunkInfo.facadeModuleId || ''
+            if (/[\\/]shiki[\\/](?:dist[\\/])?langs[\\/]/.test(id) || /@shikijs[\\/]langs[\\/]/.test(id)) {
+              return 'assets/shiki-lang-[name].[hash].js.map'
+            }
+            if (/[\\/]shiki[\\/](?:dist[\\/])?themes[\\/]/.test(id) || /@shikijs[\\/]themes[\\/]/.test(id)) {
+              return 'assets/shiki-theme-[name].[hash].js.map'
+            }
+            return 'assets/[name].[hash].js.map'
+          },
           manualChunks: {
             'vendor-react': ['react', 'react-dom', 'react-router-dom'],
             'vendor-apollo': ['@apollo/client', 'graphql'],


### PR DESCRIPTION
## Summary

Fixes the slow + variable-time production Docker builds (3 min ↔ 6m22s) by addressing the dominant cost: per-file Sentry sourcemap uploads.

The recent perf(docker) changes (#3366, #3367) optimized layer caching for `pnpm install` but did not touch the build stage. Inside `RUN pnpm build`, the Sentry Vite plugin walks `dist/` and uploads each `.js` + `.js.map` pair as a separate API call. With Shiki's `bundle/full` shipping ~190 language grammars + ~30 themes — each emitted as its own dynamic-import chunk — the build step makes 300+ uploads serially. Total wall-time = file count × Sentry API latency, so any Sentry-side jitter gets amplified ~300×.

This PR removes the bulk of those uploads without changing runtime behavior.

## Changes

### `chore(sentry): remove verbose upload debug logging`
Drops `debug: true` from `sentryVitePlugin`. With it on, every build dumps thousands of `whitelisting dist/assets/...` lines into CI logs as sentry-cli walks the output. Wall-clock impact is negligible — purely log hygiene.

### `perf(build): exclude shiki language and theme chunks from sentry upload`
Two coordinated changes in `vite.config.ts`:

1. **Rename Shiki output chunks**: switch `chunkFileNames` and `sourcemapFileNames` to function form so per-language chunks emit as `shiki-lang-<name>.<hash>.js` and per-theme as `shiki-theme-<name>.<hash>.js`. Files are still individually code-split — only the filename prefix changes.

2. **Tell the Sentry uploader to skip them**: add `ignore: ['./dist/assets/shiki-lang-*', './dist/assets/shiki-theme-*']` to `uploadLegacySourcemaps`.

**Why this is safe:** Shiki language and theme files are compiled regex tokenizer data. Application errors don't originate inside them — symbolicating them in Sentry has no practical value. We tried bundling all languages into one chunk first; that would have forced a ~3 MB download on the first code block (UX regression). This approach keeps lazy loading intact and only changes what's uploaded.

## Expected impact

- **Build time**: ~150 fewer file uploads per build. Should bring the variance back into the 2–3 min range.
- **End-user runtime**: zero change. Same chunks, same lazy loading, same sizes.
- **Sentry coverage**: unchanged for application code. Lost only for Shiki internals, which never appear in stack traces in practice.
