### PR TITLE
refactor(customers): migrate CustomerSettings PremiumWarningDialog to hook

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -54,6 +54,7 @@ import { Popper } from '~/components/designSystem/Popper'
 import { Table, TableColumn } from '~/components/designSystem/Table/Table'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import {
   SettingsListItem,
   SettingsListItemHeader,
@@ -61,7 +62,6 @@ import {
   SettingsListWrapper,
   SettingsPaddedContainer,
 } from '~/components/layouts/Settings'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import {
   EditFinalizeZeroAmountInvoiceDialog,
   EditFinalizeZeroAmountInvoiceDialogRef,
@@ -227,7 +227,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
   const editCustomerInvoiceCustomSectionsDialogRef =
     useRef<EditCustomerInvoiceCustomSectionsDialogRef>(null)
   const deleteCustomerDocumentLocale = useRef<DeleteCustomerDocumentLocaleDialogRef>(null)
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const editNetPaymentTermDialogRef = useRef<EditNetPaymentTermDialogRef>(null)
   const deleteOrganizationNetPaymentTermDialogRef =
     useRef<DeleteOrganizationNetPaymentTermDialogRef>(null)
@@ -427,7 +427,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                             onClick={() =>
                               isPremium
                                 ? editCustomerDocumentLocale?.current?.openDialog()
-                                : premiumWarningDialogRef.current?.openDialog()
+                                : openPremiumWarningDialog()
                             }
                           >
                             {translate('text_645bb193927b375079d28ad2')}
@@ -613,7 +613,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                             onClick={() =>
                               isPremium
                                 ? editInvoiceGracePeriodDialogRef?.current?.openDialog()
-                                : premiumWarningDialogRef.current?.openDialog()
+                                : openPremiumWarningDialog()
                             }
                           >
                             {translate('text_645bb193927b375079d28ad2')}
@@ -990,7 +990,6 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
           />
         </>
       )}
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </>
   )
 }

--- a/src/components/customers/__tests__/CustomerSettings.test.tsx
+++ b/src/components/customers/__tests__/CustomerSettings.test.tsx
@@ -144,13 +144,9 @@ jest.mock('~/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog', 
   return { EditFinalizeZeroAmountInvoiceDialog: MockDialog }
 })
 
-jest.mock('~/components/PremiumWarningDialog', () => {
-  const React = jest.requireActual('react')
-  const MockDialog = React.forwardRef(() => null)
-
-  MockDialog.displayName = 'PremiumWarningDialog'
-  return { PremiumWarningDialog: MockDialog }
-})
+jest.mock('~/components/dialogs/PremiumWarningDialog', () => ({
+  usePremiumWarningDialog: () => ({ open: jest.fn(), close: jest.fn() }),
+}))
 
 const createCustomerSettingsMock = (overrides = {}) => ({
   request: {


### PR DESCRIPTION
## Summary

- Swap the deprecated ref-based `PremiumWarningDialog` in `CustomerSettings.tsx` for the new hook-based `usePremiumWarningDialog`, clearing the `no-restricted-imports` warning for this file.
- Update the corresponding `jest.mock` in `CustomerSettings.test.tsx` to mock the new hook module.
- Scope intentionally limited to the `PremiumWarningDialog` warning in this file — the file still has unrelated deprecated dialog imports (Edit/Delete customer dialogs, etc.), which are out of scope for this PR.

## Changes

- `src/components/customers/CustomerSettings.tsx`
  - Remove `PremiumWarningDialog` + `PremiumWarningDialogRef` imports
  - Remove `premiumWarningDialogRef` `useRef`
  - Use `const { open: openPremiumWarningDialog } = usePremiumWarningDialog()`
  - Replace the two `premiumWarningDialogRef.current?.openDialog()` call sites with `openPremiumWarningDialog()`
  - Remove the `<PremiumWarningDialog ref={premiumWarningDialogRef} />` render
- `src/components/customers/__tests__/CustomerSettings.test.tsx`
  - Replace the old component-level mock with a mock of `usePremiumWarningDialog`

## Test plan

- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm eslint src/components/customers/CustomerSettings.tsx` no longer reports the `PremiumWarningDialog` warning
- [x] `pnpm test --testPathPatterns=CustomerSettings` — 33/33 tests pass
- [ ] Manual smoke test: open Customer Settings page as a non-premium user → clicking "Edit" on "Document language" or "Grace period" opens the premium warning dialog with the mailto CTA

https://claude.ai/code/session_01WGnLPavRnwZjPzRh1zhgZp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGnLPavRnwZjPzRh1zhgZp)_