### PR TITLE
feat(plans): v2 Plan settings section + edit drawer

### DIFF
--- a/src/components/plans/details-v2/PlanDetailsV2.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2.tsx
@@ -1,7 +1,11 @@
 import { gql } from '@apollo/client'
 
 import { DetailsPage } from '~/components/layouts/DetailsPage'
-import { LagoApiError, useGetPlanForDetailsV2Query } from '~/generated/graphql'
+import {
+  LagoApiError,
+  TaxForPlanSettingsSectionFragmentDoc,
+  useGetPlanForDetailsV2Query,
+} from '~/generated/graphql'
 
 import { PlanDetailsV2LeftSidebar } from './PlanDetailsV2LeftSidebar'
 import { PlanDetailsV2SectionId } from './sidebarSections'
@@ -15,6 +19,17 @@ gql`
     interval
     amountCurrency
     hasOverriddenPlans
+    billFixedChargesMonthly
+    billChargesMonthly
+    taxes {
+      ...TaxForPlanSettingsSection
+    }
+    fixedCharges {
+      id
+    }
+    charges {
+      id
+    }
   }
 
   query getPlanForDetailsV2($planId: ID!) {
@@ -22,6 +37,8 @@ gql`
       ...PlanDetailsV2
     }
   }
+
+  ${TaxForPlanSettingsSectionFragmentDoc}
 `
 
 const TOP_LEVEL_SECTION_IDS: PlanDetailsV2SectionId[] = [

--- a/src/components/plans/details-v2/PlanDetailsV2.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2.tsx
@@ -8,6 +8,7 @@ import {
 } from '~/generated/graphql'
 
 import { PlanDetailsV2LeftSidebar } from './PlanDetailsV2LeftSidebar'
+import { PlanDetailsV2PlanSettingsSection } from './PlanDetailsV2PlanSettingsSection'
 import { PlanDetailsV2SectionId } from './sidebarSections'
 
 gql`
@@ -94,9 +95,24 @@ export const PlanDetailsV2 = ({ planId, isInSubscriptionForm = false }: PlanDeta
         onItemClick={handleItemClick}
       />
       <div className="flex flex-1 flex-col gap-12 py-12">
-        {TOP_LEVEL_SECTION_IDS.map((id) => (
-          <section key={id} id={id} className="min-h-48 scroll-mt-12 rounded-xl bg-grey-100" />
-        ))}
+        {TOP_LEVEL_SECTION_IDS.map((id) => {
+          if (id === PlanDetailsV2SectionId.PlanSettings) {
+            return (
+              <PlanDetailsV2PlanSettingsSection
+                key={id}
+                plan={data.plan}
+                isInSubscriptionForm={isInSubscriptionForm}
+              />
+            )
+          }
+          return (
+            <section
+              key={id}
+              id={id}
+              className="min-h-48 scroll-mt-12 rounded-xl bg-grey-100"
+            />
+          )
+        })}
         <section
           id={PlanDetailsV2SectionId.AdvancedSettings}
           className="flex scroll-mt-12 flex-col gap-12"

--- a/src/components/plans/details-v2/PlanDetailsV2.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2.tsx
@@ -84,7 +84,9 @@ export const PlanDetailsV2 = ({ planId, isInSubscriptionForm = false }: PlanDeta
     return <DetailsPage.Skeleton />
   }
 
-  if (!data?.plan) {
+  const plan = data?.plan
+
+  if (!plan) {
     return null
   }
 
@@ -100,17 +102,13 @@ export const PlanDetailsV2 = ({ planId, isInSubscriptionForm = false }: PlanDeta
             return (
               <PlanDetailsV2PlanSettingsSection
                 key={id}
-                plan={data.plan}
+                plan={plan}
                 isInSubscriptionForm={isInSubscriptionForm}
               />
             )
           }
           return (
-            <section
-              key={id}
-              id={id}
-              className="min-h-48 scroll-mt-12 rounded-xl bg-grey-100"
-            />
+            <section key={id} id={id} className="min-h-48 scroll-mt-12 rounded-xl bg-grey-100" />
           )
         })}
         <section

--- a/src/components/plans/details-v2/PlanDetailsV2PlanSettingsSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2PlanSettingsSection.tsx
@@ -1,0 +1,55 @@
+import { Icon } from 'lago-design-system'
+import { useRef } from 'react'
+
+import {
+  PlanSettingsDrawer,
+  PlanSettingsDrawerRef,
+} from '~/components/plans/drawers/planSettings/PlanSettingsDrawer'
+import { PlanDetailsV2Fragment } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+import { PlanSettingsAccordion } from './accordions/PlanSettingsAccordion'
+import { SectionAccordion } from './shared/SectionAccordion'
+import { SectionHeader } from './shared/SectionHeader'
+import { PlanDetailsV2SectionId } from './sidebarSections'
+
+type PlanDetailsV2PlanSettingsSectionProps = {
+  plan: PlanDetailsV2Fragment
+  isInSubscriptionForm?: boolean
+}
+
+export const PlanDetailsV2PlanSettingsSection = ({
+  plan,
+  isInSubscriptionForm = false,
+}: PlanDetailsV2PlanSettingsSectionProps) => {
+  const { translate } = useInternationalization()
+  const drawerRef = useRef<PlanSettingsDrawerRef>(null)
+
+  return (
+    <section
+      id={PlanDetailsV2SectionId.PlanSettings}
+      className="flex scroll-mt-12 flex-col gap-6"
+    >
+      <SectionHeader
+        title={translate('text_642d5eb2783a2ad10d67031a')}
+        description={translate('text_6661fc17337de3591e29e3c1')}
+      />
+      <SectionAccordion
+        icon={<Icon name="file" size="small" color="dark" />}
+        title={translate('text_642d5eb2783a2ad10d67031a')}
+        initiallyOpen
+        actions={[
+          {
+            label: translate('text_63e51ef4985f0ebd75c212fc'),
+            onClick: () => drawerRef.current?.openDrawer(),
+            hidden: isInSubscriptionForm,
+          },
+        ]}
+      >
+        <PlanSettingsAccordion plan={plan} />
+      </SectionAccordion>
+
+      <PlanSettingsDrawer ref={drawerRef} plan={plan} />
+    </section>
+  )
+}

