### PR TITLE
fix(graduated pricing): calculation issue for graduated pricing

### DIFF
--- a/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
@@ -119,7 +119,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '1',
+            firstUnit: '2',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -170,7 +170,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2',
+            firstUnit: '3',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -222,7 +222,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '1',
+            firstUnit: '2',
             total: 9,
             perUnit: 0,
             flatFee: 0,
@@ -245,7 +245,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'perUnitAmount', '8'))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2',
+            firstUnit: '3',
             total: 17,
             perUnit: 0,
             flatFee: 0,
@@ -273,7 +273,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'flatAmount', '9'))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2',
+            firstUnit: '3',
             total: 26,
             perUnit: 0,
             flatFee: 0,
@@ -323,7 +323,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '4',
+            firstUnit: '5',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -347,7 +347,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'toValue', 8))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '8',
+            firstUnit: '9',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -453,7 +453,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '1',
+            firstUnit: '2',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -504,7 +504,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2',
+            firstUnit: '3',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -556,7 +556,7 @@ describe('useGraduatedRange()', () => {
 
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '1',
+            firstUnit: '2',
             total: 9,
             perUnit: 0,
             flatFee: 0,
@@ -579,7 +579,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'perUnitAmount', '8'))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2',
+            firstUnit: '3',
             total: 17,
             perUnit: 0,
             flatFee: 0,
@@ -607,7 +607,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'flatAmount', '9'))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '2',
+            firstUnit: '3',
             total: 26,
             perUnit: 0,
             flatFee: 0,
@@ -657,7 +657,7 @@ describe('useGraduatedRange()', () => {
         ])
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '4',
+            firstUnit: '5',
             total: 0,
             perUnit: 0,
             flatFee: 0,
@@ -681,7 +681,7 @@ describe('useGraduatedRange()', () => {
         await act(async () => await result.current.handleUpdate(1, 'toValue', 8))
         expect(result.current.infosCalculation).toStrictEqual([
           {
-            firstUnit: '8',
+            firstUnit: '9',
             total: 0,
             perUnit: 0,
             flatFee: 0,

--- a/src/hooks/plans/useGraduatedChargeForm.ts
+++ b/src/hooks/plans/useGraduatedChargeForm.ts
@@ -107,7 +107,7 @@ export const useGraduatedChargeForm: UseGraduatedChargeForm = ({
               firstUnit:
                 graduatedRanges.length === 1
                   ? `${ONE_TIER_EXAMPLE_UNITS}`
-                  : String(Number(range.fromValue) || 0),
+                  : String((Number(range.fromValue) || 0) + 1),
               total: acc.reduce<number>((accTotal, rangeCost) => {
                 return accTotal + rangeCost.total
               }, 0),


### PR DESCRIPTION
## Context

The graduated charge info bubble showed an off-by-one total. With tier 0 `0–250 @ $0` and tier 1 `250–∞ @ $0.02` it said "250 units would cost $0.02", but 250 units are entirely in tier 0 ($0). The $0.02 is actually the cost of 251 units.

## Description

Header label now uses `fromValue + 1`, matching the calculation (which already adds 1 unit at the last tier's rate) and the touching-boundary model. Tests updated.

<!-- Linear link -->
Fixes ISSUE-1894