### PR TITLE
refactor(plans): extract FixedChargeInfo

### DIFF
--- a/src/components/plans/FixedChargeInfo.tsx
+++ b/src/components/plans/FixedChargeInfo.tsx
@@ -1,0 +1,114 @@
+import { DetailsPage } from '~/components/layouts/DetailsPage'
+import { PlanDetailsChargeWrapperSwitch } from '~/components/plans/details/PlanDetailsChargeWrapperSwitch'
+import { isPlanIntervalAnnual, mapChargeIntervalCopy } from '~/components/plans/utils'
+import { chargeModelLookupTranslation } from '~/core/constants/form'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import {
+  CurrencyEnum,
+  FixedChargeChargeModelEnum,
+  FixedChargeProperties,
+  Maybe,
+  PlanInterval,
+} from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+type Tax = { id: string; name: string; rate: number }
+
+export type FixedChargeInfoCharge = {
+  id: string
+  invoiceDisplayName?: string | null
+  chargeModel: FixedChargeChargeModelEnum
+  units?: string | number | null
+  payInAdvance?: boolean | null
+  prorated?: boolean | null
+  properties?: Maybe<FixedChargeProperties>
+  addOn: { id: string; name: string; code: string }
+  taxes?: ReadonlyArray<Tax> | null
+}
+
+export type FixedChargeInfoProps = {
+  fixedCharge: FixedChargeInfoCharge
+  currency: CurrencyEnum
+  planInterval?: PlanInterval | null
+  billFixedChargesMonthly?: boolean | null
+  planTaxes?: ReadonlyArray<Tax> | null
+}
+
+export const FixedChargeInfo = ({
+  fixedCharge,
+  currency,
+  planInterval,
+  billFixedChargesMonthly,
+  planTaxes,
+}: FixedChargeInfoProps) => {
+  const { translate } = useInternationalization()
+  const isAnnual = isPlanIntervalAnnual(planInterval ?? undefined)
+
+  const fixedTaxes = fixedCharge.taxes?.length ? fixedCharge.taxes : null
+  const fallbackTaxes = planTaxes?.length ? planTaxes : null
+  const taxesApplied = fixedTaxes ?? fallbackTaxes
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="px-4 pt-4">
+        <DetailsPage.InfoGrid
+          grid={[
+            {
+              label: translate('text_65201b8216455901fe273dd5'),
+              value: translate(chargeModelLookupTranslation[fixedCharge.chargeModel]),
+            },
+            {
+              label: translate('text_65201b8216455901fe273dc1'),
+              value: translate(
+                mapChargeIntervalCopy(
+                  (planInterval as PlanInterval) ?? PlanInterval.Monthly,
+                  (isAnnual && !!billFixedChargesMonthly) || false,
+                ),
+              ),
+            },
+            {
+              label: translate('text_65771fa3f4ab9a00720726ce'),
+              value: fixedCharge.units,
+            },
+          ]}
+        />
+      </div>
+      <section className="flex flex-col gap-4 px-4 pb-4 shadow-b">
+        <PlanDetailsChargeWrapperSwitch
+          currency={currency}
+          chargeModel={fixedCharge.chargeModel}
+          values={fixedCharge.properties}
+        />
+      </section>
+      <div className="px-4 pb-4">
+        <DetailsPage.InfoGrid
+          grid={[
+            {
+              label: translate('text_65201b8216455901fe273dd9'),
+              value: fixedCharge.payInAdvance
+                ? translate('text_646e2d0cc536351b62ba6faa')
+                : translate('text_646e2d0cc536351b62ba6f8c'),
+            },
+            {
+              label: translate('text_65201b8216455901fe273df0'),
+              value: fixedCharge.prorated
+                ? translate('text_65251f46339c650084ce0d57')
+                : translate('text_65251f4cd55aeb004e5aa5ef'),
+            },
+            {
+              label: translate('text_645bb193927b375079d28a8f'),
+              value: taxesApplied
+                ? taxesApplied.map((tax) => (
+                    <div key={`fixed-charge-${fixedCharge.id}-tax-${tax.id}`}>
+                      {tax.name} (
+                      {intlFormatNumber(Number(tax.rate) / 100 || 0, { style: 'percent' })})
+                    </div>
+                  ))
+                : '-',
+            },
+          ]}
+        />
+      </div>
+    </section>
+  )
+}

