### PR TITLE
feat(plans,subscriptions): feature flag and empty v2 tabs scaffold

### DIFF
--- a/src/core/constants/tabsOptions.ts
+++ b/src/core/constants/tabsOptions.ts
@@ -25,9 +25,11 @@ export enum CustomerInvoiceDetailsTabsOptionsEnum {
 export enum CustomerSubscriptionDetailsTabsOptionsEnum {
   activityLogs = 'activity-logs',
   alerts = 'alerts',
+  editOverview = 'edit-overview',
   entitlements = 'entitlements',
   overview = 'overview',
   progressiveBilling = 'progressive-billing',
+  subscriptionPlan = 'subscription-plan',
   usage = 'usage',
 }
 
@@ -38,6 +40,7 @@ export enum IntegrationsTabsOptionsEnum {
 
 export enum PlanDetailsTabsOptionsEnum {
   activityLogs = 'activity-logs',
+  editOverview = 'edit-overview',
   overview = 'overview',
   subscriptions = 'subscriptions',
 }

--- a/src/core/utils/featureFlags.ts
+++ b/src/core/utils/featureFlags.ts
@@ -2,6 +2,7 @@
 export enum FeatureFlags {
   FTR_ENABLED = 'ftr_enabled',
   SUPERSET_PERSISTENT_FILTERS = 'superset_persistent_filters',
+  EDIT_DETAILS_PAGE = 'edit_details_page',
 }
 
 const FF_KEY = 'featureFlags'

--- a/src/pages/PlanDetails.tsx
+++ b/src/pages/PlanDetails.tsx
@@ -20,6 +20,7 @@ import {
   UPDATE_PLAN_ROUTE,
   useNavigate,
 } from '~/core/router'
+import { FeatureFlags, isFeatureFlagActive } from '~/core/utils/featureFlags'
 import {
   DeletePlanDialogFragment,
   DeletePlanDialogFragmentDoc,
@@ -187,6 +188,31 @@ const PlanDetails = () => {
             }),
             content: <PlanDetailsActivityLogs planId={planId as string} />,
             hidden: !isPremium || !hasPermissions(['auditLogsView']),
+          },
+          {
+            title: translate('text_17792001643312864fz7j4gq'),
+            link: generatePath(PLAN_DETAILS_ROUTE, {
+              planId: planId as string,
+              tab: PlanDetailsTabsOptionsEnum.editOverview,
+            }),
+            match: [
+              generatePath(PLAN_DETAILS_ROUTE, {
+                planId: planId as string,
+                tab: PlanDetailsTabsOptionsEnum.editOverview,
+              }),
+              generatePath(CUSTOMER_SUBSCRIPTION_PLAN_DETAILS, {
+                customerId: customerId || '',
+                subscriptionId: subscriptionId || '',
+                planId: planId as string,
+                tab: PlanDetailsTabsOptionsEnum.editOverview,
+              }),
+            ],
+            content: (
+              <DetailsPage.Container>
+                <div className="bg-grey-100" />
+              </DetailsPage.Container>
+            ),
+            hidden: !isFeatureFlagActive(FeatureFlags.EDIT_DETAILS_PAGE),
           },
         ]}
       />

