### PR TITLE
fix(graphs): Aggregate gross rows per month

### DIFF
--- a/src/components/graphs/__tests__/utils.test.ts
+++ b/src/components/graphs/__tests__/utils.test.ts
@@ -236,10 +236,31 @@ describe('components/graphs/utils', () => {
       expect(builtArray.length).toBe(13)
       expect(builtArray).toStrictEqual(
         data.map((d) => ({
-          ...d,
           month: DateTime.fromISO(d.month as string).toFormat(GRAPH_YEAR_MONTH_DATE_FORMAT),
+          amountCents: d.amountCents,
+          currency: d.currency,
         })),
       )
+    })
+
+    it('should sum amountCents when multiple rows share the same calendar month', () => {
+      const lastMonthISO = DateTime.utc().startOf('month').minus({ month: 1 }).toISO()
+      const data: TAreaChartDataResult = [
+        { month: lastMonthISO, amountCents: 100, currency: CurrencyEnum.Eur },
+        { month: lastMonthISO, amountCents: 250, currency: CurrencyEnum.Eur },
+      ]
+
+      const builtArray = padAndTransformDataOverLastTwelveMonth(data, CurrencyEnum.Eur)
+      const lastMonthSlot = builtArray[builtArray.length - 2]
+
+      expect(lastMonthSlot).toStrictEqual({
+        month: DateTime.utc()
+          .startOf('month')
+          .minus({ month: 1 })
+          .toFormat(GRAPH_YEAR_MONTH_DATE_FORMAT),
+        amountCents: 350,
+        currency: CurrencyEnum.Eur,
+      })
     })
   })
 

--- a/src/components/graphs/utils.ts
+++ b/src/components/graphs/utils.ts
@@ -31,18 +31,27 @@ export const padAndTransformDataOverLastTwelveMonth = (
 ) => {
   const monthsArray = getLastTwelveMonthsNumbersUntilNow()
 
-  // Create an array of 12 months and replace the values with the data if it exists, based on the month
-  // Or create a new object with the month and the amountCents set to 0
-  return monthsArray.map((month) => {
-    const item = data.find(
-      (d) => DateTime.fromISO(d.month as string).toFormat(GRAPH_YEAR_MONTH_DATE_FORMAT) === month,
-    )
+  // Analytics endpoints can emit multiple rows per calendar month when results
+  // are split across billing entities, so sum amountCents per month before
+  // mapping onto the chart axis.
+  const totalsByMonth = data.reduce<
+    Record<string, { amountCents: number; currency?: CurrencyEnum | null }>
+  >((acc, item) => {
+    const key = DateTime.fromISO(item.month as string).toFormat(GRAPH_YEAR_MONTH_DATE_FORMAT)
 
-    return item
-      ? {
-          ...item,
-          month: DateTime.fromISO(item.month as string).toFormat(GRAPH_YEAR_MONTH_DATE_FORMAT),
-        }
+    acc[key] = {
+      amountCents: (acc[key]?.amountCents ?? 0) + Number(item.amountCents),
+      currency: acc[key]?.currency ?? item.currency,
+    }
+
+    return acc
+  }, {})
+
+  return monthsArray.map((month) => {
+    const aggregated = totalsByMonth[month]
+
+    return aggregated
+      ? { month, amountCents: aggregated.amountCents, currency: aggregated.currency }
       : { currency, month, amountCents: 0 }
   })
 }


### PR DESCRIPTION
## Context

The backend change in [lago-api#5551](https://github.com/getlago/lago-api/pull/5551) makes the `grossRevenues` (and `overdueBalances`) GraphQL collection return one row per `(month, currency, billing_entity_id)` instead of one row per `(month, currency)`. This is required for the upcoming "Invoice balances" table on the customer detail page.

`Gross.tsx`'s helper `padAndTransformDataOverLastTwelveMonth` (in `src/components/graphs/utils.ts`) currently uses `.find` to look up exactly one row per calendar month. For customers with invoices spanning multiple billing entities, that meant only the first matching row's `amountCents` made it onto the chart, so the chart silently under-reported the total. The internal Lago dashboards that consume the same query (`CustomerOverview`, the analytics `Overview` and `Invoices` pages, `PortalInvoicesList`) already aggregate via `reduce`, so they were unaffected.

## Description

`padAndTransformDataOverLastTwelveMonth` now sums `amountCents` per calendar month before mapping onto the chart axis. The function's return shape is unchanged: `{ month, amountCents, currency }` per calendar slot. A regression test in `src/components/graphs/__tests__/utils.test.ts` covers the multi-row-same-month case explicitly.

| Before | After |
| --- | --- |
| First row per month wins, rest discarded | All rows per month summed |
| `.find` over data, O(months × data) | Single `reduce` pass into a map, O(months + data) |
| Item spread `...item` could leak unrelated keys | Explicit `{ month, amountCents, currency }` output |

## How to try locally

`pnpm test src/components/graphs/__tests__/utils.test.ts`

Manual: with lago-api running the change from #5551, log into an org whose customer has invoices in two billing entities, open the customer detail page, and confirm the Gross revenue chart's per-month points sum across entities (rather than showing only one entity's slice).
