### PR TITLE
fix(invoices): refetch fees after edition

### DIFF
--- a/src/components/invoices/details/DeleteAdjustedFeeDialog.tsx
+++ b/src/components/invoices/details/DeleteAdjustedFeeDialog.tsx
@@ -53,7 +53,7 @@ export const DeleteAdjustedFeeDialog = forwardRef<DeleteAdjustedFeeDialogRef>((_
         })
       }
     },
-    refetchQueries: ['getInvoiceDetails'],
+    refetchQueries: ['getInvoiceDetails', 'getInvoiceFees'],
   })
 
   useImperativeHandle(ref, () => ({

--- a/src/components/invoices/details/EditFeeDrawer.tsx
+++ b/src/components/invoices/details/EditFeeDrawer.tsx
@@ -255,7 +255,7 @@ export const EditFeeDrawer = forwardRef<EditFeeDrawerRef>((_, ref) => {
         resetForm()
       }
     },
-    refetchQueries: ['getInvoiceDetails'],
+    refetchQueries: ['getInvoiceDetails', 'getInvoiceFees'],
   })
 
   const initialValues = useMemo(() => {


### PR DESCRIPTION
## Context

When editing a fee on a draft invoice, we have a stale state. The fee isn't updated but the total is

## Description

This PR forces to refetch the fee after edition and after destroy adjusted fee

<!-- Linear link -->
Fixes ISSUE-1802