### PR TITLE
refactor(filters): migrate CustomerAccountTypeQuickFilter PremiumWarningDialog to new dialog system

### DIFF
--- a/src/components/designSystem/Filters/CustomerAccountTypeQuickFilter.tsx
+++ b/src/components/designSystem/Filters/CustomerAccountTypeQuickFilter.tsx
@@ -1,9 +1,8 @@
 import { Icon } from 'lago-design-system'
-import { useRef } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { useNavigate } from '~/core/router'
 import { CustomerAccountTypeEnum, PremiumIntegrationTypeEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -43,7 +42,7 @@ export const CustomerAccountTypeQuickFilter = () => {
   const navigate = useNavigate()
   const { isQuickFilterActive, buildQuickFilterUrlParams, hasAppliedFilters } = useFilters()
   const { organization: { premiumIntegrations } = {} } = useOrganizationInfos()
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
 
   const hasAccessToRevenueShare = !!premiumIntegrations?.includes(
     PremiumIntegrationTypeEnum.RevenueShare,
@@ -71,7 +70,7 @@ export const CustomerAccountTypeQuickFilter = () => {
         isSelected={isQuickFilterActive({ accountType: CustomerAccountTypeEnum.Partner })}
         onClick={() => {
           if (!hasAccessToRevenueShare) {
-            return premiumWarningDialogRef.current?.openDialog()
+            return openPremiumWarningDialog()
           }
 
           navigate({
@@ -85,8 +84,6 @@ export const CustomerAccountTypeQuickFilter = () => {
           {!hasAccessToRevenueShare && <Icon name="sparkles" />}
         </Typography>
       </QuickFilter>
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </>
   )
 }


### PR DESCRIPTION
## Summary

Migrates the `PremiumWarningDialog` usage inside `CustomerAccountTypeQuickFilter.tsx` from the legacy imperative ref-based dialog system to the new hook-based NiceModal dialog system, addressing one of the `no-restricted-imports` ESLint warnings around `~/components/PremiumWarningDialog`.

## Changes

- Removed the legacy `PremiumWarningDialog` + `PremiumWarningDialogRef` import in favor of `usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`.
- Replaced the local `useRef<PremiumWarningDialogRef>(null)` with the `open` function returned by the hook.
- Removed the `<PremiumWarningDialog ref={...} />` JSX (the dialog is now registered globally via NiceModal).
- Dropped the now-unused `useRef` import.

The scope is intentionally limited to the `CustomerAccountTypeQuickFilter` component — no other dialogs are present in this file.

## Test plan

- [ ] Open the customers list as a non-premium user (no `RevenueShare` integration).
- [ ] Click the "Partner" quick filter — verify the premium warning dialog opens with the default title/description/mailto content.
- [ ] As a premium user with `RevenueShare`, click the "Partner" quick filter — verify the URL search params update correctly and no dialog opens.
- [ ] Click the "Customer" quick filter — verify the URL updates correctly.
- [ ] `pnpm code:style` no longer reports a warning for this file.

---
_Generated by [Claude Code](https://claude.ai/code/session_012qNJgVP2JFhq7kk7xWv8ZP)_