### PR TITLE
refactor(wallet): migrate CreateWallet PremiumWarningDialog to new dialog system

### DIFF
--- a/src/pages/wallet/CreateWallet.tsx
+++ b/src/pages/wallet/CreateWallet.tsx
@@ -10,7 +10,6 @@ import { WarningDialog, WarningDialogRef } from '~/components/designSystem/Warni
 import { InvoiceCustomSectionInput } from '~/components/invoceCustomFooter/types'
 import { toInvoiceCustomSectionReference } from '~/components/invoceCustomFooter/utils'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import {
   CLOSE_CREATE_WALLET_BUTTON_DATA_TEST,
   SUBMIT_WALLET_DATA_TEST,
@@ -160,7 +159,6 @@ const CreateWallet = () => {
   const { organization } = useOrganizationInfos()
 
   const warningDialogRef = useRef<WarningDialogRef>(null)
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
   const formType = useMemo(() => {
     if (!!walletId) return FORM_TYPE_ENUM.edition
 
@@ -501,7 +499,6 @@ const CreateWallet = () => {
               customerData={customerData}
               isRecurringTopUpEnabled={isRecurringTopUpEnabled}
               setIsRecurringTopUpEnabled={setIsRecurringTopUpEnabled}
-              premiumWarningDialogRef={premiumWarningDialogRef}
             />
           </CenteredPage.Container>
         )}
@@ -532,8 +529,6 @@ const CreateWallet = () => {
         continueText={translate('text_645388d5bdbd7b00abffa033')}
         onContinue={() => navigateToCustomerWalletTab(wallet?.id)}
       />
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </>
   )
 }

--- a/src/pages/wallet/components/TopUpSection.tsx
+++ b/src/pages/wallet/components/TopUpSection.tsx
@@ -5,13 +5,14 @@ import { FormikProps, getIn } from 'formik'
 import { Icon } from 'lago-design-system'
 import { get } from 'lodash'
 import { DateTime } from 'luxon'
-import { FC, RefObject, useMemo, useState } from 'react'
+import { FC, useMemo, useState } from 'react'
 
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Alert } from '~/components/designSystem/Alert'
 import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import {
   AmountInputField,
   ComboBox,
@@ -22,7 +23,6 @@ import {
 } from '~/components/form'
 import { PaymentMethodsInvoiceSettings } from '~/components/paymentMethodsInvoiceSettings/PaymentMethodsInvoiceSettings'
 import { ViewTypeEnum } from '~/components/paymentMethodsInvoiceSettings/types'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { getWordingForWalletCreationAlert } from '~/components/wallets/utils'
 import {
   ADD_METADATA_DATA_TEST,
@@ -110,7 +110,6 @@ interface TopUpSectionProps {
   customerData?: GetCustomerInfosForWalletFormQuery
   isRecurringTopUpEnabled: boolean
   setIsRecurringTopUpEnabled: (value: boolean) => void
-  premiumWarningDialogRef: RefObject<PremiumWarningDialogRef>
 }
 
 export const TopUpSection: FC<TopUpSectionProps> = ({
@@ -118,10 +117,10 @@ export const TopUpSection: FC<TopUpSectionProps> = ({
   customerData,
   isRecurringTopUpEnabled,
   setIsRecurringTopUpEnabled,
-  premiumWarningDialogRef,
 }) => {
   const { isPremium } = useCurrentUser()
   const { translate } = useInternationalization()
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const [accordionIsOpen, setAccordionIsOpen] = useState(false)
 
   const recurringTransactionRules = formikProps.values?.recurringTransactionRules?.[0]
@@ -191,7 +190,7 @@ export const TopUpSection: FC<TopUpSectionProps> = ({
                   setIsRecurringTopUpEnabled(true)
                   setAccordionIsOpen(true)
                 } else {
-                  premiumWarningDialogRef.current?.openDialog()
+                  openPremiumWarningDialog()
                 }
               }}
             >


### PR DESCRIPTION
## Summary

- Replaced the legacy ref-based `PremiumWarningDialog` usage in `CreateWallet.tsx` with the new hook-based `usePremiumWarningDialog` (from `~/components/dialogs/PremiumWarningDialog`)
- The hook is now called directly inside `TopUpSection.tsx` (the only consumer of the dialog), removing the ref prop drilling
- Scope intentionally kept to the `PremiumWarningDialog` only — the existing `WarningDialog` ref and Formik usage in the same files are out of scope

## Changes

- `src/pages/wallet/CreateWallet.tsx`: removed the `PremiumWarningDialog` import, its `useRef<PremiumWarningDialogRef>`, the JSX rendering, and the `premiumWarningDialogRef` prop passed to `TopUpSection`
- `src/pages/wallet/components/TopUpSection.tsx`: dropped the `premiumWarningDialogRef` prop, added `usePremiumWarningDialog()` hook usage, swapped `premiumWarningDialogRef.current?.openDialog()` for `openPremiumWarningDialog()`

## Test plan

- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm eslint` no new warnings (total warnings down from 505 → 503, the two removed warnings correspond exactly to the legacy `PremiumWarningDialog` imports in the two edited files)
- [ ] Manually verify on the wallet create form that clicking the "Add recurring top-up" button while on a non-premium plan still opens the premium warning dialog


---
_Generated by [Claude Code](https://claude.ai/code/session_01LYTiQxj686P6vt6vqnHD3R)_