### PR TITLE
fix(sentry log): report 404 NotFound errors to Sentry from useNotFoundRedirect hook

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"635740ac-d99a-451b-b23c-7e78c59b536e","pid":1778,"procStart":"Fri May  8 09:56:24 2026","acquiredAt":1778235730030}

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ v8-compile-cache*
 TestResults/
 docker-compose.worktree.yml
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 docs/

--- a/src/hooks/__tests__/useNotFoundRedirect.test.ts
+++ b/src/hooks/__tests__/useNotFoundRedirect.test.ts
@@ -1,10 +1,15 @@
 import { ApolloError } from '@apollo/client'
+import { captureException } from '@sentry/react'
 import { renderHook, waitFor } from '@testing-library/react'
 
 import { addToast } from '~/core/apolloClient'
 import { LagoApiError } from '~/generated/graphql'
 import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
 import { AllTheProviders } from '~/test-utils'
+
+jest.mock('@sentry/react', () => ({
+  captureException: jest.fn(),
+}))
 
 const mockNavigate = jest.fn()
 
@@ -62,6 +67,7 @@ describe('useNotFoundRedirect', () => {
 
         expect(mockNavigate).not.toHaveBeenCalled()
         expect(addToast).not.toHaveBeenCalled()
+        expect(captureException).not.toHaveBeenCalled()
       })
     })
   })
@@ -81,6 +87,7 @@ describe('useNotFoundRedirect', () => {
 
         expect(mockNavigate).not.toHaveBeenCalled()
         expect(addToast).not.toHaveBeenCalled()
+        expect(captureException).not.toHaveBeenCalled()
       })
     })
   })
@@ -99,6 +106,29 @@ describe('useNotFoundRedirect', () => {
 
         await waitFor(() => {
           expect(mockNavigate).toHaveBeenCalledWith('/resources', { replace: true })
+        })
+      })
+
+      it('THEN should report the error to Sentry', async () => {
+        const notFoundError = createNotFoundError()
+
+        renderHook(
+          () =>
+            useNotFoundRedirect({
+              ...defaultArgs,
+              error: notFoundError,
+            }),
+          { wrapper: customWrapper },
+        )
+
+        await waitFor(() => {
+          expect(captureException).toHaveBeenCalledWith(notFoundError, {
+            tags: {
+              errorType: 'NotFoundRedirect',
+              fromPath: window.location.pathname,
+              redirectTo: '/resources',
+            },
+          })
         })
       })
 
@@ -136,6 +166,7 @@ describe('useNotFoundRedirect', () => {
 
         expect(mockNavigate).not.toHaveBeenCalled()
         expect(addToast).not.toHaveBeenCalled()
+        expect(captureException).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/hooks/useNotFoundRedirect.ts
+++ b/src/hooks/useNotFoundRedirect.ts
@@ -1,4 +1,5 @@
 import { ApolloError } from '@apollo/client'
+import { captureException } from '@sentry/react'
 import { useEffect } from 'react'
 
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
@@ -22,6 +23,14 @@ export const useNotFoundRedirect = ({
 
   useEffect(() => {
     if (loading || !isNotFoundError) return
+
+    captureException(error, {
+      tags: {
+        errorType: 'NotFoundRedirect',
+        fromPath: window.location.pathname,
+        redirectTo,
+      },
+    })
 
     addToast({
       severity: 'info',


### PR DESCRIPTION
## Context

Show logs on Sentry for 404s in `useNotFoundRedirect` hook

## Description

Added captureException from `@sentry/react `inside the useNotFoundRedirect hook so 404 errors are reported to Sentry with contextual tags (errorType, fromPath, redirectTo) while keeping the Apollo error link silenced to avoid duplicate toasts. Updated tests to cover the new Sentry reporting.