### PR TITLE
refactor(mrr): migrate PremiumWarningDialog to hook-based system

### DIFF
--- a/src/components/analytics/mrr/MrrBreakdownSection.tsx
+++ b/src/components/analytics/mrr/MrrBreakdownSection.tsx
@@ -11,7 +11,7 @@ import {
 import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { MRR_BREAKDOWN_PLANS_FILTER_PREFIX } from '~/core/constants/filters'
 import { getIntervalTranslationKey } from '~/core/constants/form'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -47,13 +47,10 @@ gql`
   }
 `
 
-type MrrBreakdownSectionProps = {
-  premiumWarningDialogRef: React.RefObject<PremiumWarningDialogRef>
-}
-
-export const MrrBreakdownSection = ({ premiumWarningDialogRef }: MrrBreakdownSectionProps) => {
+export const MrrBreakdownSection = () => {
   const [searchParams] = useSearchParams()
   const { translate } = useInternationalization()
+  const premiumWarningDialog = usePremiumWarningDialog()
   const { organization, hasOrganizationPremiumAddon } = useOrganizationInfos()
 
   const hasAccessToAnalyticsDashboardsFeature = hasOrganizationPremiumAddon(
@@ -112,7 +109,7 @@ export const MrrBreakdownSection = ({ premiumWarningDialogRef }: MrrBreakdownSec
               onClick={(e) => {
                 if (!hasAccessToAnalyticsDashboardsFeature) {
                   e.stopPropagation()
-                  premiumWarningDialogRef.current?.openDialog()
+                  premiumWarningDialog.open()
                 } else {
                   onClick()
                 }

--- a/src/components/analytics/mrr/MrrOverviewSection.tsx
+++ b/src/components/analytics/mrr/MrrOverviewSection.tsx
@@ -14,7 +14,7 @@ import AreaChart from '~/components/designSystem/graphs/AreaChart'
 import { getItemDateFormatedByTimeGranularity } from '~/components/designSystem/graphs/utils'
 import { HorizontalDataTable } from '~/components/designSystem/Table/HorizontalDataTable'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { MRR_BREAKDOWN_OVERVIEW_FILTER_PREFIX } from '~/core/constants/filters'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
@@ -36,10 +36,6 @@ gql`
     startingMrr
   }
 `
-
-type MrrOverviewSectionProps = {
-  premiumWarningDialogRef: React.RefObject<PremiumWarningDialogRef>
-}
 
 const AmountCell = ({
   value,
@@ -63,8 +59,9 @@ const AmountCell = ({
   )
 }
 
-export const MrrOverviewSection = ({ premiumWarningDialogRef }: MrrOverviewSectionProps) => {
+export const MrrOverviewSection = () => {
   const { translate } = useInternationalization()
+  const premiumWarningDialog = usePremiumWarningDialog()
   const {
     selectedCurrency,
     defaultCurrency,
@@ -103,7 +100,7 @@ export const MrrOverviewSection = ({ premiumWarningDialogRef }: MrrOverviewSecti
               onClick={(e) => {
                 if (!hasAccessToAnalyticsDashboardsFeature) {
                   e.stopPropagation()
-                  premiumWarningDialogRef.current?.openDialog()
+                  premiumWarningDialog.open()
                 } else {
                   onClick()
                 }

--- a/src/pages/analytics/Mrr.tsx
+++ b/src/pages/analytics/Mrr.tsx
@@ -1,17 +1,14 @@
 import { Icon } from 'lago-design-system'
-import { useRef } from 'react'
 
 import { MrrBreakdownSection } from '~/components/analytics/mrr/MrrBreakdownSection'
 import { MrrOverviewSection } from '~/components/analytics/mrr/MrrOverviewSection'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { FullscreenPage } from '~/components/layouts/FullscreenPage'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 const Mrr = () => {
   const { translate } = useInternationalization()
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
 
   return (
     <FullscreenPage.Wrapper>
@@ -26,11 +23,9 @@ const Mrr = () => {
         </Tooltip>
       </Typography>
 
-      <MrrOverviewSection premiumWarningDialogRef={premiumWarningDialogRef} />
+      <MrrOverviewSection />
 
-      <MrrBreakdownSection premiumWarningDialogRef={premiumWarningDialogRef} />
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
+      <MrrBreakdownSection />
     </FullscreenPage.Wrapper>
   )
 }


### PR DESCRIPTION
## Summary

Migrates the deprecated ref-based `PremiumWarningDialog` to the new hook-based `usePremiumWarningDialog` (NiceModal) on the MRR analytics page and its child sections.

### Changes
- `src/pages/analytics/Mrr.tsx`: removes the `premiumWarningDialogRef` and the `<PremiumWarningDialog />` JSX. Children no longer need the ref prop.
- `src/components/analytics/mrr/MrrOverviewSection.tsx`: drops the `premiumWarningDialogRef` prop and uses `usePremiumWarningDialog()` directly.
- `src/components/analytics/mrr/MrrBreakdownSection.tsx`: same migration as above.

This removes 3 `no-restricted-imports` warnings flagged by ESLint for the deprecated `~/components/PremiumWarningDialog` import in this scope.

### Scope
Scoped to the `PremiumWarningDialog` usage. The dialog ref was being passed from `Mrr.tsx` down to both child sections, so all three files were migrated together to keep behavior consistent. No other dialogs are present in these files.

## Test plan
- [ ] Navigate to the MRR analytics page as a non-premium user
- [ ] Click the "Filter" button on the overview section → premium warning dialog opens
- [ ] Click the "Filter" button on the breakdown section → premium warning dialog opens
- [ ] Verify dialog "Cancel" closes it and "Contact us" opens the mailto link

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UinZQe1JJCwBLcFdvhfvF9)_