### PR TITLE
refactor(premium): migrate PremiumFeature to usePremiumWarningDialog hook

### DIFF
--- a/src/components/premium/PremiumFeature.tsx
+++ b/src/components/premium/PremiumFeature.tsx
@@ -1,9 +1,8 @@
 import { Icon, tw } from 'lago-design-system'
-import { useRef } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 type PremiumFeatureProps = {
@@ -24,53 +23,50 @@ const PremiumFeature = ({
   'data-test': dataTest,
 }: PremiumFeatureProps) => {
   const { translate } = useInternationalization()
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const premiumWarningDialog = usePremiumWarningDialog()
 
   return (
-    <>
-      <div
-        className={tw(
-          'flex w-full flex-row items-center justify-between gap-2 rounded-xl bg-grey-100 px-6 py-4',
-          className,
-        )}
-        data-test={dataTest}
-      >
-        <div className="flex flex-col">
-          <div className="flex flex-row items-center gap-2">
-            <Typography variant="bodyHl" color="grey700">
-              {title}
-            </Typography>
-
-            <Icon name="sparkles" />
-          </div>
-
-          <Typography variant="caption" color="grey600">
-            {description}
+    <div
+      className={tw(
+        'flex w-full flex-row items-center justify-between gap-2 rounded-xl bg-grey-100 px-6 py-4',
+        className,
+      )}
+      data-test={dataTest}
+    >
+      <div className="flex flex-col">
+        <div className="flex flex-row items-center gap-2">
+          <Typography variant="bodyHl" color="grey700">
+            {title}
           </Typography>
+
+          <Icon name="sparkles" />
         </div>
 
-        <Button
-          className={buttonClassName}
-          endIcon="sparkles"
-          variant="tertiary"
-          onClick={() =>
-            premiumWarningDialogRef.current?.openDialog({
-              title,
-              description,
-              mailtoSubject: translate('text_1759493418045b173t4qhktb', {
-                feature,
-              }),
-              mailtoBody: translate('text_1759493745332hiuejhksn15', {
-                feature,
-              }),
-            })
-          }
-        >
-          {translate('text_65ae73ebe3a66bec2b91d72d')}
-        </Button>
+        <Typography variant="caption" color="grey600">
+          {description}
+        </Typography>
       </div>
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
-    </>
+
+      <Button
+        className={buttonClassName}
+        endIcon="sparkles"
+        variant="tertiary"
+        onClick={() =>
+          premiumWarningDialog.open({
+            title,
+            description,
+            mailtoSubject: translate('text_1759493418045b173t4qhktb', {
+              feature,
+            }),
+            mailtoBody: translate('text_1759493745332hiuejhksn15', {
+              feature,
+            }),
+          })
+        }
+      >
+        {translate('text_65ae73ebe3a66bec2b91d72d')}
+      </Button>
+    </div>
   )
 }
 

--- a/src/components/premium/__tests__/PremiumFeature.test.tsx
+++ b/src/components/premium/__tests__/PremiumFeature.test.tsx
@@ -1,6 +1,10 @@
-import { cleanup, screen } from '@testing-library/react'
+import NiceModal from '@ebay/nice-modal-react'
+import { cleanup, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { ReactNode } from 'react'
 
+import { PREMIUM_WARNING_DIALOG_NAME } from '~/components/dialogs/const'
+import PremiumWarningDialog from '~/components/dialogs/PremiumWarningDialog'
 import { render } from '~/test-utils'
 
 import PremiumFeature from '../PremiumFeature'
@@ -11,6 +15,12 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
     locale: 'en',
   }),
 }))
+
+NiceModal.register(PREMIUM_WARNING_DIALOG_NAME, PremiumWarningDialog)
+
+const NiceModalWrapper = ({ children }: { children: ReactNode }) => (
+  <NiceModal.Provider>{children}</NiceModal.Provider>
+)
 
 const DEFAULT_PROPS = {
   title: 'Test Title',
@@ -76,14 +86,19 @@ describe('PremiumFeature', () => {
     it('opens premium warning dialog when button is clicked', async () => {
       const user = userEvent.setup()
 
-      render(<PremiumFeature {...DEFAULT_PROPS} />)
+      render(
+        <NiceModalWrapper>
+          <PremiumFeature {...DEFAULT_PROPS} />
+        </NiceModalWrapper>,
+      )
 
       const button = screen.getByRole('button')
 
       await user.click(button)
 
-      // Dialog should be opened - check for dialog content
-      expect(screen.getByRole('dialog')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

Migrates the `PremiumFeature` component away from the deprecated imperative
ref-based `PremiumWarningDialog` (`~/components/PremiumWarningDialog`) and
onto the new hook-based `usePremiumWarningDialog` from
`~/components/dialogs/PremiumWarningDialog`. This clears the corresponding
`no-restricted-imports` ESLint warning in `src/components/premium/PremiumFeature.tsx`.

### Changes

- `src/components/premium/PremiumFeature.tsx`
  - Drop the `useRef<PremiumWarningDialogRef>` + locally rendered
    `<PremiumWarningDialog />` pattern.
  - Use the `usePremiumWarningDialog()` hook and call
    `premiumWarningDialog.open({ title, description, mailtoSubject, mailtoBody })`
    directly. The dialog is rendered globally via the registered NiceModal.
  - Remove the now-unneeded fragment wrapper since the dialog instance is
    no longer a sibling of the visual content.
- `src/components/premium/__tests__/PremiumFeature.test.tsx`
  - Register `PremiumWarningDialog` against `PREMIUM_WARNING_DIALOG_NAME`
    with NiceModal at module load time.
  - Wrap the "opens premium warning dialog when button is clicked" case in a
    `NiceModal.Provider` and switch the assertion to `waitFor`, matching the
    existing pattern used by `src/components/dialogs/__tests__/PremiumWarningDialog.test.tsx`.

### Scope

Per the migration routine: only the `PremiumWarningDialog` usage inside
`PremiumFeature.tsx` is touched. No other dialog in the file (there are
none) and no other consumer of the legacy dialog is migrated here.

## Test plan

- [x] `pnpm test --testPathPatterns=PremiumFeature` — all 10 tests pass
      (incl. the dialog interaction test and both snapshots).
- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm eslint src/components/premium/PremiumFeature.tsx
      src/components/premium/__tests__/PremiumFeature.test.tsx` — no
      warnings on either file (the previous
      `'~/components/PremiumWarningDialog' import is restricted` warning is
      gone).
- [ ] Smoke-test in the app: any place that renders `<PremiumFeature />`
      (e.g. settings sections that gate behind premium) still opens the
      premium dialog on click and the mailto link is built correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_014s36GpfV49MfDeCqaTEyA5)_