### PR TITLE
fix(not found): handle 404 errors gracefully across all detail pages

### DIFF
--- a/src/components/billableMetrics/BillableMetricDetailsOverview.tsx
+++ b/src/components/billableMetrics/BillableMetricDetailsOverview.tsx
@@ -11,7 +11,7 @@ import {
   formatAggregationType,
   formatRoundingFunction,
 } from '~/core/formats/formatBillableMetricsItems'
-import { useGetBillableMetricForDetailsOverviewQuery } from '~/generated/graphql'
+import { LagoApiError, useGetBillableMetricForDetailsOverviewQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 gql`
@@ -48,6 +48,7 @@ export const BillableMetricDetailsOverview = () => {
   const { data, loading } = useGetBillableMetricForDetailsOverviewQuery({
     variables: { id: billableMetricId as string },
     skip: !billableMetricId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
   })
   const billableMetric = data?.billableMetric
 

--- a/src/components/coupons/CouponDetailsOverview.tsx
+++ b/src/components/coupons/CouponDetailsOverview.tsx
@@ -16,6 +16,7 @@ import { couponStatusMapping } from '~/core/constants/statusCouponMapping'
 import {
   CouponFrequency,
   CouponTypeEnum,
+  LagoApiError,
   useGetCouponForDetailsOverviewQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -60,6 +61,7 @@ export const CouponDetailsOverview = () => {
   const { data, loading } = useGetCouponForDetailsOverviewQuery({
     variables: { id: couponId as string },
     skip: !couponId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
   })
 
   const coupon = data?.coupon

--- a/src/components/features/FeatureDetailsOverview.tsx
+++ b/src/components/features/FeatureDetailsOverview.tsx
@@ -6,7 +6,11 @@ import { Typography } from '~/components/designSystem/Typography'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { getPrivilegeValueTypeTranslationKey } from '~/core/constants/form'
-import { PrivilegeValueTypeEnum, useGetFeatureForDetailsOverviewQuery } from '~/generated/graphql'
+import {
+  LagoApiError,
+  PrivilegeValueTypeEnum,
+  useGetFeatureForDetailsOverviewQuery,
+} from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 gql`
@@ -40,6 +44,7 @@ export const FeatureDetailsOverview = () => {
   const { data, loading } = useGetFeatureForDetailsOverviewQuery({
     variables: { id: featureId },
     skip: !featureId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
   })
   const feature = data?.feature
 

--- a/src/components/subscriptions/SubscriptionDetailsOverview.tsx
+++ b/src/components/subscriptions/SubscriptionDetailsOverview.tsx
@@ -5,6 +5,7 @@ import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { PlanDetailsOverview } from '~/components/plans/details/PlanDetailsOverview'
 import {
   FeatureFlagEnum,
+  LagoApiError,
   SubscriptionForSubscriptionInformationsFragmentDoc,
   useGetSubscriptionForDetailsOverviewQuery,
 } from '~/generated/graphql'
@@ -44,6 +45,7 @@ export const SubscriptionDetailsOverview = () => {
     useGetSubscriptionForDetailsOverviewQuery({
       variables: { subscriptionId: subscriptionId as string },
       skip: !subscriptionId,
+      context: { silentErrorCodes: [LagoApiError.NotFound] },
     })
   const subscription = subscriptionResult?.subscription
 

--- a/src/hooks/__tests__/useNotFoundRedirect.test.ts
+++ b/src/hooks/__tests__/useNotFoundRedirect.test.ts
@@ -1,0 +1,174 @@
+import { ApolloError } from '@apollo/client'
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { addToast } from '~/core/apolloClient'
+import { LagoApiError } from '~/generated/graphql'
+import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
+import { AllTheProviders } from '~/test-utils'
+
+const mockNavigate = jest.fn()
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}))
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: jest.fn(),
+}))
+
+const createNotFoundError = () =>
+  new ApolloError({
+    graphQLErrors: [
+      {
+        message: 'not found',
+        extensions: { code: LagoApiError.NotFound },
+      },
+    ] as ApolloError['graphQLErrors'],
+  })
+
+const createOtherError = () =>
+  new ApolloError({
+    graphQLErrors: [
+      {
+        message: 'unauthorized',
+        extensions: { code: LagoApiError.Unauthorized },
+      },
+    ] as ApolloError['graphQLErrors'],
+  })
+
+describe('useNotFoundRedirect', () => {
+  const customWrapper = ({ children }: { children: React.ReactNode }) =>
+    AllTheProviders({ children })
+
+  const defaultArgs = {
+    error: undefined as ApolloError | undefined,
+    loading: false,
+    redirectTo: '/resources',
+    translateKey: 'text_some_key',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN no error occurred', () => {
+    describe('WHEN the query finishes loading', () => {
+      it('THEN should not navigate or show a toast', () => {
+        renderHook(() => useNotFoundRedirect({ ...defaultArgs, loading: false }), {
+          wrapper: customWrapper,
+        })
+
+        expect(mockNavigate).not.toHaveBeenCalled()
+        expect(addToast).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN the query is still loading', () => {
+    describe('WHEN a NotFound error is present', () => {
+      it('THEN should not navigate or show a toast yet', () => {
+        renderHook(
+          () =>
+            useNotFoundRedirect({
+              ...defaultArgs,
+              loading: true,
+              error: createNotFoundError(),
+            }),
+          { wrapper: customWrapper },
+        )
+
+        expect(mockNavigate).not.toHaveBeenCalled()
+        expect(addToast).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN a NotFound error occurred', () => {
+    describe('WHEN loading is complete', () => {
+      it('THEN should navigate to the redirect route with replace', async () => {
+        renderHook(
+          () =>
+            useNotFoundRedirect({
+              ...defaultArgs,
+              error: createNotFoundError(),
+            }),
+          { wrapper: customWrapper },
+        )
+
+        await waitFor(() => {
+          expect(mockNavigate).toHaveBeenCalledWith('/resources', { replace: true })
+        })
+      })
+
+      it('THEN should show an info toast with the provided translateKey', async () => {
+        renderHook(
+          () =>
+            useNotFoundRedirect({
+              ...defaultArgs,
+              error: createNotFoundError(),
+            }),
+          { wrapper: customWrapper },
+        )
+
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledWith({
+            severity: 'info',
+            translateKey: 'text_some_key',
+          })
+        })
+      })
+    })
+  })
+
+  describe('GIVEN a non-NotFound error occurred', () => {
+    describe('WHEN loading is complete', () => {
+      it('THEN should not navigate or show a toast', () => {
+        renderHook(
+          () =>
+            useNotFoundRedirect({
+              ...defaultArgs,
+              error: createOtherError(),
+            }),
+          { wrapper: customWrapper },
+        )
+
+        expect(mockNavigate).not.toHaveBeenCalled()
+        expect(addToast).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN the redirect route varies', () => {
+    describe('WHEN a NotFound error triggers redirect', () => {
+      it.each([
+        ['/customers', 'text_customer_key'],
+        ['/invoices', 'text_invoice_key'],
+        ['/plans', 'text_plan_key'],
+      ])(
+        'THEN should navigate to %s with the correct translateKey',
+        async (redirectTo, translateKey) => {
+          renderHook(
+            () =>
+              useNotFoundRedirect({
+                error: createNotFoundError(),
+                loading: false,
+                redirectTo,
+                translateKey,
+              }),
+            { wrapper: customWrapper },
+          )
+
+          await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith(redirectTo, { replace: true })
+            expect(addToast).toHaveBeenCalledWith({
+              severity: 'info',
+              translateKey,
+            })
+          })
+        },
+      )
+    })
+  })
+})

--- a/src/hooks/useNotFoundRedirect.ts
+++ b/src/hooks/useNotFoundRedirect.ts
@@ -1,0 +1,33 @@
+import { ApolloError } from '@apollo/client'
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
+
+type UseNotFoundRedirectArgs = {
+  error: ApolloError | undefined
+  loading: boolean
+  redirectTo: string
+  translateKey: string
+}
+
+export const useNotFoundRedirect = ({
+  error,
+  loading,
+  redirectTo,
+  translateKey,
+}: UseNotFoundRedirectArgs) => {
+  const navigate = useNavigate()
+  const isNotFoundError = hasDefinedGQLError('NotFound', error)
+
+  useEffect(() => {
+    if (loading || !isNotFoundError) return
+
+    addToast({
+      severity: 'info',
+      translateKey,
+    })
+    navigate(redirectTo, { replace: true })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, isNotFoundError])
+}

--- a/src/pages/AddOnDetails.tsx
+++ b/src/pages/AddOnDetails.tsx
@@ -11,8 +11,9 @@ import { MainHeaderAction } from '~/components/MainHeader/types'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { ADD_ONS_ROUTE, UPDATE_ADD_ON_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { CurrencyEnum, useGetAddOnForDetailsQuery } from '~/generated/graphql'
+import { CurrencyEnum, LagoApiError, useGetAddOnForDetailsQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
 import { usePermissions } from '~/hooks/usePermissions'
 
 gql`
@@ -41,10 +42,23 @@ const AddOnDetails = () => {
 
   const deleteDialogRef = useRef<DeleteAddOnDialogRef>(null)
 
-  const { data: addOnResult, loading: isAddOnLoading } = useGetAddOnForDetailsQuery({
+  const {
+    data: addOnResult,
+    loading: isAddOnLoading,
+    error: addOnError,
+  } = useGetAddOnForDetailsQuery({
     variables: {
       addOn: addOnId as string,
     },
+    skip: !addOnId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
+  })
+
+  useNotFoundRedirect({
+    error: addOnError,
+    loading: isAddOnLoading,
+    redirectTo: ADD_ONS_ROUTE,
+    translateKey: 'text_1777995443788l735b53lgd1',
   })
 
   const addOn = addOnResult?.addOn

--- a/src/pages/BillableMetricDetails.tsx
+++ b/src/pages/BillableMetricDetails.tsx
@@ -21,9 +21,10 @@ import {
   UPDATE_BILLABLE_METRIC_ROUTE,
 } from '~/core/router'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
-import { useGetBillableMetricForHeaderDetailsQuery } from '~/generated/graphql'
+import { LagoApiError, useGetBillableMetricForHeaderDetailsQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
 import { usePermissions } from '~/hooks/usePermissions'
 
 gql`
@@ -45,11 +46,19 @@ const BillableMetricDetails = () => {
 
   const deleteBillableMetricDialogRef = useRef<DeleteBillableMetricDialogRef>(null)
 
-  const { data, loading } = useGetBillableMetricForHeaderDetailsQuery({
+  const { data, loading, error } = useGetBillableMetricForHeaderDetailsQuery({
     variables: {
       id: billableMetricId as string,
     },
     skip: !billableMetricId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
+  })
+
+  useNotFoundRedirect({
+    error,
+    loading,
+    redirectTo: BILLABLE_METRICS_ROUTE,
+    translateKey: 'text_1777995443789mu6h3lr2kbg',
   })
 
   const billableMetric = data?.billableMetric

--- a/src/pages/CouponDetails.tsx
+++ b/src/pages/CouponDetails.tsx
@@ -15,11 +15,13 @@ import { CouponDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { COUPON_DETAILS_ROUTE, COUPONS_ROUTE, UPDATE_COUPON_ROUTE } from '~/core/router'
 import {
   DeleteCouponFragmentDoc,
+  LagoApiError,
   TerminateCouponFragmentDoc,
   useGetCouponForDetailsQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
 import { usePermissions } from '~/hooks/usePermissions'
 import { usePermissionsCouponActions } from '~/hooks/usePermissionsCouponActions'
 
@@ -58,11 +60,19 @@ const CouponDetails = () => {
   const { openDialog: openDeleteDialog } = useDeleteCoupon()
   const { openDialog: openTerminateDialog } = useTerminateCoupon()
 
-  const { data, loading } = useGetCouponForDetailsQuery({
+  const { data, loading, error } = useGetCouponForDetailsQuery({
     variables: {
       id: couponId as string,
     },
     skip: !couponId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
+  })
+
+  useNotFoundRedirect({
+    error,
+    loading,
+    redirectTo: COUPONS_ROUTE,
+    translateKey: 'text_1777995443788jkq4zx3m74e',
   })
 
   const coupon = data?.coupon

--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { captureException } from '@sentry/react'
 import { useEffect, useRef } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
@@ -15,7 +14,7 @@ import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { useMainHeaderTabContent } from '~/components/MainHeader/useMainHeaderTabContent'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
-import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
+import { hasDefinedGQLError } from '~/core/apolloClient'
 import { CUSTOMERS_LIST_ROUTE } from '~/core/router'
 import {
   AddCustomerDrawerFragmentDoc,
@@ -27,7 +26,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCustomerDetailsHeaderActions } from '~/hooks/customer/useCustomerDetailsHeaderActions'
 import { useCustomerDetailsHeaderEntity } from '~/hooks/customer/useCustomerDetailsHeaderEntity'
 import { useCustomerDetailsHeaderTabs } from '~/hooks/customer/useCustomerDetailsHeaderTabs'
-import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
+import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
 import ErrorImage from '~/public/images/maneki/error.svg'
 
 gql`
@@ -78,7 +77,6 @@ const CustomerDetails = () => {
   const { translate } = useInternationalization()
   const navigate = useNavigate()
   const location = useLocation()
-  const { organization } = useOrganizationInfos()
   const { customerId } = useParams()
 
   const shouldPollIntegrations = (location.state as { shouldPollIntegrations?: boolean })
@@ -93,7 +91,6 @@ const CustomerDetails = () => {
   })
 
   const customer = data?.customer
-  const isNotFoundError = hasDefinedGQLError('NotFound', error)
   const hasAnyIntegrationCustomer =
     !!customer?.netsuiteCustomer ||
     !!customer?.anrokCustomer ||
@@ -127,24 +124,12 @@ const CustomerDetails = () => {
     }
   }, [shouldPollIntegrations, hasAnyIntegrationCustomer, stopPolling, navigate, location.pathname])
 
-  // When customer is not found (404), redirect to customers list with error toast
-  useEffect(() => {
-    if (loading || !isNotFoundError) return
-
-    captureException(new Error('Customer not found'), {
-      extra: {
-        customerId,
-        organizationId: organization?.id,
-        url: location.pathname,
-      },
-    })
-
-    addToast({
-      severity: 'info',
-      translateKey: 'text_17701996981731m5uguxyg8b',
-    })
-    navigate(CUSTOMERS_LIST_ROUTE, { replace: true })
-  }, [loading, isNotFoundError, customerId, navigate, location.pathname, organization?.id])
+  useNotFoundRedirect({
+    error,
+    loading,
+    redirectTo: CUSTOMERS_LIST_ROUTE,
+    translateKey: 'text_17701996981731m5uguxyg8b',
+  })
 
   const actions = useCustomerDetailsHeaderActions({
     customerId: customerId as string,
@@ -180,7 +165,7 @@ const CustomerDetails = () => {
       {activeTabContent && <div className="p-4 md:p-12">{activeTabContent}</div>}
 
       {/* Error state (non-404) */}
-      {!!error && !isNotFoundError && (
+      {!!error && !hasDefinedGQLError('NotFound', error) && (
         <div className="px-4 pb-20 pt-12 md:px-12">
           <GenericPlaceholder
             title={translate('text_6250304370f0f700a8fdc270')}

--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -327,6 +327,7 @@ const CustomerInvoiceDetails = () => {
   } = useGetInvoiceFeesQuery({
     variables: { id: invoiceId as string },
     skip: !invoiceId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
   })
   const invoice = data?.invoice
   const invoiceFees = feesData?.invoice?.fees

--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -90,6 +90,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useLocationHistory } from '~/hooks/core/useLocationHistory'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { useGeneratePaymentUrl } from '~/hooks/useGeneratePaymentUrl'
+import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
 import { usePermissions } from '~/hooks/usePermissions'
 import { useResendEmailDialog } from '~/hooks/useResendEmailDialog'
 import { useDownloadInvoice } from '~/pages/invoiceDetails/common/useDownloadInvoice'
@@ -310,6 +311,14 @@ const CustomerInvoiceDetails = () => {
   const { data, loading, error, refetch } = useGetInvoiceDetailsQuery({
     variables: { id: invoiceId as string },
     skip: !invoiceId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
+  })
+
+  useNotFoundRedirect({
+    error,
+    loading,
+    redirectTo: INVOICES_ROUTE,
+    translateKey: 'text_1777995443788zg01psy967w',
   })
   const {
     data: feesData,

--- a/src/pages/PaymentDetails.tsx
+++ b/src/pages/PaymentDetails.tsx
@@ -38,12 +38,14 @@ import {
   CurrencyEnum,
   InvoicePaymentStatusTypeEnum,
   InvoiceStatusTypeEnum,
+  LagoApiError,
   PaymentTypeEnum,
   ProviderTypeEnum,
   useGetPaymentDetailsQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import useDownloadPaymentReceipts from '~/hooks/paymentReceipts/useDownloadPaymentReceipts'
+import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { usePermissions } from '~/hooks/usePermissions'
 import { useResendEmailDialog } from '~/hooks/useResendEmailDialog'
@@ -171,10 +173,23 @@ const PaymentDetails = () => {
   const { timezone } = useOrganizationInfos()
   const { customerId, paymentId } = useParams()
 
-  const { data = {}, loading } = useGetPaymentDetailsQuery({
+  const {
+    data = {},
+    loading,
+    error,
+  } = useGetPaymentDetailsQuery({
     variables: {
       id: paymentId as string,
     },
+    skip: !paymentId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
+  })
+
+  useNotFoundRedirect({
+    error,
+    loading,
+    redirectTo: PAYMENTS_ROUTE,
+    translateKey: 'text_1777995443788h3delxx2sno',
   })
 
   const { showResendEmailDialog } = useResendEmailDialog()

--- a/src/pages/PlanDetails.tsx
+++ b/src/pages/PlanDetails.tsx
@@ -22,10 +22,12 @@ import {
 import {
   DeletePlanDialogFragment,
   DeletePlanDialogFragmentDoc,
+  LagoApiError,
   useGetPlanForDetailsQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
 import { usePermissions } from '~/hooks/usePermissions'
 
 gql`
@@ -52,11 +54,23 @@ const PlanDetails = () => {
   const { isPremium } = useCurrentUser()
 
   const deletePlanDialogRef = useRef<DeletePlanDialogRef>(null)
-  const { data: planResult, loading: isPlanLoading } = useGetPlanForDetailsQuery({
+  const {
+    data: planResult,
+    loading: isPlanLoading,
+    error: planError,
+  } = useGetPlanForDetailsQuery({
     variables: { planId: planId as string },
     skip: !planId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
   })
   const plan = planResult?.plan
+
+  useNotFoundRedirect({
+    error: planError,
+    loading: isPlanLoading,
+    redirectTo: PLANS_ROUTE,
+    translateKey: 'text_17779954437882bskjocn0qv',
+  })
 
   useEffect(() => {
     // WARNING: This page should not be used to show overridden plan's details

--- a/src/pages/creditNoteDetails/CreditNoteDetails.tsx
+++ b/src/pages/creditNoteDetails/CreditNoteDetails.tsx
@@ -35,12 +35,14 @@ import {
   BillingEntityEmailSettingsEnum,
   CurrencyEnum,
   CustomerForCreditNoteDetailsExternalSyncFragmentDoc,
+  LagoApiError,
   useGetCreditNoteForDetailsQuery,
   useRetryTaxReportingMutation,
   useSyncIntegrationCreditNoteMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
 import { usePermissions } from '~/hooks/usePermissions'
 import { useResendEmailDialog } from '~/hooks/useResendEmailDialog'
 import { useDownloadCreditNote } from '~/pages/creditNoteDetails/common/useDownloadCreditNote'
@@ -120,6 +122,14 @@ const CreditNoteDetails = () => {
   const { data, loading, error } = useGetCreditNoteForDetailsQuery({
     variables: { id: creditNoteId as string },
     skip: !creditNoteId || !customerId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
+  })
+
+  useNotFoundRedirect({
+    error,
+    loading,
+    redirectTo: CREDIT_NOTES_ROUTE,
+    translateKey: 'text_1777995443788l05iwih1hig',
   })
 
   const { showResendEmailDialog } = useResendEmailDialog()

--- a/src/pages/features/FeatureDetails.tsx
+++ b/src/pages/features/FeatureDetails.tsx
@@ -16,10 +16,12 @@ import { FeatureDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { FEATURE_DETAILS_ROUTE, FEATURES_ROUTE, UPDATE_FEATURE_ROUTE } from '~/core/router'
 import {
   FeatureForDeleteFeatureDialogFragmentDoc,
+  LagoApiError,
   useGetFeatureForDetailsQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
 import { usePermissions } from '~/hooks/usePermissions'
 
 gql`
@@ -44,10 +46,23 @@ const FeatureDetails = () => {
 
   const deleteDialogRef = useRef<DeleteFeatureDialogRef>(null)
 
-  const { data: featureResult, loading: isFeatureLoading } = useGetFeatureForDetailsQuery({
+  const {
+    data: featureResult,
+    loading: isFeatureLoading,
+    error: featureError,
+  } = useGetFeatureForDetailsQuery({
     variables: {
       feature: featureId as string,
     },
+    skip: !featureId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
+  })
+
+  useNotFoundRedirect({
+    error: featureError,
+    loading: isFeatureLoading,
+    redirectTo: FEATURES_ROUTE,
+    translateKey: 'text_1777995443788m0uv1vvtz7j',
   })
 
   const feature = featureResult?.feature

--- a/src/pages/subscriptions/SubscriptionDetails.tsx
+++ b/src/pages/subscriptions/SubscriptionDetails.tsx
@@ -27,12 +27,14 @@ import {
 } from '~/core/router'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import {
+  LagoApiError,
   StatusTypeEnum,
   SubscriptionForProgressiveBillingTabFragmentDoc,
   useGetSubscriptionForDetailsQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
 import { usePermissions } from '~/hooks/usePermissions'
 import { useSubscriptionPermissionsActions } from '~/hooks/useSubscriptionPermissionsActions'
 
@@ -78,11 +80,22 @@ const SubscriptionDetails = () => {
   const { planId = '', customerId = '', subscriptionId = '' } = useParams()
   const { translate } = useInternationalization()
   const { openTerminateCustomerSubscriptionDialog } = useTerminateCustomerSubscriptionDialog()
-  const { data: subscriptionResult, loading: isSubscriptionLoading } =
-    useGetSubscriptionForDetailsQuery({
-      variables: { subscriptionId: subscriptionId as string },
-      skip: !subscriptionId,
-    })
+  const {
+    data: subscriptionResult,
+    loading: isSubscriptionLoading,
+    error: subscriptionError,
+  } = useGetSubscriptionForDetailsQuery({
+    variables: { subscriptionId: subscriptionId as string },
+    skip: !subscriptionId,
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
+  })
+
+  useNotFoundRedirect({
+    error: subscriptionError,
+    loading: isSubscriptionLoading,
+    redirectTo: SUBSCRIPTIONS_ROUTE,
+    translateKey: 'text_1777995443788yxv3i6i9276',
+  })
 
   const activeTabContent = useMainHeaderTabContent()
 

--- a/translations/base.json
+++ b/translations/base.json
@@ -4079,5 +4079,14 @@
   "text_177746095833445oggkposdq": "Your organization slug will be added to all URLs. For example, <b>/customers</b> will become <b>/{{slug}}/customers</b>. Existing bookmarks and shared links may no longer work.",
   "text_1777460958334ehtlaesho6e": "Edit your slug",
   "text_1777471747994p4c7cm9pri6": "Subscription {{externalSubscriptionId}} was canceled",
-  "text_17774717479940xot2f14xbr": "Subscription {{externalSubscriptionId}} is incomplete"
+  "text_17774717479940xot2f14xbr": "Subscription {{externalSubscriptionId}} is incomplete",
+  "text_1777995443788yxv3i6i9276": "Subscription not found",
+  "text_1777995443788zg01psy967w": "Invoice not found",
+  "text_1777995443788h3delxx2sno": "Payment not found",
+  "text_1777995443788l05iwih1hig": "Credit note not found",
+  "text_1777995443788jkq4zx3m74e": "Coupon not found",
+  "text_1777995443788l735b53lgd1": "Add-on not found",
+  "text_1777995443788m0uv1vvtz7j": "Feature not found",
+  "text_17779954437882bskjocn0qv": "Plan not found",
+  "text_1777995443789mu6h3lr2kbg": "Billable metric not found"
 }


### PR DESCRIPTION
## Context

Extract shared useNotFoundRedirect hook to redirect with an info toast when a resource is not found, replacing inline handling and silencing GraphQL NotFound errors across 10 detail pages.

## Description

This PR makes sure such broken 404 views are not in place and users redirect back to the appropriate list of items

<img width="1265" height="848" alt="Screenshot 2026-05-05 at 18 28 45" src="https://github.com/user-attachments/assets/ea8509ca-342a-4cf8-95ef-51020c6513da" />
<img width="1189" height="846" alt="Screenshot 2026-05-05 at 18 29 05" src="https://github.com/user-attachments/assets/8d893cd4-9360-46e4-bccd-af129f7ffc9b" />
