### PR TITLE
fix(plans): prevent charge add/delete from subscription form

### DIFF
--- a/src/components/designSystem/Selector.tsx
+++ b/src/components/designSystem/Selector.tsx
@@ -31,7 +31,7 @@ interface SelectorProps {
   'data-test'?: string
 }
 
-interface SelectorActionItem {
+export interface SelectorActionItem {
   /** Icon name. Defaults to 'dots-horizontal' */
   icon?: IconName
   /** Tooltip text. When absent, no tooltip is rendered. */

--- a/src/components/plans/UsageChargesSection.tsx
+++ b/src/components/plans/UsageChargesSection.tsx
@@ -11,7 +11,11 @@ import {
   UsageChargeDrawer,
   UsageChargeDrawerRef,
 } from '~/components/plans/drawers/usageCharge/UsageChargeDrawer'
-import { getFormattedChargeSelectorSubtitle, mapChargeIntervalCopy } from '~/components/plans/utils'
+import {
+  buildChargeHoverActions,
+  getFormattedChargeSelectorSubtitle,
+  mapChargeIntervalCopy,
+} from '~/components/plans/utils'
 import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { useDuplicatePlanVar } from '~/core/apolloClient/reactiveVars/duplicatePlanVar'
 import { FORM_TYPE_ENUM } from '~/core/constants/form'
@@ -160,31 +164,14 @@ export const UsageChargesSection = ({
         }
         hoverActions={
           <SelectorActions
-            actions={[
-              {
-                icon: 'trash',
-                tooltipCopy: translate('text_63ea0f84f400488553caa786'),
-                onClick: (e) => {
-                  e.stopPropagation()
-                  e.preventDefault()
-
-                  const deleteCharge = () => {
-                    handleChargeDelete(i)
-                  }
-
-                  if (actionType !== 'duplicate' && isUsedInSubscription) {
-                    removeChargeWarningDialogRef?.current?.openDialog({ callback: deleteCharge })
-                  } else {
-                    deleteCharge()
-                  }
-                },
-              },
-              {
-                icon: 'pen',
-                tooltipCopy: translate('text_63e51ef4985f0ebd75c212fc'),
-                onClick: () => openUsageChargeDrawer(),
-              },
-            ]}
+            actions={buildChargeHoverActions({
+              showDelete: !isInSubscriptionForm,
+              showWarningOnDelete: actionType !== 'duplicate' && isUsedInSubscription,
+              onDelete: () => handleChargeDelete(i),
+              onEdit: openUsageChargeDrawer,
+              removeChargeWarningDialogRef,
+              translate,
+            })}
           />
         }
         onClick={() => openUsageChargeDrawer()}

--- a/src/components/plans/__tests__/utils.test.ts
+++ b/src/components/plans/__tests__/utils.test.ts
@@ -1,4 +1,8 @@
+import { RefObject } from 'react'
+
+import { RemoveChargeWarningDialogRef } from '~/components/plans/RemoveChargeWarningDialog'
 import {
+  buildChargeHoverActions,
   getFormattedChargeSelectorSubtitle,
   returnFirstDefinedArrayRatesSumAsString,
   transformFilterObjectToString,
@@ -137,6 +141,122 @@ describe('utils', () => {
       })
 
       expect(result).toBe('my_code')
+    })
+  })
+
+  describe('buildChargeHoverActions', () => {
+    const translate = (key: string) => key
+    const buildDialogRef = (): {
+      ref: RefObject<RemoveChargeWarningDialogRef>
+      openDialog: jest.Mock
+    } => {
+      const openDialog = jest.fn()
+      const ref = {
+        current: { openDialog },
+      } as unknown as RefObject<RemoveChargeWarningDialogRef>
+
+      return { ref, openDialog }
+    }
+    const buildEvent = () =>
+      ({
+        stopPropagation: jest.fn(),
+        preventDefault: jest.fn(),
+      }) as unknown as React.MouseEvent
+
+    it('returns only the edit action when showDelete is false', () => {
+      const onEdit = jest.fn()
+      const onDelete = jest.fn()
+      const { ref } = buildDialogRef()
+
+      const actions = buildChargeHoverActions({
+        showDelete: false,
+        showWarningOnDelete: false,
+        onDelete,
+        onEdit,
+        removeChargeWarningDialogRef: ref,
+        translate,
+      })
+
+      expect(actions).toHaveLength(1)
+      expect(actions[0].icon).toBe('pen')
+      actions[0].onClick(buildEvent())
+      expect(onEdit).toHaveBeenCalledTimes(1)
+      expect(onDelete).not.toHaveBeenCalled()
+    })
+
+    it('returns trash and edit actions when showDelete is true', () => {
+      const { ref } = buildDialogRef()
+
+      const actions = buildChargeHoverActions({
+        showDelete: true,
+        showWarningOnDelete: false,
+        onDelete: jest.fn(),
+        onEdit: jest.fn(),
+        removeChargeWarningDialogRef: ref,
+        translate,
+      })
+
+      expect(actions).toHaveLength(2)
+      expect(actions[0].icon).toBe('trash')
+      expect(actions[1].icon).toBe('pen')
+    })
+
+    it('calls onDelete directly when showWarningOnDelete is false', () => {
+      const onDelete = jest.fn()
+      const { ref, openDialog } = buildDialogRef()
+
+      const actions = buildChargeHoverActions({
+        showDelete: true,
+        showWarningOnDelete: false,
+        onDelete,
+        onEdit: jest.fn(),
+        removeChargeWarningDialogRef: ref,
+        translate,
+      })
+
+      const event = buildEvent()
+
+      actions[0].onClick(event)
+
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1)
+      expect(event.preventDefault).toHaveBeenCalledTimes(1)
+      expect(onDelete).toHaveBeenCalledTimes(1)
+      expect(openDialog).not.toHaveBeenCalled()
+    })
+
+    it('opens the warning dialog when showWarningOnDelete is true', () => {
+      const onDelete = jest.fn()
+      const { ref, openDialog } = buildDialogRef()
+
+      const actions = buildChargeHoverActions({
+        showDelete: true,
+        showWarningOnDelete: true,
+        onDelete,
+        onEdit: jest.fn(),
+        removeChargeWarningDialogRef: ref,
+        translate,
+      })
+
+      actions[0].onClick(buildEvent())
+
+      expect(openDialog).toHaveBeenCalledTimes(1)
+      expect(openDialog).toHaveBeenCalledWith({ callback: onDelete })
+      expect(onDelete).not.toHaveBeenCalled()
+    })
+
+    it('does not throw when the dialog ref is not yet attached', () => {
+      const ref = { current: null } as RefObject<RemoveChargeWarningDialogRef>
+
+      const actions = buildChargeHoverActions({
+        showDelete: true,
+        showWarningOnDelete: true,
+        onDelete: jest.fn(),
+        onEdit: jest.fn(),
+        removeChargeWarningDialogRef: ref,
+        translate,
+      })
+
+      expect(() => actions[0].onClick(buildEvent())).not.toThrow()
     })
   })
 })

