### PR TITLE
refactor(plans): migrate ChargePercentage to usePremiumWarningDialog hook

### DIFF
--- a/src/components/plans/ChargePercentage.tsx
+++ b/src/components/plans/ChargePercentage.tsx
@@ -1,13 +1,13 @@
 import { gql } from '@apollo/client'
 import InputAdornment from '@mui/material/InputAdornment'
-import { memo, RefObject, useCallback } from 'react'
+import { memo, useCallback } from 'react'
 
 import { Alert } from '~/components/designSystem/Alert'
 import { Button } from '~/components/designSystem/Button'
 import { Popper } from '~/components/designSystem/Popper'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { useChargeFormContext, usePropertyValues } from '~/contexts/ChargeFormContext'
 import { getCurrencySymbol, intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -34,15 +34,12 @@ gql`
   }
 `
 
-interface ChargePercentageProps {
-  premiumWarningDialogRef?: RefObject<PremiumWarningDialogRef>
-}
-
-export const ChargePercentage = memo(({ premiumWarningDialogRef }: ChargePercentageProps) => {
+export const ChargePercentage = memo(() => {
   const { form, propertyCursor, currency, disabled, chargePricingUnitShortName } =
     useChargeFormContext()
   const { translate } = useInternationalization()
   const { isPremium } = useCurrentUser()
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const valuePointer = usePropertyValues(form, propertyCursor)
 
   const showFixedAmount = valuePointer?.fixedAmount !== undefined
@@ -469,7 +466,7 @@ export const ChargePercentage = memo(({ premiumWarningDialogRef }: ChargePercent
                       perTransactionMinAmount: '',
                     })
                   } else {
-                    premiumWarningDialogRef?.current?.openDialog()
+                    openPremiumWarningDialog()
                   }
 
                   closePopper()
@@ -490,7 +487,7 @@ export const ChargePercentage = memo(({ premiumWarningDialogRef }: ChargePercent
                       perTransactionMaxAmount: '',
                     })
                   } else {
-                    premiumWarningDialogRef?.current?.openDialog()
+                    openPremiumWarningDialog()
                   }
 
                   closePopper()

--- a/src/components/plans/chargeAccordion/ChargeWrapperSwitch.tsx
+++ b/src/components/plans/chargeAccordion/ChargeWrapperSwitch.tsx
@@ -1,5 +1,5 @@
 import { type AnyFormApi } from '@tanstack/react-form'
-import { memo, RefObject } from 'react'
+import { memo } from 'react'
 
 import { ChargePercentage } from '~/components/plans/ChargePercentage'
 import { CustomCharge } from '~/components/plans/CustomCharge'
@@ -11,7 +11,6 @@ import PricingGroupKeys from '~/components/plans/PricingGroupKeys'
 import { StandardCharge } from '~/components/plans/StandardCharge'
 import { LocalFixedChargeInput, LocalUsageChargeInput } from '~/components/plans/types'
 import { VolumeChargeTable } from '~/components/plans/VolumeChargeTable'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { ChargeFormProvider } from '~/contexts/ChargeFormContext'
 import { ALL_CHARGE_MODELS } from '~/core/constants/form'
 import { CurrencyEnum } from '~/generated/graphql'
@@ -24,7 +23,6 @@ interface ChargeWrapperSwitchProps {
   form: AnyFormApi
   isEdition: boolean
   localCharge: LocalFixedChargeInput | LocalUsageChargeInput
-  premiumWarningDialogRef?: RefObject<PremiumWarningDialogRef>
   propertyCursor: string
   onExpandCustomCharge?: (currentValue: string | undefined) => void
 }
@@ -37,7 +35,6 @@ export const ChargeWrapperSwitch = memo(
     disabled,
     form,
     localCharge,
-    premiumWarningDialogRef,
     propertyCursor,
     onExpandCustomCharge,
   }: ChargeWrapperSwitchProps) => {
@@ -58,9 +55,7 @@ export const ChargeWrapperSwitch = memo(
           {localCharge?.chargeModel === ALL_CHARGE_MODELS.GraduatedPercentage && (
             <GraduatedPercentageChargeTable />
           )}
-          {localCharge?.chargeModel === ALL_CHARGE_MODELS.Percentage && (
-            <ChargePercentage premiumWarningDialogRef={premiumWarningDialogRef} />
-          )}
+          {localCharge?.chargeModel === ALL_CHARGE_MODELS.Percentage && <ChargePercentage />}
           {localCharge?.chargeModel === ALL_CHARGE_MODELS.Volume && <VolumeChargeTable />}
           {localCharge?.chargeModel === ALL_CHARGE_MODELS.Custom && (
             <CustomCharge onExpandCustomCharge={onExpandCustomCharge} />

--- a/src/components/plans/drawers/usageCharge/ChargeFilterDrawerContent.tsx
+++ b/src/components/plans/drawers/usageCharge/ChargeFilterDrawerContent.tsx
@@ -1,5 +1,4 @@
 import { useStore } from '@tanstack/react-form'
-import { RefObject } from 'react'
 import { z } from 'zod'
 
 import { Chip } from '~/components/designSystem/Chip'
@@ -8,7 +7,6 @@ import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { ChargeFilter } from '~/components/plans/chargeAccordion/ChargeFilter'
 import { ChargeWrapperSwitch } from '~/components/plans/chargeAccordion/ChargeWrapperSwitch'
 import { LocalChargeFilterInput, LocalUsageChargeInput } from '~/components/plans/types'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { useChargeFilterDrawerContext } from '~/contexts/ChargeFilterDrawerContext'
 import { chargeModelLookupTranslation } from '~/core/constants/form'
 import {
@@ -53,7 +51,6 @@ const chargeFilterDefaultValues: ChargeFilterFormValues = {
 interface ChargeFilterDrawerContentExtraProps {
   billableMetricFilters: BillableMetricFilter[]
   existingFilterValues?: Set<string>
-  premiumWarningDialogRef?: RefObject<PremiumWarningDialogRef>
   chargeIndex: number
   filterIndex: number
 }
@@ -61,7 +58,6 @@ interface ChargeFilterDrawerContentExtraProps {
 const chargeFilterDrawerContentDefaultProps: ChargeFilterDrawerContentExtraProps = {
   billableMetricFilters: [],
   existingFilterValues: undefined,
-  premiumWarningDialogRef: undefined,
   chargeIndex: 0,
   filterIndex: 0,
 }
@@ -73,7 +69,6 @@ export const ChargeFilterDrawerContent = withForm({
     form,
     billableMetricFilters,
     existingFilterValues,
-    premiumWarningDialogRef,
     chargeIndex,
     filterIndex,
   }) {
@@ -152,7 +147,6 @@ export const ChargeFilterDrawerContent = withForm({
                 form={form}
                 isEdition={isEdition}
                 localCharge={{ chargeModel } as LocalUsageChargeInput}
-                premiumWarningDialogRef={premiumWarningDialogRef}
                 propertyCursor="properties"
               />
             </CenteredPage.PageSection>

--- a/src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx
+++ b/src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx
@@ -377,7 +377,6 @@ export const UsageChargeDrawerContent = withForm({
               form={filterForm}
               billableMetricFilters={form.state.values.billableMetric?.filters || []}
               existingFilterValues={existingFilterValues}
-              premiumWarningDialogRef={premiumWarningDialogRef}
               chargeIndex={editIndex}
               filterIndex={currentFilterIndex}
             />
@@ -602,7 +601,6 @@ export const UsageChargeDrawerContent = withForm({
                   form={form}
                   isEdition={isEdition || false}
                   localCharge={formValues as unknown as LocalUsageChargeInput}
-                  premiumWarningDialogRef={premiumWarningDialogRef}
                   propertyCursor="properties"
                   onExpandCustomCharge={openCustomChargeDrawer}
                 />


### PR DESCRIPTION
## Summary

Migrates the `PremiumWarningDialog` usage triggered from the percentage charge model (min/max per-transaction amount premium prompts) from the legacy ref-based `~/components/PremiumWarningDialog` to the hook-based `~/components/dialogs/PremiumWarningDialog`.

The shared dialog ref no longer needs to be threaded through `ChargeWrapperSwitch` / `ChargeFilterDrawerContent`, so the pass-through prop is dropped on the path that leads to `ChargePercentage`. `UsageChargeDrawerContent` keeps its own local ref usage (lines 246 & 728) because those direct usages are outside the scope of this PR and will be migrated separately.

## Changes

- `src/components/plans/ChargePercentage.tsx` — replace ref consumption with `usePremiumWarningDialog().open()`, drop the `premiumWarningDialogRef` prop entirely.
- `src/components/plans/chargeAccordion/ChargeWrapperSwitch.tsx` — drop the pass-through `premiumWarningDialogRef` prop (and the unused `RefObject` / `PremiumWarningDialogRef` imports).
- `src/components/plans/drawers/usageCharge/ChargeFilterDrawerContent.tsx` — drop the pass-through `premiumWarningDialogRef` prop (and the now-unused imports).
- `src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx` — stop forwarding the ref to `ChargeWrapperSwitch` and `ChargeFilterDrawerContent`. The local ref usages stay (separate migration).

This clears 3 `no-restricted-imports` warnings about the deprecated `~/components/PremiumWarningDialog` import (total project warnings: 507 → 504).

## Test plan

- [x] On a non-premium organization, open the **Create plan** flow, add a **usage charge** with the **Percentage** charge model, expand the "Min/Max per transaction" popper and click either "Min amount" or "Max amount" — the premium warning dialog must open.
- [x] On the same flow but inside a **Charge filter drawer** (Percentage filter), the same min/max popper items still trigger the premium warning dialog.
- [x] On a premium organization, the min/max popper items add the min/max input fields as before.
- [x] `pnpm code:style` passes (no new warnings/errors on the modified files).

https://claude.ai/code/session_01DX36dTA2xoK48TL2XyPioM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DX36dTA2xoK48TL2XyPioM)_