### PR TITLE
fix(api-key): rotation

### DIFF
--- a/src/components/developers/apiKeys/RotateApiKeyDialog.tsx
+++ b/src/components/developers/apiKeys/RotateApiKeyDialog.tsx
@@ -22,6 +22,8 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 
+export const ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID = 'rotate-api-key-submit-button'
+
 const ExpirationValuesEnum = {
   Now: 'Now',
   OneHour: 'OneHour',
@@ -157,6 +159,7 @@ export const RotateApiKeyDialog = forwardRef<
           <Button
             danger
             variant="primary"
+            data-test={ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID}
             onClick={async () => {
               await formikProps.submitForm()
             }}

--- a/src/components/developers/apiKeys/RotateApiKeyDialog.tsx
+++ b/src/components/developers/apiKeys/RotateApiKeyDialog.tsx
@@ -86,7 +86,7 @@ export const RotateApiKeyDialog = forwardRef<
     enableReinitialize: true,
     onSubmit: async ({ expiresAt }) => {
       const ExpirationValuesAsTime = {
-        Now: DateTime.now().toUTC().toISO(),
+        Now: null,
         OneHour: DateTime.now().toUTC().plus({ hours: 1 }).toISO(),
         OneDay: DateTime.now().toUTC().plus({ days: 1 }).toISO(),
         TwoDays: DateTime.now().toUTC().plus({ days: 2 }).toISO(),

--- a/src/components/developers/apiKeys/__tests__/RotateApiKeyDialog.test.tsx
+++ b/src/components/developers/apiKeys/__tests__/RotateApiKeyDialog.test.tsx
@@ -1,0 +1,118 @@
+import { act, cleanup, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createRef } from 'react'
+
+import {
+  ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID,
+  RotateApiKeyDialog,
+  RotateApiKeyDialogRef,
+} from '~/components/developers/apiKeys/RotateApiKeyDialog'
+import { ApiKeyForRotateApiKeyDialogFragment } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+const mockRotate = jest.fn()
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ isPremium: true }),
+}))
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useRotateApiKeyMutation: () => [mockRotate],
+}))
+
+const apiKey: ApiKeyForRotateApiKeyDialogFragment = {
+  __typename: 'SanitizedApiKey',
+  id: 'api-key-1',
+  name: 'My API Key',
+  lastUsedAt: null,
+}
+
+async function prepare() {
+  const ref = createRef<RotateApiKeyDialogRef>()
+
+  await act(() => render(<RotateApiKeyDialog ref={ref} openPremiumDialog={jest.fn()} />))
+
+  await act(() => {
+    ref.current?.openDialog({ apiKey, callBack: jest.fn() })
+  })
+
+  await waitFor(() => {
+    expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
+  })
+
+  return { ref }
+}
+
+describe('RotateApiKeyDialog', () => {
+  afterEach(() => {
+    cleanup()
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN the "Now" (immediate) expiration option', () => {
+    describe('WHEN the user submits the form', () => {
+      it('THEN it rotates the key with a null expiresAt', async () => {
+        const user = userEvent.setup()
+
+        await prepare()
+
+        // "Now" is the default selected option, no need to click any radio.
+        await act(async () => {
+          await user.click(screen.getByTestId(ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID))
+        })
+
+        await waitFor(() => {
+          expect(mockRotate).toHaveBeenCalledWith({
+            variables: {
+              input: {
+                id: 'api-key-1',
+                expiresAt: null,
+                name: 'My API Key',
+              },
+            },
+          })
+        })
+      })
+    })
+  })
+
+  describe('GIVEN a future expiration option (One week)', () => {
+    describe('WHEN the user submits the form', () => {
+      it('THEN it rotates the key with a non-null ISO expiresAt', async () => {
+        const user = userEvent.setup()
+
+        await prepare()
+
+        const oneWeekRadio = screen
+          .getAllByRole('radio')
+          .find((radio) => radio.getAttribute('value') === 'OneWeek')
+
+        expect(oneWeekRadio).toBeDefined()
+
+        await act(async () => {
+          await user.click(oneWeekRadio as HTMLElement)
+        })
+
+        await act(async () => {
+          await user.click(screen.getByTestId(ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID))
+        })
+
+        await waitFor(() => {
+          expect(mockRotate).toHaveBeenCalledTimes(1)
+        })
+
+        const submittedExpiresAt = mockRotate.mock.calls[0][0].variables.input.expiresAt
+
+        expect(submittedExpiresAt).not.toBeNull()
+        expect(typeof submittedExpiresAt).toBe('string')
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Context
When rotating an API key with the **"Now"** (immediate) option, the front was sending `expiresAt` set to the current timestamp instead of `null`.

On the API side (`ApiKeys::RotateService`), any **present** `expires_at` is treated as a premium-only feature (scheduling a future expiration):
```ruby
if params[:expires_at].present? && !License.premium?
 return result.forbidden_failure!(code: "cannot_rotate_with_provided_date")
end
expires_at = params[:expires_at] || Time.current
```

## Description
- Map the Now expiration option to null instead of the current timestamp, so the mutation sends expiresAt: null. The API then falls back to Time.current (immediate rotation) and no longer blocks non-premium users.
- Add tests for RotateApiKeyDialog:
  - non-premium user + "Now" → expiresAt: null 
  - premium user + a future option ("One week") → non-null ISO expiresAt

Fixes [lago #697](https://github.com/getlago/lago/issues/697)