### PR TITLE
refactor(role-picker): migrate PremiumWarningDialog to hook-based system

### DIFF
--- a/src/pages/settings/teamAndSecurity/members/dialogs/RolePicker.tsx
+++ b/src/pages/settings/teamAndSecurity/members/dialogs/RolePicker.tsx
@@ -1,11 +1,11 @@
 import Stack from '@mui/material/Stack'
 import { Icon } from 'lago-design-system'
-import { useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { BasicComboBoxData } from '~/components/form/ComboBox/types'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { withFieldGroup } from '~/hooks/forms/useAppform'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
@@ -24,6 +24,7 @@ const RolePicker = withFieldGroup({
     const { isPremium, currentMembership } = useCurrentUser()
     const { translate } = useInternationalization()
     const { roles, isLoadingRoles } = useRolesList()
+    const { open: openPremiumDialog } = usePremiumWarningDialog()
 
     const { getDisplayName, getDisplayDescription } = useRoleDisplayInformation()
 
@@ -57,45 +58,38 @@ const RolePicker = withFieldGroup({
       isCurrentUserAdmin,
     ])
 
-    const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
-
-    const openPremiumDialog = () => premiumWarningDialogRef.current?.openDialog()
-
     return (
-      <>
-        <div className="flex flex-col gap-4">
-          <group.AppField name="role">
-            {(field) => (
-              <field.ComboBoxField
-                label={translate('text_664f035a68227f00e261b7ec')}
-                data={rolesDataForCombobox}
-                placeholder={translate('text_1767193385926vevp8z0azr2')}
-                PopperProps={{ displayInDialog: true }}
-                sortValues={false}
-              />
-            )}
-          </group.AppField>
-          {!isPremium && (
-            <div className="flex items-center justify-between gap-4 rounded-xl bg-grey-100 px-6 py-4">
-              <Stack>
-                <Stack direction="row" gap={2} alignItems="center">
-                  <Typography variant="bodyHl" color="grey700">
-                    {translate('text_665edfd17997c0006f09cdb2')}
-                  </Typography>
-                  <Icon name="sparkles" />
-                </Stack>
-                <Typography variant="caption" color="grey600">
-                  {translate('text_665edfd17997c0006f09cdb3')}
-                </Typography>
-              </Stack>
-              <Button variant="tertiary" endIcon="sparkles" onClick={openPremiumDialog}>
-                {translate('text_65ae73ebe3a66bec2b91d72d')}
-              </Button>
-            </div>
+      <div className="flex flex-col gap-4">
+        <group.AppField name="role">
+          {(field) => (
+            <field.ComboBoxField
+              label={translate('text_664f035a68227f00e261b7ec')}
+              data={rolesDataForCombobox}
+              placeholder={translate('text_1767193385926vevp8z0azr2')}
+              PopperProps={{ displayInDialog: true }}
+              sortValues={false}
+            />
           )}
-        </div>
-        <PremiumWarningDialog ref={premiumWarningDialogRef} />
-      </>
+        </group.AppField>
+        {!isPremium && (
+          <div className="flex items-center justify-between gap-4 rounded-xl bg-grey-100 px-6 py-4">
+            <Stack>
+              <Stack direction="row" gap={2} alignItems="center">
+                <Typography variant="bodyHl" color="grey700">
+                  {translate('text_665edfd17997c0006f09cdb2')}
+                </Typography>
+                <Icon name="sparkles" />
+              </Stack>
+              <Typography variant="caption" color="grey600">
+                {translate('text_665edfd17997c0006f09cdb3')}
+              </Typography>
+            </Stack>
+            <Button variant="tertiary" endIcon="sparkles" onClick={() => openPremiumDialog()}>
+              {translate('text_65ae73ebe3a66bec2b91d72d')}
+            </Button>
+          </div>
+        )}
+      </div>
     )
   },
 })


### PR DESCRIPTION
## Summary

Migrates the deprecated ref-based `PremiumWarningDialog` (from `~/components/PremiumWarningDialog`) to the new hook-based NiceModal dialog system (`usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`) in the `RolePicker` component.

### Changes

- Replaced `PremiumWarningDialog` + `PremiumWarningDialogRef` import with `usePremiumWarningDialog` hook
- Removed the local `useRef<PremiumWarningDialogRef>(null)` and the manual `<PremiumWarningDialog ref={...} />` rendering — the dialog is now rendered globally via NiceModal
- Replaced the local `openPremiumDialog` callback with the `open` function returned by the hook
- Cleaned up the now-unused `useRef` import and the wrapping `<>...</>` fragment (we only had one element to return after the dialog moved out)

### Why

This clears out the `no-restricted-imports` ESLint warning on `~/components/PremiumWarningDialog` for this file, and follows the migration path defined for the new dialog management system.

## Test plan

- [x] `pnpm eslint` — no warnings remain on `RolePicker.tsx`
- [x] `pnpm types` — type check passes
- [x] `pnpm test --testPathPatterns=RolePicker` — all 14 RolePicker tests pass
- [ ] Manual QA: open the invite-member flow as a non-premium user and click the "Unlock" / sparkles button to confirm the premium warning dialog still opens correctly

https://claude.ai/code/session_01TfJc2xu1nkPV9p3XetoGKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfJc2xu1nkPV9p3XetoGKE)_