### PR TITLE
refactor(customer): migrate FreemiumAlert to usePremiumWarningDialog hook

### DIFF
--- a/src/pages/CustomerRequestOverduePayment/components/FreemiumAlert.tsx
+++ b/src/pages/CustomerRequestOverduePayment/components/FreemiumAlert.tsx
@@ -1,38 +1,34 @@
 import { Icon } from 'lago-design-system'
-import { FC, useRef } from 'react'
+import { FC } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 export const FreemiumAlert: FC = () => {
   const { translate } = useInternationalization()
-  const premiumDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const premiumWarningDialog = usePremiumWarningDialog()
 
   return (
-    <>
-      <div className="flex items-center gap-4 bg-yellow-100 p-12 shadow-b">
-        <div className="flex-1">
-          <div className="flex flex-row items-center gap-2">
-            <Typography variant="bodyHl" color="textSecondary">
-              {translate('text_66b25adfd834ed0104345eb7')}
-            </Typography>
-            <Icon name="sparkles" />
-          </div>
-          <Typography variant="caption">{translate('text_66b25adfd834ed0104345eb8')}</Typography>
+    <div className="flex items-center gap-4 bg-yellow-100 p-12 shadow-b">
+      <div className="flex-1">
+        <div className="flex flex-row items-center gap-2">
+          <Typography variant="bodyHl" color="textSecondary">
+            {translate('text_66b25adfd834ed0104345eb7')}
+          </Typography>
+          <Icon name="sparkles" />
         </div>
-        <Button
-          variant="tertiary"
-          size="large"
-          endIcon="sparkles"
-          onClick={() => premiumDialogRef.current?.openDialog()}
-        >
-          {translate('text_65ae73ebe3a66bec2b91d72d')}
-        </Button>
+        <Typography variant="caption">{translate('text_66b25adfd834ed0104345eb8')}</Typography>
       </div>
-
-      <PremiumWarningDialog ref={premiumDialogRef} />
-    </>
+      <Button
+        variant="tertiary"
+        size="large"
+        endIcon="sparkles"
+        onClick={() => premiumWarningDialog.open()}
+      >
+        {translate('text_65ae73ebe3a66bec2b91d72d')}
+      </Button>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary

- Migrate `FreemiumAlert` (`src/pages/CustomerRequestOverduePayment/components/FreemiumAlert.tsx`) from the deprecated ref-based `PremiumWarningDialog` to the new hook-based `usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`.
- Drops the local `useRef`/`PremiumWarningDialogRef` plumbing and the inline `<PremiumWarningDialog ref={...} />` since the dialog is now rendered via NiceModal registration.
- Resolves the `no-restricted-imports` lint warning for `~/components/PremiumWarningDialog` in this file (one less warning out of the ~50 still flagged in the codebase).

## Scope

- Single file change, scoped strictly to the PremiumWarningDialog usage as requested. No other deprecated dialogs were present in the file.

## Test plan

- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm exec eslint src/pages/CustomerRequestOverduePayment/components/FreemiumAlert.tsx` reports no warnings
- [x] `pnpm exec prettier --check` passes
- [x] Pre-push `pnpm code:style` (lint + types + translations) passes
- [ ] Manual smoke test: open the customer request overdue payment page on a freemium org and confirm the "Upgrade" button still opens the premium warning dialog

https://claude.ai/code/session_01WTa8VDaBhrCmhs7cLhgy9Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTa8VDaBhrCmhs7cLhgy9Z)_