### PR TITLE
refactor(invoices): migrate CustomerInvoiceDetails PremiumWarningDialog to new dialog system

### DIFF
--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -7,6 +7,7 @@ import { createCreditNoteForInvoiceButtonProps } from '~/components/creditNote/u
 import { Alert } from '~/components/designSystem/Alert'
 import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { buildInvoiceDocumentData } from '~/components/emails/buildDocumentData'
 import { AddMetadataDrawer, AddMetadataDrawerRef } from '~/components/invoices/AddMetadataDrawer'
 import {
@@ -28,7 +29,6 @@ import { VoidInvoiceDialog, VoidInvoiceDialogRef } from '~/components/invoices/V
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { useMainHeaderTabContent } from '~/components/MainHeader/useMainHeaderTabContent'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { addToast, LagoGQLError } from '~/core/apolloClient'
 import { invoiceStatusMapping, paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
 import {
@@ -302,7 +302,7 @@ const CustomerInvoiceDetails = () => {
   const { isPremium } = useCurrentUser()
   const { hasPermissions } = usePermissions()
   const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const updateInvoicePaymentStatusDialog = useRef<UpdateInvoicePaymentStatusDialogRef>(null)
   const addMetadataDrawerDialogRef = useRef<AddMetadataDrawerRef>(null)
   const voidInvoiceDialogRef = useRef<VoidInvoiceDialogRef>(null)
@@ -832,7 +832,7 @@ const CustomerInvoiceDetails = () => {
                 }),
               )
             } else {
-              premiumWarningDialogRef.current?.openDialog()
+              openPremiumWarningDialog()
             }
             closePopper()
           },
@@ -849,7 +849,7 @@ const CustomerInvoiceDetails = () => {
                 }),
               )
             } else {
-              premiumWarningDialogRef.current?.openDialog()
+              openPremiumWarningDialog()
             }
             closePopper()
           },
@@ -1017,7 +1017,6 @@ const CustomerInvoiceDetails = () => {
       )}
 
       <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
       <UpdateInvoicePaymentStatusDialog ref={updateInvoicePaymentStatusDialog} />
       <VoidInvoiceDialog ref={voidInvoiceDialogRef} />
       <DisputeInvoiceDialog ref={disputeInvoiceDialogRef} />

--- a/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
+++ b/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
@@ -250,8 +250,8 @@ jest.mock('~/components/invoices/AddMetadataDrawer', () => ({
   AddMetadataDrawer: () => null,
 }))
 
-jest.mock('~/components/PremiumWarningDialog', () => ({
-  PremiumWarningDialog: () => null,
+jest.mock('~/components/dialogs/PremiumWarningDialog', () => ({
+  usePremiumWarningDialog: () => ({ open: jest.fn(), close: jest.fn() }),
 }))
 
 jest.mock('~/components/invoices/InvoiceCreditNoteList', () => ({


### PR DESCRIPTION
## Summary

Migrates the `PremiumWarningDialog` usage inside `src/pages/CustomerInvoiceDetails.tsx` from the deprecated imperative ref-based dialog system to the new hook-based NiceModal dialog system. This clears one of the `no-restricted-imports` ESLint warnings flagged for the legacy `~/components/PremiumWarningDialog` import.

## Changes

- `src/pages/CustomerInvoiceDetails.tsx`
  - Replaced `import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'` with `import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'`.
  - Dropped the `premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)` and the `<PremiumWarningDialog ref={...} />` JSX render — the new system mounts the dialog via NiceModal.
  - Pulled the open function from the hook: `const { open: openPremiumWarningDialog } = usePremiumWarningDialog()`.
  - Updated the two non-premium dropdown actions ("Issue credit note" and "Record payment") to call `openPremiumWarningDialog()` instead of `premiumWarningDialogRef.current?.openDialog()`.

- `src/pages/__tests__/CustomerInvoiceDetails.test.tsx`
  - Updated the Jest mock from the legacy module to the new one (`~/components/dialogs/PremiumWarningDialog` → `usePremiumWarningDialog: () => ({ open: jest.fn(), close: jest.fn() })`), matching the pattern used in other tests in the codebase.

## Scope

Per the migration routine, the scope is intentionally limited to the `PremiumWarningDialog` warning. The file still imports a handful of other legacy dialogs (`DisputeInvoiceDialog`, `EditInvoicePaymentStatusDialog`, `FinalizeInvoiceDialog`, `VoidInvoiceDialog`); those are full `forwardRef` dialogs with their own data flows and are out of scope here.

## Test plan

- [x] `pnpm tsc --noEmit` — passes with no errors.
- [x] `pnpm eslint src/pages/CustomerInvoiceDetails.tsx` — the `PremiumWarningDialog` import warning is gone; remaining warnings are for other legacy dialogs in the same file (intentionally out of scope).
- [x] `pnpm jest src/pages/__tests__/CustomerInvoiceDetails.test.tsx` — 41/41 tests pass.
- [ ] Manual smoke: as a non-premium user on a customer invoice detail page, click "Issue credit note" and "Record payment" from the actions dropdown and confirm the premium upsell dialog opens.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnTs7AMv4JyZw1xwKtn763)_