### PR TITLE
refactor(invoices): migrate InvoicesList PremiumWarningDialog to new dialog system

### DIFF
--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -11,6 +11,7 @@ import { Table } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { buildInvoiceDocumentData } from '~/components/emails/buildDocumentData'
 import {
   UpdateInvoicePaymentStatusDialog,
@@ -27,7 +28,6 @@ import {
 import { getEmptyStateConfig } from '~/components/invoices/utils/emptyStateMapping'
 import { getMostRecentPaymentMethodId } from '~/components/invoices/utils/getMostRecentPaymentMethodId'
 import { VoidInvoiceDialog, VoidInvoiceDialogRef } from '~/components/invoices/VoidInvoiceDialog'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import {
   invoiceStatusMapping,
@@ -94,6 +94,8 @@ const InvoicesList = ({
   const { hasFeatureFlag } = useOrganizationInfos()
   const { showResendEmailDialog } = useResendEmailDialog()
 
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
+
   const { handleDownloadFile } = useDownloadFile()
 
   const hasAccessToMultiPaymentFlow = hasFeatureFlag(FeatureFlagEnum.MultiplePaymentMethods)
@@ -101,7 +103,6 @@ const InvoicesList = ({
   const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
   const updateInvoicePaymentStatusDialog = useRef<UpdateInvoicePaymentStatusDialogRef>(null)
   const voidInvoiceDialogRef = useRef<VoidInvoiceDialogRef>(null)
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
   const resendInvoiceForCollectionDialogRef = useRef<ResendInvoiceForCollectionDialogRef>(null)
 
   const [downloadInvoice] = useDownloadInvoiceItemMutation({
@@ -158,7 +159,7 @@ const InvoicesList = ({
         if (isPremium) {
           navigate(generatePath(CREATE_INVOICE_PAYMENT_ROUTE, { invoiceId: id }))
         } else {
-          premiumWarningDialogRef.current?.openDialog()
+          openPremiumWarningDialog()
         }
       },
     }
@@ -178,7 +179,7 @@ const InvoicesList = ({
         endIcon: 'sparkles',
         title: translate('text_636bdef6565341dcb9cfb127'),
         onAction: () => {
-          premiumWarningDialogRef.current?.openDialog()
+          openPremiumWarningDialog()
         },
       }
     }
@@ -597,7 +598,6 @@ const InvoicesList = ({
       <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
       <UpdateInvoicePaymentStatusDialog ref={updateInvoicePaymentStatusDialog} />
       <VoidInvoiceDialog ref={voidInvoiceDialogRef} />
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
       <ResendInvoiceForCollectionDialog ref={resendInvoiceForCollectionDialogRef} />
     </div>
   )

--- a/src/components/invoices/__tests__/InvoicesList.test.tsx
+++ b/src/components/invoices/__tests__/InvoicesList.test.tsx
@@ -120,6 +120,15 @@ jest.mock('~/hooks/useResendEmailDialog', () => ({
   }),
 }))
 
+const mockOpenPremiumWarningDialog = jest.fn()
+
+jest.mock('~/components/dialogs/PremiumWarningDialog', () => ({
+  usePremiumWarningDialog: () => ({
+    open: mockOpenPremiumWarningDialog,
+    close: jest.fn(),
+  }),
+}))
+
 jest.mock('~/generated/graphql', () => ({
   ...jest.requireActual('~/generated/graphql'),
   useDownloadInvoiceItemMutation: (options: typeof downloadInvoiceCallbacks) => {
@@ -1449,7 +1458,8 @@ describe('InvoicesList', () => {
       // Click triggers premium warning dialog - this tests line 156
       await user.click(recordPaymentButton)
 
-      // Navigation should NOT have been called since user is not premium
+      // Premium warning dialog should open and navigation should NOT have been called
+      expect(mockOpenPremiumWarningDialog).toHaveBeenCalled()
       expect(testMockNavigateFn).not.toHaveBeenCalled()
     })
 
@@ -1471,7 +1481,8 @@ describe('InvoicesList', () => {
       // Click triggers premium warning dialog - this tests line 176
       await user.click(issueCreditNoteButton)
 
-      // Navigation should NOT have been called since user is not premium
+      // Premium warning dialog should open and navigation should NOT have been called
+      expect(mockOpenPremiumWarningDialog).toHaveBeenCalled()
       expect(testMockNavigateFn).not.toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
## Summary

Migrates the `PremiumWarningDialog` usage in `InvoicesList` from the deprecated imperative ref-based dialog (`~/components/PremiumWarningDialog`) to the new hook-based NiceModal system (`usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`).

This clears the `no-restricted-imports` ESLint warning for `PremiumWarningDialog` in that file.

## Changes

- `src/components/invoices/InvoicesList.tsx`
  - Replace the `PremiumWarningDialog` / `PremiumWarningDialogRef` import with `usePremiumWarningDialog`.
  - Replace the `premiumWarningDialogRef` ref + the two `premiumWarningDialogRef.current?.openDialog()` call sites with the hook's `open()` function.
  - Remove the `<PremiumWarningDialog ref={...} />` element from the JSX (the dialog is now rendered via NiceModal, already registered in `src/core/overlays/registeredDialogs.ts`).
- `src/components/invoices/__tests__/InvoicesList.test.tsx`
  - Mock `usePremiumWarningDialog` (the new hook requires a `NiceModal.Provider`, which the test render helper doesn't supply).
  - Strengthen the two "non-premium user click" tests to assert the dialog's `open` is called, in addition to the existing "navigation not called" assertion.

## Scope

Intentionally scoped to **only** the `PremiumWarningDialog` warning. The other deprecated dialogs in this file (`FinalizeInvoiceDialog`, `EditInvoicePaymentStatusDialog`, `VoidInvoiceDialog`, `ResendInvoiceForCollectionDialog`) are full form/confirmation dialogs with their own ref interfaces and mutations; migrating them is out of scope and significantly more complex.

## Test plan

- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm exec eslint src/components/invoices/InvoicesList.tsx` no longer reports the `PremiumWarningDialog` warning
- [x] `pnpm exec prettier --check` passes on both files
- [x] Jest: `InvoicesList.test.tsx` — 73 passed, 8 snapshots passed

https://claude.ai/code/session_015uBAawnV6R1G18BDj5Dc24

---
_Generated by [Claude Code](https://claude.ai/code/session_015uBAawnV6R1G18BDj5Dc24)_