### PR TITLE
refactor(api-keys): migrate PremiumWarningDialog to new dialog system

### DIFF
--- a/src/components/developers/apiKeys/ApiKeys.tsx
+++ b/src/components/developers/apiKeys/ApiKeys.tsx
@@ -19,6 +19,7 @@ import {
   RotateApiKeyDialog,
   RotateApiKeyDialogRef,
 } from '~/components/developers/apiKeys/RotateApiKeyDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import {
   SettingsListItem,
   SettingsListItemHeader,
@@ -26,7 +27,6 @@ import {
   SettingsListWrapper,
   SettingsPageHeaderContainer,
 } from '~/components/layouts/Settings'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { addToast } from '~/core/apolloClient'
 import { CREATE_API_KEYS_ROUTE, UPDATE_API_KEYS_ROUTE, useLocation } from '~/core/router'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
@@ -100,7 +100,7 @@ export const ApiKeys = () => {
 
   const rotateApiKeyDialogRef = useRef<RotateApiKeyDialogRef>(null)
   const deleteApiKeyDialogRef = useRef<DeleteApiKeyDialogRef>(null)
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const premiumWarningDialog = usePremiumWarningDialog()
   const [showOrganizationId, setShowOrganizationId] = useState(false)
   const [shownApiKeysMap, setShownApiKeysMap] = useState<Map<string, string>>(new Map())
 
@@ -263,7 +263,7 @@ export const ApiKeys = () => {
                         endIcon={showPremiumAddApiKeyState ? 'sparkles' : undefined}
                         onClick={() => {
                           if (showPremiumAddApiKeyState) {
-                            premiumWarningDialogRef.current?.openDialog()
+                            premiumWarningDialog.open()
                           } else {
                             // Navigate to BrowserRouter route from MemoryRouter without page reload
                             setMainRouterUrl(CREATE_API_KEYS_ROUTE)
@@ -523,10 +523,9 @@ export const ApiKeys = () => {
         </SettingsListWrapper>
       </div>
 
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
       <RotateApiKeyDialog
         ref={rotateApiKeyDialogRef}
-        openPremiumDialog={() => premiumWarningDialogRef.current?.openDialog()}
+        openPremiumDialog={() => premiumWarningDialog.open()}
       />
       <DeleteApiKeyDialog ref={deleteApiKeyDialogRef} />
     </div>


### PR DESCRIPTION
## Summary

Migrates the `PremiumWarningDialog` usage in `src/components/developers/apiKeys/ApiKeys.tsx` from the legacy imperative ref-based system to the new hook-based NiceModal system, removing one occurrence of the `no-restricted-imports` ESLint warning.

## Changes

- Replace `import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'` with `import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'`.
- Replace `useRef<PremiumWarningDialogRef>(null)` with `const premiumWarningDialog = usePremiumWarningDialog()`.
- Swap `premiumWarningDialogRef.current?.openDialog()` for `premiumWarningDialog.open()` (both in the "Add API key" button click handler and in the `openPremiumDialog` prop passed to `RotateApiKeyDialog`).
- Remove the `<PremiumWarningDialog ref={…} />` JSX — the dialog is now rendered globally via NiceModal registration.

## Scope

Scoped strictly to the `PremiumWarningDialog` warning, as requested. The two other deprecated dialogs in this file (`DeleteApiKeyDialog`, `RotateApiKeyDialog`) still use the legacy ref pattern and would each require a non-trivial dialog rewrite (they have not yet been ported to the new system) — left untouched to keep this PR minimal.

## Test plan

- [x] `pnpm exec tsc --noEmit` passes (exit 0).
- [x] `pnpm exec eslint src/components/developers/apiKeys/ApiKeys.tsx` — the PremiumWarningDialog warning is gone (only the two unrelated dialog warnings remain).
- [x] `pnpm jest src/components/developers/apiKeys/__tests__/ApiKeys.test.tsx` — both tests pass.
- [ ] Manual verification: open the developer panel API Keys tab as a non-premium user with at least one existing key, click "Add API key" → the premium warning dialog should open; close it and trigger Rotate → the "Upgrade" CTA inside the rotate dialog should also open the same premium warning dialog.

---
_Generated by [Claude Code](https://claude.ai/code/session_015JNccbzTu6B5P7w25YHSdd)_