### PR TITLE
fix(invoice): Reflect progressive billing credit in regenerate total

### DIFF
--- a/src/components/invoices/details/InvoiceDetailsTableFooter.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableFooter.tsx
@@ -78,11 +78,17 @@ const computeSubtotal = (
     const subTotalIncludingTaxesAmountCents =
       subTotalExcludingTax + applyTaxRateToAmount(subTotalExcludingTax, { taxRate: totalRate })
 
+    const progressiveBillingCreditAmountCents = Number(
+      invoice?.progressiveBillingCreditAmountCents || 0,
+    )
+
+    const totalAmountCents = subTotalIncludingTaxesAmountCents - progressiveBillingCreditAmountCents
+
     return {
       subTotalExcludingTax,
       subTotalIncludingTaxesAmountCents,
-      totalAmountCents: subTotalIncludingTaxesAmountCents,
-      totalDueAmountCents: subTotalIncludingTaxesAmountCents - invoice?.totalSettledAmountCents,
+      totalAmountCents,
+      totalDueAmountCents: totalAmountCents - invoice?.totalSettledAmountCents,
     }
   }
 

--- a/src/components/invoices/details/__tests__/InvoiceDetailsTableFooter.test.tsx
+++ b/src/components/invoices/details/__tests__/InvoiceDetailsTableFooter.test.tsx
@@ -238,6 +238,37 @@ describe('InvoiceDetailsTableFooter', () => {
         expect(screen.queryByTestId(REGENERATE_ALERT_TEST_ID)).not.toBeInTheDocument()
       })
     })
+
+    describe('WHEN there is a progressive billing credit and fees are recomputed', () => {
+      it('THEN the total should subtract the progressive billing credit', () => {
+        const invoice = createMockInvoice({
+          status: InvoiceStatusTypeEnum.Voided,
+          progressiveBillingCreditAmountCents: '50000',
+          appliedTaxes: [],
+        })
+
+        const invoiceFees: FeeForInvoiceDetailsTableFooterFragment[] = [
+          { id: 'fee-1', amountCents: '80000' },
+        ]
+
+        render(
+          <table>
+            <InvoiceDetailsTableFooter
+              canHaveUnitPrice={false}
+              invoice={invoice}
+              invoiceFees={invoiceFees}
+              isRegenerateFlow={true}
+            />
+          </table>,
+        )
+
+        // Subtotal incl. tax is $800.00, progressive billing credit is -$500.00,
+        // so the total must reflect the deduction: $300.00 (not $800.00).
+        expect(screen.getByTestId('invoice-details-table-footer-total-value').textContent).toBe(
+          '$300.00',
+        )
+      })
+    })
   })
 
   describe('GIVEN the invoice has applied taxes', () => {


### PR DESCRIPTION
## Context

In the void & regenerate flow, the invoice footer recomputes the total client-side from the editable fees (the backend total isn't authoritative until the invoice is regenerated on submit). That recomputation summed the fees and taxes but never subtracted the progressive billing credit, even though it was displayed as a deduction row ("Usage already billed"). The total appeared inflated by the already-billed amount (e.g. $960 instead of $460), while a normal invoice — which reads the total straight from the backend — was unaffected.

## Description

- Subtract `progressiveBillingCreditAmountCents` from the recomputed total (and total due) in `computeSubtotal`, so the total matches the deduction already shown in the footer.
- This path is only hit in the regenerate flow (fees are passed only when editing is enabled), so normal invoices keep using the backend total.
- Added a unit test asserting the regenerate total reflects the progressive billing credit.

Note: the preview subtracts the credit after tax, while the backend applies it before tax — the residual tax difference is already covered by the "taxes will be recalculated" alert.

<!-- Linear link -->
Fixes BIL-107