### PR TITLE
refactor(plans): extract SubFee body + plan update hook

### DIFF
--- a/src/components/plans/SubscriptionFeeInfo.tsx
+++ b/src/components/plans/SubscriptionFeeInfo.tsx
@@ -1,0 +1,66 @@
+import { Typography } from '~/components/designSystem/Typography'
+import { DetailsPage } from '~/components/layouts/DetailsPage'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { CurrencyEnum } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+type SubscriptionFeeInfoPlan = {
+  amountCents?: string | number | null
+  amountCurrency?: CurrencyEnum | null
+  payInAdvance?: boolean | null
+  trialPeriod?: number | null
+  taxes?: Array<{ id: string; name?: string | null; rate?: number | null }> | null
+}
+
+type SubscriptionFeeInfoProps = {
+  plan: SubscriptionFeeInfoPlan
+}
+
+export const SubscriptionFeeInfo = ({ plan }: SubscriptionFeeInfoProps) => {
+  const { translate } = useInternationalization()
+  const currency = plan.amountCurrency ?? CurrencyEnum.Usd
+
+  return (
+    <div className="flex flex-col gap-6">
+      <DetailsPage.TableDisplay
+        name="subscription-fee"
+        header={[translate('text_624453d52e945301380e49b6')]}
+        body={[
+          [
+            intlFormatNumber(deserializeAmount(plan.amountCents || 0, currency), {
+              currency,
+            }),
+          ],
+        ]}
+      />
+      <DetailsPage.InfoGrid
+        grid={[
+          {
+            label: translate('text_65201b8216455901fe273dd9'),
+            value: plan.payInAdvance
+              ? translate('text_646e2d0cc536351b62ba6faa')
+              : translate('text_646e2d0cc536351b62ba6f8c'),
+          },
+          {
+            label: translate('text_65201b8216455901fe273dcd'),
+            value: plan.trialPeriod,
+          },
+          {
+            label: translate('text_645bb193927b375079d28a8f'),
+            value: !!plan.taxes?.length
+              ? plan.taxes.map((tax, i) => (
+                  <div key={`subscription-fee-tax-${tax.id ?? i}`}>
+                    <Typography variant="body" color="grey700">
+                      {tax.name} (
+                      {intlFormatNumber(Number(tax.rate) / 100 || 0, { style: 'percent' })})
+                    </Typography>
+                  </div>
+                ))
+              : '-',
+          },
+        ]}
+      />
+    </div>
+  )
+}

