### PR TITLE
refactor(plans): extract shared accordion helpers

### DIFF
--- a/src/components/plans/CommitmentsSection.tsx
+++ b/src/components/plans/CommitmentsSection.tsx
@@ -6,16 +6,17 @@ import { Chip } from '~/components/designSystem/Chip'
 import { Selector, SelectorActions } from '~/components/designSystem/Selector'
 import { Typography } from '~/components/designSystem/Typography'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
+import { mapCommitmentToDrawerValues } from '~/components/plans/drawers/minimumCommitment/mapToDrawerValues'
 import {
   MinimumCommitmentDrawer,
   MinimumCommitmentDrawerRef,
   MinimumCommitmentFormValues,
 } from '~/components/plans/drawers/minimumCommitment/MinimumCommitmentDrawer'
+import { MinimumCommitmentPremiumGate } from '~/components/plans/MinimumCommitmentPremiumGate'
 import {
   mapChargeIntervalCopy,
   returnFirstDefinedArrayRatesSumAsString,
 } from '~/components/plans/utils'
-import PremiumFeature from '~/components/premium/PremiumFeature'
 import { getIntervalTranslationKey } from '~/core/constants/form'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CommitmentTypeEnum, CurrencyEnum } from '~/generated/graphql'
@@ -46,11 +47,7 @@ export const CommitmentsSection = ({ form }: CommitmentsSectionProps) => {
   }, [commitment?.taxes])
 
   const openMinimumCommitmentDrawer = () => {
-    minimumCommitmentDrawerRef.current?.openDrawer({
-      amountCents: commitment?.amountCents || '',
-      invoiceDisplayName: commitment?.invoiceDisplayName || undefined,
-      taxes: commitment?.taxes || [],
-    })
+    minimumCommitmentDrawerRef.current?.openDrawer(mapCommitmentToDrawerValues(commitment))
   }
 
   const handleDrawerSave = (values: MinimumCommitmentFormValues) => {
@@ -118,13 +115,7 @@ export const CommitmentsSection = ({ form }: CommitmentsSectionProps) => {
         />
       )}
 
