### PR TITLE
chore(useMatch): Ban useMatch in favor of matchPath + strippedPathname

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,18 +54,24 @@
   // Wrong — triggers full MUI bundle parsing
   import { Button } from '@mui/material'
   ```
-- Never import `useNavigate`, `Link`, or `useLocation` from `react-router-dom`.
+- Never import `useNavigate`, `Link`, `useLocation`, or `useMatch` from `react-router-dom`.
   Import them from `~/core/router` — the slug-aware wrappers auto-prepend
   `/${organizationSlug}` to navigation targets and expose `strippedPathname`
-  on the location object. Enforced by the custom
-  `lago/no-direct-rrd-nav-import` ESLint rule. Other `react-router-dom`
-  exports (`useParams`, `matchPath`, `generatePath`, `Outlet`, etc.) are
-  unrestricted.
+  on the location object. Instead of `useMatch`, use `matchPath` (from
+  `react-router-dom`) with `strippedPathname` from the slug-aware
+  `useLocation` — this is the established pattern throughout the codebase.
+  Enforced by the custom `lago/no-direct-rrd-nav-import` ESLint rule.
+  Other `react-router-dom` exports (`useParams`, `matchPath`, `generatePath`,
+  `Outlet`, etc.) are unrestricted.
   ```typescript
-  // Correct
+  // Correct — slug-aware wrappers
   import { useNavigate, Link, useLocation } from '~/core/router'
-  // Wrong — bypasses slug-awareness, flagged by ESLint as error
-  import { useNavigate, Link, useLocation } from 'react-router-dom'
+  // Correct — route matching with strippedPathname
+  import { matchPath } from 'react-router-dom'
+  const { strippedPathname } = useLocation()
+  const match = matchPath(SOME_ROUTE, strippedPathname)
+  // Wrong — useMatch uses raw pathname (includes slug), never matches
+  import { useMatch } from 'react-router-dom'
   ```
 
 ## Organization slug architecture

--- a/packages/configs/eslint-rules/no-direct-rrd-nav-import.js
+++ b/packages/configs/eslint-rules/no-direct-rrd-nav-import.js
@@ -1,29 +1,31 @@
 /**
- * ESLint rule to forbid importing `useNavigate`, `Link`, and `useLocation`
- * directly from `react-router-dom`. These must be imported from
+ * ESLint rule to forbid importing `useNavigate`, `Link`, `useLocation`, and
+ * `useMatch` directly from `react-router-dom`. These must be imported from
  * `~/core/router` so the org slug is automatically prepended (for
- * `useNavigate`/`Link`) or so `strippedPathname` is available (for
- * `useLocation`).
+ * `useNavigate`/`Link`) or `strippedPathname` is available (for
+ * `useLocation`). `useMatch` is banned because it matches against the
+ * full pathname (including the slug prefix), so route constants never
+ * match — use `matchPath` + `strippedPathname` instead.
  *
  * Exceptions (auth callbacks, Error404, and the wrappers themselves) can
  * opt out with an `// eslint-disable-next-line` comment on the import.
  */
 
-const RESTRICTED = new Set(['useNavigate', 'Link', 'useLocation'])
+const RESTRICTED = new Set(['useNavigate', 'Link', 'useLocation', 'useMatch'])
 
 export default {
   meta: {
     type: 'problem',
     docs: {
       description:
-        "Disallow importing useNavigate, Link, and useLocation from 'react-router-dom'. Use '~/core/router' so the org slug is prepended and strippedPathname is available.",
+        "Disallow importing useNavigate, Link, useLocation, and useMatch from 'react-router-dom'. Use '~/core/router' for slug-aware wrappers. useMatch is banned — use matchPath + strippedPathname instead.",
       recommended: true,
     },
     fixable: null,
     schema: [],
     messages: {
       noDirectImport:
-        "Import '{{name}}' from '~/core/router' instead of 'react-router-dom' to ensure the org slug is prepended automatically (useNavigate/Link) or strippedPathname is available (useLocation).",
+        "Import '{{name}}' from '~/core/router' instead of 'react-router-dom' to ensure the org slug is prepended automatically (useNavigate/Link) or strippedPathname is available (useLocation). useMatch is banned — use matchPath + strippedPathname instead.",
     },
   },
   create(context) {


### PR DESCRIPTION
  ## Context

  `useMatch` from react-router-dom matches against the full URL pathname
  which includes the `/:organizationSlug` prefix. Route constants are
  defined without this prefix, so `useMatch` never matches — this caused
  the billable metric duplication bug (ISSUE-1895).

  ## Description

  - Add `useMatch` to the `lago/no-direct-rrd-nav-import` ESLint rule restricted set, preventing future usage.
  - Update CLAUDE.md to document the ban and the established `matchPath` + `strippedPathname` pattern as the replacement.
  - Align `CreateBillableMetric.tsx` with the codebase-wide pattern (`matchPath` + `strippedPathname` from slug-aware `useLocation`).