### PR TITLE
fix(org slug): Cover iframe multi-org case to auto-detect org slug

### DIFF
--- a/src/hooks/core/__tests__/useLocationHistory.test.ts
+++ b/src/hooks/core/__tests__/useLocationHistory.test.ts
@@ -141,6 +141,98 @@ describe('useLocationHistory()', () => {
           replace: true,
         })
       })
+
+      // Iframe context propagation: Salesforce/Hubspot embed Lago via
+      // `?sfdc=true` / `?ifrm=true`. When session expires, the auth guard
+      // must carry these flags onto `/login` so `useIframeConfig` (read by
+      // Login.tsx) hides Google/Okta — those flows can't complete in an
+      // embedded iframe. Without this, the iframe shows the full SSO UI and
+      // the user is locked out of the email+password fallback.
+      describe('GIVEN the requested URL carries iframe params', () => {
+        it('THEN propagates `?sfdc=true` (Salesforce) onto the /login URL', () => {
+          const sfdcLocation: Location = {
+            pathname: '/customer/abc-123/create/subscription',
+            search: '?sfdc=true',
+            hash: '',
+            state: null,
+            key: 'sfdc-key',
+          }
+
+          const { result } = renderHook(() => useLocationHistory())
+
+          act(() => {
+            result.current.onRouteEnter({ private: true }, sfdcLocation)
+          })
+
+          expect(mockNavigate).toHaveBeenCalledWith('/login?sfdc=true', {
+            state: { from: sfdcLocation, orgId: 'org-id-123' },
+            replace: true,
+          })
+        })
+
+        it('THEN propagates `?ifrm=true` (Hubspot) onto the /login URL', () => {
+          const ifrmLocation: Location = {
+            pathname: '/customer/abc-123/create-invoice',
+            search: '?ifrm=true',
+            hash: '',
+            state: null,
+            key: 'ifrm-key',
+          }
+
+          const { result } = renderHook(() => useLocationHistory())
+
+          act(() => {
+            result.current.onRouteEnter({ private: true }, ifrmLocation)
+          })
+
+          expect(mockNavigate).toHaveBeenCalledWith('/login?ifrm=true', {
+            state: { from: ifrmLocation, orgId: 'org-id-123' },
+            replace: true,
+          })
+        })
+
+        it('THEN preserves the full search string when other params are present alongside the iframe flag', () => {
+          const richLocation: Location = {
+            pathname: '/customer/abc-123/create/subscription',
+            search: '?sfdc=true&plan=foo',
+            hash: '',
+            state: null,
+            key: 'rich-key',
+          }
+
+          const { result } = renderHook(() => useLocationHistory())
+
+          act(() => {
+            result.current.onRouteEnter({ private: true }, richLocation)
+          })
+
+          expect(mockNavigate).toHaveBeenCalledWith('/login?sfdc=true&plan=foo', {
+            state: { from: richLocation, orgId: 'org-id-123' },
+            replace: true,
+          })
+        })
+
+        it('THEN does NOT propagate non-iframe search params (avoids leaking unrelated query state to /login)', () => {
+          const nonIframeLocation: Location = {
+            pathname: '/customers/123',
+            search: '?tab=overview&filter=active',
+            hash: '',
+            state: null,
+            key: 'non-iframe-key',
+          }
+
+          const { result } = renderHook(() => useLocationHistory())
+
+          act(() => {
+            result.current.onRouteEnter({ private: true }, nonIframeLocation)
+          })
+
+          expect(mockNavigate).toHaveBeenCalledWith('/login', {
+            state: { from: nonIframeLocation, orgId: 'org-id-123' },
+            replace: true,
+          })
+        })
+      })
     })
 
     describe('when accessing an onlyPublic route while authenticated', () => {

--- a/src/hooks/core/useLocationHistory.ts
+++ b/src/hooks/core/useLocationHistory.ts
@@ -16,6 +16,7 @@ import {
 } from '~/core/router'
 import { stripOrgSlug } from '~/core/router/utils/stripOrgSlug'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { hasIframeParams } from '~/hooks/useIframeConfig'
 import { TMembershipPermissions, usePermissions } from '~/hooks/usePermissions'
 
 type GoBack = (
@@ -129,9 +130,20 @@ export const useLocationHistory: UseLocationHistoryReturn = () => {
       } else if (routeConfig.private && !isAuthenticated) {
         /**
          * In case of navigation to a private route while NOT authenticated
-         * Redirect to login and store the intended destination in router state
+         * Redirect to login and store the intended destination in router state.
+         *
+         * Iframe params (`?sfdc=true` / `?ifrm=true`) are propagated onto the
+         * `/login` URL so `useIframeConfig` (read inside Login.tsx) keeps
+         * detecting the embed context and hides Google/Okta buttons. Without
+         * this, Salesforce/Hubspot users would see the full SSO UI inside the
+         * iframe — Google/Okta auth flows can't complete in an embedded frame
+         * (CSP / popup blockers / cookie scoping), only email+password works.
          */
-        navigate(LOGIN_ROUTE, {
+        const loginPath = hasIframeParams(location.search)
+          ? `${LOGIN_ROUTE}${location.search}`
+          : LOGIN_ROUTE
+
+        navigate(loginPath, {
           state: {
             from: location,
             orgId: getItemFromLS(ORGANIZATION_LS_KEY_ID),

--- a/src/hooks/useIframeConfig.ts
+++ b/src/hooks/useIframeConfig.ts
@@ -13,6 +13,25 @@ type TUseIframeConfigReturn = {
   isRunningInSalesForceIframe: boolean
 }
 
+/**
+ * Pure check for iframe context query params (`?sfdc=true` for Salesforce,
+ * `?ifrm=true` for Hubspot). Use when you have a `search` string in hand
+ * (e.g. inside a pure resolver, or against a saved Location) and don't want
+ * to subscribe to React Router via `useIframeConfig`.
+ *
+ * Strict `=== 'true'` (not truthy) — defensive: the only valid embed values
+ * Salesforce/Hubspot send are `true`. Any other value is treated as "not
+ * iframe context" so we don't trigger LS-based slug auto-recovery on bad
+ * input.
+ */
+export const hasIframeParams = (search: string | undefined): boolean => {
+  if (!search) return false
+
+  const params = new URLSearchParams(search)
+
+  return params.get('sfdc') === 'true' || params.get('ifrm') === 'true'
+}
+
 export const useIframeConfig = (): TUseIframeConfigReturn => {
   const [searchParams] = useSearchParams()
 

--- a/src/layouts/OrganizationLayout.tsx
+++ b/src/layouts/OrganizationLayout.tsx
@@ -13,8 +13,10 @@ import {
 } from '~/core/apolloClient/reactiveVars'
 import { useLocation, useNavigate } from '~/core/router'
 import { LEGACY_APP_PATH_SEGMENTS } from '~/core/router/legacyPaths'
+import { resolveOrgSlug } from '~/core/router/utils/orgSlug'
 import { useIsAuthenticated } from '~/hooks/auth/useIsAuthenticated'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { hasIframeParams } from '~/hooks/useIframeConfig'
 
 const Error404 = lazy(() => import('~/pages/Error404'))
 
@@ -32,11 +34,20 @@ const OrganizationLayout = () => {
     (m) => m.organization.slug === organizationSlug,
   )?.organization
 
-  // Single-membership auto-recovery: when a user with exactly one org lands
-  // on a legacy pre-migration path (e.g. `/customers`), redirect them to
-  // `/${theirOnlySlug}${legacyPath}` instead of showing a 404. No ambiguity
-  // exists — we know which org they meant. Users with multiple memberships
-  // keep the explicit 404 + "go home" flow because we can't pick for them.
+  // Auto-recovery for legacy pre-migration paths (e.g. `/customers`).
+  //
+  // - Single-membership users: redirect to `/${theirOnlySlug}${legacyPath}`.
+  //   No ambiguity — we know which org they meant.
+  // - Multi-membership users on iframe-embedded URLs (`?ifrm=true` /
+  //   `?sfdc=true`, used by Hubspot/Salesforce CRM cards): use the
+  //   LS-based slug from `resolveOrgSlug(currentUser)`. Pre-migration the
+  //   iframe relied implicitly on the LS-injected `x-lago-organization`
+  //   header for GraphQL scoping, so trusting LS to derive the slug here
+  //   restores the same UX contract — when LS is correct the iframe loads,
+  //   when LS is stale the inner queries 404 (same as pre-migration, no regression).
+  // - Multi-membership users on non-iframe slug-less URLs: NO auto-recover.
+  //   They still get the explicit 404 + "go home" flow because they have
+  //   agency to pick the right org manually.
   //
   // Scope-limited to `LEGACY_APP_PATH_SEGMENTS` on purpose: genuinely unknown
   // slugs (typos, revoked orgs, etc.) still produce a 404 — silently
@@ -46,7 +57,12 @@ const OrganizationLayout = () => {
     currentUser?.memberships.length === 1
       ? currentUser.memberships[0]?.organization.slug
       : undefined
-  const shouldAutoRecoverLegacyPath = !loading && !org && isLegacyPath && !!soleMembershipSlug
+
+  const isIframeContext = hasIframeParams(location.search)
+  const lsBasedSlugForIframe = isIframeContext ? resolveOrgSlug(currentUser) : undefined
+
+  const recoveredSlug = soleMembershipSlug ?? lsBasedSlugForIframe
+  const shouldAutoRecoverLegacyPath = !loading && !org && isLegacyPath && !!recoveredSlug
 
   // If currentOrgId already exists and differs from org.id, the user switched org
   // (e.g. browser back after org switch). In that case, call switchCurrentOrganization
@@ -61,14 +77,15 @@ const OrganizationLayout = () => {
     }
   }, [org?.id, currentOrgId, client])
 
-  // Auto-recover legacy paths for single-membership users (see block above).
+  // Auto-recover legacy paths for single-membership users and for
+  // multi-membership users on iframe-embedded URLs (see block above).
   // Runs in an effect (not render) to avoid React's "cannot update during
   // render" warning when navigation triggers a parent re-render. `replace`
   // keeps history clean — the legacy URL never gets a back-button entry.
   useEffect(() => {
     if (!shouldAutoRecoverLegacyPath) return
 
-    navigate(`/${soleMembershipSlug}${location.pathname}${location.search}${location.hash}`, {
+    navigate(`/${recoveredSlug}${location.pathname}${location.search}${location.hash}`, {
       replace: true,
       skipSlugPrepend: true,
       state: { autoRecoveredFromLegacy: true },
@@ -78,7 +95,8 @@ const OrganizationLayout = () => {
       level: 'info',
       tags: {
         attemptedSlug: organizationSlug ?? '',
-        recoveredToSlug: soleMembershipSlug ?? '',
+        recoveredToSlug: recoveredSlug ?? '',
+        mode: soleMembershipSlug ? 'single-org' : 'multi-org-iframe',
       },
       extra: { fullPath: location.pathname },
     })

--- a/src/layouts/__tests__/OrganizationLayout.test.tsx
+++ b/src/layouts/__tests__/OrganizationLayout.test.tsx
@@ -94,7 +94,11 @@ const defaultMemberships = [
 describe('OrganizationLayout', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockUseLocation.mockReturnValue({ pathname: `/${TEST_ORG_SLUG}/customers` })
+    mockUseLocation.mockReturnValue({
+      pathname: `/${TEST_ORG_SLUG}/customers`,
+      search: '',
+      hash: '',
+    })
     mockLocationHistoryVar.mockReturnValue([])
     mockGetCurrentOrganizationId.mockReturnValue(TEST_ORG_ID)
   })
@@ -287,6 +291,7 @@ describe('OrganizationLayout', () => {
           tags: expect.objectContaining({
             attemptedSlug: 'customers',
             recoveredToSlug: TEST_ORG_SLUG,
+            mode: 'single-org',
           }),
         }),
       )
@@ -313,6 +318,166 @@ describe('OrganizationLayout', () => {
       renderHook(() => OrganizationLayout())
 
       expect(mockNavigate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('GIVEN a legacy path AND the user has multiple memberships', () => {
+    describe('WHEN the URL has the Hubspot iframe param ?ifrm=true', () => {
+      it('THEN should auto-redirect using the LS-based slug and tag the Sentry event with mode=multi-org-iframe', () => {
+        mockUseParams.mockReturnValue({ organizationSlug: 'customers' })
+        mockUseLocation.mockReturnValue({
+          pathname: '/customers',
+          search: '?ifrm=true',
+          hash: '',
+        })
+        mockCurrentOrganizationVar.mockReturnValue(TEST_ORG_ID)
+        // resolveOrgSlug() reads getCurrentOrganizationId() under the hood
+        mockGetCurrentOrganizationId.mockReturnValue(TEST_ORG_ID)
+        mockUseCurrentUser.mockReturnValue({
+          currentUser: { memberships: defaultMemberships },
+          loading: false,
+        })
+
+        renderHook(() => OrganizationLayout())
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+          `/${TEST_ORG_SLUG}/customers?ifrm=true`,
+          expect.objectContaining({
+            replace: true,
+            skipSlugPrepend: true,
+          }),
+        )
+        expect(Sentry.captureMessage).toHaveBeenCalledWith(
+          'legacy_url_auto_recovered',
+          expect.objectContaining({
+            level: 'info',
+            tags: expect.objectContaining({
+              attemptedSlug: 'customers',
+              recoveredToSlug: TEST_ORG_SLUG,
+              mode: 'multi-org-iframe',
+            }),
+          }),
+        )
+      })
+    })
+
+    describe('WHEN the URL has the Salesforce iframe param ?sfdc=true', () => {
+      it('THEN should auto-redirect using the LS-based slug', () => {
+        mockUseParams.mockReturnValue({ organizationSlug: 'customers' })
+        mockUseLocation.mockReturnValue({
+          pathname: '/customers',
+          search: '?sfdc=true',
+          hash: '',
+        })
+        mockCurrentOrganizationVar.mockReturnValue(OTHER_ORG_ID)
+        mockGetCurrentOrganizationId.mockReturnValue(OTHER_ORG_ID)
+        mockUseCurrentUser.mockReturnValue({
+          currentUser: { memberships: defaultMemberships },
+          loading: false,
+        })
+
+        renderHook(() => OrganizationLayout())
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+          `/other-corp/customers?sfdc=true`,
+          expect.objectContaining({
+            replace: true,
+            skipSlugPrepend: true,
+          }),
+        )
+      })
+    })
+
+    describe('WHEN the URL has NO iframe param', () => {
+      it('THEN should NOT auto-redirect (multi-org user keeps the explicit 404 + go-home flow)', () => {
+        mockUseParams.mockReturnValue({ organizationSlug: 'customers' })
+        mockUseLocation.mockReturnValue({
+          pathname: '/customers',
+          search: '',
+          hash: '',
+        })
+        mockCurrentOrganizationVar.mockReturnValue(TEST_ORG_ID)
+        mockGetCurrentOrganizationId.mockReturnValue(TEST_ORG_ID)
+        mockUseCurrentUser.mockReturnValue({
+          currentUser: { memberships: defaultMemberships },
+          loading: false,
+        })
+
+        renderHook(() => OrganizationLayout())
+
+        expect(mockNavigate).not.toHaveBeenCalled()
+        expect(Sentry.captureMessage).not.toHaveBeenCalledWith(
+          'legacy_url_auto_recovered',
+          expect.anything(),
+        )
+      })
+    })
+
+    describe('WHEN the URL has an iframe param but the slug is NOT a legacy path', () => {
+      it('THEN should NOT auto-redirect (genuinely unknown slug → 404 stays explicit)', () => {
+        mockUseParams.mockReturnValue({ organizationSlug: 'totally-unknown' })
+        mockUseLocation.mockReturnValue({
+          pathname: '/totally-unknown',
+          search: '?ifrm=true',
+          hash: '',
+        })
+        mockCurrentOrganizationVar.mockReturnValue(TEST_ORG_ID)
+        mockGetCurrentOrganizationId.mockReturnValue(TEST_ORG_ID)
+        mockUseCurrentUser.mockReturnValue({
+          currentUser: { memberships: defaultMemberships },
+          loading: false,
+        })
+
+        renderHook(() => OrganizationLayout())
+
+        expect(mockNavigate).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the URL has an iframe param and the iframe param value is something other than "true"', () => {
+      it('THEN should NOT trigger the iframe-context branch', () => {
+        mockUseParams.mockReturnValue({ organizationSlug: 'customers' })
+        mockUseLocation.mockReturnValue({
+          pathname: '/customers',
+          search: '?ifrm=false',
+          hash: '',
+        })
+        mockCurrentOrganizationVar.mockReturnValue(TEST_ORG_ID)
+        mockGetCurrentOrganizationId.mockReturnValue(TEST_ORG_ID)
+        mockUseCurrentUser.mockReturnValue({
+          currentUser: { memberships: defaultMemberships },
+          loading: false,
+        })
+
+        renderHook(() => OrganizationLayout())
+
+        expect(mockNavigate).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN LS holds an org id that does NOT match any of the user memberships', () => {
+      it('THEN should fall back to the first membership slug (resolveOrgSlug fallback)', () => {
+        mockUseParams.mockReturnValue({ organizationSlug: 'customers' })
+        mockUseLocation.mockReturnValue({
+          pathname: '/customers',
+          search: '?ifrm=true',
+          hash: '',
+        })
+        mockCurrentOrganizationVar.mockReturnValue('stale-org-id-not-in-memberships')
+        mockGetCurrentOrganizationId.mockReturnValue('stale-org-id-not-in-memberships')
+        mockUseCurrentUser.mockReturnValue({
+          currentUser: { memberships: defaultMemberships },
+          loading: false,
+        })
+
+        renderHook(() => OrganizationLayout())
+
+        // resolveOrgSlug fallback: first membership's slug
+        expect(mockNavigate).toHaveBeenCalledWith(
+          `/${TEST_ORG_SLUG}/customers?ifrm=true`,
+          expect.objectContaining({ replace: true, skipSlugPrepend: true }),
+        )
+      })
     })
   })
 

--- a/src/pages/home/__tests__/utils.test.ts
+++ b/src/pages/home/__tests__/utils.test.ts
@@ -10,7 +10,7 @@ jest.mock('~/core/router/utils/permissionRouteMap', () => ({
 }))
 
 jest.mock('~/core/router/legacyPaths', () => ({
-  LEGACY_APP_PATH_SEGMENTS: new Set(['customers', 'plans', 'features']),
+  LEGACY_APP_PATH_SEGMENTS: new Set(['customers', 'customer', 'plans', 'features']),
 }))
 
 // `resolveOrgSlug` reads the reactive var; mock it via the underlying util.
@@ -126,6 +126,85 @@ describe('resolveRedirectTarget()', () => {
             { organization: { id: 'org-b', slug: 'beta' } },
           ]),
           savedLocation: { pathname: '/customers/123' },
+        }),
+      )
+
+      expect(result).toEqual({ to: `/${SLUG}/analytics`, consumesSsoLs: false })
+    })
+  })
+
+  // Iframe context (Salesforce/Hubspot CRM embeds) — slug-less legacy URLs
+  // get auto-recovered using the LS-based slug regardless of membership
+  // count, because the iframe hides the chrome and the user has no agency
+  // to pick an org manually. Mirrors `OrganizationLayout`'s post-auth fix
+  // (LAGO-1443) but for the post-LOGIN flow when session was expired.
+  describe('GIVEN a multi-org user logs in with a savedLocation carrying iframe params', () => {
+    const multiOrgUser = buildUser([
+      { organization: { id: ORG_ID, slug: SLUG } },
+      { organization: { id: 'org-b', slug: 'beta' } },
+    ])
+
+    it('THEN prepends LS-based slug for `?sfdc=true` (Salesforce) and preserves the iframe param', () => {
+      const result = resolveRedirectTarget(
+        baseInput({
+          currentUser: multiOrgUser,
+          savedLocation: {
+            pathname: '/customer/abc-123/create/subscription',
+            search: '?sfdc=true',
+            hash: '',
+          },
+        }),
+      )
+
+      expect(result).toEqual({
+        to: `/${SLUG}/customer/abc-123/create/subscription?sfdc=true`,
+        consumesSsoLs: false,
+      })
+    })
+
+    it('THEN prepends LS-based slug for `?ifrm=true` (Hubspot)', () => {
+      const result = resolveRedirectTarget(
+        baseInput({
+          currentUser: multiOrgUser,
+          savedLocation: {
+            pathname: '/customer/abc-123/create-invoice',
+            search: '?ifrm=true',
+          },
+        }),
+      )
+
+      expect(result).toEqual({
+        to: `/${SLUG}/customer/abc-123/create-invoice?ifrm=true`,
+        consumesSsoLs: false,
+      })
+    })
+
+    it('THEN preserves additional query params alongside the iframe flag', () => {
+      const result = resolveRedirectTarget(
+        baseInput({
+          currentUser: multiOrgUser,
+          savedLocation: {
+            pathname: '/customer/abc-123/create/subscription',
+            search: '?sfdc=true&plan=foo',
+          },
+        }),
+      )
+
+      expect(result).toEqual({
+        to: `/${SLUG}/customer/abc-123/create/subscription?sfdc=true&plan=foo`,
+        consumesSsoLs: false,
+      })
+    })
+
+    it('THEN does NOT auto-recover when the iframe flag is `false` (defensive)', () => {
+      mockHasPermissions.mockReturnValueOnce(true) // analytics
+      const result = resolveRedirectTarget(
+        baseInput({
+          currentUser: multiOrgUser,
+          savedLocation: {
+            pathname: '/customer/abc-123/create/subscription',
+            search: '?sfdc=false',
+          },
         }),
       )
 

--- a/src/pages/home/utils.ts
+++ b/src/pages/home/utils.ts
@@ -11,6 +11,7 @@ import { LEGACY_APP_PATH_SEGMENTS } from '~/core/router/legacyPaths'
 import { ensureSlugPrefix, pathHasValidSlug, resolveOrgSlug } from '~/core/router/utils/orgSlug'
 import { getRouteForPermission } from '~/core/router/utils/permissionRouteMap'
 import { CurrentUserInfosFragment } from '~/generated/graphql'
+import { hasIframeParams } from '~/hooks/useIframeConfig'
 import { TMembershipPermissions } from '~/hooks/usePermissions'
 
 type CurrentUser = CurrentUserInfosFragment | undefined
@@ -53,7 +54,8 @@ export type ResolveRedirectResult = {
  *   1. `ssoRedirectPath` — drained by caller after success.
  *   2. `savedLocation` (router-state `from`) — validated against the user's
  *      memberships to avoid stale-org leaks; legacy slug-less paths get
- *      prepended for single-membership users only.
+ *      prepended for single-membership users, OR for any user when the URL
+ *      carries iframe context params (Salesforce/Hubspot embeds).
  *   3. Permission-based default (analytics → customers → first view route).
  *   4. `FORBIDDEN_ROUTE` fallback.
  *
@@ -100,22 +102,29 @@ export const resolveRedirectTarget = (
       return { to: savedLocation, consumesSsoLs: false }
     }
 
-    // Legacy path without slug (pre-migration bookmark) — prepend current
-    // org slug only for single-membership users (no ambiguity).
-    const isSingleMembership = currentUser?.memberships?.length === 1
     const isLegacySegment = LEGACY_APP_PATH_SEGMENTS.has(savedSlug ?? '')
+    const isSlugLessLegacyPath =
+      isLegacySegment && !pathHasValidSlug(savedLocation.pathname, currentUser)
 
-    if (
-      isSingleMembership &&
-      isLegacySegment &&
-      !pathHasValidSlug(savedLocation.pathname, currentUser)
-    ) {
-      const search = savedLocation.search || ''
-      const hash = savedLocation.hash || ''
+    if (isSlugLessLegacyPath) {
+      // Legacy slug-less path — prepend current org slug when:
+      //   a) user has a single membership (no ambiguity), OR
+      //   b) URL carries iframe context params — Salesforce/Hubspot embeds
+      //      hide chrome and lock the URL, so the user has no agency to
+      //      switch orgs manually. We trust the LS-based slug (the same
+      //      contract pre-migration used via the `x-lago-organization`
+      //      header for GraphQL scoping).
+      const isSingleMembership = currentUser?.memberships?.length === 1
+      const isIframeContext = hasIframeParams(savedLocation.search)
 
-      return {
-        to: `/${slug}${savedLocation.pathname}${search}${hash}`,
-        consumesSsoLs: false,
+      if (isSingleMembership || isIframeContext) {
+        const search = savedLocation.search || ''
+        const hash = savedLocation.hash || ''
+
+        return {
+          to: `/${slug}${savedLocation.pathname}${search}${hash}`,
+          consumesSsoLs: false,
+        }
       }
     }
   }


### PR DESCRIPTION
## Context

Added iframe slug recovery in `OrganizationLayout` for the post-auth flow. Testing against `getlago/lago-salesforce` surfaced two gaps that broke multi-org users on the "session expired → re-login" path:

1. Auth guard drops search params on `/login` (preexisting issue from #2838), so `useIframeConfig` loses iframe context and renders Google/Okta buttons.
2. Home only prepends the slug for single-membership users — multi-org in iframe fell through to the default redirect after login.

## Description

- `useLocationHistory`: propagate iframe params onto the `/login` URL.
- `Home/utils` (`resolveRedirectTarget`): extend the slug-less legacy branch to fire for any user when the URL carries iframe params
- `useIframeConfig`: extracted `hasIframeParams(search)` shared helper, reused across `OrganizationLayout`, `Home/utils`, `useLocationHistory`.

**Multi-org with LS pointing to a different org's slug still produces a 404, same UX as pre-migration, documented as known limitation. This needs a separated investigation.**

<!-- Linear link -->
Fixes LAGO-1443