### PR TITLE
fix(deps): patch brace-expansion and ws CVEs via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,9 @@
   "pnpm": {
     "overrides": {
       "axios": ">=1.15.2",
+      "brace-expansion@5": ">=5.0.6",
       "flatted": ">=3.4.2",
+      "ws@8": ">=8.20.1",
       "svgo": ">=3.3.3",
       "follow-redirects": ">=1.16.0",
       "uuid": ">=14.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,9 @@ settings:
 
 overrides:
   axios: '>=1.15.2'
+  brace-expansion@5: '>=5.0.6'
   flatted: '>=3.4.2'
+  ws@8: '>=8.20.1'
   svgo: '>=3.3.3'
   follow-redirects: '>=1.16.0'
   uuid: '>=14.0.0'
@@ -17,7 +19,7 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 3.14.1
-        version: 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ebay/nice-modal-react':
         specifier: 1.2.13
         version: 1.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -146,13 +148,13 @@ importers:
         version: 5.2.8-1
       apollo-link-timeout:
         specifier: 4.0.0
-        version: 4.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       apollo-upload-client:
         specifier: 17.0.0
-        version: 17.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.0)
+        version: 17.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.0)
       apollo3-cache-persist:
         specifier: 0.15.0
-        version: 0.15.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 0.15.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       decimal.js:
         specifier: 10.6.0
         version: 10.6.0
@@ -164,7 +166,7 @@ importers:
         version: 16.14.0
       graphql-ruby-client:
         specifier: 1.14.9
-        version: 1.14.9(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.0)
+        version: 1.14.9(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.0)
       html-react-parser:
         specifier: 5.2.17
         version: 5.2.17(@types/react@18.3.29)(react@18.3.1)
@@ -303,7 +305,7 @@ importers:
         version: 5.2.11
       '@types/apollo-upload-client':
         specifier: 17.0.5
-        version: 17.0.5(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 17.0.5(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -4583,8 +4585,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5737,7 +5739,7 @@ packages:
       crossws: ~0.3
       graphql: ^15.10.1 || ^16
       uWebSockets.js: ^20
-      ws: ^8
+      ws: '>=8.20.1'
     peerDependenciesMeta:
       '@fastify/websocket':
         optional: true
@@ -6139,12 +6141,12 @@ packages:
   isomorphic-ws@5.0.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
     peerDependencies:
-      ws: '*'
+      ws: '>=8.20.1'
 
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
-      ws: '*'
+      ws: '>=8.20.1'
 
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -7815,8 +7817,8 @@ packages:
   react-is@19.2.0:
     resolution: {integrity: sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==}
 
-  react-is@19.2.6:
-    resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -8801,8 +8803,8 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -8884,7 +8886,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.0)
       '@wry/caches': 1.0.1
@@ -8901,7 +8903,7 @@ snapshots:
       tslib: 2.8.1
       zen-observable-ts: 1.2.5
     optionalDependencies:
-      graphql-ws: 6.0.6(graphql@16.14.0)(ws@8.19.0)
+      graphql-ws: 6.0.6(graphql@16.14.0)(ws@8.21.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -11018,10 +11020,10 @@ snapshots:
       '@graphql-tools/utils': 10.10.3(graphql@16.14.0)
       '@whatwg-node/disposablestack': 0.0.6
       graphql: 16.14.0
-      graphql-ws: 6.0.6(graphql@16.14.0)(ws@8.19.0)
-      isows: 1.0.7(ws@8.19.0)
+      graphql-ws: 6.0.6(graphql@16.14.0)(ws@8.21.0)
+      isows: 1.0.7(ws@8.21.0)
       tslib: 2.8.1
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - '@fastify/websocket'
       - bufferutil
@@ -11049,9 +11051,9 @@ snapshots:
       '@graphql-tools/utils': 11.0.0(graphql@16.14.0)
       '@types/ws': 8.5.13
       graphql: 16.14.0
-      isomorphic-ws: 5.0.0(ws@8.19.0)
+      isomorphic-ws: 5.0.0(ws@8.21.0)
       tslib: 2.8.1
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11173,10 +11175,10 @@ snapshots:
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.14.0
-      isomorphic-ws: 5.0.0(ws@8.19.0)
+      isomorphic-ws: 5.0.0(ws@8.21.0)
       sync-fetch: 0.6.0
       tslib: 2.8.1
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - '@fastify/websocket'
       - '@types/node'
@@ -12680,9 +12682,9 @@ snapshots:
 
   '@types/actioncable@5.2.11': {}
 
-  '@types/apollo-upload-client@17.0.5(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@types/apollo-upload-client@17.0.5(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/extract-files': 13.0.1
       graphql: 16.14.0
     transitivePeerDependencies:
@@ -13153,19 +13155,19 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  apollo-link-timeout@4.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  apollo-link-timeout@4.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
-      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  apollo-upload-client@17.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.0):
+  apollo-upload-client@17.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.0):
     dependencies:
-      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       extract-files: 11.0.0
       graphql: 16.14.0
 
-  apollo3-cache-persist@0.15.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  apollo3-cache-persist@0.15.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
-      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   arch@2.2.0: {}
 
@@ -13416,7 +13418,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.3
 
@@ -14783,9 +14785,9 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  graphql-ruby-client@1.14.9(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.0):
+  graphql-ruby-client@1.14.9(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.0):
     dependencies:
-      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       glob: 10.5.0
       graphql: 16.14.0
       minimist: 1.2.8
@@ -14795,11 +14797,11 @@ snapshots:
       graphql: 16.14.0
       tslib: 2.8.1
 
-  graphql-ws@6.0.6(graphql@16.14.0)(ws@8.19.0):
+  graphql-ws@6.0.6(graphql@16.14.0)(ws@8.21.0):
     dependencies:
       graphql: 16.14.0
     optionalDependencies:
-      ws: 8.19.0
+      ws: 8.21.0
 
   graphql@16.14.0: {}
 
@@ -15196,13 +15198,13 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isomorphic-ws@5.0.0(ws@8.19.0):
+  isomorphic-ws@5.0.0(ws@8.21.0):
     dependencies:
-      ws: 8.19.0
+      ws: 8.21.0
 
-  isows@1.0.7(ws@8.19.0):
+  isows@1.0.7(ws@8.21.0):
     dependencies:
-      ws: 8.19.0
+      ws: 8.21.0
 
   isstream@0.1.2: {}
 
@@ -15699,7 +15701,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.19.0
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -16355,7 +16357,7 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.4:
     dependencies:
@@ -16371,7 +16373,7 @@ snapshots:
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 
@@ -17167,7 +17169,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       ansi-styles: 5.2.0
       react-is-18: react-is@18.3.1
-      react-is-19: react-is@19.2.6
+      react-is-19: react-is@19.2.7
 
   prismjs@1.30.0: {}
 
@@ -17316,7 +17318,7 @@ snapshots:
 
   react-is@19.2.0: {}
 
-  react-is@19.2.6: {}
+  react-is@19.2.7: {}
 
   react-markdown@10.1.0(@types/react@18.3.29)(react@18.3.1):
     dependencies:
@@ -18533,7 +18535,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@8.19.0: {}
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
## Summary

Fixes two CVEs that have been open for ≥3 weeks (created 2026-05-18), identified via `pnpm audit`.

Both vulnerabilities live in stale lockfile entries — all immediate parent packages already declare compatible version ranges (`^5.0.2` and `^8.18+` respectively) but pnpm keeps the locked version without an explicit override.

### CVE-1: brace-expansion (GHSA-jxxr-4gwj-5jf2 / CVE-2026-45149)
- **Severity**: Moderate (CVSS 6.5)
- **Issue**: Large numeric range defeats documented `max` DoS protection — expanding `{1..10000000}` allocates ~505 MB before the limit is applied
- **Installed**: `5.0.5` → **Fixed**: `>=5.0.6`
- **Chain**: `@graphql-codegen/cli > graphql-config > minimatch > brace-expansion`
- **Fix**: `pnpm.overrides["brace-expansion@5"] = ">=5.0.6"` (scoped to 5.x only; 1.x and 2.x instances are unaffected)

### CVE-2: ws (GHSA-58qx-3vcg-4xpx / CVE-2026-45736)
- **Severity**: Moderate (CVSS 4.4)
- **Issue**: Uninitialized memory disclosure when a `TypedArray` is passed as the `close()` reason argument
- **Installed**: `8.19.0` → **Fixed**: `8.21.0`
- **Chain**: `@graphql-codegen/cli > @graphql-tools/url-loader > ws`
- **Fix**: `pnpm.overrides["ws@8"] = ">=8.20.1"` (scoped to 8.x only)

## Verification

```
pnpm audit
# brace-expansion: no vulnerabilities found ✓
# ws: no vulnerabilities found ✓
# Remaining 3 alerts (qs, tmp, react-router) are < 3 weeks old
```

## Test plan
- [ ] `pnpm install` succeeds without errors
- [ ] `pnpm audit` no longer reports brace-expansion or ws vulnerabilities
- [ ] CI passes (no runtime usage of these packages is affected — both are transitive dev/codegen dependencies)

https://claude.ai/code/session_01WBZ561rARCp3o1UqyBMFNj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBZ561rARCp3o1UqyBMFNj)_