### PR TITLE
refactor(CreateCustomer): migrate PremiumWarningDialog to new dialog system

### DIFF
--- a/src/pages/createCustomers/CreateCustomer.tsx
+++ b/src/pages/createCustomers/CreateCustomer.tsx
@@ -6,8 +6,8 @@ import { SUBMIT_CUSTOMER_DATA_TEST } from '~/components/customers/utils/dataTest
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
 import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { extractThirdPartyErrorMessage, hasDefinedGQLError } from '~/core/apolloClient'
 import { scrollToFirstInputError } from '~/core/form/scrollToFirstInputError'
 import { PremiumIntegrationTypeEnum, useGetBillingEntitiesQuery } from '~/generated/graphql'
@@ -34,7 +34,7 @@ const STRIPE_CUSTOMER_ERROR_MESSAGE_DETAILS = 'Stripe: resource_missing'
 const CreateCustomer = () => {
   const { translate } = useInternationalization()
   const warningDialogRef = useRef<WarningDialogRef>(null)
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const { organization: { premiumIntegrations } = {} } = useOrganizationInfos()
   const { getPaymentProvider } = usePaymentProviders()
   const { taxProviders } = useTaxProviders()
@@ -202,7 +202,7 @@ const CreateCustomer = () => {
                   type="button"
                   className="flex items-center justify-between"
                   onClick={() => {
-                    premiumWarningDialogRef.current?.openDialog()
+                    openPremiumWarningDialog()
                   }}
                 >
                   <form.AppField name="isPartner">
@@ -252,8 +252,6 @@ const CreateCustomer = () => {
         continueText={translate('text_645388d5bdbd7b00abffa033')}
         onContinue={onClose}
       />
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </CenteredPage.Wrapper>
   )
 }


### PR DESCRIPTION
## Summary

Migrate the deprecated imperative ref-based `PremiumWarningDialog` usage in `src/pages/createCustomers/CreateCustomer.tsx` to the new hook-based `usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`.

This removes one of the `no-restricted-imports` ESLint warnings about the deprecated dialog system (warning count: 488 → 487).

## Changes

- Replaced the import of `PremiumWarningDialog`/`PremiumWarningDialogRef` from `~/components/PremiumWarningDialog` with `usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`.
- Removed the `useRef<PremiumWarningDialogRef>` ref and the `<PremiumWarningDialog ref={...} />` JSX (the new system renders via NiceModal).
- Switched the trigger from `premiumWarningDialogRef.current?.openDialog()` to `openPremiumWarningDialog()`.

The `WarningDialog` (also deprecated) in the same file was intentionally left untouched to keep this change scoped to the warning dialog originally targeted by the routine.

## Scope

- 1 file changed, 3 insertions, 5 deletions
- No other `PremiumWarningDialog` consumers (5 remaining files) are touched in this PR — they can be migrated independently.

## Test plan

- [x] `pnpm tsc --noEmit` — passes
- [x] `pnpm eslint src/pages/createCustomers/CreateCustomer.tsx` — `PremiumWarningDialog` warning removed
- [x] `pnpm test src/pages/createCustomers/__tests__/CreateCustomer.test.tsx` — 19/19 passing, snapshots match
- [ ] Manual: open the customer creation page on a non-premium org and verify the premium warning dialog still opens when toggling the "partner account" switch

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKWgKpjCCUohscrjcST3qZ)_