### PR TITLE
refactor(payments): migrate PaymentsPage to usePremiumWarningDialog hook

### DIFF
--- a/src/pages/PaymentsPage.tsx
+++ b/src/pages/PaymentsPage.tsx
@@ -1,11 +1,10 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { PaymentsList } from '~/components/invoices/PaymentsList'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { SearchInput } from '~/components/SearchInput'
 import { CREATE_PAYMENT_ROUTE } from '~/core/router'
 import { PaymentForPaymentsListFragmentDoc, useGetPaymentsListLazyQuery } from '~/generated/graphql'
@@ -46,8 +45,7 @@ const PaymentsPage = () => {
   const { translate } = useInternationalization()
   const { isPremium } = useCurrentUser()
   const navigate = useNavigate()
-
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
 
   const [getPayments, { data, loading, error, fetchMore, variables }] = useGetPaymentsListLazyQuery(
     {
@@ -84,7 +82,7 @@ const PaymentsPage = () => {
                 if (isPremium) {
                   navigate(CREATE_PAYMENT_ROUTE)
                 } else {
-                  premiumWarningDialogRef.current?.openDialog()
+                  openPremiumWarningDialog()
                 }
               },
             },
@@ -106,8 +104,6 @@ const PaymentsPage = () => {
         metadata={data?.payments?.metadata}
         variables={variables}
       />
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </>
   )
 }

--- a/src/pages/__tests__/PaymentsPage.test.tsx
+++ b/src/pages/__tests__/PaymentsPage.test.tsx
@@ -62,8 +62,13 @@ jest.mock('~/components/invoices/PaymentsList', () => ({
   PaymentsList: () => <div data-test="payments-list-mock">PaymentsList</div>,
 }))
 
-jest.mock('~/components/PremiumWarningDialog', () => ({
-  PremiumWarningDialog: () => null,
+const mockOpenPremiumWarningDialog = jest.fn()
+
+jest.mock('~/components/dialogs/PremiumWarningDialog', () => ({
+  usePremiumWarningDialog: () => ({
+    open: mockOpenPremiumWarningDialog,
+    close: jest.fn(),
+  }),
 }))
 
 describe('PaymentsPage', () => {
@@ -71,6 +76,7 @@ describe('PaymentsPage', () => {
     jest.clearAllMocks()
     capturedConfig = null
     mockIsPremium.mockReturnValue(true)
+    mockOpenPremiumWarningDialog.mockClear()
   })
 
   describe('GIVEN the page is rendered', () => {
@@ -140,7 +146,7 @@ describe('PaymentsPage', () => {
         expect(action?.type === 'action' && action.endIcon).toBe('sparkles')
       })
 
-      it('THEN clicking the action should not navigate', () => {
+      it('THEN clicking the action should open the premium warning dialog', () => {
         render(<PaymentsPage />)
 
         const action = capturedConfig?.actions?.items[0]
@@ -150,6 +156,7 @@ describe('PaymentsPage', () => {
         }
 
         expect(testMockNavigateFn).not.toHaveBeenCalled()
+        expect(mockOpenPremiumWarningDialog).toHaveBeenCalled()
       })
     })
   })


### PR DESCRIPTION
## Summary

Migrate `src/pages/PaymentsPage.tsx` from the deprecated ref-based `PremiumWarningDialog` (`~/components/PremiumWarningDialog`) to the new hook-based `usePremiumWarningDialog` (`~/components/dialogs/PremiumWarningDialog`).

This removes one of the `no-restricted-imports` warnings flagged by ESLint (511 → 510 remaining warnings overall).

## Changes

- Replaced legacy import with `usePremiumWarningDialog` hook
- Removed `useRef<PremiumWarningDialogRef>` and the `<PremiumWarningDialog ref={...} />` JSX node
- Replaced `premiumWarningDialogRef.current?.openDialog()` with `openPremiumWarningDialog()`
- Removed the unused `useRef` React import

Scope intentionally kept tight to the warning dialog migration in this single file (no other deprecated dialog imports were present).

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm eslint src/pages/PaymentsPage.tsx` no longer flags the file
- [x] Smoke-test the Payments page: when not premium, clicking "Create payment" should open the premium warning dialog; when premium, it should navigate to the create payment route

https://claude.ai/code/session_013NqrRvxYamjy4c5PCwS3FU

---
_Generated by [Claude Code](https://claude.ai/code/session_013NqrRvxYamjy4c5PCwS3FU)_