### PR TITLE
refactor(invoices): remove deprecated PremiumWarningDialog from InvoicesPage

### DIFF
--- a/src/pages/InvoicesPage.tsx
+++ b/src/pages/InvoicesPage.tsx
@@ -22,7 +22,6 @@ import InvoicesList from '~/components/invoices/InvoicesList'
 import { VoidInvoiceDialog, VoidInvoiceDialogRef } from '~/components/invoices/VoidInvoiceDialog'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { SearchInput } from '~/components/SearchInput'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { INVOICE_LIST_FILTER_PREFIX } from '~/core/constants/filters'
@@ -150,7 +149,6 @@ const InvoicesPage = () => {
     PremiumIntegrationTypeEnum.RevenueShare,
   )
 
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
   const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
   const updateInvoicePaymentStatusDialog = useRef<UpdateInvoicePaymentStatusDialogRef>(null)
   const voidInvoiceDialogRef = useRef<VoidInvoiceDialogRef>(null)
@@ -308,7 +306,6 @@ const InvoicesPage = () => {
         variables={variables}
       />
 
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
       <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
       <UpdateInvoicePaymentStatusDialog ref={updateInvoicePaymentStatusDialog} />
       <VoidInvoiceDialog ref={voidInvoiceDialogRef} />

--- a/src/pages/__tests__/InvoicesPage.test.tsx
+++ b/src/pages/__tests__/InvoicesPage.test.tsx
@@ -79,10 +79,6 @@ jest.mock('~/components/invoices/InvoicesList', () => ({
   default: () => <div data-test="invoices-list-mock">InvoicesList</div>,
 }))
 
-jest.mock('~/components/PremiumWarningDialog', () => ({
-  PremiumWarningDialog: () => null,
-}))
-
 jest.mock('~/components/invoices/FinalizeInvoiceDialog', () => ({
   FinalizeInvoiceDialog: () => null,
 }))


### PR DESCRIPTION
## Summary

Resolves the `no-restricted-imports` ESLint warning for `~/components/PremiumWarningDialog` in `src/pages/InvoicesPage.tsx`.

## Context

The legacy ref-based `PremiumWarningDialog` was imported, ref'd (`premiumWarningDialogRef`) and rendered in `InvoicesPage`, but the ref was **never actually invoked** anywhere in the file or in any child component (no `.openDialog()` call, ref is not passed down). It was dead code.

The new hook-based `usePremiumWarningDialog` (in `src/components/dialogs/PremiumWarningDialog.tsx`) is already registered globally via NiceModal in `src/core/overlays/registeredDialogs.ts`, so it can be invoked on-demand from any component that genuinely needs to surface the premium warning — no parent JSX render required.

## Changes

- `src/pages/InvoicesPage.tsx`: removed the deprecated import, the unused ref, and the `<PremiumWarningDialog ref={...} />` JSX render.
- `src/pages/__tests__/InvoicesPage.test.tsx`: removed the matching `jest.mock('~/components/PremiumWarningDialog', ...)`, which became unnecessary once the component is no longer rendered.

## Verification

- `pnpm eslint src/pages/InvoicesPage.tsx` — the `PremiumWarningDialog` warning is gone (4 unrelated deprecated-dialog warnings remain in the file; out of scope for this PR).
- `pnpm tsc --noEmit` — passes.
- `pnpm test src/pages/__tests__/InvoicesPage.test.tsx` — all 5 tests pass.
- Total project warnings: 485 → 484.

## Test plan

- [x] ESLint warning removed for the targeted file
- [x] TypeScript check passes
- [x] InvoicesPage Jest test suite passes
- [ ] CI green

https://claude.ai/code/session_01MgdBJVpdFZa7YiAcwkRbQQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgdBJVpdFZa7YiAcwkRbQQ)_