### PR TITLE
refactor(forecasts): migrate Forecasts page to usePremiumWarningDialog hook

### DIFF
--- a/src/pages/forecasts/Forecasts.tsx
+++ b/src/pages/forecasts/Forecasts.tsx
@@ -1,5 +1,4 @@
 import { Icon, tw } from 'lago-design-system'
-import { useRef } from 'react'
 
 import { AiBadge } from '~/components/designSystem/AiBadge'
 import { Chip } from '~/components/designSystem/Chip'
@@ -7,7 +6,6 @@ import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { FullscreenPage } from '~/components/layouts/FullscreenPage'
 import PremiumFeature from '~/components/premium/PremiumFeature'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { PremiumIntegrationTypeEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
@@ -37,7 +35,6 @@ export const BadgeAI = ({
 
 const Forecasts = () => {
   const { translate } = useInternationalization()
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
   const { hasOrganizationPremiumAddon } = useOrganizationInfos()
 
   const hasAccessToForecastsFeature = hasOrganizationPremiumAddon(
@@ -45,50 +42,44 @@ const Forecasts = () => {
   )
 
   return (
-    <>
-      <FullscreenPage.Wrapper>
-        <div className="flex items-center gap-2">
-          <Typography variant="headline" color="grey700">
-            {translate('text_1753014457040hxp6wkphkvw')}
-          </Typography>
+    <FullscreenPage.Wrapper>
+      <div className="flex items-center gap-2">
+        <Typography variant="headline" color="grey700">
+          {translate('text_1753014457040hxp6wkphkvw')}
+        </Typography>
 
-          <Tooltip
-            placement="top-start"
-            title={translate('text_17530144570400ri03obw5mv')}
-            className="flex"
-          >
-            <Icon name="info-circle" className="text-grey-600" />
-          </Tooltip>
+        <Tooltip
+          placement="top-start"
+          title={translate('text_17530144570400ri03obw5mv')}
+          className="flex"
+        >
+          <Icon name="info-circle" className="text-grey-600" />
+        </Tooltip>
 
-          <BadgeAI badgeClassName="px-2 py-1" iconSize={16} textClassName="text-sm" />
+        <BadgeAI badgeClassName="px-2 py-1" iconSize={16} textClassName="text-sm" />
 
-          <Chip
-            className="bg-purple-100 !px-2 !py-0.5 text-purple-600"
-            color="info600"
-            size="small"
-            label={translate('text_65d8d71a640c5400917f8a13')}
-          />
-        </div>
+        <Chip
+          className="bg-purple-100 !px-2 !py-0.5 text-purple-600"
+          color="info600"
+          size="small"
+          label={translate('text_65d8d71a640c5400917f8a13')}
+        />
+      </div>
 
-        {!hasAccessToForecastsFeature && (
-          <div className="max-w-2xl">
-            <div>
-              <PremiumFeature
-                title={translate('text_1761560753771d6ppz3evqxc')}
-                description={translate('text_1761560714509hv9325ywuzq')}
-                feature={translate('text_1753014457040hxp6wkphkvw')}
-              />
-            </div>
+      {!hasAccessToForecastsFeature && (
+        <div className="max-w-2xl">
+          <div>
+            <PremiumFeature
+              title={translate('text_1761560753771d6ppz3evqxc')}
+              description={translate('text_1761560714509hv9325ywuzq')}
+              feature={translate('text_1753014457040hxp6wkphkvw')}
+            />
           </div>
-        )}
+        </div>
+      )}
 
-        {hasAccessToForecastsFeature && (
-          <ForecastsOverviewSection premiumWarningDialogRef={premiumWarningDialogRef} />
-        )}
-      </FullscreenPage.Wrapper>
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
-    </>
+      {hasAccessToForecastsFeature && <ForecastsOverviewSection />}
+    </FullscreenPage.Wrapper>
   )
 }
 

--- a/src/pages/forecasts/ForecastsOverviewSection.tsx
+++ b/src/pages/forecasts/ForecastsOverviewSection.tsx
@@ -10,7 +10,7 @@ import {
   RowType,
 } from '~/components/designSystem/Table/HorizontalDataTable'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { FORECASTS_FILTER_PREFIX } from '~/core/constants/filters'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
@@ -20,10 +20,6 @@ import { useForecastsAnalyticsOverview } from '~/pages/forecasts/useForecastsAna
 import { FORECASTS_GRAPH_COLORS } from '~/pages/forecasts/utils'
 import ErrorImage from '~/public/images/maneki/error.svg'
 import { tw } from '~/styles/utils'
-
-type ForecastsOverviewSectionProps = {
-  premiumWarningDialogRef: React.RefObject<PremiumWarningDialogRef>
-}
 
 const ForecastsRowLabel = ({ label, color }: { label: string; color: string }) => (
   <div className="flex items-center gap-2">
@@ -59,10 +55,9 @@ const AmountCell = ({
   )
 }
 
-export const ForecastsOverviewSection = ({
-  premiumWarningDialogRef,
-}: ForecastsOverviewSectionProps) => {
+export const ForecastsOverviewSection = () => {
   const { translate } = useInternationalization()
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
 
   const {
     selectedCurrency,
@@ -183,7 +178,7 @@ export const ForecastsOverviewSection = ({
               onClick={(e) => {
                 if (!hasAccessToForecastsFeature) {
                   e.stopPropagation()
-                  premiumWarningDialogRef.current?.openDialog()
+                  openPremiumWarningDialog()
                 } else {
                   onClick()
                 }


### PR DESCRIPTION
## Summary

- Replace the deprecated `~/components/PremiumWarningDialog` ref-based dialog usage in `src/pages/forecasts/Forecasts.tsx` with the new hook-based `usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`.
- Move the dialog opening logic directly inside `ForecastsOverviewSection`, removing the need for the parent to forward a ref. The component no longer needs the `premiumWarningDialogRef` prop.
- Clears the `no-restricted-imports` ESLint warnings for `~/components/PremiumWarningDialog` in these two files.

## Scope

Scoped to the Forecasts page only — no other dialogs were present in these files.

## Test plan

- [ ] `pnpm code:style` passes (lint, types, translations)
- [ ] Visit the Forecasts page on a non-premium org and click the "Filter" button: the premium warning dialog should still open as before
- [ ] On a premium org, the filter button opens the filters panel as before

https://claude.ai/code/session_01HoKTo3zRQi76uXQhX9iHkQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoKTo3zRQi76uXQhX9iHkQ)_