### PR TITLE
feat(billable-metrics): add duplicate action to BM list

### DIFF
--- a/src/pages/BillableMetricsList.tsx
+++ b/src/pages/BillableMetricsList.tsx
@@ -19,6 +19,7 @@ import { BillableMetricDetailsTabsOptionsEnum } from '~/core/constants/tabsOptio
 import {
   BILLABLE_METRIC_DETAILS_ROUTE,
   CREATE_BILLABLE_METRIC_ROUTE,
+  DUPLICATE_BILLABLE_METRIC_ROUTE,
   UPDATE_BILLABLE_METRIC_ROUTE,
 } from '~/core/router'
 import { useBillableMetricsLazyQuery } from '~/generated/graphql'
@@ -50,7 +51,7 @@ gql`
 `
 
 const BillableMetricsList = () => {
-  const { translate } = useInternationalization()
+  const { translate, locale } = useInternationalization()
   const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
   const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
@@ -67,6 +68,49 @@ const BillableMetricsList = () => {
 
   const canUpdateBillableMetrics = hasPermissions(['billableMetricsUpdate'])
   const canDeleteBillableMetrics = hasPermissions(['billableMetricsDelete'])
+  const canCreateBillableMetrics = hasPermissions(['billableMetricsCreate'])
+
+  const getActions = (id: string): ActionItem<{ id: string }>[] => {
+    const actions: ActionItem<{ id: string }>[] = []
+
+    if (canUpdateBillableMetrics) {
+      actions.push({
+        startIcon: 'pen',
+        title: translate('text_6256de3bba111e00b3bfa531'),
+        onAction: () =>
+          navigate(
+            generatePath(UPDATE_BILLABLE_METRIC_ROUTE, {
+              billableMetricId: id,
+            }),
+          ),
+      })
+    }
+
+    if (canCreateBillableMetrics) {
+      actions.push({
+        startIcon: 'duplicate',
+        title: translate('text_64fa170e02f348164797a6af'),
+        onAction: () =>
+          navigate(
+            generatePath(DUPLICATE_BILLABLE_METRIC_ROUTE, {
+              billableMetricId: id,
+            }),
+          ),
+      })
+    }
+
+    if (canDeleteBillableMetrics) {
+      actions.push({
+        startIcon: 'trash',
+        title: translate('text_6256de3bba111e00b3bfa533'),
+        onAction: () => {
+          deleteDialogRef.current?.openDialog({ billableMetricId: id })
+        },
+      })
+    }
+
+    return actions
+  }
 
   const billableMetricsTotalCount = data?.billableMetrics?.metadata?.totalCount
 
@@ -159,40 +203,18 @@ const BillableMetricsList = () => {
               ),
             },
           ]}
