### PR TITLE
refactor(plans): extract UsageChargeInfo

### DIFF
--- a/src/components/plans/UsageChargeInfo.tsx
+++ b/src/components/plans/UsageChargeInfo.tsx
@@ -1,0 +1,215 @@
+import { DetailsPage } from '~/components/layouts/DetailsPage'
+import { Accordion } from '~/components/designSystem/Accordion'
+import { Typography } from '~/components/designSystem/Typography'
+import { ConditionalWrapper } from '~/components/ConditionalWrapper'
+import { PlanDetailsChargeWrapperSwitch } from '~/components/plans/details/PlanDetailsChargeWrapperSwitch'
+import { isPlanIntervalAnnual, mapChargeIntervalCopy } from '~/components/plans/utils'
+import { composeChargeFilterDisplayName } from '~/core/formats/formatInvoiceItemsMap'
+import { chargeModelLookupTranslation } from '~/core/constants/form'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import {
+  AppliedPricingUnit,
+  ChargeFilter,
+  ChargeModelEnum,
+  CurrencyEnum,
+  Maybe,
+  PlanInterval,
+  Properties,
+  RegroupPaidFeesEnum,
+} from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+type Tax = { id: string; name: string; rate: number; code?: string }
+
+export type UsageChargeInfoCharge = {
+  __typename?: 'Charge'
+  id: string
+  chargeModel: ChargeModelEnum
+  invoiceDisplayName?: string | null
+  invoiceable?: boolean | null
+  payInAdvance?: boolean | null
+  prorated?: boolean | null
+  minAmountCents?: string | number | null
+  regroupPaidFees?: RegroupPaidFeesEnum | null
+  properties?: Maybe<Properties>
+  filters?: ReadonlyArray<ChargeFilter> | null
+  appliedPricingUnit?: Maybe<AppliedPricingUnit>
+  taxes?: ReadonlyArray<Tax> | null
+  billableMetric: {
+    id: string
+    name: string
+    code?: string
+    recurring?: boolean | null
+    filters?: ReadonlyArray<{ id?: string; key: string; values: string[] }> | null
+  }
+}
+
+export type UsageChargeInfoProps = {
+  charge: UsageChargeInfoCharge
+  currency: CurrencyEnum
+  planInterval?: PlanInterval | null
+  billChargesMonthly?: boolean | null
+  planTaxes?: ReadonlyArray<Tax> | null
+}
+
+export const UsageChargeInfo = ({
+  charge,
+  currency,
+  planInterval,
+  billChargesMonthly,
+  planTaxes,
+}: UsageChargeInfoProps) => {
+  const { translate } = useInternationalization()
+  const isAnnual = isPlanIntervalAnnual(planInterval ?? undefined)
+  const chargeTaxes = charge.taxes?.length ? charge.taxes : null
+  const fallbackTaxes = planTaxes?.length ? planTaxes : null
+  const taxesApplied = chargeTaxes ?? fallbackTaxes
+
+  const invoicingStrategy = (() => {
+    if (!charge.payInAdvance) return translate('text_66968fba80f8f89a8aefdec0')
+    if (charge.invoiceable) return translate('text_66968fba80f8f89a8aefdebf')
+    if (charge.regroupPaidFees === RegroupPaidFeesEnum.Invoice)
+      return translate('text_66968fba80f8f89a8aefdec0')
+    return translate('text_6682c52081acea9052074686')
+  })()
+
+  return (
+    <section className="flex flex-col gap-4">
+      {!!charge.appliedPricingUnit && (
+        <div className="p-4 shadow-b">
+          <DetailsPage.InfoGrid
+            grid={[
+              {
+                label: translate('text_17502505476284yyq70yy6mx'),
+                value: charge.appliedPricingUnit.pricingUnit.name,
+              },
+              {
+                label: translate('text_1750411499858su5b7bbp5t9'),
+                value: translate('text_1750424999815sw5whlu1xj0', {
+                  shortName: charge.appliedPricingUnit.pricingUnit?.shortName,
+                  conversionRateAmount: intlFormatNumber(
+                    charge.appliedPricingUnit?.conversionRate,
+                    { maximumFractionDigits: 15, currency },
+                  ),
+                }),
+              },
+            ]}
+          />
+        </div>
+      )}
+
+      <div className="px-4 pt-4">
+        <DetailsPage.InfoGrid
+          grid={[
+            {
+              label: translate('text_65201b8216455901fe273dd5'),
+              value: translate(chargeModelLookupTranslation[charge.chargeModel]),
+            },
+            {
+              label: translate('text_65201b8216455901fe273dc1'),
+              value: translate(
+                mapChargeIntervalCopy(
+                  (planInterval as PlanInterval) ?? PlanInterval.Monthly,
+                  (isAnnual && !!billChargesMonthly) || false,
+                ),
+              ),
+            },
+          ]}
+        />
+      </div>
+
+      <section className="flex flex-col gap-4 px-4 pb-4 shadow-b">
+        <ConditionalWrapper
+          condition={!!charge.billableMetric?.filters?.length}
+          invalidWrapper={(children) => <div>{children}</div>}
+          validWrapper={(children) => (
+            <Accordion
+              summary={
+                <Typography variant="bodyHl" color="grey700">
+                  {translate('text_64e620bca31226337ffc62ad')}
+                </Typography>
+              }
+            >
+              {children}
+            </Accordion>
+          )}
+        >
+          <PlanDetailsChargeWrapperSwitch
+            currency={currency}
+            chargeModel={charge.chargeModel}
+            values={charge.properties}
+            chargeAppliedPricingUnit={charge.appliedPricingUnit}
+          />
+        </ConditionalWrapper>
+
+        {charge.filters?.map((filter, i) => {
+          const fallbackName = composeChargeFilterDisplayName(filter as never)
+          return (
+            <Accordion
+              key={`usage-charge-info-${charge.id}-filter-${i}`}
+              summary={
+                <Typography noWrap variant="bodyHl" color="grey700">
+                  {filter.invoiceDisplayName || fallbackName}
+                </Typography>
+              }
+            >
+              <PlanDetailsChargeWrapperSwitch
+                currency={currency}
+                chargeModel={charge.chargeModel}
+                values={filter.properties}
+                chargeAppliedPricingUnit={charge.appliedPricingUnit}
+              />
+            </Accordion>
+          )
+        })}
+      </section>
+
+      <div className="px-4 pb-4">
+        <DetailsPage.InfoGrid
+          grid={[
+            {
+              label: translate('text_65201b8216455901fe273dd9'),
+              value: charge.payInAdvance
+                ? translate('text_646e2d0cc536351b62ba6faa')
+                : translate('text_646e2d0cc536351b62ba6f8c'),
+            },
+            {
+              label: translate('text_65201b8216455901fe273ddb'),
+              value: intlFormatNumber(
+                deserializeAmount(charge.minAmountCents ?? 0, currency),
+                {
+                  currencyDisplay: 'symbol',
+                  currency,
+                  pricingUnitShortName: charge.appliedPricingUnit?.pricingUnit?.shortName,
+                  maximumFractionDigits: 15,
+                },
+              ),
+            },
+            {
+              label: translate('text_65201b8216455901fe273df0'),
+              value: charge.prorated
+                ? translate('text_65251f46339c650084ce0d57')
+                : translate('text_65251f4cd55aeb004e5aa5ef'),
+            },
+            {
+              label: translate('text_6682c52081acea90520744ca'),
+              value: invoicingStrategy,
+            },
+            {
+              label: translate('text_645bb193927b375079d28a8f'),
+              value: taxesApplied
+                ? taxesApplied.map((tax) => (
+                    <div key={`usage-charge-${charge.id}-tax-${tax.id}`}>
+                      {tax.name} (
+                      {intlFormatNumber(Number(tax.rate) / 100 || 0, { style: 'percent' })})
+                    </div>
+                  ))
+                : '-',
+            },
+          ]}
+        />
+      </div>
+    </section>
+  )
+}