--- a/src/components/plans/details-v2/PlanDetailsV2PlanSettingsSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2PlanSettingsSection.tsx
@@ -26,10 +26,7 @@ export const PlanDetailsV2PlanSettingsSection = ({
   const drawerRef = useRef<PlanSettingsDrawerRef>(null)
 
   return (
-    <section
-      id={PlanDetailsV2SectionId.PlanSettings}
-      className="flex scroll-mt-12 flex-col gap-6"
-    >
+    <section id={PlanDetailsV2SectionId.PlanSettings} className="flex scroll-mt-12 flex-col gap-6">
       <SectionHeader
         title={translate('text_642d5eb2783a2ad10d67031a')}
         description={translate('text_6661fc17337de3591e29e3c1')}

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2.test.tsx
@@ -1,10 +1,11 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { screen, waitFor } from '@testing-library/react'
 
-import { CurrencyEnum, GetPlanForDetailsV2Document, PlanInterval } from '~/generated/graphql'
+import { GetPlanForDetailsV2Document } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
 import { PlanDetailsV2 } from '../PlanDetailsV2'
+import { PLAN_DETAILS_V2_FIXTURE_ID, planDetailsV2Fixture } from './fixtures'
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({
@@ -12,31 +13,19 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
   }),
 }))
 
