### PR TITLE
refactor(analytics): migrate Usage breakdown section to usePremiumWarningDialog hook

### DIFF
--- a/src/components/analytics/usage/UsageBreakdownIndividualSection.tsx
+++ b/src/components/analytics/usage/UsageBreakdownIndividualSection.tsx
@@ -10,12 +10,11 @@ import {
   Filters,
   formatFiltersForUsageOverviewQuery,
 } from '~/components/designSystem/Filters'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { TimeGranularityEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 type UsageBreakdownIndividualSectionProps = {
-  premiumWarningDialogRef: React.RefObject<PremiumWarningDialogRef>
   availableFilters: AvailableFiltersEnum[]
   filtersPrefix: string
   isBillableMetricRecurring: boolean
@@ -23,7 +22,6 @@ type UsageBreakdownIndividualSectionProps = {
 }
 
 const UsageBreakdownIndividualSection = ({
-  premiumWarningDialogRef,
   availableFilters,
   filtersPrefix,
   isBillableMetricRecurring,
@@ -32,6 +30,7 @@ const UsageBreakdownIndividualSection = ({
   const { translate } = useInternationalization()
   const [searchParams] = useSearchParams()
   const [showDeletedBillableMetrics, setShowDeletedBillableMetrics] = useState<boolean>(false)
+  const premiumWarningDialog = usePremiumWarningDialog()
 
   const timeGranularity = useMemo(() => {
     const filters = formatFiltersForUsageOverviewQuery(searchParams)
@@ -79,7 +78,7 @@ const UsageBreakdownIndividualSection = ({
               onClick={(e) => {
                 if (!hasAccessToAnalyticsDashboardsFeature) {
                   e.stopPropagation()
-                  premiumWarningDialogRef.current?.openDialog()
+                  premiumWarningDialog.open()
                 } else {
                   onClick()
                 }

--- a/src/components/analytics/usage/UsageBreakdownSection.tsx
+++ b/src/components/analytics/usage/UsageBreakdownSection.tsx
@@ -9,23 +9,18 @@ import {
 } from '~/components/designSystem/Filters'
 import { NavigationTab, TabManagedBy } from '~/components/designSystem/NavigationTab'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import {
   ANALYTICS_USAGE_BREAKDOWN_METERED_FILTER_PREFIX,
   ANALYTICS_USAGE_BREAKDOWN_RECURRING_FILTER_PREFIX,
 } from '~/core/constants/filters'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
-type UsageBreakdownSectionProps = {
-  premiumWarningDialogRef: React.RefObject<PremiumWarningDialogRef>
-}
-
 const TRANSLATIONS_MAP: Record<UsageBreakdownType, string> = {
   [UsageBreakdownType.Units]: 'text_17465414264637hzft31ck6c',
   [UsageBreakdownType.Amount]: 'text_1746541426463wcwfuryd12g',
 }
 
-const UsageBreakdownSection = ({ premiumWarningDialogRef }: UsageBreakdownSectionProps) => {
+const UsageBreakdownSection = () => {
   const { translate } = useInternationalization()
 
   const [breakdownType, setBreakdownType] = useState<UsageBreakdownType>(UsageBreakdownType.Units)
@@ -61,7 +56,6 @@ const UsageBreakdownSection = ({ premiumWarningDialogRef }: UsageBreakdownSectio
                 availableFilters={UsageBreakdownMeteredAvailableFilters}
                 filtersPrefix={ANALYTICS_USAGE_BREAKDOWN_METERED_FILTER_PREFIX}
                 breakdownType={breakdownType}
-                premiumWarningDialogRef={premiumWarningDialogRef}
                 isBillableMetricRecurring={false}
               />
             ),
@@ -72,7 +66,6 @@ const UsageBreakdownSection = ({ premiumWarningDialogRef }: UsageBreakdownSectio
               <UsageBreakdownIndividualSection
                 availableFilters={UsageBreakdownRecurringAvailableFilters}
                 filtersPrefix={ANALYTICS_USAGE_BREAKDOWN_RECURRING_FILTER_PREFIX}
-                premiumWarningDialogRef={premiumWarningDialogRef}
                 breakdownType={breakdownType}
                 isBillableMetricRecurring={true}
               />

--- a/src/pages/analytics/Usage.tsx
+++ b/src/pages/analytics/Usage.tsx
@@ -12,7 +12,7 @@ const Usage = () => {
     <FullscreenPage.Wrapper>
       <UsageOverviewSection premiumWarningDialogRef={premiumWarningDialogRef} />
 
-      <UsageBreakdownSection premiumWarningDialogRef={premiumWarningDialogRef} />
+      <UsageBreakdownSection />
 
       <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </FullscreenPage.Wrapper>


### PR DESCRIPTION
## Summary

Migrate the deprecated ref-based `PremiumWarningDialog` usage inside the Usage analytics breakdown chain to the new hook-based `usePremiumWarningDialog`.

## Changes

- **`src/components/analytics/usage/UsageBreakdownIndividualSection.tsx`**
  - Replaced the `PremiumWarningDialogRef` import with `usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`.
  - Removed the `premiumWarningDialogRef` prop and call the `premiumWarningDialog.open()` hook directly from the click handler.
- **`src/components/analytics/usage/UsageBreakdownSection.tsx`**
  - Dropped the `premiumWarningDialogRef` prop (and its props type) since the only consumer no longer needs it.
- **`src/pages/analytics/Usage.tsx`**
  - Stopped passing `premiumWarningDialogRef` to `<UsageBreakdownSection />`. The ref + dialog rendering remain in place for `<UsageOverviewSection />`, which still relies on the legacy dialog (out of scope).

## Scope

Per the routine, only the warning dialog usage in `UsageBreakdownIndividualSection.tsx` was migrated. The legacy `PremiumWarningDialog` import in `Usage.tsx` is intentionally kept to serve `UsageOverviewSection`, which still uses the old API and is tracked by other open ESLint warnings.

## Test plan

- [ ] `pnpm tsc --noEmit` passes (verified locally — no errors on the changed files)
- [ ] `pnpm eslint` no longer reports `PremiumWarningDialog` warnings on `UsageBreakdownIndividualSection.tsx` and `UsageBreakdownSection.tsx`
- [ ] Manual: open the Analytics → Usage page on a non-premium account and click the filter button on a breakdown tab → the premium warning dialog should open

https://claude.ai/code/session_01MkADdjFbrtNbEnAVUaPCp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkADdjFbrtNbEnAVUaPCp7)_