--- a/src/components/plans/SubscriptionFeeInfo.tsx
+++ b/src/components/plans/SubscriptionFeeInfo.tsx
@@ -44,7 +44,7 @@ export const SubscriptionFeeInfo = ({ plan }: SubscriptionFeeInfoProps) => {
           },
           {
             label: translate('text_65201b8216455901fe273dcd'),
-            value: plan.trialPeriod,
+            value: plan.trialPeriod || '-',
           },
           {
             label: translate('text_645bb193927b375079d28a8f'),

--- a/src/components/plans/__tests__/SubscriptionFeeInfo.test.tsx
+++ b/src/components/plans/__tests__/SubscriptionFeeInfo.test.tsx
@@ -1,0 +1,57 @@
+import { screen } from '@testing-library/react'
+
+import { CurrencyEnum } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import { SubscriptionFeeInfo } from '../SubscriptionFeeInfo'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+const basePlan = {
+  __typename: 'Plan' as const,
+  id: 'plan_1',
+  amountCents: '1000',
+  amountCurrency: CurrencyEnum.Usd,
+  payInAdvance: false,
+  trialPeriod: 14,
+  taxes: [],
+}
+
+describe('SubscriptionFeeInfo', () => {
+  it('renders the amount cell + the pay-in-advance / trial / taxes grid', () => {
+    render(<SubscriptionFeeInfo plan={basePlan} />)
+
+    expect(screen.getByText('text_624453d52e945301380e49b6')).toBeInTheDocument()
+    expect(screen.getByText('text_646e2d0cc536351b62ba6f8c')).toBeInTheDocument()
+    expect(screen.getByText('14')).toBeInTheDocument()
+  })
+
+  it('shows "Pay in advance" copy when payInAdvance=true', () => {
+    render(<SubscriptionFeeInfo plan={{ ...basePlan, payInAdvance: true }} />)
+
+    expect(screen.getByText('text_646e2d0cc536351b62ba6faa')).toBeInTheDocument()
+  })
+
+  it('renders a "-" placeholder when no taxes are attached', () => {
+    render(<SubscriptionFeeInfo plan={basePlan} />)
+
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+
+  it('lists each tax as "Name (rate%)" when taxes are present', () => {
+    render(
+      <SubscriptionFeeInfo
+        plan={{
+          ...basePlan,
+          taxes: [{ id: 't1', code: 'vat20', name: 'VAT', rate: 20 }],
+        }}
+      />,
+    )
+
+    expect(screen.getByText(/VAT/)).toBeInTheDocument()
+  })
+})

--- a/src/components/plans/__tests__/SubscriptionFeeInfo.test.tsx
+++ b/src/components/plans/__tests__/SubscriptionFeeInfo.test.tsx
@@ -47,7 +47,7 @@ describe('SubscriptionFeeInfo', () => {
       <SubscriptionFeeInfo
         plan={{
           ...basePlan,
-          taxes: [{ id: 't1', code: 'vat20', name: 'VAT', rate: 20 }],
+          taxes: [{ id: 't1', name: 'VAT', rate: 20 }],
         }}
       />,
     )

--- a/src/components/plans/details/PlanDetailsAdvancedFeeAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsAdvancedFeeAccordion.tsx
@@ -1,9 +1,7 @@
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Typography } from '~/components/designSystem/Typography'
-import { DetailsPage } from '~/components/layouts/DetailsPage'
-import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
-import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { CurrencyEnum, EditPlanFragment } from '~/generated/graphql'
+import { SubscriptionFeeInfo } from '~/components/plans/SubscriptionFeeInfo'
+import { EditPlanFragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 export const PlanDetailsSubscriptionFeeAccordion = ({
@@ -21,50 +19,7 @@ export const PlanDetailsSubscriptionFeeAccordion = ({
         </Typography>
       }
     >
-      <div className="flex flex-col gap-6">
-        <DetailsPage.TableDisplay
-          name="subscription-fee"
-          header={[translate('text_624453d52e945301380e49b6')]}
-          body={[
-            [
-              intlFormatNumber(
-                deserializeAmount(plan?.amountCents || 0, plan?.amountCurrency || CurrencyEnum.Usd),
-                { currency: plan?.amountCurrency || CurrencyEnum.Usd },
-              ),
-            ],
-          ]}
-        />
-        <DetailsPage.InfoGrid
-          grid={[
-            {
-              label: translate('text_65201b8216455901fe273dd9'),
-              value: plan?.payInAdvance
-                ? translate('text_646e2d0cc536351b62ba6faa')
-                : translate('text_646e2d0cc536351b62ba6f8c'),
-            },
-            {
-              label: translate('text_65201b8216455901fe273dcd'),
-              value: plan?.trialPeriod,
-            },
-            {
-              label: translate('text_645bb193927b375079d28a8f'),
-              value: !!plan?.taxes?.length
-                ? plan?.taxes?.map((tax, i) => (
-                    <div key={`plan-details-subscription-fee-taxe-${i}`}>
-                      <Typography variant="body" color="grey700">
-                        {tax.name} (
-                        {intlFormatNumber(Number(tax.rate) / 100 || 0, {
-                          style: 'percent',
-                        })}
-                        )
-                      </Typography>
-                    </div>
-                  ))
-                : '-',
-            },
-          ]}
-        />
-      </div>
+      <SubscriptionFeeInfo plan={plan ?? {}} />
     </Accordion>
   )
 }

--- a/src/components/plans/drawers/planSettings/PlanSettingsDrawer.tsx
+++ b/src/components/plans/drawers/planSettings/PlanSettingsDrawer.tsx
@@ -1,18 +1,14 @@
-import { revalidateLogic } from '@tanstack/react-form'
 import { forwardRef, useImperativeHandle } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { useFormDrawer } from '~/components/drawers/useDrawer'
-import { useCascadeFormDialog } from '~/components/plans/details-v2/shared/useCascadeFormDialog'
 import { PlanSettingsSection } from '~/components/plans/PlanSettingsSection'
-import { PlanFormInput } from '~/components/plans/types'
-import { serializePlanInput } from '~/core/serializers'
-import { planFormSchema } from '~/formValidation/planFormSchema'
 import { PlanDetailsV2Fragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { useAppForm } from '~/hooks/forms/useAppform'
-import { usePlanUpdate } from '~/hooks/plans/usePlanUpdate'
-import { buildPlanSettingsValues } from '~/hooks/plans/utils'
+import {
+  buildUpdatePlanFormDefaults,
+  useUpdatePlanWithCascade,
+} from '~/hooks/plans/useUpdatePlanWithCascade'
 
 const PLAN_SETTINGS_FORM_ID = 'plan-settings-drawer-form'
 
@@ -25,79 +21,30 @@ type PlanSettingsDrawerProps = {
   plan: PlanDetailsV2Fragment
 }
 
-const buildDrawerDefaults = (plan: PlanDetailsV2Fragment): PlanFormInput => {
-  const settingsDefaults = buildPlanSettingsValues(plan)
-
-  return {
-    ...settingsDefaults,
-    // PlanSettingsSection only reads fixedCharges.length / charges.length to
-    // gate the bill*Monthly switches. We seed length-only stubs and cast to
-    // satisfy PlanFormInput — the drawer never edits these arrays.
-    fixedCharges: settingsDefaults.fixedCharges as unknown as PlanFormInput['fixedCharges'],
-    charges: settingsDefaults.charges as unknown as PlanFormInput['charges'],
-    amountCents: '0',
-    trialPeriod: 0,
-    payInAdvance: false,
-    minimumCommitment: {},
-    entitlements: [],
-    nonRecurringUsageThresholds: undefined,
-    recurringUsageThreshold: undefined,
-    invoiceDisplayName: undefined,
-    cascadeUpdates: undefined,
-  }
-}
-
 export const PlanSettingsDrawer = forwardRef<PlanSettingsDrawerRef, PlanSettingsDrawerProps>(
   ({ plan }, ref) => {
     const { translate } = useInternationalization()
     const drawer = useFormDrawer()
-    const { openCascadeDialog } = useCascadeFormDialog()
 
-    const { update } = usePlanUpdate({
+    const { form, submit } = useUpdatePlanWithCascade({
+      plan,
       onSuccess() {
         drawer.close()
       },
     })
 
-    const form = useAppForm({
-      defaultValues: buildDrawerDefaults(plan),
-      validationLogic: revalidateLogic(),
-      validators: { onDynamic: planFormSchema },
-      onSubmit: async ({ value }) => {
-        const serialized = serializePlanInput(value)
-
-        await update({ variables: { input: { ...serialized, id: plan.id } } })
-      },
-    })
-
-    const handleSubmit = () => {
-      if (plan.hasOverriddenPlans) {
-        return openCascadeDialog({
-          title: translate('text_1729604107534r3hsj7i64gp'),
-          mainActionLabel: translate('text_1729604107534dfyz8j53ho5'),
-          hasOverriddenPlans: true,
-          onConfirm: async (cascadeUpdates) => {
-            form.setFieldValue('cascadeUpdates', cascadeUpdates)
-            await form.handleSubmit()
-          },
-        })
-      }
-
-      return form.handleSubmit()
-    }
-
     const openSettingsDrawer = () => {
-      form.reset(buildDrawerDefaults(plan), { keepDefaultValues: true })
+      form.reset(buildUpdatePlanFormDefaults(plan), { keepDefaultValues: true })
 
       drawer.open({
         title: translate('text_642d5eb2783a2ad10d67031a'),
-        form: { id: PLAN_SETTINGS_FORM_ID, submit: handleSubmit },
+        form: { id: PLAN_SETTINGS_FORM_ID, submit },
         mainAction: (
           <form.Subscribe selector={({ canSubmit }) => canSubmit}>
             {(canSubmit) => (
               <Button
                 data-test="plan-settings-drawer-save"
-                onClick={handleSubmit}
+                onClick={submit}
                 disabled={!canSubmit}
               >
                 {translate('text_17295436903260tlyb1gp1i7')}

--- a/src/components/plans/drawers/planSettings/PlanSettingsDrawer.tsx
+++ b/src/components/plans/drawers/planSettings/PlanSettingsDrawer.tsx
@@ -42,11 +42,7 @@ export const PlanSettingsDrawer = forwardRef<PlanSettingsDrawerRef, PlanSettings
         mainAction: (
           <form.Subscribe selector={({ canSubmit }) => canSubmit}>
             {(canSubmit) => (
-              <Button
-                data-test="plan-settings-drawer-save"
-                onClick={submit}
-                disabled={!canSubmit}
-              >
+              <Button data-test="plan-settings-drawer-save" onClick={submit} disabled={!canSubmit}>
                 {translate('text_17295436903260tlyb1gp1i7')}
               </Button>
             )}

--- a/src/hooks/plans/__tests__/useUpdatePlanWithCascade.test.tsx
+++ b/src/hooks/plans/__tests__/useUpdatePlanWithCascade.test.tsx
@@ -1,0 +1,118 @@
+import { MockedProvider, MockedResponse } from '@apollo/client/testing'
+import NiceModal from '@ebay/nice-modal-react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { ReactNode } from 'react'
+
+import { FORM_DIALOG_NAME } from '~/components/dialogs/const'
+import FormDialog from '~/components/dialogs/FormDialog'
+import { addToast } from '~/core/apolloClient'
+import { CurrencyEnum, PlanInterval, UpdatePlanDocument } from '~/generated/graphql'
+
+import { useUpdatePlanWithCascade } from '../useUpdatePlanWithCascade'
+
+NiceModal.register(FORM_DIALOG_NAME, FormDialog)
+
+jest.mock('~/core/apolloClient', () => {
+  const actual = jest.requireActual('~/core/apolloClient')
+  return { ...actual, addToast: jest.fn() }
+})
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+const basePlan = {
+  __typename: 'Plan' as const,
+  id: 'plan_1',
+  name: 'Pro',
+  code: 'pro',
+  description: null,
+  interval: PlanInterval.Monthly,
+  amountCurrency: CurrencyEnum.Usd,
+  hasOverriddenPlans: false,
+  billFixedChargesMonthly: false,
+  billChargesMonthly: false,
+  taxes: [],
+  fixedCharges: [],
+  charges: [],
+}
+
+const updateMock: MockedResponse = {
+  request: { query: UpdatePlanDocument },
+  variableMatcher: (vars) => vars?.input?.id === basePlan.id,
+  result: { data: { updatePlan: { ...basePlan, name: 'Pro Renamed' } } },
+}
+
+const wrapper = (mocks: MockedResponse[]) =>
+  function MockedWrapper({ children }: { children: ReactNode }) {
+    return (
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NiceModal.Provider>{children}</NiceModal.Provider>
+      </MockedProvider>
+    )
+  }
+
+describe('useUpdatePlanWithCascade', () => {
+  beforeEach(() => {
+    ;(addToast as jest.Mock).mockClear()
+  })
+
+  it('seeds the form with plan-settings values from the plan', () => {
+    const { result } = renderHook(() => useUpdatePlanWithCascade({ plan: basePlan }), {
+      wrapper: wrapper([]),
+    })
+
+    expect(result.current.form.state.values.name).toBe('Pro')
+    expect(result.current.form.state.values.code).toBe('pro')
+    expect(result.current.form.state.values.interval).toBe(PlanInterval.Monthly)
+  })
+
+  it('runs updatePlan + onSuccess directly when the plan has no overrides', async () => {
+    const onSuccess = jest.fn()
+    const { result } = renderHook(
+      () => useUpdatePlanWithCascade({ plan: basePlan, onSuccess }),
+      { wrapper: wrapper([updateMock]) },
+    )
+
+    act(() => {
+      result.current.form.setFieldValue('name', 'Pro Renamed')
+    })
+
+    await act(async () => {
+      await result.current.submit()
+    })
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+
+    expect(addToast).toHaveBeenCalledWith({
+      severity: 'success',
+      translateKey: 'text_625fd165963a7b00c8f598a0',
+    })
+  })
+
+  it('opens the cascade dialog when the plan has overridden subs', async () => {
+    const { result } = renderHook(
+      () =>
+        useUpdatePlanWithCascade({
+          plan: { ...basePlan, hasOverriddenPlans: true },
+        }),
+      { wrapper: wrapper([updateMock]) },
+    )
+
+    act(() => {
+      result.current.form.setFieldValue('name', 'Pro Renamed')
+    })
+
+    act(() => {
+      result.current.submit()
+    })
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain('text_1729604107534r3hsj7i64gp')
+    })
+  })
+})

--- a/src/hooks/plans/__tests__/useUpdatePlanWithCascade.test.tsx
+++ b/src/hooks/plans/__tests__/useUpdatePlanWithCascade.test.tsx
@@ -71,10 +71,9 @@ describe('useUpdatePlanWithCascade', () => {
 
   it('runs updatePlan + onSuccess directly when the plan has no overrides', async () => {
     const onSuccess = jest.fn()
-    const { result } = renderHook(
-      () => useUpdatePlanWithCascade({ plan: basePlan, onSuccess }),
-      { wrapper: wrapper([updateMock]) },
-    )
+    const { result } = renderHook(() => useUpdatePlanWithCascade({ plan: basePlan, onSuccess }), {
+      wrapper: wrapper([updateMock]),
+    })
 
     act(() => {
       result.current.form.setFieldValue('name', 'Pro Renamed')

--- a/src/hooks/plans/useUpdatePlanWithCascade.ts
+++ b/src/hooks/plans/useUpdatePlanWithCascade.ts
@@ -38,10 +38,7 @@ export const buildUpdatePlanFormDefaults = (plan: PlanDetailsV2Fragment): PlanFo
   }
 }
 
-export const useUpdatePlanWithCascade = ({
-  plan,
-  onSuccess,
-}: UseUpdatePlanWithCascadeOptions) => {
+export const useUpdatePlanWithCascade = ({ plan, onSuccess }: UseUpdatePlanWithCascadeOptions) => {
   const { translate } = useInternationalization()
   const { openCascadeDialog } = useCascadeFormDialog()
 

--- a/src/hooks/plans/useUpdatePlanWithCascade.ts
+++ b/src/hooks/plans/useUpdatePlanWithCascade.ts
@@ -1,0 +1,82 @@
+import { revalidateLogic } from '@tanstack/react-form'
+
+import { useCascadeFormDialog } from '~/components/plans/details-v2/shared/useCascadeFormDialog'
+import { PlanFormInput } from '~/components/plans/types'
+import { serializePlanInput } from '~/core/serializers'
+import { planFormSchema } from '~/formValidation/planFormSchema'
+import { PlanDetailsV2Fragment } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
+import { usePlanUpdate } from '~/hooks/plans/usePlanUpdate'
+import { buildPlanSettingsValues } from '~/hooks/plans/utils'
+
+type UseUpdatePlanWithCascadeOptions = {
+  plan: PlanDetailsV2Fragment
+  onSuccess?: () => void
+}
+
+export const buildUpdatePlanFormDefaults = (plan: PlanDetailsV2Fragment): PlanFormInput => {
+  const settingsDefaults = buildPlanSettingsValues(plan)
+
+  return {
+    ...settingsDefaults,
+    // PlanSettingsSection only reads fixedCharges.length / charges.length to
+    // gate the bill*Monthly switches. We seed length-only stubs and cast to
+    // satisfy PlanFormInput — neither the form nor the mutation touches the
+    // contents.
+    fixedCharges: settingsDefaults.fixedCharges as unknown as PlanFormInput['fixedCharges'],
+    charges: settingsDefaults.charges as unknown as PlanFormInput['charges'],
+    amountCents: '0',
+    trialPeriod: 0,
+    payInAdvance: false,
+    minimumCommitment: {},
+    entitlements: [],
+    nonRecurringUsageThresholds: undefined,
+    recurringUsageThreshold: undefined,
+    invoiceDisplayName: undefined,
+    cascadeUpdates: undefined,
+  }
+}
+
+export const useUpdatePlanWithCascade = ({
+  plan,
+  onSuccess,
+}: UseUpdatePlanWithCascadeOptions) => {
+  const { translate } = useInternationalization()
+  const { openCascadeDialog } = useCascadeFormDialog()
+
+  const { update } = usePlanUpdate({
+    onSuccess() {
+      onSuccess?.()
+    },
+  })
+
+  const form = useAppForm({
+    defaultValues: buildUpdatePlanFormDefaults(plan),
+    validationLogic: revalidateLogic(),
+    validators: { onDynamic: planFormSchema },
+    onSubmit: async ({ value }) => {
+      const serialized = serializePlanInput(value)
+
+      await update({ variables: { input: { ...serialized, id: plan.id } } })
+    },
+  })
+
+  const submit = () => {
+    if (plan.hasOverriddenPlans) {
+      return openCascadeDialog({
+        title: translate('text_1729604107534r3hsj7i64gp'),
+        mainActionLabel: translate('text_1729604107534dfyz8j53ho5'),
+        hasOverriddenPlans: true,
+        onConfirm: async (cascadeUpdates) => {
+          form.setFieldValue('cascadeUpdates', cascadeUpdates)
+          await form.handleSubmit()
+        },
+      })
+    }
+
+    return form.handleSubmit()
+  }
+
+  return { form, submit }
+}


### PR DESCRIPTION
Part of LAGO-1469 — refactor only.

Pure consolidation. Stacks on \`lago-1468\`.

- \`SubscriptionFeeInfo\` — presentation-only \`TableDisplay\` + \`InfoGrid\` body lifted out of \`PlanDetailsSubscriptionFeeAccordion\`. v1 now calls it; v2 will too.
- \`useUpdatePlanWithCascade({ plan, onSuccess })\` — bundles the \`useAppForm\` + cascade routing + \`usePlanUpdate\` glue that \`PlanSettingsDrawer\` was running inline. The drawer now consumes the hook; the v2 Subscription fee composer (LAGO-1469 PR2) will reuse it.

No behavior change. Existing tests cover the refactor.