### PR TITLE
fix(deps): patch follow-redirects and uuid security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,9 @@
   "pnpm": {
     "overrides": {
       "flatted": ">=3.4.2",
-      "svgo": ">=3.3.3"
+      "svgo": ">=3.3.3",
+      "follow-redirects": ">=1.16.0",
+      "uuid": ">=14.0.0"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   flatted: '>=3.4.2'
   svgo: '>=3.3.3'
+  follow-redirects: '>=1.16.0'
+  uuid: '>=14.0.0'
 
 importers:
 
@@ -5470,8 +5472,8 @@ packages:
     resolution: {integrity: sha512-Y8CrO98EcXVCiYE4s5z0LTMbeYjKyd3MAEUJqxA7B8yGRlmdrG5UDqq4pVrUAfAu2tMFgpQESvBhBu9Xg1tpow==}
     engines: {node: '>=0.4.0'}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -8562,14 +8564,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -10345,7 +10341,7 @@ snapshots:
       safe-buffer: 5.2.1
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
-      uuid: 8.3.2
+      uuid: 14.0.0
 
   '@cypress/xvfb@1.2.4(supports-color@8.1.1)':
     dependencies:
@@ -13105,7 +13101,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -14433,7 +14429,7 @@ snapshots:
 
   flow-parser@0.258.1: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -15274,7 +15270,7 @@ snapshots:
     dependencies:
       mkdirp: 1.0.4
       strip-ansi: 6.0.1
-      uuid: 8.3.2
+      uuid: 14.0.0
       xml: 1.0.1
 
   jest-leak-detector@30.3.0:
@@ -18201,9 +18197,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@10.0.0: {}
-
-  uuid@8.3.2: {}
+  uuid@14.0.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 
@@ -18278,7 +18272,7 @@ snapshots:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
       '@swc/core': 1.13.5
       '@swc/wasm': 1.13.20
-      uuid: 10.0.0
+      uuid: 14.0.0
       vite: 7.3.2(@types/node@24.12.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@swc/helpers'


### PR DESCRIPTION
## Summary

Patches two open moderate security advisories via `pnpm.overrides`:

- **GHSA-r4q5-vmmm-2653** — `follow-redirects <=1.15.11` leaks custom authentication headers (e.g. `X-API-Key`) to cross-domain redirect targets. Overridden to `>=1.16.0`.
- **GHSA-w5hq-g745-h8pq** — `uuid <14.0.0` missing buffer bounds check in `v3`/`v5`/`v6` when an external `buf` is provided. Overridden to `>=14.0.0`.

## Why overrides (not direct upgrades)

### follow-redirects
- Transitive path: `@nangohq/frontend@0.70.1 → @nangohq/types@0.70.1 → axios@1.15.0 → follow-redirects@1.15.11`
- `@nangohq/types@0.70.1` is the latest published version and pins `axios@1.15.0`
- `axios@1.15.0` declares `follow-redirects: ^1.15.11` which admits `1.16.0`, but pnpm's lockfile resolution kept the older pin — an override is required to force resolution

### uuid
- Two vulnerable paths:
  - `cypress@15.14.1 → @cypress/request@3.0.10 → uuid@8.3.2` — latest cypress still uses `@cypress/request@^3.0.10`; `@cypress/request@4.0.0` already uses `uuid@^14.0.0` but cypress hasn't adopted it yet
  - `vite-plugin-top-level-await@1.6.0 → uuid@10.0.0` — latest version, pins uuid exactly with no upstream fix
- Both `@cypress/request@4.0.0` and `jest-junit@17.0.0` already declare `uuid@^14.0.0`, confirming v14 is safe in these internal-use contexts

## Verification

```
pnpm audit → found 0 vulnerabilities (was 3 moderate)
```

| Package | Before | After |
|---|---|---|
| follow-redirects | 1.15.11 | 1.16.0 |
| uuid (cypress path) | 8.3.2 | 14.0.0 |
| uuid (vite-plugin path) | 10.0.0 | 14.0.0 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xytn3YanBf5Y7Rr3zZJKSp)_