### PR TITLE
fix(billable-metrics): allow editing custom expression when duplicating

### DIFF
--- a/src/pages/CreateBillableMetric.tsx
+++ b/src/pages/CreateBillableMetric.tsx
@@ -93,7 +93,8 @@ const CreateBillableMetric = () => {
 
   const warningDirtyAttributesDialogRef = useRef<WarningDialogRef>(null)
   const customExpressionDrawerRef = useRef<CustomExpressionDrawerRef>(null)
-  const canBeEdited = !isDuplicate && !billableMetric?.hasSubscriptions && !billableMetric?.hasPlans
+  const canBeEdited =
+    isDuplicate || (!billableMetric?.hasSubscriptions && !billableMetric?.hasPlans)
 
   const formikProps = useFormik<
     CreateBillableMetricInput & {


### PR DESCRIPTION
## Context

  When duplicating a billable metric with a custom expression aggregation,
  the expression input in the drawer was incorrectly disabled. Other
  structural fields (name, code, aggregation type) were editable in
  duplicate mode, but the custom expression was not.

  ## Description

  Fix the `canBeEdited` logic in `CreateBillableMetric.tsx` to treat
  duplicates as fully editable. The previous condition (`!isDuplicate && ...`)
  incorrectly blocked editing in duplicate mode. Changed to
  `isDuplicate || (...)` so that duplicates are always editable, while
  edit mode still respects subscription/plan constraints.

<!-- Linear link -->
Fixes ING-199