### PR TITLE
fix(NavLayout): prevent content overlapping burger menu

### DIFF
--- a/src/layouts/NavLayout.tsx
+++ b/src/layouts/NavLayout.tsx
@@ -37,7 +37,7 @@ const NavBurgerButton = ({
   return (
     <Button
       {...(dataTest ? { 'data-test': dataTest } : {})}
-      className="absolute left-4 top-2 z-drawer !w-[36px] !p-[10px] md:hidden"
+      className="absolute left-4 top-2 z-drawer !w-[36px] !bg-white !p-[10px] md:hidden"
       icon="burger"
       variant="quaternary"
       onClick={(e) => {


### PR DESCRIPTION
## Context

On mobile (<776px), the burger menu is absolutely positioned inside `NavWrapper` while page content scrolls inside `ContentWrapper`. When the user scrolls, content (e.g. breadcrumb) rides up underneath the burger icon, causing a visual overlap.

Added an opaque white background to the burger button so scrolling content is cleanly hidden behind it instead of bleeding through.

<!-- Linear link -->
Fixes ISSUE-1929