-      {!hasCommitment && !isPremium && (
-        <PremiumFeature
-          title={translate('text_17700400130439xuo82ha60n')}
-          description={translate('text_1770040013043awgs0eemonf')}
-          feature={translate('text_65d601bffb11e0f9d1d9f569')}
-        />
-      )}
+      {!hasCommitment && !isPremium && <MinimumCommitmentPremiumGate />}
 
       {!hasCommitment && isPremium && (
         <Button

--- a/src/components/plans/FeatureEntitlementSection.tsx
+++ b/src/components/plans/FeatureEntitlementSection.tsx
@@ -6,6 +6,10 @@ import { Button } from '~/components/designSystem/Button'
 import { Selector, SelectorActions } from '~/components/designSystem/Selector'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import {
+  removeEntitlementByFeatureCode,
+  upsertEntitlement,
+} from '~/components/plans/drawers/featureEntitlement/entitlementHelpers'
+import {
   FeatureEntitlementDrawer,
   FeatureEntitlementDrawerRef,
   FeatureEntitlementFormValues,
@@ -58,24 +62,15 @@ export const FeatureEntitlementSection: FC<FeatureEntitlementSectionProps> = ({ 
   const entitlements = useStore(form.store, (s) => s.values.entitlements)
 
   const handleDrawerSave = (values: FeatureEntitlementFormValues) => {
-    const current = form.state.values.entitlements || []
-    const existingIndex = current.findIndex((e) => e.featureCode === values.featureCode)
-    const newFeatureObject = {
-      featureId: values.featureId,
-      featureName: values.featureName,
-      featureCode: values.featureCode,
-      privileges: values.privileges,
-    }
-
-    const updated = [...current]
-
-    if (existingIndex >= 0) {
-      updated[existingIndex] = newFeatureObject
-    } else {
-      updated.push(newFeatureObject)
-    }
-
-    form.setFieldValue('entitlements', updated)
+    form.setFieldValue(
+      'entitlements',
+      upsertEntitlement(form.state.values.entitlements, {
+        featureId: values.featureId,
+        featureName: values.featureName,
+        featureCode: values.featureCode,
+        privileges: values.privileges,
+      }),
+    )
   }
 
   return (
@@ -116,8 +111,9 @@ export const FeatureEntitlementSection: FC<FeatureEntitlementSectionProps> = ({ 
                         onClick: () => {
                           form.setFieldValue(
                             'entitlements',
-                            form.state.values.entitlements.filter(
-                              (e) => e.featureCode !== entitlement.featureCode,
+                            removeEntitlementByFeatureCode(
+                              form.state.values.entitlements,
+                              entitlement.featureCode,
                             ),
                           )
                         },
@@ -154,7 +150,7 @@ export const FeatureEntitlementSection: FC<FeatureEntitlementSectionProps> = ({ 
         onDelete={(featureCode) => {
           form.setFieldValue(
             'entitlements',
-            form.state.values.entitlements.filter((e) => e.featureCode !== featureCode),
+            removeEntitlementByFeatureCode(form.state.values.entitlements, featureCode),
           )
         }}
       />

--- a/src/components/plans/MinimumCommitmentPremiumGate.tsx
+++ b/src/components/plans/MinimumCommitmentPremiumGate.tsx
@@ -1,0 +1,17 @@
+import PremiumFeature from '~/components/premium/PremiumFeature'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+export const MINIMUM_COMMITMENT_PREMIUM_GATE_TEST_ID = 'minimum-commitment-premium-gate'
+
+export const MinimumCommitmentPremiumGate = () => {
+  const { translate } = useInternationalization()
+
+  return (
+    <PremiumFeature
+      data-test={MINIMUM_COMMITMENT_PREMIUM_GATE_TEST_ID}
+      title={translate('text_17700400130439xuo82ha60n')}
+      description={translate('text_1770040013043awgs0eemonf')}
+      feature={translate('text_65d601bffb11e0f9d1d9f569')}
+    />
+  )
+}

--- a/src/components/plans/ProgressiveBillingPremiumGate.tsx
+++ b/src/components/plans/ProgressiveBillingPremiumGate.tsx
@@ -1,0 +1,17 @@
+import PremiumFeature from '~/components/premium/PremiumFeature'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+export const PROGRESSIVE_BILLING_PREMIUM_GATE_TEST_ID = 'progressive-billing-premium-gate'
+
+export const ProgressiveBillingPremiumGate = () => {
+  const { translate } = useInternationalization()
+
+  return (
+    <PremiumFeature
+      data-test={PROGRESSIVE_BILLING_PREMIUM_GATE_TEST_ID}
+      title={translate('text_1724345142892pcnx5m2k3r2')}
+      description={translate('text_1724345142892ljzi79afhmc')}
+      feature={translate('text_1724179887722baucvj7bvc1')}
+    />
+  )
+}

--- a/src/components/plans/ProgressiveBillingSection.tsx
+++ b/src/components/plans/ProgressiveBillingSection.tsx
@@ -6,11 +6,12 @@ import { Chip } from '~/components/designSystem/Chip'
 import { Selector, SelectorActions } from '~/components/designSystem/Selector'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { ProgressiveBillingFormValues } from '~/components/plans/drawers/progressiveBilling/constants'
+import { mapFormThresholdsToDrawerValues } from '~/components/plans/drawers/progressiveBilling/mapToDrawerValues'
 import {
   ProgressiveBillingDrawer,
   ProgressiveBillingDrawerRef,
 } from '~/components/plans/drawers/progressiveBilling/ProgressiveBillingDrawer'
-import PremiumFeature from '~/components/premium/PremiumFeature'
+import { ProgressiveBillingPremiumGate } from '~/components/plans/ProgressiveBillingPremiumGate'
 import { PremiumIntegrationTypeEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { PlanFormType } from '~/hooks/plans/usePlanForm'
@@ -54,20 +55,9 @@ export const ProgressiveBillingSection: FC<ProgressiveBillingSectionProps> = ({ 
   }
 
   const openDrawer = () => {
-    progressiveBillingDrawerRef.current?.openDrawer({
-      nonRecurringUsageThresholds: (nonRecurringUsageThresholds ?? []).map((t) => ({
-        amountCents: String(t.amountCents),
-        thresholdDisplayName: t.thresholdDisplayName ?? undefined,
-        recurring: false as const,
-      })),
-      recurringUsageThreshold: recurringUsageThreshold
-        ? {
-            amountCents: String(recurringUsageThreshold.amountCents),
-            thresholdDisplayName: recurringUsageThreshold.thresholdDisplayName ?? undefined,
-            recurring: true as const,
-          }
-        : undefined,
-    })
+    progressiveBillingDrawerRef.current?.openDrawer(
+      mapFormThresholdsToDrawerValues(nonRecurringUsageThresholds, recurringUsageThreshold),
+    )
   }
 
   return (
@@ -109,13 +99,7 @@ export const ProgressiveBillingSection: FC<ProgressiveBillingSectionProps> = ({ 
         />
       )}
 
-      {!hasThresholds && !hasPremiumIntegration && (
-        <PremiumFeature
-          title={translate('text_1724345142892pcnx5m2k3r2')}
-          description={translate('text_1724345142892ljzi79afhmc')}
-          feature={translate('text_1724179887722baucvj7bvc1')}
-        />
-      )}
+      {!hasThresholds && !hasPremiumIntegration && <ProgressiveBillingPremiumGate />}
 
       {!hasThresholds && hasPremiumIntegration && (
         <Button

--- a/src/components/plans/__tests__/MinimumCommitmentPremiumGate.test.tsx
+++ b/src/components/plans/__tests__/MinimumCommitmentPremiumGate.test.tsx
@@ -1,0 +1,31 @@
+import NiceModal from '@ebay/nice-modal-react'
+import { screen } from '@testing-library/react'
+
+import { PREMIUM_WARNING_DIALOG_NAME } from '~/components/dialogs/const'
+import PremiumWarningDialog from '~/components/dialogs/PremiumWarningDialog'
+import {
+  MINIMUM_COMMITMENT_PREMIUM_GATE_TEST_ID,
+  MinimumCommitmentPremiumGate,
+} from '~/components/plans/MinimumCommitmentPremiumGate'
+import { render } from '~/test-utils'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+    locale: 'en',
+  }),
+}))
+
+NiceModal.register(PREMIUM_WARNING_DIALOG_NAME, PremiumWarningDialog)
+
+describe('MinimumCommitmentPremiumGate', () => {
+  it('renders PremiumFeature with minimum-commitment title + description', () => {
+    render(<MinimumCommitmentPremiumGate />)
+
+    const gate = screen.getByTestId(MINIMUM_COMMITMENT_PREMIUM_GATE_TEST_ID)
+
+    expect(gate).toBeInTheDocument()
+    expect(gate).toHaveTextContent('text_17700400130439xuo82ha60n')
+    expect(gate).toHaveTextContent('text_1770040013043awgs0eemonf')
+  })
+})

--- a/src/components/plans/__tests__/ProgressiveBillingPremiumGate.test.tsx
+++ b/src/components/plans/__tests__/ProgressiveBillingPremiumGate.test.tsx
@@ -1,0 +1,31 @@
+import NiceModal from '@ebay/nice-modal-react'
+import { screen } from '@testing-library/react'
+
+import { PREMIUM_WARNING_DIALOG_NAME } from '~/components/dialogs/const'
+import PremiumWarningDialog from '~/components/dialogs/PremiumWarningDialog'
+import {
+  PROGRESSIVE_BILLING_PREMIUM_GATE_TEST_ID,
+  ProgressiveBillingPremiumGate,
+} from '~/components/plans/ProgressiveBillingPremiumGate'
+import { render } from '~/test-utils'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+    locale: 'en',
+  }),
+}))
+
+NiceModal.register(PREMIUM_WARNING_DIALOG_NAME, PremiumWarningDialog)
+
+describe('ProgressiveBillingPremiumGate', () => {
+  it('renders PremiumFeature with progressive-billing title + description', () => {
+    render(<ProgressiveBillingPremiumGate />)
+
+    const gate = screen.getByTestId(PROGRESSIVE_BILLING_PREMIUM_GATE_TEST_ID)
+
+    expect(gate).toBeInTheDocument()
+    expect(gate).toHaveTextContent('text_1724345142892pcnx5m2k3r2')
+    expect(gate).toHaveTextContent('text_1724345142892ljzi79afhmc')
+  })
+})

--- a/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
@@ -18,8 +18,8 @@ import {
   VolumeRangesFragmentDoc,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
 import { useFixedChargeMutationsWithCascade } from '~/hooks/plans/useFixedChargeMutationsWithCascade'
-import { usePermissions } from '~/hooks/usePermissions'
 
 import { SectionAccordion } from './shared/SectionAccordion'
 import { SectionHeader } from './shared/SectionHeader'
@@ -103,12 +103,8 @@ export const PlanDetailsV2FixedChargesSection = forwardRef<
   Props
 >(({ plan, isInSubscriptionForm = false }, ref) => {
   const { translate } = useInternationalization()
-  const { hasPermissions } = usePermissions()
+  const { canCreate, canUpdate, canDelete } = useAccordionPermissions(isInSubscriptionForm)
   const drawerRef = useRef<FixedChargeDrawerRef>(null)
-
-  const canCreate = hasPermissions(['plansCreate']) && !isInSubscriptionForm
-  const canUpdate = hasPermissions(['plansUpdate']) && !isInSubscriptionForm
-  const canDelete = hasPermissions(['plansDelete']) && !isInSubscriptionForm
 
   const { handleSaveCharge, handleDeleteCharge } = useFixedChargeMutationsWithCascade({
     planId: plan.id,

--- a/src/components/plans/details-v2/PlanDetailsV2PlanSettingsSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2PlanSettingsSection.tsx
@@ -12,7 +12,7 @@ import {
   PlanForUpdateWithCascadeFragmentDoc,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { usePermissions } from '~/hooks/usePermissions'
+import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
 
 import { SectionAccordion } from './shared/SectionAccordion'
 import { SectionHeader } from './shared/SectionHeader'
@@ -39,10 +39,8 @@ export const PlanDetailsV2PlanSettingsSection = ({
   isInSubscriptionForm = false,
 }: PlanDetailsV2PlanSettingsSectionProps) => {
   const { translate } = useInternationalization()
-  const { hasPermissions } = usePermissions()
+  const { canUpdate } = useAccordionPermissions(isInSubscriptionForm)
   const drawerRef = useRef<PlanSettingsDrawerRef>(null)
-
-  const canUpdate = hasPermissions(['plansUpdate']) && !isInSubscriptionForm
 
   return (
     <section id={PlanDetailsV2SectionId.PlanSettings} className="flex scroll-mt-12 flex-col gap-6">

--- a/src/components/plans/details-v2/PlanDetailsV2UsageChargesSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2UsageChargesSection.tsx
@@ -25,10 +25,10 @@ import {
   VolumeRangesFragmentDoc,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
 import { useChargeMutationsWithCascade } from '~/hooks/plans/useChargeMutationsWithCascade'
 import { useCustomPricingUnits } from '~/hooks/plans/useCustomPricingUnits'
 import { toLocalUsageChargeInput } from '~/hooks/plans/utils'
-import { usePermissions } from '~/hooks/usePermissions'
 
 import { SectionAccordion } from './shared/SectionAccordion'
 import { SectionHeader } from './shared/SectionHeader'
@@ -147,13 +147,9 @@ export const PlanDetailsV2UsageChargesSection = forwardRef<
   Props
 >(({ plan, isInSubscriptionForm = false }, ref) => {
   const { translate } = useInternationalization()
-  const { hasPermissions } = usePermissions()
+  const { canCreate, canUpdate, canDelete } = useAccordionPermissions(isInSubscriptionForm)
   const { hasAnyPricingUnitConfigured } = useCustomPricingUnits()
   const drawerRef = useRef<UsageChargeDrawerRef>(null)
-
-  const canCreate = hasPermissions(['plansCreate']) && !isInSubscriptionForm
-  const canUpdate = hasPermissions(['plansUpdate']) && !isInSubscriptionForm
-  const canDelete = hasPermissions(['plansDelete']) && !isInSubscriptionForm
 
   const { handleSaveCharge, handleDeleteCharge } = useChargeMutationsWithCascade({
     planId: plan.id,

--- a/src/components/plans/details-v2/SubscriptionFeeAccordion.tsx
+++ b/src/components/plans/details-v2/SubscriptionFeeAccordion.tsx
@@ -12,8 +12,8 @@ import { PlanFormProvider } from '~/contexts/PlanFormContext'
 import { getIntervalTranslationKey } from '~/core/constants/form'
 import { PlanDetailsV2Fragment, PlanForUpdateWithCascadeFragmentDoc } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
 import { useUpdatePlanWithCascade } from '~/hooks/plans/useUpdatePlanWithCascade'
-import { usePermissions } from '~/hooks/usePermissions'
 
 import { SectionAccordion } from './shared/SectionAccordion'
 import { PlanDetailsV2SectionId } from './sidebarSections'
@@ -42,10 +42,8 @@ export const SubscriptionFeeAccordion = ({
   isInSubscriptionForm = false,
 }: SubscriptionFeeAccordionProps) => {
   const { translate } = useInternationalization()
-  const { hasPermissions } = usePermissions()
+  const { canUpdate } = useAccordionPermissions(isInSubscriptionForm)
   const drawerRef = useRef<SubscriptionFeeDrawerRef>(null)
-
-  const canUpdate = hasPermissions(['plansUpdate']) && !isInSubscriptionForm
 
   const { form, submit } = useUpdatePlanWithCascade({ plan })
 

--- a/src/components/plans/details-v2/accordions/EntitlementAccordion.tsx
+++ b/src/components/plans/details-v2/accordions/EntitlementAccordion.tsx
@@ -1,6 +1,10 @@
 import { useRef } from 'react'
 
 import {
+  removeEntitlementByFeatureCode,
+  upsertEntitlement,
+} from '~/components/plans/drawers/featureEntitlement/entitlementHelpers'
+import {
   FeatureEntitlementDrawer,
   FeatureEntitlementDrawerRef,
   FeatureEntitlementFormValues,
@@ -8,11 +12,8 @@ import {
 import { EntitlementInfo } from '~/components/plans/EntitlementInfo'
 import { PlanDetailsV2Fragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import {
-  buildUpdatePlanFormDefaults,
-  useUpdatePlanWithCascade,
-} from '~/hooks/plans/useUpdatePlanWithCascade'
-import { usePermissions } from '~/hooks/usePermissions'
+import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
+import { useUpdatePlanWithCascade } from '~/hooks/plans/useUpdatePlanWithCascade'
 
 import { SectionAccordion } from '../shared/SectionAccordion'
 import { SectionHeader } from '../shared/SectionHeader'
@@ -28,48 +29,34 @@ export const EntitlementAccordion = ({
   isInSubscriptionForm = false,
 }: EntitlementAccordionProps) => {
   const { translate } = useInternationalization()
-  const { hasPermissions } = usePermissions()
+  const { canCreate, canUpdate, canDelete } = useAccordionPermissions(isInSubscriptionForm)
   const drawerRef = useRef<FeatureEntitlementDrawerRef>(null)
-
-  const canCreate = hasPermissions(['plansCreate']) && !isInSubscriptionForm
-  const canUpdate = hasPermissions(['plansUpdate']) && !isInSubscriptionForm
-  const canDelete = hasPermissions(['plansDelete']) && !isInSubscriptionForm
 
   const entitlements = plan.entitlements ?? []
 
-  const { form, submit } = useUpdatePlanWithCascade({ plan, includeAdvancedFields: true })
-
-  const applyAndSubmit = (mutate: () => void): Promise<boolean> => {
-    form.reset(buildUpdatePlanFormDefaults(plan), { keepDefaultValues: true })
-    mutate()
-    return submit()
-  }
+  const { form, applyAndSubmit } = useUpdatePlanWithCascade({
+    plan,
+    includeAdvancedFields: true,
+  })
 
   const handleSave = (values: FeatureEntitlementFormValues): Promise<boolean> =>
     applyAndSubmit(() => {
-      const current = form.state.values.entitlements || []
-      const idx = current.findIndex((e) => e.featureCode === values.featureCode)
-      const next = {
-        featureId: values.featureId,
-        featureName: values.featureName,
-        featureCode: values.featureCode,
-        privileges: values.privileges,
-      }
-      const updated = [...current]
-
-      if (idx >= 0) {
-        updated[idx] = next
-      } else {
-        updated.push(next)
-      }
-      form.setFieldValue('entitlements', updated)
+      form.setFieldValue(
+        'entitlements',
+        upsertEntitlement(form.state.values.entitlements, {
+          featureId: values.featureId,
+          featureName: values.featureName,
+          featureCode: values.featureCode,
+          privileges: values.privileges,
+        }),
+      )
     })
 
   const handleDelete = (featureCode: string): Promise<boolean> =>
     applyAndSubmit(() =>
       form.setFieldValue(
         'entitlements',
-        (form.state.values.entitlements || []).filter((e) => e.featureCode !== featureCode),
+        removeEntitlementByFeatureCode(form.state.values.entitlements, featureCode),
       ),
     )
 

--- a/src/components/plans/details-v2/accordions/MinimumCommitmentAccordion.tsx
+++ b/src/components/plans/details-v2/accordions/MinimumCommitmentAccordion.tsx
@@ -1,25 +1,22 @@
 import { useRef } from 'react'
 
 import { Chip } from '~/components/designSystem/Chip'
+import { mapCommitmentToDrawerValues } from '~/components/plans/drawers/minimumCommitment/mapToDrawerValues'
 import {
   MinimumCommitmentDrawer,
   MinimumCommitmentDrawerRef,
   MinimumCommitmentFormValues,
 } from '~/components/plans/drawers/minimumCommitment/MinimumCommitmentDrawer'
 import { MinimumCommitmentInfo } from '~/components/plans/MinimumCommitmentInfo'
+import { MinimumCommitmentPremiumGate } from '~/components/plans/MinimumCommitmentPremiumGate'
 import { mapChargeIntervalCopy } from '~/components/plans/utils'
-import PremiumFeature from '~/components/premium/PremiumFeature'
 import { PlanFormProvider } from '~/contexts/PlanFormContext'
 import { getIntervalTranslationKey } from '~/core/constants/form'
-import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { CommitmentTypeEnum, CurrencyEnum, PlanDetailsV2Fragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import {
-  buildUpdatePlanFormDefaults,
-  useUpdatePlanWithCascade,
-} from '~/hooks/plans/useUpdatePlanWithCascade'
+import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
+import { useUpdatePlanWithCascade } from '~/hooks/plans/useUpdatePlanWithCascade'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
-import { usePermissions } from '~/hooks/usePermissions'
 
 import { SectionAccordion } from '../shared/SectionAccordion'
 import { SectionHeader } from '../shared/SectionHeader'
@@ -36,24 +33,17 @@ export const MinimumCommitmentAccordion = ({
 }: MinimumCommitmentAccordionProps) => {
   const { translate } = useInternationalization()
   const { isPremium } = useCurrentUser()
-  const { hasPermissions } = usePermissions()
+  const { canCreate, canUpdate, canDelete } = useAccordionPermissions(isInSubscriptionForm)
   const drawerRef = useRef<MinimumCommitmentDrawerRef>(null)
-
-  const canCreate = hasPermissions(['plansCreate']) && !isInSubscriptionForm
-  const canUpdate = hasPermissions(['plansUpdate']) && !isInSubscriptionForm
-  const canDelete = hasPermissions(['plansDelete']) && !isInSubscriptionForm
 
   const currency = plan.amountCurrency || CurrencyEnum.Usd
   const commitment = plan.minimumCommitment
   const hasCommitment = !!commitment?.amountCents && !isNaN(Number(commitment.amountCents))
 
-  const { form, submit } = useUpdatePlanWithCascade({ plan, includeAdvancedFields: true })
-
-  const applyAndSubmit = (mutate: () => void): Promise<boolean> => {
-    form.reset(buildUpdatePlanFormDefaults(plan), { keepDefaultValues: true })
-    mutate()
-    return submit()
-  }
+  const { form, applyAndSubmit } = useUpdatePlanWithCascade({
+    plan,
+    includeAdvancedFields: true,
+  })
 
   const handleSave = (values: MinimumCommitmentFormValues): Promise<boolean> =>
     applyAndSubmit(() =>
@@ -67,13 +57,9 @@ export const MinimumCommitmentAccordion = ({
     applyAndSubmit(() => form.setFieldValue('minimumCommitment', {}))
 
   const openEditDrawer = () =>
-    drawerRef.current?.openDrawer({
-      amountCents: commitment?.amountCents
-        ? String(deserializeAmount(commitment.amountCents, currency))
-        : '',
-      invoiceDisplayName: commitment?.invoiceDisplayName || undefined,
-      taxes: commitment?.taxes || [],
-    })
+    drawerRef.current?.openDrawer(
+      mapCommitmentToDrawerValues(commitment, { deserialize: true, currency }),
+    )
 
   const intervalBadge = plan.interval ? (
     <Chip label={translate(getIntervalTranslationKey[plan.interval])} />
@@ -96,13 +82,7 @@ export const MinimumCommitmentAccordion = ({
         }}
       />
 
-      {!isPremium && !hasCommitment && (
-        <PremiumFeature
-          title={translate('text_17700400130439xuo82ha60n')}
-          description={translate('text_1770040013043awgs0eemonf')}
-          feature={translate('text_65d601bffb11e0f9d1d9f569')}
-        />
-      )}
+      {!isPremium && !hasCommitment && <MinimumCommitmentPremiumGate />}
 
       {hasCommitment && (
         <SectionAccordion

--- a/src/components/plans/details-v2/accordions/ProgressiveBillingAccordion.tsx
+++ b/src/components/plans/details-v2/accordions/ProgressiveBillingAccordion.tsx
@@ -1,26 +1,23 @@
 import { useRef } from 'react'
 
 import { ProgressiveBillingFormValues } from '~/components/plans/drawers/progressiveBilling/constants'
+import { mapPlanThresholdsToDrawerValues } from '~/components/plans/drawers/progressiveBilling/mapToDrawerValues'
 import {
   ProgressiveBillingDrawer,
   ProgressiveBillingDrawerRef,
 } from '~/components/plans/drawers/progressiveBilling/ProgressiveBillingDrawer'
 import { ProgressiveBillingInfo } from '~/components/plans/ProgressiveBillingInfo'
-import PremiumFeature from '~/components/premium/PremiumFeature'
+import { ProgressiveBillingPremiumGate } from '~/components/plans/ProgressiveBillingPremiumGate'
 import { PlanFormProvider } from '~/contexts/PlanFormContext'
-import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import {
   CurrencyEnum,
   PlanDetailsV2Fragment,
   PremiumIntegrationTypeEnum,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import {
-  buildUpdatePlanFormDefaults,
-  useUpdatePlanWithCascade,
-} from '~/hooks/plans/useUpdatePlanWithCascade'
+import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
+import { useUpdatePlanWithCascade } from '~/hooks/plans/useUpdatePlanWithCascade'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
-import { usePermissions } from '~/hooks/usePermissions'
 
 import { SectionAccordion } from '../shared/SectionAccordion'
 import { SectionHeader } from '../shared/SectionHeader'
@@ -37,12 +34,8 @@ export const ProgressiveBillingAccordion = ({
 }: ProgressiveBillingAccordionProps) => {
   const { translate } = useInternationalization()
   const { organization: { premiumIntegrations } = {} } = useOrganizationInfos()
-  const { hasPermissions } = usePermissions()
+  const { canCreate, canUpdate, canDelete } = useAccordionPermissions(isInSubscriptionForm)
   const drawerRef = useRef<ProgressiveBillingDrawerRef>(null)
-
-  const canCreate = hasPermissions(['plansCreate']) && !isInSubscriptionForm
-  const canUpdate = hasPermissions(['plansUpdate']) && !isInSubscriptionForm
-  const canDelete = hasPermissions(['plansDelete']) && !isInSubscriptionForm
 
   const currency = plan.amountCurrency || CurrencyEnum.Usd
   const hasThresholds = !!plan.usageThresholds?.length
@@ -51,13 +44,10 @@ export const ProgressiveBillingAccordion = ({
     PremiumIntegrationTypeEnum.ProgressiveBilling,
   )
 
-  const { form, submit } = useUpdatePlanWithCascade({ plan, includeAdvancedFields: true })
-
-  const applyAndSubmit = (mutate: () => void): Promise<boolean> => {
-    form.reset(buildUpdatePlanFormDefaults(plan), { keepDefaultValues: true })
-    mutate()
-    return submit()
-  }
+  const { form, applyAndSubmit } = useUpdatePlanWithCascade({
+    plan,
+    includeAdvancedFields: true,
+  })
 
   const handleSave = (values: ProgressiveBillingFormValues): Promise<boolean> =>
     applyAndSubmit(() => {
@@ -72,25 +62,7 @@ export const ProgressiveBillingAccordion = ({
     })
 
   const openEditDrawer = () => {
-    const nonRecurring = (plan.usageThresholds ?? [])
-      .filter((t) => !t.recurring)
-      .map((t) => ({
-        amountCents: String(deserializeAmount(t.amountCents, currency)),
-        thresholdDisplayName: t.thresholdDisplayName ?? undefined,
-        recurring: false as const,
-      }))
-    const recurring = (plan.usageThresholds ?? []).find((t) => t.recurring)
-
-    drawerRef.current?.openDrawer({
-      nonRecurringUsageThresholds: nonRecurring,
-      recurringUsageThreshold: recurring
-        ? {
-            amountCents: String(deserializeAmount(recurring.amountCents, currency)),
-            thresholdDisplayName: recurring.thresholdDisplayName ?? undefined,
-            recurring: true as const,
-          }
-        : undefined,
-    })
+    drawerRef.current?.openDrawer(mapPlanThresholdsToDrawerValues(plan.usageThresholds, currency))
   }
 
   return (
@@ -108,13 +80,7 @@ export const ProgressiveBillingAccordion = ({
         }}
       />
 
-      {!hasThresholds && !hasPremiumIntegration && (
-        <PremiumFeature
-          title={translate('text_1724345142892pcnx5m2k3r2')}
-          description={translate('text_1724345142892ljzi79afhmc')}
-          feature={translate('text_1724179887722baucvj7bvc1')}
-        />
-      )}
+      {!hasThresholds && !hasPremiumIntegration && <ProgressiveBillingPremiumGate />}
 
       {hasThresholds && (
         <SectionAccordion

--- a/src/components/plans/drawers/featureEntitlement/__tests__/entitlementHelpers.test.ts
+++ b/src/components/plans/drawers/featureEntitlement/__tests__/entitlementHelpers.test.ts
@@ -1,0 +1,71 @@
+import { removeEntitlementByFeatureCode, upsertEntitlement } from '../entitlementHelpers'
+
+type Entry = { featureCode: string; featureName?: string }
+
+describe('upsertEntitlement', () => {
+  it('appends when list is null', () => {
+    const result = upsertEntitlement<Entry>(null, { featureCode: 'a' })
+
+    expect(result).toEqual([{ featureCode: 'a' }])
+  })
+
+  it('appends when list is undefined', () => {
+    const result = upsertEntitlement<Entry>(undefined, { featureCode: 'a' })
+
+    expect(result).toEqual([{ featureCode: 'a' }])
+  })
+
+  it('appends when featureCode is new', () => {
+    const result = upsertEntitlement<Entry>([{ featureCode: 'a' }], { featureCode: 'b' })
+
+    expect(result).toEqual([{ featureCode: 'a' }, { featureCode: 'b' }])
+  })
+
+  it('replaces existing entry at same index', () => {
+    const list: Entry[] = [{ featureCode: 'a', featureName: 'old' }, { featureCode: 'b' }]
+    const result = upsertEntitlement(list, { featureCode: 'a', featureName: 'new' })
+
+    expect(result).toEqual([{ featureCode: 'a', featureName: 'new' }, { featureCode: 'b' }])
+  })
+
+  it('returns a new array (does not mutate input)', () => {
+    const list: Entry[] = [{ featureCode: 'a' }]
+    const result = upsertEntitlement(list, { featureCode: 'b' })
+
+    expect(result).not.toBe(list)
+    expect(list).toEqual([{ featureCode: 'a' }])
+  })
+})
+
+describe('removeEntitlementByFeatureCode', () => {
+  it('returns empty array when list is null', () => {
+    expect(removeEntitlementByFeatureCode<Entry>(null, 'a')).toEqual([])
+  })
+
+  it('returns empty array when list is undefined', () => {
+    expect(removeEntitlementByFeatureCode<Entry>(undefined, 'a')).toEqual([])
+  })
+
+  it('removes the entry matching featureCode', () => {
+    const result = removeEntitlementByFeatureCode<Entry>(
+      [{ featureCode: 'a' }, { featureCode: 'b' }, { featureCode: 'c' }],
+      'b',
+    )
+
+    expect(result).toEqual([{ featureCode: 'a' }, { featureCode: 'c' }])
+  })
+
+  it('returns equivalent list when no entry matches', () => {
+    const list: Entry[] = [{ featureCode: 'a' }]
+
+    expect(removeEntitlementByFeatureCode(list, 'zzz')).toEqual([{ featureCode: 'a' }])
+  })
+
+  it('returns a new array (does not mutate input)', () => {
+    const list: Entry[] = [{ featureCode: 'a' }]
+    const result = removeEntitlementByFeatureCode(list, 'a')
+
+    expect(result).not.toBe(list)
+    expect(list).toEqual([{ featureCode: 'a' }])
+  })
+})

--- a/src/components/plans/drawers/featureEntitlement/entitlementHelpers.ts
+++ b/src/components/plans/drawers/featureEntitlement/entitlementHelpers.ts
@@ -1,0 +1,21 @@
+type Entitlement = { featureCode: string }
+
+export const upsertEntitlement = <T extends Entitlement>(
+  list: ReadonlyArray<T> | null | undefined,
+  next: T,
+): T[] => {
+  const current = list ? [...list] : []
+  const idx = current.findIndex((entitlement) => entitlement.featureCode === next.featureCode)
+
+  if (idx >= 0) {
+    current[idx] = next
+    return current
+  }
+  current.push(next)
+  return current
+}
+
+export const removeEntitlementByFeatureCode = <T extends Entitlement>(
+  list: ReadonlyArray<T> | null | undefined,
+  featureCode: string,
+): T[] => (list ?? []).filter((entitlement) => entitlement.featureCode !== featureCode)

--- a/src/components/plans/drawers/minimumCommitment/__tests__/mapToDrawerValues.test.ts
+++ b/src/components/plans/drawers/minimumCommitment/__tests__/mapToDrawerValues.test.ts
@@ -1,0 +1,74 @@
+import { CurrencyEnum, TaxForPlanAndChargesInPlanFormFragment } from '~/generated/graphql'
+
+import { mapCommitmentToDrawerValues } from '../mapToDrawerValues'
+
+const tax = (id: string): TaxForPlanAndChargesInPlanFormFragment =>
+  ({ id, code: id, name: id, rate: 0 }) as TaxForPlanAndChargesInPlanFormFragment
+
+describe('mapCommitmentToDrawerValues', () => {
+  it('returns blank payload when commitment is null', () => {
+    expect(mapCommitmentToDrawerValues(null)).toEqual({
+      amountCents: '',
+      invoiceDisplayName: undefined,
+      taxes: [],
+    })
+  })
+
+  it('returns blank payload when commitment is undefined', () => {
+    expect(mapCommitmentToDrawerValues(undefined)).toEqual({
+      amountCents: '',
+      invoiceDisplayName: undefined,
+      taxes: [],
+    })
+  })
+
+  it('passes amountCents through as string when deserialize is false', () => {
+    expect(
+      mapCommitmentToDrawerValues({
+        amountCents: '12345',
+        invoiceDisplayName: 'Display',
+        taxes: [],
+      }),
+    ).toMatchObject({
+      amountCents: '12345',
+      invoiceDisplayName: 'Display',
+    })
+  })
+
+  it('deserializes amountCents to major units when deserialize=true', () => {
+    expect(
+      mapCommitmentToDrawerValues(
+        { amountCents: 10000 },
+        { deserialize: true, currency: CurrencyEnum.Usd },
+      ).amountCents,
+    ).toBe('100')
+  })
+
+  it('returns empty string for null/undefined/empty amountCents', () => {
+    expect(mapCommitmentToDrawerValues({ amountCents: null }).amountCents).toBe('')
+    expect(mapCommitmentToDrawerValues({ amountCents: undefined }).amountCents).toBe('')
+    expect(mapCommitmentToDrawerValues({ amountCents: '' }).amountCents).toBe('')
+  })
+
+  it('stringifies numeric amountCents including 0', () => {
+    expect(mapCommitmentToDrawerValues({ amountCents: 0 }).amountCents).toBe('0')
+  })
+
+  it('coerces null invoiceDisplayName to undefined', () => {
+    expect(
+      mapCommitmentToDrawerValues({ invoiceDisplayName: null }).invoiceDisplayName,
+    ).toBeUndefined()
+  })
+
+  it('copies taxes array (defensive clone)', () => {
+    const taxes = [tax('vat')]
+    const result = mapCommitmentToDrawerValues({ taxes })
+
+    expect(result.taxes).toEqual(taxes)
+    expect(result.taxes).not.toBe(taxes)
+  })
+
+  it('defaults taxes to [] when missing', () => {
+    expect(mapCommitmentToDrawerValues({}).taxes).toEqual([])
+  })
+})

--- a/src/components/plans/drawers/minimumCommitment/mapToDrawerValues.ts
+++ b/src/components/plans/drawers/minimumCommitment/mapToDrawerValues.ts
@@ -1,0 +1,34 @@
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { CurrencyEnum, TaxForPlanAndChargesInPlanFormFragment } from '~/generated/graphql'
+
+import { MinimumCommitmentFormValues } from './MinimumCommitmentDrawer'
+
+type CommitmentSource = {
+  amountCents?: string | number | null
+  invoiceDisplayName?: string | null
+  taxes?: ReadonlyArray<TaxForPlanAndChargesInPlanFormFragment> | null
+}
+
+type MapOptions = {
+  /** When true, amountCents is treated as backend cents and converted to major units. */
+  deserialize?: boolean
+  currency?: CurrencyEnum
+}
+
+export const mapCommitmentToDrawerValues = (
+  commitment: CommitmentSource | null | undefined,
+  { deserialize = false, currency }: MapOptions = {},
+): MinimumCommitmentFormValues => {
+  const raw = commitment?.amountCents
+  let amountCents = ''
+
+  if (raw !== undefined && raw !== null && raw !== '') {
+    amountCents = deserialize && currency ? String(deserializeAmount(raw, currency)) : String(raw)
+  }
+
+  return {
+    amountCents,
+    invoiceDisplayName: commitment?.invoiceDisplayName || undefined,
+    taxes: commitment?.taxes ? [...commitment.taxes] : [],
+  }
+}

--- a/src/components/plans/drawers/progressiveBilling/__tests__/mapToDrawerValues.test.ts
+++ b/src/components/plans/drawers/progressiveBilling/__tests__/mapToDrawerValues.test.ts
@@ -1,0 +1,102 @@
+import { CurrencyEnum } from '~/generated/graphql'
+
+import {
+  mapFormThresholdsToDrawerValues,
+  mapPlanThresholdsToDrawerValues,
+} from '../mapToDrawerValues'
+
+describe('mapPlanThresholdsToDrawerValues', () => {
+  it('returns empty payload when usageThresholds is null', () => {
+    expect(mapPlanThresholdsToDrawerValues(null, CurrencyEnum.Usd)).toEqual({
+      nonRecurringUsageThresholds: [],
+      recurringUsageThreshold: undefined,
+    })
+  })
+
+  it('returns empty payload when usageThresholds is undefined', () => {
+    expect(mapPlanThresholdsToDrawerValues(undefined, CurrencyEnum.Usd)).toEqual({
+      nonRecurringUsageThresholds: [],
+      recurringUsageThreshold: undefined,
+    })
+  })
+
+  it('maps non-recurring thresholds and deserializes amounts to major units', () => {
+    const result = mapPlanThresholdsToDrawerValues(
+      [
+        { amountCents: 1000, recurring: false, thresholdDisplayName: 'First' },
+        { amountCents: '5000', recurring: false, thresholdDisplayName: null },
+      ],
+      CurrencyEnum.Usd,
+    )
+
+    expect(result.nonRecurringUsageThresholds).toEqual([
+      { amountCents: '10', thresholdDisplayName: 'First', recurring: false },
+      { amountCents: '50', thresholdDisplayName: undefined, recurring: false },
+    ])
+    expect(result.recurringUsageThreshold).toBeUndefined()
+  })
+
+  it('maps single recurring threshold separately', () => {
+    const result = mapPlanThresholdsToDrawerValues(
+      [{ amountCents: 7500, recurring: true, thresholdDisplayName: 'Recurring' }],
+      CurrencyEnum.Usd,
+    )
+
+    expect(result.nonRecurringUsageThresholds).toEqual([])
+    expect(result.recurringUsageThreshold).toEqual({
+      amountCents: '75',
+      thresholdDisplayName: 'Recurring',
+      recurring: true,
+    })
+  })
+
+  it('maps mixed recurring + non-recurring thresholds', () => {
+    const result = mapPlanThresholdsToDrawerValues(
+      [
+        { amountCents: 1000, recurring: false, thresholdDisplayName: 'A' },
+        { amountCents: 3000, recurring: true, thresholdDisplayName: 'R' },
+        { amountCents: 2000, recurring: false, thresholdDisplayName: 'B' },
+      ],
+      CurrencyEnum.Usd,
+    )
+
+    expect(result.nonRecurringUsageThresholds).toHaveLength(2)
+    expect(result.nonRecurringUsageThresholds[0].thresholdDisplayName).toBe('A')
+    expect(result.nonRecurringUsageThresholds[1].thresholdDisplayName).toBe('B')
+    expect(result.recurringUsageThreshold?.thresholdDisplayName).toBe('R')
+  })
+})
+
+describe('mapFormThresholdsToDrawerValues', () => {
+  it('returns empty payload when both inputs are null/undefined', () => {
+    expect(mapFormThresholdsToDrawerValues(null, null)).toEqual({
+      nonRecurringUsageThresholds: [],
+      recurringUsageThreshold: undefined,
+    })
+  })
+
+  it('passes amountCents through as string without deserialize', () => {
+    const result = mapFormThresholdsToDrawerValues(
+      [{ amountCents: '12.5', thresholdDisplayName: 'A' }],
+      { amountCents: 99, thresholdDisplayName: 'R' },
+    )
+
+    expect(result.nonRecurringUsageThresholds).toEqual([
+      { amountCents: '12.5', thresholdDisplayName: 'A', recurring: false },
+    ])
+    expect(result.recurringUsageThreshold).toEqual({
+      amountCents: '99',
+      thresholdDisplayName: 'R',
+      recurring: true,
+    })
+  })
+
+  it('converts null displayName to undefined', () => {
+    const result = mapFormThresholdsToDrawerValues(
+      [{ amountCents: '1', thresholdDisplayName: null }],
+      undefined,
+    )
+
+    expect(result.nonRecurringUsageThresholds[0].thresholdDisplayName).toBeUndefined()
+  })
+})

--- a/src/components/plans/drawers/progressiveBilling/mapToDrawerValues.ts
+++ b/src/components/plans/drawers/progressiveBilling/mapToDrawerValues.ts
@@ -1,0 +1,59 @@
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { CurrencyEnum } from '~/generated/graphql'
+
+import { ProgressiveBillingFormValues } from './constants'
+
+type PlanUsageThreshold = {
+  amountCents: string | number
+  recurring: boolean
+  thresholdDisplayName?: string | null
+}
+
+type FormThreshold = {
+  amountCents: string | number
+  thresholdDisplayName?: string | null
+}
+
+export const mapPlanThresholdsToDrawerValues = (
+  usageThresholds: ReadonlyArray<PlanUsageThreshold> | null | undefined,
+  currency: CurrencyEnum,
+): ProgressiveBillingFormValues => {
+  const list = usageThresholds ?? []
+  const nonRecurringUsageThresholds = list
+    .filter((threshold) => !threshold.recurring)
+    .map((threshold) => ({
+      amountCents: String(deserializeAmount(threshold.amountCents, currency)),
+      thresholdDisplayName: threshold.thresholdDisplayName ?? undefined,
+      recurring: false as const,
+    }))
+  const recurring = list.find((threshold) => threshold.recurring)
+
+  return {
+    nonRecurringUsageThresholds,
+    recurringUsageThreshold: recurring
+      ? {
+          amountCents: String(deserializeAmount(recurring.amountCents, currency)),
+          thresholdDisplayName: recurring.thresholdDisplayName ?? undefined,
+          recurring: true as const,
+        }
+      : undefined,
+  }
+}
+
+export const mapFormThresholdsToDrawerValues = (
+  nonRecurringUsageThresholds: ReadonlyArray<FormThreshold> | null | undefined,
+  recurringUsageThreshold: FormThreshold | null | undefined,
+): ProgressiveBillingFormValues => ({
+  nonRecurringUsageThresholds: (nonRecurringUsageThresholds ?? []).map((threshold) => ({
+    amountCents: String(threshold.amountCents),
+    thresholdDisplayName: threshold.thresholdDisplayName ?? undefined,
+    recurring: false as const,
+  })),
+  recurringUsageThreshold: recurringUsageThreshold
+    ? {
+        amountCents: String(recurringUsageThreshold.amountCents),
+        thresholdDisplayName: recurringUsageThreshold.thresholdDisplayName ?? undefined,
+        recurring: true as const,
+      }
+    : undefined,
+})

--- a/src/hooks/plans/__tests__/useAccordionPermissions.test.tsx
+++ b/src/hooks/plans/__tests__/useAccordionPermissions.test.tsx
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react'
+
+import { GetCurrentUserInfosDocument } from '~/generated/graphql'
+import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
+import { AllTheProviders } from '~/test-utils'
+
+type PlanPermissions = {
+  plansCreate: boolean
+  plansUpdate: boolean
+  plansDelete: boolean
+}
+
+const DEFAULT_PERMISSIONS: PlanPermissions = {
+  plansCreate: true,
+  plansUpdate: true,
+  plansDelete: true,
+}
+
+const mockCurrentUser = {
+  currentMembership: {
+    id: '2',
+    organization: { id: '3', name: 'Organization', logoUrl: 'https://logo.com' },
+    permissions: DEFAULT_PERMISSIONS,
+  },
+}
+
+jest.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mockCurrentUser,
+}))
+
+const prepare = (permissions: Partial<PlanPermissions> = {}, isInSubscriptionForm = false) => {
+  const membership = {
+    id: '2',
+    organization: { id: '3', name: 'Organization', logoUrl: 'https://logo.com' },
+    permissions: { ...DEFAULT_PERMISSIONS, ...permissions },
+  }
+
+  mockCurrentUser.currentMembership = membership
+
+  const mocks = [
+    {
+      request: { query: GetCurrentUserInfosDocument },
+      result: {
+        data: {
+          currentUser: {
+            id: '1',
+            email: 'gavin@hooli.com',
+            premium: true,
+            memberships: [membership],
+            __typename: 'User',
+          },
+        },
+      },
+    },
+  ]
+
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    AllTheProviders({ children, mocks, forceTypenames: true })
+
+  return renderHook(() => useAccordionPermissions(isInSubscriptionForm), { wrapper })
+}
+
+describe('useAccordionPermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns all true when user has every plan permission and not in subscription form', () => {
+    const { result } = prepare()
+
+    expect(result.current).toEqual({ canCreate: true, canUpdate: true, canDelete: true })
+  })
+
+  it('gates each capability on its own permission flag', () => {
+    expect(prepare({ plansCreate: false }).result.current.canCreate).toBe(false)
+    expect(prepare({ plansUpdate: false }).result.current.canUpdate).toBe(false)
+    expect(prepare({ plansDelete: false }).result.current.canDelete).toBe(false)
+  })
+
+  it('forces all flags to false when isInSubscriptionForm=true', () => {
+    const { result } = prepare(DEFAULT_PERMISSIONS, true)
+
+    expect(result.current).toEqual({ canCreate: false, canUpdate: false, canDelete: false })
+  })
+
+  it('keeps unrelated flags true when only one permission is revoked', () => {
+    const { result } = prepare({ plansCreate: false })
+
+    expect(result.current).toEqual({ canCreate: false, canUpdate: true, canDelete: true })
+  })
+})

--- a/src/hooks/plans/__tests__/useUpdatePlanWithCascade.test.tsx
+++ b/src/hooks/plans/__tests__/useUpdatePlanWithCascade.test.tsx
@@ -180,6 +180,51 @@ describe('useUpdatePlanWithCascade', () => {
     })
   })
 
+  it('applyAndSubmit runs the mutator after resetting and then submits', async () => {
+    const onSuccess = jest.fn()
+    const { result } = renderHook(
+      () =>
+        useUpdatePlanWithCascade({
+          plan: basePlan,
+          includeAdvancedFields: true,
+          onSuccess,
+        }),
+      { wrapper: wrapper([updateMock]) },
+    )
+
+    await act(async () => {
+      await result.current.applyAndSubmit(() => {
+        result.current.form.setFieldValue('name', 'Pro Renamed')
+      })
+    })
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+    expect(result.current.form.state.values.name).toBe('Pro Renamed')
+  })
+
+  it('applyAndSubmit opens the cascade dialog when the plan has overridden subs', async () => {
+    const { result } = renderHook(
+      () =>
+        useUpdatePlanWithCascade({
+          plan: { ...basePlan, hasOverriddenPlans: true },
+          includeAdvancedFields: true,
+        }),
+      { wrapper: wrapper([updateMock]) },
+    )
+
+    act(() => {
+      void result.current.applyAndSubmit(() => {
+        result.current.form.setFieldValue('name', 'Pro Renamed')
+      })
+    })
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain('text_1729604107534r3hsj7i64gp')
+    })
+  })
+
   it('opens the cascade dialog when the plan has overridden subs', async () => {
     const { result } = renderHook(
       () =>

--- a/src/hooks/plans/useAccordionPermissions.ts
+++ b/src/hooks/plans/useAccordionPermissions.ts
@@ -1,0 +1,12 @@
+import { usePermissions } from '~/hooks/usePermissions'
+
+export const useAccordionPermissions = (isInSubscriptionForm: boolean) => {
+  const { hasPermissions } = usePermissions()
+  const editable = !isInSubscriptionForm
+
+  return {
+    canCreate: hasPermissions(['plansCreate']) && editable,
+    canUpdate: hasPermissions(['plansUpdate']) && editable,
+    canDelete: hasPermissions(['plansDelete']) && editable,
+  }
+}

--- a/src/hooks/plans/useUpdatePlanWithCascade.ts
+++ b/src/hooks/plans/useUpdatePlanWithCascade.ts
@@ -210,5 +210,11 @@ export const useUpdatePlanWithCascade = ({
     return true
   }
 
-  return { form, submit }
+  const applyAndSubmit = (mutate: () => void): Promise<boolean> => {
+    form.reset(buildUpdatePlanFormDefaults(plan), { keepDefaultValues: true })
+    mutate()
+    return submit()
+  }
+
+  return { form, submit, applyAndSubmit }
 }


### PR DESCRIPTION
Pulls out duplicated logic between v1 plan form sections (`ProgressiveBillingSection`, `CommitmentsSection`, `FeatureEntitlementSection`) and v2 details accordions (`ProgressiveBillingAccordion`, `MinimumCommitmentAccordion`, `EntitlementAccordion`, `SubscriptionFeeAccordion`, `PlanDetailsV2*Section`).

## What's extracted

| Helper | Location | Replaces |
| --- | --- | --- |
| `useUpdatePlanWithCascade().applyAndSubmit(mutate)` | `src/hooks/plans/useUpdatePlanWithCascade.ts` | Identical 3-line `reset → mutate → submit` closure in 3 v2 accordions |
| `useAccordionPermissions(isInSubscriptionForm)` | `src/hooks/plans/useAccordionPermissions.ts` | `hasPermissions([...]) && !isInSubscriptionForm` triad in 5 v2 sections |
| `mapPlanThresholdsToDrawerValues` / `mapFormThresholdsToDrawerValues` | `src/components/plans/drawers/progressiveBilling/mapToDrawerValues.ts` | Plan→drawer + form→drawer payload mapping (v1 + v2) |
| `mapCommitmentToDrawerValues` | `src/components/plans/drawers/minimumCommitment/mapToDrawerValues.ts` | Commitment→drawer payload mapping (v1 + v2, optional `deserialize`) |
| `upsertEntitlement` / `removeEntitlementByFeatureCode` | `src/components/plans/drawers/featureEntitlement/entitlementHelpers.ts` | Entitlement upsert + remove-by-featureCode logic (v1 + v2) |
| `ProgressiveBillingPremiumGate` / `MinimumCommitmentPremiumGate` | `src/components/plans/` | Duplicated `<PremiumFeature>` blocks (v1 + v2) |

## Tests

Every helper has dedicated unit/component coverage:

- `mapToDrawerValues.test.ts` x2 (thresholds, commitment) — null/undefined inputs, deserialize math, displayName fallbacks, taxes clone
- `entitlementHelpers.test.ts` — append/replace, no-op delete, immutability
- `useAccordionPermissions.test.tsx` — per-permission gating, `isInSubscriptionForm` forces all false
- `useUpdatePlanWithCascade.test.tsx` — new `applyAndSubmit` cases (direct submit + cascade dialog path)
- `*PremiumGate.test.tsx` — render via `data-test` selector

41 new tests, all green. All pre-existing accordion + form-section tests (98 tests) still pass.

## Branch dependency

Branched from `lago-1472` because the v2 accordion files (`ProgressiveBillingAccordion`, `MinimumCommitmentAccordion`, `EntitlementAccordion`) only exist on that branch. **Merge after #3568** — once 1472 lands on main, this PR's diff against main is clean.

Fixes: pure refactor, no behavior change.