### PR TITLE
refactor(billingEntity): migrate EmailScenarios PremiumWarningDialog to hook

### DIFF
--- a/src/pages/settings/BillingEntity/sections/BillingEntityEmailScenarios.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityEmailScenarios.tsx
@@ -1,5 +1,4 @@
 import { Icon } from 'lago-design-system'
-import { useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Avatar } from '~/components/designSystem/Avatar'
@@ -7,6 +6,7 @@ import { Button } from '~/components/designSystem/Button'
 import { Table, TableColumn } from '~/components/designSystem/Table/Table'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { Switch } from '~/components/form'
 import {
   SettingsListItem,
@@ -16,7 +16,6 @@ import {
   SettingsPaddedContainer,
 } from '~/components/layouts/Settings'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import {
   BILLING_ENTITY_EMAIL_SCENARIOS_CONFIG_ROUTE,
   BILLING_ENTITY_ROUTE,
@@ -73,7 +72,7 @@ const BillingEntityEmailScenarios = () => {
   const { translate } = useInternationalization()
   const { isPremium } = useCurrentUser()
   const { hasPermissions } = usePermissions()
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const { billingEntityCode } = useParams()
   const { hasOrganizationPremiumAddon } = useOrganizationInfos()
 
@@ -182,7 +181,7 @@ const BillingEntityEmailScenarios = () => {
                                       if (hasAccess) {
                                         await updateEmailSettings(setting, value)
                                       } else {
-                                        premiumWarningDialogRef.current?.openDialog()
+                                        openPremiumWarningDialog()
                                       }
                                     }}
                                   />
@@ -224,8 +223,6 @@ const BillingEntityEmailScenarios = () => {
           )}
         </SettingsListWrapper>
       </SettingsPaddedContainer>
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </>
   )
 }


### PR DESCRIPTION
## Summary

Migrates the deprecated ref-based `PremiumWarningDialog` usage in
`BillingEntityEmailScenarios.tsx` to the new hook-based
`usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`.

This silences the `no-restricted-imports` ESLint warning on that file and
brings it in line with the new NiceModal-based dialog management system.

## Changes

- Replace `import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'`
  with `import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'`
- Replace the `useRef<PremiumWarningDialogRef>` with `const { open: openPremiumWarningDialog } = usePremiumWarningDialog()`
- Replace `premiumWarningDialogRef.current?.openDialog()` with `openPremiumWarningDialog()`
- Drop the now-unused `<PremiumWarningDialog ref={...} />` JSX node and the `useRef` React import

## Scope

Scope is intentionally limited to the single `PremiumWarningDialog` usage in
`BillingEntityEmailScenarios.tsx`. No other dialogs are present in this file.

## Test plan

- [x] `pnpm code:style` — no remaining warnings for the migrated file
- [ ] Manually verify the premium upsell dialog still opens for non-premium
  users when toggling an email scenario switch in the Billing Entity email
  scenarios settings page


---
_Generated by [Claude Code](https://claude.ai/code/session_0146QcmjbEh2dK9k1VMPcaMZ)_