--- a/src/components/plans/form/FixedChargesSection.tsx
+++ b/src/components/plans/form/FixedChargesSection.tsx
@@ -16,7 +16,11 @@ import {
   RemoveChargeWarningDialogRef,
 } from '~/components/plans/RemoveChargeWarningDialog'
 import { LocalFixedChargeInput } from '~/components/plans/types'
-import { getFormattedChargeSelectorSubtitle, mapChargeIntervalCopy } from '~/components/plans/utils'
+import {
+  buildChargeHoverActions,
+  getFormattedChargeSelectorSubtitle,
+  mapChargeIntervalCopy,
+} from '~/components/plans/utils'
 import { useDuplicatePlanVar } from '~/core/apolloClient/reactiveVars/duplicatePlanVar'
 import {
   GraduatedChargeFragmentDoc,
@@ -191,38 +195,14 @@ export const FixedChargesSection = ({
                       }
                       hoverActions={
                         <SelectorActions
-                          actions={[
-                            {
-                              icon: 'trash',
-                              tooltipCopy: translate('text_63ea0f84f400488553caa786'),
-                              onClick: (e) => {
-                                e.stopPropagation()
-                                e.preventDefault()
-
-                                const deleteCharge = () => {
-                                  const localChargesAfterDelete = [
-                                    ...form.state.values.fixedCharges,
-                                  ]
-
-                                  localChargesAfterDelete.splice(i, 1)
-                                  form.setFieldValue('fixedCharges', localChargesAfterDelete)
-                                }
-
-                                if (actionType !== 'duplicate' && isUsedInSubscription) {
-                                  removeChargeWarningDialogRef?.current?.openDialog({
-                                    callback: deleteCharge,
-                                  })
-                                } else {
-                                  deleteCharge()
-                                }
-                              },
-                            },
-                            {
-                              icon: 'pen',
-                              tooltipCopy: translate('text_63e51ef4985f0ebd75c212fc'),
-                              onClick: () => openFixedChargeDrawer(),
-                            },
-                          ]}
+                          actions={buildChargeHoverActions({
+                            showDelete: !isInSubscriptionForm,
+                            showWarningOnDelete: actionType !== 'duplicate' && isUsedInSubscription,
+                            onDelete: () => handleChargeDelete(i),
+                            onEdit: openFixedChargeDrawer,
+                            removeChargeWarningDialogRef,
+                            translate,
+                          })}
                         />
                       }
                       data-test={`fixed-charge-selector-${i}`}

--- a/src/components/plans/utils.ts
+++ b/src/components/plans/utils.ts
@@ -1,3 +1,7 @@
+import { RefObject } from 'react'
+
+import { SelectorActionItem } from '~/components/designSystem/Selector'
+import { RemoveChargeWarningDialogRef } from '~/components/plans/RemoveChargeWarningDialog'
 import {
   ALL_FILTER_VALUES,
   AnyChargeModel,
@@ -81,4 +85,49 @@ export const getFormattedChargeSelectorSubtitle = ({
   translate: TranslateFunc
 }): string => {
   return [translate(chargeModelLookupTranslation[chargeModel]), code].filter(Boolean).join(' • ')
+}
+
+export const buildChargeHoverActions = ({
+  showDelete,
+  showWarningOnDelete,
+  onDelete,
+  onEdit,
+  removeChargeWarningDialogRef,
+  translate,
+}: {
+  showDelete: boolean
+  showWarningOnDelete: boolean
+  onDelete: () => void
+  onEdit: () => void
+  removeChargeWarningDialogRef: RefObject<RemoveChargeWarningDialogRef>
+  translate: TranslateFunc
+}): SelectorActionItem[] => {
+  const actions: SelectorActionItem[] = []
+
+  if (showDelete) {
+    const onTrashClick = (e: React.MouseEvent) => {
+      e.stopPropagation()
+      e.preventDefault()
+
+      if (showWarningOnDelete) {
+        removeChargeWarningDialogRef.current?.openDialog({ callback: onDelete })
+      } else {
+        onDelete()
+      }
+    }
+
+    actions.push({
+      icon: 'trash',
+      tooltipCopy: translate('text_63ea0f84f400488553caa786'),
+      onClick: onTrashClick,
+    })
+  }
+
+  actions.push({
+    icon: 'pen',
+    tooltipCopy: translate('text_63e51ef4985f0ebd75c212fc'),
+    onClick: onEdit,
+  })
+
+  return actions
 }


### PR DESCRIPTION
## Context

The TanStack Form migration of the plan form (reused inside `CreateSubscription`) added an `isInSubscriptionForm` flag and correctly gated:

- the "Add a fixed charge" / "Add a usage charge" buttons on each section,
- the delete button inside `FixedChargeDrawer` / `UsageChargeDrawer`,
- the charge model selector.

But the hover **trash** icon rendered by `SelectorActions` on every fixed/usage charge row was left rendering unconditionally. It calls a local splice on the form values, bypassing the drawer entirely, so a user can wipe a charge from the subscription create/edit form. Charges and fixed charges are plan-template concerns — the subscription form should only let users tweak existing charge details (units, taxes, invoice display name) inside the drawer, never structural add/delete.

## Description

**1. Bug fix — hide the trash hover action in the subscription form**

Both `FixedChargesSection` and `UsageChargesSection` now drop the trash entry from their `SelectorActions` when `isInSubscriptionForm` is true. The pen (edit) action stays — drawer-side restrictions already prevent editing things the subscription context shouldn't touch, and edit is the legitimate use case in the subscription form.

**2. Refactor — extract a shared `buildChargeHoverActions` helper**

The two sections built their hover-action arrays with code that was 95% identical (only the delete callback differed — inline splice vs `handleChargeDelete(index)`). Both can call `handleChargeDelete`, so the only real difference disappears.

A pure helper `buildChargeHoverActions` was added to `components/plans/utils.ts`:

```ts
buildChargeHoverActions({
  showDelete,             // !isInSubscriptionForm — caller-computed
  showWarningOnDelete,    // actionType !== 'duplicate' && isUsedInSubscription
  onDelete,               // () => void, closes over the row index
  onEdit,                 // () => void, opens the drawer for the row
  removeChargeWarningDialogRef,
  translate,
})
```

- Single source of truth for the gate (`!isInSubscriptionForm`) and the warning-dialog branch.
- Pure — no React deps — and so unit-testable in isolation.
- Each section's JSX shrinks to a 6-line call.
- `SelectorActionItem` is now exported from `components/designSystem/Selector` so the helper's return type stays explicit.

**Tests**

Added 5 jest cases in `components/plans/__tests__/utils.test.ts`:

- returns only the edit action when `showDelete` is false,
- returns trash + edit when `showDelete` is true,
- calls `onDelete` directly when `showWarningOnDelete` is false,
- opens the warning dialog with `onDelete` as callback when `showWarningOnDelete` is true,
- does not throw when the dialog ref is null.

<!-- Linear link -->
Fixes ISSUE-1877