### PR TITLE
fix(deps): patch sanitize-html (critical XSS) and systeminformation (high cmd injection) CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "react-router-dom": "6.30.3",
     "recharts": "2.15.4",
     "remark-gfm": "4.0.1",
-    "sanitize-html": "2.17.3",
+    "sanitize-html": "2.17.4",
     "shiki": "4.0.2",
     "tippy.js": "6.3.7",
     "tiptap-markdown": "0.9.0",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "sanitize-html": "2.17.3"
+    "sanitize-html": "2.17.4"
   },
   "devDependencies": {
     "@svgr/core": "8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,8 +217,8 @@ importers:
         specifier: 4.0.1
         version: 4.0.1
       sanitize-html:
-        specifier: 2.17.3
-        version: 2.17.3
+        specifier: 2.17.4
+        version: 2.17.4
       shiki:
         specifier: 4.0.2
         version: 4.0.2
@@ -521,8 +521,8 @@ importers:
         specifier: 6.30.3
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sanitize-html:
-        specifier: 2.17.3
-        version: 2.17.3
+        specifier: 2.17.4
+        version: 2.17.4
     devDependencies:
       '@svgr/core':
         specifier: 8.1.0
@@ -6368,6 +6368,9 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -7941,8 +7944,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sanitize-html@2.17.3:
-    resolution: {integrity: sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==}
+  sanitize-html@2.17.4:
+    resolution: {integrity: sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==}
 
   sax@1.5.0:
     resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
@@ -8212,8 +8215,8 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  systeminformation@5.31.1:
-    resolution: {integrity: sha512-6pRwxoGeV/roJYpsfcP6tN9mep6pPeCtXbUOCdVa0nme05Brwcwdge/fVNhIZn2wuUitAKZm4IYa7QjnRIa9zA==}
+  systeminformation@5.31.6:
+    resolution: {integrity: sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -13615,7 +13618,7 @@ snapshots:
       proxy-from-env: 1.0.0
       request-progress: 3.0.0
       supports-color: 8.1.1
-      systeminformation: 5.31.1
+      systeminformation: 5.31.6
       tmp: 0.2.5
       tree-kill: 1.2.2
       tslib: 1.14.1
@@ -15553,6 +15556,10 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.13
+
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -17396,12 +17403,13 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanitize-html@2.17.3:
+  sanitize-html@2.17.4:
     dependencies:
       deepmerge: 4.3.1
       escape-string-regexp: 4.0.0
       htmlparser2: 10.1.0
       is-plain-object: 5.0.0
+      launder: 1.7.1
       parse-srcset: 1.0.2
       postcss: 8.5.14
 
@@ -17732,7 +17740,7 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
-  systeminformation@5.31.1: {}
+  systeminformation@5.31.6: {}
 
   tailwind-api-utils@1.0.3(tailwindcss@3.4.19(ts-node@10.9.2(@swc/core@1.15.11)(@swc/wasm@1.13.20)(@types/node@24.12.3)(typescript@5.9.3))):
     dependencies:


### PR DESCRIPTION
## Summary

Patches two open security advisories identified via `pnpm audit`:

### 1. `sanitize-html` — [GHSA-rpr9-rxv7-x643](https://github.com/advisories/GHSA-rpr9-rxv7-x643) · **Critical (CVSS 9.3)**

- **Issue:** Default XSS bypass via `<xmp>` raw-text passthrough. Attacker-controlled `<xmp>` content bypasses sanitization and is re-emitted as live HTML/JS in the output.
- **Affected paths:** `lago-front → sanitize-html@2.17.3` and `lago-design-system → sanitize-html@2.17.3` (direct deps in both `package.json` and `packages/design-system/package.json`)
- **Fix:** Bump `sanitize-html` `2.17.3` → `2.17.4`. v2.17.4 adds `xmp` to `nonTextTagsArray`, so disallowed `xmp` content is dropped entirely instead of passed through as raw HTML. *(Note: the npm advisory database listed no patched version at time of publication — v2.17.4 was released the same day as the advisory and is the intended fix.)*

### 2. `systeminformation` — [GHSA-hvx9-hwr7-wjj9](https://github.com/advisories/GHSA-hvx9-hwr7-wjj9) · **High (CVSS 7.8)**

- **Issue:** Command injection in `networkInterfaces()` via unsanitized NetworkManager connection profile name on Linux (`execSync()` with unescaped shell string).
- **Affected path:** `lago-front → cypress@15.14.2 → systeminformation@5.31.1` (transitive dev dep)
- **Fix:** Lockfile refresh via `pnpm update --depth Infinity -r systeminformation`. cypress@15.14.2 already declares `systeminformation: ^5.31.1`, so `5.31.6` (the patched version) is admitted by the range — the lockfile was simply stale. No `package.json` change needed.

## Verification

```
pnpm audit → 0 vulnerabilities (was 1 critical + 1 high)
```

| Package | Before | After |
|---|---|---|
| `sanitize-html` | 2.17.3 | **2.17.4** |
| `systeminformation` | 5.31.1 | **5.31.6** |

## Test plan

- [ ] `pnpm audit` returns no vulnerabilities
- [ ] `pnpm install` succeeds without errors
- [ ] CI passes (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAjsAv5xTXwMVV4KGMC3EP)_