--- a/src/components/plans/__tests__/FixedChargeInfo.test.tsx
+++ b/src/components/plans/__tests__/FixedChargeInfo.test.tsx
@@ -1,0 +1,86 @@
+import { screen } from '@testing-library/react'
+
+import { CurrencyEnum, FixedChargeChargeModelEnum, PlanInterval } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import { FixedChargeInfo } from '../FixedChargeInfo'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (k: string) => k }),
+}))
+
+const baseCharge = {
+  id: 'fc_1',
+  invoiceDisplayName: 'Onboarding fee',
+  chargeModel: FixedChargeChargeModelEnum.Standard,
+  units: '1',
+  payInAdvance: true,
+  prorated: false,
+  properties: { amount: '49.99' },
+  addOn: { id: 'addon_1', name: 'Onboarding', code: 'onboarding' },
+  taxes: [],
+}
+
+describe('FixedChargeInfo', () => {
+  it('renders charge model + interval + units', () => {
+    render(
+      <FixedChargeInfo
+        fixedCharge={baseCharge}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        billFixedChargesMonthly={false}
+        planTaxes={[]}
+      />,
+    )
+
+    expect(screen.getByText('text_65201b8216455901fe273dd5')).toBeInTheDocument()
+    expect(screen.getByText('text_65201b8216455901fe273dc1')).toBeInTheDocument()
+    expect(screen.getByText('text_65771fa3f4ab9a00720726ce')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('renders payInAdvance + taxes options when prorated is false', () => {
+    render(
+      <FixedChargeInfo
+        fixedCharge={{ ...baseCharge, payInAdvance: false }}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[]}
+      />,
+    )
+
+    expect(screen.getByText('text_646e2d0cc536351b62ba6f8c')).toBeInTheDocument()
+    expect(screen.getByText('text_65251f4cd55aeb004e5aa5ef')).toBeInTheDocument()
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+
+  it('falls back to planTaxes when fixedCharge has none', () => {
+    render(
+      <FixedChargeInfo
+        fixedCharge={{ ...baseCharge, taxes: [] }}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[{ id: 'tax_1', name: 'VAT', rate: 20 }]}
+      />,
+    )
+
+    expect(screen.getByText(/VAT/)).toBeInTheDocument()
+  })
+
+  it('uses fixedCharge.taxes when present, ignoring plan taxes', () => {
+    render(
+      <FixedChargeInfo
+        fixedCharge={{
+          ...baseCharge,
+          taxes: [{ id: 'tax_2', name: 'GST', rate: 10 }],
+        }}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[{ id: 'tax_1', name: 'VAT', rate: 20 }]}
+      />,
+    )
+
+    expect(screen.getByText(/GST/)).toBeInTheDocument()
+    expect(screen.queryByText(/VAT/)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/plans/details/PlanDetailsFixedChargesSection.tsx
+++ b/src/components/plans/details/PlanDetailsFixedChargesSection.tsx
@@ -1,12 +1,7 @@
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Typography } from '~/components/designSystem/Typography'
-import { DetailsPage } from '~/components/layouts/DetailsPage'
-import { PlanDetailsChargeWrapperSwitch } from '~/components/plans/details/PlanDetailsChargeWrapperSwitch'
-import { isPlanIntervalAnnual, mapChargeIntervalCopy } from '~/components/plans/utils'
-import { chargeModelLookupTranslation } from '~/core/constants/form'
-import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
-import { CurrencyEnum, EditPlanFragment, PlanInterval } from '~/generated/graphql'
-import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { FixedChargeInfo } from '~/components/plans/FixedChargeInfo'
+import { CurrencyEnum, EditPlanFragment } from '~/generated/graphql'
 
 export const PlanDetailsFixedChargesSection = ({
   currency,
@@ -15,104 +10,32 @@ export const PlanDetailsFixedChargesSection = ({
   currency: CurrencyEnum
   plan?: EditPlanFragment | null
 }) => {
-  const { translate } = useInternationalization()
-
-  const isAnnual = isPlanIntervalAnnual(plan?.interval)
-
   return (
     <div className="flex flex-col gap-6">
-      {plan?.fixedCharges?.map((fixedCharge, i) => {
-        const fixedTaxes = !!fixedCharge?.taxes?.length && fixedCharge.taxes
-        const planTaxes = !!plan?.taxes?.length && plan.taxes
-        const taxesApplied = fixedTaxes || planTaxes
-
-        return (
-          <Accordion
-            noContentMargin
-            key={`plan-details_fixed-charges-section_fixed-charge-${i}`}
-            summary={
-              <div>
-                <Typography variant="bodyHl" color="grey700">
-                  {fixedCharge.invoiceDisplayName || fixedCharge.addOn.name}
-                </Typography>
-                <Typography variant="caption" noWrap>
-                  {fixedCharge.addOn.code}
-                </Typography>
-              </div>
-            }
-          >
-            <section className="flex flex-col gap-4">
-              {/* Charge main infos */}
-              <div className="px-4 pt-4">
-                <DetailsPage.InfoGrid
-                  grid={[
-                    {
-                      label: translate('text_65201b8216455901fe273dd5'),
-                      value: translate(chargeModelLookupTranslation[fixedCharge.chargeModel]),
-                    },
-                    {
-                      label: translate('text_65201b8216455901fe273dc1'),
-                      value: translate(
-                        mapChargeIntervalCopy(
-                          plan?.interval as PlanInterval,
-                          (isAnnual && !!plan?.billFixedChargesMonthly) || false,
-                        ),
-                      ),
-                    },
-                    {
-                      label: translate('text_65771fa3f4ab9a00720726ce'),
-                      value: fixedCharge?.units,
-                    },
-                  ]}
-                />
-              </div>
-              {/* Properties accordion */}
-              <section className="flex flex-col gap-4 px-4 pb-4 shadow-b">
-                <PlanDetailsChargeWrapperSwitch
-                  currency={currency}
-                  chargeModel={fixedCharge.chargeModel}
-                  values={fixedCharge.properties}
-                />
-              </section>
-              {/* Options */}
-              <div className="px-4 pb-4">
-                <DetailsPage.InfoGrid
-                  grid={[
-                    {
-                      label: translate('text_65201b8216455901fe273dd9'),
-                      value: fixedCharge?.payInAdvance
-                        ? translate('text_646e2d0cc536351b62ba6faa')
-                        : translate('text_646e2d0cc536351b62ba6f8c'),
-                    },
-                    {
-                      label: translate('text_65201b8216455901fe273df0'),
-                      value: fixedCharge.prorated
-                        ? translate('text_65251f46339c650084ce0d57')
-                        : translate('text_65251f4cd55aeb004e5aa5ef'),
-                    },
-                    {
-                      label: translate('text_645bb193927b375079d28a8f'),
-                      value: !!taxesApplied
-                        ? taxesApplied.map((tax, taxIndex) => (
-                            <div
-                              key={`plan-details-fixed-charge-${i}-section-accordion-tax-${taxIndex}`}
-                            >
-                              {tax.name} (
-                              {intlFormatNumber(Number(tax.rate) / 100 || 0, {
-                                style: 'percent',
-                              })}
-                              )
-                            </div>
-                          ))
-                        : '-',
-                    },
-                  ]}
-                />
-              </div>
-            </section>
-          </Accordion>
-        )
-      })}
+      {plan?.fixedCharges?.map((fixedCharge, i) => (
+        <Accordion
+          noContentMargin
+          key={`plan-details_fixed-charges-section_fixed-charge-${i}`}
+          summary={
+            <div>
+              <Typography variant="bodyHl" color="grey700">
+                {fixedCharge.invoiceDisplayName || fixedCharge.addOn.name}
+              </Typography>
+              <Typography variant="caption" noWrap>
+                {fixedCharge.addOn.code}
+              </Typography>
+            </div>
+          }
+        >
+          <FixedChargeInfo
+            fixedCharge={fixedCharge}
+            currency={currency}
+            planInterval={plan?.interval}
+            billFixedChargesMonthly={plan?.billFixedChargesMonthly}
+            planTaxes={plan?.taxes}
+          />
+        </Accordion>
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
Part of LAGO-1470 — refactor only.

Extracts the per-charge body of `details/PlanDetailsFixedChargesSection`
into a shared `FixedChargeInfo` component. v1 consumer migrated to use it;
v2 (LAGO-1470 PR2) will consume the same component inside `SectionAccordion`.

No behavior change. No new translation keys.