### PR TITLE
fix(deps): patch axios and @babel/plugin-transform-modules-systemjs CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@babel/preset-env": "7.29.3",
+    "@babel/preset-env": "7.29.5",
     "@babel/preset-react": "7.28.5",
     "@babel/preset-typescript": "7.28.5",
     "@emotion/react": "11.14.0",
@@ -188,6 +188,7 @@
   },
   "pnpm": {
     "overrides": {
+      "axios": ">=1.15.2",
       "flatted": ">=3.4.2",
       "svgo": ">=3.3.3",
       "follow-redirects": ">=1.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  axios: '>=1.15.2'
   flatted: '>=3.4.2'
   svgo: '>=3.3.3'
   follow-redirects: '>=1.16.0'
@@ -235,8 +236,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@babel/preset-env':
-        specifier: 7.29.3
-        version: 7.29.3(@babel/core@7.29.0)
+        specifier: 7.29.5
+        version: 7.29.5(@babel/core@7.29.0)
       '@babel/preset-react':
         specifier: 7.28.5
         version: 7.28.5(@babel/core@7.29.0)
@@ -401,7 +402,7 @@ importers:
         version: 16.0.0
       jscodeshift:
         specifier: 17.3.0
-        version: 17.3.0(@babel/preset-env@7.29.3(@babel/core@7.29.0))
+        version: 17.3.0(@babel/preset-env@7.29.5(@babel/core@7.29.0))
       npm-run-all2:
         specifier: 8.0.4
         version: 8.0.4
@@ -1111,8 +1112,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1327,8 +1328,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/preset-env@7.29.3':
-    resolution: {integrity: sha512-ySZypNLAIH1ClygLDQzVMoGQRViATnkHkYYV6TcNDz+8+jwZCdsguGvsb3EY5d9wyWyhmF1iSuFM0Yh5XPnqSA==}
+  '@babel/preset-env@7.29.5':
+    resolution: {integrity: sha512-/69t2aEzGKHD76DyLbHysF/QH2LJOB8iFnYO37unDTKBTubzcMRv0f3H5EiN1Q6ajOd/eB7dAInF0qdFVS06kA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4376,8 +4377,8 @@ packages:
     resolution: {integrity: sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==}
     engines: {node: '>=4'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -8808,7 +8809,7 @@ snapshots:
 
   '@babel/code-frame@7.27.1':
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -8871,7 +8872,7 @@ snapshots:
   '@babel/generator@7.28.5':
     dependencies:
       '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -9103,7 +9104,7 @@ snapshots:
 
   '@babel/parser@7.28.5':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.0':
     dependencies:
@@ -9473,7 +9474,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -9720,7 +9721,7 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.3(@babel/core@7.29.0)':
+  '@babel/preset-env@7.29.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/compat-data': 7.29.3
       '@babel/core': 7.29.0
@@ -9762,7 +9763,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
@@ -9886,8 +9887,8 @@ snapshots:
       '@babel/generator': 7.28.5
       '@babel/helper-globals': 7.28.0
       '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -9907,7 +9908,7 @@ snapshots:
   '@babel/types@7.28.4':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.28.5':
     dependencies:
@@ -10318,7 +10319,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/runtime': 7.28.6
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -11546,7 +11547,7 @@ snapshots:
 
   '@nangohq/types@0.70.1':
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       json-schema: 0.4.0
       type-fest: 4.41.0
     transitivePeerDependencies:
@@ -13053,7 +13054,7 @@ snapshots:
 
   axe-core@4.10.2: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -13094,7 +13095,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.6
       cosmiconfig: 7.1.0
-      resolve: 1.22.10
+      resolve: 1.22.11
 
   babel-plugin-polyfill-corejs2@0.4.15(@babel/core@7.29.0):
     dependencies:
@@ -14023,7 +14024,7 @@ snapshots:
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.16.1
-      resolve: 1.22.10
+      resolve: 1.22.11
     transitivePeerDependencies:
       - supports-color
 
@@ -15437,7 +15438,7 @@ snapshots:
 
   jsbn@0.1.1: {}
 
-  jscodeshift@17.3.0(@babel/preset-env@7.29.3(@babel/core@7.29.0)):
+  jscodeshift@17.3.0(@babel/preset-env@7.29.5(@babel/core@7.29.0)):
     dependencies:
       '@babel/core': 7.28.4
       '@babel/parser': 7.28.4
@@ -15458,7 +15459,7 @@ snapshots:
       tmp: 0.2.5
       write-file-atomic: 5.0.1
     optionalDependencies:
-      '@babel/preset-env': 7.29.3(@babel/core@7.29.0)
+      '@babel/preset-env': 7.29.5(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16631,7 +16632,7 @@ snapshots:
       postcss: 8.5.13
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
-      resolve: 1.22.10
+      resolve: 1.22.11
 
   postcss-js@4.0.1(postcss@8.5.13):
     dependencies:


### PR DESCRIPTION
## Summary

Two groups of security vulnerabilities fixed:

### 1. `@babel/plugin-transform-modules-systemjs` — [GHSA-fv7c-fp4j-7gwp](https://github.com/advisories/GHSA-fv7c-fp4j-7gwp) · **High (CVSS 8.2)**

- **Issue:** When compiling malicious input, Babel can generate arbitrary code in the output.
- **Affected path:** `lago-front → @babel/preset-env@7.29.3 → @babel/plugin-transform-modules-systemjs@7.29.0`
- **Fix:** Bump `@babel/preset-env` from `7.29.3` → `7.29.5` (direct devDependency). `@babel/preset-env@7.29.5` depends on `^7.29.4` of the plugin, picking up the patched version.

### 2. `axios` — 13 advisories including [GHSA-q8qp-cvcw-x6jj](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj) and others · **High/Moderate/Low**

- **Issue:** Multiple prototype pollution gadgets in axios (credential injection, request hijacking, SSRF, CRLF injection, DoS, auth bypass, etc.). All require `axios >=1.15.2`.
- **Affected path:** `lago-front → @nangohq/frontend@0.70.1 → @nangohq/types@0.70.1 → axios@1.15.0` (pinned exactly)
- **Blocker:** `@nangohq/types@0.70.1` is the latest release of the actively-maintained [NangoHQ/nango](https://github.com/NangoHQ/nango) — no upstream patch available yet (advisories published 2026-05-05).
- **Fix:** Add `pnpm.overrides` entry `"axios": ">=1.15.2"`. This is a last-resort measure; the override should be removed once NangoHQ publishes a new release with `axios >=1.15.2`.

> ⚠️ The axios override hides this specific vulnerability from future Dependabot/Renovate scans. A follow-up issue should be opened on [NangoHQ/nango](https://github.com/NangoHQ/nango) to track the upstream fix.

## Verification

```
pnpm audit → No known vulnerabilities found
axios installed: 1.16.0 (was 1.15.0)
@babel/plugin-transform-modules-systemjs installed: 7.29.4 (was 7.29.0)
```

## Test plan

- [ ] `pnpm audit` returns no vulnerabilities
- [ ] `pnpm install` succeeds without errors
- [ ] CI passes (no regressions from the babel/preset-env bump)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3XZFVBHG6Bf2a6dpkyrki)_