### PR TITLE
chore(dialogs): migrate PremiumWarningDialog usage in CustomerInvoicesList

### DIFF
--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -10,6 +10,7 @@ import { ActionItem } from '~/components/designSystem/Table'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { buildInvoiceDocumentData } from '~/components/emails/buildDocumentData'
 import {
   UpdateInvoicePaymentStatusDialog,
@@ -25,7 +26,6 @@ import {
 } from '~/components/invoices/ResendInvoiceForCollectionDialog'
 import { getMostRecentPaymentMethodId } from '~/components/invoices/utils/getMostRecentPaymentMethodId'
 import { VoidInvoiceDialog, VoidInvoiceDialogRef } from '~/components/invoices/VoidInvoiceDialog'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import {
   invoiceStatusMapping,
@@ -190,7 +190,7 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
   const actions = usePermissionsInvoiceActions()
   const { hasFeatureFlag } = useOrganizationInfos()
   const hasAccessToMultiPaymentFlow = hasFeatureFlag(FeatureFlagEnum.MultiplePaymentMethods)
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const resendInvoiceForCollectionDialogRef = useRef<ResendInvoiceForCollectionDialogRef>(null)
   const { handleDownloadFile } = useDownloadFile()
   const { showResendEmailDialog } = useResendEmailDialog()
@@ -518,7 +518,7 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
                       if (isPremium) {
                         navigate(generatePath(CREATE_INVOICE_PAYMENT_ROUTE, { invoiceId: id }))
                       } else {
-                        premiumWarningDialogRef.current?.openDialog()
+                        openPremiumWarningDialog()
                       }
                     },
                   }
@@ -584,7 +584,7 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
                     endIcon: 'sparkles',
                     title: translate('text_636bdef6565341dcb9cfb127'),
                     onAction: () => {
-                      premiumWarningDialogRef.current?.openDialog()
+                      openPremiumWarningDialog()
                     },
                   }
                 : null,
@@ -628,7 +628,6 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
       <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
       <UpdateInvoicePaymentStatusDialog ref={updateInvoicePaymentStatusDialog} />
       <VoidInvoiceDialog ref={voidInvoiceDialogRef} />
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
       <ResendInvoiceForCollectionDialog ref={resendInvoiceForCollectionDialogRef} />
     </>
   )


### PR DESCRIPTION
## Summary

Migrates the deprecated `~/components/PremiumWarningDialog` (legacy imperative ref-based dialog) to the new hook-based dialog system (`usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`) inside `src/components/customers/CustomerInvoicesList.tsx`.

- Swaps the import to the new dialog hook.
- Replaces `useRef<PremiumWarningDialogRef>` + `premiumWarningDialogRef.current?.openDialog()` calls with `const { open: openPremiumWarningDialog } = usePremiumWarningDialog()` and direct `openPremiumWarningDialog()` invocations.
- Removes the now-unneeded `<PremiumWarningDialog ref={...} />` render from the JSX tree (the dialog is rendered via NiceModal at the registration level).

The PremiumWarningDialog instance is already registered in `src/core/overlays/registeredDialogs.ts`, so no further wiring is required.

## Scope

This PR is intentionally scoped to a single deprecated import: only the `PremiumWarningDialog` usage was migrated. The other legacy dialogs still imported in this file (`FinalizeInvoiceDialog`, `UpdateInvoicePaymentStatusDialog`, `VoidInvoiceDialog`, `ResendInvoiceForCollectionDialog`) are intentionally left untouched — they each have their own migration paths and would broaden the diff considerably.

Net effect: removes 1 `no-restricted-imports` ESLint warning (project total goes from 512 → 511).

## Test plan

- [x] `pnpm exec tsc --noEmit` — passes clean
- [x] `pnpm exec eslint src/components/customers/CustomerInvoicesList.tsx` — PremiumWarningDialog warning removed; only the (out-of-scope) sibling-dialog warnings remain
- [x] `pnpm jest --testPathPatterns=CustomerInvoicesList` — 3/3 tests pass
- [ ] Manual: open the customer invoices list as a non-premium user and trigger the actions that previously displayed the premium warning (Record payment, Issue credit note) — confirm the new dialog opens and closes correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01Axvru4N6efipt4FwxU2pc6)_