### PR TITLE
refactor(plans): migrate UsageChargesSection PremiumWarningDialog to new dialog system

### DIFF
--- a/src/components/plans/UsageChargesSection.tsx
+++ b/src/components/plans/UsageChargesSection.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { useStore } from '@tanstack/react-form'
-import { RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { Chip } from '~/components/designSystem/Chip'
@@ -16,7 +16,6 @@ import {
   getFormattedChargeSelectorSubtitle,
   mapChargeIntervalCopy,
 } from '~/components/plans/utils'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { useDuplicatePlanVar } from '~/core/apolloClient/reactiveVars/duplicatePlanVar'
 import { FORM_TYPE_ENUM } from '~/core/constants/form'
 import { PlanInterval } from '~/generated/graphql'
@@ -41,7 +40,6 @@ export const USAGE_CHARGES_ADD_BUTTON_TEST_ID = 'add-usage-charge'
 interface UsageChargesSectionProps {
   form: PlanFormType
   alreadyExistingCharges?: LocalUsageChargeInput[] | null
-  premiumWarningDialogRef: RefObject<PremiumWarningDialogRef>
   canBeEdited?: boolean
   isInSubscriptionForm?: boolean
   isEdition: boolean
@@ -54,7 +52,6 @@ export const UsageChargesSection = ({
   canBeEdited,
   isInSubscriptionForm,
   isEdition,
-  premiumWarningDialogRef,
   subscriptionFormType,
 }: UsageChargesSectionProps) => {
   const { translate } = useInternationalization()
@@ -216,7 +213,6 @@ export const UsageChargesSection = ({
         disabled={isEdition && !canBeEdited}
         isEdition={isEdition}
         isInSubscriptionForm={isInSubscriptionForm}
-        premiumWarningDialogRef={premiumWarningDialogRef}
         subscriptionFormType={subscriptionFormType}
         onSave={handleDrawerSave}
         onDelete={handleChargeDelete}

--- a/src/components/plans/__tests__/UsageChargesSection.test.tsx
+++ b/src/components/plans/__tests__/UsageChargesSection.test.tsx
@@ -1,8 +1,6 @@
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { createRef } from 'react'
 
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { AggregationTypeEnum, ChargeModelEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 import { createMockPlanForm } from '~/test-utils/createMockPlanForm'
@@ -89,8 +87,6 @@ const createMockCharge = (overrides: Partial<LocalUsageChargeInput> = {}): Local
 
 const createForm = (overrides: Partial<PlanFormInput> = {}) => createMockPlanForm(overrides)
 
-const premiumWarningDialogRef = createRef<PremiumWarningDialogRef>()
-
 // --- Tests ---
 
 describe('UsageChargesSection', () => {
@@ -103,13 +99,7 @@ describe('UsageChargesSection', () => {
       it('THEN should render the add usage charge button', () => {
         const form = createForm()
 
-        render(
-          <UsageChargesSection
-            form={form}
-            isEdition={false}
-            premiumWarningDialogRef={premiumWarningDialogRef}
-          />,
-        )
+        render(<UsageChargesSection form={form} isEdition={false} />)
 
         expect(screen.getByTestId(USAGE_CHARGES_ADD_BUTTON_TEST_ID)).toBeInTheDocument()
       })
@@ -117,13 +107,7 @@ describe('UsageChargesSection', () => {
       it('THEN should render the mocked drawer', () => {
         const form = createForm()
 
-        render(
-          <UsageChargesSection
-            form={form}
-            isEdition={false}
-            premiumWarningDialogRef={premiumWarningDialogRef}
-          />,
-        )
+        render(<UsageChargesSection form={form} isEdition={false} />)
 
         expect(screen.getByTestId('usage-charge-drawer-mock')).toBeInTheDocument()
       })
@@ -134,12 +118,7 @@ describe('UsageChargesSection', () => {
         const form = createForm()
 
         const { container } = render(
-          <UsageChargesSection
-            form={form}
-            isEdition={false}
-            isInSubscriptionForm
-            premiumWarningDialogRef={premiumWarningDialogRef}
-          />,
+          <UsageChargesSection form={form} isEdition={false} isInSubscriptionForm />,
         )
 
         expect(screen.queryByTestId(USAGE_CHARGES_ADD_BUTTON_TEST_ID)).not.toBeInTheDocument()
@@ -156,13 +135,7 @@ describe('UsageChargesSection', () => {
       it('THEN should render charge selectors', () => {
         const form = createForm({ charges: [charge] })
 
-        render(
-          <UsageChargesSection
-            form={form}
-            isEdition={false}
-            premiumWarningDialogRef={premiumWarningDialogRef}
-          />,
-        )
+        render(<UsageChargesSection form={form} isEdition={false} />)
 
         expect(screen.getByTestId('usage-charge-selector-0')).toBeInTheDocument()
       })
@@ -182,13 +155,7 @@ describe('UsageChargesSection', () => {
         })
         const form = createForm({ charges: [meteredCharge, recurringCharge] })
 
-        render(
-          <UsageChargesSection
-            form={form}
-            isEdition={false}
-            premiumWarningDialogRef={premiumWarningDialogRef}
-          />,
-        )
+        render(<UsageChargesSection form={form} isEdition={false} />)
 
         expect(screen.getByTestId('usage-charge-selector-0')).toBeInTheDocument()
         expect(screen.getByTestId('usage-charge-selector-1')).toBeInTheDocument()
@@ -202,13 +169,7 @@ describe('UsageChargesSection', () => {
         const user = userEvent.setup()
         const form = createForm()
 
-        render(
-          <UsageChargesSection
-            form={form}
-            isEdition={false}
-            premiumWarningDialogRef={premiumWarningDialogRef}
-          />,
-        )
+        render(<UsageChargesSection form={form} isEdition={false} />)
 
         await user.click(screen.getByTestId(USAGE_CHARGES_ADD_BUTTON_TEST_ID))
 
@@ -225,13 +186,7 @@ describe('UsageChargesSection', () => {
         const charge = createMockCharge()
         const form = createForm({ charges: [charge] })
 
-        render(
-          <UsageChargesSection
-            form={form}
-            isEdition={false}
-            premiumWarningDialogRef={premiumWarningDialogRef}
-          />,
-        )
+        render(<UsageChargesSection form={form} isEdition={false} />)
 
         await user.click(screen.getByTestId('usage-charge-selector-0'))
 

--- a/src/components/plans/drawers/usageCharge/UsageChargeDrawer.tsx
+++ b/src/components/plans/drawers/usageCharge/UsageChargeDrawer.tsx
@@ -13,7 +13,6 @@ import {
   LocalPricingUnitType,
   LocalUsageChargeInput,
 } from '~/components/plans/types'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { PlanFormProvider, usePlanFormContext } from '~/contexts/PlanFormContext'
 import { useDuplicatePlanVar } from '~/core/apolloClient'
 import {
@@ -216,7 +215,6 @@ interface UsageChargeDrawerProps {
   disabled?: boolean
   isEdition?: boolean
   isInSubscriptionForm?: boolean
-  premiumWarningDialogRef?: React.RefObject<PremiumWarningDialogRef>
   subscriptionFormType?: keyof typeof FORM_TYPE_ENUM
   onSave: (
     charge: LocalUsageChargeInput,
@@ -237,7 +235,6 @@ export const UsageChargeDrawer = forwardRef<UsageChargeDrawerRef, UsageChargeDra
       disabled,
       isEdition,
       isInSubscriptionForm,
-      premiumWarningDialogRef,
       subscriptionFormType,
       onSave,
       onDelete,
@@ -333,7 +330,6 @@ export const UsageChargeDrawer = forwardRef<UsageChargeDrawerRef, UsageChargeDra
               isEdition={isEdition}
               disabled={disabled}
               isInSubscriptionForm={isInSubscriptionForm}
-              premiumWarningDialogRef={premiumWarningDialogRef}
               subscriptionFormType={subscriptionFormType}
               amountCurrency={amountCurrency}
               editIndex={editIndexRef.current}

--- a/src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx
+++ b/src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx
@@ -1,11 +1,12 @@
 import { revalidateLogic, useStore } from '@tanstack/react-form'
-import { RefObject, useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { z } from 'zod'
 
 import { Button } from '~/components/designSystem/Button'
 import { Card } from '~/components/designSystem/Card'
 import { Selector, SelectorActions } from '~/components/designSystem/Selector'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { DRAWER_TRANSITION_DURATION } from '~/components/drawers/const'
 import { useDrawer } from '~/components/drawers/useDrawer'
 import { ComboboxItem, JsonEditor } from '~/components/form'
@@ -26,7 +27,6 @@ import {
   LocalUsageChargeInput,
 } from '~/components/plans/types'
 import { mapChargeIntervalCopy } from '~/components/plans/utils'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { TaxesSelectorSection } from '~/components/taxes/TaxesSelectorSection'
 import { ChargeFilterDrawerProvider } from '~/contexts/ChargeFilterDrawerContext'
 import {
@@ -64,7 +64,6 @@ interface UsageChargeDrawerContentExtraProps {
   isEdition?: boolean
   disabled?: boolean
   isInSubscriptionForm?: boolean
-  premiumWarningDialogRef?: RefObject<PremiumWarningDialogRef>
   subscriptionFormType?: keyof typeof FORM_TYPE_ENUM
   amountCurrency?: string
   editIndex: number
@@ -79,7 +78,6 @@ const usageChargeDrawerContentDefaultProps: UsageChargeDrawerContentExtraProps =
   isEdition: false,
   disabled: false,
   isInSubscriptionForm: false,
-  premiumWarningDialogRef: undefined,
   subscriptionFormType: undefined,
   amountCurrency: undefined,
   editIndex: -1,
@@ -98,7 +96,6 @@ export const UsageChargeDrawerContent = withForm({
     isEdition,
     disabled,
     isInSubscriptionForm,
-    premiumWarningDialogRef,
     subscriptionFormType,
     amountCurrency,
     editIndex,
@@ -108,6 +105,7 @@ export const UsageChargeDrawerContent = withForm({
     interval,
   }) {
     const { translate } = useInternationalization()
+    const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
     const { isPremium } = useCurrentUser()
     const { hasAnyPricingUnitConfigured } = useCustomPricingUnits()
 
@@ -243,7 +241,7 @@ export const UsageChargeDrawerContent = withForm({
 
           // Check premium gating for graduated percentage
           if (!isPremium && value === ChargeModelEnum.GraduatedPercentage) {
-            premiumWarningDialogRef?.current?.openDialog()
+            openPremiumWarningDialog()
             return
           }
 
@@ -269,7 +267,7 @@ export const UsageChargeDrawerContent = withForm({
           value as UsageChargeDrawerFormValues[keyof UsageChargeDrawerFormValues],
         )
       },
-      [form, isPremium, premiumWarningDialogRef],
+      [form, isPremium, openPremiumWarningDialog],
     )
 
     const handleFormSubmit = (event: React.FormEvent) => {
@@ -723,7 +721,7 @@ export const UsageChargeDrawerContent = withForm({
                   <ChargeInvoicingStrategyOption
                     localCharge={formValues as unknown as LocalUsageChargeInput}
                     disabled={isInSubscriptionForm || isExistingChargeDisabled}
-                    openPremiumDialog={() => premiumWarningDialogRef?.current?.openDialog()}
+                    openPremiumDialog={() => openPremiumWarningDialog()}
                     handleUpdate={({ regroupPaidFees, invoiceable }) => {
                       form.setFieldValue('regroupPaidFees', regroupPaidFees)
                       form.setFieldValue('invoiceable', invoiceable)

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -20,7 +20,6 @@ import { ProgressiveBillingSection } from '~/components/plans/ProgressiveBilling
 import { SubscriptionFeeSection } from '~/components/plans/SubscriptionFeeSection'
 import { LocalUsageChargeInput } from '~/components/plans/types'
 import { UsageChargesSection } from '~/components/plans/UsageChargesSection'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE } from '~/components/subscriptions/SubscriptionUsageLifetimeGraph'
 import { PlanFormProvider } from '~/contexts/PlanFormContext'
 import { useDuplicatePlanVar } from '~/core/apolloClient'
@@ -150,7 +149,6 @@ const CreatePlan = () => {
   const { translate } = useInternationalization()
   const { type: actionType } = useDuplicatePlanVar()
   const [searchParams] = useSearchParams()
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
   const { form, isEdition, loading, plan, type } = usePlanForm({})
   const warningDialogRef = useRef<WarningDialogRef>(null)
   const { openCascadeDialog } = useCascadeFormDialog()
@@ -294,7 +292,6 @@ const CreatePlan = () => {
                       form={form}
                       canBeEdited={canBeEdited}
                       isEdition={isEdition}
-                      premiumWarningDialogRef={premiumWarningDialogRef}
                       alreadyExistingCharges={plan?.charges as LocalUsageChargeInput[]}
                     />
                   </CenteredPage.SubsectionWrapper>
@@ -358,7 +355,6 @@ const CreatePlan = () => {
         onContinue={() => planCloseRedirection()}
       />
       <EditInvoiceDisplayNameDialog ref={editInvoiceDisplayNameDialogRef} />
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </PlanFormProvider>
   )
 }

--- a/src/pages/__tests__/CreatePlan.test.tsx
+++ b/src/pages/__tests__/CreatePlan.test.tsx
@@ -174,20 +174,6 @@ jest.mock('~/components/invoices/EditInvoiceDisplayNameDialog', () => {
   return { EditInvoiceDisplayNameDialog: MockDialog }
 })
 
-jest.mock('~/components/PremiumWarningDialog', () => {
-  const React = jest.requireActual('react')
-
-  const MockDialog = React.forwardRef((_props: unknown, ref: unknown) => {
-    React.useImperativeHandle(ref, () => ({ openDialog: jest.fn() }))
-
-    return React.createElement('div', { 'data-test': 'premium-warning-dialog-mock' })
-  })
-
-  MockDialog.displayName = 'PremiumWarningDialog'
-
-  return { PremiumWarningDialog: MockDialog }
-})
-
 jest.mock('~/styles/mainObjectsForm', () => {
   const React = jest.requireActual('react')
 

--- a/src/pages/subscriptions/CreateSubscription.tsx
+++ b/src/pages/subscriptions/CreateSubscription.tsx
@@ -29,7 +29,6 @@ import { SubscriptionFeeSection } from '~/components/plans/SubscriptionFeeSectio
 import { LocalUsageChargeInput } from '~/components/plans/types'
 import { UsageChargesSection } from '~/components/plans/UsageChargesSection'
 import PremiumFeature from '~/components/premium/PremiumFeature'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { FeatureEntitlementSection } from '~/components/subscriptions/FeatureEntitlementSection'
 import { buildSubscriptionDefaultValues } from '~/components/subscriptions/form/buildSubscriptionDefaultValues'
 import { SubscriptionInformationFormSection } from '~/components/subscriptions/form/SubscriptionInformationFormSection'
@@ -146,7 +145,6 @@ const CreateSubscription = () => {
 
   const editInvoiceDisplayNameDialogRef = useRef<EditInvoiceDisplayNameDialogRef>(null)
   const warningDialogRef = useRef<WarningDialogRef>(null)
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
   const [showCurrencyError, setShowCurrencyError] = useState<boolean>(false)
   const hasAccessToMultiPaymentFlow = hasFeatureFlag(FeatureFlagEnum.MultiplePaymentMethods)
 
@@ -607,7 +605,6 @@ const CreateSubscription = () => {
                                   form={planForm}
                                   isEdition={formType === FORM_TYPE_ENUM.edition}
                                   isInSubscriptionForm={isInSubscriptionForm}
-                                  premiumWarningDialogRef={premiumWarningDialogRef}
                                   subscriptionFormType={formType}
                                 />
                               </CenteredPage.SubsectionWrapper>
@@ -658,7 +655,6 @@ const CreateSubscription = () => {
       />
 
       <EditInvoiceDisplayNameDialog ref={editInvoiceDisplayNameDialogRef} />
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </>
   )
 }

--- a/src/pages/subscriptions/__tests__/CreateSubscription.test.tsx
+++ b/src/pages/subscriptions/__tests__/CreateSubscription.test.tsx
@@ -281,10 +281,6 @@ jest.mock('~/components/subscriptions/FeatureEntitlementSection', () => ({
   FeatureEntitlementSection: () => <div data-test="feature-entitlement-section" />,
 }))
 
-jest.mock('~/components/PremiumWarningDialog', () => ({
-  PremiumWarningDialog: () => <div data-test="premium-warning-dialog" />,
-}))
-
 jest.mock('~/components/invoices/EditInvoiceDisplayNameDialog', () => ({
   EditInvoiceDisplayNameDialog: () => <div data-test="edit-invoice-display-name-dialog" />,
 }))


### PR DESCRIPTION
## Summary

Migrates the deprecated ref-based `PremiumWarningDialog` usage that flowed through the `UsageChargesSection` chain to the new hook-based `usePremiumWarningDialog` system in `~/components/dialogs`.

The dialog ref was being created in `CreatePlan` and `CreateSubscription`, then forwarded through `UsageChargesSection` → `UsageChargeDrawer` → `UsageChargeDrawerContent` only to be opened at the leaf. The entire prop drilling chain is replaced by calling the hook directly inside `UsageChargeDrawerContent`, the actual consumer.

### Changes

- `UsageChargeDrawerContent.tsx`: import and call `usePremiumWarningDialog()`; drop `premiumWarningDialogRef` prop, `RefObject` import and `PremiumWarningDialogRef` import.
- `UsageChargeDrawer.tsx` / `UsageChargesSection.tsx`: remove `premiumWarningDialogRef` prop and stop forwarding it.
- `CreatePlan.tsx` / `CreateSubscription.tsx`: drop the local `useRef<PremiumWarningDialogRef>`, the `<PremiumWarningDialog ref={...} />` instance and the now-unused imports.
- Tests updated to match the new prop shape; the now-unnecessary `~/components/PremiumWarningDialog` jest mocks were removed from `CreatePlan.test.tsx` and `CreateSubscription.test.tsx`.

### Scope

Strictly the `PremiumWarningDialog` migration — other deprecated dialogs in the same files (`RemoveChargeWarningDialog`, `WarningDialog`, `EditInvoiceDisplayNameDialog`) are out of scope.

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm code:style` shows 0 errors (remaining warnings are unrelated deprecated dialogs)
- [x] `UsageChargesSection`, `CreatePlan` and `CreateSubscription` jest suites pass
- [ ] Manual: open create-plan, switch charge model to graduated percentage as a non-premium user → premium dialog appears
- [ ] Manual: open create-plan, toggle pay-in-advance → invoice-strategy upsell opens the premium dialog
- [ ] Manual: same flows from a subscription edit context

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzAjyuyCwPiwhKFXjATNA6)_