### PR TITLE
chore(dialogs): migrate UsageBillableMetric to usePremiumWarningDialog hook

### DIFF
--- a/src/pages/analytics/UsageBillableMetric.tsx
+++ b/src/pages/analytics/UsageBillableMetric.tsx
@@ -1,5 +1,5 @@
 import { tw } from 'lago-design-system'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { AnalyticsStateProvider } from '~/components/analytics/AnalyticsStateContext'
@@ -16,9 +16,9 @@ import StackedBarChart from '~/components/designSystem/graphs/StackedBarChart'
 import { getItemDateFormatedByTimeGranularity } from '~/components/designSystem/graphs/utils'
 import { HorizontalDataTable } from '~/components/designSystem/Table/HorizontalDataTable'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { PageBannerHeaderWithBurgerMenu } from '~/components/layouts/CenteredPage'
 import { FullscreenPage } from '~/components/layouts/FullscreenPage'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { ANALYTICS_USAGE_BILLABLE_METRIC_FILTER_PREFIX } from '~/core/constants/filters'
 import { NewAnalyticsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -61,7 +61,7 @@ const AmountCell = ({ value, currency, displayFormat }: AmountCellProps) => {
 
 const UsageBillableMetric = () => {
   const { translate } = useInternationalization()
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const navigate = useNavigate()
 
   const { billableMetricCode } = useParams()
@@ -144,7 +144,7 @@ const UsageBillableMetric = () => {
                 onClick={(e) => {
                   if (!hasAccessToAnalyticsDashboardsFeature) {
                     e.stopPropagation()
-                    premiumWarningDialogRef.current?.openDialog()
+                    openPremiumWarningDialog()
                   } else {
                     onClick()
                   }
@@ -257,8 +257,6 @@ const UsageBillableMetric = () => {
           </div>
         </div>
       </FullscreenPage.Wrapper>
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </>
   )
 }


### PR DESCRIPTION
## Summary

Migrates `src/pages/analytics/UsageBillableMetric.tsx` from the deprecated imperative ref-based `PremiumWarningDialog` to the new hook-based `usePremiumWarningDialog`. This fixes one of the `no-restricted-imports` lint warnings about the legacy dialog system.

### Changes

- Replaced `import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'` with `import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'`
- Replaced `useRef<PremiumWarningDialogRef>(null)` with `const { open: openPremiumWarningDialog } = usePremiumWarningDialog()`
- Replaced `premiumWarningDialogRef.current?.openDialog()` with `openPremiumWarningDialog()`
- Removed the `<PremiumWarningDialog ref={...} />` JSX element (the dialog is now rendered via NiceModal)
- Removed the now-unused `useRef` React import

### Scope

The change is scoped to this single file — the dialog ref was created and consumed locally, so no other consumer files needed to be touched. No other deprecated dialogs are present in this file.

## Test plan

- [x] `pnpm eslint src/pages/analytics/UsageBillableMetric.tsx` — no warnings
- [x] `pnpm exec tsc --noEmit` — clean
- [x] Total project lint warnings dropped from 507 to 506
- [ ] Manual: navigate to a billable metric usage page as a non-premium user and click the "Filter" button — the premium warning dialog should open


---
_Generated by [Claude Code](https://claude.ai/code/session_01JGYyULrv3cRXqUJTURYWcD)_