### PR TITLE
refactor(plans): extract plan settings primitives for reuse

### DIFF
--- a/src/components/plans/PlanSettingsInfo.tsx
+++ b/src/components/plans/PlanSettingsInfo.tsx
@@ -1,0 +1,57 @@
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
+import { DetailsPage } from '~/components/layouts/DetailsPage'
+import { getIntervalTranslationKey } from '~/core/constants/form'
+import { PlanInterval } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+type PlanSettingsInfoProps = {
+  plan: {
+    name?: string | null
+    code?: string | null
+    description?: string | null
+    interval?: PlanInterval | null
+    amountCurrency?: string | null
+  }
+}
+
+export const PlanSettingsInfo = ({ plan }: PlanSettingsInfoProps) => {
+  const { translate } = useInternationalization()
+
+  return (
+    <div className="flex flex-col gap-4">
+      <DetailsPage.InfoGrid
+        grid={[
+          {
+            label: translate('text_62442e40cea25600b0b6d852'),
+            value: plan.name ?? undefined,
+          },
+          {
+            label: translate('text_642d5eb2783a2ad10d670320'),
+            value: plan.code ? (
+              <TypographyWithCopy variant="body" color="grey700">
+                {plan.code}
+              </TypographyWithCopy>
+            ) : undefined,
+          },
+          {
+            label: translate('text_65201b8216455901fe273dc1'),
+            value: plan.interval
+              ? translate(getIntervalTranslationKey[plan.interval])
+              : undefined,
+          },
+          {
+            label: translate('text_632b4acf0c41206cbcb8c324'),
+            value: plan.amountCurrency ?? undefined,
+          },
+        ]}
+      />
+
+      {!!plan.description && (
+        <DetailsPage.InfoGridItem
+          label={translate('text_6388b923e514213fed58331c')}
+          value={plan.description}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/plans/PlanSettingsInfo.tsx
+++ b/src/components/plans/PlanSettingsInfo.tsx
@@ -35,9 +35,7 @@ export const PlanSettingsInfo = ({ plan }: PlanSettingsInfoProps) => {
           },
           {
             label: translate('text_65201b8216455901fe273dc1'),
-            value: plan.interval
-              ? translate(getIntervalTranslationKey[plan.interval])
-              : undefined,
+            value: plan.interval ? translate(getIntervalTranslationKey[plan.interval]) : undefined,
           },
           {
             label: translate('text_632b4acf0c41206cbcb8c324'),

--- a/src/components/plans/__tests__/PlanSettingsInfo.test.tsx
+++ b/src/components/plans/__tests__/PlanSettingsInfo.test.tsx
@@ -1,0 +1,44 @@
+import { screen } from '@testing-library/react'
+
+import { CurrencyEnum, PlanInterval } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import { PlanSettingsInfo } from '../PlanSettingsInfo'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+const basePlan = {
+  __typename: 'Plan' as const,
+  name: 'Pro',
+  code: 'pro',
+  description: null,
+  interval: PlanInterval.Monthly,
+  amountCurrency: CurrencyEnum.Usd,
+}
+
+describe('PlanSettingsInfo', () => {
+  it('renders name, code, interval and currency', () => {
+    render(<PlanSettingsInfo plan={basePlan} />)
+
+    expect(screen.getByText('Pro')).toBeInTheDocument()
+    expect(screen.getByText('pro')).toBeInTheDocument()
+    expect(screen.getByText(CurrencyEnum.Usd)).toBeInTheDocument()
+  })
+
+  it('omits the description row when description is empty', () => {
+    render(<PlanSettingsInfo plan={basePlan} />)
+
+    expect(screen.queryByText('text_6388b923e514213fed58331c')).not.toBeInTheDocument()
+  })
+
+  it('renders the description row when description is non-empty', () => {
+    render(<PlanSettingsInfo plan={{ ...basePlan, description: 'A pro plan' }} />)
+
+    expect(screen.getByText('text_6388b923e514213fed58331c')).toBeInTheDocument()
+    expect(screen.getByText('A pro plan')).toBeInTheDocument()
+  })
+})

--- a/src/components/plans/details/PlanDetailsOverview.tsx
+++ b/src/components/plans/details/PlanDetailsOverview.tsx
@@ -1,14 +1,12 @@
 import { gql } from '@apollo/client'
 
-import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { PlanDetailsFixedChargesSection } from '~/components/plans/details/PlanDetailsFixedChargesSection'
-import { getIntervalTranslationKey } from '~/core/constants/form'
+import { PlanSettingsInfo } from '~/components/plans/PlanSettingsInfo'
 import {
   CurrencyEnum,
   EditPlanFragmentDoc,
   LagoApiError,
-  PlanInterval,
   useGetPlanForDetailsOverviewSectionQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -62,39 +60,7 @@ export const PlanDetailsOverview = ({
         <DetailsPage.SectionTitle variant="subhead1" noWrap>
           {translate('text_642d5eb2783a2ad10d67031a')}
         </DetailsPage.SectionTitle>
-        <div className="flex flex-col gap-4">
-          <DetailsPage.InfoGrid
-            grid={[
-              {
-                label: translate('text_62442e40cea25600b0b6d852'),
-                value: plan?.name,
-              },
-              {
-                label: translate('text_642d5eb2783a2ad10d670320'),
-                value: plan?.code ? (
-                  <TypographyWithCopy variant="body" color="grey700">
-                    {plan.code}
-                  </TypographyWithCopy>
-                ) : undefined,
-              },
-              {
-                label: translate('text_65201b8216455901fe273dc1'),
-                value: translate(getIntervalTranslationKey[plan?.interval as PlanInterval]),
-              },
-              {
-                label: translate('text_632b4acf0c41206cbcb8c324'),
-                value: plan?.amountCurrency,
-              },
-            ]}
-          />
-
-          {!!plan?.description && (
-            <DetailsPage.InfoGridItem
-              label={translate('text_6388b923e514213fed58331c')}
-              value={plan?.description}
-            />
-          )}
-        </div>
+        <PlanSettingsInfo plan={plan} />
       </section>
       <section>
         <DetailsPage.SectionTitle variant="subhead1" noWrap>

--- a/src/hooks/plans/__tests__/usePlanUpdate.test.tsx
+++ b/src/hooks/plans/__tests__/usePlanUpdate.test.tsx
@@ -1,0 +1,61 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { ReactNode } from 'react'
+
+import { addToast } from '~/core/apolloClient'
+import { UpdatePlanDocument } from '~/generated/graphql'
+
+import { usePlanUpdate } from '../usePlanUpdate'
+
+jest.mock('~/core/apolloClient', () => {
+  const actual = jest.requireActual('~/core/apolloClient')
+  return { ...actual, addToast: jest.fn() }
+})
+
+const wrapper = (mocks: Parameters<typeof MockedProvider>[0]['mocks']) =>
+  function MockedWrapper({ children }: { children: ReactNode }) {
+    return (
+      <MockedProvider mocks={mocks} addTypename={false}>
+        {children}
+      </MockedProvider>
+    )
+  }
+
+const PLAN_ID = 'plan_1'
+
+const updateMock = {
+  request: {
+    query: UpdatePlanDocument,
+    variables: { input: { id: PLAN_ID, name: 'X' } },
+  },
+  result: {
+    data: { updatePlan: { __typename: 'Plan', id: PLAN_ID, name: 'X' } },
+  },
+}
+
+describe('usePlanUpdate', () => {
+  beforeEach(() => {
+    ;(addToast as jest.Mock).mockClear()
+  })
+
+  it('fires the success toast and onSuccess callback when the mutation completes', async () => {
+    const onSuccess = jest.fn()
+    const { result } = renderHook(() => usePlanUpdate({ onSuccess }), {
+      wrapper: wrapper([updateMock]),
+    })
+
+    await act(async () => {
+      await result.current.update({ variables: { input: { id: PLAN_ID, name: 'X' } } })
+    })
+
+    await waitFor(() => {
+      expect(addToast).toHaveBeenCalledWith({
+        severity: 'success',
+        translateKey: 'text_625fd165963a7b00c8f598a0',
+      })
+    })
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ id: PLAN_ID }))
+  })
+})

--- a/src/hooks/plans/__tests__/usePlanUpdate.test.tsx
+++ b/src/hooks/plans/__tests__/usePlanUpdate.test.tsx
@@ -1,9 +1,9 @@
-import { MockedProvider } from '@apollo/client/testing'
+import { MockedProvider, MockedResponse } from '@apollo/client/testing'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { ReactNode } from 'react'
 
 import { addToast } from '~/core/apolloClient'
-import { UpdatePlanDocument } from '~/generated/graphql'
+import { UpdatePlanDocument, UpdatePlanInput } from '~/generated/graphql'
 
 import { usePlanUpdate } from '../usePlanUpdate'
 
@@ -12,7 +12,7 @@ jest.mock('~/core/apolloClient', () => {
   return { ...actual, addToast: jest.fn() }
 })
 
-const wrapper = (mocks: Parameters<typeof MockedProvider>[0]['mocks']) =>
+const wrapper = (mocks: MockedResponse[]) =>
   function MockedWrapper({ children }: { children: ReactNode }) {
     return (
       <MockedProvider mocks={mocks} addTypename={false}>
@@ -23,10 +23,12 @@ const wrapper = (mocks: Parameters<typeof MockedProvider>[0]['mocks']) =>
 
 const PLAN_ID = 'plan_1'
 
-const updateMock = {
+const mutationInput = { id: PLAN_ID, name: 'X' } as unknown as UpdatePlanInput
+
+const updateMock: MockedResponse = {
   request: {
     query: UpdatePlanDocument,
-    variables: { input: { id: PLAN_ID, name: 'X' } },
+    variables: { input: mutationInput },
   },
   result: {
     data: { updatePlan: { __typename: 'Plan', id: PLAN_ID, name: 'X' } },
@@ -45,7 +47,7 @@ describe('usePlanUpdate', () => {
     })
 
     await act(async () => {
-      await result.current.update({ variables: { input: { id: PLAN_ID, name: 'X' } } })
+      await result.current.update({ variables: { input: mutationInput } })
     })
 
     await waitFor(() => {

--- a/src/hooks/plans/__tests__/utils.test.ts
+++ b/src/hooks/plans/__tests__/utils.test.ts
@@ -1,4 +1,6 @@
-import { formatAnyToValueForChargeFormArrays } from '../utils'
+import { CurrencyEnum, PlanInterval } from '~/generated/graphql'
+
+import { buildPlanSettingsValues, formatAnyToValueForChargeFormArrays } from '../utils'
 
 describe('formattedToValue', () => {
   describe('GIVEN toValue is null', () => {
@@ -73,5 +75,56 @@ describe('formattedToValue', () => {
     it('THEN handles string fromValue', () => {
       expect(formatAnyToValueForChargeFormArrays(5, '10')).toBe(11)
     })
+  })
+})
+
+describe('buildPlanSettingsValues', () => {
+  const plan = {
+    name: 'Pro',
+    code: 'pro',
+    description: 'A pro plan',
+    interval: PlanInterval.Yearly,
+    amountCurrency: CurrencyEnum.Eur,
+    billChargesMonthly: true,
+    billFixedChargesMonthly: false,
+    taxes: [{ id: 't1', code: 'vat', name: 'VAT', rate: 20 }],
+    fixedCharges: [{ id: 'fc1' }, { id: 'fc2' }],
+    charges: [{ id: 'c1' }],
+  }
+
+  it('maps each plan-settings field 1:1 from the plan', () => {
+    const values = buildPlanSettingsValues(plan)
+
+    expect(values.name).toBe('Pro')
+    expect(values.code).toBe('pro')
+    expect(values.description).toBe('A pro plan')
+    expect(values.interval).toBe(PlanInterval.Yearly)
+    expect(values.amountCurrency).toBe(CurrencyEnum.Eur)
+    expect(values.billChargesMonthly).toBe(true)
+    expect(values.billFixedChargesMonthly).toBe(false)
+    expect(values.taxes).toEqual(plan.taxes)
+  })
+
+  it('preserves fixedCharges/charges presence (length-only)', () => {
+    const values = buildPlanSettingsValues(plan)
+
+    expect(values.fixedCharges).toHaveLength(2)
+    expect(values.charges).toHaveLength(1)
+  })
+
+  it('defaults to empty values when fields are missing', () => {
+    const values = buildPlanSettingsValues({
+      name: 'Free',
+      code: 'free',
+      interval: PlanInterval.Monthly,
+      amountCurrency: CurrencyEnum.Usd,
+    })
+
+    expect(values.description).toBe('')
+    expect(values.billChargesMonthly).toBe(false)
+    expect(values.billFixedChargesMonthly).toBe(false)
+    expect(values.taxes).toEqual([])
+    expect(values.fixedCharges).toEqual([])
+    expect(values.charges).toEqual([])
   })
 })

--- a/src/hooks/plans/usePlanForm.tsx
+++ b/src/hooks/plans/usePlanForm.tsx
@@ -39,7 +39,6 @@ import {
   EditPlanFragment,
   EditPlanFragmentDoc,
   LagoApiError,
-  PlanInterval,
   PlanItemFragmentDoc,
   useCreatePlanMutation,
   useGetSinglePlanQuery,
@@ -47,6 +46,7 @@ import {
 } from '~/generated/graphql'
 import { useAppForm } from '~/hooks/forms/useAppform'
 import { useCustomPricingUnits } from '~/hooks/plans/useCustomPricingUnits'
+import { buildPlanSettingsValues } from '~/hooks/plans/utils'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
 gql`
@@ -82,120 +82,123 @@ const buildDefaultValues = (
   type: PLAN_FORM_TYPE,
   initialCurrency: CurrencyEnum,
   hasAnyPricingUnitConfigured: boolean,
-): PlanFormInput => ({
-  name: type === FORM_TYPE_ENUM.duplicate ? '' : plan?.name || '',
-  code: type === FORM_TYPE_ENUM.duplicate ? '' : plan?.code || '',
-  description: plan?.description || '',
-  entitlements:
-    plan?.entitlements?.map(({ code, privileges, name, ...restEntitlement }) => ({
-      featureName: name || '',
-      featureCode: code,
-      privileges: privileges.map(
-        ({ code: privilegeCode, name: privilegeName, value, ...restPrivilege }) => ({
-          privilegeCode,
-          privilegeName,
-          value: value || '',
-          ...restPrivilege,
-        }),
-      ),
-      ...restEntitlement,
-    })) || [],
-  interval: plan?.interval || PlanInterval.Monthly,
-  taxes: plan?.taxes || [],
-  invoiceDisplayName: plan?.invoiceDisplayName || undefined,
-  payInAdvance: plan?.payInAdvance || false,
-  amountCents: isNaN(plan?.amountCents)
-    ? '0'
-    : String(deserializeAmount(plan?.amountCents || 0, initialCurrency)),
-  amountCurrency: initialCurrency,
-  trialPeriod: plan?.trialPeriod ?? 0,
-  billChargesMonthly: plan?.billChargesMonthly || false,
-  billFixedChargesMonthly: plan?.billFixedChargesMonthly || false,
-  minimumCommitment: !!plan?.minimumCommitment
-    ? {
-        ...plan?.minimumCommitment,
-        amountCents: String(
-          deserializeAmount(plan?.minimumCommitment.amountCents || 0, initialCurrency),
+): PlanFormInput => {
+  const settingsDefaults = buildPlanSettingsValues(plan ?? {})
+
+  return {
+    ...settingsDefaults,
+    name: type === FORM_TYPE_ENUM.duplicate ? '' : settingsDefaults.name,
+    code: type === FORM_TYPE_ENUM.duplicate ? '' : settingsDefaults.code,
+    amountCurrency: initialCurrency,
+    entitlements:
+      plan?.entitlements?.map(({ code, privileges, name, ...restEntitlement }) => ({
+        featureName: name || '',
+        featureCode: code,
+        privileges: privileges.map(
+          ({ code: privilegeCode, name: privilegeName, value, ...restPrivilege }) => ({
+            privilegeCode,
+            privilegeName,
+            value: value || '',
+            ...restPrivilege,
+          }),
         ),
-      }
-    : {},
-  nonRecurringUsageThresholds:
-    plan?.usageThresholds && plan?.usageThresholds.length > 0
-      ? plan?.usageThresholds
-          .filter(({ recurring }) => !recurring)
-          .map((threshold) => ({
-            ...threshold,
-            amountCents: deserializeAmount(threshold.amountCents || 0, initialCurrency),
-          }))
-          .sort((a, b) => a.amountCents - b.amountCents)
-      : undefined,
-  recurringUsageThreshold: plan?.usageThresholds
-    ?.map((threshold) => ({
-      ...threshold,
-      amountCents: deserializeAmount(threshold.amountCents || 0, initialCurrency),
-    }))
-    .find(({ recurring }) => !!recurring),
-  fixedCharges: plan?.fixedCharges || [],
-  charges: plan?.charges
-    ? (plan?.charges.map(
-        ({
-          taxes,
-          properties,
-          minAmountCents,
-          payInAdvance,
-          invoiceDisplayName,
-          filters,
-          appliedPricingUnit,
-          ...charge
-        }) => {
-          return {
-            appliedPricingUnit:
-              !hasAnyPricingUnitConfigured && !appliedPricingUnit
-                ? undefined
-                : {
-                    code: appliedPricingUnit?.pricingUnit?.code || initialCurrency,
-                    conversionRate: String(appliedPricingUnit?.conversionRate || ''),
-                    shortName: appliedPricingUnit?.pricingUnit?.shortName || initialCurrency,
-                    type: !!appliedPricingUnit?.pricingUnit?.code
-                      ? LocalPricingUnitType.Custom
-                      : LocalPricingUnitType.Fiat,
+        ...restEntitlement,
+      })) || [],
+    invoiceDisplayName: plan?.invoiceDisplayName || undefined,
+    payInAdvance: plan?.payInAdvance || false,
+    amountCents: isNaN(plan?.amountCents)
+      ? '0'
+      : String(deserializeAmount(plan?.amountCents || 0, initialCurrency)),
+    trialPeriod: plan?.trialPeriod ?? 0,
+    minimumCommitment: !!plan?.minimumCommitment
+      ? {
+          ...plan?.minimumCommitment,
+          amountCents: String(
+            deserializeAmount(plan?.minimumCommitment.amountCents || 0, initialCurrency),
+          ),
+        }
+      : {},
+    nonRecurringUsageThresholds:
+      plan?.usageThresholds && plan?.usageThresholds.length > 0
+        ? plan?.usageThresholds
+            .filter(({ recurring }) => !recurring)
+            .map((threshold) => ({
+              ...threshold,
+              amountCents: deserializeAmount(threshold.amountCents || 0, initialCurrency),
+            }))
+            .sort((a, b) => a.amountCents - b.amountCents)
+        : undefined,
+    recurringUsageThreshold: plan?.usageThresholds
+      ?.map((threshold) => ({
+        ...threshold,
+        amountCents: deserializeAmount(threshold.amountCents || 0, initialCurrency),
+      }))
+      .find(({ recurring }) => !!recurring),
+    fixedCharges: plan?.fixedCharges || [],
+    charges: plan?.charges
+      ? (plan?.charges.map(
+          ({
+            taxes,
+            properties,
+            minAmountCents,
+            payInAdvance,
+            invoiceDisplayName,
+            filters,
+            appliedPricingUnit,
+            ...charge
+          }) => {
+            return {
+              appliedPricingUnit:
+                !hasAnyPricingUnitConfigured && !appliedPricingUnit
+                  ? undefined
+                  : {
+                      code: appliedPricingUnit?.pricingUnit?.code || initialCurrency,
+                      conversionRate: String(appliedPricingUnit?.conversionRate || ''),
+                      shortName: appliedPricingUnit?.pricingUnit?.shortName || initialCurrency,
+                      type: !!appliedPricingUnit?.pricingUnit?.code
+                        ? LocalPricingUnitType.Custom
+                        : LocalPricingUnitType.Fiat,
+                    },
+              invoiceDisplayName: invoiceDisplayName || '',
+              taxes: taxes || [],
+              minAmountCents:
+                isNaN(minAmountCents) || minAmountCents === '0'
+                  ? undefined
+                  : String(
+                      deserializeAmount(
+                        minAmountCents || 0,
+                        plan.amountCurrency || CurrencyEnum.Usd,
+                      ),
+                    ),
+              payInAdvance: payInAdvance || false,
+              properties: properties ? getPropertyShape(properties) : undefined,
+              regroupPaidFees: charge.regroupPaidFees || null,
+              filters: (filters || []).map((filter) => {
+                const values = Object.entries(filter.values || {}).reduce<string[]>(
+                  (acc, [key, objectValues]) => {
+                    ;(objectValues as string[]).map((v) => {
+                      acc.push(transformFilterObjectToString(key, v))
+                    })
+
+                    return acc
                   },
-            invoiceDisplayName: invoiceDisplayName || '',
-            taxes: taxes || [],
-            minAmountCents:
-              isNaN(minAmountCents) || minAmountCents === '0'
-                ? undefined
-                : String(
-                    deserializeAmount(minAmountCents || 0, plan.amountCurrency || CurrencyEnum.Usd),
-                  ),
-            payInAdvance: payInAdvance || false,
-            properties: properties ? getPropertyShape(properties) : undefined,
-            regroupPaidFees: charge.regroupPaidFees || null,
-            filters: (filters || []).map((filter) => {
-              const values = Object.entries(filter.values || {}).reduce<string[]>(
-                (acc, [key, objectValues]) => {
-                  ;(objectValues as string[]).map((v) => {
-                    acc.push(transformFilterObjectToString(key, v))
-                  })
+                  [],
+                )
 
-                  return acc
-                },
-                [],
-              )
-
-              return {
-                ...filter,
-                properties: getPropertyShape(filter.properties),
-                values,
-              }
-            }),
-            ...charge,
-          }
-        },
-      ) as LocalUsageChargeInput[])
-    : ([] as LocalUsageChargeInput[]),
-  cascadeUpdates: undefined,
-})
+                return {
+                  ...filter,
+                  properties: getPropertyShape(filter.properties),
+                  values,
+                }
+              }),
+              ...charge,
+            }
+          },
+        ) as LocalUsageChargeInput[])
+      : ([] as LocalUsageChargeInput[]),
+    cascadeUpdates: undefined,
+  }
+}
 
 export const usePlanForm = ({
   planIdToFetch,

--- a/src/hooks/plans/usePlanForm.tsx
+++ b/src/hooks/plans/usePlanForm.tsx
@@ -42,10 +42,10 @@ import {
   PlanItemFragmentDoc,
   useCreatePlanMutation,
   useGetSinglePlanQuery,
-  useUpdatePlanMutation,
 } from '~/generated/graphql'
 import { useAppForm } from '~/hooks/forms/useAppform'
 import { useCustomPricingUnits } from '~/hooks/plans/useCustomPricingUnits'
+import { usePlanUpdate } from '~/hooks/plans/usePlanUpdate'
 import { buildPlanSettingsValues } from '~/hooks/plans/utils'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
@@ -257,51 +257,43 @@ export const usePlanForm = ({
       }
     },
   })
-  const [update, { error: updateError }] = useUpdatePlanMutation({
-    context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
-    onCompleted({ updatePlan }) {
-      if (!!updatePlan) {
-        const origin = searchParams.get('origin')
-        const originSubscriptionId = searchParams.get('subscriptionId')
-        const originCustomerId = searchParams.get('customerId')
+  const { update, error: updateError } = usePlanUpdate({
+    onSuccess(updatePlan) {
+      const origin = searchParams.get('origin')
+      const originSubscriptionId = searchParams.get('subscriptionId')
+      const originCustomerId = searchParams.get('customerId')
 
-        addToast({
-          severity: 'success',
-          translateKey: 'text_625fd165963a7b00c8f598a0',
-        })
-
-        if (
-          origin === REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE &&
-          originSubscriptionId &&
-          !!originCustomerId
-        ) {
-          navigate(
-            generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
-              customerId: originCustomerId,
-              subscriptionId: originSubscriptionId,
-              tab: CustomerSubscriptionDetailsTabsOptionsEnum.usage,
-            }),
-          )
-        } else if (
-          origin === REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE &&
-          !!originSubscriptionId &&
-          updatePlan?.id
-        ) {
-          navigate(
-            generatePath(PLAN_SUBSCRIPTION_DETAILS_ROUTE, {
-              planId: updatePlan?.id,
-              subscriptionId: originSubscriptionId,
-              tab: CustomerSubscriptionDetailsTabsOptionsEnum.usage,
-            }),
-          )
-        } else {
-          navigate(
-            generatePath(PLAN_DETAILS_ROUTE, {
-              planId: updatePlan.id,
-              tab: PlanDetailsTabsOptionsEnum.overview,
-            }),
-          )
-        }
+      if (
+        origin === REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE &&
+        originSubscriptionId &&
+        !!originCustomerId
+      ) {
+        navigate(
+          generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
+            customerId: originCustomerId,
+            subscriptionId: originSubscriptionId,
+            tab: CustomerSubscriptionDetailsTabsOptionsEnum.usage,
+          }),
+        )
+      } else if (
+        origin === REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE &&
+        !!originSubscriptionId &&
+        updatePlan?.id
+      ) {
+        navigate(
+          generatePath(PLAN_SUBSCRIPTION_DETAILS_ROUTE, {
+            planId: updatePlan?.id,
+            subscriptionId: originSubscriptionId,
+            tab: CustomerSubscriptionDetailsTabsOptionsEnum.usage,
+          }),
+        )
+      } else {
+        navigate(
+          generatePath(PLAN_DETAILS_ROUTE, {
+            planId: updatePlan.id,
+            tab: PlanDetailsTabsOptionsEnum.overview,
+          }),
+        )
       }
     },
   })

--- a/src/hooks/plans/usePlanUpdate.ts
+++ b/src/hooks/plans/usePlanUpdate.ts
@@ -1,0 +1,22 @@
+import { addToast } from '~/core/apolloClient'
+import { LagoApiError, UpdatePlanMutation, useUpdatePlanMutation } from '~/generated/graphql'
+
+type UpdatePlanResult = NonNullable<UpdatePlanMutation['updatePlan']>
+
+type UsePlanUpdateOptions = {
+  onSuccess?: (updatePlan: UpdatePlanResult) => void
+}
+
+export const usePlanUpdate = ({ onSuccess }: UsePlanUpdateOptions = {}) => {
+  const [update, { error }] = useUpdatePlanMutation({
+    context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
+    onCompleted({ updatePlan }) {
+      if (updatePlan) {
+        addToast({ severity: 'success', translateKey: 'text_625fd165963a7b00c8f598a0' })
+        onSuccess?.(updatePlan)
+      }
+    },
+  })
+
+  return { update, error }
+}

--- a/src/hooks/plans/utils.ts
+++ b/src/hooks/plans/utils.ts
@@ -1,3 +1,9 @@
+import {
+  CurrencyEnum,
+  PlanInterval,
+  TaxForPlanSettingsSectionFragment,
+} from '~/generated/graphql'
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const formatAnyToValueForChargeFormArrays = (toValue: any, fromValue: number | string) => {
   if (toValue === null) return null
@@ -8,3 +14,42 @@ export const formatAnyToValueForChargeFormArrays = (toValue: any, fromValue: num
 
   return Number(toValue || 0)
 }
+
+type PlanSettingsSourceShape = {
+  name?: string | null
+  code?: string | null
+  description?: string | null
+  interval?: PlanInterval | null
+  amountCurrency?: CurrencyEnum | null
+  billChargesMonthly?: boolean | null
+  billFixedChargesMonthly?: boolean | null
+  taxes?: TaxForPlanSettingsSectionFragment[] | null
+  fixedCharges?: Array<{ id: string }> | null
+  charges?: Array<{ id: string }> | null
+}
+
+export type PlanSettingsValues = {
+  name: string
+  code: string
+  description: string
+  interval: PlanInterval
+  amountCurrency: CurrencyEnum
+  billChargesMonthly: boolean
+  billFixedChargesMonthly: boolean
+  taxes: TaxForPlanSettingsSectionFragment[]
+  fixedCharges: Array<{ id: string }>
+  charges: Array<{ id: string }>
+}
+
+export const buildPlanSettingsValues = (plan: PlanSettingsSourceShape): PlanSettingsValues => ({
+  name: plan.name ?? '',
+  code: plan.code ?? '',
+  description: plan.description ?? '',
+  interval: plan.interval ?? PlanInterval.Monthly,
+  amountCurrency: plan.amountCurrency ?? CurrencyEnum.Usd,
+  billChargesMonthly: plan.billChargesMonthly ?? false,
+  billFixedChargesMonthly: plan.billFixedChargesMonthly ?? false,
+  taxes: plan.taxes ?? [],
+  fixedCharges: (plan.fixedCharges ?? []).map((fc) => ({ id: fc.id })),
+  charges: (plan.charges ?? []).map((c) => ({ id: c.id })),
+})

--- a/src/hooks/plans/utils.ts
+++ b/src/hooks/plans/utils.ts
@@ -1,8 +1,4 @@
-import {
-  CurrencyEnum,
-  PlanInterval,
-  TaxForPlanSettingsSectionFragment,
-} from '~/generated/graphql'
+import { CurrencyEnum, PlanInterval, TaxForPlanSettingsSectionFragment } from '~/generated/graphql'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const formatAnyToValueForChargeFormArrays = (toValue: any, fromValue: number | string) => {


### PR DESCRIPTION
Part of LAGO-1468 — refactor only.

Pure extraction. No behavior change. Builds the primitives that the v2 inline-edit Plan settings section (LAGO-1468 PR2) will consume; v1 (\`PlanDetailsOverview\`, \`usePlanForm\`) is refactored to use them too.

- \`PlanSettingsInfo\` — presentation-only \`InfoGrid\` lifted out of \`PlanDetailsOverview\`. v1 now calls it; v2 will too.
- \`buildPlanSettingsValues(plan)\` — helper returning the plan-settings subset of \`PlanFormInput\`. \`usePlanForm.buildDefaultValues\` delegates the relevant fields to it.
- \`usePlanUpdate({ onSuccess })\` — wraps \`useUpdatePlanMutation\` + standard success toast. \`usePlanForm\` uses it with its existing navigate-on-success callback.

**Better reviewed hiding white spaces**