### PR TITLE
migrate EditInvoiceDisplayNameDialog from Formik to TanStack Form

### DIFF
--- a/src/components/invoices/EditInvoiceDisplayNameDialog.tsx
+++ b/src/components/invoices/EditInvoiceDisplayNameDialog.tsx
@@ -1,12 +1,12 @@
-import { useFormik } from 'formik'
+import { revalidateLogic, useStore } from '@tanstack/react-form'
 import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
-import { object, string } from 'yup'
+import { z } from 'zod'
 
 import { Button } from '~/components/designSystem/Button'
 import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { TextInputField } from '~/components/form'
 import { InputMaybe } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 type EditInvoiceDisplayNameDialogProps = {
   invoiceDisplayName: InputMaybe<string> | undefined
@@ -18,76 +18,78 @@ export interface EditInvoiceDisplayNameDialogRef {
   closeDialog: () => unknown
 }
 
+const editInvoiceDisplayNameSchema = z.object({
+  invoiceDisplayName: z.string(),
+})
+
 export const EditInvoiceDisplayNameDialog = forwardRef<EditInvoiceDisplayNameDialogRef>(
   (_, ref) => {
     const { translate } = useInternationalization()
     const dialogRef = useRef<DialogRef>(null)
     const [data, setData] = useState<EditInvoiceDisplayNameDialogProps>()
 
-    const formikProps = useFormik<Omit<EditInvoiceDisplayNameDialogProps, 'callback'>>({
-      initialValues: {
-        invoiceDisplayName: data?.invoiceDisplayName || '',
+    const form = useAppForm({
+      defaultValues: {
+        invoiceDisplayName: (data?.invoiceDisplayName ?? '') as string,
       },
-      validationSchema: object().shape({
-        invoiceDisplayName: string(),
-      }),
-      validateOnMount: true,
-      enableReinitialize: true,
-      onSubmit: async (values, formikBag) => {
-        data?.callback(values.invoiceDisplayName || '')
-
-        dialogRef?.current?.closeDialog()
-        formikBag.resetForm()
+      validationLogic: revalidateLogic(),
+      validators: {
+        onDynamic: editInvoiceDisplayNameSchema,
+      },
+      onSubmit: async ({ value }) => {
+        data?.callback(value.invoiceDisplayName ?? '')
+        dialogRef.current?.closeDialog()
       },
     })
+
+    const isDirty = useStore(form.store, (state) => state.isDirty)
 
     useImperativeHandle(ref, () => ({
       openDialog: (datas) => {
         setData(datas)
+        form.reset({ invoiceDisplayName: datas?.invoiceDisplayName ?? '' })
         dialogRef.current?.openDialog()
       },
       closeDialog: () => dialogRef.current?.closeDialog(),
     }))
 
     return (
-      <Dialog
-        ref={dialogRef}
-        title={translate('text_65018c8e5c6b626f030bcf1e')}
-        description={translate('text_65018c8e5c6b626f030bcf22')}
-        onClose={() => {
-          formikProps.resetForm()
-          formikProps.validateForm()
-        }}
-        actions={({ closeDialog }) => (
-          <>
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_63eba8c65a6c8043feee2a14')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!formikProps.isValid || !formikProps.dirty}
-              onClick={async () => {
-                await formikProps.submitForm()
-                closeDialog()
-              }}
-            >
-              {translate('text_65018c8e5c6b626f030bcf32')}
-            </Button>
-          </>
-        )}
-      >
-        <TextInputField
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus
-          cleanable
-          className="mb-8"
-          name="invoiceDisplayName"
-          label={translate('text_65018c8e5c6b626f030bcf26')}
-          placeholder={translate('text_65018c8e5c6b626f030bcf2a')}
-          error={formikProps.errors.invoiceDisplayName}
-          formikProps={formikProps}
-        />
-      </Dialog>
+      <form.AppForm>
+        <Dialog
+          ref={dialogRef}
+          title={translate('text_65018c8e5c6b626f030bcf1e')}
+          description={translate('text_65018c8e5c6b626f030bcf22')}
+          formId="edit-invoice-display-name-dialog"
+          formSubmit={(e) => {
+            e.preventDefault()
+            form.handleSubmit()
+          }}
+          onClose={() => form.reset()}
+          actions={({ closeDialog }) => (
+            <>
+              <Button variant="quaternary" onClick={closeDialog}>
+                {translate('text_63eba8c65a6c8043feee2a14')}
+              </Button>
+              <form.SubmitButton disabled={!isDirty}>
+                {translate('text_65018c8e5c6b626f030bcf32')}
+              </form.SubmitButton>
+            </>
+          )}
+        >
+          <form.AppField name="invoiceDisplayName">
+            {(field) => (
+              <field.TextInputField
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
+                cleanable
+                className="mb-8"
+                label={translate('text_65018c8e5c6b626f030bcf26')}
+                placeholder={translate('text_65018c8e5c6b626f030bcf2a')}
+              />
+            )}
+          </form.AppField>
+        </Dialog>
+      </form.AppForm>
     )
   },
 )


### PR DESCRIPTION
## Summary

- Replaces `useFormik` + Yup with `useAppForm` + Zod in `EditInvoiceDisplayNameDialog`
- Uses the `Dialog` component's built-in `formId` / `formSubmit` props so the entire dialog (input + actions) is wrapped in a single `<form>` — this restores native Enter-key submission
- Subscribes to `isDirty` via `useStore` and passes it as `disabled` to `form.SubmitButton`, preserving the original "save button disabled until the user makes a change" behaviour
- Resets form with new initial values when `openDialog` is called (replaces Formik's `enableReinitialize: true`)

## Validation mapping

| Field | Yup (before) | Zod (after) | Notes |
|-------|-------------|-------------|-------|
| `invoiceDisplayName` | `string()` | `z.string()` | No required constraint — empty string is valid |

No server-side error handling was present in the original form.

## Test plan

- [ ] Open the dialog from a plan/subscription/invoice — pre-filled value appears in the field
- [ ] Save button is disabled initially; becomes enabled after typing any change
- [ ] Pressing Enter in the input submits the form (closes dialog + triggers callback)
- [ ] Clicking Cancel closes the dialog without calling the callback
- [ ] Re-opening the dialog after a cancel shows the original value (not the cancelled edit)
- [ ] TypeScript check passes (`pnpm tsc --noEmit`)
- [ ] ESLint passes with no new errors (`pnpm eslint src/components/invoices/EditInvoiceDisplayNameDialog.tsx`)

https://claude.ai/code/session_01GZxMhDj6fKUqqq113r9pJq

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZxMhDj6fKUqqq113r9pJq)_