--- a/src/pages/PlanDetails.tsx
+++ b/src/pages/PlanDetails.tsx
@@ -2,6 +2,7 @@ import { gql } from '@apollo/client'
 import { useEffect, useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
+import { Typography } from '~/components/designSystem/Typography'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { MainHeaderAction } from '~/components/MainHeader/types'
@@ -209,7 +210,9 @@ const PlanDetails = () => {
             ],
             content: (
               <DetailsPage.Container>
-                <div className="bg-grey-100" />
+                <Typography variant="body">
+                  {translate('text_17792001643312864fz7j4gq')}
+                </Typography>
               </DetailsPage.Container>
             ),
             hidden: !isFeatureFlagActive(FeatureFlags.EDIT_DETAILS_PAGE),

--- a/src/pages/PlanDetails.tsx
+++ b/src/pages/PlanDetails.tsx
@@ -210,9 +210,7 @@ const PlanDetails = () => {
             ],
             content: (
               <DetailsPage.Container>
-                <Typography variant="body">
-                  {translate('text_17792001643312864fz7j4gq')}
-                </Typography>
+                <Typography variant="body">{translate('text_17792001643312864fz7j4gq')}</Typography>
               </DetailsPage.Container>
             ),
             hidden: !isFeatureFlagActive(FeatureFlags.EDIT_DETAILS_PAGE),

--- a/src/pages/__tests__/PlanDetails.test.tsx
+++ b/src/pages/__tests__/PlanDetails.test.tsx
@@ -66,6 +66,13 @@ jest.mock('~/generated/graphql', () => ({
     mockUseGetPlanForDetailsQuery(options),
 }))
 
+const mockIsFeatureFlagActive = jest.fn().mockReturnValue(false)
+
+jest.mock('~/core/utils/featureFlags', () => ({
+  ...jest.requireActual('~/core/utils/featureFlags'),
+  isFeatureFlagActive: (flag: string) => mockIsFeatureFlagActive(flag),
+}))
+
 interface MainHeaderDropdownAction {
   type: string
   items: { hidden?: boolean; label: string }[]
@@ -83,6 +90,7 @@ describe('PlanDetails', () => {
 
     useParamsMock.mockReturnValue({ planId: 'plan-123' })
     mockIsPremium.mockReturnValue(true)
+    mockIsFeatureFlagActive.mockReturnValue(false)
     mockUseGetPlanForDetailsQuery.mockReturnValue({
       data: {
         plan: {
@@ -241,6 +249,37 @@ describe('PlanDetails', () => {
         render(<PlanDetails />)
 
         expect(testMockNavigateFn).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN the EDIT_DETAILS_PAGE feature flag', () => {
+    describe('WHEN the flag is off', () => {
+      it('THEN should hide the edit overview tab', () => {
+        mockHasPermissions.mockReturnValue(true)
+        mockIsFeatureFlagActive.mockReturnValue(false)
+
+        render(<PlanDetails />)
+
+        const tabs = mockMainHeaderConfigure.mock.calls[0]?.[0]?.tabs as MainHeaderTabConfig[]
+        const editOverviewTab = tabs.find((t) => t.title === 'text_17792001643312864fz7j4gq')
+
+        expect(editOverviewTab?.hidden).toBe(true)
+      })
+    })
+
+    describe('WHEN the flag is on', () => {
+      it('THEN should render the edit overview tab as visible', () => {
+        mockHasPermissions.mockReturnValue(true)
+        mockIsFeatureFlagActive.mockReturnValue(true)
+
+        render(<PlanDetails />)
+
+        const tabs = mockMainHeaderConfigure.mock.calls[0]?.[0]?.tabs as MainHeaderTabConfig[]
+        const editOverviewTab = tabs.find((t) => t.title === 'text_17792001643312864fz7j4gq')
+
+        expect(editOverviewTab).toBeDefined()
+        expect(editOverviewTab?.hidden).toBe(false)
       })
     })
   })

--- a/src/pages/subscriptions/SubscriptionDetails.tsx
+++ b/src/pages/subscriptions/SubscriptionDetails.tsx
@@ -27,6 +27,7 @@ import {
   useNavigate,
 } from '~/core/router'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
+import { FeatureFlags, isFeatureFlagActive } from '~/core/utils/featureFlags'
 import {
   LagoApiError,
   StatusTypeEnum,
@@ -257,6 +258,52 @@ const SubscriptionDetails = () => {
           </DetailsPage.Container>
         ),
         hidden: !subscription?.externalId || !isPremium || !hasPermissions(['auditLogsView']),
+      },
+      {
+        title: translate('text_17792001643312864fz7j4gq'),
+        link: !!customerId
+          ? getCustomerSubscriptionDetailsRoute(
+              CustomerSubscriptionDetailsTabsOptionsEnum.editOverview,
+            )
+          : getPlanSubscriptionDetailsRoute(
+              CustomerSubscriptionDetailsTabsOptionsEnum.editOverview,
+            ),
+        match: [
+          getCustomerSubscriptionDetailsRoute(
+            CustomerSubscriptionDetailsTabsOptionsEnum.editOverview,
+          ),
+          getPlanSubscriptionDetailsRoute(CustomerSubscriptionDetailsTabsOptionsEnum.editOverview),
+        ],
+        content: (
+          <DetailsPage.Container>
+            <div className="bg-grey-100" />
+          </DetailsPage.Container>
+        ),
+        hidden: !isFeatureFlagActive(FeatureFlags.EDIT_DETAILS_PAGE),
+      },
+      {
+        title: translate('text_17792001643316pbexygvpu2'),
+        link: !!customerId
+          ? getCustomerSubscriptionDetailsRoute(
+              CustomerSubscriptionDetailsTabsOptionsEnum.subscriptionPlan,
+            )
+          : getPlanSubscriptionDetailsRoute(
+              CustomerSubscriptionDetailsTabsOptionsEnum.subscriptionPlan,
+            ),
+        match: [
+          getCustomerSubscriptionDetailsRoute(
+            CustomerSubscriptionDetailsTabsOptionsEnum.subscriptionPlan,
+          ),
+          getPlanSubscriptionDetailsRoute(
+            CustomerSubscriptionDetailsTabsOptionsEnum.subscriptionPlan,
+          ),
+        ],
+        content: (
+          <DetailsPage.Container>
+            <div className="bg-grey-100" />
+          </DetailsPage.Container>
+        ),
+        hidden: !isFeatureFlagActive(FeatureFlags.EDIT_DETAILS_PAGE),
       },
     ]
   }, [

--- a/src/pages/subscriptions/SubscriptionDetails.tsx
+++ b/src/pages/subscriptions/SubscriptionDetails.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { useTerminateCustomerSubscriptionDialog } from '~/components/customers/subscriptions/TerminateCustomerSubscriptionDialog'
+import { Typography } from '~/components/designSystem/Typography'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { MainHeaderAction } from '~/components/MainHeader/types'
@@ -276,7 +277,7 @@ const SubscriptionDetails = () => {
         ],
         content: (
           <DetailsPage.Container>
-            <div className="bg-grey-100" />
+            <Typography variant="body">{translate('text_17792001643312864fz7j4gq')}</Typography>
           </DetailsPage.Container>
         ),
         hidden: !isFeatureFlagActive(FeatureFlags.EDIT_DETAILS_PAGE),
@@ -300,7 +301,7 @@ const SubscriptionDetails = () => {
         ],
         content: (
           <DetailsPage.Container>
-            <div className="bg-grey-100" />
+            <Typography variant="body">{translate('text_17792001643316pbexygvpu2')}</Typography>
           </DetailsPage.Container>
         ),
         hidden: !isFeatureFlagActive(FeatureFlags.EDIT_DETAILS_PAGE),

--- a/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
+++ b/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
@@ -110,6 +110,13 @@ jest.mock('~/hooks/useSubscriptionPermissionsActions', () => ({
   }),
 }))
 
+const mockIsFeatureFlagActive = jest.fn().mockReturnValue(false)
+
+jest.mock('~/core/utils/featureFlags', () => ({
+  ...jest.requireActual('~/core/utils/featureFlags'),
+  isFeatureFlagActive: (flag: string) => mockIsFeatureFlagActive(flag),
+}))
+
 describe('SubscriptionDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -118,6 +125,7 @@ describe('SubscriptionDetails', () => {
     mockCanEditSubscription.mockReturnValue(true)
     mockIsStatusEditable.mockReturnValue(true)
     mockUseCurrentUser.mockReturnValue({ isPremium: true })
+    mockIsFeatureFlagActive.mockReturnValue(false)
 
     const useParamsMock = jest.requireMock('react-router-dom').useParams as jest.Mock
 
@@ -325,10 +333,10 @@ describe('SubscriptionDetails', () => {
 
   describe('GIVEN tab configuration', () => {
     describe('WHEN all conditions are met (premium, permissions, active status)', () => {
-      it('THEN should configure 6 tabs', () => {
+      it('THEN should configure 8 tabs', () => {
         render(<SubscriptionDetails />)
 
-        expect(capturedConfig?.tabs).toHaveLength(6)
+        expect(capturedConfig?.tabs).toHaveLength(8)
       })
     })
 
@@ -484,13 +492,69 @@ describe('SubscriptionDetails', () => {
       it('THEN should still configure tabs', () => {
         render(<SubscriptionDetails />)
 
-        expect(capturedConfig?.tabs).toHaveLength(6)
+        expect(capturedConfig?.tabs).toHaveLength(8)
       })
 
       it('THEN should still display the active tab content', () => {
         render(<SubscriptionDetails />)
 
         expect(screen.getByTestId('active-tab-content')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN the EDIT_DETAILS_PAGE feature flag', () => {
+    describe('WHEN the flag is off', () => {
+      it('THEN should hide the edit overview tab', () => {
+        mockIsFeatureFlagActive.mockReturnValue(false)
+
+        render(<SubscriptionDetails />)
+
+        const editOverviewTab = capturedConfig?.tabs?.find(
+          (t) => t.title === 'text_17792001643312864fz7j4gq',
+        )
+
+        expect(editOverviewTab?.hidden).toBe(true)
+      })
+
+      it('THEN should hide the subscription plan tab', () => {
+        mockIsFeatureFlagActive.mockReturnValue(false)
+
+        render(<SubscriptionDetails />)
+
+        const subPlanTab = capturedConfig?.tabs?.find(
+          (t) => t.title === 'text_17792001643316pbexygvpu2',
+        )
+
+        expect(subPlanTab?.hidden).toBe(true)
+      })
+    })
+
+    describe('WHEN the flag is on', () => {
+      it('THEN should render the edit overview tab as visible', () => {
+        mockIsFeatureFlagActive.mockReturnValue(true)
+
+        render(<SubscriptionDetails />)
+
+        const editOverviewTab = capturedConfig?.tabs?.find(
+          (t) => t.title === 'text_17792001643312864fz7j4gq',
+        )
+
+        expect(editOverviewTab).toBeDefined()
+        expect(editOverviewTab?.hidden).toBe(false)
+      })
+
+      it('THEN should render the subscription plan tab as visible', () => {
+        mockIsFeatureFlagActive.mockReturnValue(true)
+
+        render(<SubscriptionDetails />)
+
+        const subPlanTab = capturedConfig?.tabs?.find(
+          (t) => t.title === 'text_17792001643316pbexygvpu2',
+        )
+
+        expect(subPlanTab).toBeDefined()
+        expect(subPlanTab?.hidden).toBe(false)
       })
     })
   })

--- a/translations/base.json
+++ b/translations/base.json
@@ -4164,5 +4164,7 @@
   "text_17768523811635qaasto1ziv": "No content available",
   "text_1779108075497ugghnttia9w": "Invoice {{invoiceNumber}} for {{totalAmount}} is ready to be finalized",
   "text_17791987800304a3fihrighy": "Subscription settings",
-  "text_1779198780030g64up7d4imi": "Define how the subscription is paid and define the invoice settings."
+  "text_1779198780030g64up7d4imi": "Define how the subscription is paid and define the invoice settings.",
+  "text_17792001643312864fz7j4gq": "Edit overview",
+  "text_17792001643316pbexygvpu2": "Subscription plan"
 }


### PR DESCRIPTION
## Summary
- Adds `EDIT_DETAILS_PAGE` localStorage feature flag.
- Appends three flag-gated placeholder tabs: Plan / `Edit overview`, Sub / `Edit overview`, Sub / `Subscription plan`. Content is `<div class="bg-grey-100" />` until subsequent step PRs (LAGO-1465+) fill it in.
- Records the cascade-endpoint audit confirming no BE gap blocks the rest of LAGO-1269.

Linear: [LAGO-1464](https://linear.app/getlago/issue/LAGO-1464/plansub-v2-step-0-feature-flag-empty-tabs-scaffold) (parent LAGO-1269)

## Endpoint audit (cascadeUpdates)

All ten plan-level mutation inputs accept `cascadeUpdates` ✅:
- `Charge{Create,Update}Input`, `DestroyChargeInput`
- `ChargeFilter{Create,Update}Input`, `DestroyChargeFilterInput`
- `FixedCharge{Create,Update}Input`, `DestroyFixedChargeInput`
- `UpdatePlanInput`

Sub-level inputs intentionally do not — they write per-subscription overrides, not the parent plan:
- `{Create,Update,Destroy}SubscriptionChargeFilterInput`
- `UpdateSubscriptionChargeInput`, `UpdateSubscriptionFixedChargeInput`, `UpdateSubscriptionInput`

No BE ticket needed.

Verify locally:
\`\`\`bash
awk '/^export type [A-Z][a-zA-Z]+ = \{/{n=\$3} /cascadeUpdates\?: InputMaybe/{print n}' \
  src/generated/graphql.tsx | sort -u
\`\`\`

## Test plan
- [ ] Flag off (default \`localStorage.featureFlags\` absent or \`[]\`) → only legacy tabs visible on Plan and Subscription detail pages.
- [ ] Set \`localStorage.featureFlags = '[\"edit_details_page\"]'\` → three new tabs appear; each navigates to its route and renders the grey placeholder.
- [ ] \`pnpm test\` green on changed files (\`PlanDetails.test\`, \`SubscriptionDetails.test\`). One unrelated flake noted in \`EditInvoiceIssuingDatePolicyDialogContentBase\` — passes in isolation.
- [ ] \`pnpm code:style\` green (no new warnings on edited files).