### PR TITLE
refactor(invoices): migrate PremiumWarningDialog to NiceModal hook in InvoiceCreditNoteList

### DIFF
--- a/src/components/invoices/InvoiceCreditNoteList.tsx
+++ b/src/components/invoices/InvoiceCreditNoteList.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import CreditNotesTable from '~/components/creditNote/CreditNotesTable'
@@ -9,7 +8,7 @@ import { ButtonLink } from '~/components/designSystem/ButtonLink'
 import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { CUSTOMER_INVOICE_CREATE_CREDIT_NOTE_ROUTE } from '~/core/router'
 import {
   CreditNotesForTableFragmentDoc,
@@ -56,7 +55,7 @@ export const InvoiceCreditNoteList = () => {
   const { isPremium } = useCurrentUser()
   const { hasPermissions } = usePermissions()
   const canIssueCreditNote = hasPermissions(['creditNotesCreate'])
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
+  const premiumWarningDialog = usePremiumWarningDialog()
   const { data, loading, error, fetchMore, variables } = useGetInvoiceCreditNotesQuery({
     variables: { invoiceId: invoiceId as string, limit: 20 },
     skip: !invoiceId || !customerId,
@@ -106,7 +105,7 @@ export const InvoiceCreditNoteList = () => {
                   ) : (
                     <Button
                       variant="quaternary"
-                      onClick={() => premiumWarningDialogRef.current?.openDialog()}
+                      onClick={() => premiumWarningDialog.open()}
                       endIcon="sparkles"
                     >
                       {translate('text_636bdef6565341dcb9cfb127')}
@@ -146,8 +145,6 @@ export const InvoiceCreditNoteList = () => {
           />
         )}
       </>
-
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Migrates the deprecated imperative ref-based `PremiumWarningDialog` import from `~/components/PremiumWarningDialog` to the new hook-based NiceModal dialog system (`usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`) in `src/components/invoices/InvoiceCreditNoteList.tsx`.

This addresses one of the ESLint `no-restricted-imports` warnings flagging usage of the legacy dialog component.

## Changes

- Replaced `PremiumWarningDialog` + `PremiumWarningDialogRef` import with `usePremiumWarningDialog` hook
- Removed the `useRef<PremiumWarningDialogRef>` ref pattern
- Replaced `premiumWarningDialogRef.current?.openDialog()` with `premiumWarningDialog.open()`
- Removed the `<PremiumWarningDialog ref={...} />` JSX element (dialog is now rendered via NiceModal)
- Removed the now-unused `useRef` import from React

## Scope

Scoped to the `PremiumWarningDialog` usage in `InvoiceCreditNoteList.tsx` only — no other deprecated dialogs are present in this file.

## Test plan

- [ ] Verify the "Issue credit note" button in the invoice credit note list still opens the premium warning dialog when the user is not premium
- [ ] Verify the dialog closes correctly via the close button and the mailto link still works
- [ ] Verify no regressions for premium users (button should still link to credit note creation)
- [x] `pnpm code:style` passes (no new errors introduced)

---
_Generated by [Claude Code](https://claude.ai/code/session_01482Uc6mWR1EJN5pF9RTyGJ)_