### PR TITLE
chore: enable Renovate lockFileMaintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,13 @@
     "enabled": true,
     "schedule": "at any time"
   },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"],
+    "commitMessagePrefix": "chore(deps)",
+    "automerge": true,
+    "automergeType": "branch"
+  },
   "packageRules": [
     {
       "matchDepTypes": ["overrides"],


### PR DESCRIPTION
Enables Renovate `lockFileMaintenance` to recreate `pnpm-lock.yaml` weekly (monday <5am), bumping transitive deps to newest in-range and clearing drifted transitive CVEs automatically.

- Weekly schedule, branch automerge — matches existing patch automerge policy.
- In-range only; direct pinned deps (`rangeStrategy: pin`) unaffected.
- Existing `overrides` disable rule + manual security pins untouched.