### PR TITLE
feat(invoices): add tax recalc alert in regenerate flow

### DIFF
--- a/src/components/invoices/details/InvoiceDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTable.tsx
@@ -523,7 +523,7 @@ export const InvoiceDetailsTable = memo(
               invoiceFees={onAdd ? fees : null}
               canHaveUnitPrice={canHaveUnitPrice}
               hasTaxProviderError={hasTaxProviderError}
-              hideDiscounts={!!onAdd}
+              isRegenerateFlow={!!onAdd}
             />
           </table>
         </div>

--- a/src/components/invoices/details/InvoiceDetailsTableFooter.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableFooter.tsx
@@ -57,7 +57,7 @@ interface InvoiceDetailsTableFooterProps {
   invoice: InvoiceForDetailsTableFooterFragment
   hasTaxProviderError?: boolean
   invoiceFees?: FeeForInvoiceDetailsTableFooterFragment[] | null
-  hideDiscounts?: boolean
+  isRegenerateFlow?: boolean
 }
 
 const applyTaxRateToAmount = (amount: number, tax: { taxRate: number }) => {
@@ -97,6 +97,7 @@ const computeSubtotal = (
 export const CREDIT_ROW_GRANTED_TEST_ID = 'credit-row-granted'
 export const CREDIT_ROW_PURCHASED_TEST_ID = 'credit-row-purchased'
 export const CREDIT_ROW_LEGACY_TEST_ID = 'credit-row-legacy'
+export const REGENERATE_ALERT_TEST_ID = 'invoice-details-table-footer-regenerate-alert'
 
 const CreditRow = ({
   label,
@@ -137,19 +138,19 @@ export const InvoiceDetailsTableFooter = memo(
     invoice,
     hasTaxProviderError,
     invoiceFees,
-    hideDiscounts,
+    isRegenerateFlow,
   }: InvoiceDetailsTableFooterProps) => {
     const { translate } = useInternationalization()
 
     const colSpan = canHaveUnitPrice ? 3 : 2
     const isLegacyInvoice = invoice?.versionNumber < 3
     const currency = invoice?.currency || CurrencyEnum.Usd
-    const hasCreditNotes = !!Number(invoice?.creditNotesAmountCents) && !hideDiscounts
-    const hasPrepaidCredit = !!Number(invoice?.prepaidCreditAmountCents) && !hideDiscounts
-    const hasGrantedCredit = !!Number(invoice?.prepaidGrantedCreditAmountCents) && !hideDiscounts
+    const hasCreditNotes = !!Number(invoice?.creditNotesAmountCents) && !isRegenerateFlow
+    const hasPrepaidCredit = !!Number(invoice?.prepaidCreditAmountCents) && !isRegenerateFlow
+    const hasGrantedCredit = !!Number(invoice?.prepaidGrantedCreditAmountCents) && !isRegenerateFlow
     const hasPurchasedCredit =
-      !!Number(invoice?.prepaidPurchasedCreditAmountCents) && !hideDiscounts
-    const hasCoupon = !!Number(invoice?.couponsAmountCents) && !hideDiscounts
+      !!Number(invoice?.prepaidPurchasedCreditAmountCents) && !isRegenerateFlow
+    const hasCoupon = !!Number(invoice?.couponsAmountCents) && !isRegenerateFlow
     const isPending = invoice.status === InvoiceStatusTypeEnum.Pending
 
     const shouldDisplayPlaceholder = isPending || hasTaxProviderError
@@ -167,6 +168,16 @@ export const InvoiceDetailsTableFooter = memo(
 
     return (
       <tfoot>
+        {isRegenerateFlow && (
+          <tr>
+            <td></td>
+            <td colSpan={colSpan + 1}>
+              <Alert type="info" data-test={REGENERATE_ALERT_TEST_ID}>
+                {translate('text_1777385516575oti5gavf3ze')}
+              </Alert>
+            </td>
+          </tr>
+        )}
         {invoice.invoiceType !== InvoiceTypeEnum.Credit && (
           <>
             {!!Number(invoice.progressiveBillingCreditAmountCents) && (

--- a/src/components/invoices/details/__tests__/InvoiceDetailsTableFooter.test.tsx
+++ b/src/components/invoices/details/__tests__/InvoiceDetailsTableFooter.test.tsx
@@ -5,6 +5,7 @@ import {
   CREDIT_ROW_LEGACY_TEST_ID,
   CREDIT_ROW_PURCHASED_TEST_ID,
   InvoiceDetailsTableFooter,
+  REGENERATE_ALERT_TEST_ID,
 } from '~/components/invoices/details/InvoiceDetailsTableFooter'
 import {
   CurrencyEnum,
@@ -126,7 +127,7 @@ describe('InvoiceDetailsTableFooter', () => {
       })
     })
 
-    describe('WHEN hideDiscounts is true', () => {
+    describe('WHEN isRegenerateFlow is true', () => {
       it('THEN should not display any prepaid credit rows', () => {
         const invoice = createMockInvoice({
           prepaidCreditAmountCents: '8000',
@@ -139,7 +140,7 @@ describe('InvoiceDetailsTableFooter', () => {
             <InvoiceDetailsTableFooter
               canHaveUnitPrice={false}
               invoice={invoice}
-              hideDiscounts={true}
+              isRegenerateFlow={true}
             />
           </table>,
         )
@@ -205,6 +206,36 @@ describe('InvoiceDetailsTableFooter', () => {
         ).toBeInTheDocument()
         expect(screen.getByTestId('invoice-details-table-footer-tax-0-label')).toBeInTheDocument()
         expect(screen.getByTestId('invoice-details-table-footer-tax-0-value')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN the invoice is rendered in the regenerate flow', () => {
+    describe('WHEN isRegenerateFlow is true', () => {
+      it('THEN should display the tax recalculation alert', () => {
+        const invoice = createMockInvoice()
+
+        render(
+          <table>
+            <InvoiceDetailsTableFooter
+              canHaveUnitPrice={false}
+              invoice={invoice}
+              isRegenerateFlow={true}
+            />
+          </table>,
+        )
+
+        expect(screen.getByTestId(REGENERATE_ALERT_TEST_ID)).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN isRegenerateFlow is not set', () => {
+      it('THEN should not display the tax recalculation alert', () => {
+        const invoice = createMockInvoice()
+
+        renderFooter(invoice)
+
+        expect(screen.queryByTestId(REGENERATE_ALERT_TEST_ID)).not.toBeInTheDocument()
       })
     })
   })

--- a/translations/base.json
+++ b/translations/base.json
@@ -4058,5 +4058,6 @@
   "text_177688333872224m25xpq3m2": "Calendar",
   "text_1775559630554ourrtpgddty": "Copied to clipboard",
   "text_1776951742342o96gqg8qg8j": "Downgrading from {{planName}} on {{dateStartNewPlan}}",
-  "text_1777281711979fsxgdzarsdb": "More actions"
+  "text_1777281711979fsxgdzarsdb": "More actions",
+  "text_1777385516575oti5gavf3ze": "Taxes will be recalculated after invoice generation, using the current tax configuration. They may differ from the original invoice."
 }


### PR DESCRIPTION
## Context

We have an issue while regenerating invoices.

In the meantime, orga or customer settings may have defined new taxes but the flow shows "original" onces.

A correct fix we're working on it to have a new endpoint returning the correct taxes but in the meantime we're only displaying an explanation alert to the customer about the situation.

## Summary
- Adds an info alert in the invoice details footer during the regenerate flow, warning that taxes will be recalculated using the current tax configuration and may differ from the original invoice
- Renames the local `hideDiscounts` prop to `isRegenerateFlow` so the same flag drives both the discount hiding and the new alert
- Adds unit tests covering the alert visibility for the regenerate and non-regenerate cases (and updates the existing prop-rename test)

Closes [ISSUE-1858](https://linear.app/getlago/issue/ISSUE-1858/add-alert-in-regenerate-flow-to-mention-that-taxes-can-change-after).
