### PR TITLE
refactor(analytics): migrate PrepaidCredits PremiumWarningDialog to hook

### DIFF
--- a/src/components/analytics/prepaidCredits/PrepaidCreditsOverviewSection.tsx
+++ b/src/components/analytics/prepaidCredits/PrepaidCreditsOverviewSection.tsx
@@ -14,7 +14,7 @@ import StackedBarChart from '~/components/designSystem/graphs/StackedBarChart'
 import { getItemDateFormatedByTimeGranularity } from '~/components/designSystem/graphs/utils'
 import { HorizontalDataTable } from '~/components/designSystem/Table/HorizontalDataTable'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { PREPAID_CREDITS_OVERVIEW_FILTER_PREFIX } from '~/core/constants/filters'
 import { CurrencyEnum, TimeGranularityEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -36,10 +36,6 @@ gql`
     voidedCreditsQuantity
   }
 `
-type PrepaidCreditsOverviewSectionProps = {
-  premiumWarningDialogRef: React.RefObject<PremiumWarningDialogRef>
-}
-
 const PREPAID_CREDITS_GRAPH_COLORS = {
   offeredAmount: '#ABF5DC',
   purchasedAmount: '#36B389',
@@ -85,10 +81,9 @@ const CreditsRowLabel = ({ label, color }: { label: string; color: string }) => 
   </div>
 )
 
-export const PrepaidCreditsOverviewSection = ({
-  premiumWarningDialogRef,
-}: PrepaidCreditsOverviewSectionProps) => {
+export const PrepaidCreditsOverviewSection = () => {
   const { translate } = useInternationalization()
+  const premiumWarningDialog = usePremiumWarningDialog()
 
   const {
     selectedCurrency,
@@ -125,7 +120,7 @@ export const PrepaidCreditsOverviewSection = ({
               onClick={(e) => {
                 if (!hasAccessToAnalyticsDashboardsFeature) {
                   e.stopPropagation()
-                  premiumWarningDialogRef.current?.openDialog()
+                  premiumWarningDialog.open()
                 } else {
                   onClick()
                 }

--- a/src/pages/analytics/PrepaidCredits.tsx
+++ b/src/pages/analytics/PrepaidCredits.tsx
@@ -1,16 +1,13 @@
 import { Icon } from 'lago-design-system'
-import { useRef } from 'react'
 
 import { PrepaidCreditsOverviewSection } from '~/components/analytics/prepaidCredits/PrepaidCreditsOverviewSection'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { FullscreenPage } from '~/components/layouts/FullscreenPage'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 const PrepaidCredits = () => {
   const { translate } = useInternationalization()
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
 
   return (
     <FullscreenPage.Wrapper>
@@ -26,9 +23,7 @@ const PrepaidCredits = () => {
         </Tooltip>
       </Typography>
 
-      <PrepaidCreditsOverviewSection premiumWarningDialogRef={premiumWarningDialogRef} />
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
+      <PrepaidCreditsOverviewSection />
     </FullscreenPage.Wrapper>
   )
 }


### PR DESCRIPTION
## Summary

Migrates the deprecated ref-based `PremiumWarningDialog` import in `pages/analytics/PrepaidCredits.tsx` to the new hook-based `usePremiumWarningDialog` system.

## Changes

- **`src/pages/analytics/PrepaidCredits.tsx`**: removed the legacy `PremiumWarningDialog` import, the `useRef<PremiumWarningDialogRef>` hook, and the rendered `<PremiumWarningDialog>` JSX. The dialog is now opened via the hook directly inside the child component that triggers it.
- **`src/components/analytics/prepaidCredits/PrepaidCreditsOverviewSection.tsx`**: removed the `premiumWarningDialogRef` prop. The component now consumes `usePremiumWarningDialog` directly and calls `premiumWarningDialog.open()` when the user lacks access to the analytics dashboard feature.

The scope is intentionally kept to the `PremiumWarningDialog` migration in this file (and the directly coupled child section that previously received the ref). No other dialog usages were touched.

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm code:style` passes for the changed files (no new warnings)
- [ ] Manually verify on `/[org]/analytics/prepaid-credits` that clicking the filter button (when the user does not have analytics dashboards access) still opens the premium warning dialog


---
_Generated by [Claude Code](https://claude.ai/code/session_01BUHz9taBRMguwHQbKAZ9Qb)_