### PR TITLE
bug(wallet): Refresh wallet balance after top-up

### DIFF
--- a/src/components/MainHeader/types.ts
+++ b/src/components/MainHeader/types.ts
@@ -124,4 +124,12 @@ export interface MainHeaderConfig {
 
   /** Filter — pages include their own providers */
   filtersSection?: ReactNode
+
+  /**
+   * Serializable value included in the config snapshot. The snapshot strips the tabs'
+   * `content` ReactNode (to avoid re-render loops), so pages whose content reflects
+   * mutable data must bump this key when that data changes, otherwise the header keeps
+   * showing stale content (e.g. a wallet balance after a top-up/void).
+   */
+  snapshotKey?: string | number | boolean
 }

--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -368,6 +368,13 @@ export const Table = <T extends DataItem>({
   const handleRowClick = (e: MouseEvent<HTMLTableRowElement>, item: T) => {
     if (!onRowActionLink && !onRowActionClick) return
 
+    // Ignore clicks bubbling up from portaled content (dialogs, poppers) rendered
+    // inside a cell: they are React descendants of the row but live outside its DOM
+    // subtree, so they would otherwise trigger the row navigation.
+    if (e.target instanceof Node && !e.currentTarget.contains(e.target)) {
+      return
+    }
+
     // Prevent row action when clicking on button or link in cell
     if (e.target instanceof HTMLAnchorElement || e.target instanceof HTMLButtonElement) {
       return

--- a/src/components/wallets/VoidWalletDialog.tsx
+++ b/src/components/wallets/VoidWalletDialog.tsx
@@ -16,14 +16,6 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { WalletDetailsTabsOptionsEnum } from '~/pages/wallet/WalletDetails'
 
 gql`
-  mutation createCustomerWalletTransaction($input: CreateCustomerWalletTransactionInput!) {
-    createCustomerWalletTransaction(input: $input) {
-      collection {
-        id
-      }
-    }
-  }
-
   fragment WalletForVoidTransaction on Wallet {
     id
     currency

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -4483,6 +4483,7 @@ export enum IntegrationTypeEnum {
   ProjectedUsage = 'projected_usage',
   RemoveBrandingWatermark = 'remove_branding_watermark',
   RevenueAnalytics = 'revenue_analytics',
+  RevenueRecognition = 'revenue_recognition',
   RevenueShare = 'revenue_share',
   Salesforce = 'salesforce',
   SecurityLogs = 'security_logs',
@@ -6971,6 +6972,7 @@ export enum PremiumIntegrationTypeEnum {
   ProjectedUsage = 'projected_usage',
   RemoveBrandingWatermark = 'remove_branding_watermark',
   RevenueAnalytics = 'revenue_analytics',
+  RevenueRecognition = 'revenue_recognition',
   RevenueShare = 'revenue_share',
   Salesforce = 'salesforce',
   SecurityLogs = 'security_logs',
@@ -12712,13 +12714,6 @@ export type TerminateCustomerWalletMutationVariables = Exact<{
 
 export type TerminateCustomerWalletMutation = { __typename?: 'Mutation', terminateCustomerWallet?: { __typename?: 'Wallet', id: string, status: WalletStatusEnum, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, expirationAt?: any | null, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, name?: string | null, rateAmount: number, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, priority: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean, customer?: { __typename?: 'Customer', id: string, hasActiveWallet: boolean } | null } | null };
 
-export type CreateCustomerWalletTransactionMutationVariables = Exact<{
-  input: CreateCustomerWalletTransactionInput;
-}>;
-
-
-export type CreateCustomerWalletTransactionMutation = { __typename?: 'Mutation', createCustomerWalletTransaction?: { __typename?: 'WalletTransactionCollection', collection: Array<{ __typename?: 'WalletTransaction', id: string }> } | null };
-
 export type WalletForVoidTransactionFragment = { __typename?: 'Wallet', id: string, currency: CurrencyEnum, rateAmount: number, creditsBalance: number };
 
 export type GetWalletAlertsQueryVariables = Exact<{
@@ -15457,6 +15452,13 @@ export type GetWalletForTopUpQueryVariables = Exact<{
 
 
 export type GetWalletForTopUpQuery = { __typename?: 'Query', wallet?: { __typename?: 'Wallet', id: string, name?: string | null, currency: CurrencyEnum, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, paidTopUpMinAmountCents?: any | null, paidTopUpMaxAmountCents?: any | null, priority: number } | null };
+
+export type CreateCustomerWalletTransactionMutationVariables = Exact<{
+  input: CreateCustomerWalletTransactionInput;
+}>;
+
+
+export type CreateCustomerWalletTransactionMutation = { __typename?: 'Mutation', createCustomerWalletTransaction?: { __typename?: 'WalletTransactionCollection', collection: Array<{ __typename?: 'WalletTransaction', id: string, wallet?: { __typename?: 'Wallet', id: string, code?: string | null, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, expirationAt?: any | null, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, name?: string | null, rateAmount: number, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, priority: number, paidTopUpMinAmountCents?: any | null, paidTopUpMinCredits?: any | null, paidTopUpMaxAmountCents?: any | null, paymentMethodType?: PaymentMethodTypeEnum | null, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean, paymentMethod?: { __typename?: 'PaymentMethod', details?: { __typename?: 'PaymentMethodDetails', type?: string | null, brand?: string | null, last4?: string | null } | null } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, name: string, code: string }> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', method: RecurringTransactionMethodEnum, transactionName?: string | null, paidCredits: string, grantedCredits: string, trigger: RecurringTransactionTriggerEnum, thresholdCredits?: string | null, expirationAt?: any | null, interval?: RecurringTransactionIntervalEnum | null }> | null } | null }> } | null };
 
 export type WalletForTopUpFragment = { __typename?: 'Wallet', id: string, name?: string | null, currency: CurrencyEnum, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, paidTopUpMinAmountCents?: any | null, paidTopUpMaxAmountCents?: any | null, priority: number };
 
@@ -30844,41 +30846,6 @@ export function useTerminateCustomerWalletMutation(baseOptions?: Apollo.Mutation
 export type TerminateCustomerWalletMutationHookResult = ReturnType<typeof useTerminateCustomerWalletMutation>;
 export type TerminateCustomerWalletMutationResult = Apollo.MutationResult<TerminateCustomerWalletMutation>;
 export type TerminateCustomerWalletMutationOptions = Apollo.BaseMutationOptions<TerminateCustomerWalletMutation, TerminateCustomerWalletMutationVariables>;
-export const CreateCustomerWalletTransactionDocument = gql`
-    mutation createCustomerWalletTransaction($input: CreateCustomerWalletTransactionInput!) {
-  createCustomerWalletTransaction(input: $input) {
-    collection {
-      id
-    }
-  }
-}
-    `;
-export type CreateCustomerWalletTransactionMutationFn = Apollo.MutationFunction<CreateCustomerWalletTransactionMutation, CreateCustomerWalletTransactionMutationVariables>;
-
-/**
- * __useCreateCustomerWalletTransactionMutation__
- *
- * To run a mutation, you first call `useCreateCustomerWalletTransactionMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useCreateCustomerWalletTransactionMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [createCustomerWalletTransactionMutation, { data, loading, error }] = useCreateCustomerWalletTransactionMutation({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useCreateCustomerWalletTransactionMutation(baseOptions?: Apollo.MutationHookOptions<CreateCustomerWalletTransactionMutation, CreateCustomerWalletTransactionMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateCustomerWalletTransactionMutation, CreateCustomerWalletTransactionMutationVariables>(CreateCustomerWalletTransactionDocument, options);
-      }
-export type CreateCustomerWalletTransactionMutationHookResult = ReturnType<typeof useCreateCustomerWalletTransactionMutation>;
-export type CreateCustomerWalletTransactionMutationResult = Apollo.MutationResult<CreateCustomerWalletTransactionMutation>;
-export type CreateCustomerWalletTransactionMutationOptions = Apollo.BaseMutationOptions<CreateCustomerWalletTransactionMutation, CreateCustomerWalletTransactionMutationVariables>;
 export const GetWalletAlertsDocument = gql`
     query getWalletAlerts($walletId: String!) {
   walletAlerts(walletId: $walletId) {
@@ -43209,6 +43176,45 @@ export type GetWalletForTopUpQueryHookResult = ReturnType<typeof useGetWalletFor
 export type GetWalletForTopUpLazyQueryHookResult = ReturnType<typeof useGetWalletForTopUpLazyQuery>;
 export type GetWalletForTopUpSuspenseQueryHookResult = ReturnType<typeof useGetWalletForTopUpSuspenseQuery>;
 export type GetWalletForTopUpQueryResult = Apollo.QueryResult<GetWalletForTopUpQuery, GetWalletForTopUpQueryVariables>;
+export const CreateCustomerWalletTransactionDocument = gql`
+    mutation createCustomerWalletTransaction($input: CreateCustomerWalletTransactionInput!) {
+  createCustomerWalletTransaction(input: $input) {
+    collection {
+      id
+      wallet {
+        id
+        ...WalletDetails
+      }
+    }
+  }
+}
+    ${WalletDetailsFragmentDoc}`;
+export type CreateCustomerWalletTransactionMutationFn = Apollo.MutationFunction<CreateCustomerWalletTransactionMutation, CreateCustomerWalletTransactionMutationVariables>;
+
+/**
+ * __useCreateCustomerWalletTransactionMutation__
+ *
+ * To run a mutation, you first call `useCreateCustomerWalletTransactionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateCustomerWalletTransactionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createCustomerWalletTransactionMutation, { data, loading, error }] = useCreateCustomerWalletTransactionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useCreateCustomerWalletTransactionMutation(baseOptions?: Apollo.MutationHookOptions<CreateCustomerWalletTransactionMutation, CreateCustomerWalletTransactionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateCustomerWalletTransactionMutation, CreateCustomerWalletTransactionMutationVariables>(CreateCustomerWalletTransactionDocument, options);
+      }
+export type CreateCustomerWalletTransactionMutationHookResult = ReturnType<typeof useCreateCustomerWalletTransactionMutation>;
+export type CreateCustomerWalletTransactionMutationResult = Apollo.MutationResult<CreateCustomerWalletTransactionMutation>;
+export type CreateCustomerWalletTransactionMutationOptions = Apollo.BaseMutationOptions<CreateCustomerWalletTransactionMutation, CreateCustomerWalletTransactionMutationVariables>;
 export const GetWalletAlertToEditDocument = gql`
     query getWalletAlertToEdit($id: ID!) {
   walletAlert(id: $id) {

--- a/src/pages/wallet/CreateWalletTopUp.tsx
+++ b/src/pages/wallet/CreateWalletTopUp.tsx
@@ -45,6 +45,7 @@ import {
   useGetInvoiceStatusQuery,
   useGetWalletForTopUpQuery,
   useVoidInvoiceMutation,
+  WalletDetailsFragmentDoc,
   WalletStatusEnum,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -70,6 +71,10 @@ gql`
     createCustomerWalletTransaction(input: $input) {
       collection {
         id
+        wallet {
+          id
+          ...WalletDetails
+        }
       }
     }
   }
@@ -84,6 +89,8 @@ gql`
     paidTopUpMaxAmountCents
     priority
   }
+
+  ${WalletDetailsFragmentDoc}
 `
 
 export const CREATE_ACTIVE_WALLET_TOP_UP_ID = 'active-wallet'

--- a/src/pages/wallet/WalletDetails.tsx
+++ b/src/pages/wallet/WalletDetails.tsx
@@ -156,6 +156,18 @@ const WalletDetails = () => {
     createdAt: intlFormatDateTimeOrgaTZ(wallet?.createdAt).date,
   })
 
+  // The MainHeader config snapshot strips the tabs' `content` ReactNode, so a balance
+  // change alone would not re-push the config and the header would keep stale values.
+  // Bumping this key on balance changes forces the fresh content through (credits fields
+  // are derived from their *Cents counterparts, so the cents alone are enough).
+  const walletSnapshotKey = [
+    wallet?.balanceCents,
+    wallet?.ongoingBalanceCents,
+    wallet?.ongoingUsageBalanceCents,
+    wallet?.consumedAmountCents,
+    wallet?.status,
+  ].join('|')
+
   const tabs = useMemo(() => {
     return [
       {
@@ -309,6 +321,7 @@ const WalletDetails = () => {
         }}
         actions={{ items: headerActions, loading }}
         tabs={tabs}
+        snapshotKey={walletSnapshotKey}
       />
 
       <>{activeTabContent}</>


### PR DESCRIPTION
## Context

After a wallet top-up (notably free/granted credits), the new transaction appeared in the list but the wallet balance and ongoing balance kept showing the old values until a hard browser refresh.

## Description

The `createCustomerWalletTransaction` mutation only returned the transaction id, so the cached `Wallet` entity was never updated. It now returns the updated wallet (`WalletDetails` fragment), letting Apollo normalize the fresh balances into the cache so every view reflects them immediately. Also de-duplicated the mutation that was redundantly declared in `VoidWalletDialog`.

<!-- Linear link -->
Fixes ING-270