### PR TITLE
refactor(integrations): migrate PremiumWarningDialog to hook-based dialog system

### DIFF
--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -7,6 +7,7 @@ import { Avatar } from '~/components/designSystem/Avatar'
 import { Button } from '~/components/designSystem/Button'
 import { Chip } from '~/components/designSystem/Chip'
 import { Selector, SelectorActions } from '~/components/designSystem/Selector'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import {
   SettingsListItem,
   SettingsListItemLoadingSkeleton,
@@ -15,7 +16,6 @@ import {
 } from '~/components/layouts/Settings'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { useMainHeaderTabContent } from '~/components/MainHeader/useMainHeaderTabContent'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import {
   AddAdyenDialog,
   AddAdyenDialogRef,
@@ -176,7 +176,7 @@ const Integrations = () => {
   const { isPremium } = useCurrentUser()
   const { organization: { premiumIntegrations } = {} } = useOrganizationInfos()
 
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const addAnrokDialogRef = useRef<AddAnrokDialogRef>(null)
   const addAvalaraDialogRef = useRef<AddAvalaraDialogRef>(null)
   const addStripeDialogRef = useRef<AddStripeDialogRef>(null)
@@ -373,7 +373,7 @@ const Integrations = () => {
                         }
                         onClick={() => {
                           if (!isPremium) {
-                            premiumWarningDialogRef.current?.openDialog({
+                            openPremiumWarningDialog({
                               title: translate('text_661ff6e56ef7e1b7c542b1ea'),
                               description: translate('text_661ff6e56ef7e1b7c542b1f6'),
                               mailtoSubject: translate('text_666887641443e4a75b9ead3d'),
@@ -411,7 +411,7 @@ const Integrations = () => {
                         }
                         onClick={() => {
                           if (!hasAccessToAvalaraPremiumIntegration) {
-                            premiumWarningDialogRef.current?.openDialog({
+                            openPremiumWarningDialog({
                               title: translate('text_661ff6e56ef7e1b7c542b1ea'),
                               description: translate('text_661ff6e56ef7e1b7c542b1f6'),
                               mailtoSubject: translate('text_1744296980972iaigqgcpb8t'),
@@ -506,7 +506,7 @@ const Integrations = () => {
                         )}
                         onClick={() => {
                           if (!hasAccessToHubspotPremiumIntegration) {
-                            premiumWarningDialogRef.current?.openDialog({
+                            openPremiumWarningDialog({
                               title: translate('text_661ff6e56ef7e1b7c542b1ea'),
                               description: translate('text_661ff6e56ef7e1b7c542b1f6'),
                               mailtoSubject: translate('text_172718956805392syzumhdlm'),
@@ -545,7 +545,7 @@ const Integrations = () => {
                         }
                         onClick={() => {
                           if (!hasAccessToNetsuitePremiumIntegration) {
-                            premiumWarningDialogRef.current?.openDialog({
+                            openPremiumWarningDialog({
                               title: translate('text_661ff6e56ef7e1b7c542b1ea'),
                               description: translate('text_661ff6e56ef7e1b7c542b1f6'),
                               mailtoSubject: translate('text_661ff6e56ef7e1b7c542b220'),
@@ -583,7 +583,7 @@ const Integrations = () => {
                         )}
                         onClick={() => {
                           if (!hasAccessToSalesforcePremiumIntegration) {
-                            premiumWarningDialogRef.current?.openDialog({
+                            openPremiumWarningDialog({
                               title: translate('text_661ff6e56ef7e1b7c542b1ea'),
                               description: translate('text_661ff6e56ef7e1b7c542b1f6'),
                               mailtoSubject: translate('text_173150719524652xb2nd3f7r'),
@@ -668,7 +668,7 @@ const Integrations = () => {
                         }
                         onClick={() => {
                           if (!hasAccessToXeroPremiumIntegration) {
-                            premiumWarningDialogRef.current?.openDialog({
+                            openPremiumWarningDialog({
                               title: translate('text_661ff6e56ef7e1b7c542b1ea'),
                               description: translate('text_661ff6e56ef7e1b7c542b1f6'),
                               mailtoSubject: translate('text_6672ebb8b1b50be550ecca09'),
@@ -861,7 +861,6 @@ const Integrations = () => {
       <AddHubspotDialog ref={addHubspotDialogRef} />
       <AddSalesforceDialog ref={addSalesforceDialogRef} />
       <AddFlutterwaveDialog ref={addFlutterwaveDialogRef} />
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/__tests__/Integrations.test.tsx
+++ b/src/pages/settings/__tests__/Integrations.test.tsx
@@ -60,8 +60,11 @@ jest.mock('~/components/settings/integrations/AddLagoTaxManagementDialog', () =>
 jest.mock('~/components/settings/integrations/AddFlutterwaveDialog', () => ({
   AddFlutterwaveDialog: () => null,
 }))
-jest.mock('~/components/PremiumWarningDialog', () => ({
-  PremiumWarningDialog: () => null,
+jest.mock('~/components/dialogs/PremiumWarningDialog', () => ({
+  usePremiumWarningDialog: () => ({
+    open: jest.fn(),
+    close: jest.fn(),
+  }),
 }))
 
 const mockRefetch = jest.fn()


### PR DESCRIPTION
## Summary

Migrate the `PremiumWarningDialog` usage in the `Integrations` settings page from the deprecated imperative ref-based system (`~/components/PremiumWarningDialog`) to the new hook-based NiceModal system (`usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`).

This removes one of the `no-restricted-imports` warnings flagged by ESLint (total warnings: 496 → 495). Scope is intentionally limited to `PremiumWarningDialog` only — the other `Add*Dialog` components in this file (Adyen, Anrok, Avalara, etc.) remain on the legacy ref-based system and are out of scope.

## Changes

- `src/pages/settings/Integrations.tsx`
  - Replace import `{ PremiumWarningDialog, PremiumWarningDialogRef }` with `{ usePremiumWarningDialog }`
  - Replace `useRef<PremiumWarningDialogRef>(null)` with the hook destructuring `const { open: openPremiumWarningDialog } = usePremiumWarningDialog()`
  - Replace the 6 `premiumWarningDialogRef.current?.openDialog(...)` calls with `openPremiumWarningDialog(...)`
  - Remove the now-unnecessary `<PremiumWarningDialog ref={premiumWarningDialogRef} />` JSX (the dialog is now rendered via NiceModal)
- `src/pages/settings/__tests__/Integrations.test.tsx`
  - Update Jest mock to target the new hook-based module

## Test plan

- [x] `pnpm eslint src/pages/settings/Integrations.tsx` — 0 errors, PremiumWarningDialog warning removed
- [x] `pnpm types` — passes
- [x] `pnpm test src/pages/settings/__tests__/Integrations.test.tsx` — all 17 tests pass
- [ ] Manual smoke test: clicking a premium-gated integration (e.g. Anrok, Avalara, Netsuite, Xero, Hubspot, Salesforce) as a non-premium user opens the premium warning dialog with the correct title/description/mailto

🤖 Generated via Claude Code on the web


---
_Generated by [Claude Code](https://claude.ai/code/session_01GaXi5fzAuAAqoY85Lxk9LY)_