### PR TITLE
refactor(sub): extract form sections for v2 reuse

### DIFF
--- a/src/components/subscriptions/form/InvoicingPaymentsFormSection.tsx
+++ b/src/components/subscriptions/form/InvoicingPaymentsFormSection.tsx
@@ -1,0 +1,57 @@
+import { CenteredPage } from '~/components/layouts/CenteredPage'
+import { PaymentMethodsInvoiceSettings } from '~/components/paymentMethodsInvoiceSettings/PaymentMethodsInvoiceSettings'
+import {
+  PaymentMethodsInvoiceSettingsProps,
+  ViewTypeEnum,
+} from '~/components/paymentMethodsInvoiceSettings/types'
+import { FORM_TYPE_ENUM } from '~/core/constants/form'
+import { Customer, Maybe } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { withForm } from '~/hooks/forms/useAppform'
+
+import { buildSubscriptionDefaultValues } from './buildSubscriptionDefaultValues'
+
+type CustomerForPayments = Maybe<Partial<Pick<Customer, 'id' | 'externalId'>>>
+
+interface InvoicingPaymentsFormSectionExtraProps {
+  customer: CustomerForPayments
+}
+
+const invoicingPaymentsDefaultProps: InvoicingPaymentsFormSectionExtraProps = {
+  customer: null,
+}
+
+const TYPING_PLACEHOLDER_DATE = '2026-01-01'
+
+export const InvoicingPaymentsFormSection = withForm({
+  defaultValues: buildSubscriptionDefaultValues(
+    undefined,
+    FORM_TYPE_ENUM.creation,
+    TYPING_PLACEHOLDER_DATE,
+  ),
+  props: invoicingPaymentsDefaultProps,
+  render: function InvoicingPaymentsFormSection({ form, customer }) {
+    const { translate } = useInternationalization()
+
+    if (!customer?.externalId && !customer?.id) return null
+
+    return (
+      <CenteredPage.PageSection>
+        <CenteredPage.PageSectionTitle
+          title={translate('text_1762862388271au34vz50g8i')}
+          description={translate('text_1779198780030g64up7d4imi')}
+        />
+        <PaymentMethodsInvoiceSettings
+          customer={customer}
+          formikProps={
+            {
+              values: form.state.values,
+              setFieldValue: form.setFieldValue,
+            } as PaymentMethodsInvoiceSettingsProps<ViewTypeEnum.Subscription>['formikProps']
+          }
+          viewType={ViewTypeEnum.Subscription}
+        />
+      </CenteredPage.PageSection>
+    )
+  },
+})

--- a/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
+++ b/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
@@ -175,22 +175,22 @@ export const SubscriptionInformationFormSection = withForm({
                   />
                 )}
               </form.AppField>
-              <Tooltip
-                className="mt-7 h-fit"
-                disableHoverListener={formType !== FORM_TYPE_ENUM.creation}
-                placement="top-end"
-                title={translate('text_63aa085d28b8510cd46443ff')}
-              >
-                <Button
-                  icon="trash"
-                  disabled={formType !== FORM_TYPE_ENUM.creation}
-                  variant="quaternary"
-                  onClick={() => {
-                    form.setFieldValue('externalId', '')
-                    setShouldDisplaySubscriptionExternalId(false)
-                  }}
-                />
-              </Tooltip>
+              {formType === FORM_TYPE_ENUM.creation && (
+                <Tooltip
+                  className="mt-7 h-fit"
+                  placement="top-end"
+                  title={translate('text_63aa085d28b8510cd46443ff')}
+                >
+                  <Button
+                    icon="trash"
+                    variant="quaternary"
+                    onClick={() => {
+                      form.setFieldValue('externalId', '')
+                      setShouldDisplaySubscriptionExternalId(false)
+                    }}
+                  />
+                </Tooltip>
+              )}
             </div>
           )}
 

