### PR TITLE
refactor(premium): migrate PremiumFeature PremiumWarningDialog to hook-based system

### DIFF
--- a/src/components/premium/PremiumFeature.tsx
+++ b/src/components/premium/PremiumFeature.tsx
@@ -1,9 +1,8 @@
 import { Icon, tw } from 'lago-design-system'
-import { useRef } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 type PremiumFeatureProps = {
@@ -24,53 +23,50 @@ const PremiumFeature = ({
   'data-test': dataTest,
 }: PremiumFeatureProps) => {
   const { translate } = useInternationalization()
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
 
   return (
-    <>
-      <div
-        className={tw(
-          'flex w-full flex-row items-center justify-between gap-2 rounded-xl bg-grey-100 px-6 py-4',
-          className,
-        )}
-        data-test={dataTest}
-      >
-        <div className="flex flex-col">
-          <div className="flex flex-row items-center gap-2">
-            <Typography variant="bodyHl" color="grey700">
-              {title}
-            </Typography>
-
-            <Icon name="sparkles" />
-          </div>
-
-          <Typography variant="caption" color="grey600">
-            {description}
+    <div
+      className={tw(
+        'flex w-full flex-row items-center justify-between gap-2 rounded-xl bg-grey-100 px-6 py-4',
+        className,
+      )}
+      data-test={dataTest}
+    >
+      <div className="flex flex-col">
+        <div className="flex flex-row items-center gap-2">
+          <Typography variant="bodyHl" color="grey700">
+            {title}
           </Typography>
+
+          <Icon name="sparkles" />
         </div>
 
-        <Button
-          className={buttonClassName}
-          endIcon="sparkles"
-          variant="tertiary"
-          onClick={() =>
-            premiumWarningDialogRef.current?.openDialog({
-              title,
-              description,
-              mailtoSubject: translate('text_1759493418045b173t4qhktb', {
-                feature,
-              }),
-              mailtoBody: translate('text_1759493745332hiuejhksn15', {
-                feature,
-              }),
-            })
-          }
-        >
-          {translate('text_65ae73ebe3a66bec2b91d72d')}
-        </Button>
+        <Typography variant="caption" color="grey600">
+          {description}
+        </Typography>
       </div>
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
-    </>
+
+      <Button
+        className={buttonClassName}
+        endIcon="sparkles"
+        variant="tertiary"
+        onClick={() =>
+          openPremiumWarningDialog({
+            title,
+            description,
+            mailtoSubject: translate('text_1759493418045b173t4qhktb', {
+              feature,
+            }),
+            mailtoBody: translate('text_1759493745332hiuejhksn15', {
+              feature,
+            }),
+          })
+        }
+      >
+        {translate('text_65ae73ebe3a66bec2b91d72d')}
+      </Button>
+    </div>
   )
 }
 

--- a/src/components/premium/__tests__/PremiumFeature.test.tsx
+++ b/src/components/premium/__tests__/PremiumFeature.test.tsx
@@ -1,9 +1,19 @@
-import { cleanup, screen } from '@testing-library/react'
+import NiceModal from '@ebay/nice-modal-react'
+import { cleanup, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { ReactNode } from 'react'
 
+import { PREMIUM_WARNING_DIALOG_NAME } from '~/components/dialogs/const'
+import PremiumWarningDialog from '~/components/dialogs/PremiumWarningDialog'
 import { render } from '~/test-utils'
 
 import PremiumFeature from '../PremiumFeature'
+
+NiceModal.register(PREMIUM_WARNING_DIALOG_NAME, PremiumWarningDialog)
+
+const NiceModalWrapper = ({ children }: { children: ReactNode }) => (
+  <NiceModal.Provider>{children}</NiceModal.Provider>
+)
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({
@@ -76,14 +86,20 @@ describe('PremiumFeature', () => {
     it('opens premium warning dialog when button is clicked', async () => {
       const user = userEvent.setup()
 
-      render(<PremiumFeature {...DEFAULT_PROPS} />)
+      render(
+        <NiceModalWrapper>
+          <PremiumFeature {...DEFAULT_PROPS} />
+        </NiceModalWrapper>,
+      )
 
       const button = screen.getByRole('button')
 
       await user.click(button)
 
       // Dialog should be opened - check for dialog content
-      expect(screen.getByRole('dialog')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

Migrate the `PremiumWarningDialog` usage in the `PremiumFeature` component from the deprecated imperative ref-based system (`~/components/PremiumWarningDialog`) to the new hook-based NiceModal system (`usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`).

This removes one of the `no-restricted-imports` warnings flagged by ESLint (PremiumWarningDialog occurrences in source: 26 → 25). Scope is intentionally limited to this single consumer — only the `PremiumWarningDialog` was present in this file, so no other dialogs needed migrating.

This consumer matters because `PremiumFeature` is a shared wrapper used across many feature gates, so converging it onto the hook-based system pays off broadly.

## Changes

- `src/components/premium/PremiumFeature.tsx`
  - Replace import `{ PremiumWarningDialog, PremiumWarningDialogRef }` from `~/components/PremiumWarningDialog` with `{ usePremiumWarningDialog }` from `~/components/dialogs/PremiumWarningDialog`
  - Drop `useRef<PremiumWarningDialogRef>(null)` in favor of `const { open: openPremiumWarningDialog } = usePremiumWarningDialog()`
  - Replace `premiumWarningDialogRef.current?.openDialog(...)` with `openPremiumWarningDialog(...)`
  - Remove the `<PremiumWarningDialog ref={premiumWarningDialogRef} />` JSX (the dialog is now rendered via NiceModal) and the surrounding fragment
  - Drop the now-unused `useRef` import from React
- `src/components/premium/__tests__/PremiumFeature.test.tsx`
  - Register the dialog with NiceModal and wrap the dialog-interaction test in `<NiceModal.Provider>` so `openPremiumWarningDialog` has a dispatch context
  - Use `waitFor` around the `getByRole('dialog')` assertion since NiceModal opens the dialog asynchronously
  - Snapshot tests required no change — the fragment removal does not affect `container.firstChild`

## Test plan

- [x] `pnpm eslint src/components/premium/PremiumFeature.tsx` — 0 warnings, PremiumWarningDialog warning removed
- [x] `pnpm test src/components/premium/__tests__/PremiumFeature.test.tsx` — all 10 tests pass (including the snapshot tests, unchanged)
- [x] `pnpm code:style` (pre-push hook) — passes (lint, types, translations)
- [ ] Manual smoke test: render any premium-gated feature using `<PremiumFeature />` as a non-premium user and click the upgrade button — the premium warning dialog should open with the correct title/description/mailto subject and body

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVq9AFdQiR2pYR6MgrKuC6)_