### PR TITLE
refactor(settings): migrate BillingEntityEmailScenariosConfig PremiumWarningDialog to hook

### DIFF
--- a/src/pages/settings/BillingEntity/sections/BillingEntityEmailScenariosConfig.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityEmailScenariosConfig.tsx
@@ -1,14 +1,14 @@
 import { Icon } from 'lago-design-system'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import EmailPreview, { DisplayEnum } from '~/components/emails/EmailPreview'
 import { Switch } from '~/components/form'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { LanguageSettingsButton } from '~/components/settings/LanguageSettingsButton'
 import { BILLING_ENTITY_EMAIL_SCENARIOS_ROUTE, BILLING_ENTITY_ROUTE } from '~/core/router'
 import { LocaleEnum } from '~/core/translations'
@@ -26,7 +26,7 @@ import { usePermissions } from '~/hooks/usePermissions'
 import { EMAIL_SCENARIOS } from '~/pages/settings/BillingEntity/sections/BillingEntityEmailScenarios'
 
 const BillingEntityEmailScenariosConfig = () => {
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
 
   const [invoiceLanguage, setInvoiceLanguage] = useState<LocaleEnum>(LocaleEnum.en)
   const [display, setDisplay] = useState<DisplayEnum>(DisplayEnum.desktop)
@@ -98,7 +98,7 @@ const BillingEntityEmailScenariosConfig = () => {
                       if (hasAccess) {
                         await updateEmailSettings(type as BillingEntityEmailSettingsEnum, value)
                       } else {
-                        premiumWarningDialogRef.current?.openDialog()
+                        openPremiumWarningDialog()
                       }
                     }}
                   />
@@ -161,8 +161,6 @@ const BillingEntityEmailScenariosConfig = () => {
             invoiceLanguage={invoiceLanguage}
           />
         </div>
-
-        <PremiumWarningDialog ref={premiumWarningDialogRef} />
       </div>
     </>
   )


### PR DESCRIPTION
## Summary

- Migrates the deprecated ref-based `PremiumWarningDialog` usage in `src/pages/settings/BillingEntity/sections/BillingEntityEmailScenariosConfig.tsx` to the new hook-based `usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`.
- Removes the matching `no-restricted-imports` ESLint warning for this file (one of many similar warnings across the codebase — this PR is intentionally scoped to a single consumer).

## Changes

- Replaced the `useRef<PremiumWarningDialogRef>(null)` + `<PremiumWarningDialog ref={…} />` rendering with `const { open: openPremiumWarningDialog } = usePremiumWarningDialog()`.
- Updated the only call site (the email-toggle Switch's `onChange`) from `premiumWarningDialogRef.current?.openDialog()` to `openPremiumWarningDialog()`.
- Dropped the now-unused `useRef` React import and the legacy `~/components/PremiumWarningDialog` import.

## Test plan

- [ ] `pnpm eslint src/pages/settings/BillingEntity/sections/BillingEntityEmailScenariosConfig.tsx` passes with no warnings on this file.
- [ ] Manually toggle an email scenario as a non-premium user on a Billing Entity email-config page and confirm the Premium upsell dialog opens with the same title/description/CTA as before.
- [ ] Toggling as a premium user still updates the email settings without showing the dialog.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QK1XovgLQkXkKCNmC3TNDz)_