### PR TITLE
chore(docker): mount SENTRY_AUTH_TOKEN as build secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,16 +38,23 @@ COPY . .
 
 # Late ARGs — declared here so a change to APP_VERSION only invalidates the
 # final `pnpm build` step, never the install above.
+# SENTRY_AUTH_TOKEN is intentionally NOT an ARG: it's a credential, and ARG
+# values can leak into the final image's history layers and are flagged by
+# the Dockerfile linter (SecretsUsedInArgOrEnv). It's mounted as a build
+# secret on the RUN below instead.
 ARG SENTRY_DSN
 ARG SENTRY_ORG
 ARG SENTRY_FRONT_PROJECT
-ARG SENTRY_AUTH_TOKEN
 ARG APP_VERSION
 ENV APP_VERSION=$APP_VERSION
 
-# `pnpm build` runs `prebuild` first, which builds `lago-design-system`
-# (source is now present, unlike in the deps stage).
-RUN pnpm build
+# `pnpm build` runs `prebuild` first, which builds `lago-design-system`.
+# `--mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN` exposes
+# the secret only as an env var to this single RUN — never written to the
+# image filesystem, never persisted in build history. Requires the calling
+# workflow to pass `secrets: sentry_auth_token=...` to docker buildx build.
+RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
+    pnpm build
 
 
 # --- runtime stage: nginx serving the built dist ---------------------------


### PR DESCRIPTION
> ⚠️ **Coordinated change with [lago-deploy #1567](https://github.com/getlago/lago-deploy/pull/1567).** This PR alone will break image builds. Merge order: land both at once (squash-merge same minute), or land lago-deploy first.

## Summary

The latest production build log surfaced this Dockerfile lint warning:

```
SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ARG "SENTRY_AUTH_TOKEN") (line 44)
```

`ARG`-passed values are accessible to any subsequent instruction in the same build stage and can leak into image build history. For credentials, BuildKit's `--mount=type=secret` is the correct primitive: the value is exposed only to the specified RUN command, never written to a layer, never persisted.

## Changes

- Drops `ARG SENTRY_AUTH_TOKEN` from the Dockerfile.
- Mounts the secret on the `pnpm build` RUN as an env var via `--mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN`. Vite's `loadEnv` picks it up identically to the previous ARG-based path.
- Adds inline comments explaining the change so the next person doesn't ARG it back.

## Required corresponding workflow change in lago-deploy

[lago-deploy #1567](https://github.com/getlago/lago-deploy/pull/1567) updates both `build-front-production-image.yml` and `deploy-preview.yml`:

```diff
   - name: Build and push
     uses: docker/build-push-action@v2
     with:
       build-args: |
         SENTRY_ORG=${{ vars.SENTRY_ORG }}
         SENTRY_FRONT_PROJECT=${{ vars.SENTRY_FRONT_PROJECT }}
-        SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
         APP_VERSION=${{ steps.version.outputs.version }}
+      secrets: |
+        sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
```

Without that change, `--mount=type=secret,id=sentry_auth_token` will fail to resolve, the env var won't be set, and `shouldUploadSourceMaps` will fall through to `false` — the build itself succeeds (no source map upload), but symbolication in Sentry stops working.