--- a/src/components/plans/UsageChargeInfo.tsx
+++ b/src/components/plans/UsageChargeInfo.tsx
@@ -1,11 +1,11 @@
-import { DetailsPage } from '~/components/layouts/DetailsPage'
+import { ConditionalWrapper } from '~/components/ConditionalWrapper'
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Typography } from '~/components/designSystem/Typography'
-import { ConditionalWrapper } from '~/components/ConditionalWrapper'
+import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { PlanDetailsChargeWrapperSwitch } from '~/components/plans/details/PlanDetailsChargeWrapperSwitch'
 import { isPlanIntervalAnnual, mapChargeIntervalCopy } from '~/components/plans/utils'
-import { composeChargeFilterDisplayName } from '~/core/formats/formatInvoiceItemsMap'
 import { chargeModelLookupTranslation } from '~/core/constants/form'
+import { composeChargeFilterDisplayName } from '~/core/formats/formatInvoiceItemsMap'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import {
@@ -191,15 +191,12 @@ export const UsageChargeInfo = ({
             },
             {
               label: translate('text_65201b8216455901fe273ddb'),
-              value: intlFormatNumber(
-                deserializeAmount(charge.minAmountCents ?? 0, currency),
-                {
-                  currencyDisplay: 'symbol',
-                  currency,
-                  pricingUnitShortName: charge.appliedPricingUnit?.pricingUnit?.shortName,
-                  maximumFractionDigits: 15,
-                },
-              ),
+              value: intlFormatNumber(deserializeAmount(charge.minAmountCents ?? 0, currency), {
+                currencyDisplay: 'symbol',
+                currency,
+                pricingUnitShortName: charge.appliedPricingUnit?.pricingUnit?.shortName,
+                maximumFractionDigits: 15,
+              }),
             },
             {
               label: translate('text_65201b8216455901fe273df0'),

--- a/src/components/plans/UsageChargeInfo.tsx
+++ b/src/components/plans/UsageChargeInfo.tsx
@@ -144,7 +144,10 @@ export const UsageChargeInfo = ({
         </ConditionalWrapper>
 
         {charge.filters?.map((filter, i) => {
-          const fallbackName = composeChargeFilterDisplayName(filter as never)
+          const fallbackName = composeChargeFilterDisplayName({
+            ...filter,
+            values: filter.values as Record<string, string[]>,
+          })
           return (
             <Accordion
               key={`usage-charge-info-${charge.id}-filter-${i}`}

--- a/src/components/plans/UsageChargeInfo.tsx
+++ b/src/components/plans/UsageChargeInfo.tsx
@@ -74,6 +74,18 @@ export const UsageChargeInfo = ({
     return translate('text_6682c52081acea9052074686')
   })()
 
+  const invoicingRow = charge.billableMetric?.recurring
+    ? {
+        label: translate('text_646e2d0cc536351b62ba6f16'),
+        value: charge.invoiceable
+          ? translate('text_65251f46339c650084ce0d57')
+          : translate('text_65251f4cd55aeb004e5aa5ef'),
+      }
+    : {
+        label: translate('text_6682c52081acea90520744ca'),
+        value: invoicingStrategy,
+      }
+
   return (
     <section className="flex flex-col gap-4">
       {!!charge.appliedPricingUnit && (
@@ -195,10 +207,7 @@ export const UsageChargeInfo = ({
                 ? translate('text_65251f46339c650084ce0d57')
                 : translate('text_65251f4cd55aeb004e5aa5ef'),
             },
-            {
-              label: translate('text_6682c52081acea90520744ca'),
-              value: invoicingStrategy,
-            },
+            invoicingRow,
             {
               label: translate('text_645bb193927b375079d28a8f'),
               value: taxesApplied

--- a/src/components/plans/__tests__/UsageChargeInfo.test.tsx
+++ b/src/components/plans/__tests__/UsageChargeInfo.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from '@testing-library/react'
+
+import {
+  ChargeModelEnum,
+  CurrencyEnum,
+  PlanInterval,
+  RegroupPaidFeesEnum,
+} from '~/generated/graphql'
+
+import { UsageChargeInfo, UsageChargeInfoCharge } from '../UsageChargeInfo'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (k: string) => k }),
+}))
+
+const buildCharge = (overrides: Partial<UsageChargeInfoCharge> = {}): UsageChargeInfoCharge => ({
+  __typename: 'Charge',
+  id: 'charge_1',
+  chargeModel: ChargeModelEnum.Standard,
+  invoiceDisplayName: null,
+  invoiceable: true,
+  payInAdvance: false,
+  prorated: false,
+  minAmountCents: '0',
+  regroupPaidFees: null,
+  properties: { amount: '10', graduatedRanges: null, volumeRanges: null } as never,
+  filters: [],
+  appliedPricingUnit: null,
+  taxes: [],
+  billableMetric: {
+    __typename: 'BillableMetric',
+    id: 'bm_1',
+    name: 'API calls',
+    code: 'api_calls',
+    recurring: false,
+    filters: [],
+  } as never,
+  ...overrides,
+})
+
+describe('UsageChargeInfo', () => {
+  it('renders standard charge amount via PlanDetailsChargeWrapperSwitch', () => {
+    render(
+      <UsageChargeInfo
+        charge={buildCharge()}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[]}
+      />,
+    )
+    expect(screen.getByText('text_65201b8216455901fe273dd5')).toBeInTheDocument()
+  })
+
+  it('does not render a filter sub-accordion when charge has no filters', () => {
+    render(
+      <UsageChargeInfo
+        charge={buildCharge({ filters: [] })}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[]}
+      />,
+    )
+    expect(screen.queryByText('text_64e620bca31226337ffc62ad')).not.toBeInTheDocument()
+  })
+
+  it('renders the filter sub-accordion when charge has filters', () => {
+    const charge = buildCharge({
+      filters: [
+        {
+          __typename: 'ChargeFilter',
+          id: 'flt_1',
+          invoiceDisplayName: 'Region: EU',
+          values: ['{"region":"eu"}'] as never,
+          properties: { amount: '15', graduatedRanges: null, volumeRanges: null } as never,
+        } as never,
+      ],
+    })
+    render(
+      <UsageChargeInfo
+        charge={charge}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[]}
+      />,
+    )
+    expect(screen.getByText('Region: EU')).toBeInTheDocument()
+  })
+
+  it('renders "Pay later" when payInAdvance is false', () => {
+    render(
+      <UsageChargeInfo
+        charge={buildCharge({ payInAdvance: false })}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[]}
+      />,
+    )
+    expect(screen.getByText('text_646e2d0cc536351b62ba6f8c')).toBeInTheDocument()
+  })
+
+  it('falls back to invoiced strategy when payInAdvance + invoiceable', () => {
+    render(
+      <UsageChargeInfo
+        charge={buildCharge({ payInAdvance: true, invoiceable: true })}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[]}
+      />,
+    )
+    expect(screen.getByText('text_66968fba80f8f89a8aefdebf')).toBeInTheDocument()
+  })
+
+  it('uses regrouped invoice strategy when payInAdvance + non-invoiceable + regroup=invoice', () => {
+    render(
+      <UsageChargeInfo
+        charge={buildCharge({
+          payInAdvance: true,
+          invoiceable: false,
+          regroupPaidFees: RegroupPaidFeesEnum.Invoice,
+        })}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[]}
+      />,
+    )
+    expect(screen.getByText('text_66968fba80f8f89a8aefdec0')).toBeInTheDocument()
+  })
+
+  it('uses plan taxes when charge has no taxes', () => {
+    render(
+      <UsageChargeInfo
+        charge={buildCharge({ taxes: [] })}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[
+          { __typename: 'Tax', id: 't1', name: 'VAT', code: 'vat', rate: 20 } as never,
+        ]}
+      />,
+    )
+    expect(screen.getByText(/VAT/)).toBeInTheDocument()
+  })
+})

--- a/src/components/plans/__tests__/UsageChargeInfo.test.tsx
+++ b/src/components/plans/__tests__/UsageChargeInfo.test.tsx
@@ -157,6 +157,55 @@ describe('UsageChargeInfo', () => {
     expect(screen.getByText('text_6682c52081acea9052074686')).toBeInTheDocument()
   })
 
+  it('uses "Invoiceable" row for recurring billable metrics', () => {
+    render(
+      <UsageChargeInfo
+        charge={buildCharge({
+          invoiceable: false,
+          billableMetric: {
+            __typename: 'BillableMetric',
+            id: 'bm_recurring',
+            name: 'Active users',
+            code: 'active_users',
+            recurring: true,
+            filters: [],
+          } as never,
+        })}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[]}
+      />,
+    )
+    // "Invoiceable" label key (recurring 4th row)
+    expect(screen.getByText('text_646e2d0cc536351b62ba6f16')).toBeInTheDocument()
+    // "Invoicing strategy" label key (metered 4th row) must NOT appear
+    expect(screen.queryByText('text_6682c52081acea90520744ca')).not.toBeInTheDocument()
+    // The yes/no value for invoiceable=false (may appear more than once due to prorated row)
+    expect(screen.getAllByText('text_65251f4cd55aeb004e5aa5ef').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('uses "Invoicing strategy" row for non-recurring (metered) billable metrics', () => {
+    render(
+      <UsageChargeInfo
+        charge={buildCharge({
+          billableMetric: {
+            __typename: 'BillableMetric',
+            id: 'bm_metered',
+            name: 'API calls',
+            code: 'api_calls',
+            recurring: false,
+            filters: [],
+          } as never,
+        })}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[]}
+      />,
+    )
+    expect(screen.getByText('text_6682c52081acea90520744ca')).toBeInTheDocument()
+    expect(screen.queryByText('text_646e2d0cc536351b62ba6f16')).not.toBeInTheDocument()
+  })
+
   it('uses charge.taxes when present, ignoring plan taxes', () => {
     render(
       <UsageChargeInfo

--- a/src/components/plans/__tests__/UsageChargeInfo.test.tsx
+++ b/src/components/plans/__tests__/UsageChargeInfo.test.tsx
@@ -133,9 +133,7 @@ describe('UsageChargeInfo', () => {
         charge={buildCharge({ taxes: [] })}
         currency={CurrencyEnum.Usd}
         planInterval={PlanInterval.Monthly}
-        planTaxes={[
-          { __typename: 'Tax', id: 't1', name: 'VAT', code: 'vat', rate: 20 } as never,
-        ]}
+        planTaxes={[{ __typename: 'Tax', id: 't1', name: 'VAT', code: 'vat', rate: 20 } as never]}
       />,
     )
     expect(screen.getByText(/VAT/)).toBeInTheDocument()
@@ -210,9 +208,7 @@ describe('UsageChargeInfo', () => {
     render(
       <UsageChargeInfo
         charge={buildCharge({
-          taxes: [
-            { __typename: 'Tax', id: 't_gst', name: 'GST', code: 'gst', rate: 10 } as never,
-          ],
+          taxes: [{ __typename: 'Tax', id: 't_gst', name: 'GST', code: 'gst', rate: 10 } as never],
         })}
         currency={CurrencyEnum.Usd}
         planInterval={PlanInterval.Monthly}

--- a/src/components/plans/__tests__/UsageChargeInfo.test.tsx
+++ b/src/components/plans/__tests__/UsageChargeInfo.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 
 import {
   ChargeModelEnum,
@@ -6,6 +6,7 @@ import {
   PlanInterval,
   RegroupPaidFeesEnum,
 } from '~/generated/graphql'
+import { render } from '~/test-utils'
 
 import { UsageChargeInfo, UsageChargeInfoCharge } from '../UsageChargeInfo'
 
@@ -138,5 +139,40 @@ describe('UsageChargeInfo', () => {
       />,
     )
     expect(screen.getByText(/VAT/)).toBeInTheDocument()
+  })
+
+  it('uses succeeding-month strategy when payInAdvance + non-invoiceable + regroup is null', () => {
+    render(
+      <UsageChargeInfo
+        charge={buildCharge({
+          payInAdvance: true,
+          invoiceable: false,
+          regroupPaidFees: null,
+        })}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[]}
+      />,
+    )
+    expect(screen.getByText('text_6682c52081acea9052074686')).toBeInTheDocument()
+  })
+
+  it('uses charge.taxes when present, ignoring plan taxes', () => {
+    render(
+      <UsageChargeInfo
+        charge={buildCharge({
+          taxes: [
+            { __typename: 'Tax', id: 't_gst', name: 'GST', code: 'gst', rate: 10 } as never,
+          ],
+        })}
+        currency={CurrencyEnum.Usd}
+        planInterval={PlanInterval.Monthly}
+        planTaxes={[
+          { __typename: 'Tax', id: 't_vat', name: 'VAT', code: 'vat', rate: 20 } as never,
+        ]}
+      />,
+    )
+    expect(screen.getByText(/GST/)).toBeInTheDocument()
+    expect(screen.queryByText(/VAT/)).not.toBeInTheDocument()
   })
 })

--- a/src/components/plans/details/PlanDetailsUsageChargesSection.tsx
+++ b/src/components/plans/details/PlanDetailsUsageChargesSection.tsx
@@ -1,18 +1,7 @@
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Typography } from '~/components/designSystem/Typography'
-import { DetailsPage } from '~/components/layouts/DetailsPage'
-import { PlanDetailsUsageChargesSectionAccordion } from '~/components/plans/details/PlanDetailsUsageChargesSectionAccordion'
-import { isPlanIntervalAnnual, mapChargeIntervalCopy } from '~/components/plans/utils'
-import { chargeModelLookupTranslation } from '~/core/constants/form'
-import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
-import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import {
-  Charge,
-  CurrencyEnum,
-  EditPlanFragment,
-  PlanInterval,
-  RegroupPaidFeesEnum,
-} from '~/generated/graphql'
+import { UsageChargeInfo, UsageChargeInfoCharge } from '~/components/plans/UsageChargeInfo'
+import { CurrencyEnum, EditPlanFragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 export const PlanDetailsUsageChargesSection = ({
@@ -38,21 +27,6 @@ export const PlanDetailsUsageChargesSection = ({
         recurringCharges: EditPlanFragment['charges']
       },
     ) ?? {}
-
-  const isAnnual = isPlanIntervalAnnual(plan?.interval)
-
-  const getInvoicingStrategyTextValue = (charge: Charge) => {
-    if (!charge.payInAdvance) {
-      return translate('text_66968fba80f8f89a8aefdec0')
-    }
-    if (charge.invoiceable) {
-      return translate('text_66968fba80f8f89a8aefdebf')
-    }
-    if (charge.regroupPaidFees === RegroupPaidFeesEnum.Invoice) {
-      return translate('text_66968fba80f8f89a8aefdec0')
-    }
-    return translate('text_6682c52081acea9052074686')
-  }
 
   return (
     <section className="flex flex-col gap-12">
@@ -81,112 +55,13 @@ export const PlanDetailsUsageChargesSection = ({
                 </div>
               }
             >
-              <section className="flex flex-col gap-4">
-                {!!charge.appliedPricingUnit && (
-                  <div className="p-4 shadow-b">
-                    <DetailsPage.InfoGrid
-                      grid={[
-                        {
-                          label: translate('text_17502505476284yyq70yy6mx'),
-                          value: charge.appliedPricingUnit.pricingUnit.name,
-                        },
-                        {
-                          label: translate('text_1750411499858su5b7bbp5t9'),
-                          value: translate('text_1750424999815sw5whlu1xj0', {
-                            shortName: charge.appliedPricingUnit.pricingUnit?.shortName,
-                            conversionRateAmount: intlFormatNumber(
-                              charge.appliedPricingUnit?.conversionRate,
-                              {
-                                maximumFractionDigits: 15,
-                                currency: currency,
-                              },
-                            ),
-                          }),
-                        },
-                      ]}
-                    />
-                  </div>
-                )}
-                {/* Charge main infos */}
-                <div className="px-4 pt-4">
-                  <DetailsPage.InfoGrid
-                    grid={[
-                      {
-                        label: translate('text_65201b8216455901fe273dd5'),
-                        value: translate(chargeModelLookupTranslation[charge.chargeModel]),
-                      },
-                      {
-                        label: translate('text_65201b8216455901fe273dc1'),
-                        value: translate(
-                          mapChargeIntervalCopy(
-                            plan?.interval as PlanInterval,
-                            (isAnnual && !!plan?.billChargesMonthly) || false,
-                          ),
-                        ),
-                      },
-                    ]}
-                  />
-                </div>
-                {/* Properties accordion */}
-                <PlanDetailsUsageChargesSectionAccordion
-                  currency={currency}
-                  charge={charge as Charge}
-                />
-                {/* Options */}
-                <div className="px-4 pb-4">
-                  <DetailsPage.InfoGrid
-                    grid={[
-                      {
-                        label: translate('text_65201b8216455901fe273dd9'),
-                        value: charge?.payInAdvance
-                          ? translate('text_646e2d0cc536351b62ba6faa')
-                          : translate('text_646e2d0cc536351b62ba6f8c'),
-                      },
-                      {
-                        label: translate('text_65201b8216455901fe273ddb'),
-                        value: intlFormatNumber(
-                          deserializeAmount(charge.minAmountCents, currency),
-                          {
-                            currencyDisplay: 'symbol',
-                            currency,
-                            pricingUnitShortName: charge.appliedPricingUnit?.pricingUnit?.shortName,
-                            maximumFractionDigits: 15,
-                          },
-                        ),
-                      },
-                      {
-                        label: translate('text_65201b8216455901fe273df0'),
-                        value: charge.prorated
-                          ? translate('text_65251f46339c650084ce0d57')
-                          : translate('text_65251f4cd55aeb004e5aa5ef'),
-                      },
-                      {
-                        label: translate('text_6682c52081acea90520744ca'),
-                        value: getInvoicingStrategyTextValue(charge as Charge),
-                      },
-                      {
-                        label: translate('text_645bb193927b375079d28a8f'),
-                        value:
-                          !!charge?.taxes?.length || !!plan?.taxes?.length
-                            ? (charge.taxes?.length ? charge.taxes : plan?.taxes)?.map(
-                                (tax, taxIndex) => (
-                                  <div
-                                    key={`plan-details-charge-${i}-section-accordion-tax-${taxIndex}`}
-                                  >
-                                    {tax.name} (
-                                    {intlFormatNumber(Number(tax.rate) / 100 || 0, {
-                                      style: 'percent',
-                                    })}
-                                    )
-                                  </div>
-                                ),
-                              )
-                            : '-',
-                      },
-                    ]}
-                  />
-                </div>
-              </section>
+              <UsageChargeInfo
+                charge={charge as UsageChargeInfoCharge}
+                currency={currency}
+                planInterval={plan?.interval}
+                billChargesMonthly={plan?.billChargesMonthly}
+                planTaxes={plan?.taxes}
+              />
             </Accordion>
           ))}
         </div>
@@ -216,117 +91,13 @@ export const PlanDetailsUsageChargesSection = ({
                 </div>
               }
             >
-              <section className="flex flex-col gap-4">
-                {!!charge.appliedPricingUnit && (
-                  <div className="p-4 shadow-b">
-                    <DetailsPage.InfoGrid
-                      grid={[
-                        {
-                          label: translate('text_17502505476284yyq70yy6mx'),
-                          value: charge.appliedPricingUnit.pricingUnit.name,
-                        },
-                        {
-                          label: translate('text_1750411499858su5b7bbp5t9'),
-                          value: translate('text_1750424999815sw5whlu1xj0', {
-                            shortName: charge.appliedPricingUnit?.pricingUnit?.shortName,
-                            conversionRateAmount: intlFormatNumber(
-                              charge.appliedPricingUnit?.conversionRate,
-                              {
-                                maximumFractionDigits: 15,
-                                currency: currency,
-                              },
-                            ),
-                          }),
-                        },
-                      ]}
-                    />
-                  </div>
-                )}
-
-                {/* Charge main infos */}
-                <div className="px-4 pt-4">
-                  <DetailsPage.InfoGrid
-                    grid={[
-                      {
-                        label: translate('text_65201b8216455901fe273dd5'),
-                        value: translate(chargeModelLookupTranslation[charge.chargeModel]),
-                      },
-                      {
-                        label: translate('text_65201b8216455901fe273dc1'),
-                        value: translate(
-                          mapChargeIntervalCopy(
-                            plan?.interval as PlanInterval,
-                            (plan?.interval === PlanInterval.Yearly &&
-                              !!plan?.billChargesMonthly) ||
-                              false,
-                          ),
-                        ),
-                      },
-                    ]}
-                  />
-                </div>
-                {/* Properties accordion */}
-                <PlanDetailsUsageChargesSectionAccordion
-                  currency={currency}
-                  charge={charge as Charge}
-                />
-                {/* Options */}
-                <div className="px-4 pb-4">
-                  <DetailsPage.InfoGrid
-                    grid={[
-                      {
-                        label: translate('text_65201b8216455901fe273dd9'),
-                        value: charge?.payInAdvance
-                          ? translate('text_646e2d0cc536351b62ba6faa')
-                          : translate('text_646e2d0cc536351b62ba6f8c'),
-                      },
-                      {
-                        label: translate('text_65201b8216455901fe273ddb'),
-                        value: intlFormatNumber(
-                          deserializeAmount(charge.minAmountCents, currency),
-                          {
-                            currencyDisplay: 'symbol',
-                            currency,
-                            pricingUnitShortName: charge.appliedPricingUnit?.pricingUnit?.shortName,
-                            maximumFractionDigits: 15,
-                          },
-                        ),
-                      },
-                      {
-                        label: translate('text_65201b8216455901fe273df0'),
-                        value: charge.prorated
-                          ? translate('text_65251f46339c650084ce0d57')
-                          : translate('text_65251f4cd55aeb004e5aa5ef'),
-                      },
-                      {
-                        label: translate('text_646e2d0cc536351b62ba6f16'),
-                        value: charge.invoiceable
-                          ? translate('text_65251f46339c650084ce0d57')
-                          : translate('text_65251f4cd55aeb004e5aa5ef'),
-                      },
-                      {
-                        label: translate('text_645bb193927b375079d28a8f'),
-                        value:
-                          !!charge?.taxes?.length || !!plan?.taxes?.length
-                            ? (charge.taxes?.length ? charge.taxes : plan?.taxes)?.map(
-                                (tax, taxIndex) => (
-                                  <div
-                                    key={`plan-details-charge-${i}-section-accordion-tax-${taxIndex}`}
-                                  >
-                                    {tax.name} (
-                                    {intlFormatNumber(Number(tax.rate) / 100 || 0, {
-                                      style: 'percent',
-                                    })}
-                                    )
-                                  </div>
-                                ),
-                              )
-                            : '-',
-                      },
-                    ]}
-                  />
-                </div>
-              </section>
+              <UsageChargeInfo
+                charge={charge as UsageChargeInfoCharge}
+                currency={currency}
+                planInterval={plan?.interval}
+                billChargesMonthly={plan?.billChargesMonthly}
+                planTaxes={plan?.taxes}
+              />
             </Accordion>
           ))}
         </div>


### PR DESCRIPTION
Part of LAGO-1471 — refactor only

Extract the read-only per-usage-charge body from v1 `PlanDetailsUsageChargesSection` into a shared `UsageChargeInfo` component. v1 keeps its metered / recurring split and consumes the new component verbatim. The metered vs recurring footer-row divergence is preserved inside `UsageChargeInfo` by branching on `charge.billableMetric.recurring` — no behavior change.

Sets up PR2 (v2 Usage charges section + CRUD) to reuse the same body without duplication.