--- a/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
+++ b/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
@@ -159,10 +159,7 @@ export const SubscriptionInformationFormSection = withForm({
           description={translate('text_66630368f4333b00795b0e1c')}
         />
 
-        <div
-          className="flex flex-col gap-6"
-          data-test="create-subscription-form-wrapper"
-        >
+        <div className="flex flex-col gap-6" data-test="create-subscription-form-wrapper">
           {!!shouldDisplaySubscriptionExternalId && (
             <div className="flex flex-row gap-3 [&>*:first-child]:flex-1">
               <form.AppField name="externalId">
@@ -308,12 +305,7 @@ export const SubscriptionInformationFormSection = withForm({
                     subscriptionAtValue: state.values.subscriptionAt,
                   })}
                 >
-                  {({
-                    endingAtErrors,
-                    subscriptionAtErrors,
-                    endingAtValue,
-                    subscriptionAtValue,
-                  }) =>
+                  {({ endingAtErrors, subscriptionAtErrors, endingAtValue, subscriptionAtValue }) =>
                     !endingAtErrors?.length &&
                     !subscriptionAtErrors?.length && (
                       <SubscriptionDatesOffsetHelperComponent

--- a/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
+++ b/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
@@ -19,7 +19,10 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { withForm } from '~/hooks/forms/useAppform'
 
-import { buildSubscriptionDefaultValues } from './buildSubscriptionDefaultValues'
+import {
+  buildSubscriptionDefaultValues,
+  SubscriptionFormType,
+} from './buildSubscriptionDefaultValues'
 
 const getBillingTimeSelectorTranslationKey = (planInterval?: PlanInterval) => {
   switch (planInterval) {
@@ -35,7 +38,7 @@ const getBillingTimeSelectorTranslationKey = (planInterval?: PlanInterval) => {
 }
 
 interface SubscriptionInformationFormSectionExtraProps {
-  formType: string
+  formType: SubscriptionFormType
   subscription: GetSubscriptionForCreateSubscriptionQuery['subscription'] | undefined
   customerTimezone?: TimezoneEnum | null
   shouldDisplaySubscriptionExternalId: boolean

--- a/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
+++ b/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
@@ -1,0 +1,335 @@
+import { useStore } from '@tanstack/react-form'
+import { DateTime } from 'luxon'
+import { Dispatch, SetStateAction, useMemo } from 'react'
+
+import { SubscriptionDatesOffsetHelperComponent } from '~/components/customers/subscriptions/SubscriptionDatesOffsetHelperComponent'
+import { Alert } from '~/components/designSystem/Alert'
+import { Button } from '~/components/designSystem/Button'
+import { Tooltip } from '~/components/designSystem/Tooltip'
+import { CenteredPage } from '~/components/layouts/CenteredPage'
+import { FORM_TYPE_ENUM } from '~/core/constants/form'
+import { DateFormat, getTimezoneConfig, intlFormatDateTime } from '~/core/timezone'
+import {
+  BillingTimeEnum,
+  GetSubscriptionForCreateSubscriptionQuery,
+  PlanInterval,
+  StatusTypeEnum,
+  TimezoneEnum,
+} from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { withForm } from '~/hooks/forms/useAppform'
+
+import { buildSubscriptionDefaultValues } from './buildSubscriptionDefaultValues'
+
+const getBillingTimeSelectorTranslationKey = (planInterval?: PlanInterval) => {
+  switch (planInterval) {
+    case PlanInterval.Yearly:
+      return 'text_62ebd597d5d5130a03ced107'
+    case PlanInterval.Weekly:
+      return 'text_62ebd597d5d5130a03ced101'
+    case PlanInterval.Quarterly:
+      return 'text_64d6357b00dea100ad1cba27'
+    default:
+      return 'text_62ea7cd44cd4b14bb9ac1db9'
+  }
+}
+
+interface SubscriptionInformationFormSectionExtraProps {
+  formType: string
+  subscription: GetSubscriptionForCreateSubscriptionQuery['subscription'] | undefined
+  customerTimezone?: TimezoneEnum | null
+  shouldDisplaySubscriptionExternalId: boolean
+  setShouldDisplaySubscriptionExternalId: Dispatch<SetStateAction<boolean>>
+  shouldDisplaySubscriptionName: boolean
+  setShouldDisplaySubscriptionName: Dispatch<SetStateAction<boolean>>
+  selectedPlanInterval?: PlanInterval
+}
+
+const subscriptionInformationDefaultProps: SubscriptionInformationFormSectionExtraProps = {
+  formType: FORM_TYPE_ENUM.creation,
+  subscription: undefined,
+  customerTimezone: undefined,
+  shouldDisplaySubscriptionExternalId: false,
+  setShouldDisplaySubscriptionExternalId: () => {},
+  shouldDisplaySubscriptionName: false,
+  setShouldDisplaySubscriptionName: () => {},
+  selectedPlanInterval: undefined,
+}
+
+const TYPING_PLACEHOLDER_DATE = '2026-01-01'
+
+export const SubscriptionInformationFormSection = withForm({
+  defaultValues: buildSubscriptionDefaultValues(
+    undefined,
+    FORM_TYPE_ENUM.creation,
+    TYPING_PLACEHOLDER_DATE,
+  ),
+  props: subscriptionInformationDefaultProps,
+  render: function SubscriptionInformationFormSection({
+    form,
+    formType,
+    subscription,
+    customerTimezone,
+    shouldDisplaySubscriptionExternalId,
+    setShouldDisplaySubscriptionExternalId,
+    shouldDisplaySubscriptionName,
+    setShouldDisplaySubscriptionName,
+    selectedPlanInterval,
+  }) {
+    const { translate } = useInternationalization()
+
+    const subscriptionBillingTime = useStore(form.store, (state) => state.values.billingTime)
+    const subscriptionAt = useStore(form.store, (state) => state.values.subscriptionAt)
+
+    const billingTimeHelper = useMemo(() => {
+      const billingTime = subscriptionBillingTime
+      const currentDate = subscriptionAt
+        ? DateTime.fromISO(subscriptionAt)
+        : DateTime.now().setLocale('en-gb')
+      const formattedCurrentDate = currentDate.toFormat('LL/dd/yyyy')
+      const february29 = `02/29/${DateTime.now().year}`
+      const currentDay = currentDate.get('day')
+
+      if (!selectedPlanInterval) return undefined
+
+      switch (selectedPlanInterval) {
+        case PlanInterval.Monthly:
+          if (billingTime === BillingTimeEnum.Calendar)
+            return translate('text_62ea7cd44cd4b14bb9ac1d7e')
+
+          if (currentDay <= 28) {
+            return translate('text_62ea7cd44cd4b14bb9ac1d82', { day: currentDay })
+          } else if (currentDay === 29) {
+            return translate('text_62ea7cd44cd4b14bb9ac1d86')
+          } else if (currentDay === 30) {
+            return translate('text_62ea7cd44cd4b14bb9ac1d8a')
+          }
+          return translate('text_62ea7cd44cd4b14bb9ac1d8e')
+
+        case PlanInterval.Yearly:
+          if (billingTime === BillingTimeEnum.Calendar)
+            return translate('text_62ea7cd44cd4b14bb9ac1d92')
+
+          if (formattedCurrentDate === february29) return translate('text_62ea7cd44cd4b14bb9ac1d9a')
+
+          return translate('text_62ea7cd44cd4b14bb9ac1d96', {
+            date: intlFormatDateTime(currentDate.toISO() || '', {
+              formatDate: DateFormat.DATE_MED_SHORT,
+            }).date,
+          })
+
+        case PlanInterval.Semiannual:
+          return billingTime === BillingTimeEnum.Calendar
+            ? translate('text_1757502242292q05inkc09vq')
+            : translate('text_1757504174992y39ailqcch0', {
+                date: intlFormatDateTime(currentDate.toISO() || '', {
+                  formatDate: DateFormat.DATE_MED_SHORT,
+                }).date,
+              })
+
+        case PlanInterval.Quarterly:
+          if (billingTime === BillingTimeEnum.Calendar)
+            return translate('text_64d6357b00dea100ad1cba34')
+
+          if (currentDay <= 28) {
+            return translate('text_64d6357b00dea100ad1cba36', { day: currentDay })
+          } else if (currentDay === 29) {
+            return translate('text_64d63ec2f6bd3f41a6e353ac')
+          } else if (currentDay === 30) {
+            return translate('text_64d63ec2f6bd3f41a6e353b0')
+          }
+          return translate('text_64d63ec2f6bd3f41a6e353b4')
+
+        case PlanInterval.Weekly:
+        default:
+          return billingTime === BillingTimeEnum.Calendar
+            ? translate('text_62ea7cd44cd4b14bb9ac1d9e')
+            : translate('text_62ea7cd44cd4b14bb9ac1da2', { day: currentDate.weekdayLong })
+      }
+    }, [subscriptionBillingTime, subscriptionAt, selectedPlanInterval, translate])
+
+    return (
+      <CenteredPage.PageSection>
+        {!subscription?.plan.parent && formType === FORM_TYPE_ENUM.edition && (
+          <Alert type="info">{translate('text_652525609f420d00b83dd602')}</Alert>
+        )}
+
+        <CenteredPage.PageSectionTitle
+          title={translate('text_17791987800304a3fihrighy')}
+          description={translate('text_66630368f4333b00795b0e1c')}
+        />
+
+        <div
+          className="flex flex-col gap-6"
+          data-test="create-subscription-form-wrapper"
+        >
+          {!!shouldDisplaySubscriptionExternalId && (
+            <div className="flex flex-row gap-3 [&>*:first-child]:flex-1">
+              <form.AppField name="externalId">
+                {(field) => (
+                  <field.TextInputField
+                    disabled={formType !== FORM_TYPE_ENUM.creation}
+                    label={translate('text_642a94e522316cd9e1875224')}
+                    placeholder={translate('text_642ac1d1407baafb9e4390ee')}
+                    helperText={translate('text_642ac28c65c2180085afe31a')}
+                  />
+                )}
+              </form.AppField>
+              <Tooltip
+                className="mt-7 h-fit"
+                disableHoverListener={formType !== FORM_TYPE_ENUM.creation}
+                placement="top-end"
+                title={translate('text_63aa085d28b8510cd46443ff')}
+              >
+                <Button
+                  icon="trash"
+                  disabled={formType !== FORM_TYPE_ENUM.creation}
+                  variant="quaternary"
+                  onClick={() => {
+                    form.setFieldValue('externalId', '')
+                    setShouldDisplaySubscriptionExternalId(false)
+                  }}
+                />
+              </Tooltip>
+            </div>
+          )}
+
+          {!!shouldDisplaySubscriptionName && (
+            <div className="flex flex-row gap-3 [&>*:first-child]:flex-1">
+              <form.AppField name="name">
+                {(field) => (
+                  <field.TextInputField
+                    label={translate('text_62d7f6178ec94cd09370e2b9')}
+                    placeholder={translate('text_62d7f6178ec94cd09370e2cb')}
+                    helperText={translate('text_62d7f6178ec94cd09370e2d9')}
+                  />
+                )}
+              </form.AppField>
+              <Tooltip
+                className="mt-7 h-fit"
+                disableHoverListener={formType !== FORM_TYPE_ENUM.creation}
+                placement="top-end"
+                title={translate('text_63aa085d28b8510cd46443ff')}
+              >
+                <Button
+                  icon="trash"
+                  variant="quaternary"
+                  onClick={() => {
+                    form.setFieldValue('name', '')
+                    setShouldDisplaySubscriptionName(false)
+                  }}
+                />
+              </Tooltip>
+            </div>
+          )}
+
+          {(!shouldDisplaySubscriptionExternalId || !shouldDisplaySubscriptionName) && (
+            <div className="flex items-center gap-4">
+              {!shouldDisplaySubscriptionExternalId && (
+                <Button
+                  startIcon="plus"
+                  disabled={formType !== FORM_TYPE_ENUM.creation}
+                  variant="inline"
+                  onClick={() => setShouldDisplaySubscriptionExternalId(true)}
+                  data-test="show-external-id"
+                >
+                  {translate('text_65118a52df984447c1869472')}
+                </Button>
+              )}
+              {!shouldDisplaySubscriptionName && (
+                <Button
+                  startIcon="plus"
+                  variant="inline"
+                  onClick={() => setShouldDisplaySubscriptionName(true)}
+                  data-test="show-name"
+                >
+                  {translate('text_65118a52df984447c186947c')}
+                </Button>
+              )}
+            </div>
+          )}
+
+          {formType !== FORM_TYPE_ENUM.upgradeDowngrade && (
+            <>
+              <form.AppField name="billingTime">
+                {(field) => (
+                  <field.ButtonSelectorField
+                    disabled={formType !== FORM_TYPE_ENUM.creation}
+                    label={translate('text_62ea7cd44cd4b14bb9ac1db7')}
+                    helperText={billingTimeHelper}
+                    options={[
+                      {
+                        label: translate(
+                          getBillingTimeSelectorTranslationKey(selectedPlanInterval),
+                        ),
+                        value: BillingTimeEnum.Calendar,
+                      },
+                      {
+                        label: translate('text_62ea7cd44cd4b14bb9ac1dbb'),
+                        value: BillingTimeEnum.Anniversary,
+                      },
+                    ]}
+                  />
+                )}
+              </form.AppField>
+
+              <div>
+                <div className="flex items-start gap-6 [&>*]:flex-1">
+                  <form.AppField name="subscriptionAt">
+                    {(field) => (
+                      <field.DatePickerField
+                        disabled={
+                          formType !== FORM_TYPE_ENUM.creation &&
+                          subscription?.status !== StatusTypeEnum.Pending
+                        }
+                        placement="auto"
+                        label={translate('text_64ef55a730b88e3d2117b3c4')}
+                        defaultZone={getTimezoneConfig(TimezoneEnum.TzUtc).name}
+                      />
+                    )}
+                  </form.AppField>
+                  <form.AppField name="endingAt">
+                    {(field) => (
+                      <field.DatePickerField
+                        disablePast
+                        placement="auto"
+                        label={translate('text_64ef55a730b88e3d2117b3cc')}
+                        defaultZone={getTimezoneConfig(TimezoneEnum.TzUtc).name}
+                        inputProps={{ cleanable: true }}
+                      />
+                    )}
+                  </form.AppField>
+                </div>
+                <form.Subscribe
+                  selector={(state) => ({
+                    endingAtErrors: state.fieldMeta.endingAt?.errors,
+                    subscriptionAtErrors: state.fieldMeta.subscriptionAt?.errors,
+                    endingAtValue: state.values.endingAt,
+                    subscriptionAtValue: state.values.subscriptionAt,
+                  })}
+                >
+                  {({
+                    endingAtErrors,
+                    subscriptionAtErrors,
+                    endingAtValue,
+                    subscriptionAtValue,
+                  }) =>
+                    !endingAtErrors?.length &&
+                    !subscriptionAtErrors?.length && (
+                      <SubscriptionDatesOffsetHelperComponent
+                        className="mt-1"
+                        customerTimezone={customerTimezone}
+                        subscriptionAt={subscriptionAtValue}
+                        endingAt={endingAtValue}
+                      />
+                    )
+                  }
+                </form.Subscribe>
+              </div>
+            </>
+          )}
+        </div>
+      </CenteredPage.PageSection>
+    )
+  },
+})

--- a/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
+++ b/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
@@ -1,5 +1,4 @@
 import { useStore } from '@tanstack/react-form'
-import { DateTime } from 'luxon'
 import { Dispatch, SetStateAction, useMemo } from 'react'
 
 import { SubscriptionDatesOffsetHelperComponent } from '~/components/customers/subscriptions/SubscriptionDatesOffsetHelperComponent'
@@ -8,7 +7,7 @@ import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { FORM_TYPE_ENUM } from '~/core/constants/form'
-import { DateFormat, getTimezoneConfig, intlFormatDateTime } from '~/core/timezone'
+import { getTimezoneConfig } from '~/core/timezone'
 import {
   BillingTimeEnum,
   GetSubscriptionForCreateSubscriptionQuery,
@@ -23,6 +22,7 @@ import {
   buildSubscriptionDefaultValues,
   SubscriptionFormType,
 } from './buildSubscriptionDefaultValues'
+import { getBillingTimeHelperKey } from './getBillingTimeHelperKey'
 
 const getBillingTimeSelectorTranslationKey = (planInterval?: PlanInterval) => {
   switch (planInterval) {
@@ -85,70 +85,13 @@ export const SubscriptionInformationFormSection = withForm({
     const subscriptionAt = useStore(form.store, (state) => state.values.subscriptionAt)
 
     const billingTimeHelper = useMemo(() => {
-      const billingTime = subscriptionBillingTime
-      const currentDate = subscriptionAt
-        ? DateTime.fromISO(subscriptionAt)
-        : DateTime.now().setLocale('en-gb')
-      const formattedCurrentDate = currentDate.toFormat('LL/dd/yyyy')
-      const february29 = `02/29/${DateTime.now().year}`
-      const currentDay = currentDate.get('day')
+      const helper = getBillingTimeHelperKey(
+        subscriptionBillingTime,
+        subscriptionAt,
+        selectedPlanInterval,
+      )
 
-      if (!selectedPlanInterval) return undefined
-
-      switch (selectedPlanInterval) {
-        case PlanInterval.Monthly:
-          if (billingTime === BillingTimeEnum.Calendar)
-            return translate('text_62ea7cd44cd4b14bb9ac1d7e')
-
-          if (currentDay <= 28) {
-            return translate('text_62ea7cd44cd4b14bb9ac1d82', { day: currentDay })
-          } else if (currentDay === 29) {
-            return translate('text_62ea7cd44cd4b14bb9ac1d86')
-          } else if (currentDay === 30) {
-            return translate('text_62ea7cd44cd4b14bb9ac1d8a')
-          }
-          return translate('text_62ea7cd44cd4b14bb9ac1d8e')
-
-        case PlanInterval.Yearly:
-          if (billingTime === BillingTimeEnum.Calendar)
-            return translate('text_62ea7cd44cd4b14bb9ac1d92')
-
-          if (formattedCurrentDate === february29) return translate('text_62ea7cd44cd4b14bb9ac1d9a')
-
-          return translate('text_62ea7cd44cd4b14bb9ac1d96', {
-            date: intlFormatDateTime(currentDate.toISO() || '', {
-              formatDate: DateFormat.DATE_MED_SHORT,
-            }).date,
-          })
-
-        case PlanInterval.Semiannual:
-          return billingTime === BillingTimeEnum.Calendar
-            ? translate('text_1757502242292q05inkc09vq')
-            : translate('text_1757504174992y39ailqcch0', {
-                date: intlFormatDateTime(currentDate.toISO() || '', {
-                  formatDate: DateFormat.DATE_MED_SHORT,
-                }).date,
-              })
-
-        case PlanInterval.Quarterly:
-          if (billingTime === BillingTimeEnum.Calendar)
-            return translate('text_64d6357b00dea100ad1cba34')
-
-          if (currentDay <= 28) {
-            return translate('text_64d6357b00dea100ad1cba36', { day: currentDay })
-          } else if (currentDay === 29) {
-            return translate('text_64d63ec2f6bd3f41a6e353ac')
-          } else if (currentDay === 30) {
-            return translate('text_64d63ec2f6bd3f41a6e353b0')
-          }
-          return translate('text_64d63ec2f6bd3f41a6e353b4')
-
-        case PlanInterval.Weekly:
-        default:
-          return billingTime === BillingTimeEnum.Calendar
-            ? translate('text_62ea7cd44cd4b14bb9ac1d9e')
-            : translate('text_62ea7cd44cd4b14bb9ac1da2', { day: currentDate.weekdayLong })
-      }
+      return helper ? translate(helper.key, helper.variables) : undefined
     }, [subscriptionBillingTime, subscriptionAt, selectedPlanInterval, translate])
 
     return (

--- a/src/components/subscriptions/form/__tests__/InvoicingPaymentsFormSection.test.tsx
+++ b/src/components/subscriptions/form/__tests__/InvoicingPaymentsFormSection.test.tsx
@@ -4,7 +4,7 @@ import { render } from '~/test-utils'
 
 import { InvoicingPaymentsFormSection } from '../InvoicingPaymentsFormSection'
 
-const mockPaymentMethodsInvoiceSettings = jest.fn((_props: Record<string, unknown>) => null)
+const mockPaymentMethodsInvoiceSettings: jest.Mock<null, [Record<string, unknown>]> = jest.fn()
 
 jest.mock('~/components/paymentMethodsInvoiceSettings/PaymentMethodsInvoiceSettings', () => ({
   PaymentMethodsInvoiceSettings: (props: Record<string, unknown>) => {

--- a/src/components/subscriptions/form/__tests__/InvoicingPaymentsFormSection.test.tsx
+++ b/src/components/subscriptions/form/__tests__/InvoicingPaymentsFormSection.test.tsx
@@ -1,0 +1,108 @@
+import { screen } from '@testing-library/react'
+
+import { render } from '~/test-utils'
+
+import { InvoicingPaymentsFormSection } from '../InvoicingPaymentsFormSection'
+
+const mockPaymentMethodsInvoiceSettings = jest.fn((_props: Record<string, unknown>) => null)
+
+jest.mock('~/components/paymentMethodsInvoiceSettings/PaymentMethodsInvoiceSettings', () => ({
+  PaymentMethodsInvoiceSettings: (props: Record<string, unknown>) => {
+    mockPaymentMethodsInvoiceSettings(props)
+    return null
+  },
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+jest.mock('@tanstack/react-form', () => ({
+  revalidateLogic: jest.fn(() => ({})),
+}))
+
+jest.mock('~/hooks/forms/useAppform', () => ({
+  useAppForm: jest.fn(),
+  withForm: jest.fn(
+    ({
+      render: RenderComponent,
+      props: defaultProps,
+    }: {
+      render: React.FC<Record<string, unknown>>
+      defaultValues: Record<string, unknown>
+      props: Record<string, unknown>
+    }) => {
+      const WithFormWrapper = (receivedProps: Record<string, unknown>) => {
+        return <RenderComponent {...defaultProps} {...receivedProps} />
+      }
+
+      WithFormWrapper.displayName = 'WithFormWrapper'
+
+      return WithFormWrapper
+    },
+  ),
+}))
+
+const createMockForm = () => ({
+  setFieldValue: jest.fn(),
+  state: { values: { planId: 'plan-1' } },
+})
+
+describe('InvoicingPaymentsFormSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN a customer with id', () => {
+    it('THEN should render the section title and forward props to PaymentMethodsInvoiceSettings', () => {
+      render(
+        <InvoicingPaymentsFormSection
+          // @ts-expect-error — mock form shape
+          form={createMockForm()}
+          customer={{ id: 'cust-1' }}
+        />,
+      )
+
+      expect(screen.getByText('text_1762862388271au34vz50g8i')).toBeInTheDocument()
+      expect(mockPaymentMethodsInvoiceSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customer: { id: 'cust-1' },
+          viewType: 'subscription',
+          formikProps: expect.objectContaining({
+            values: expect.any(Object),
+            setFieldValue: expect.any(Function),
+          }),
+        }),
+      )
+    })
+  })
+
+  describe('GIVEN a customer with externalId only', () => {
+    it('THEN should render the section', () => {
+      render(
+        <InvoicingPaymentsFormSection
+          // @ts-expect-error — mock form shape
+          form={createMockForm()}
+          customer={{ externalId: 'ext-1' }}
+        />,
+      )
+
+      expect(screen.getByText('text_1762862388271au34vz50g8i')).toBeInTheDocument()
+    })
+  })
+
+  describe('GIVEN a customer without id or externalId', () => {
+    it('THEN should not render', () => {
+      render(
+        <InvoicingPaymentsFormSection
+          // @ts-expect-error — mock form shape
+          form={createMockForm()}
+          customer={null}
+        />,
+      )
+
+      expect(screen.queryByText('text_1762862388271au34vz50g8i')).not.toBeInTheDocument()
+      expect(mockPaymentMethodsInvoiceSettings).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/subscriptions/form/__tests__/SubscriptionInformationFormSection.test.tsx
+++ b/src/components/subscriptions/form/__tests__/SubscriptionInformationFormSection.test.tsx
@@ -91,7 +91,12 @@ const createMockForm = (values: Record<string, unknown> = {}) => ({
   }) => {
     const value = selector({
       fieldMeta: {},
-      values: { billingTime: BillingTimeEnum.Calendar, subscriptionAt: '', endingAt: '', ...values },
+      values: {
+        billingTime: BillingTimeEnum.Calendar,
+        subscriptionAt: '',
+        endingAt: '',
+        ...values,
+      },
     })
 
     return <>{children(value)}</>

--- a/src/components/subscriptions/form/__tests__/SubscriptionInformationFormSection.test.tsx
+++ b/src/components/subscriptions/form/__tests__/SubscriptionInformationFormSection.test.tsx
@@ -1,0 +1,155 @@
+import { screen } from '@testing-library/react'
+
+import { FORM_TYPE_ENUM } from '~/core/constants/form'
+import { BillingTimeEnum, PlanInterval } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import { SubscriptionInformationFormSection } from '../SubscriptionInformationFormSection'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+jest.mock('~/hooks/forms/formContext', () => ({
+  useFieldContext: jest.fn(),
+}))
+
+const mockSetFieldValue = jest.fn()
+
+jest.mock('@tanstack/react-form', () => ({
+  revalidateLogic: jest.fn(() => ({})),
+  useStore: (
+    store: { state: { values: Record<string, unknown> } },
+    selector: (state: { values: Record<string, unknown> }) => unknown,
+  ) => selector(store.state),
+}))
+
+jest.mock('~/hooks/forms/useAppform', () => ({
+  useAppForm: jest.fn(),
+  withForm: jest.fn(
+    ({
+      render: RenderComponent,
+      props: defaultProps,
+    }: {
+      render: React.FC<Record<string, unknown>>
+      defaultValues: Record<string, unknown>
+      props: Record<string, unknown>
+    }) => {
+      const WithFormWrapper = (receivedProps: Record<string, unknown>) => {
+        return <RenderComponent {...defaultProps} {...receivedProps} />
+      }
+
+      WithFormWrapper.displayName = 'WithFormWrapper'
+
+      return WithFormWrapper
+    },
+  ),
+}))
+
+const createMockForm = (values: Record<string, unknown> = {}) => ({
+  setFieldValue: mockSetFieldValue,
+  store: {
+    state: {
+      values: { billingTime: BillingTimeEnum.Calendar, subscriptionAt: '', ...values },
+    },
+  },
+  AppField: ({
+    children,
+    name,
+  }: {
+    children: (field: Record<string, React.FC<Record<string, unknown>>>) => React.ReactNode
+    name: string
+  }) => {
+    const FieldComponent: React.FC<Record<string, unknown>> = (fieldProps) => (
+      <input
+        name={name}
+        disabled={fieldProps.disabled as boolean | undefined}
+        placeholder={fieldProps.placeholder as string | undefined}
+        aria-label={fieldProps.label as string | undefined}
+      />
+    )
+
+    return (
+      <>
+        {children({
+          TextInputField: FieldComponent,
+          DatePickerField: FieldComponent,
+          ButtonSelectorField: FieldComponent,
+        })}
+      </>
+    )
+  },
+  Subscribe: ({
+    children,
+    selector,
+  }: {
+    children: (value: unknown) => React.ReactNode
+    selector: (state: {
+      fieldMeta: Record<string, { errors?: unknown[] }>
+      values: Record<string, unknown>
+    }) => unknown
+  }) => {
+    const value = selector({
+      fieldMeta: {},
+      values: { billingTime: BillingTimeEnum.Calendar, subscriptionAt: '', endingAt: '', ...values },
+    })
+
+    return <>{children(value)}</>
+  },
+})
+
+const renderSection = (
+  overrides: Partial<{
+    formType: string
+    shouldDisplaySubscriptionExternalId: boolean
+    shouldDisplaySubscriptionName: boolean
+    selectedPlanInterval: PlanInterval
+  }> = {},
+) =>
+  render(
+    <SubscriptionInformationFormSection
+      // @ts-expect-error — mock form shape
+      form={createMockForm()}
+      formType={overrides.formType ?? FORM_TYPE_ENUM.creation}
+      subscription={undefined}
+      customerTimezone={undefined}
+      shouldDisplaySubscriptionExternalId={overrides.shouldDisplaySubscriptionExternalId ?? false}
+      setShouldDisplaySubscriptionExternalId={jest.fn()}
+      shouldDisplaySubscriptionName={overrides.shouldDisplaySubscriptionName ?? false}
+      setShouldDisplaySubscriptionName={jest.fn()}
+      selectedPlanInterval={overrides.selectedPlanInterval}
+    />,
+  )
+
+describe('SubscriptionInformationFormSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN show-flags are off', () => {
+    it('THEN should render the show external-id and show name buttons', () => {
+      renderSection()
+
+      expect(screen.getByTestId('show-external-id')).toBeInTheDocument()
+      expect(screen.getByTestId('show-name')).toBeInTheDocument()
+    })
+  })
+
+  describe('GIVEN externalId display is enabled', () => {
+    it('THEN should render the externalId field and hide its add button', () => {
+      renderSection({ shouldDisplaySubscriptionExternalId: true })
+
+      expect(screen.queryByTestId('show-external-id')).not.toBeInTheDocument()
+      expect(screen.getByTestId('create-subscription-form-wrapper')).toBeInTheDocument()
+    })
+  })
+
+  describe('GIVEN formType is upgradeDowngrade', () => {
+    it('THEN should hide the show buttons section but keep the form wrapper', () => {
+      renderSection({ formType: FORM_TYPE_ENUM.upgradeDowngrade })
+
+      expect(screen.getByTestId('create-subscription-form-wrapper')).toBeInTheDocument()
+      expect(screen.queryByText('text_62ea7cd44cd4b14bb9ac1db7')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/subscriptions/form/__tests__/SubscriptionInformationFormSection.test.tsx
+++ b/src/components/subscriptions/form/__tests__/SubscriptionInformationFormSection.test.tsx
@@ -4,6 +4,7 @@ import { FORM_TYPE_ENUM } from '~/core/constants/form'
 import { BillingTimeEnum, PlanInterval } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
+import { SubscriptionFormType } from '../buildSubscriptionDefaultValues'
 import { SubscriptionInformationFormSection } from '../SubscriptionInformationFormSection'
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
@@ -105,7 +106,7 @@ const createMockForm = (values: Record<string, unknown> = {}) => ({
 
 const renderSection = (
   overrides: Partial<{
-    formType: string
+    formType: SubscriptionFormType
     shouldDisplaySubscriptionExternalId: boolean
     shouldDisplaySubscriptionName: boolean
     selectedPlanInterval: PlanInterval

--- a/src/components/subscriptions/form/__tests__/buildSubscriptionDefaultValues.test.ts
+++ b/src/components/subscriptions/form/__tests__/buildSubscriptionDefaultValues.test.ts
@@ -1,0 +1,130 @@
+import { FORM_TYPE_ENUM } from '~/core/constants/form'
+import { BillingTimeEnum } from '~/generated/graphql'
+
+import {
+  buildSubscriptionDefaultValues,
+  SubscriptionDefaultsSource,
+} from '../buildSubscriptionDefaultValues'
+
+const CURRENT_DATE = '2026-05-20T00:00:00.000Z'
+
+const baseSubscription = {
+  id: 'sub-1',
+  name: 'My subscription',
+  externalId: 'ext-1',
+  subscriptionAt: '2026-01-01T00:00:00.000Z',
+  endingAt: '2026-12-31T00:00:00.000Z',
+  billingTime: BillingTimeEnum.Anniversary,
+  plan: { id: 'plan-1' },
+  paymentMethodType: null,
+  paymentMethod: null,
+  selectedInvoiceCustomSections: [],
+  skipInvoiceCustomSections: false,
+} as unknown as SubscriptionDefaultsSource
+
+describe('buildSubscriptionDefaultValues', () => {
+  describe('GIVEN no subscription (creation flow)', () => {
+    it('THEN should return empty defaults with the provided currentDate', () => {
+      const result = buildSubscriptionDefaultValues(
+        undefined,
+        FORM_TYPE_ENUM.creation,
+        CURRENT_DATE,
+      )
+
+      expect(result).toEqual({
+        planId: '',
+        name: '',
+        externalId: '',
+        subscriptionAt: CURRENT_DATE,
+        endingAt: undefined,
+        billingTime: BillingTimeEnum.Calendar,
+        paymentMethod: { paymentMethodType: undefined, paymentMethodId: undefined },
+        invoiceCustomSection: { invoiceCustomSections: [], skipInvoiceCustomSections: false },
+      })
+    })
+  })
+
+  describe('GIVEN a subscription with formType=edition', () => {
+    it('THEN should hydrate planId, name, externalId, dates and billingTime from the subscription', () => {
+      const result = buildSubscriptionDefaultValues(
+        baseSubscription,
+        FORM_TYPE_ENUM.edition,
+        CURRENT_DATE,
+      )
+
+      expect(result).toMatchObject({
+        planId: 'plan-1',
+        name: 'My subscription',
+        externalId: 'ext-1',
+        subscriptionAt: '2026-01-01T00:00:00.000Z',
+        endingAt: '2026-12-31T00:00:00.000Z',
+        billingTime: BillingTimeEnum.Anniversary,
+      })
+    })
+  })
+
+  describe('GIVEN formType=upgradeDowngrade', () => {
+    it('THEN should clear planId and name even when present on the subscription', () => {
+      const result = buildSubscriptionDefaultValues(
+        baseSubscription,
+        FORM_TYPE_ENUM.upgradeDowngrade,
+        CURRENT_DATE,
+      )
+
+      expect(result.planId).toBe('')
+      expect(result.name).toBe('')
+    })
+
+    it('THEN should preserve other fields (externalId, dates, billingTime)', () => {
+      const result = buildSubscriptionDefaultValues(
+        baseSubscription,
+        FORM_TYPE_ENUM.upgradeDowngrade,
+        CURRENT_DATE,
+      )
+
+      expect(result.externalId).toBe('ext-1')
+      expect(result.subscriptionAt).toBe('2026-01-01T00:00:00.000Z')
+      expect(result.endingAt).toBe('2026-12-31T00:00:00.000Z')
+      expect(result.billingTime).toBe(BillingTimeEnum.Anniversary)
+    })
+  })
+
+  describe('GIVEN a subscription missing subscriptionAt', () => {
+    it('THEN should fall back to the provided currentDate', () => {
+      const subscription = {
+        ...baseSubscription,
+        subscriptionAt: undefined,
+      } as unknown as SubscriptionDefaultsSource
+      const result = buildSubscriptionDefaultValues(
+        subscription,
+        FORM_TYPE_ENUM.edition,
+        CURRENT_DATE,
+      )
+
+      expect(result.subscriptionAt).toBe(CURRENT_DATE)
+    })
+  })
+
+  describe('GIVEN a subscription with payment method + custom invoice sections', () => {
+    it('THEN should map paymentMethod and invoiceCustomSection correctly', () => {
+      const subscription = {
+        ...baseSubscription,
+        paymentMethodType: 'card',
+        paymentMethod: { id: 'pm-1' },
+        selectedInvoiceCustomSections: [{ id: 'section-1' }],
+        skipInvoiceCustomSections: true,
+      } as unknown as SubscriptionDefaultsSource
+      const result = buildSubscriptionDefaultValues(
+        subscription,
+        FORM_TYPE_ENUM.edition,
+        CURRENT_DATE,
+      )
+
+      expect(result.paymentMethod).toEqual({ paymentMethodType: 'card', paymentMethodId: 'pm-1' })
+      expect(result.invoiceCustomSection).toEqual({
+        invoiceCustomSections: [{ id: 'section-1' }],
+        skipInvoiceCustomSections: true,
+      })
+    })
+  })
+})

--- a/src/components/subscriptions/form/__tests__/getBillingTimeHelperKey.test.ts
+++ b/src/components/subscriptions/form/__tests__/getBillingTimeHelperKey.test.ts
@@ -1,0 +1,232 @@
+import { BillingTimeEnum, PlanInterval } from '~/generated/graphql'
+
+import { getBillingTimeHelperKey } from '../getBillingTimeHelperKey'
+
+const SUB_AT_MID_MONTH = '2026-05-15T12:00:00.000'
+const SUB_AT_DAY_29 = '2026-05-29T12:00:00.000'
+const SUB_AT_DAY_30 = '2026-05-30T12:00:00.000'
+const SUB_AT_DAY_31 = '2026-05-31T12:00:00.000'
+
+describe('getBillingTimeHelperKey', () => {
+  describe('GIVEN no plan interval', () => {
+    it('THEN should return undefined', () => {
+      const result = getBillingTimeHelperKey(BillingTimeEnum.Calendar, SUB_AT_MID_MONTH, undefined)
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('GIVEN plan interval Monthly', () => {
+    describe('WHEN billingTime is Calendar', () => {
+      it('THEN should return calendar billing key', () => {
+        const result = getBillingTimeHelperKey(
+          BillingTimeEnum.Calendar,
+          SUB_AT_MID_MONTH,
+          PlanInterval.Monthly,
+        )
+
+        expect(result).toEqual({ key: 'text_62ea7cd44cd4b14bb9ac1d7e' })
+      })
+    })
+
+    describe('WHEN billingTime is Anniversary and current day ≤ 28', () => {
+      it('THEN should return key with day variable', () => {
+        const result = getBillingTimeHelperKey(
+          BillingTimeEnum.Anniversary,
+          SUB_AT_MID_MONTH,
+          PlanInterval.Monthly,
+        )
+
+        expect(result).toEqual({
+          key: 'text_62ea7cd44cd4b14bb9ac1d82',
+          variables: { day: 15 },
+        })
+      })
+    })
+
+    describe('WHEN billingTime is Anniversary and current day = 29', () => {
+      it('THEN should return key for day 29', () => {
+        const result = getBillingTimeHelperKey(
+          BillingTimeEnum.Anniversary,
+          SUB_AT_DAY_29,
+          PlanInterval.Monthly,
+        )
+
+        expect(result).toEqual({ key: 'text_62ea7cd44cd4b14bb9ac1d86' })
+      })
+    })
+
+    describe('WHEN billingTime is Anniversary and current day = 30', () => {
+      it('THEN should return key for day 30', () => {
+        const result = getBillingTimeHelperKey(
+          BillingTimeEnum.Anniversary,
+          SUB_AT_DAY_30,
+          PlanInterval.Monthly,
+        )
+
+        expect(result).toEqual({ key: 'text_62ea7cd44cd4b14bb9ac1d8a' })
+      })
+    })
+
+    describe('WHEN billingTime is Anniversary and current day ≥ 31', () => {
+      it('THEN should return key for end-of-month', () => {
+        const result = getBillingTimeHelperKey(
+          BillingTimeEnum.Anniversary,
+          SUB_AT_DAY_31,
+          PlanInterval.Monthly,
+        )
+
+        expect(result).toEqual({ key: 'text_62ea7cd44cd4b14bb9ac1d8e' })
+      })
+    })
+  })
+
+  describe('GIVEN plan interval Yearly', () => {
+    describe('WHEN billingTime is Calendar', () => {
+      it('THEN should return calendar yearly key', () => {
+        const result = getBillingTimeHelperKey(
+          BillingTimeEnum.Calendar,
+          SUB_AT_MID_MONTH,
+          PlanInterval.Yearly,
+        )
+
+        expect(result).toEqual({ key: 'text_62ea7cd44cd4b14bb9ac1d92' })
+      })
+    })
+
+    describe('WHEN billingTime is Anniversary on Feb 29 of the current year', () => {
+      it('THEN should return Feb-29 key when the current year is a leap year', () => {
+        const currentYear = new Date().getFullYear()
+        const isLeapYear =
+          (currentYear % 4 === 0 && currentYear % 100 !== 0) || currentYear % 400 === 0
+
+        if (!isLeapYear) {
+          return // helper only matches Feb-29 against the current year
+        }
+
+        const isoDate = `${currentYear}-02-29T12:00:00.000`
+        const result = getBillingTimeHelperKey(
+          BillingTimeEnum.Anniversary,
+          isoDate,
+          PlanInterval.Yearly,
+        )
+
+        expect(result).toEqual({ key: 'text_62ea7cd44cd4b14bb9ac1d9a' })
+      })
+    })
+
+    describe('WHEN billingTime is Anniversary on non-Feb-29', () => {
+      it('THEN should return key with date variable', () => {
+        const result = getBillingTimeHelperKey(
+          BillingTimeEnum.Anniversary,
+          SUB_AT_MID_MONTH,
+          PlanInterval.Yearly,
+        )
+
+        expect(result?.key).toBe('text_62ea7cd44cd4b14bb9ac1d96')
+        expect(result?.variables).toHaveProperty('date')
+      })
+    })
+  })
+
+  describe('GIVEN plan interval Quarterly', () => {
+    it('WHEN Calendar THEN returns calendar quarterly key', () => {
+      const result = getBillingTimeHelperKey(
+        BillingTimeEnum.Calendar,
+        SUB_AT_MID_MONTH,
+        PlanInterval.Quarterly,
+      )
+
+      expect(result).toEqual({ key: 'text_64d6357b00dea100ad1cba34' })
+    })
+
+    it('WHEN Anniversary day ≤ 28 THEN returns key with day variable', () => {
+      const result = getBillingTimeHelperKey(
+        BillingTimeEnum.Anniversary,
+        SUB_AT_MID_MONTH,
+        PlanInterval.Quarterly,
+      )
+
+      expect(result).toEqual({
+        key: 'text_64d6357b00dea100ad1cba36',
+        variables: { day: 15 },
+      })
+    })
+
+    it('WHEN Anniversary day = 29 THEN returns day-29 key', () => {
+      const result = getBillingTimeHelperKey(
+        BillingTimeEnum.Anniversary,
+        SUB_AT_DAY_29,
+        PlanInterval.Quarterly,
+      )
+
+      expect(result).toEqual({ key: 'text_64d63ec2f6bd3f41a6e353ac' })
+    })
+
+    it('WHEN Anniversary day = 30 THEN returns day-30 key', () => {
+      const result = getBillingTimeHelperKey(
+        BillingTimeEnum.Anniversary,
+        SUB_AT_DAY_30,
+        PlanInterval.Quarterly,
+      )
+
+      expect(result).toEqual({ key: 'text_64d63ec2f6bd3f41a6e353b0' })
+    })
+
+    it('WHEN Anniversary day ≥ 31 THEN returns end-of-month key', () => {
+      const result = getBillingTimeHelperKey(
+        BillingTimeEnum.Anniversary,
+        SUB_AT_DAY_31,
+        PlanInterval.Quarterly,
+      )
+
+      expect(result).toEqual({ key: 'text_64d63ec2f6bd3f41a6e353b4' })
+    })
+  })
+
+  describe('GIVEN plan interval Semiannual', () => {
+    it('WHEN Calendar THEN returns calendar semiannual key', () => {
+      const result = getBillingTimeHelperKey(
+        BillingTimeEnum.Calendar,
+        SUB_AT_MID_MONTH,
+        PlanInterval.Semiannual,
+      )
+
+      expect(result).toEqual({ key: 'text_1757502242292q05inkc09vq' })
+    })
+
+    it('WHEN Anniversary THEN returns key with date variable', () => {
+      const result = getBillingTimeHelperKey(
+        BillingTimeEnum.Anniversary,
+        SUB_AT_MID_MONTH,
+        PlanInterval.Semiannual,
+      )
+
+      expect(result?.key).toBe('text_1757504174992y39ailqcch0')
+      expect(result?.variables).toHaveProperty('date')
+    })
+  })
+
+  describe('GIVEN plan interval Weekly', () => {
+    it('WHEN Calendar THEN returns calendar weekly key', () => {
+      const result = getBillingTimeHelperKey(
+        BillingTimeEnum.Calendar,
+        SUB_AT_MID_MONTH,
+        PlanInterval.Weekly,
+      )
+
+      expect(result).toEqual({ key: 'text_62ea7cd44cd4b14bb9ac1d9e' })
+    })
+
+    it('WHEN Anniversary THEN returns key with weekday variable', () => {
+      const result = getBillingTimeHelperKey(
+        BillingTimeEnum.Anniversary,
+        SUB_AT_MID_MONTH,
+        PlanInterval.Weekly,
+      )
+
+      expect(result?.key).toBe('text_62ea7cd44cd4b14bb9ac1da2')
+      expect(result?.variables).toHaveProperty('day')
+    })
+  })
+})

--- a/src/components/subscriptions/form/buildSubscriptionDefaultValues.ts
+++ b/src/components/subscriptions/form/buildSubscriptionDefaultValues.ts
@@ -11,8 +11,11 @@ export const buildSubscriptionDefaultValues = (
   formType: SubscriptionFormType,
   currentDate: string,
 ): SubscriptionFormValues => ({
-  planId: formType !== FORM_TYPE_ENUM.upgradeDowngrade ? subscription?.plan?.id || '' : '',
-  name: formType !== FORM_TYPE_ENUM.upgradeDowngrade ? subscription?.name || '' : '',
+  planId:
+    subscription?.plan?.id && formType !== FORM_TYPE_ENUM.upgradeDowngrade
+      ? subscription.plan.id
+      : '',
+  name: subscription?.name && formType !== FORM_TYPE_ENUM.upgradeDowngrade ? subscription.name : '',
   externalId: subscription?.externalId || '',
   subscriptionAt: subscription?.subscriptionAt || currentDate,
   endingAt: subscription?.endingAt || undefined,

--- a/src/components/subscriptions/form/buildSubscriptionDefaultValues.ts
+++ b/src/components/subscriptions/form/buildSubscriptionDefaultValues.ts
@@ -4,9 +4,11 @@ import { BillingTimeEnum, GetSubscriptionForCreateSubscriptionQuery } from '~/ge
 
 export type SubscriptionDefaultsSource = GetSubscriptionForCreateSubscriptionQuery['subscription']
 
+export type SubscriptionFormType = keyof typeof FORM_TYPE_ENUM
+
 export const buildSubscriptionDefaultValues = (
   subscription: SubscriptionDefaultsSource,
-  formType: string,
+  formType: SubscriptionFormType,
   currentDate: string,
 ): SubscriptionFormValues => ({
   planId: formType !== FORM_TYPE_ENUM.upgradeDowngrade ? subscription?.plan?.id || '' : '',

--- a/src/components/subscriptions/form/buildSubscriptionDefaultValues.ts
+++ b/src/components/subscriptions/form/buildSubscriptionDefaultValues.ts
@@ -1,0 +1,30 @@
+import { FORM_TYPE_ENUM } from '~/core/constants/form'
+import { SubscriptionFormValues } from '~/formValidation/subscriptionFormSchema'
+import {
+  BillingTimeEnum,
+  GetSubscriptionForCreateSubscriptionQuery,
+} from '~/generated/graphql'
+
+export type SubscriptionDefaultsSource =
+  GetSubscriptionForCreateSubscriptionQuery['subscription']
+
+export const buildSubscriptionDefaultValues = (
+  subscription: SubscriptionDefaultsSource,
+  formType: string,
+  currentDate: string,
+): SubscriptionFormValues => ({
+  planId: formType !== FORM_TYPE_ENUM.upgradeDowngrade ? subscription?.plan?.id || '' : '',
+  name: formType !== FORM_TYPE_ENUM.upgradeDowngrade ? subscription?.name || '' : '',
+  externalId: subscription?.externalId || '',
+  subscriptionAt: subscription?.subscriptionAt || currentDate,
+  endingAt: subscription?.endingAt || undefined,
+  billingTime: subscription?.billingTime || BillingTimeEnum.Calendar,
+  paymentMethod: {
+    paymentMethodType: subscription?.paymentMethodType,
+    paymentMethodId: subscription?.paymentMethod?.id,
+  },
+  invoiceCustomSection: {
+    invoiceCustomSections: subscription?.selectedInvoiceCustomSections || [],
+    skipInvoiceCustomSections: subscription?.skipInvoiceCustomSections || false,
+  },
+})

--- a/src/components/subscriptions/form/buildSubscriptionDefaultValues.ts
+++ b/src/components/subscriptions/form/buildSubscriptionDefaultValues.ts
@@ -1,12 +1,8 @@
 import { FORM_TYPE_ENUM } from '~/core/constants/form'
 import { SubscriptionFormValues } from '~/formValidation/subscriptionFormSchema'
-import {
-  BillingTimeEnum,
-  GetSubscriptionForCreateSubscriptionQuery,
-} from '~/generated/graphql'
+import { BillingTimeEnum, GetSubscriptionForCreateSubscriptionQuery } from '~/generated/graphql'
 
-export type SubscriptionDefaultsSource =
-  GetSubscriptionForCreateSubscriptionQuery['subscription']
+export type SubscriptionDefaultsSource = GetSubscriptionForCreateSubscriptionQuery['subscription']
 
 export const buildSubscriptionDefaultValues = (
   subscription: SubscriptionDefaultsSource,

--- a/src/components/subscriptions/form/getBillingTimeHelperKey.ts
+++ b/src/components/subscriptions/form/getBillingTimeHelperKey.ts
@@ -1,0 +1,92 @@
+import { DateTime } from 'luxon'
+
+import { DateFormat, intlFormatDateTime } from '~/core/timezone'
+import { BillingTimeEnum, PlanInterval } from '~/generated/graphql'
+
+export type BillingTimeHelperKey =
+  | { key: string; variables?: Record<string, string | number> }
+  | undefined
+
+export const getBillingTimeHelperKey = (
+  billingTime: BillingTimeEnum,
+  subscriptionAt: string | undefined,
+  selectedPlanInterval: PlanInterval | undefined,
+): BillingTimeHelperKey => {
+  if (!selectedPlanInterval) return undefined
+
+  const currentDate = subscriptionAt
+    ? DateTime.fromISO(subscriptionAt)
+    : DateTime.now().setLocale('en-gb')
+  const formattedCurrentDate = currentDate.toFormat('LL/dd/yyyy')
+  const february29 = `02/29/${DateTime.now().year}`
+  const currentDay = currentDate.get('day')
+
+  switch (selectedPlanInterval) {
+    case PlanInterval.Monthly:
+      if (billingTime === BillingTimeEnum.Calendar) {
+        return { key: 'text_62ea7cd44cd4b14bb9ac1d7e' }
+      }
+
+      if (currentDay <= 28) {
+        return { key: 'text_62ea7cd44cd4b14bb9ac1d82', variables: { day: currentDay } }
+      } else if (currentDay === 29) {
+        return { key: 'text_62ea7cd44cd4b14bb9ac1d86' }
+      } else if (currentDay === 30) {
+        return { key: 'text_62ea7cd44cd4b14bb9ac1d8a' }
+      }
+      return { key: 'text_62ea7cd44cd4b14bb9ac1d8e' }
+
+    case PlanInterval.Yearly:
+      if (billingTime === BillingTimeEnum.Calendar) {
+        return { key: 'text_62ea7cd44cd4b14bb9ac1d92' }
+      }
+
+      if (formattedCurrentDate === february29) {
+        return { key: 'text_62ea7cd44cd4b14bb9ac1d9a' }
+      }
+
+      return {
+        key: 'text_62ea7cd44cd4b14bb9ac1d96',
+        variables: {
+          date: intlFormatDateTime(currentDate.toISO() || '', {
+            formatDate: DateFormat.DATE_MED_SHORT,
+          }).date,
+        },
+      }
+
+    case PlanInterval.Semiannual:
+      return billingTime === BillingTimeEnum.Calendar
+        ? { key: 'text_1757502242292q05inkc09vq' }
+        : {
+            key: 'text_1757504174992y39ailqcch0',
+            variables: {
+              date: intlFormatDateTime(currentDate.toISO() || '', {
+                formatDate: DateFormat.DATE_MED_SHORT,
+              }).date,
+            },
+          }
+
+    case PlanInterval.Quarterly:
+      if (billingTime === BillingTimeEnum.Calendar) {
+        return { key: 'text_64d6357b00dea100ad1cba34' }
+      }
+
+      if (currentDay <= 28) {
+        return { key: 'text_64d6357b00dea100ad1cba36', variables: { day: currentDay } }
+      } else if (currentDay === 29) {
+        return { key: 'text_64d63ec2f6bd3f41a6e353ac' }
+      } else if (currentDay === 30) {
+        return { key: 'text_64d63ec2f6bd3f41a6e353b0' }
+      }
+      return { key: 'text_64d63ec2f6bd3f41a6e353b4' }
+
+    case PlanInterval.Weekly:
+    default:
+      return billingTime === BillingTimeEnum.Calendar
+        ? { key: 'text_62ea7cd44cd4b14bb9ac1d9e' }
+        : {
+            key: 'text_62ea7cd44cd4b14bb9ac1da2',
+            variables: { day: currentDate.weekdayLong ?? '' },
+          }
+  }
+}

--- a/src/pages/subscriptions/CreateSubscription.tsx
+++ b/src/pages/subscriptions/CreateSubscription.tsx
@@ -4,12 +4,10 @@ import { DateTime } from 'luxon'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { generatePath, useParams, useSearchParams } from 'react-router-dom'
 
-import { SubscriptionDatesOffsetHelperComponent } from '~/components/customers/subscriptions/SubscriptionDatesOffsetHelperComponent'
 import { Alert } from '~/components/designSystem/Alert'
 import { Avatar } from '~/components/designSystem/Avatar'
 import { Button } from '~/components/designSystem/Button'
 import { Selector } from '~/components/designSystem/Selector'
-import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
 import { BasicComboBoxData, ComboboxItem } from '~/components/form'
@@ -33,6 +31,8 @@ import { UsageChargesSection } from '~/components/plans/UsageChargesSection'
 import PremiumFeature from '~/components/premium/PremiumFeature'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { FeatureEntitlementSection } from '~/components/subscriptions/FeatureEntitlementSection'
+import { buildSubscriptionDefaultValues } from '~/components/subscriptions/form/buildSubscriptionDefaultValues'
+import { SubscriptionInformationFormSection } from '~/components/subscriptions/form/SubscriptionInformationFormSection'
 import { ProgressiveBillingSection } from '~/components/subscriptions/ProgressiveBillingSection'
 import { REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE } from '~/components/subscriptions/SubscriptionUsageLifetimeGraph'
 import { PlanFormProvider } from '~/contexts/PlanFormContext'
@@ -45,11 +45,10 @@ import {
   useLocation,
   useNavigate,
 } from '~/core/router'
-import { DateFormat, getTimezoneConfig, intlFormatDateTime } from '~/core/timezone'
+import { getTimezoneConfig } from '~/core/timezone'
 import { subscriptionFormSchema } from '~/formValidation/subscriptionFormSchema'
 import {
   AddSubscriptionPlanFragmentDoc,
-  BillingTimeEnum,
   CurrencyEnum,
   FeatureEntitlementForPlanFragmentDoc,
   FeatureFlagEnum,
@@ -62,7 +61,6 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAddSubscription } from '~/hooks/customer/useAddSubscription'
-import { buildSubscriptionDefaultValues } from '~/components/subscriptions/form/buildSubscriptionDefaultValues'
 import { useAppForm } from '~/hooks/forms/useAppform'
 import { usePlanForm } from '~/hooks/plans/usePlanForm'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
@@ -70,19 +68,6 @@ import { useIframeConfig } from '~/hooks/useIframeConfig'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { FormLoadingSkeleton } from '~/styles/mainObjectsForm'
 import { tw } from '~/styles/utils'
-
-const getBillingTimeSelectorTranslationKey = (planInterval?: PlanInterval) => {
-  switch (planInterval) {
-    case PlanInterval.Yearly:
-      return 'text_62ebd597d5d5130a03ced107'
-    case PlanInterval.Weekly:
-      return 'text_62ebd597d5d5130a03ced101'
-    case PlanInterval.Quarterly:
-      return 'text_64d6357b00dea100ad1cba27'
-    default:
-      return 'text_62ea7cd44cd4b14bb9ac1db9'
-  }
-}
 
 gql`
   fragment AddSubscriptionPlan on Plan {
@@ -323,76 +308,6 @@ const CreateSubscription = () => {
     }, [])
   }, [formType, planData?.plans?.collection, subscription?.plan])
 
-  const subscriptionBillingTime = useStore(subscriptionForm.store, (s) => s.values.billingTime)
-  const subscriptionAt = useStore(subscriptionForm.store, (s) => s.values.subscriptionAt)
-
-  const billingTimeHelper = useMemo(() => {
-    const billingTime = subscriptionBillingTime
-    const currentDate = subscriptionAt
-      ? DateTime.fromISO(subscriptionAt)
-      : DateTime.now().setLocale('en-gb')
-    const formattedCurrentDate = currentDate.toFormat('LL/dd/yyyy')
-    const february29 = `02/29/${DateTime.now().year}`
-    const currentDay = currentDate.get('day')
-
-    if (!selectedPlan) return undefined
-
-    switch (selectedPlan?.interval) {
-      case PlanInterval.Monthly:
-        if (billingTime === BillingTimeEnum.Calendar)
-          return translate('text_62ea7cd44cd4b14bb9ac1d7e')
-
-        if (currentDay <= 28) {
-          return translate('text_62ea7cd44cd4b14bb9ac1d82', { day: currentDay })
-        } else if (currentDay === 29) {
-          return translate('text_62ea7cd44cd4b14bb9ac1d86')
-        } else if (currentDay === 30) {
-          return translate('text_62ea7cd44cd4b14bb9ac1d8a')
-        }
-        return translate('text_62ea7cd44cd4b14bb9ac1d8e')
-
-      case PlanInterval.Yearly:
-        if (billingTime === BillingTimeEnum.Calendar)
-          return translate('text_62ea7cd44cd4b14bb9ac1d92')
-
-        if (formattedCurrentDate === february29) return translate('text_62ea7cd44cd4b14bb9ac1d9a')
-
-        return translate('text_62ea7cd44cd4b14bb9ac1d96', {
-          date: intlFormatDateTime(currentDate.toISO() || '', {
-            formatDate: DateFormat.DATE_MED_SHORT,
-          }).date,
-        })
-
-      case PlanInterval.Semiannual:
-        return billingTime === BillingTimeEnum.Calendar
-          ? translate('text_1757502242292q05inkc09vq')
-          : translate('text_1757504174992y39ailqcch0', {
-              date: intlFormatDateTime(currentDate.toISO() || '', {
-                formatDate: DateFormat.DATE_MED_SHORT,
-              }).date,
-            })
-
-      case PlanInterval.Quarterly:
-        if (billingTime === BillingTimeEnum.Calendar)
-          return translate('text_64d6357b00dea100ad1cba34')
-
-        if (currentDay <= 28) {
-          return translate('text_64d6357b00dea100ad1cba36', { day: currentDay })
-        } else if (currentDay === 29) {
-          return translate('text_64d63ec2f6bd3f41a6e353ac')
-        } else if (currentDay === 30) {
-          return translate('text_64d63ec2f6bd3f41a6e353b0')
-        }
-        return translate('text_64d63ec2f6bd3f41a6e353b4')
-
-      case PlanInterval.Weekly:
-      default:
-        return billingTime === BillingTimeEnum.Calendar
-          ? translate('text_62ea7cd44cd4b14bb9ac1d9e')
-          : translate('text_62ea7cd44cd4b14bb9ac1da2', { day: currentDate.weekdayLong })
-    }
-  }, [subscriptionBillingTime, subscriptionAt, selectedPlan, translate])
-
   const handleFormSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     subscriptionForm.handleSubmit()
@@ -577,190 +492,19 @@ const CreateSubscription = () => {
                   {!!subscriptionPlanId && (
                     <>
                       {/* Section: Subscription settings */}
-                      <CenteredPage.PageSection>
-                        {!subscription?.plan.parent && formType === FORM_TYPE_ENUM.edition && (
-                          <Alert type="info">{translate('text_652525609f420d00b83dd602')}</Alert>
-                        )}
-
-                        <CenteredPage.PageSectionTitle
-                          title={translate('text_17791987800304a3fihrighy')}
-                          description={translate('text_66630368f4333b00795b0e1c')}
-                        />
-
-                        <div
-                          className="flex flex-col gap-6"
-                          data-test="create-subscription-form-wrapper"
-                        >
-                          {!!shouldDisplaySubscriptionExternalId && (
-                            <div className="flex flex-row gap-3 [&>*:first-child]:flex-1">
-                              <subscriptionForm.AppField name="externalId">
-                                {(field) => (
-                                  <field.TextInputField
-                                    disabled={formType !== FORM_TYPE_ENUM.creation}
-                                    label={translate('text_642a94e522316cd9e1875224')}
-                                    placeholder={translate('text_642ac1d1407baafb9e4390ee')}
-                                    helperText={translate('text_642ac28c65c2180085afe31a')}
-                                  />
-                                )}
-                              </subscriptionForm.AppField>
-                              <Tooltip
-                                className="mt-7 h-fit"
-                                disableHoverListener={formType !== FORM_TYPE_ENUM.creation}
-                                placement="top-end"
-                                title={translate('text_63aa085d28b8510cd46443ff')}
-                              >
-                                <Button
-                                  icon="trash"
-                                  disabled={formType !== FORM_TYPE_ENUM.creation}
-                                  variant="quaternary"
-                                  onClick={() => {
-                                    subscriptionForm.setFieldValue('externalId', '')
-                                    setShouldDisplaySubscriptionExternalId(false)
-                                  }}
-                                />
-                              </Tooltip>
-                            </div>
-                          )}
-
-                          {!!shouldDisplaySubscriptionName && (
-                            <div className="flex flex-row gap-3 [&>*:first-child]:flex-1">
-                              <subscriptionForm.AppField name="name">
-                                {(field) => (
-                                  <field.TextInputField
-                                    label={translate('text_62d7f6178ec94cd09370e2b9')}
-                                    placeholder={translate('text_62d7f6178ec94cd09370e2cb')}
-                                    helperText={translate('text_62d7f6178ec94cd09370e2d9')}
-                                  />
-                                )}
-                              </subscriptionForm.AppField>
-                              <Tooltip
-                                className="mt-7 h-fit"
-                                disableHoverListener={formType !== FORM_TYPE_ENUM.creation}
-                                placement="top-end"
-                                title={translate('text_63aa085d28b8510cd46443ff')}
-                              >
-                                <Button
-                                  icon="trash"
-                                  variant="quaternary"
-                                  onClick={() => {
-                                    subscriptionForm.setFieldValue('name', '')
-                                    setShouldDisplaySubscriptionName(false)
-                                  }}
-                                />
-                              </Tooltip>
-                            </div>
-                          )}
-
-                          {(!shouldDisplaySubscriptionExternalId ||
-                            !shouldDisplaySubscriptionName) && (
-                            <div className="flex items-center gap-4">
-                              {!shouldDisplaySubscriptionExternalId && (
-                                <Button
-                                  startIcon="plus"
-                                  disabled={formType !== FORM_TYPE_ENUM.creation}
-                                  variant="inline"
-                                  onClick={() => setShouldDisplaySubscriptionExternalId(true)}
-                                  data-test="show-external-id"
-                                >
-                                  {translate('text_65118a52df984447c1869472')}
-                                </Button>
-                              )}
-                              {!shouldDisplaySubscriptionName && (
-                                <Button
-                                  startIcon="plus"
-                                  variant="inline"
-                                  onClick={() => setShouldDisplaySubscriptionName(true)}
-                                  data-test="show-name"
-                                >
-                                  {translate('text_65118a52df984447c186947c')}
-                                </Button>
-                              )}
-                            </div>
-                          )}
-
-                          {formType !== FORM_TYPE_ENUM.upgradeDowngrade && (
-                            <>
-                              <subscriptionForm.AppField name="billingTime">
-                                {(field) => (
-                                  <field.ButtonSelectorField
-                                    disabled={formType !== FORM_TYPE_ENUM.creation}
-                                    label={translate('text_62ea7cd44cd4b14bb9ac1db7')}
-                                    helperText={billingTimeHelper}
-                                    options={[
-                                      {
-                                        label: translate(
-                                          getBillingTimeSelectorTranslationKey(
-                                            selectedPlan?.interval,
-                                          ),
-                                        ),
-                                        value: BillingTimeEnum.Calendar,
-                                      },
-                                      {
-                                        label: translate('text_62ea7cd44cd4b14bb9ac1dbb'),
-                                        value: BillingTimeEnum.Anniversary,
-                                      },
-                                    ]}
-                                  />
-                                )}
-                              </subscriptionForm.AppField>
-
-                              <div>
-                                <div className="flex items-start gap-6 [&>*]:flex-1">
-                                  <subscriptionForm.AppField name="subscriptionAt">
-                                    {(field) => (
-                                      <field.DatePickerField
-                                        disabled={
-                                          formType !== FORM_TYPE_ENUM.creation &&
-                                          subscription?.status !== StatusTypeEnum.Pending
-                                        }
-                                        placement="auto"
-                                        label={translate('text_64ef55a730b88e3d2117b3c4')}
-                                        defaultZone={getTimezoneConfig(TimezoneEnum.TzUtc).name}
-                                      />
-                                    )}
-                                  </subscriptionForm.AppField>
-                                  <subscriptionForm.AppField name="endingAt">
-                                    {(field) => (
-                                      <field.DatePickerField
-                                        disablePast
-                                        placement="auto"
-                                        label={translate('text_64ef55a730b88e3d2117b3cc')}
-                                        defaultZone={getTimezoneConfig(TimezoneEnum.TzUtc).name}
-                                        inputProps={{ cleanable: true }}
-                                      />
-                                    )}
-                                  </subscriptionForm.AppField>
-                                </div>
-                                <subscriptionForm.Subscribe
-                                  selector={(s) => ({
-                                    endingAtErrors: s.fieldMeta.endingAt?.errors,
-                                    subscriptionAtErrors: s.fieldMeta.subscriptionAt?.errors,
-                                    endingAtValue: s.values.endingAt,
-                                    subscriptionAtValue: s.values.subscriptionAt,
-                                  })}
-                                >
-                                  {({
-                                    endingAtErrors,
-                                    subscriptionAtErrors,
-                                    endingAtValue,
-                                    subscriptionAtValue,
-                                  }) =>
-                                    !endingAtErrors?.length &&
-                                    !subscriptionAtErrors?.length && (
-                                      <SubscriptionDatesOffsetHelperComponent
-                                        className="mt-1"
-                                        customerTimezone={customer?.applicableTimezone}
-                                        subscriptionAt={subscriptionAtValue}
-                                        endingAt={endingAtValue}
-                                      />
-                                    )
-                                  }
-                                </subscriptionForm.Subscribe>
-                              </div>
-                            </>
-                          )}
-                        </div>
-                      </CenteredPage.PageSection>
+                      <SubscriptionInformationFormSection
+                        form={subscriptionForm}
+                        formType={formType}
+                        subscription={subscription}
+                        customerTimezone={customer?.applicableTimezone}
+                        shouldDisplaySubscriptionExternalId={shouldDisplaySubscriptionExternalId}
+                        setShouldDisplaySubscriptionExternalId={
+                          setShouldDisplaySubscriptionExternalId
+                        }
+                        shouldDisplaySubscriptionName={shouldDisplaySubscriptionName}
+                        setShouldDisplaySubscriptionName={setShouldDisplaySubscriptionName}
+                        selectedPlanInterval={selectedPlan?.interval}
+                      />
 
                       {/* Section: Invoicing & payments */}
                       {hasAccessToMultiPaymentFlow && (customer?.externalId || customer?.id) && (

--- a/src/pages/subscriptions/CreateSubscription.tsx
+++ b/src/pages/subscriptions/CreateSubscription.tsx
@@ -46,17 +46,13 @@ import {
   useNavigate,
 } from '~/core/router'
 import { DateFormat, getTimezoneConfig, intlFormatDateTime } from '~/core/timezone'
-import {
-  subscriptionFormSchema,
-  SubscriptionFormValues,
-} from '~/formValidation/subscriptionFormSchema'
+import { subscriptionFormSchema } from '~/formValidation/subscriptionFormSchema'
 import {
   AddSubscriptionPlanFragmentDoc,
   BillingTimeEnum,
   CurrencyEnum,
   FeatureEntitlementForPlanFragmentDoc,
   FeatureFlagEnum,
-  GetSubscriptionForCreateSubscriptionQuery,
   PlanInterval,
   StatusTypeEnum,
   TimezoneEnum,
@@ -66,6 +62,7 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAddSubscription } from '~/hooks/customer/useAddSubscription'
+import { buildSubscriptionDefaultValues } from '~/components/subscriptions/form/buildSubscriptionDefaultValues'
 import { useAppForm } from '~/hooks/forms/useAppform'
 import { usePlanForm } from '~/hooks/plans/usePlanForm'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
@@ -149,29 +146,6 @@ gql`
   ${AddSubscriptionPlanFragmentDoc}
   ${FeatureEntitlementForPlanFragmentDoc}
 `
-
-type SubscriptionData = GetSubscriptionForCreateSubscriptionQuery['subscription']
-
-const buildSubscriptionDefaultValues = (
-  sub: SubscriptionData,
-  ft: string,
-  currentDate: string,
-): SubscriptionFormValues => ({
-  planId: ft !== FORM_TYPE_ENUM.upgradeDowngrade ? sub?.plan?.id || '' : '',
-  name: ft !== FORM_TYPE_ENUM.upgradeDowngrade ? sub?.name || '' : '',
-  externalId: sub?.externalId || '',
-  subscriptionAt: sub?.subscriptionAt || currentDate,
-  endingAt: sub?.endingAt || undefined,
-  billingTime: sub?.billingTime || BillingTimeEnum.Calendar,
-  paymentMethod: {
-    paymentMethodType: sub?.paymentMethodType,
-    paymentMethodId: sub?.paymentMethod?.id,
-  },
-  invoiceCustomSection: {
-    invoiceCustomSections: sub?.selectedInvoiceCustomSections || [],
-    skipInvoiceCustomSections: sub?.skipInvoiceCustomSections || false,
-  },
-})
 
 const CreateSubscription = () => {
   const location = useLocation()

--- a/src/pages/subscriptions/CreateSubscription.tsx
+++ b/src/pages/subscriptions/CreateSubscription.tsx
@@ -17,11 +17,6 @@ import {
   EditInvoiceDisplayNameDialogRef,
 } from '~/components/invoices/EditInvoiceDisplayNameDialog'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
-import { PaymentMethodsInvoiceSettings } from '~/components/paymentMethodsInvoiceSettings/PaymentMethodsInvoiceSettings'
-import {
-  PaymentMethodsInvoiceSettingsProps,
-  ViewTypeEnum,
-} from '~/components/paymentMethodsInvoiceSettings/types'
 import { CommitmentsSection } from '~/components/plans/CommitmentsSection'
 import { FixedChargesSection } from '~/components/plans/form/FixedChargesSection'
 import { PlanSettingsSection } from '~/components/plans/PlanSettingsSection'
@@ -32,6 +27,7 @@ import PremiumFeature from '~/components/premium/PremiumFeature'
 import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { FeatureEntitlementSection } from '~/components/subscriptions/FeatureEntitlementSection'
 import { buildSubscriptionDefaultValues } from '~/components/subscriptions/form/buildSubscriptionDefaultValues'
+import { InvoicingPaymentsFormSection } from '~/components/subscriptions/form/InvoicingPaymentsFormSection'
 import { SubscriptionInformationFormSection } from '~/components/subscriptions/form/SubscriptionInformationFormSection'
 import { ProgressiveBillingSection } from '~/components/subscriptions/ProgressiveBillingSection'
 import { REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE } from '~/components/subscriptions/SubscriptionUsageLifetimeGraph'
@@ -507,23 +503,11 @@ const CreateSubscription = () => {
                       />
 
                       {/* Section: Invoicing & payments */}
-                      {hasAccessToMultiPaymentFlow && (customer?.externalId || customer?.id) && (
-                        <CenteredPage.PageSection>
-                          <CenteredPage.PageSectionTitle
-                            title={translate('text_1762862388271au34vz50g8i')}
-                            description={translate('text_1779198780030g64up7d4imi')}
-                          />
-                          <PaymentMethodsInvoiceSettings
-                            customer={customer}
-                            formikProps={
-                              {
-                                values: subscriptionForm.state.values,
-                                setFieldValue: subscriptionForm.setFieldValue,
-                              } as PaymentMethodsInvoiceSettingsProps<ViewTypeEnum.Subscription>['formikProps']
-                            }
-                            viewType={ViewTypeEnum.Subscription}
-                          />
-                        </CenteredPage.PageSection>
+                      {hasAccessToMultiPaymentFlow && (
+                        <InvoicingPaymentsFormSection
+                          form={subscriptionForm}
+                          customer={customer ?? null}
+                        />
                       )}
                     </>
                   )}

--- a/src/pages/subscriptions/__tests__/CreateSubscription.test.tsx
+++ b/src/pages/subscriptions/__tests__/CreateSubscription.test.tsx
@@ -147,6 +147,24 @@ const mockSubscriptionForm = {
 
 jest.mock('~/hooks/forms/useAppform', () => ({
   useAppForm: jest.fn(() => mockSubscriptionForm),
+  withForm: jest.fn(
+    ({
+      render: RenderComponent,
+      props: defaultProps,
+    }: {
+      render: React.FC<Record<string, unknown>>
+      defaultValues: Record<string, unknown>
+      props: Record<string, unknown>
+    }) => {
+      const WithFormWrapper = (receivedProps: Record<string, unknown>) => {
+        return <RenderComponent {...defaultProps} {...receivedProps} />
+      }
+
+      WithFormWrapper.displayName = 'WithFormWrapper'
+
+      return WithFormWrapper
+    },
+  ),
 }))
 
 jest.mock('@tanstack/react-form', () => ({


### PR DESCRIPTION


## Summary
- Extracts `Subscription information` and `Invoicing & payments` blocks from `CreateSubscription.tsx` into reusable TanStack `withForm` section components under `src/components/subscriptions/form/`.
- Lifts `buildSubscriptionDefaultValues` helper to a shared module so the new sections can declare matching defaults for `withForm` typing.
- UX byte-identical: same fields, same Zod schema, same disable rules.

## Why
Step 1 of the Plan/Sub v2 inline-edit initiative (parent LAGO-1269). The new sub-overview drawers (LAGO-1474, LAGO-1475) will render these same form blocks inside section-edit drawers. Extracting now keeps the rewrite work additive.

## Notes
- Linear description originally referenced Formik / `formikProps`. Stale — `CreateSubscription` migrated to TanStack Form (`useAppForm`) earlier. New sections use `withForm` from `~/hooks/forms/useAppform`.
- `PaymentMethodsInvoiceSettings` itself is still on the formikProps API; the existing TanStack→formikProps shim is preserved inside `InvoicingPaymentsFormSection` until that component is migrated separately.


Fixes LAGO-1465