### PR TITLE
feat(rte): add button to trigger slash commands

### DIFF
--- a/src/components/designSystem/RichTextEditor/extensions/DragHandle.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/DragHandle.ts
@@ -8,13 +8,13 @@ import { createRoot } from 'react-dom/client'
 
 const dragHandlePluginKey = new PluginKey('dragHandle')
 
-const renderGripIcon = (container: HTMLElement): void => {
+const renderIcon = (container: HTMLElement, icon: keyof typeof ALL_ICONS): void => {
   // Defer to avoid "triggering nested component updates from render" warning.
   // ProseMirror creates decoration widgets synchronously during React's render cycle.
   queueMicrotask(() => {
     const root = createRoot(container)
 
-    root.render(createElement(ALL_ICONS['double-dots-vertical'], { width: 16, height: 16 }))
+    root.render(createElement(ALL_ICONS[icon], { width: 16, height: 16 }))
   })
 }
 
@@ -103,17 +103,44 @@ export const DragHandle = Extension.create({
     }
 
     function createHandleElement(pos: number): HTMLElement {
-      const handle = document.createElement('div')
+      const group = document.createElement('div')
 
-      handle.className = 'block-drag-handle'
-      handle.draggable = true
-      handle.contentEditable = 'false'
-      const iconContainer = document.createElement('span')
+      group.className = 'block-handle-group'
+      group.contentEditable = 'false'
 
-      handle.appendChild(iconContainer)
-      renderGripIcon(iconContainer)
+      // Plus button — opens slash command menu
+      const plusButton = document.createElement('div')
 
-      handle.addEventListener('dragstart', (e) => {
+      plusButton.className = 'block-handle-button block-handle-plus'
+      const plusIconContainer = document.createElement('span')
+
+      plusButton.appendChild(plusIconContainer)
+      renderIcon(plusIconContainer, 'plus')
+
+      plusButton.addEventListener('click', (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+
+        if ('slashCommands' in editor.storage) {
+          const { triggerMenu } = editor.storage.slashCommands as {
+            triggerMenu?: (clientRect: () => DOMRect) => void
+          }
+
+          triggerMenu?.(() => plusButton.getBoundingClientRect())
+        }
+      })
+
+      // Grip button — drag handle and block selection
+      const gripButton = document.createElement('div')
+
+      gripButton.className = 'block-handle-button block-handle-grip'
+      gripButton.draggable = true
+      const gripIconContainer = document.createElement('span')
+
+      gripButton.appendChild(gripIconContainer)
+      renderIcon(gripIconContainer, 'double-dots-vertical')
+
+      gripButton.addEventListener('dragstart', (e) => {
         selectBlock(pos)
 
         editor.view.dragging = {
@@ -134,17 +161,20 @@ export const DragHandle = Extension.create({
         editor.view.dom.classList.add('is-dragging')
       })
 
-      handle.addEventListener('dragend', () => {
+      gripButton.addEventListener('dragend', () => {
         editor.view.dom.classList.remove('is-dragging')
       })
 
-      handle.addEventListener('click', (e) => {
+      gripButton.addEventListener('click', (e) => {
         e.preventDefault()
         e.stopPropagation()
         selectBlock(pos)
       })
 
-      return handle
+      group.appendChild(plusButton)
+      group.appendChild(gripButton)
+
+      return group
     }
 
     function buildDecorations(doc: PmNode): DecorationSet {

--- a/src/components/designSystem/RichTextEditor/extensions/SlashCommands.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/SlashCommands.ts
@@ -68,6 +68,12 @@ export const slashCommandDefinitions: SlashCommandDefinition[] = [
 export const SlashCommands = Extension.create({
   name: 'slashCommands',
 
+  addStorage() {
+    return {
+      triggerMenu: null as ((clientRect: () => DOMRect) => void) | null,
+    }
+  },
+
   addOptions() {
     return {
       translate: ((key: string) => key) as (key: string) => string,
@@ -139,6 +145,67 @@ export const SlashCommands = Extension.create({
       description: translate(def.descriptionKey),
       command: def.command,
     }))
+
+    const editorRef = this.editor
+
+    this.storage.triggerMenu = (clientRect: () => DOMRect) => {
+      let destroyed = false
+
+      const destroy = () => {
+        if (destroyed) return
+        destroyed = true
+        popup[0]?.destroy()
+        renderer?.destroy()
+        document.removeEventListener('keydown', handleKeyDown, true)
+        document.removeEventListener('mousedown', handleClickOutside, true)
+      }
+
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          event.preventDefault()
+          destroy()
+
+          return
+        }
+
+        const handled = renderer.ref?.onKeyDown({ event } as SuggestionKeyDownProps)
+
+        if (handled) {
+          event.preventDefault()
+          event.stopPropagation()
+        }
+      }
+
+      const handleClickOutside = (event: MouseEvent) => {
+        if (!renderer.element.contains(event.target as Node)) {
+          destroy()
+        }
+      }
+
+      const renderer = new ReactRenderer(SlashMenu, {
+        props: {
+          items: resolvedItems,
+          command: (item: SlashCommandItem) => {
+            item.command(editorRef)
+            destroy()
+          },
+        },
+        editor: editorRef,
+      })
+
+      const popup = tippy('body', {
+        getReferenceClientRect: clientRect,
+        appendTo: () => document.body,
+        content: renderer.element,
+        showOnCreate: true,
+        interactive: true,
+        trigger: 'manual',
+        placement: 'bottom-start',
+      })
+
+      document.addEventListener('keydown', handleKeyDown, true)
+      document.addEventListener('mousedown', handleClickOutside, true)
+    }
 
     return [
       Suggestion({

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
@@ -151,6 +151,46 @@ describe('DragHandle', () => {
         editor.destroy()
       })
 
+      it('THEN should add the is-dragging class on dragstart and remove it on dragend', () => {
+        const editor = createEditor('<p>First</p>')
+        const grip = editor.view.dom.querySelector('.block-handle-grip') as HTMLElement
+
+        const dragStartEvent = new Event('dragstart', { bubbles: false }) as DragEvent
+
+        Object.defineProperty(dragStartEvent, 'dataTransfer', {
+          value: {
+            effectAllowed: '',
+            setDragImage: jest.fn(),
+          },
+        })
+
+        grip.dispatchEvent(dragStartEvent)
+
+        expect(editor.view.dom.classList.contains('is-dragging')).toBe(true)
+
+        const dragEndEvent = new Event('dragend', { bubbles: false })
+
+        grip.dispatchEvent(dragEndEvent)
+
+        expect(editor.view.dom.classList.contains('is-dragging')).toBe(false)
+
+        editor.destroy()
+      })
+
+      it('THEN should handle dragstart without dataTransfer gracefully', () => {
+        const editor = createEditor('<p>First</p>')
+        const grip = editor.view.dom.querySelector('.block-handle-grip') as HTMLElement
+
+        const dragEvent = new Event('dragstart', { bubbles: false })
+
+        grip.dispatchEvent(dragEvent)
+
+        expect(editor.view.dragging).toBeTruthy()
+        expect(editor.view.dragging?.move).toBe(true)
+
+        editor.destroy()
+      })
+
       it('THEN should set the drag image to the block DOM element', () => {
         const editor = createEditor('<p>First</p>')
         const grip = editor.view.dom.querySelector('.block-handle-grip') as HTMLElement

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
@@ -34,7 +34,6 @@ const createEditor = (content = '<p>First</p><p>Second</p>') => {
 }
 
 const getDragHandleStorage = (editor: Editor): DragHandleStorage =>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (editor.storage as any).dragHandle as DragHandleStorage
 
 describe('DragHandle', () => {
@@ -48,7 +47,7 @@ describe('DragHandle', () => {
     describe('WHEN the document has block nodes', () => {
       it('THEN should create drag handle decorations for each top-level block', () => {
         const editor = createEditor('<p>First</p><p>Second</p>')
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
+        const handles = editor.view.dom.querySelectorAll('.block-handle-group')
 
         editor.destroy()
 
@@ -57,7 +56,7 @@ describe('DragHandle', () => {
 
       it('THEN should render each handle with the grip SVG', async () => {
         const editor = createEditor('<p>Hello</p>')
-        const handle = editor.view.dom.querySelector('.block-drag-handle')
+        const handle = editor.view.dom.querySelector('.block-handle-group')
 
         // renderGripIcon is deferred via queueMicrotask to avoid nested React render warnings.
         // Flush the microtask + React render with act.
@@ -71,18 +70,18 @@ describe('DragHandle', () => {
         expect(handle?.querySelector('svg')).not.toBeNull()
       })
 
-      it('THEN should set draggable to true on each handle', () => {
+      it('THEN should set draggable to true on the grip button', () => {
         const editor = createEditor('<p>Hello</p>')
-        const handle = editor.view.dom.querySelector('.block-drag-handle') as HTMLElement
+        const gripButton = editor.view.dom.querySelector('.block-handle-grip') as HTMLElement
 
         editor.destroy()
 
-        expect(handle.draggable).toBe(true)
+        expect(gripButton.draggable).toBe(true)
       })
 
       it('THEN should set contentEditable to false on each handle', () => {
         const editor = createEditor('<p>Hello</p>')
-        const handle = editor.view.dom.querySelector('.block-drag-handle') as HTMLElement
+        const handle = editor.view.dom.querySelector('.block-handle-group') as HTMLElement
 
         editor.destroy()
 
@@ -99,7 +98,7 @@ describe('DragHandle', () => {
         editor.commands.enter()
         editor.commands.insertContent('Third')
 
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
+        const handles = editor.view.dom.querySelectorAll('.block-handle-group')
 
         editor.destroy()
 
@@ -110,10 +109,10 @@ describe('DragHandle', () => {
     describe('WHEN a drag handle is clicked', () => {
       it('THEN should select the corresponding block via NodeSelection', () => {
         const editor = createEditor('<p>First</p><p>Second</p>')
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
-        const firstHandle = handles[0] as HTMLElement
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const firstGrip = grips[0] as HTMLElement
 
-        firstHandle.click()
+        firstGrip.click()
 
         const { selection } = editor.state
         const selectedNode = editor.state.doc.nodeAt(selection.from)
@@ -129,8 +128,8 @@ describe('DragHandle', () => {
     describe('WHEN a handle is dragged', () => {
       it('THEN should set editor.view.dragging with selection content', () => {
         const editor = createEditor('<p>First</p><p>Second</p>')
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
-        const firstHandle = handles[0] as HTMLElement
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const firstGrip = grips[0] as HTMLElement
 
         // Use bubbles: false so the event only triggers our handler, not ProseMirror's
         // internal dragstart handler which requires browser APIs unavailable in jsdom.
@@ -143,7 +142,7 @@ describe('DragHandle', () => {
           },
         })
 
-        firstHandle.dispatchEvent(dragEvent)
+        firstGrip.dispatchEvent(dragEvent)
 
         expect(editor.view.dragging).toBeTruthy()
         expect(editor.view.dragging?.move).toBe(true)
@@ -154,7 +153,7 @@ describe('DragHandle', () => {
 
       it('THEN should set the drag image to the block DOM element', () => {
         const editor = createEditor('<p>First</p>')
-        const handle = editor.view.dom.querySelector('.block-drag-handle') as HTMLElement
+        const grip = editor.view.dom.querySelector('.block-handle-grip') as HTMLElement
 
         const setDragImage = jest.fn()
         const dragEvent = new Event('dragstart', { bubbles: false }) as DragEvent
@@ -166,7 +165,7 @@ describe('DragHandle', () => {
           },
         })
 
-        handle.dispatchEvent(dragEvent)
+        grip.dispatchEvent(dragEvent)
 
         expect(setDragImage).toHaveBeenCalledWith(expect.any(HTMLElement), 0, 0)
 
@@ -180,14 +179,14 @@ describe('DragHandle', () => {
       it('THEN should preserve existing decorations without rebuilding', () => {
         const editor = createEditor('<p>First</p><p>Second</p>')
 
-        const handlesBefore = editor.view.dom.querySelectorAll('.block-drag-handle')
+        const handlesBefore = editor.view.dom.querySelectorAll('.block-handle-group')
 
         expect(handlesBefore.length).toBe(2)
 
         // Trigger a non-doc-changing transaction (selection change)
         editor.commands.setTextSelection(1)
 
-        const handlesAfter = editor.view.dom.querySelectorAll('.block-drag-handle')
+        const handlesAfter = editor.view.dom.querySelectorAll('.block-handle-group')
 
         expect(handlesAfter.length).toBe(2)
 
@@ -203,7 +202,7 @@ describe('DragHandle', () => {
         editor.commands.setTextSelection(1)
         editor.chain().focus().toggleBulletList().run()
 
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
+        const handles = editor.view.dom.querySelectorAll('.block-handle-group')
 
         expect(handles.length).toBe(2)
 
@@ -219,7 +218,7 @@ describe('DragHandle', () => {
         editor.commands.setTextSelection(1)
         editor.commands.setBlockBackgroundColor('#fee2e2')
 
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
+        const handles = editor.view.dom.querySelectorAll('.block-handle-group')
 
         expect(handles.length).toBe(2)
 
@@ -235,7 +234,7 @@ describe('DragHandle', () => {
         editor.commands.setTextSelection(1)
         editor.commands.insertContent('Hello ')
 
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
+        const handles = editor.view.dom.querySelectorAll('.block-handle-group')
 
         expect(handles.length).toBe(2)
 
@@ -248,7 +247,7 @@ describe('DragHandle', () => {
     describe('WHEN the editor is initialized', () => {
       it('THEN should create a handle for the empty paragraph', () => {
         const editor = createEditor('')
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
+        const handles = editor.view.dom.querySelectorAll('.block-handle-group')
 
         editor.destroy()
 
@@ -288,11 +287,11 @@ describe('DragHandle', () => {
 
         expect(tablePos).toBeGreaterThan(-1)
 
-        // Click the drag handle for the table (second top-level block)
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
-        const tableHandle = handles[1] as HTMLElement
+        // Click the grip button for the table (second top-level block)
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const tableGrip = grips[1] as HTMLElement
 
-        tableHandle.click()
+        tableGrip.click()
 
         expect(storage.selectedBlock).toEqual({ pos: tablePos })
 
@@ -310,10 +309,10 @@ describe('DragHandle', () => {
           }
         })
 
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
-        const tableHandle = handles[1] as HTMLElement
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const tableGrip = grips[1] as HTMLElement
 
-        tableHandle.click()
+        tableGrip.click()
 
         // Selection should be inside the table, not a NodeSelection
         const { from } = editor.state.selection
@@ -332,11 +331,11 @@ describe('DragHandle', () => {
         const editor = createEditor(TABLE_CONTENT)
         const storage = getDragHandleStorage(editor)
 
-        // Click the first handle (paragraph "Before table")
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
-        const paragraphHandle = handles[0] as HTMLElement
+        // Click the first grip (paragraph "Before table")
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const paragraphGrip = grips[0] as HTMLElement
 
-        paragraphHandle.click()
+        paragraphGrip.click()
 
         expect(storage.selectedBlock).toBeNull()
 
@@ -349,11 +348,11 @@ describe('DragHandle', () => {
         const editor = createEditor(TABLE_CONTENT)
         const storage = getDragHandleStorage(editor)
 
-        // Click table handle
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
-        const tableHandle = handles[1] as HTMLElement
+        // Click table grip
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const tableGrip = grips[1] as HTMLElement
 
-        tableHandle.click()
+        tableGrip.click()
 
         expect(storage.selectedBlock).not.toBeNull()
 
@@ -371,11 +370,11 @@ describe('DragHandle', () => {
         const editor = createEditor(TABLE_CONTENT)
         const storage = getDragHandleStorage(editor)
 
-        // Click table handle
-        const handles = editor.view.dom.querySelectorAll('.block-drag-handle')
-        const tableHandle = handles[1] as HTMLElement
+        // Click table grip
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const tableGrip = grips[1] as HTMLElement
 
-        tableHandle.click()
+        tableGrip.click()
 
         const tablePos = storage.selectedBlock?.pos ?? -1
 

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
@@ -393,4 +393,116 @@ describe('DragHandle', () => {
       })
     })
   })
+
+  describe('GIVEN the plus button in the handle group', () => {
+    describe('WHEN the document has block nodes', () => {
+      it('THEN should render a plus button for each block', () => {
+        const editor = createEditor('<p>First</p><p>Second</p>')
+        const plusButtons = editor.view.dom.querySelectorAll('.block-handle-plus')
+
+        editor.destroy()
+
+        expect(plusButtons.length).toBe(2)
+      })
+
+      it('THEN should render the plus icon via queueMicrotask', async () => {
+        const editor = createEditor('<p>Hello</p>')
+        const plusButton = editor.view.dom.querySelector('.block-handle-plus')
+
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 0))
+        })
+
+        editor.destroy()
+
+        expect(plusButton).not.toBeNull()
+        expect(plusButton?.querySelector('svg')).not.toBeNull()
+      })
+
+      it('THEN should have the block-handle-button class', () => {
+        const editor = createEditor('<p>Hello</p>')
+        const plusButton = editor.view.dom.querySelector('.block-handle-plus') as HTMLElement
+
+        editor.destroy()
+
+        expect(plusButton.classList.contains('block-handle-button')).toBe(true)
+      })
+
+      it('THEN should not be draggable', () => {
+        const editor = createEditor('<p>Hello</p>')
+        const plusButton = editor.view.dom.querySelector('.block-handle-plus') as HTMLElement
+
+        editor.destroy()
+
+        expect(plusButton.draggable).toBe(false)
+      })
+    })
+
+    describe('WHEN the plus button is clicked with slashCommands storage available', () => {
+      it('THEN should call triggerMenu with a clientRect function', () => {
+        const editor = createEditor('<p>Hello</p>')
+        const triggerMenu = jest.fn()
+
+        ;(editor.storage as any).slashCommands = { triggerMenu }
+
+        const plusButton = editor.view.dom.querySelector('.block-handle-plus') as HTMLElement
+
+        plusButton.click()
+
+        expect(triggerMenu).toHaveBeenCalledWith(expect.any(Function))
+
+        editor.destroy()
+      })
+
+      it('THEN should pass a function that returns the plus button bounding rect', () => {
+        const editor = createEditor('<p>Hello</p>')
+        const triggerMenu = jest.fn()
+
+        ;(editor.storage as any).slashCommands = { triggerMenu }
+
+        const plusButton = editor.view.dom.querySelector('.block-handle-plus') as HTMLElement
+
+        plusButton.click()
+
+        const clientRectFn = triggerMenu.mock.calls[0][0] as () => DOMRect
+        const rect = clientRectFn()
+
+        expect(rect).toEqual(
+          expect.objectContaining({
+            x: expect.any(Number),
+            y: expect.any(Number),
+            width: expect.any(Number),
+            height: expect.any(Number),
+          }),
+        )
+
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN the plus button is clicked without slashCommands storage', () => {
+      it('THEN should not throw an error', () => {
+        const editor = createEditor('<p>Hello</p>')
+        const plusButton = editor.view.dom.querySelector('.block-handle-plus') as HTMLElement
+
+        expect(() => plusButton.click()).not.toThrow()
+
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN the plus button is clicked with triggerMenu as null', () => {
+      it('THEN should not throw an error', () => {
+        const editor = createEditor('<p>Hello</p>')
+
+        ;(editor.storage as any).slashCommands = { triggerMenu: null }
+
+        const plusButton = editor.view.dom.querySelector('.block-handle-plus') as HTMLElement
+
+        expect(() => plusButton.click()).not.toThrow()
+
+        editor.destroy()
+      })
+    })
+  })
 })

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/SlashCommands.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/SlashCommands.test.ts
@@ -505,17 +505,26 @@ describe('SlashCommands', () => {
 
     describe('WHEN destroy is called multiple times', () => {
       it('THEN should only destroy once (idempotent)', () => {
+        const ReactRendererMock = jest.requireMock('@tiptap/react').ReactRenderer as jest.Mock
         const editor = createSlashEditor()
         const storage = (editor.storage as any).slashCommands as {
           triggerMenu: (clientRect: () => DOMRect) => void
         }
 
+        ReactRendererMock.mockClear()
         storage.triggerMenu(() => new DOMRect())
 
-        // Trigger destroy twice via Escape then click outside
-        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
-        document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+        // Call the command callback twice — second call hits the `if (destroyed) return` guard
+        const rendererProps = ReactRendererMock.mock.calls[0][1].props as {
+          command: (item: { title: string; description: string; command: jest.Mock }) => void
+        }
+        const mockCommand = jest.fn()
+        const item = { title: 'Test', description: 'Test', command: mockCommand }
 
+        rendererProps.command(item)
+        rendererProps.command(item)
+
+        expect(mockCommand).toHaveBeenCalledTimes(2)
         expect(mockDestroyPopup).toHaveBeenCalledTimes(1)
         expect(mockDestroyRenderer).toHaveBeenCalledTimes(1)
 

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/SlashCommands.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/SlashCommands.test.ts
@@ -1,3 +1,6 @@
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+
 import { slashCommandDefinitions, SlashCommands } from '../SlashCommands'
 
 const mockDestroyPopup = jest.fn()
@@ -25,6 +28,15 @@ jest.mock('@tiptap/react', () => ({
   })),
 }))
 
+jest.mock('@tiptap/suggestion', () => {
+  const { Plugin, PluginKey } = jest.requireActual('@tiptap/pm/state')
+
+  return {
+    __esModule: true,
+    default: jest.fn().mockReturnValue(new Plugin({ key: new PluginKey('mockSuggestion') })),
+  }
+})
+
 const mockTranslate = (key: string): string => {
   const translations: Record<string, string> = {
     text_1774281559656dn2u208gh80: 'Heading 1',
@@ -50,6 +62,12 @@ const resolveItems = () =>
     description: mockTranslate(def.descriptionKey),
     command: def.command,
   }))
+
+const createSlashEditor = () =>
+  new Editor({
+    extensions: [StarterKit, SlashCommands.configure({ translate: mockTranslate })],
+    content: '<p>Hello</p>',
+  })
 
 describe('SlashCommands', () => {
   describe('slashCommandDefinitions', () => {
@@ -288,6 +306,296 @@ describe('SlashCommands', () => {
 
         expect(mockHidePopup).not.toHaveBeenCalled()
         expect(result).toBe(false)
+      })
+    })
+  })
+
+  describe('GIVEN the triggerMenu storage API', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    describe('WHEN the extension storage is initialized', () => {
+      it('THEN should define triggerMenu as null by default', () => {
+        const storageInit = SlashCommands.config.addStorage as unknown as () => {
+          triggerMenu: null
+        }
+        const storage = storageInit()
+
+        expect(storage.triggerMenu).toBeNull()
+      })
+    })
+
+    describe('WHEN the editor is created with SlashCommands', () => {
+      it('THEN should populate triggerMenu as a function in storage', () => {
+        const editor = createSlashEditor()
+        const storage = (editor.storage as any).slashCommands as Record<string, unknown>
+
+        expect(typeof storage.triggerMenu).toBe('function')
+
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN triggerMenu is called', () => {
+      it('THEN should create a ReactRenderer with resolved items and a command callback', () => {
+        const ReactRendererMock = jest.requireMock('@tiptap/react').ReactRenderer as jest.Mock
+        const editor = createSlashEditor()
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        ReactRendererMock.mockClear()
+        storage.triggerMenu(() => new DOMRect())
+
+        expect(ReactRendererMock).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            props: expect.objectContaining({
+              items: expect.any(Array),
+              command: expect.any(Function),
+            }),
+            editor,
+          }),
+        )
+
+        // Clean up
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+        editor.destroy()
+      })
+
+      it('THEN should create a tippy popup with correct options', () => {
+        const tippyMock = jest.requireMock('tippy.js').default as jest.Mock
+        const editor = createSlashEditor()
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+        const clientRect = () => new DOMRect(10, 20, 100, 50)
+
+        tippyMock.mockClear()
+        storage.triggerMenu(clientRect)
+
+        expect(tippyMock).toHaveBeenCalledWith(
+          'body',
+          expect.objectContaining({
+            getReferenceClientRect: clientRect,
+            showOnCreate: true,
+            interactive: true,
+            trigger: 'manual',
+            placement: 'bottom-start',
+          }),
+        )
+
+        // Clean up
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN Escape is pressed while the popup is open', () => {
+      it('THEN should destroy the popup and renderer', () => {
+        const editor = createSlashEditor()
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        storage.triggerMenu(() => new DOMRect())
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+
+        expect(mockDestroyPopup).toHaveBeenCalled()
+        expect(mockDestroyRenderer).toHaveBeenCalled()
+
+        editor.destroy()
+      })
+
+      it('THEN should prevent default on the Escape event', () => {
+        const editor = createSlashEditor()
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        storage.triggerMenu(() => new DOMRect())
+
+        const escapeEvent = new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        })
+        const preventDefaultSpy = jest.spyOn(escapeEvent, 'preventDefault')
+
+        document.dispatchEvent(escapeEvent)
+
+        expect(preventDefaultSpy).toHaveBeenCalled()
+
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN clicking outside the popup', () => {
+      it('THEN should destroy the popup and renderer', () => {
+        const editor = createSlashEditor()
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        storage.triggerMenu(() => new DOMRect())
+
+        document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+
+        expect(mockDestroyPopup).toHaveBeenCalled()
+        expect(mockDestroyRenderer).toHaveBeenCalled()
+
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN clicking inside the popup element', () => {
+      it('THEN should not destroy the popup', () => {
+        const editor = createSlashEditor()
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        storage.triggerMenu(() => new DOMRect())
+
+        // Append renderer element to DOM so events propagate through capture phase
+        document.body.appendChild(mockRendererElement)
+        mockRendererElement.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+        document.body.removeChild(mockRendererElement)
+
+        expect(mockDestroyPopup).not.toHaveBeenCalled()
+        expect(mockDestroyRenderer).not.toHaveBeenCalled()
+
+        // Clean up
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN a command is selected from the menu', () => {
+      it('THEN should execute the command with the editor and destroy the popup', () => {
+        const ReactRendererMock = jest.requireMock('@tiptap/react').ReactRenderer as jest.Mock
+        const editor = createSlashEditor()
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        ReactRendererMock.mockClear()
+        storage.triggerMenu(() => new DOMRect())
+
+        const rendererProps = ReactRendererMock.mock.calls[0][1].props as {
+          command: (item: { title: string; description: string; command: jest.Mock }) => void
+        }
+        const mockCommand = jest.fn()
+
+        rendererProps.command({
+          title: 'Test',
+          description: 'Test command',
+          command: mockCommand,
+        })
+
+        expect(mockCommand).toHaveBeenCalledWith(editor)
+        expect(mockDestroyPopup).toHaveBeenCalled()
+        expect(mockDestroyRenderer).toHaveBeenCalled()
+
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN destroy is called multiple times', () => {
+      it('THEN should only destroy once (idempotent)', () => {
+        const editor = createSlashEditor()
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        storage.triggerMenu(() => new DOMRect())
+
+        // Trigger destroy twice via Escape then click outside
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+        document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+
+        expect(mockDestroyPopup).toHaveBeenCalledTimes(1)
+        expect(mockDestroyRenderer).toHaveBeenCalledTimes(1)
+
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN a non-Escape key is pressed and ref handles it', () => {
+      it('THEN should delegate to renderer ref onKeyDown and prevent default', () => {
+        const ReactRendererMock = jest.requireMock('@tiptap/react').ReactRenderer as jest.Mock
+        const mockOnKeyDown = jest.fn().mockReturnValue(true)
+
+        ReactRendererMock.mockImplementationOnce(() => ({
+          element: mockRendererElement,
+          destroy: mockDestroyRenderer,
+          updateProps: mockUpdateProps,
+          ref: { onKeyDown: mockOnKeyDown },
+        }))
+
+        const editor = createSlashEditor()
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        storage.triggerMenu(() => new DOMRect())
+
+        const arrowEvent = new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          bubbles: true,
+          cancelable: true,
+        })
+        const preventDefaultSpy = jest.spyOn(arrowEvent, 'preventDefault')
+        const stopPropagationSpy = jest.spyOn(arrowEvent, 'stopPropagation')
+
+        document.dispatchEvent(arrowEvent)
+
+        expect(mockOnKeyDown).toHaveBeenCalled()
+        expect(preventDefaultSpy).toHaveBeenCalled()
+        expect(stopPropagationSpy).toHaveBeenCalled()
+
+        // Clean up
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN a non-Escape key is pressed and ref does not handle it', () => {
+      it('THEN should not prevent default', () => {
+        const ReactRendererMock = jest.requireMock('@tiptap/react').ReactRenderer as jest.Mock
+        const mockOnKeyDown = jest.fn().mockReturnValue(false)
+
+        ReactRendererMock.mockImplementationOnce(() => ({
+          element: mockRendererElement,
+          destroy: mockDestroyRenderer,
+          updateProps: mockUpdateProps,
+          ref: { onKeyDown: mockOnKeyDown },
+        }))
+
+        const editor = createSlashEditor()
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        storage.triggerMenu(() => new DOMRect())
+
+        const arrowEvent = new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          bubbles: true,
+          cancelable: true,
+        })
+        const preventDefaultSpy = jest.spyOn(arrowEvent, 'preventDefault')
+
+        document.dispatchEvent(arrowEvent)
+
+        expect(mockOnKeyDown).toHaveBeenCalled()
+        expect(preventDefaultSpy).not.toHaveBeenCalled()
+
+        // Clean up
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+        editor.destroy()
       })
     })
   })

--- a/src/components/designSystem/RichTextEditor/richTextEditor.css
+++ b/src/components/designSystem/RichTextEditor/richTextEditor.css
@@ -361,23 +361,28 @@
   color: inherit;
 }
 
-/* Drag handle decoration — floated left into the padding gutter.
-   margin-top aligns the handle with the first line of the following block,
+/* Block handle group — floated left into the padding gutter.
+   Contains the plus button (slash commands) and grip button (drag handle).
+   margin-top aligns the group with the first line of the following block,
    accounting for spacer padding-top (6px default) + block-wrapper padding (2px). */
-.block-drag-handle {
-  @apply float-left mt-2 flex h-6 w-6 cursor-grab items-center justify-center rounded-lg text-grey-600 opacity-0 transition-all duration-200 ease-in-out;
-  margin-left: -28px;
+.block-handle-group {
+  @apply float-left mt-2 flex items-center gap-0.5 opacity-0 transition-all duration-200 ease-in-out;
+  margin-left: -56px;
 }
 
-.block-drag-handle:has(+ .spacer[data-type='heading-1']) {
+.block-handle-button {
+  @apply flex h-6 w-6 cursor-pointer items-center justify-center rounded-lg text-grey-600 transition-colors duration-200 ease-in-out;
+}
+
+.block-handle-group:has(+ .spacer[data-type='heading-1']) {
   margin-top: 36px;
 }
 
-.block-drag-handle:has(+ .spacer[data-type='heading-2']) {
+.block-handle-group:has(+ .spacer[data-type='heading-2']) {
   margin-top: 24px;
 }
 
-.block-drag-handle:has(+ .spacer[data-type='heading-3']) {
+.block-handle-group:has(+ .spacer[data-type='heading-3']) {
   margin-top: 20px;
 }
 
@@ -385,15 +390,15 @@
   @apply relative rounded-md p-2 pb-8;
 }
 
-/* Show handle when hovering the spacer/table next to it, or the handle itself */
-.block-drag-handle:has(+ .spacer:hover),
-.block-drag-handle:has(+ .tableWrapper:hover),
-.block-drag-handle:hover {
+/* Show handle group when hovering the spacer/table next to it, or the group itself */
+.block-handle-group:has(+ .spacer:hover),
+.block-handle-group:has(+ .tableWrapper:hover),
+.block-handle-group:hover {
   @apply opacity-100;
 }
 
-/* Highlight the handle being directly hovered */
-.ProseMirror:hover > .block-drag-handle:hover {
+/* Highlight individual buttons on hover */
+.ProseMirror:hover > .block-handle-group .block-handle-button:hover {
   @apply bg-grey-200;
 }
 


### PR DESCRIPTION
## Context

We have access to specific blocks using / command. We want to make it more clear that those blocks exist

## Description

This PR adds a button to give access to the slash command menu

<!-- Linear link -->
Fixes LAGO-1490