### PR TITLE
fix(layouts): restore DetailsPage max-width

### DIFF
--- a/src/components/layouts/DetailsPage.tsx
+++ b/src/components/layouts/DetailsPage.tsx
@@ -10,7 +10,13 @@ const DetailsPageContainer: FC<PropsWithChildren<{ className?: string }>> = ({
   className,
   children,
 }) => {
-  return <div className={tw('flex flex-col gap-12 px-4 pb-20 md:px-12', className)}>{children}</div>
+  return (
+    <div
+      className={tw('box-content flex max-w-168 flex-col gap-12 px-4 pb-20 md:px-12', className)}
+    >
+      {children}
+    </div>
+  )
 }
 
 const DetailsPageHeader: FC<{


### PR DESCRIPTION
Restores the `box-content flex max-w-168` cap on `DetailsPage.Container`, dropped in #3215 (MainHeader migration) — detail pages have rendered full-width since. `box-content` keeps the content width independent of the page padding.