### PR TITLE
refactor(analytics): migrate Usage PremiumWarningDialog to hook-based system

### DIFF
--- a/src/components/analytics/usage/UsageOverviewSection.tsx
+++ b/src/components/analytics/usage/UsageOverviewSection.tsx
@@ -12,19 +12,16 @@ import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder
 import AreaChart from '~/components/designSystem/graphs/AreaChart'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { ANALYTICS_USAGE_OVERVIEW_FILTER_PREFIX } from '~/core/constants/filters'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import ErrorImage from '~/public/images/maneki/error.svg'
 
-type UsageOverviewSectionProps = {
-  premiumWarningDialogRef: React.RefObject<PremiumWarningDialogRef>
-}
-
-const UsageOverviewSection = ({ premiumWarningDialogRef }: UsageOverviewSectionProps) => {
+const UsageOverviewSection = () => {
   const { translate } = useInternationalization()
+  const premiumWarningDialog = usePremiumWarningDialog()
 
   const {
     selectedCurrency,
@@ -60,7 +57,7 @@ const UsageOverviewSection = ({ premiumWarningDialogRef }: UsageOverviewSectionP
             onClick={(e) => {
               if (!hasAccessToAnalyticsDashboardsFeature) {
                 e.stopPropagation()
-                premiumWarningDialogRef.current?.openDialog()
+                premiumWarningDialog.open()
               } else {
                 onClick()
               }

--- a/src/pages/analytics/Usage.tsx
+++ b/src/pages/analytics/Usage.tsx
@@ -1,20 +1,13 @@
-import { useRef } from 'react'
-
 import UsageBreakdownSection from '~/components/analytics/usage/UsageBreakdownSection'
 import UsageOverviewSection from '~/components/analytics/usage/UsageOverviewSection'
 import { FullscreenPage } from '~/components/layouts/FullscreenPage'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 
 const Usage = () => {
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
-
   return (
     <FullscreenPage.Wrapper>
-      <UsageOverviewSection premiumWarningDialogRef={premiumWarningDialogRef} />
+      <UsageOverviewSection />
 
       <UsageBreakdownSection />
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </FullscreenPage.Wrapper>
   )
 }


### PR DESCRIPTION
## Summary

Migrates the `PremiumWarningDialog` usage in the Usage analytics page from the legacy imperative `forwardRef` + `useImperativeHandle` pattern to the new hook-based NiceModal system (`usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`).

This addresses the `no-restricted-imports` ESLint warning that flags `~/components/PremiumWarningDialog` as deprecated.

### Changes

- **`src/pages/analytics/Usage.tsx`**: removed the `useRef<PremiumWarningDialogRef>`, the legacy `PremiumWarningDialog` import and its JSX rendering, and the prop passed down to `UsageOverviewSection` — the dialog is now rendered via NiceModal so the page no longer needs to host it.
- **`src/components/analytics/usage/UsageOverviewSection.tsx`**: dropped the `premiumWarningDialogRef` prop (and its type), imported `usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`, and replaced `premiumWarningDialogRef.current?.openDialog()` with `premiumWarningDialog.open()`.

Scope was kept minimal: only the `PremiumWarningDialog` migration in these two files. No other deprecated imports in this surface area.

## Test plan

- [ ] `pnpm code:style` passes (verified locally — warning count went from 498 → 496, confirming the two `PremiumWarningDialog` warnings on these files are gone)
- [ ] Visit the Usage analytics page as a non-premium user and confirm the filter button still opens the Premium warning dialog
- [ ] As a premium user, the filter button opens the filters drawer as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013wLZCAiAPmgixPfKJ1K5Cu)_