### PR TITLE
refactor(dates): migrate custom DateTime.toFormat usage to intlFormatDateTime

### DIFF
--- a/src/components/creditNote/CreditNoteItemsForm.tsx
+++ b/src/components/creditNote/CreditNoteItemsForm.tsx
@@ -1,12 +1,12 @@
 import { FormikProps } from 'formik'
 import _get from 'lodash/get'
-import { DateTime } from 'luxon'
 import { FC, useMemo } from 'react'
 
 import { CreditNoteFormItem } from '~/components/creditNote/CreditNoteFormItem'
 import { CreditNoteForm, FeesPerInvoice, FromFee } from '~/components/creditNote/types'
 import { Typography } from '~/components/designSystem/Typography'
 import { Checkbox } from '~/components/form/Checkbox'
+import { intlFormatDateTime } from '~/core/timezone'
 import { CurrencyEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
@@ -149,9 +149,7 @@ export const CreditNoteItemsForm: FC<CreditNoteItemsFormProps> = ({
                   formikKey={`fees.${subKey}.fees.${feeIndex}`}
                   maxValue={fee?.maxAmount || 0}
                   feeSucceededAt={
-                    !!fee?.succeededAt
-                      ? DateTime.fromISO(fee?.succeededAt).toFormat('LLL. dd, yyyy')
-                      : undefined
+                    !!fee?.succeededAt ? intlFormatDateTime(fee?.succeededAt).date : undefined
                   }
                   isReadOnly={fee?.isReadOnly}
                 />

--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -765,7 +765,7 @@ const CreateInvoice = () => {
                   <Typography variant="caption" color="grey600">
                     {translate('text_6453819268763979024ad01b')}
                   </Typography>
-                  <Typography>{DateTime.now().toFormat('LLL. dd, yyyy')}</Typography>
+                  <Typography>{intlFormatDateTime(DateTime.now().toISO()).date}</Typography>
                 </div>
 
                 <div className={tw('flex gap-4', customerIsPartner && 'flex-row-reverse')}>

--- a/src/pages/subscriptions/CreateSubscription.tsx
+++ b/src/pages/subscriptions/CreateSubscription.tsx
@@ -49,7 +49,7 @@ import {
   CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE,
   PLAN_SUBSCRIPTION_DETAILS_ROUTE,
 } from '~/core/router'
-import { getTimezoneConfig } from '~/core/timezone'
+import { DateFormat, getTimezoneConfig, intlFormatDateTime } from '~/core/timezone'
 import {
   subscriptionFormSchema,
   SubscriptionFormValues,
@@ -387,12 +387,20 @@ const CreateSubscription = () => {
 
         if (formattedCurrentDate === february29) return translate('text_62ea7cd44cd4b14bb9ac1d9a')
 
-        return translate('text_62ea7cd44cd4b14bb9ac1d96', { date: currentDate.toFormat('LLL. dd') })
+        return translate('text_62ea7cd44cd4b14bb9ac1d96', {
+          date: intlFormatDateTime(currentDate.toISO() || '', {
+            formatDate: DateFormat.DATE_MED_SHORT,
+          }).date,
+        })
 
       case PlanInterval.Semiannual:
         return billingTime === BillingTimeEnum.Calendar
           ? translate('text_1757502242292q05inkc09vq')
-          : translate('text_1757504174992y39ailqcch0', { date: currentDate.toFormat('LLL. dd') })
+          : translate('text_1757504174992y39ailqcch0', {
+              date: intlFormatDateTime(currentDate.toISO() || '', {
+                formatDate: DateFormat.DATE_MED_SHORT,
+              }).date,
+            })
 
       case PlanInterval.Quarterly:
         if (billingTime === BillingTimeEnum.Calendar)

--- a/src/pages/wallet/components/SettingsSection.tsx
+++ b/src/pages/wallet/components/SettingsSection.tsx
@@ -22,6 +22,7 @@ import {
 } from '~/components/wallets/utils/dataTestConstants'
 import { dateErrorCodes, FORM_TYPE_ENUM } from '~/core/constants/form'
 import { getCurrencySymbol } from '~/core/formats/intlFormatNumber'
+import { intlFormatDateTime } from '~/core/timezone'
 import { CurrencyEnum, GetCustomerInfosForWalletFormQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { TWalletDataForm } from '~/pages/wallet/types'
@@ -148,7 +149,7 @@ export const SettingsSection: FC<SettingsSectionProps> = ({
               error={
                 formikProps.errors.expirationAt === dateErrorCodes.shouldBeInFuture
                   ? translate('text_630ccd87b251590eaa5f9831', {
-                      date: DateTime.now().toFormat('LLL. dd, yyyy'),
+                      date: intlFormatDateTime(DateTime.now().toISO() || '').date,
                     })
                   : undefined
               }


### PR DESCRIPTION
## Summary
- Replace deprecated Luxon `toFormat` date-display calls with `intlFormatDateTime` in 4 files (`CreateInvoice`, `CreditNoteItemsForm`, `CreateSubscription`, wallet `SettingsSection`)
- Partial progress on [ISSUE-1232](https://linear.app/getlago/issue/ISSUE-1232) — quick-win display sites only
- Internal comparison keys (e.g. `february29` check) and machine-format usages (`GRAPH_YEAR_MONTH_DATE_FORMAT`, `yyyyMM` invoice prefix) intentionally left untouched
