### PR TITLE
refactor(revenue-streams): migrate PremiumWarningDialog to hook-based system

### DIFF
--- a/src/components/analytics/revenueStreams/RevenueStreamsBreakdownSection.tsx
+++ b/src/components/analytics/revenueStreams/RevenueStreamsBreakdownSection.tsx
@@ -2,16 +2,9 @@ import { RevenueStreamsCustomerBreakdownSection } from '~/components/analytics/r
 import { RevenueStreamsPlanBreakdownSection } from '~/components/analytics/revenueStreams/RevenueStreamsPlanBreakdownSection'
 import { NavigationTab, TabManagedBy } from '~/components/designSystem/NavigationTab'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
-type RevenueStreamsBreakdownSectionProps = {
-  premiumWarningDialogRef: React.RefObject<PremiumWarningDialogRef>
-}
-
-export const RevenueStreamsBreakdownSection = ({
-  premiumWarningDialogRef,
-}: RevenueStreamsBreakdownSectionProps) => {
+export const RevenueStreamsBreakdownSection = () => {
   const { translate } = useInternationalization()
 
   return (
@@ -30,19 +23,11 @@ export const RevenueStreamsBreakdownSection = ({
         tabs={[
           {
             title: translate('text_62442e40cea25600b0b6d85a'),
-            component: (
-              <RevenueStreamsPlanBreakdownSection
-                premiumWarningDialogRef={premiumWarningDialogRef}
-              />
-            ),
+            component: <RevenueStreamsPlanBreakdownSection />,
           },
           {
             title: translate('text_624efab67eb2570101d117a5'),
-            component: (
-              <RevenueStreamsCustomerBreakdownSection
-                premiumWarningDialogRef={premiumWarningDialogRef}
-              />
-            ),
+            component: <RevenueStreamsCustomerBreakdownSection />,
           },
         ]}
       />

--- a/src/components/analytics/revenueStreams/RevenueStreamsCustomerBreakdownSection.tsx
+++ b/src/components/analytics/revenueStreams/RevenueStreamsCustomerBreakdownSection.tsx
@@ -11,7 +11,7 @@ import {
 import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { REVENUE_STREAMS_BREAKDOWN_CUSTOMER_FILTER_PREFIX } from '~/core/constants/filters'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
@@ -42,16 +42,11 @@ gql`
   }
 `
 
-type RevenueStreamsCustomerBreakdownSectionProps = {
-  premiumWarningDialogRef: React.RefObject<PremiumWarningDialogRef>
-}
-
-export const RevenueStreamsCustomerBreakdownSection = ({
-  premiumWarningDialogRef,
-}: RevenueStreamsCustomerBreakdownSectionProps) => {
+export const RevenueStreamsCustomerBreakdownSection = () => {
   const [searchParams] = useSearchParams()
   const { organization, hasOrganizationPremiumAddon } = useOrganizationInfos()
   const { translate } = useInternationalization()
+  const premiumWarningDialog = usePremiumWarningDialog()
 
   const hasAccessToAnalyticsDashboardsFeature = hasOrganizationPremiumAddon(
     PremiumIntegrationTypeEnum.AnalyticsDashboards,
@@ -100,7 +95,7 @@ export const RevenueStreamsCustomerBreakdownSection = ({
               onClick={(e) => {
                 if (!hasAccessToAnalyticsDashboardsFeature) {
                   e.stopPropagation()
-                  premiumWarningDialogRef.current?.openDialog()
+                  premiumWarningDialog.open()
                 } else {
                   onClick()
                 }

--- a/src/components/analytics/revenueStreams/RevenueStreamsOverviewSection.tsx
+++ b/src/components/analytics/revenueStreams/RevenueStreamsOverviewSection.tsx
@@ -15,7 +15,7 @@ import MultipleLineChart from '~/components/designSystem/graphs/MultipleLineChar
 import { getItemDateFormatedByTimeGranularity } from '~/components/designSystem/graphs/utils'
 import { HorizontalDataTable, RowType } from '~/components/designSystem/Table/HorizontalDataTable'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { REVENUE_STREAMS_OVERVIEW_FILTER_PREFIX } from '~/core/constants/filters'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
@@ -46,14 +46,9 @@ gql`
   }
 `
 
-type RevenueStreamsOverviewSectionProps = {
-  premiumWarningDialogRef: React.RefObject<PremiumWarningDialogRef>
-}
-
-export const RevenueStreamsOverviewSection = ({
-  premiumWarningDialogRef,
-}: RevenueStreamsOverviewSectionProps) => {
+export const RevenueStreamsOverviewSection = () => {
   const { translate } = useInternationalization()
+  const premiumWarningDialog = usePremiumWarningDialog()
   const {
     selectedCurrency,
     defaultCurrency,
@@ -91,7 +86,7 @@ export const RevenueStreamsOverviewSection = ({
               onClick={(e) => {
                 if (!hasAccessToAnalyticsDashboardsFeature) {
                   e.stopPropagation()
-                  premiumWarningDialogRef.current?.openDialog()
+                  premiumWarningDialog.open()
                 } else {
                   onClick()
                 }

--- a/src/components/analytics/revenueStreams/RevenueStreamsPlanBreakdownSection.tsx
+++ b/src/components/analytics/revenueStreams/RevenueStreamsPlanBreakdownSection.tsx
@@ -11,7 +11,7 @@ import {
 import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { REVENUE_STREAMS_BREAKDOWN_PLAN_FILTER_PREFIX } from '~/core/constants/filters'
 import { getIntervalTranslationKey } from '~/core/constants/form'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -47,16 +47,11 @@ gql`
   }
 `
 
-type RevenueStreamsPlanBreakdownSectionProps = {
-  premiumWarningDialogRef: React.RefObject<PremiumWarningDialogRef>
-}
-
-export const RevenueStreamsPlanBreakdownSection = ({
-  premiumWarningDialogRef,
-}: RevenueStreamsPlanBreakdownSectionProps) => {
+export const RevenueStreamsPlanBreakdownSection = () => {
   const [searchParams] = useSearchParams()
   const { organization, hasOrganizationPremiumAddon } = useOrganizationInfos()
   const { translate } = useInternationalization()
+  const premiumWarningDialog = usePremiumWarningDialog()
 
   const hasAccessToAnalyticsDashboardsFeature = hasOrganizationPremiumAddon(
     PremiumIntegrationTypeEnum.AnalyticsDashboards,
@@ -105,7 +100,7 @@ export const RevenueStreamsPlanBreakdownSection = ({
               onClick={(e) => {
                 if (!hasAccessToAnalyticsDashboardsFeature) {
                   e.stopPropagation()
-                  premiumWarningDialogRef.current?.openDialog()
+                  premiumWarningDialog.open()
                 } else {
                   onClick()
                 }

--- a/src/pages/analytics/RevenueStreams.tsx
+++ b/src/pages/analytics/RevenueStreams.tsx
@@ -1,17 +1,14 @@
 import { Icon } from 'lago-design-system'
-import { useRef } from 'react'
 
 import { RevenueStreamsBreakdownSection } from '~/components/analytics/revenueStreams/RevenueStreamsBreakdownSection'
 import { RevenueStreamsOverviewSection } from '~/components/analytics/revenueStreams/RevenueStreamsOverviewSection'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { FullscreenPage } from '~/components/layouts/FullscreenPage'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 const RevenueStreams = () => {
   const { translate } = useInternationalization()
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
 
   return (
     <FullscreenPage.Wrapper>
@@ -26,11 +23,9 @@ const RevenueStreams = () => {
         </Tooltip>
       </Typography>
 
-      <RevenueStreamsOverviewSection premiumWarningDialogRef={premiumWarningDialogRef} />
+      <RevenueStreamsOverviewSection />
 
-      <RevenueStreamsBreakdownSection premiumWarningDialogRef={premiumWarningDialogRef} />
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
+      <RevenueStreamsBreakdownSection />
     </FullscreenPage.Wrapper>
   )
 }


### PR DESCRIPTION
## Summary

Migrates the `PremiumWarningDialog` usage on the Revenue Streams analytics page from the legacy ref-based `~/components/PremiumWarningDialog` to the new hook-based `usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`.

The shared dialog ref no longer needs to be threaded through component props — every section consumes the globally-registered NiceModal directly via the hook.

## Changes

- `src/pages/analytics/RevenueStreams.tsx` — drop the local `useRef`, the `<PremiumWarningDialog>` instance, and the prop wiring.
- `src/components/analytics/revenueStreams/RevenueStreamsBreakdownSection.tsx` — remove the pass-through `premiumWarningDialogRef` prop.
- `src/components/analytics/revenueStreams/RevenueStreamsOverviewSection.tsx` — replace ref consumption with `usePremiumWarningDialog().open()`.
- `src/components/analytics/revenueStreams/RevenueStreamsPlanBreakdownSection.tsx` — same migration.
- `src/components/analytics/revenueStreams/RevenueStreamsCustomerBreakdownSection.tsx` — same migration.

This clears 5 `no-restricted-imports` warnings about the deprecated `~/components/PremiumWarningDialog` import.

## Test plan

- [ ] On a non-premium organization, navigate to **Analytics → Revenue streams** and click the filter button on the overview, plan-breakdown, and customer-breakdown sections — the premium warning dialog should open in each case.
- [ ] On a premium organization, the same filter buttons should open the filters popper as before.
- [ ] `pnpm code:style` passes (no new warnings/errors on the modified files).

https://claude.ai/code/session_01SQFmi1ogMAmU7GELahezfU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQFmi1ogMAmU7GELahezfU)_