### PR TITLE
feat(sentry): migrate sourcemap upload to debug IDs

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -81,25 +81,25 @@ export default defineConfig(({ mode }) => {
         authToken: sentryAuthToken,
         release: {
           name: appVersion,
-          // Use release-based source map instead of Debug IDs
-          // This is needed because Debug ID injection is not working correctly
-          // with this build setup. The legacy method matches source maps by
-          // release name + file path instead of Debug IDs.
-          // Docs: https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/vite/
-          uploadLegacySourcemaps: {
-            paths: ['./dist'],
-            urlPrefix: '~/',
-            // Skip Shiki language and theme grammar chunks. They're regex
-            // tokenizer data, not application code — runtime errors don't
-            // originate inside them, so symbolicating them in Sentry has
-            // no practical value. Each language is its own dynamic-import
-            // chunk (see chunkFileNames below); ignoring this glob removes
-            // ~150 .js + .js.map upload pairs per build.
-            ignore: ['./dist/assets/shiki-lang-*', './dist/assets/shiki-theme-*'],
-          },
         },
         sourcemaps: {
-          disable: true,
+          // Modern Debug ID-based upload: the plugin injects a stable Debug
+          // ID into each emitted JS file at build time and writes the same
+          // ID into the matching .map. Sentry symbolicates errors by reading
+          // the ID from the served JS — no release-name + path coupling,
+          // and only .map files get uploaded (vs both .js and .map under
+          // the legacy uploader), roughly halving request count.
+          assets: ['./dist/**'],
+          // Skip Shiki language and theme grammar chunks (renamed with a
+          // stable prefix in #3428). They're tokenizer data, not app code
+          // — runtime errors don't originate inside them, so symbolicating
+          // them in Sentry has no practical value.
+          ignore: ['./dist/assets/shiki-lang-*', './dist/assets/shiki-theme-*'],
+          // We deliberately do NOT delete .map files after upload. Lago is
+          // open source — the JS sources are already public on GitHub, so
+          // shipping source maps to production exposes nothing new and lets
+          // self-hosters / contributors debug their own deployments with
+          // readable stack frames in browser devtools.
         },
         telemetry: false,
       }),


### PR DESCRIPTION
> ⚠️ **The second commit must be dropped before merging** — see verification section.

## Summary

Replaces the legacy release-name-based sourcemap upload with the modern Debug ID flow recommended by the Sentry docs and `@sentry/vite-plugin`.

A previous attempt at Debug IDs failed and left this comment in the config:

> _Debug ID injection is not working correctly with this build setup. The legacy method matches source maps by release name + file path instead of Debug IDs._

That comment is now stale. Several relevant fixes have shipped in `@sentry/vite-plugin` since whenever it was written:

| Version | Fix |
|---|---|
| 4.0.1 | Switched release injection to Rollup's `renderChunk` hook (more reliable than transform-stage injection) |
| 4.6.2 | Prevented double-injection of Debug IDs across Rollup chunks (most likely root cause of the previous breakage) |
| 4.7.0 | Debug ID injection now respects `sourcemap.ignore` |
| 4.8.0 | Combined injection snippets, optimized chunk processing |
| 5.2.0 | Passes `mapDir` to `rewriteSourcesHook` |

We're on **5.2.0** (latest, published 2026-04-08) with Vite 7.3.2, `@vitejs/plugin-react-swc` 4.3.0, `vite-plugin-wasm` 3.6.0, `vite-plugin-top-level-await` 1.6.0 — none of which are known to interfere at these versions. The Sentry plugin already runs last in the plugins array, which is the required ordering for `renderChunk`-based injection.

## Build-speed connection

This change is **partly** related to the slow-build investigation that motivated #3428 (now merged):
- Debug IDs upload only `.map` files (the legacy path uploaded both `.js` + `.map`), roughly halving request count.
- Stacks on top of the Shiki ignore already in place from #3428.

But the dominant fix was #3428 — this PR's main motivation is correctness/maintainability (modern flow, no release-name coupling, robust against re-deploys with the same `APP_VERSION`).

## Changes

### `feat(sentry): migrate sourcemap upload to debug IDs`
- Drops `release.uploadLegacySourcemaps` and `sourcemaps.disable: true`.
- Adds `sourcemaps.assets: ['./dist/**']` so the plugin walks the build output, injects Debug IDs into each `.js` file, and uploads `.map` files only.
- Keeps `release.name: appVersion` so events are still grouped per deploy in Sentry; matching no longer depends on it.
- Moves the Shiki language/theme ignore from `uploadLegacySourcemaps.ignore` (added in #3428) into `sourcemaps.ignore`.
- **Does NOT** enable `filesToDeleteAfterUpload`. Lago is open source — the JS source is already public on GitHub, so shipping `.map` files to production exposes nothing new and lets self-hosters / contributors debug their deployments in browser devtools with readable stack frames. If we ever decide otherwise, dropping `.map` files is a one-line change.

### `chore(sentry): add temporary debug-id verification trigger [DROP BEFORE MERGE]`
Adds `window.__triggerSentryDebugIdTest()` in `main.tsx`. Triggers a thrown error on demand from the browser console for end-to-end verification on a real deployment. **This commit must not reach main.**

## Verification plan (alex will run)

1. Set `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_FRONT_PROJECT`, `APP_VERSION` in argoCD for this deployment.
2. Deploy this branch.
3. (Optional, local) Confirm Debug IDs were injected into the bundles:
   ```sh
   grep -l "_sentryDebugIds" dist/assets/*.js | head
   head -c 500 dist/assets/index-*.js.map | grep -o '"debugId":"[^"]*"' | head -1
   ```
4. Open the deployed app, open devtools console, call:
   ```js
   window.__triggerSentryDebugIdTest()
   ```
5. Open the resulting event in Sentry. It should resolve to readable TypeScript paths in `src/` — file name, line number, original variable names. If it shows minified `a.b.c` frames, Debug IDs are not being matched.

## Test plan

- [ ] Local build succeeds with Sentry env vars set.
- [ ] `_sentryDebugIds` appears in built JS files.
- [ ] `debugId` field appears in `.map` files.
- [ ] Deploy to staging via argoCD.
- [ ] `window.__triggerSentryDebugIdTest()` throws and Sentry shows symbolicated stack frames pointing at this file in `src/main.tsx`.
- [ ] Drop the verification commit (`git rebase -i HEAD~2` and remove it).
- [ ] Confirm CI build is green and not noticeably slower than the legacy uploader path.

## Rollback

If symbolication fails after deploy, leave both commits, post findings, and we'll either tune the config or revert to the legacy uploader. No production user impact in either case (sourcemap upload is build-time only).