### PR TITLE
test(e2e): fix skipped e2e tests

### DIFF
--- a/cypress/e2e/10-resources/t10-create-taxes.cy.ts
+++ b/cypress/e2e/10-resources/t10-create-taxes.cy.ts
@@ -2,6 +2,7 @@ import {
   APPLY_TAX_BUTTON_TEST_ID,
   APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID,
 } from '~/pages/settings/BillingEntity/sections/taxes/dataTestConstants'
+
 import {
   TAX_TEN_CODE,
   TAX_TEN_NAME,

--- a/cypress/e2e/10-resources/t10-create-taxes.cy.ts
+++ b/cypress/e2e/10-resources/t10-create-taxes.cy.ts
@@ -1,7 +1,7 @@
 import {
   APPLY_TAX_BUTTON_TEST_ID,
   APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID,
-} from '../../src/pages/settings/BillingEntity/sections/taxes/dataTestConstants'
+} from '~/pages/settings/BillingEntity/sections/taxes/dataTestConstants'
 import {
   TAX_TEN_CODE,
   TAX_TEN_NAME,

--- a/cypress/e2e/10-resources/t10-create-taxes.cy.ts
+++ b/cypress/e2e/10-resources/t10-create-taxes.cy.ts
@@ -43,14 +43,14 @@ describe('Create taxes', () => {
 
   it('should assign tax to billing entity', () => {
     // Navigate to settings — auto-redirects to default billing entity page
+    // after the billing entities GraphQL query resolves
     cy.visitApp('/settings')
+    cy.url().should('include', '/billing-entity/')
 
     // Extract billing entity code from redirected URL
     cy.url().then((url) => {
       const match = url.match(/billing-entity\/([^/]+)/)
-      const billingEntityCode = match?.[1]
-
-      expect(billingEntityCode).to.exist
+      const billingEntityCode = match?.[1] as string
 
       // Navigate to the billing entity's taxes settings
       cy.visitApp(`/settings/billing-entity/${billingEntityCode}/taxes`)

--- a/cypress/e2e/10-resources/t10-create-taxes.cy.ts
+++ b/cypress/e2e/10-resources/t10-create-taxes.cy.ts
@@ -1,11 +1,15 @@
 import {
+  APPLY_TAX_BUTTON_TEST_ID,
+  APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID,
+} from '../../src/pages/settings/BillingEntity/sections/taxes/dataTestConstants'
+import {
   TAX_TEN_CODE,
   TAX_TEN_NAME,
   TAX_TWENTY_CODE,
   TAX_TWENTY_NAME,
 } from '../../support/reusableConstants'
 
-describe.skip('Create taxes', () => {
+describe('Create taxes', () => {
   beforeEach(() => {
     cy.login()
   })
@@ -37,19 +41,39 @@ describe.skip('Create taxes', () => {
     cy.get(`[data-test="${TAX_TWENTY_CODE}"]`).should('exist')
   })
 
-  it('should assign tax to organization', () => {
-    cy.visitApp('/settings/invoice')
-    cy.url().should('include', '/settings/invoice')
+  it('should assign tax to billing entity', () => {
+    // Navigate to settings — auto-redirects to default billing entity page
+    cy.visitApp('/settings')
 
-    // Make sure no tax are already assigned
-    cy.get('[data-test="table-invoice-settings-taxes"]').should('not.exist')
+    // Extract billing entity code from redirected URL
+    cy.url().then((url) => {
+      const match = url.match(/billing-entity\/([^/]+)/)
+      const billingEntityCode = match?.[1]
 
-    // Assign tax 20%
-    cy.get('[data-test="add-tax-button"]').click()
-    cy.get('[data-test="add-organization-tax-dialog"]').should('exist')
-    cy.get('input[name="selectTax"]').click()
-    cy.get('[data-option-index="1"]').click()
-    cy.get('[data-test="submit-add-organization-tax-dialog-assign-button"]').click()
-    cy.get(`[data-test="applied-tax-${TAX_TWENTY_CODE}"]`).should('exist')
+      expect(billingEntityCode).to.exist
+
+      // Navigate to the billing entity's taxes settings
+      cy.visitApp(`/settings/billing-entity/${billingEntityCode}/taxes`)
+      cy.url().should('include', `/settings/billing-entity/${billingEntityCode}/taxes`)
+
+      // Make sure no taxes are already assigned
+      cy.get('[data-test="table-billing-entity-taxes"]').should('not.exist')
+
+      // Apply the 20% tax to the billing entity
+      cy.get(`[data-test="${APPLY_TAX_BUTTON_TEST_ID}"]`).click()
+      cy.get(`[data-test="${APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID}"]`).should('exist')
+
+      // Search and select the tax in the ComboBox
+      cy.get('input[name="billingEntityApplyTaxes"]').click()
+      cy.get('input[name="billingEntityApplyTaxes"]').type(TAX_TWENTY_NAME)
+      cy.get('[data-option-index="0"]').click()
+
+      // Submit the dialog
+      cy.get(`[data-test="${APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID}"]`).click()
+
+      // Verify the tax appears in the table
+      cy.get('[data-test="table-billing-entity-taxes"]').should('exist')
+      cy.get(`[data-test="${TAX_TWENTY_CODE}"]`).should('exist')
+    })
   })
 })

--- a/cypress/e2e/t30-create-one-off-invoice.cy.ts
+++ b/cypress/e2e/t30-create-one-off-invoice.cy.ts
@@ -64,10 +64,10 @@ describe('Create one-off', () => {
 
     cy.get('[data-test="create-invoice-button"]').click({ force: true })
 
-    // Check created invoice amounts display
-    cy.get('[data-test="navigation-tab-bar"]').within(() => {
-      cy.get('[role="tab"]').contains('Invoices').click({ force: true })
-    })
+    // Check created invoice amounts display — navigate to invoices tab
+    cy.get('[data-test="navigation-tab-bar"] [role="tab"]')
+      .contains('Invoices')
+      .click({ force: true })
     cy.get('#table-customer-invoices-row-0').should('exist')
 
     cy.get('#table-customer-invoices-row-0')

--- a/cypress/e2e/t30-create-one-off-invoice.cy.ts
+++ b/cypress/e2e/t30-create-one-off-invoice.cy.ts
@@ -128,7 +128,10 @@ describe('Create one-off', () => {
       // - 10% tax on $10,065.66 = $1,006.57
       // - Total = $10,065.66 + $2,013.13 + $1,006.57 = $13,085.36
       cy.get('[data-test="one-off-invoice-subtotal-value"]').should('have.text', '$10,065.66')
-      cy.get('[data-test="one-off-invoice-tax-item-0-label"]').should('have.text', 'Twenty tax (20%)')
+      cy.get('[data-test="one-off-invoice-tax-item-0-label"]').should(
+        'have.text',
+        'Twenty tax (20%)',
+      )
       cy.get('[data-test="one-off-invoice-tax-item-0-value"]').should('have.text', '$2,013.13')
       cy.get('[data-test="one-off-invoice-tax-item-1-label"]').should('have.text', 'Ten tax (10%)')
       cy.get('[data-test="one-off-invoice-tax-item-1-value"]').should('have.text', '$1,006.57')

--- a/cypress/e2e/t30-create-one-off-invoice.cy.ts
+++ b/cypress/e2e/t30-create-one-off-invoice.cy.ts
@@ -52,9 +52,9 @@ describe('Create one-off', () => {
     // - 10% on $3,020.00 = $302.00 (applied to item with ten_tax only)
     // - Total = $6,040.00 + $1,208.00 + $302.00 = $7,550.00
     cy.get('[data-test="one-off-invoice-subtotal-value"]').should('have.text', '$6,040.00')
-    cy.get('[data-test="one-off-invoice-tax-item-0-label"]').should('have.text', 'twenty (20%)')
+    cy.get('[data-test="one-off-invoice-tax-item-0-label"]').should('have.text', 'Twenty tax (20%)')
     cy.get('[data-test="one-off-invoice-tax-item-0-value"]').should('have.text', '$1,208.00')
-    cy.get('[data-test="one-off-invoice-tax-item-1-label"]').should('have.text', 'ten (10%)')
+    cy.get('[data-test="one-off-invoice-tax-item-1-label"]').should('have.text', 'Ten tax (10%)')
     cy.get('[data-test="one-off-invoice-tax-item-1-value"]').should('have.text', '$302.00')
     cy.get('[data-test="one-off-invoice-subtotal-amount-due-value"]').should(
       'have.text',
@@ -82,7 +82,7 @@ describe('Create one-off', () => {
     )
     cy.get('[data-test="invoice-details-table-footer-tax-0-label"]').should(
       'have.text',
-      'twenty (20.00% on $6,040.00)',
+      'Twenty tax (20.00% on $6,040.00)',
     )
     cy.get('[data-test="invoice-details-table-footer-tax-0-value"]').should(
       'have.text',
@@ -90,7 +90,7 @@ describe('Create one-off', () => {
     )
     cy.get('[data-test="invoice-details-table-footer-tax-1-label"]').should(
       'have.text',
-      'ten (10.00% on $3,020.00)',
+      'Ten tax (10.00% on $3,020.00)',
     )
     cy.get('[data-test="invoice-details-table-footer-tax-1-value"]').should('have.text', '$302.00')
     cy.get('[data-test="invoice-details-table-footer-subtotal-incl-tax-value"]').should(
@@ -136,9 +136,9 @@ describe('Create one-off', () => {
       // - 10% tax on $10,065.66 = $1,006.57
       // - Total = $10,065.66 + $2,013.13 + $1,006.57 = $13,085.36
       cy.get('[data-test="one-off-invoice-subtotal-value"]').should('have.text', '$10,065.66')
-      cy.get('[data-test="one-off-invoice-tax-item-0-label"]').should('have.text', 'twenty (20%)')
+      cy.get('[data-test="one-off-invoice-tax-item-0-label"]').should('have.text', 'Twenty tax (20%)')
       cy.get('[data-test="one-off-invoice-tax-item-0-value"]').should('have.text', '$2,013.13')
-      cy.get('[data-test="one-off-invoice-tax-item-1-label"]').should('have.text', 'ten (10%)')
+      cy.get('[data-test="one-off-invoice-tax-item-1-label"]').should('have.text', 'Ten tax (10%)')
       cy.get('[data-test="one-off-invoice-tax-item-1-value"]').should('have.text', '$1,006.57')
       cy.get('[data-test="one-off-invoice-subtotal-amount-due-value"]').should(
         'have.text',

--- a/cypress/e2e/t30-create-one-off-invoice.cy.ts
+++ b/cypress/e2e/t30-create-one-off-invoice.cy.ts
@@ -64,18 +64,10 @@ describe('Create one-off', () => {
 
     cy.get('[data-test="create-invoice-button"]').click({ force: true })
 
-    // Check created invoice amounts display — navigate to invoices tab
-    cy.get('[data-test="navigation-tab-bar"] [role="tab"]')
-      .contains('Invoices')
-      .click({ force: true })
-    cy.get('#table-customer-invoices-row-0').should('exist')
+    // After creation, the app navigates to the invoice detail page (overview tab)
+    cy.url().should('include', '/overview')
 
-    cy.get('#table-customer-invoices-row-0')
-      .focus()
-      .click({ force: true })
-      .url()
-      .should('include', '/overview')
-
+    // Verify invoice amounts on the detail page
     cy.get('[data-test="invoice-details-table-footer-subtotal-excl-tax-value"]').should(
       'have.text',
       '$6,040.00',

--- a/cypress/e2e/t30-create-one-off-invoice.cy.ts
+++ b/cypress/e2e/t30-create-one-off-invoice.cy.ts
@@ -5,7 +5,7 @@ import {
 
 import { customerName } from '../support/reusableConstants'
 
-describe.skip('Create one-off', () => {
+describe('Create one-off', () => {
   beforeEach(() => {
     cy.login()
   })
@@ -22,7 +22,7 @@ describe.skip('Create one-off', () => {
     cy.get('[data-option-index="0"]').click({ force: true })
     cy.get('[data-test="invoice-item"]').should('have.length', 1)
 
-    // Edit it's tax rate
+    // Edit its tax rate
     cy.get('[data-test="invoice-item-actions-button"]').click({ force: true })
     cy.get('[data-test="invoice-item-edit-taxes"]').click({ force: true })
     cy.get(`[data-test="add-tax-button"]`).click({ force: true })
@@ -34,7 +34,7 @@ describe.skip('Create one-off', () => {
 
     cy.get('[role="dialog"]').should('not.exist')
 
-    // Add another item
+    // Add another item (same add-on, default taxes only)
     cy.get('[data-test="add-item-button"]').click({ force: true })
     cy.get('[data-option-index="0"]').click({ force: true })
     cy.get('[data-test="invoice-item"]').should('have.length', 2)
@@ -43,6 +43,14 @@ describe.skip('Create one-off', () => {
     cy.get('[data-test="one-off-invoice-tax-item-1"]').should('exist')
     cy.get('[data-test="one-off-invoice-tax-item-2"]').should('not.exist')
 
+    // Amount math:
+    // - Add-on unit price: $3,020.00 (from seed data)
+    // - 2 items x $3,020.00 = $6,040.00 subtotal
+    // - Item 1 has 20% tax (twenty_tax) added manually + 10% org-level tax (ten_tax)
+    // - Item 2 has only the 10% org-level tax (ten_tax) applied via billing entity
+    // - 20% on $6,040.00 = $1,208.00
+    // - 10% on $3,020.00 = $302.00 (applied to item with ten_tax only)
+    // - Total = $6,040.00 + $1,208.00 + $302.00 = $7,550.00
     cy.get('[data-test="one-off-invoice-subtotal-value"]').should('have.text', '$6,040.00')
     cy.get('[data-test="one-off-invoice-tax-item-0-label"]').should('have.text', 'twenty (20%)')
     cy.get('[data-test="one-off-invoice-tax-item-0-value"]').should('have.text', '$1,208.00')
@@ -57,7 +65,7 @@ describe.skip('Create one-off', () => {
     cy.get('[data-test="create-invoice-button"]').click({ force: true })
 
     // Check created invoice amounts display
-    cy.get(`[data-test="customer-navigation-wrapper"]`).within(() => {
+    cy.get('[data-test="navigation-tab-bar"]').within(() => {
       cy.get('[role="tab"]').contains('Invoices').click({ force: true })
     })
     cy.get('#table-customer-invoices-row-0').should('exist')
@@ -108,7 +116,7 @@ describe.skip('Create one-off', () => {
       cy.get('[data-option-index="0"]').click({ force: true })
       cy.get('[data-test="invoice-item"]').should('have.length', 1)
 
-      // Edit it's tax rate
+      // Edit its tax rate
       cy.get('[data-test="invoice-item-actions-button"]').click({ force: true })
       cy.get('[data-test="invoice-item-edit-taxes"]').click({ force: true })
       cy.get(`[data-test="add-tax-button"]`).click({ force: true })
@@ -118,10 +126,15 @@ describe.skip('Create one-off', () => {
       cy.get('[data-option-index="0"]').click({ force: true })
       cy.get('[data-test="edit-invoice-item-tax-dialog-submit-button"]').click({ force: true })
 
-      // Update it's units
+      // Update units to 3.333
       cy.get('input[name="fees.0.units"]').clear().type('3.333')
 
-      // Check displayed amounts
+      // Amount math:
+      // - Add-on unit price: $3,020.00, units: 3.333
+      // - 1 item x $3,020.00 x 3.333 = $10,065.66 subtotal (rounded)
+      // - 20% tax on $10,065.66 = $2,013.13
+      // - 10% tax on $10,065.66 = $1,006.57
+      // - Total = $10,065.66 + $2,013.13 + $1,006.57 = $13,085.36
       cy.get('[data-test="one-off-invoice-subtotal-value"]').should('have.text', '$10,065.66')
       cy.get('[data-test="one-off-invoice-tax-item-0-label"]').should('have.text', 'twenty (20%)')
       cy.get('[data-test="one-off-invoice-tax-item-0-value"]').should('have.text', '$2,013.13')

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.projectKey=getlago_lago-front
 sonar.sources=src
 
 # Exclusions from source files
-sonar.exclusions=**/types.{ts,tsx},**/fixtures.ts,**/core/constants/**,**/generated/**,**/styles/**,**/pages/__devOnly/**,**/__tests__/**,**/*.test.{ts,tsx},**/*.spec.{ts,tsx},src/test-utils.tsx
+sonar.exclusions=**/types.{ts,tsx},**/fixtures.ts,**/core/constants/**,**/generated/**,**/styles/**,**/pages/__devOnly/**,**/__tests__/**,**/*.test.{ts,tsx},**/*.spec.{ts,tsx},src/test-utils.tsx,**/dataTestConstants.ts
 
 # Test files inclusion - only include actual test files
 # Test files are in __tests__ directories with .test. or .spec. in filename
@@ -18,7 +18,7 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info
 
 # Coverage exclusions - files excluded from code coverage calculation
 # Excludes constant files (const.ts, *Const.ts) as they typically don't need test coverage
-sonar.coverage.exclusions=**/const.ts,**/*Const.ts,**/*Types.ts,**/types.ts,**/__mocks__/**
+sonar.coverage.exclusions=**/const.ts,**/*Const.ts,**/*Types.ts,**/types.ts,**/__mocks__/**,**/dataTestConstants.ts
 
 # Duplication exclusions - mock files naturally duplicate the modules they mock
 sonar.cpd.exclusions=**/__mocks__/**

--- a/src/components/invoices/InvoiceTaxesDisplay.tsx
+++ b/src/components/invoices/InvoiceTaxesDisplay.tsx
@@ -4,8 +4,14 @@ import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { CurrencyEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
-export const INVOICE_TAX_ITEM = 'one-off-invoice-tax-item'
-export const INVOICE_TAX_ITEM_NO_TAX = 'one-off-invoice-tax-item-no-tax'
+import {
+  INVOICE_TAX_ITEM,
+  INVOICE_TAX_ITEM_LABEL_SUFFIX,
+  INVOICE_TAX_ITEM_NO_TAX,
+  INVOICE_TAX_ITEM_VALUE_SUFFIX,
+} from '~/components/invoices/dataTestConstants'
+
+export { INVOICE_TAX_ITEM, INVOICE_TAX_ITEM_NO_TAX } from '~/components/invoices/dataTestConstants'
 
 export type TaxMapType = Map<
   string,
@@ -73,10 +79,18 @@ export const InvoiceTaxesDisplay = ({
                 key={`${INVOICE_TAX_ITEM}-${i}`}
                 data-test={`${INVOICE_TAX_ITEM}-${i}`}
               >
-                <Typography variant="bodyHl" color="grey600">
+                <Typography
+                  variant="bodyHl"
+                  color="grey600"
+                  data-test={`${INVOICE_TAX_ITEM}-${i}${INVOICE_TAX_ITEM_LABEL_SUFFIX}`}
+                >
                   {taxToDisplay.label}
                 </Typography>
-                <Typography variant="body" color="grey700">
+                <Typography
+                  variant="body"
+                  color="grey700"
+                  data-test={`${INVOICE_TAX_ITEM}-${i}${INVOICE_TAX_ITEM_VALUE_SUFFIX}`}
+                >
                   {taxValue}
                 </Typography>
               </div>
@@ -98,10 +112,18 @@ export const InvoiceTaxesDisplay = ({
                 key={`${INVOICE_TAX_ITEM}-${i}`}
                 data-test={`${INVOICE_TAX_ITEM}-${i}`}
               >
-                <Typography variant="bodyHl" color="grey600">
+                <Typography
+                  variant="bodyHl"
+                  color="grey600"
+                  data-test={`${INVOICE_TAX_ITEM}-${i}${INVOICE_TAX_ITEM_LABEL_SUFFIX}`}
+                >
                   {taxToDisplay.label}
                 </Typography>
-                <Typography variant="body" color="grey700">
+                <Typography
+                  variant="body"
+                  color="grey700"
+                  data-test={`${INVOICE_TAX_ITEM}-${i}${INVOICE_TAX_ITEM_VALUE_SUFFIX}`}
+                >
                   {!hasAnyFee
                     ? '-'
                     : intlFormatNumber(taxToDisplay.amount, {

--- a/src/components/invoices/InvoiceTaxesDisplay.tsx
+++ b/src/components/invoices/InvoiceTaxesDisplay.tsx
@@ -1,15 +1,14 @@
 import { Typography } from '~/components/designSystem/Typography'
-import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
-import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { CurrencyEnum } from '~/generated/graphql'
-import { useInternationalization } from '~/hooks/core/useInternationalization'
-
 import {
   INVOICE_TAX_ITEM,
   INVOICE_TAX_ITEM_LABEL_SUFFIX,
   INVOICE_TAX_ITEM_NO_TAX,
   INVOICE_TAX_ITEM_VALUE_SUFFIX,
 } from '~/components/invoices/dataTestConstants'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { CurrencyEnum } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 export { INVOICE_TAX_ITEM, INVOICE_TAX_ITEM_NO_TAX } from '~/components/invoices/dataTestConstants'
 

--- a/src/components/invoices/__tests__/InvoiceTaxesDisplay.test.tsx
+++ b/src/components/invoices/__tests__/InvoiceTaxesDisplay.test.tsx
@@ -3,12 +3,8 @@ import { screen } from '@testing-library/react'
 import { CurrencyEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
-import {
-  INVOICE_TAX_ITEM,
-  INVOICE_TAX_ITEM_NO_TAX,
-  InvoiceTaxesDisplay,
-  TaxMapType,
-} from '../InvoiceTaxesDisplay'
+import { INVOICE_TAX_ITEM, INVOICE_TAX_ITEM_NO_TAX } from '../dataTestConstants'
+import { InvoiceTaxesDisplay, TaxMapType } from '../InvoiceTaxesDisplay'
 
 jest.mock('~/core/formats/intlFormatNumber', () => ({
   intlFormatNumber: jest.fn((amount: number, options?: { currency?: string }) => {

--- a/src/components/invoices/dataTestConstants.ts
+++ b/src/components/invoices/dataTestConstants.ts
@@ -1,0 +1,7 @@
+// Data test constants for invoice components
+
+// InvoiceTaxesDisplay
+export const INVOICE_TAX_ITEM = 'one-off-invoice-tax-item'
+export const INVOICE_TAX_ITEM_NO_TAX = 'one-off-invoice-tax-item-no-tax'
+export const INVOICE_TAX_ITEM_LABEL_SUFFIX = '-label'
+export const INVOICE_TAX_ITEM_VALUE_SUFFIX = '-value'

--- a/src/pages/settings/BillingEntity/sections/taxes/ApplyTaxDialog.tsx
+++ b/src/pages/settings/BillingEntity/sections/taxes/ApplyTaxDialog.tsx
@@ -11,6 +11,10 @@ import {
   useGetTaxesForApplyTaxLazyQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import {
+  APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID,
+  APPLY_TAX_DIALOG_TEST_ID,
+} from '~/pages/settings/BillingEntity/sections/taxes/dataTestConstants'
 
 gql`
   fragment TaxItemForApplyTax on Tax {
@@ -92,6 +96,7 @@ export const ApplyTaxDialog = forwardRef<ApplyTaxDialogRef>((_, ref) => {
   return (
     <Dialog
       ref={dialogRef}
+      data-test={APPLY_TAX_DIALOG_TEST_ID}
       title={translate('text_1743600025132l3aadb2il09')}
       description={<Typography>{translate('text_17436000251322d5x6wtpjq1')}</Typography>}
       actions={({ closeDialog }) => (
@@ -102,6 +107,7 @@ export const ApplyTaxDialog = forwardRef<ApplyTaxDialogRef>((_, ref) => {
 
           <Button
             variant="primary"
+            data-test={APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID}
             onClick={async () => {
               if (billingEntityId && taxCode) {
                 applyTax({

--- a/src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx
@@ -26,6 +26,7 @@ import {
   ApplyTaxDialog,
   ApplyTaxDialogRef,
 } from '~/pages/settings/BillingEntity/sections/taxes/ApplyTaxDialog'
+import { APPLY_TAX_BUTTON_TEST_ID } from '~/pages/settings/BillingEntity/sections/taxes/dataTestConstants'
 import {
   RemoveTaxDialog,
   RemoveTaxDialogRef,
@@ -125,7 +126,7 @@ const BillingEntityTaxesSettings = () => {
                               applyTaxDialogRef?.current?.openDialog(billingEntity.id)
                             }
                           }}
-                          data-test="apply-tax-button"
+                          data-test={APPLY_TAX_BUTTON_TEST_ID}
                         >
                           {translate('text_1743241419871j03yn6wurna')}
                         </Button>

--- a/src/pages/settings/BillingEntity/sections/taxes/dataTestConstants.ts
+++ b/src/pages/settings/BillingEntity/sections/taxes/dataTestConstants.ts
@@ -1,0 +1,8 @@
+// Data test constants for billing entity tax components
+
+// BillingEntityTaxesSettings
+export const APPLY_TAX_BUTTON_TEST_ID = 'apply-tax-button'
+
+// ApplyTaxDialog
+export const APPLY_TAX_DIALOG_TEST_ID = 'apply-tax-dialog'
+export const APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID = 'apply-tax-dialog-submit-button'


### PR DESCRIPTION
## Context

We skipped some e2e tests before because they were too flaky. Now we want them back

## Description

This PR
- Puts back on the test create-one-off-invoice
- Puts back on the test create-taxes

<!-- Linear link -->
Fixes ISSUE-1767