### PR TITLE
chore: fix typing on permissions

### DIFF
--- a/src/pages/settings/teamAndSecurity/roles/common/__tests__/permissionsConst.test.ts
+++ b/src/pages/settings/teamAndSecurity/roles/common/__tests__/permissionsConst.test.ts
@@ -144,13 +144,6 @@ describe('permissionsConst', () => {
   })
 
   describe('permissionDescriptionMapping', () => {
-    it('has descriptions for all permissions in allPermissions', () => {
-      allPermissions.forEach((permission) => {
-        expect(permissionDescriptionMapping).toHaveProperty(permission)
-        expect(typeof permissionDescriptionMapping[permission]).toBe('string')
-      })
-    })
-
     it('has no orphaned descriptions (all keys are valid permissions)', () => {
       const descriptionKeys = Object.keys(permissionDescriptionMapping) as PermissionName[]
 
@@ -171,18 +164,15 @@ describe('permissionsConst', () => {
 
       expect(translationKeys).toHaveLength(uniqueKeys.length)
     })
-
-    it('covers all permission enum values', () => {
-      const enumKeys = Object.keys(PermissionEnum)
-      const descriptionKeys = Object.keys(permissionDescriptionMapping)
-
-      expect(descriptionKeys.sort()).toEqual(enumKeys.sort())
-    })
   })
 
   describe('data integrity across all constants', () => {
-    it('maintains consistency between allPermissions and permissionDescriptionMapping', () => {
-      expect(allPermissions.sort()).toEqual(Object.keys(permissionDescriptionMapping).sort())
+    it('permissionDescriptionMapping keys are a subset of allPermissions', () => {
+      const descriptionKeys = Object.keys(permissionDescriptionMapping) as PermissionName[]
+
+      descriptionKeys.forEach((key) => {
+        expect(allPermissions).toContain(key)
+      })
     })
 
     it('permissionGroupMapping only uses permissions from allPermissions', () => {

--- a/src/pages/settings/teamAndSecurity/roles/common/permissionsConst.ts
+++ b/src/pages/settings/teamAndSecurity/roles/common/permissionsConst.ts
@@ -131,7 +131,7 @@ export const groupNameMapping: Record<string, string> = {
   wallets: 'text_62d175066d2dbf1d50bc937c',
 }
 
-export const permissionDescriptionMapping: Record<PermissionName, string> = {
+export const permissionDescriptionMapping: Partial<Record<PermissionName, string>> = {
   // Addons
   AddonsCreate: 'text_1766047581847fumm5ku57ir',
   AddonsDelete: 'text_17660475818471if48pmb0dl',

--- a/src/pages/settings/teamAndSecurity/roles/hooks/__tests__/useGetPermissionGrouping.test.ts
+++ b/src/pages/settings/teamAndSecurity/roles/hooks/__tests__/useGetPermissionGrouping.test.ts
@@ -2,6 +2,10 @@ import { renderHook } from '@testing-library/react'
 
 import { useGetPermissionGrouping } from '../useGetPermissionGrouping'
 
+jest.mock('~/core/apolloClient', () => ({
+  envGlobalVar: () => ({ appEnv: 'production' }),
+}))
+
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({
     translate: (key: string) => key,
@@ -52,6 +56,14 @@ describe('useGetPermissionGrouping', () => {
     expect(result.current.permissionGrouping).toHaveProperty('other')
     expect(result.current.permissionGrouping.other.permissions).toHaveLength(1)
     expect(result.current.permissionGrouping.other.permissions[0].name).toBe('unknownPermission')
+  })
+
+  it('falls back to permission key name when description mapping is missing', () => {
+    const { result } = renderHook(() => useGetPermissionGrouping(['unknownPermission' as never]))
+
+    expect(result.current.permissionGrouping.other.permissions[0].description).toBe(
+      'unknownPermission',
+    )
   })
 
   it('adds multiple unmapped permissions to "other" key', () => {

--- a/src/pages/settings/teamAndSecurity/roles/hooks/useGetPermissionGrouping.ts
+++ b/src/pages/settings/teamAndSecurity/roles/hooks/useGetPermissionGrouping.ts
@@ -1,3 +1,5 @@
+import { envGlobalVar } from '~/core/apolloClient'
+import { AppEnvEnum } from '~/core/constants/globalTypes'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import {
   groupNameMapping,
@@ -16,7 +18,20 @@ export const useGetPermissionGrouping = (
   const { translate } = useInternationalization()
 
   const getPermissionDescription = (permissionName: PermissionName): string => {
-    return translate(permissionDescriptionMapping[permissionName]) || permissionName
+    const translationKey = permissionDescriptionMapping[permissionName]
+
+    if (!translationKey) {
+      const { appEnv } = envGlobalVar()
+
+      if (appEnv === AppEnvEnum.development) {
+        // eslint-disable-next-line no-console
+        console.warn(`Missing permission description mapping for: ${permissionName}`)
+      }
+
+      return permissionName
+    }
+
+    return translate(translationKey) || permissionName
   }
 
   const getPermissionGroupDisplayName = (groupKey: string): string => {


### PR DESCRIPTION
## Context

We use the generated typing PermissionName to create a mapping between the permission and it's description.
The issue was that when back end merges, front end will block every merge until the new permissions have their typing. Meaning multiple branches will be waiting for the fix to be merged to main

## Description

This PR fixes this merge issue by
- Using only partial typing
- Adding a console warn to explicitly help us find the missing key in the mapping