-const PLAN_ID = 'plan_1'
-
 const planMock = {
-  request: { query: GetPlanForDetailsV2Document, variables: { planId: PLAN_ID } },
-  result: {
-    data: {
-      plan: {
-        __typename: 'Plan',
-        id: PLAN_ID,
-        name: 'Pro',
-        code: 'pro',
-        description: null,
-        interval: PlanInterval.Monthly,
-        amountCurrency: CurrencyEnum.Usd,
-        hasOverriddenPlans: false,
-      },
-    },
+  request: {
+    query: GetPlanForDetailsV2Document,
+    variables: { planId: PLAN_DETAILS_V2_FIXTURE_ID },
   },
+  result: { data: { plan: planDetailsV2Fixture } },
 }
 
 describe('PlanDetailsV2', () => {
   it('renders the sidebar and every plan section anchor once the query resolves', async () => {
     render(
       <MockedProvider mocks={[planMock]} addTypename={false}>
-        <PlanDetailsV2 planId={PLAN_ID} />
+        <PlanDetailsV2 planId={PLAN_DETAILS_V2_FIXTURE_ID} />
       </MockedProvider>,
     )
 
@@ -60,7 +49,7 @@ describe('PlanDetailsV2', () => {
   it('hides the sub-flow sections when isInSubscriptionForm=true', async () => {
     render(
       <MockedProvider mocks={[planMock]} addTypename={false}>
-        <PlanDetailsV2 planId={PLAN_ID} isInSubscriptionForm />
+        <PlanDetailsV2 planId={PLAN_DETAILS_V2_FIXTURE_ID} isInSubscriptionForm />
       </MockedProvider>,
     )
 
@@ -76,7 +65,7 @@ describe('PlanDetailsV2', () => {
   it('does not render the sidebar while the query is loading', () => {
     render(
       <MockedProvider mocks={[planMock]} addTypename={false}>
-        <PlanDetailsV2 planId={PLAN_ID} />
+        <PlanDetailsV2 planId={PLAN_DETAILS_V2_FIXTURE_ID} />
       </MockedProvider>,
     )
 

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2.test.tsx
@@ -4,8 +4,9 @@ import { screen, waitFor } from '@testing-library/react'
 import { GetPlanForDetailsV2Document } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
-import { PlanDetailsV2 } from '../PlanDetailsV2'
 import { PLAN_DETAILS_V2_FIXTURE_ID, planDetailsV2Fixture } from './fixtures'
+
+import { PlanDetailsV2 } from '../PlanDetailsV2'
 
 jest.mock('~/components/plans/drawers/planSettings/PlanSettingsDrawer', () => {
   const { forwardRef, useImperativeHandle } = jest.requireActual('react')

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2.test.tsx
@@ -7,6 +7,17 @@ import { render } from '~/test-utils'
 import { PlanDetailsV2 } from '../PlanDetailsV2'
 import { PLAN_DETAILS_V2_FIXTURE_ID, planDetailsV2Fixture } from './fixtures'
 
+jest.mock('~/components/plans/drawers/planSettings/PlanSettingsDrawer', () => {
+  const { forwardRef, useImperativeHandle } = jest.requireActual('react')
+
+  const PlanSettingsDrawer = forwardRef((_props: unknown, ref: unknown) => {
+    useImperativeHandle(ref, () => ({ openDrawer: jest.fn(), closeDrawer: jest.fn() }))
+    return null
+  })
+
+  return { __esModule: true, PlanSettingsDrawer }
+})
+
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({
     translate: (key: string) => key,

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2PlanSettingsSection.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2PlanSettingsSection.test.tsx
@@ -1,15 +1,15 @@
 import { MockedProvider } from '@apollo/client/testing'
 import NiceModal from '@ebay/nice-modal-react'
-import { screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ReactNode } from 'react'
 
 import { FORM_DIALOG_NAME } from '~/components/dialogs/const'
 import FormDialog from '~/components/dialogs/FormDialog'
-import { render } from '~/test-utils'
+
+import { planDetailsV2Fixture } from './fixtures'
 
 import { PlanDetailsV2PlanSettingsSection } from '../PlanDetailsV2PlanSettingsSection'
-import { planDetailsV2Fixture } from './fixtures'
 
 NiceModal.register(FORM_DIALOG_NAME, FormDialog)
 
@@ -78,10 +78,9 @@ describe('PlanDetailsV2PlanSettingsSection', () => {
   })
 
   it('hides the Edit action when isInSubscriptionForm is true', () => {
-    render(
-      <PlanDetailsV2PlanSettingsSection plan={planDetailsV2Fixture} isInSubscriptionForm />,
-      { wrapper: Wrapper },
-    )
+    render(<PlanDetailsV2PlanSettingsSection plan={planDetailsV2Fixture} isInSubscriptionForm />, {
+      wrapper: Wrapper,
+    })
 
     expect(screen.queryByRole('button', { name: /actions/i })).not.toBeInTheDocument()
   })

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2PlanSettingsSection.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2PlanSettingsSection.test.tsx
@@ -1,0 +1,88 @@
+import { MockedProvider } from '@apollo/client/testing'
+import NiceModal from '@ebay/nice-modal-react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ReactNode } from 'react'
+
+import { FORM_DIALOG_NAME } from '~/components/dialogs/const'
+import FormDialog from '~/components/dialogs/FormDialog'
+import { render } from '~/test-utils'
+
+import { PlanDetailsV2PlanSettingsSection } from '../PlanDetailsV2PlanSettingsSection'
+import { planDetailsV2Fixture } from './fixtures'
+
+NiceModal.register(FORM_DIALOG_NAME, FormDialog)
+
+const mockOpenDrawer = jest.fn()
+const mockCloseDrawer = jest.fn()
+
+jest.mock('~/components/plans/drawers/planSettings/PlanSettingsDrawer', () => {
+  const { forwardRef, useImperativeHandle } = jest.requireActual('react')
+
+  const PlanSettingsDrawer = forwardRef((_props: unknown, ref: unknown) => {
+    useImperativeHandle(ref, () => ({
+      openDrawer: mockOpenDrawer,
+      closeDrawer: mockCloseDrawer,
+    }))
+    return null
+  })
+
+  return { __esModule: true, PlanSettingsDrawer }
+})
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <MockedProvider mocks={[]} addTypename={false}>
+    <NiceModal.Provider>{children}</NiceModal.Provider>
+  </MockedProvider>
+)
+
+describe('PlanDetailsV2PlanSettingsSection', () => {
+  beforeEach(() => {
+    mockOpenDrawer.mockClear()
+    mockCloseDrawer.mockClear()
+  })
+
+  it('renders the section header and accordion summary', () => {
+    render(<PlanDetailsV2PlanSettingsSection plan={planDetailsV2Fixture} />, { wrapper: Wrapper })
+
+    expect(screen.getAllByText('text_642d5eb2783a2ad10d67031a').length).toBeGreaterThan(0)
+  })
+
+  it('opens the drawer when Edit is clicked in plan mode', async () => {
+    render(<PlanDetailsV2PlanSettingsSection plan={planDetailsV2Fixture} />, { wrapper: Wrapper })
+
+    await userEvent.click(await screen.findByRole('button', { name: /actions/i }))
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'text_63e51ef4985f0ebd75c212fc' }),
+    )
+
+    await waitFor(() => expect(mockOpenDrawer).toHaveBeenCalledTimes(1))
+  })
+
+  // Drift test (memory/feedback_drift_test_pattern.md): lock in the Edit
+  // action present in plan mode so a future refactor can't silently drop it.
+  it('should keep the Edit action wired when isInSubscriptionForm is undefined or false', async () => {
+    render(<PlanDetailsV2PlanSettingsSection plan={planDetailsV2Fixture} />, { wrapper: Wrapper })
+
+    await userEvent.click(await screen.findByRole('button', { name: /actions/i }))
+
+    expect(
+      await screen.findByRole('button', { name: 'text_63e51ef4985f0ebd75c212fc' }),
+    ).toBeInTheDocument()
+  })
+
+  it('hides the Edit action when isInSubscriptionForm is true', () => {
+    render(
+      <PlanDetailsV2PlanSettingsSection plan={planDetailsV2Fixture} isInSubscriptionForm />,
+      { wrapper: Wrapper },
+    )
+
+    expect(screen.queryByRole('button', { name: /actions/i })).not.toBeInTheDocument()
+  })
+})

--- a/src/components/plans/details-v2/__tests__/fixtures.ts
+++ b/src/components/plans/details-v2/__tests__/fixtures.ts
@@ -1,0 +1,19 @@
+import { CurrencyEnum, PlanDetailsV2Fragment, PlanInterval } from '~/generated/graphql'
+
+export const PLAN_DETAILS_V2_FIXTURE_ID = 'plan_1'
+
+export const planDetailsV2Fixture: PlanDetailsV2Fragment & { __typename: 'Plan' } = {
+  __typename: 'Plan',
+  id: PLAN_DETAILS_V2_FIXTURE_ID,
+  name: 'Pro',
+  code: 'pro',
+  description: null,
+  interval: PlanInterval.Monthly,
+  amountCurrency: CurrencyEnum.Usd,
+  hasOverriddenPlans: false,
+  billFixedChargesMonthly: false,
+  billChargesMonthly: false,
+  taxes: [],
+  fixedCharges: [],
+  charges: [],
+}

--- a/src/components/plans/details-v2/accordions/PlanSettingsAccordion.tsx
+++ b/src/components/plans/details-v2/accordions/PlanSettingsAccordion.tsx
@@ -1,0 +1,10 @@
+import { PlanSettingsInfo } from '~/components/plans/PlanSettingsInfo'
+import { PlanDetailsV2Fragment } from '~/generated/graphql'
+
+type PlanSettingsAccordionProps = {
+  plan: PlanDetailsV2Fragment
+}
+
+export const PlanSettingsAccordion = ({ plan }: PlanSettingsAccordionProps) => (
+  <PlanSettingsInfo plan={plan} />
+)

--- a/src/components/plans/details-v2/accordions/__tests__/PlanSettingsAccordion.test.tsx
+++ b/src/components/plans/details-v2/accordions/__tests__/PlanSettingsAccordion.test.tsx
@@ -1,0 +1,23 @@
+import { screen } from '@testing-library/react'
+
+import { CurrencyEnum } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import { planDetailsV2Fixture } from '../../__tests__/fixtures'
+import { PlanSettingsAccordion } from '../PlanSettingsAccordion'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+describe('PlanSettingsAccordion', () => {
+  it('renders the shared PlanSettingsInfo content', () => {
+    render(<PlanSettingsAccordion plan={planDetailsV2Fixture} />)
+
+    expect(screen.getByText('Pro')).toBeInTheDocument()
+    expect(screen.getByText('pro')).toBeInTheDocument()
+    expect(screen.getByText(CurrencyEnum.Usd)).toBeInTheDocument()
+  })
+})

--- a/src/components/plans/details-v2/shared/useCascadeFormDialog.tsx
+++ b/src/components/plans/details-v2/shared/useCascadeFormDialog.tsx
@@ -55,7 +55,7 @@ export const useCascadeFormDialog = () => {
       ),
       children: (
         <form.AppForm>
-          <div className="p-4">
+          <div className="p-8">
             <form.AppField name="cascadeUpdates">
               {(field) => (
                 <field.SwitchField

--- a/src/components/plans/drawers/planSettings/PlanSettingsDrawer.tsx
+++ b/src/components/plans/drawers/planSettings/PlanSettingsDrawer.tsx
@@ -25,18 +25,27 @@ type PlanSettingsDrawerProps = {
   plan: PlanDetailsV2Fragment
 }
 
-const buildDrawerDefaults = (plan: PlanDetailsV2Fragment): PlanFormInput => ({
-  ...buildPlanSettingsValues(plan),
-  amountCents: '0',
-  trialPeriod: 0,
-  payInAdvance: false,
-  minimumCommitment: {},
-  entitlements: [],
-  nonRecurringUsageThresholds: undefined,
-  recurringUsageThreshold: undefined,
-  invoiceDisplayName: undefined,
-  cascadeUpdates: undefined,
-})
+const buildDrawerDefaults = (plan: PlanDetailsV2Fragment): PlanFormInput => {
+  const settingsDefaults = buildPlanSettingsValues(plan)
+
+  return {
+    ...settingsDefaults,
+    // PlanSettingsSection only reads fixedCharges.length / charges.length to
+    // gate the bill*Monthly switches. We seed length-only stubs and cast to
+    // satisfy PlanFormInput — the drawer never edits these arrays.
+    fixedCharges: settingsDefaults.fixedCharges as unknown as PlanFormInput['fixedCharges'],
+    charges: settingsDefaults.charges as unknown as PlanFormInput['charges'],
+    amountCents: '0',
+    trialPeriod: 0,
+    payInAdvance: false,
+    minimumCommitment: {},
+    entitlements: [],
+    nonRecurringUsageThresholds: undefined,
+    recurringUsageThreshold: undefined,
+    invoiceDisplayName: undefined,
+    cascadeUpdates: undefined,
+  }
+}
 
 export const PlanSettingsDrawer = forwardRef<PlanSettingsDrawerRef, PlanSettingsDrawerProps>(
   ({ plan }, ref) => {
@@ -88,7 +97,6 @@ export const PlanSettingsDrawer = forwardRef<PlanSettingsDrawerRef, PlanSettings
             {(canSubmit) => (
               <Button
                 data-test="plan-settings-drawer-save"
-                form={PLAN_SETTINGS_FORM_ID}
                 onClick={handleSubmit}
                 disabled={!canSubmit}
               >

--- a/src/components/plans/drawers/planSettings/PlanSettingsDrawer.tsx
+++ b/src/components/plans/drawers/planSettings/PlanSettingsDrawer.tsx
@@ -1,0 +1,113 @@
+import { revalidateLogic } from '@tanstack/react-form'
+import { forwardRef, useImperativeHandle } from 'react'
+
+import { Button } from '~/components/designSystem/Button'
+import { useFormDrawer } from '~/components/drawers/useDrawer'
+import { useCascadeFormDialog } from '~/components/plans/details-v2/shared/useCascadeFormDialog'
+import { PlanSettingsSection } from '~/components/plans/PlanSettingsSection'
+import { PlanFormInput } from '~/components/plans/types'
+import { serializePlanInput } from '~/core/serializers'
+import { planFormSchema } from '~/formValidation/planFormSchema'
+import { PlanDetailsV2Fragment } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
+import { usePlanUpdate } from '~/hooks/plans/usePlanUpdate'
+import { buildPlanSettingsValues } from '~/hooks/plans/utils'
+
+const PLAN_SETTINGS_FORM_ID = 'plan-settings-drawer-form'
+
+export interface PlanSettingsDrawerRef {
+  openDrawer: () => void
+  closeDrawer: () => void
+}
+
+type PlanSettingsDrawerProps = {
+  plan: PlanDetailsV2Fragment
+}
+
+const buildDrawerDefaults = (plan: PlanDetailsV2Fragment): PlanFormInput => ({
+  ...buildPlanSettingsValues(plan),
+  amountCents: '0',
+  trialPeriod: 0,
+  payInAdvance: false,
+  minimumCommitment: {},
+  entitlements: [],
+  nonRecurringUsageThresholds: undefined,
+  recurringUsageThreshold: undefined,
+  invoiceDisplayName: undefined,
+  cascadeUpdates: undefined,
+})
+
+export const PlanSettingsDrawer = forwardRef<PlanSettingsDrawerRef, PlanSettingsDrawerProps>(
+  ({ plan }, ref) => {
+    const { translate } = useInternationalization()
+    const drawer = useFormDrawer()
+    const { openCascadeDialog } = useCascadeFormDialog()
+
+    const { update } = usePlanUpdate({
+      onSuccess() {
+        drawer.close()
+      },
+    })
+
+    const form = useAppForm({
+      defaultValues: buildDrawerDefaults(plan),
+      validationLogic: revalidateLogic(),
+      validators: { onDynamic: planFormSchema },
+      onSubmit: async ({ value }) => {
+        const serialized = serializePlanInput(value)
+
+        await update({ variables: { input: { ...serialized, id: plan.id } } })
+      },
+    })
+
+    const handleSubmit = () => {
+      if (plan.hasOverriddenPlans) {
+        return openCascadeDialog({
+          title: translate('text_1729604107534r3hsj7i64gp'),
+          mainActionLabel: translate('text_1729604107534dfyz8j53ho5'),
+          hasOverriddenPlans: true,
+          onConfirm: async (cascadeUpdates) => {
+            form.setFieldValue('cascadeUpdates', cascadeUpdates)
+            await form.handleSubmit()
+          },
+        })
+      }
+
+      return form.handleSubmit()
+    }
+
+    const openSettingsDrawer = () => {
+      form.reset(buildDrawerDefaults(plan), { keepDefaultValues: true })
+
+      drawer.open({
+        title: translate('text_642d5eb2783a2ad10d67031a'),
+        form: { id: PLAN_SETTINGS_FORM_ID, submit: handleSubmit },
+        mainAction: (
+          <form.Subscribe selector={({ canSubmit }) => canSubmit}>
+            {(canSubmit) => (
+              <Button
+                data-test="plan-settings-drawer-save"
+                form={PLAN_SETTINGS_FORM_ID}
+                onClick={handleSubmit}
+                disabled={!canSubmit}
+              >
+                {translate('text_17295436903260tlyb1gp1i7')}
+              </Button>
+            )}
+          </form.Subscribe>
+        ),
+        children: <PlanSettingsSection form={form} canBeEdited isEdition />,
+      })
+    }
+
+    useImperativeHandle(ref, () => ({
+      openDrawer: openSettingsDrawer,
+      closeDrawer: () => drawer.close(),
+    }))
+
+    return null
+  },
+)
+
+PlanSettingsDrawer.displayName = 'PlanSettingsDrawer'

--- a/src/components/plans/drawers/planSettings/__tests__/PlanSettingsDrawer.test.tsx
+++ b/src/components/plans/drawers/planSettings/__tests__/PlanSettingsDrawer.test.tsx
@@ -1,0 +1,156 @@
+import { MockedProvider, MockedResponse } from '@apollo/client/testing'
+import NiceModal from '@ebay/nice-modal-react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createRef, ReactNode } from 'react'
+
+import { FORM_DIALOG_NAME } from '~/components/dialogs/const'
+import FormDialog from '~/components/dialogs/FormDialog'
+import { UpdatePlanDocument } from '~/generated/graphql'
+
+import { planDetailsV2Fixture } from '../../../details-v2/__tests__/fixtures'
+import { PlanSettingsDrawer, PlanSettingsDrawerRef } from '../PlanSettingsDrawer'
+
+NiceModal.register(FORM_DIALOG_NAME, FormDialog)
+
+type CapturedDrawerArgs = {
+  title?: ReactNode
+  children?: ReactNode
+  mainAction?: ReactNode
+  form?: { id: string; submit: () => void }
+}
+
+let lastDrawerArgs: CapturedDrawerArgs | null = null
+const mockClose = jest.fn()
+
+jest.mock('~/components/drawers/useDrawer', () => ({
+  useFormDrawer: () => ({
+    open: jest.fn((args: CapturedDrawerArgs) => {
+      lastDrawerArgs = args
+    }),
+    close: mockClose,
+  }),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+const updateMockFactory = (cascadeUpdates: boolean | undefined): MockedResponse => ({
+  request: { query: UpdatePlanDocument },
+  variableMatcher: (vars) => {
+    const input = vars?.input
+    if (!input || input.id !== planDetailsV2Fixture.id || input.name !== 'Pro Renamed') {
+      return false
+    }
+    if (cascadeUpdates === undefined) {
+      return input.cascadeUpdates === undefined
+    }
+    return input.cascadeUpdates === cascadeUpdates
+  },
+  result: {
+    data: { updatePlan: { ...planDetailsV2Fixture, name: 'Pro Renamed' } },
+  },
+})
+
+const renderHarness = (plan = planDetailsV2Fixture, mocks: MockedResponse[] = []) => {
+  const ref = createRef<PlanSettingsDrawerRef>()
+
+  const utils = render(
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <NiceModal.Provider>
+        <PlanSettingsDrawer ref={ref} plan={plan} />
+      </NiceModal.Provider>
+    </MockedProvider>,
+  )
+
+  return { ref, ...utils }
+}
+
+const renderDrawerBody = () => {
+  if (!lastDrawerArgs?.children) {
+    throw new Error('Drawer was not opened')
+  }
+  return render(
+    <MockedProvider mocks={[]} addTypename={false}>
+      <NiceModal.Provider>{lastDrawerArgs.children}</NiceModal.Provider>
+    </MockedProvider>,
+  )
+}
+
+describe('PlanSettingsDrawer', () => {
+  beforeEach(() => {
+    lastDrawerArgs = null
+    mockClose.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('opens with current plan values pre-filled', async () => {
+    const { ref } = renderHarness()
+
+    act(() => ref.current?.openDrawer())
+
+    expect(lastDrawerArgs?.title).toBe('text_642d5eb2783a2ad10d67031a')
+
+    renderDrawerBody()
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Pro')).toBeInTheDocument()
+    })
+    expect(screen.getByDisplayValue('pro')).toBeInTheDocument()
+  })
+
+  it('submits updatePlan without opening the cascade dialog when no overrides exist', async () => {
+    const { ref } = renderHarness(planDetailsV2Fixture, [updateMockFactory(undefined)])
+
+    act(() => ref.current?.openDrawer())
+
+    renderDrawerBody()
+
+    await waitFor(() => screen.getByDisplayValue('Pro'))
+
+    const nameInput = screen.getByDisplayValue('Pro') as HTMLInputElement
+
+    await userEvent.clear(nameInput)
+    await userEvent.type(nameInput, 'Pro Renamed')
+
+    await act(async () => {
+      lastDrawerArgs?.form?.submit()
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('text_1729604107534r3hsj7i64gp')).not.toBeInTheDocument()
+    })
+  })
+
+  it('opens the cascade dialog when plan has overridden subs', async () => {
+    const { ref } = renderHarness(
+      { ...planDetailsV2Fixture, hasOverriddenPlans: true },
+      [updateMockFactory(true)],
+    )
+
+    act(() => ref.current?.openDrawer())
+
+    renderDrawerBody()
+
+    await waitFor(() => screen.getByDisplayValue('Pro'))
+
+    const nameInput = screen.getByDisplayValue('Pro') as HTMLInputElement
+
+    await userEvent.clear(nameInput)
+    await userEvent.type(nameInput, 'Pro Renamed')
+
+    await act(async () => {
+      lastDrawerArgs?.form?.submit()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('text_1729604107534r3hsj7i64gp')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/plans/drawers/planSettings/__tests__/PlanSettingsDrawer.test.tsx
+++ b/src/components/plans/drawers/planSettings/__tests__/PlanSettingsDrawer.test.tsx
@@ -129,10 +129,9 @@ describe('PlanSettingsDrawer', () => {
   })
 
   it('opens the cascade dialog when plan has overridden subs', async () => {
-    const { ref } = renderHarness(
-      { ...planDetailsV2Fixture, hasOverriddenPlans: true },
-      [updateMockFactory(true)],
-    )
+    const { ref } = renderHarness({ ...planDetailsV2Fixture, hasOverriddenPlans: true }, [
+      updateMockFactory(true),
+    ])
 
     act(() => ref.current?.openDrawer())
 

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -11546,14 +11546,14 @@ export type PlanForUsageChargeAccordionFragment = { __typename?: 'Plan', billCha
 
 export type VolumeRangesFragment = { __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null };
 
-export type PlanDetailsV2Fragment = { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, amountCurrency: CurrencyEnum, hasOverriddenPlans?: boolean | null };
+export type PlanDetailsV2Fragment = { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, amountCurrency: CurrencyEnum, hasOverriddenPlans?: boolean | null, billFixedChargesMonthly?: boolean | null, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string }> | null, charges?: Array<{ __typename?: 'Charge', id: string }> | null };
 
 export type GetPlanForDetailsV2QueryVariables = Exact<{
   planId: Scalars['ID']['input'];
 }>;
 
 
-export type GetPlanForDetailsV2Query = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, amountCurrency: CurrencyEnum, hasOverriddenPlans?: boolean | null } | null };
+export type GetPlanForDetailsV2Query = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, amountCurrency: CurrencyEnum, hasOverriddenPlans?: boolean | null, billFixedChargesMonthly?: boolean | null, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string }> | null, charges?: Array<{ __typename?: 'Charge', id: string }> | null } | null };
 
 export type PlanDetailsActivityLogsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -12712,7 +12712,7 @@ export type UpdatePlanMutationVariables = Exact<{
 }>;
 
 
-export type UpdatePlanMutation = { __typename?: 'Mutation', updatePlan?: { __typename?: 'Plan', id: string, name: string, code: string, chargesCount: number, activeSubscriptionsCount: number, createdAt: any, draftInvoicesCount: number, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, hasOverriddenPlans?: boolean | null, billFixedChargesMonthly?: boolean | null, minimumCommitment?: { __typename?: 'Commitment', amountCents: any, commitmentType: CommitmentTypeEnum, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null } | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, regroupPaidFees?: RegroupPaidFeesEnum | null, appliedPricingUnit?: { __typename?: 'AppliedPricingUnit', conversionRate: number, pricingUnit: { __typename?: 'PricingUnit', id: string, code: string, name: string, shortName: string } } | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, filters?: Array<{ __typename?: 'BillableMetricFilter', key: string, values: Array<string>, id: string }> | null }, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, pricingGroupKeys?: Array<string> | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: number, rate: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, filters?: Array<{ __typename?: 'ChargeFilter', invoiceDisplayName?: string | null, values: any, properties: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, pricingGroupKeys?: Array<string> | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: number, rate: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null, usageThresholds?: Array<{ __typename?: 'UsageThreshold', id: string, amountCents: any, recurring: boolean, thresholdDisplayName?: string | null }> | null, entitlements?: Array<{ __typename?: 'PlanEntitlement', code: string, name: string, privileges: Array<{ __typename?: 'PlanEntitlementPrivilegeObject', code: string, name?: string | null, value: string, valueType: PrivilegeValueTypeEnum, config: { __typename?: 'PrivilegeConfigObject', selectOptions?: Array<string> | null } }> }> | null, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string, prorated: boolean, units: string, chargeModel: FixedChargeChargeModelEnum, invoiceDisplayName?: string | null, payInAdvance: boolean, addOn: { __typename?: 'AddOn', id: string, name: string, code: string }, properties?: { __typename?: 'FixedChargeProperties', amount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null }> | null } | null };
+export type UpdatePlanMutation = { __typename?: 'Mutation', updatePlan?: { __typename?: 'Plan', id: string, name: string, code: string, chargesCount: number, activeSubscriptionsCount: number, createdAt: any, draftInvoicesCount: number, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, hasOverriddenPlans?: boolean | null, billFixedChargesMonthly?: boolean | null, minimumCommitment?: { __typename?: 'Commitment', amountCents: any, commitmentType: CommitmentTypeEnum, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null } | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, regroupPaidFees?: RegroupPaidFeesEnum | null, appliedPricingUnit?: { __typename?: 'AppliedPricingUnit', conversionRate: number, pricingUnit: { __typename?: 'PricingUnit', id: string, code: string, name: string, shortName: string } } | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, filters?: Array<{ __typename?: 'BillableMetricFilter', key: string, values: Array<string>, id: string }> | null }, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, pricingGroupKeys?: Array<string> | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: number, rate: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, filters?: Array<{ __typename?: 'ChargeFilter', invoiceDisplayName?: string | null, values: any, properties: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, pricingGroupKeys?: Array<string> | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: number, rate: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null, usageThresholds?: Array<{ __typename?: 'UsageThreshold', id: string, amountCents: any, recurring: boolean, thresholdDisplayName?: string | null }> | null, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string, prorated: boolean, units: string, chargeModel: FixedChargeChargeModelEnum, invoiceDisplayName?: string | null, payInAdvance: boolean, addOn: { __typename?: 'AddOn', id: string, name: string, code: string }, properties?: { __typename?: 'FixedChargeProperties', amount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null }> | null, entitlements?: Array<{ __typename?: 'PlanEntitlement', code: string, name: string, privileges: Array<{ __typename?: 'PlanEntitlementPrivilegeObject', code: string, name?: string | null, value: string, valueType: PrivilegeValueTypeEnum, config: { __typename?: 'PrivilegeConfigObject', selectOptions?: Array<string> | null } }> }> | null } | null };
 
 export type EditAddOnFragment = { __typename?: 'AddOn', id: string, name: string, code: string, description?: string | null, amountCents: any, amountCurrency: CurrencyEnum, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null };
 
@@ -16777,6 +16777,14 @@ export const InvoiceForInvoiceDetailsTableFragmentDoc = gql`
 }
     ${FeeForInvoiceDetailsTableFragmentDoc}
 ${InvoiceForFormatInvoiceItemMapFragmentDoc}`;
+export const TaxForPlanSettingsSectionFragmentDoc = gql`
+    fragment TaxForPlanSettingsSection on Tax {
+  id
+  code
+  name
+  rate
+}
+    `;
 export const PlanDetailsV2FragmentDoc = gql`
     fragment PlanDetailsV2 on Plan {
   id
@@ -16786,8 +16794,19 @@ export const PlanDetailsV2FragmentDoc = gql`
   interval
   amountCurrency
   hasOverriddenPlans
+  billFixedChargesMonthly
+  billChargesMonthly
+  taxes {
+    ...TaxForPlanSettingsSection
+  }
+  fixedCharges {
+    id
+  }
+  charges {
+    id
+  }
 }
-    `;
+    ${TaxForPlanSettingsSectionFragmentDoc}`;
 export const FeatureObjectEntitlementPrivilegeForPlanFragmentDoc = gql`
     fragment FeatureObjectEntitlementPrivilegeForPlan on FeatureObject {
   id
@@ -18231,14 +18250,6 @@ ${TaxForTaxesSelectorSectionFragmentDoc}`;
 export const PlanForUsageChargeAccordionFragmentDoc = gql`
     fragment PlanForUsageChargeAccordion on Plan {
   billChargesMonthly
-}
-    `;
-export const TaxForPlanSettingsSectionFragmentDoc = gql`
-    fragment TaxForPlanSettingsSection on Tax {
-  id
-  code
-  name
-  rate
 }
     `;
 export const PlanForSettingsSectionFragmentDoc = gql`
@@ -31068,11 +31079,13 @@ export const UpdatePlanDocument = gql`
     ...PlanItem
     ...DeletePlanDialog
     ...EditPlan
+    ...PlanDetailsV2
   }
 }
     ${PlanItemFragmentDoc}
 ${DeletePlanDialogFragmentDoc}
-${EditPlanFragmentDoc}`;
+${EditPlanFragmentDoc}
+${PlanDetailsV2FragmentDoc}`;
 export type UpdatePlanMutationFn = Apollo.MutationFunction<UpdatePlanMutation, UpdatePlanMutationVariables>;
 
 /**

--- a/src/hooks/plans/usePlanForm.tsx
+++ b/src/hooks/plans/usePlanForm.tsx
@@ -39,6 +39,7 @@ import {
   EditPlanFragment,
   EditPlanFragmentDoc,
   LagoApiError,
+  PlanDetailsV2FragmentDoc,
   PlanItemFragmentDoc,
   useCreatePlanMutation,
   useGetSinglePlanQuery,
@@ -67,12 +68,14 @@ gql`
       ...PlanItem
       ...DeletePlanDialog
       ...EditPlan
+      ...PlanDetailsV2
     }
   }
 
   ${PlanItemFragmentDoc}
   ${DeletePlanDialogFragmentDoc}
   ${EditPlanFragmentDoc}
+  ${PlanDetailsV2FragmentDoc}
 `
 
 export type PlanFormType = ReturnType<typeof usePlanForm>['form']

--- a/src/pages/__tests__/PlanDetails.test.tsx
+++ b/src/pages/__tests__/PlanDetails.test.tsx
@@ -30,6 +30,10 @@ jest.mock('~/components/plans/details/PlanDetailsOverview', () => ({
   PlanDetailsOverview: () => null,
 }))
 
+jest.mock('~/components/plans/details-v2/PlanDetailsV2', () => ({
+  PlanDetailsV2: () => null,
+}))
+
 jest.mock('~/components/plans/details/PlanDetailsActivityLogs', () => ({
   PlanDetailsActivityLogs: () => null,
 }))


### PR DESCRIPTION
Fixes LAGO-1468

Stacks on \`lago-1468-extract\` (PR #3535). First real section of \`PlanDetailsV2\` end-to-end. Validates the \`SectionAccordion\` + drawer + \`useCascadeFormDialog\` pattern that LAGO-1469+ will reuse.

- Extends \`PlanDetailsV2\` fragment with \`taxes\`, \`bill*Monthly\`, plus presence-only \`fixedCharges\` / \`charges\`. Spreads the fragment into \`updatePlan\`'s response so Apollo auto-normalizes the v2 cache after edits.
- New \`PlanSettingsAccordion\` mounts the shared \`PlanSettingsInfo\` (extracted in the base PR) inside a \`SectionAccordion\`.
- New \`PlanSettingsDrawer\` (\`useFormDrawer\` + \`useAppForm\`) mounts the existing \`PlanSettingsSection\`. Submit routes through \`useCascadeFormDialog\` — short-circuits when no overridden subs exist.
- In sub mode (\`isInSubscriptionForm\`) the Edit action is hidden; sub-flow wiring lands in LAGO-1473.
- Drift test pins the Edit action present in plan mode.
- Bumps the cascade dialog inner padding from \`p-4\` to \`p-8\` to align with design.