-          actionColumnTooltip={
-            canUpdateBillableMetrics && canDeleteBillableMetrics
-              ? () => translate('text_6256de3bba111e00b3bfa51b')
-              : undefined
-          }
-          actionColumn={(billableMetric) => {
-            const { id } = billableMetric
-            const actions: ActionItem<typeof billableMetric>[] = []
+          actionColumnTooltip={({ id }) => {
+            const actions = getActions(id)
 
-            if (canUpdateBillableMetrics) {
-              actions.push({
-                startIcon: 'pen',
-                title: translate('text_6256de3bba111e00b3bfa531'),
-                onAction: () =>
-                  navigate(
-                    generatePath(UPDATE_BILLABLE_METRIC_ROUTE, {
-                      billableMetricId: id,
-                    }),
-                  ),
-              })
-            }
+            if (!actions.length) return ''
 
-            if (canDeleteBillableMetrics) {
-              actions.push({
-                startIcon: 'trash',
-                title: translate('text_6256de3bba111e00b3bfa533'),
-                onAction: () => {
-                  deleteDialogRef.current?.openDialog({ billableMetricId: id })
-                },
-              })
-            }
+            const listLocale = locale === 'en' ? 'en-GB' : locale
 
-            return actions
+            return new Intl.ListFormat(listLocale, { type: 'disjunction' }).format(
+              actions.map((a) => String(a.title)),
+            )
           }}
+          actionColumn={({ id }) => getActions(id)}
           placeholder={{
             errorState: !!variables?.searchTerm
               ? {

--- a/src/pages/BillableMetricsList.tsx
+++ b/src/pages/BillableMetricsList.tsx
@@ -9,7 +9,7 @@ import {
 } from '~/components/billableMetrics/DeleteBillableMetricDialog'
 import { Avatar } from '~/components/designSystem/Avatar'
 import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
-import { Table } from '~/components/designSystem/Table/Table'
+import { Table, TableColumn, TablePlaceholder } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
 import { Typography } from '~/components/designSystem/Typography'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
@@ -22,7 +22,7 @@ import {
   DUPLICATE_BILLABLE_METRIC_ROUTE,
   UPDATE_BILLABLE_METRIC_ROUTE,
 } from '~/core/router'
-import { useBillableMetricsLazyQuery } from '~/generated/graphql'
+import { BillableMetricItemFragment, useBillableMetricsLazyQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useDebouncedSearch } from '~/hooks/useDebouncedSearch'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
@@ -114,6 +114,87 @@ const BillableMetricsList = () => {
 
   const billableMetricsTotalCount = data?.billableMetrics?.metadata?.totalCount
 
+  const getRowLink = ({ id }: BillableMetricItemFragment) =>
+    generatePath(BILLABLE_METRIC_DETAILS_ROUTE, {
+      billableMetricId: id,
+      tab: BillableMetricDetailsTabsOptionsEnum.overview,
+    })
+
+  const columns: TableColumn<BillableMetricItemFragment>[] = [
+    {
+      key: 'name',
+      title: translate('text_623b497ad05b960101be343e'),
+      minWidth: 200,
+      maxSpace: true,
+      content: ({ name, code }) => (
+        <div className="flex items-center gap-3">
+          <Avatar size="big" variant="connector">
+            <Icon name="pulse" color="dark" />
+          </Avatar>
+          <div>
+            <Typography color="textSecondary" variant="bodyHl" noWrap>
+              {name}
+            </Typography>
+            <Typography variant="caption" noWrap>
+              {code}
+            </Typography>
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: 'createdAt',
+      title: translate('text_623b497ad05b960101be3440'),
+      minWidth: 140,
+      content: ({ createdAt }) => (
+        <Typography variant="body" color="grey600">
+          {intlFormatDateTimeOrgaTZ(createdAt).date}
+        </Typography>
+      ),
+    },
+  ]
+
+  const getActionColumnTooltip = ({ id }: BillableMetricItemFragment) => {
+    const actions = getActions(id)
+
+    if (!actions.length) return ''
+
+    const listLocale = locale === 'en' ? 'en-GB' : locale
+
+    return new Intl.ListFormat(listLocale, { type: 'disjunction' }).format(
+      actions.map((a) => String(a.title)),
+    )
+  }
+
+  const placeholder: TablePlaceholder = {
+    errorState: !!variables?.searchTerm
+      ? {
+          title: translate('text_623b53fea66c76017eaebb6e'),
+          subtitle: translate('text_63bab307a61c62af497e0599'),
+        }
+      : {
+          title: translate('text_623b53fea66c76017eaebb6e'),
+          subtitle: translate('text_623b53fea66c76017eaebb76'),
+          buttonTitle: translate('text_623b53fea66c76017eaebb7a'),
+          buttonAction: () => location.reload(),
+          buttonVariant: 'primary',
+        },
+    emptyState: !!variables?.searchTerm
+      ? {
+          title: translate('text_63bab307a61c62af497e05a2'),
+          subtitle: translate('text_63bab307a61c62af497e05a4'),
+        }
+      : {
+          title: translate('text_623b53fea66c76017eaebb70'),
+          subtitle: translate('text_623b53fea66c76017eaebb78'),
+          ...(canCreateBillableMetrics && {
+            buttonTitle: translate('text_623b53fea66c76017eaebb7c'),
+            buttonAction: () => navigate(CREATE_BILLABLE_METRIC_ROUTE),
+            buttonVariant: 'primary',
+          }),
+        },
+  }
+
   return (
     <>
       <MainHeader.Configure
@@ -164,85 +245,11 @@ const BillableMetricsList = () => {
           rowSize={72}
           isLoading={isLoading}
           hasError={!!error}
-          onRowActionLink={({ id }) =>
-            generatePath(BILLABLE_METRIC_DETAILS_ROUTE, {
-              billableMetricId: id,
-              tab: BillableMetricDetailsTabsOptionsEnum.overview,
-            })
-          }
-          columns={[
-            {
-              key: 'name',
-              title: translate('text_623b497ad05b960101be343e'),
-              minWidth: 200,
-              maxSpace: true,
-              content: ({ name, code }) => (
-                <div className="flex items-center gap-3">
-                  <Avatar size="big" variant="connector">
-                    <Icon name="pulse" color="dark" />
-                  </Avatar>
-                  <div>
-                    <Typography color="textSecondary" variant="bodyHl" noWrap>
-                      {name}
-                    </Typography>
-                    <Typography variant="caption" noWrap>
-                      {code}
-                    </Typography>
-                  </div>
-                </div>
-              ),
-            },
-            {
-              key: 'createdAt',
-              title: translate('text_623b497ad05b960101be3440'),
-              minWidth: 140,
-              content: ({ createdAt }) => (
-                <Typography variant="body" color="grey600">
-                  {intlFormatDateTimeOrgaTZ(createdAt).date}
-                </Typography>
-              ),
-            },
-          ]}
-          actionColumnTooltip={({ id }) => {
-            const actions = getActions(id)
-
-            if (!actions.length) return ''
-
-            const listLocale = locale === 'en' ? 'en-GB' : locale
-
-            return new Intl.ListFormat(listLocale, { type: 'disjunction' }).format(
-              actions.map((a) => String(a.title)),
-            )
-          }}
+          onRowActionLink={getRowLink}
+          columns={columns}
+          actionColumnTooltip={getActionColumnTooltip}
           actionColumn={({ id }) => getActions(id)}
-          placeholder={{
-            errorState: !!variables?.searchTerm
-              ? {
-                  title: translate('text_623b53fea66c76017eaebb6e'),
-                  subtitle: translate('text_63bab307a61c62af497e0599'),
-                }
-              : {
-                  title: translate('text_623b53fea66c76017eaebb6e'),
-                  subtitle: translate('text_623b53fea66c76017eaebb76'),
-                  buttonTitle: translate('text_623b53fea66c76017eaebb7a'),
-                  buttonAction: () => location.reload(),
-                  buttonVariant: 'primary',
-                },
-            emptyState: !!variables?.searchTerm
-              ? {
-                  title: translate('text_63bab307a61c62af497e05a2'),
-                  subtitle: translate('text_63bab307a61c62af497e05a4'),
-                }
-              : {
-                  title: translate('text_623b53fea66c76017eaebb70'),
-                  subtitle: translate('text_623b53fea66c76017eaebb78'),
-                  ...(hasPermissions(['billableMetricsCreate']) && {
-                    buttonTitle: translate('text_623b53fea66c76017eaebb7c'),
-                    buttonAction: () => navigate(CREATE_BILLABLE_METRIC_ROUTE),
-                    buttonVariant: 'primary',
-                  }),
-                },
-          }}
+          placeholder={placeholder}
         />
       </InfiniteScroll>
 

--- a/src/pages/__tests__/BillableMetricsList.test.tsx
+++ b/src/pages/__tests__/BillableMetricsList.test.tsx
@@ -45,7 +45,7 @@ jest.mock('~/hooks/usePermissions', () => ({
 }))
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
-  useInternationalization: () => ({ translate: (key: string) => key }),
+  useInternationalization: () => ({ translate: (key: string) => key, locale: 'en' }),
 }))
 
 jest.mock('~/hooks/useOrganizationInfos', () => ({
@@ -145,83 +145,129 @@ describe('BillableMetricsList', () => {
     })
   })
 
-  describe('GIVEN user has all row-level permissions', () => {
-    describe('WHEN actionColumn is called for a row item', () => {
-      it('THEN should return edit and delete actions', () => {
-        mockHasPermissions.mockReturnValue(true)
+  type RowAction = { startIcon: string; title: string }
+
+  const ROW = { id: 'bm-1', name: 'Test BM', code: 'test' }
+
+  const EDIT_TITLE = 'text_6256de3bba111e00b3bfa531'
+  const DUPLICATE_TITLE = 'text_64fa170e02f348164797a6af'
+  const DELETE_TITLE = 'text_6256de3bba111e00b3bfa533'
+
+  const setPermissions = (perms: string[]) => {
+    mockHasPermissions.mockImplementation((requested: string[]) =>
+      requested.every((p) => perms.includes(p)),
+    )
+  }
+
+  const getTableProps = () => mockTableProps.mock.calls[0]?.[0]
+
+  const getActionsFor = (item: Record<string, unknown>): RowAction[] =>
+    (getTableProps().actionColumn as (i: Record<string, unknown>) => RowAction[])(item)
+
+  const getTooltipFor = (item: Record<string, unknown>): string =>
+    (getTableProps().actionColumnTooltip as (i: Record<string, unknown>) => string)(item)
+
+  describe('GIVEN actionColumn', () => {
+    it.each([
+      {
+        name: 'no permissions',
+        permissions: [],
+        expectedIcons: [] as string[],
+      },
+      {
+        name: 'only update',
+        permissions: ['billableMetricsUpdate'],
+        expectedIcons: ['pen'],
+      },
+      {
+        name: 'only create',
+        permissions: ['billableMetricsCreate'],
+        expectedIcons: ['duplicate'],
+      },
+      {
+        name: 'only delete',
+        permissions: ['billableMetricsDelete'],
+        expectedIcons: ['trash'],
+      },
+      {
+        name: 'update + create',
+        permissions: ['billableMetricsUpdate', 'billableMetricsCreate'],
+        expectedIcons: ['pen', 'duplicate'],
+      },
+      {
+        name: 'update + delete',
+        permissions: ['billableMetricsUpdate', 'billableMetricsDelete'],
+        expectedIcons: ['pen', 'trash'],
+      },
+      {
+        name: 'create + delete',
+        permissions: ['billableMetricsCreate', 'billableMetricsDelete'],
+        expectedIcons: ['duplicate', 'trash'],
+      },
+      {
+        name: 'all permissions',
+        permissions: ['billableMetricsUpdate', 'billableMetricsCreate', 'billableMetricsDelete'],
+        expectedIcons: ['pen', 'duplicate', 'trash'],
+      },
+    ])(
+      'WHEN $name THEN returns $expectedIcons.length action(s) in expected order',
+      ({ permissions, expectedIcons }) => {
+        setPermissions(permissions)
 
         render(<BillableMetricsList />)
 
-        const actionColumn = mockTableProps.mock.calls[0]?.[0]?.actionColumn as (
-          item: Record<string, unknown>,
-        ) => { startIcon: string }[]
+        const actions = getActionsFor(ROW)
 
-        const actions = actionColumn({ id: 'bm-1', name: 'Test BM', code: 'test' })
-
-        expect(actions).toHaveLength(2)
-        expect(actions[0]).toEqual(expect.objectContaining({ startIcon: 'pen' }))
-        expect(actions[1]).toEqual(expect.objectContaining({ startIcon: 'trash' }))
-      })
-    })
+        expect(actions).toHaveLength(expectedIcons.length)
+        expect(actions.map((a) => a.startIcon)).toEqual(expectedIcons)
+      },
+    )
   })
 
-  describe('GIVEN user has no row-level permissions', () => {
-    describe('WHEN actionColumn is called for a row item', () => {
-      it('THEN should return empty array', () => {
-        mockHasPermissions.mockReturnValue(false)
+  describe('GIVEN actionColumnTooltip', () => {
+    it.each([
+      { name: 'no permissions', permissions: [] as string[], expected: '' },
+      {
+        name: 'only update',
+        permissions: ['billableMetricsUpdate'],
+        expected: EDIT_TITLE,
+      },
+      {
+        name: 'only create',
+        permissions: ['billableMetricsCreate'],
+        expected: DUPLICATE_TITLE,
+      },
+      {
+        name: 'only delete',
+        permissions: ['billableMetricsDelete'],
+        expected: DELETE_TITLE,
+      },
+      {
+        name: 'update + create',
+        permissions: ['billableMetricsUpdate', 'billableMetricsCreate'],
+        expected: `${EDIT_TITLE} or ${DUPLICATE_TITLE}`,
+      },
+      {
+        name: 'update + delete',
+        permissions: ['billableMetricsUpdate', 'billableMetricsDelete'],
+        expected: `${EDIT_TITLE} or ${DELETE_TITLE}`,
+      },
+      {
+        name: 'create + delete',
+        permissions: ['billableMetricsCreate', 'billableMetricsDelete'],
+        expected: `${DUPLICATE_TITLE} or ${DELETE_TITLE}`,
+      },
+      {
+        name: 'all permissions (no Oxford comma)',
+        permissions: ['billableMetricsUpdate', 'billableMetricsCreate', 'billableMetricsDelete'],
+        expected: `${EDIT_TITLE}, ${DUPLICATE_TITLE} or ${DELETE_TITLE}`,
+      },
+    ])('WHEN $name THEN tooltip is "$expected"', ({ permissions, expected }) => {
+      setPermissions(permissions)
 
-        render(<BillableMetricsList />)
+      render(<BillableMetricsList />)
 
-        const actionColumn = mockTableProps.mock.calls[0]?.[0]?.actionColumn as (
-          item: Record<string, unknown>,
-        ) => unknown[]
-
-        const actions = actionColumn({ id: 'bm-1', name: 'Test BM', code: 'test' })
-
-        expect(actions).toEqual([])
-      })
-    })
-  })
-
-  describe('GIVEN user has only billableMetricsUpdate permission', () => {
-    describe('WHEN actionColumn is called', () => {
-      it('THEN should return only the edit action', () => {
-        mockHasPermissions.mockImplementation((perms: string[]) =>
-          perms.includes('billableMetricsUpdate'),
-        )
-
-        render(<BillableMetricsList />)
-
-        const actionColumn = mockTableProps.mock.calls[0]?.[0]?.actionColumn as (
-          item: Record<string, unknown>,
-        ) => { startIcon: string }[]
-
-        const actions = actionColumn({ id: 'bm-1', name: 'Test BM', code: 'test' })
-
-        expect(actions).toHaveLength(1)
-        expect(actions[0]).toEqual(expect.objectContaining({ startIcon: 'pen' }))
-      })
-    })
-  })
-
-  describe('GIVEN user has only billableMetricsDelete permission', () => {
-    describe('WHEN actionColumn is called', () => {
-      it('THEN should return only the delete action', () => {
-        mockHasPermissions.mockImplementation((perms: string[]) =>
-          perms.includes('billableMetricsDelete'),
-        )
-
-        render(<BillableMetricsList />)
-
-        const actionColumn = mockTableProps.mock.calls[0]?.[0]?.actionColumn as (
-          item: Record<string, unknown>,
-        ) => { startIcon: string }[]
-
-        const actions = actionColumn({ id: 'bm-1', name: 'Test BM', code: 'test' })
-
-        expect(actions).toHaveLength(1)
-        expect(actions[0]).toEqual(expect.objectContaining({ startIcon: 'trash' }))
-      })
+      expect(getTooltipFor(ROW)).toBe(expected)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Add **Duplicate** row action in Billable Metrics list (gated on `billableMetricsCreate`). It's already available from the BM details page
- Refactor row actions into a single `getActions` helper used by both `actionColumn` and `actionColumnTooltip`.
- Tooltip now adapts to whichever combination of permissions the user has, via `Intl.ListFormat` (en uses `en-GB` to avoid Oxford comma).

Closes [ISSUE-1046](https://linear.app/getlago/issue/ISSUE-1046/allow-to-access-bm-duplicate-action-from-bm-list).
