### PR TITLE
fix(subs): refresh progressive billing tab on toggle

### DIFF
--- a/src/components/MainHeader/__tests__/MainHeaderConfigure.test.tsx
+++ b/src/components/MainHeader/__tests__/MainHeaderConfigure.test.tsx
@@ -83,6 +83,81 @@ describe('MainHeaderConfigure', () => {
     })
   })
 
+  describe('GIVEN only tab content changes (content is stripped from the snapshot)', () => {
+    const ReadTabContentSpy: FC<{ onContent: (content: unknown) => void }> = ({ onContent }) => {
+      const { config } = useMainHeaderReader()
+
+      onContent(config?.tabs?.[0]?.content)
+
+      return null
+    }
+
+    const makeConfig = (
+      label: string,
+      snapshotKey?: string | number | boolean,
+    ): MainHeaderConfig => ({
+      breadcrumb: [{ label: 'Page', path: '/page' }],
+      tabs: [
+        {
+          title: 'Tab',
+          link: '/page/tab',
+          snapshotKey,
+          content: <span>{label}</span>,
+        },
+      ],
+    })
+
+    describe('WHEN content changes but no snapshotKey is set', () => {
+      it('THEN the stale content is kept (the bug this guards against)', () => {
+        let captured: unknown = null
+
+        const { rerender } = render(
+          <MainHeaderProvider>
+            <MainHeaderConfigure {...makeConfig('OLD')} />
+            <ReadTabContentSpy onContent={(c) => (captured = c)} />
+          </MainHeaderProvider>,
+        )
+
+        expect(captured).toEqual(<span>OLD</span>)
+
+        rerender(
+          <MainHeaderProvider>
+            <MainHeaderConfigure {...makeConfig('NEW')} />
+            <ReadTabContentSpy onContent={(c) => (captured = c)} />
+          </MainHeaderProvider>,
+        )
+
+        // No snapshotKey change → setConfig skipped → context still holds OLD content.
+        expect(captured).toEqual(<span>OLD</span>)
+      })
+    })
+
+    describe('WHEN content changes together with snapshotKey', () => {
+      it('THEN the fresh content is pushed to context', () => {
+        let captured: unknown = null
+
+        const { rerender } = render(
+          <MainHeaderProvider>
+            <MainHeaderConfigure {...makeConfig('OLD', 'a')} />
+            <ReadTabContentSpy onContent={(c) => (captured = c)} />
+          </MainHeaderProvider>,
+        )
+
+        expect(captured).toEqual(<span>OLD</span>)
+
+        rerender(
+          <MainHeaderProvider>
+            <MainHeaderConfigure {...makeConfig('NEW', 'b')} />
+            <ReadTabContentSpy onContent={(c) => (captured = c)} />
+          </MainHeaderProvider>,
+        )
+
+        // snapshotKey changed → setConfig fires → context holds NEW content.
+        expect(captured).toEqual(<span>NEW</span>)
+      })
+    })
+  })
+
   describe('GIVEN the config changes', () => {
     describe('WHEN a new breadcrumb is provided', () => {
       it('THEN should update the context config', () => {

--- a/src/components/MainHeader/types.ts
+++ b/src/components/MainHeader/types.ts
@@ -15,6 +15,13 @@ import { NavigationTabBarItem } from './NavigationTabBar'
  */
 export type MainHeaderTab = NavigationTabBarItem & {
   content: ReactNode
+  /**
+   * Serializable value included in the config snapshot. `content` (ReactNode) is
+   * stripped from the snapshot, so a tab whose content reflects reactive state
+   * (e.g. a toggle the user flips while staying on the page) must encode that
+   * state here, otherwise the stale content stays in context until a full reload.
+   */
+  snapshotKey?: string | number | boolean
 }
 
 // ─── Action types ───────────────────────────────────────────────

--- a/src/pages/subscriptions/SubscriptionDetails.tsx
+++ b/src/pages/subscriptions/SubscriptionDetails.tsx
@@ -178,6 +178,11 @@ const SubscriptionDetails = () => {
             CustomerSubscriptionDetailsTabsOptionsEnum.progressiveBilling,
           ),
         ],
+        // The MainHeader config snapshot strips `content` (ReactNode), so content-only
+        // changes don't re-push to context. This tab's content reflects reactive
+        // subscription state (progressive billing toggle, threshold reset), so encode
+        // those bits in snapshotKey to force a refresh when they change.
+        snapshotKey: `${isSubscriptionLoading}-${!!subscription?.progressiveBillingDisabled}-${subscription?.usageThresholds?.length ?? 0}`,
         content: (
           <DetailsPage.Container>
             <SubscriptionProgressiveBillingTab


### PR DESCRIPTION
Fixes LAGO-1511

## Problem

Enabling/disabling progressive billing on the subscription Progressive billing tab (`switchProgressiveBillingDisabledValue`, and threshold reset) did not refresh the tab. The rule kept showing its previous state until a full page reload.

## Root cause

Not an Apollo cache issue: the mutation normalizes fine and the `getSubscriptionForDetails` query updates. The stale read is in the MainHeader config layer.

`MainHeaderConfigure.configSnapshot()` builds a change-detection fingerprint with `JSON.stringify` and deliberately strips `content` (a ReactNode, not serializable). `setConfig` only fires when that fingerprint changes. The Progressive billing tab's `content` closes over `subscription`, but a toggle changes none of the tab's serializable fields (title/link/match/hidden), so the fingerprint is identical, `setConfig` is skipped, and the context keeps the stale content closure. `useMainHeaderTabContent` then renders that old content.

## Fix

`snapshotKey` is the existing escape hatch for exactly this case (the snapshot replacer keeps it by key name, and `MainHeaderCustomAction` already uses it), but it was typed only on actions, not on tabs.

- `MainHeaderTab`: add `snapshotKey?: string | number | boolean`.
- `SubscriptionDetails`: set `snapshotKey` on the Progressive billing tab, encoding the reactive bits its content depends on (loading, `progressiveBillingDisabled`, threshold count). Toggling/resetting now trips the snapshot, so fresh content is re-pushed to context.

No new machinery: this just exposes the existing actions pattern to tabs, type-safe.

## Changes

- `src/components/MainHeader/types.ts`: `snapshotKey` on `MainHeaderTab` + doc.
- `src/pages/subscriptions/SubscriptionDetails.tsx`: `snapshotKey` on the Progressive billing tab.
- `src/components/MainHeader/__tests__/MainHeaderConfigure.test.tsx`: 2 regression tests (content-only change stays stale without `snapshotKey`; changing `snapshotKey` re-pushes fresh content).

## Note

Any tab whose content reflects reactive parent state that does not alter its serializable fields is exposed to this class of bug; Progressive billing is the observed instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
