### PR TITLE
feat(details): release v2 details layouts

### DIFF
--- a/cypress/e2e/10-resources/t50-edit-plan.cy.ts
+++ b/cypress/e2e/10-resources/t50-edit-plan.cy.ts
@@ -1,45 +1,64 @@
 import {
+  DETAILS_ADD_USAGE_CHARGE_TEST_ID,
+  PLAN_SETTINGS_ACCORDION_TEST_ID,
+  PLAN_SETTINGS_EDIT_TEST_ID,
+  USAGE_CHARGE_ACCORDION_TEST_ID_PREFIX,
+} from '~/components/plans/details-v2/detailsV2TestIds'
+
+import {
   customerName,
   planWithChargeCodeNew,
   planWithChargesName,
 } from '../../support/reusableConstants'
+
+// Mirrors BASE_DRAWER_CLOSE_BUTTON_TEST_ID from BaseDrawer.tsx — not imported
+// because Cypress specs cannot import React component files.
+const BASE_DRAWER_CLOSE_BUTTON_TEST_ID = 'base-drawer-close-button'
+
+// Navigate from the plans list to the plan details page (v2 edit layout)
+// through the list's "View and edit" action.
+const goToPlanDetails = () => {
+  cy.visitApp('/plans')
+  cy.get(`[data-test="${planWithChargesName}"] [data-test="open-action-button"]`).click({
+    force: true,
+  })
+  cy.get('[data-test="tab-internal-button-link-update-plan"]').click({ force: true })
+  cy.url().should('include', '/overview')
+}
+
+// Open the plan settings drawer from the section accordion actions menu.
+const openPlanSettingsDrawer = () => {
+  cy.get(`[data-test="${PLAN_SETTINGS_ACCORDION_TEST_ID}-actions"]`).click({ force: true })
+  cy.get(`[data-test="${PLAN_SETTINGS_EDIT_TEST_ID}"]`).click({ force: true })
+  cy.get('input[name="name"]').should('exist')
+}
 
 describe('Edit plan', () => {
   beforeEach(() => {
     cy.login()
   })
 
-  it('should be able to close the form without warning dialog when no data has changed', () => {
-    cy.visitApp('/plans')
-    cy.get(`[data-test="${planWithChargesName}"] [data-test="open-action-button"]`).click({
-      force: true,
-    })
-    // The list action now lands on the plan details page; the edit form is
-    // reached through the details header actions dropdown.
-    cy.get('[data-test="tab-internal-button-link-update-plan"]').click({ force: true })
-    cy.get('[data-test="plan-details-actions"]').click()
-    cy.get('[data-test="plan-details-edit"]').click()
-    cy.get('input[name="name"]').should('exist')
-    cy.get('[data-test="close-create-plan-button"]').click({ force: true })
-    cy.get('[data-test="close-create-plan-button"]').should('not.exist')
+  it('should be able to open and close the plan settings drawer without saving', () => {
+    goToPlanDetails()
+    openPlanSettingsDrawer()
+
+    cy.get(`[data-test="${BASE_DRAWER_CLOSE_BUTTON_TEST_ID}"]`).click({ force: true })
+    cy.get('[data-test="base-drawer-paper"]').should('not.exist')
     cy.url().should('include', '/overview')
   })
 
   it('should be able to update plan code', () => {
-    cy.visitApp('/plans')
-    cy.get(`[data-test="${planWithChargesName}"] [data-test="open-action-button"]`).click({
-      force: true,
-    })
-    cy.get('[data-test="tab-internal-button-link-update-plan"]').click({ force: true })
-    cy.get('[data-test="plan-details-actions"]').click()
-    cy.get('[data-test="plan-details-edit"]').click()
+    goToPlanDetails()
+    openPlanSettingsDrawer()
+
     cy.get('input[name="name"]').should('not.be.disabled')
     cy.get('input[name="code"]').should('not.be.disabled')
-
     cy.get('input[name="code"]').clear().type(planWithChargeCodeNew)
-    cy.get('[data-test="submit"]', { timeout: 10000 }).should('not.be.disabled')
-    cy.get('[data-test="submit"]').click()
-    cy.url({ timeout: 10000 }).should('include', '/overview')
+
+    cy.get('[data-test="plan-settings-drawer-save"]').should('not.be.disabled')
+    cy.get('[data-test="plan-settings-drawer-save"]').click()
+    cy.get('[data-test="base-drawer-paper"]', { timeout: 10000 }).should('not.exist')
+    cy.contains(planWithChargeCodeNew).should('exist')
   })
 
   it('should add plan to customer', () => {
@@ -57,31 +76,37 @@ describe('Edit plan', () => {
   })
 
   it('should not be able to update locked fields of a used plan', () => {
-    cy.visitApp('/plans')
-    cy.get(`[data-test="${planWithChargesName}"] [data-test="open-action-button"]`).click({
-      force: true,
-    })
-    cy.get('[data-test="tab-internal-button-link-update-plan"]').click({ force: true })
-    cy.get('[data-test="plan-details-actions"]').click()
-    cy.get('[data-test="plan-details-edit"]').click()
+    goToPlanDetails()
+    openPlanSettingsDrawer()
 
-    // Name should still be editable
+    // Name stays editable on a used plan, code locks
     cy.get('input[name="name"]').should('not.be.disabled')
+    cy.get('input[name="code"]').should('be.disabled')
 
-    // Verify existing charges are displayed
-    cy.get('[data-test="usage-charge-selector-0"]').should('exist')
+    cy.get(`[data-test="${BASE_DRAWER_CLOSE_BUTTON_TEST_ID}"]`).click({ force: true })
+    cy.get('[data-test="base-drawer-paper"]').should('not.exist')
 
-    // Should be able to add a new charge even on a used plan
-    cy.get('[data-test="add-usage-charge"]').scrollIntoView()
-    cy.get('[data-test="add-usage-charge"]').click()
+    // Existing charges are displayed
+    cy.get(`[data-test="${USAGE_CHARGE_ACCORDION_TEST_ID_PREFIX}0"]`).should('exist')
+
+    // Should be able to add a new charge even on a used plan; the granular
+    // mutation saves immediately when the drawer is submitted. The charge gets
+    // a unique code (regenerated on each test retry) so the assertion targets
+    // this exact charge instead of a count, which is unstable across retries
+    // and cache-first repaints.
+    const chargeCode = `e2e_charge_${Math.round(Math.random() * 100000)}`
+
+    cy.get(`[data-test="${DETAILS_ADD_USAGE_CHARGE_TEST_ID}"]`).scrollIntoView()
+    cy.get(`[data-test="${DETAILS_ADD_USAGE_CHARGE_TEST_ID}"]`).click()
     cy.get('[data-option-index]', { timeout: 30000 }).should('exist')
     cy.contains('[role="option"]', 'bm count').click({ force: true })
+    cy.get('[data-test="base-drawer-paper"]').within(() => {
+      cy.get('input[name="code"]').clear().type(chargeCode)
+    })
     cy.get('input[name="properties.amount"]').type('3000')
     cy.get('[data-test="usage-charge-drawer-save"]').should('not.be.disabled').click()
     cy.get('[data-test="base-drawer-paper"]', { timeout: 10000 }).should('not.exist')
 
-    cy.get('[data-test="submit"]').should('not.be.disabled')
-    cy.get('[data-test="submit"]').click({ force: true })
-    cy.url().should('include', '/overview')
+    cy.contains(chargeCode, { timeout: 10000 }).should('exist')
   })
 })

--- a/cypress/e2e/10-resources/t50-edit-plan.cy.ts
+++ b/cypress/e2e/10-resources/t50-edit-plan.cy.ts
@@ -14,7 +14,11 @@ describe('Edit plan', () => {
     cy.get(`[data-test="${planWithChargesName}"] [data-test="open-action-button"]`).click({
       force: true,
     })
+    // The list action now lands on the plan details page; the edit form is
+    // reached through the details header actions dropdown.
     cy.get('[data-test="tab-internal-button-link-update-plan"]').click({ force: true })
+    cy.get('[data-test="plan-details-actions"]').click()
+    cy.get('[data-test="plan-details-edit"]').click()
     cy.get('input[name="name"]').should('exist')
     cy.get('[data-test="close-create-plan-button"]').click({ force: true })
     cy.get('[data-test="close-create-plan-button"]').should('not.exist')
@@ -27,6 +31,8 @@ describe('Edit plan', () => {
       force: true,
     })
     cy.get('[data-test="tab-internal-button-link-update-plan"]').click({ force: true })
+    cy.get('[data-test="plan-details-actions"]').click()
+    cy.get('[data-test="plan-details-edit"]').click()
     cy.get('input[name="name"]').should('not.be.disabled')
     cy.get('input[name="code"]').should('not.be.disabled')
 
@@ -56,6 +62,8 @@ describe('Edit plan', () => {
       force: true,
     })
     cy.get('[data-test="tab-internal-button-link-update-plan"]').click({ force: true })
+    cy.get('[data-test="plan-details-actions"]').click()
+    cy.get('[data-test="plan-details-edit"]').click()
 
     // Name should still be editable
     cy.get('input[name="name"]').should('not.be.disabled')

--- a/src/components/customerPortal/wallet/__tests__/WalletSection.test.tsx
+++ b/src/components/customerPortal/wallet/__tests__/WalletSection.test.tsx
@@ -241,6 +241,7 @@ describe('WalletSection', () => {
     render(<WalletSection viewWallet={mockViewWallet} />)
 
     const viewButton = screen.getByTestId(WALLET_SECTION_VIEW_BUTTON_TEST_ID)
+
     await userEvent.click(viewButton)
 
     expect(mockViewWallet).toHaveBeenCalledWith('wallet-1')

--- a/src/components/designSystem/RichTextEditor/BlockControls/__tests__/BlockToolbar.test.tsx
+++ b/src/components/designSystem/RichTextEditor/BlockControls/__tests__/BlockToolbar.test.tsx
@@ -315,7 +315,6 @@ describe('BlockToolbar', () => {
   })
 
   describe('GIVEN the useEditorState selector', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let capturedSelector: any = null
 
     const captureSelectorAndRender = () => {

--- a/src/components/designSystem/RichTextEditor/Table/__tests__/TableControls.test.tsx
+++ b/src/components/designSystem/RichTextEditor/Table/__tests__/TableControls.test.tsx
@@ -171,7 +171,6 @@ jest.mock('@tiptap/pm/state', () => ({
 }))
 
 jest.mock('@tiptap/pm/tables', () => {
-  // eslint-disable-next-line @typescript-eslint/no-extraneous-class
   function CellSelection() {}
 
   ;(CellSelection as unknown as Record<string, jest.Mock>).rowSelection = jest.fn()

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
@@ -602,6 +602,7 @@ describe('DragHandle', () => {
 
         // Select the first block
         const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+
         ;(grips[0] as HTMLElement).click()
 
         const event = new KeyboardEvent('keydown', {
@@ -630,6 +631,7 @@ describe('DragHandle', () => {
 
         // Select first block via grip
         const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+
         ;(grips[0] as HTMLElement).click()
 
         expect(storage.hideMenu).toBe(false)
@@ -662,6 +664,7 @@ describe('DragHandle', () => {
 
         // Select first block
         const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+
         ;(grips[0] as HTMLElement).click()
 
         // First ESC — hides menu
@@ -701,6 +704,7 @@ describe('DragHandle', () => {
 
         // Select table via grip
         const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+
         ;(grips[1] as HTMLElement).click()
 
         expect(storage.selectedBlock).not.toBeNull()
@@ -728,6 +732,7 @@ describe('DragHandle', () => {
 
         // Select table via grip
         const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+
         ;(grips[1] as HTMLElement).click()
 
         // First ESC
@@ -776,6 +781,7 @@ describe('DragHandle', () => {
 
         // Select first block
         const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+
         ;(grips[0] as HTMLElement).click()
 
         expect(editor.state.selection instanceof NodeSelection).toBe(true)
@@ -807,6 +813,7 @@ describe('DragHandle', () => {
 
         // Select table via grip
         const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+
         ;(grips[1] as HTMLElement).click()
 
         expect(storage.selectedBlock).not.toBeNull()
@@ -837,6 +844,7 @@ describe('DragHandle', () => {
 
         // Select first block
         const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+
         ;(grips[0] as HTMLElement).click()
 
         expect(editor.state.selection instanceof NodeSelection).toBe(true)

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/baseExtensions.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/baseExtensions.test.ts
@@ -8,9 +8,7 @@ const createEditor = (content = '') =>
     content,
   })
 
-const getMarkdown = (editor: Editor): string =>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (editor.storage as any).markdown.getMarkdown()
+const getMarkdown = (editor: Editor): string => (editor.storage as any).markdown.getMarkdown()
 
 describe('getBaseExtensions', () => {
   describe('GIVEN no options are provided', () => {

--- a/src/components/developers/activityLogs/__tests__/ActivityLogDetails.test.tsx
+++ b/src/components/developers/activityLogs/__tests__/ActivityLogDetails.test.tsx
@@ -181,6 +181,7 @@ describe('ActivityLogDetails', () => {
         })
 
         const closeButton = screen.getByTestId(ACTIVITY_LOG_DETAILS_CLOSE_BUTTON_TEST_ID)
+
         await user.click(closeButton)
 
         expect(mockGoBack).toHaveBeenCalledTimes(1)
@@ -202,6 +203,7 @@ describe('ActivityLogDetails', () => {
         })
 
         const customerLink = screen.getByTestId(ACTIVITY_LOG_DETAILS_CUSTOMER_LINK_TEST_ID)
+
         await user.click(customerLink)
 
         expect(mockSetMainRouterUrl).toHaveBeenCalledWith(
@@ -228,6 +230,7 @@ describe('ActivityLogDetails', () => {
         })
 
         const subscriptionLink = screen.getByTestId(ACTIVITY_LOG_DETAILS_SUBSCRIPTION_LINK_TEST_ID)
+
         await user.click(subscriptionLink)
 
         expect(mockSetMainRouterUrl).toHaveBeenCalledWith(

--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -151,7 +151,6 @@ export const ComboBox = ({
       noOptionsText={emptyText ?? translate('text_623b3acb8ee4e000ba87d082')}
       selectOnFocus={allowAddValue}
       clearOnBlur
-      clearOnEscape
       handleHomeEndKeys={allowAddValue}
       freeSolo={allowAddValue}
       isOptionEqualToValue={(option, val) => {

--- a/src/components/form/NameAndCodeGroup/__tests__/NameAndCodeGroup.test.tsx
+++ b/src/components/form/NameAndCodeGroup/__tests__/NameAndCodeGroup.test.tsx
@@ -13,7 +13,7 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 }))
 
 // Ref to access the form instance from tests
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 let formRef: any = null
 
 // Wrapper component that provides form context

--- a/src/components/plans/UsageChargeInfo.tsx
+++ b/src/components/plans/UsageChargeInfo.tsx
@@ -171,6 +171,7 @@ export const UsageChargeInfo = ({
             ...filter,
             values: filter.values as Record<string, string[]>,
           })
+
           return (
             <Accordion
               key={`usage-charge-info-${charge.id}-filter-${i}`}

--- a/src/components/plans/__tests__/UsageChargeInfo.test.tsx
+++ b/src/components/plans/__tests__/UsageChargeInfo.test.tsx
@@ -119,6 +119,7 @@ describe('UsageChargeInfo', () => {
         } as never,
       ],
     })
+
     render(
       <UsageChargeInfo
         charge={charge}

--- a/src/components/plans/chargeAccordion/options/ChargePayInAdvanceOption.tsx
+++ b/src/components/plans/chargeAccordion/options/ChargePayInAdvanceOption.tsx
@@ -1,67 +1,65 @@
-import { FC } from 'react'
-
-import { Typography } from '~/components/designSystem/Typography'
-import { Radio } from '~/components/form'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { withFieldGroup } from '~/hooks/forms/useAppform'
 
-interface ChargePayInAdvanceOptionProps {
-  chargePayInAdvanceDescription: string | undefined
-  disabled?: boolean
-  isPayInAdvanceOptionDisabled: boolean
+export type ChargePayInAdvanceOptionValues = {
   payInAdvance: boolean
-  handleUpdate: ({
-    invoiceable,
-    payInAdvance,
-    regroupPaidFees,
-  }: {
-    payInAdvance: boolean
-    invoiceable?: boolean
-    regroupPaidFees?: null
-  }) => void
 }
 
-export const ChargePayInAdvanceOption: FC<ChargePayInAdvanceOptionProps> = ({
-  chargePayInAdvanceDescription,
-  disabled,
-  isPayInAdvanceOptionDisabled,
-  payInAdvance,
-  handleUpdate,
-}) => {
-  const { translate } = useInternationalization()
+export type ChargePayInAdvanceOptionProps = {
+  disabled?: boolean
+  isPayInAdvanceOptionDisabled?: boolean
+  description?: string
+  onPayInAdvanceChange?: (payInAdvance: boolean) => void
+}
 
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-1">
-        <Typography variant="captionHl" color="textSecondary" component="legend">
-          {translate('text_6682c52081acea90520743a8')}
-        </Typography>
-        {!!chargePayInAdvanceDescription && (
-          <Typography variant="caption">{chargePayInAdvanceDescription}</Typography>
+const defaultValues: ChargePayInAdvanceOptionValues = {
+  payInAdvance: false,
+}
+
+const defaultProps: ChargePayInAdvanceOptionProps = {
+  disabled: false,
+  isPayInAdvanceOptionDisabled: false,
+}
+
+export const ChargePayInAdvanceOption = withFieldGroup({
+  defaultValues,
+  props: defaultProps,
+  render: function Render({
+    group,
+    disabled,
+    isPayInAdvanceOptionDisabled,
+    description,
+    onPayInAdvanceChange,
+  }) {
+    const { translate } = useInternationalization()
+
+    return (
+      <group.AppField
+        name="payInAdvance"
+        listeners={{
+          onChange: ({ value }) => onPayInAdvanceChange?.(value),
+        }}
+      >
+        {(field) => (
+          <field.RadioGroupField
+            label={translate('text_6682c52081acea90520743a8')}
+            description={description ?? translate('text_1781703119230q5zam349txb')}
+            optionLabelVariant="body"
+            disabled={disabled}
+            options={[
+              {
+                label: translate('text_6682c52081acea90520743ac'),
+                value: false,
+              },
+              {
+                label: translate('text_6682c52081acea90520743ae'),
+                value: true,
+                disabled: isPayInAdvanceOptionDisabled,
+              },
+            ]}
+          />
         )}
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <Radio
-          checked={!payInAdvance}
-          disabled={disabled}
-          label={translate('text_6682c52081acea90520743ac')}
-          labelVariant="body"
-          onChange={() => {
-            handleUpdate({ invoiceable: true, payInAdvance: false, regroupPaidFees: null })
-          }}
-          value={!payInAdvance}
-        />
-        <Radio
-          checked={payInAdvance}
-          disabled={isPayInAdvanceOptionDisabled || disabled}
-          label={translate('text_6682c52081acea90520744c8')}
-          labelVariant="body"
-          onChange={() => {
-            handleUpdate({ payInAdvance: true })
-          }}
-          value={payInAdvance}
-        />
-      </div>
-    </div>
-  )
-}
+      </group.AppField>
+    )
+  },
+})

--- a/src/components/plans/details-v2/PlanDetailsV2.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2.tsx
@@ -14,6 +14,8 @@ import {
   useGetPlanForDetailsV2Query,
 } from '~/generated/graphql'
 import { useDetailsV2ChargeMutations } from '~/hooks/plans/useDetailsV2ChargeMutations'
+import { useSubscriptionPremiumGate } from '~/hooks/plans/useSubscriptionPremiumGate'
+import { tw } from '~/styles/utils'
 
 import { EntitlementAccordionRef } from './accordions/EntitlementAccordion'
 import { PlanDetailsV2AdvancedSection } from './PlanDetailsV2AdvancedSection'
@@ -82,6 +84,7 @@ export const PlanDetailsV2 = ({
   subscriptionId,
   banner,
 }: PlanDetailsV2Props) => {
+  const { isGated, openPremiumDialog } = useSubscriptionPremiumGate(isInSubscriptionForm)
   const { data, loading } = useGetPlanForDetailsV2Query({
     variables: { planId },
     skip: !planId,
@@ -103,6 +106,13 @@ export const PlanDetailsV2 = ({
   }
 
   const handleAddClick = (id: string) => {
+    // Sub plan-override editing is premium-gated: freemium users get the upsell
+    // modal instead of the create drawer.
+    if (isGated) {
+      openPremiumDialog()
+      return
+    }
+
     if (id === PlanDetailsV2SectionId.FixedCharges) {
       fixedChargesRef.current?.openCreate()
     }
@@ -135,8 +145,10 @@ export const PlanDetailsV2 = ({
         onAddClick={handleAddClick}
       />
       <div className="flex flex-1 flex-col">
-        {!!banner && <div className="-ml-12">{banner}</div>}
-        <div className="flex flex-col gap-12 py-12 not-last-child:pb-12 not-last-child:shadow-b">
+        {!!banner && <div className="mt-12">{banner}</div>}
+        <div
+          className={tw('flex flex-col gap-12 py-12 not-last-child:pb-12 not-last-child:shadow-b')}
+        >
           {TOP_LEVEL_SECTION_IDS.map((id) => {
             if (id === PlanDetailsV2SectionId.PlanSettings) {
               return (

--- a/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
@@ -24,6 +24,7 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
+import { useSubscriptionPremiumGate } from '~/hooks/plans/useSubscriptionPremiumGate'
 
 import { SectionAccordion } from './shared/SectionAccordion'
 import { SectionHeader } from './shared/SectionHeader'
@@ -120,6 +121,7 @@ export const PlanDetailsV2FixedChargesSection = forwardRef<
 >(({ plan, isInSubscriptionForm = false, fixedChargeMutations }, ref) => {
   const { translate } = useInternationalization()
   const { canCreate, canUpdate, canDelete } = useAccordionPermissions(isInSubscriptionForm)
+  const { gateOnClick, premiumIcon } = useSubscriptionPremiumGate(isInSubscriptionForm)
   const drawerRef = useRef<FixedChargeDrawerRef>(null)
   const removeChargeWarningDialogRef = useRef<RemoveChargeWarningDialogRef>(null)
 
@@ -209,7 +211,8 @@ export const PlanDetailsV2FixedChargesSection = forwardRef<
             {
               label: translate('text_63e51ef4985f0ebd75c212fc'),
               startIcon: 'pen',
-              onClick: () => openEdit(toLocalInput(fixedCharge), index),
+              endIcon: premiumIcon,
+              onClick: gateOnClick(() => openEdit(toLocalInput(fixedCharge), index)),
               hidden: !canUpdate,
             },
             {

--- a/src/components/plans/details-v2/PlanDetailsV2LeftSidebar.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2LeftSidebar.tsx
@@ -10,6 +10,7 @@ import {
   UsageChargeForPlanDetailsSidebarFragment,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { tw } from '~/styles/utils'
 
 import { getEntitlementSectionId, PlanDetailsV2SectionId } from './sidebarSections'
 
@@ -128,6 +129,7 @@ type PlanDetailsV2LeftSidebarProps = {
   entitlements?: EntitlementForPlanDetailsSidebarFragment[]
   onItemClick: (id: string) => void
   onAddClick?: (id: string) => void
+  className?: string
 }
 
 export const PlanDetailsV2LeftSidebar = ({
@@ -137,6 +139,7 @@ export const PlanDetailsV2LeftSidebar = ({
   entitlements = [],
   onItemClick,
   onAddClick,
+  className,
 }: PlanDetailsV2LeftSidebarProps) => {
   const { translate } = useInternationalization()
   const sections = useMemo(
@@ -184,7 +187,7 @@ export const PlanDetailsV2LeftSidebar = ({
               <button
                 type="button"
                 data-test={`sidebar-toggle-${item.id}`}
-                className="flex items-center justify-center rounded-l-lg px-1 py-2.5 hover:bg-grey-300"
+                className="flex items-center justify-center rounded-l-lg px-1 py-2.5 hover:bg-grey-300 focus-visible:ring focus-visible:ring-inset"
                 onClick={() => toggleExpanded(item.id)}
               >
                 <Icon
@@ -197,7 +200,15 @@ export const PlanDetailsV2LeftSidebar = ({
           )}
           <button
             type="button"
-            className="flex flex-1 items-center gap-2 px-2 py-1 text-left"
+            className={tw(
+              'flex flex-1 items-center gap-2 px-2 py-1 text-left focus-visible:ring focus-visible:ring-inset',
+              // The row clips children to its rounded-lg shape (content-visibility:auto
+              // ⇒ contain:paint), so the focus ring's square corners get shaved off
+              // wherever the button meets the row's outer edge. Round the outer-facing
+              // corners — left when no toggle precedes, right when no add button follows.
+              !isGroup && 'rounded-l-lg',
+              !showAddButton && 'rounded-r-lg',
+            )}
             // Leaves pad left to clear the chevron column and step in per depth; groups
             // rely on the chevron for their left slot. The row itself stays full-width.
             style={!isGroup ? { paddingLeft: getLeafPaddingLeft(depth) } : undefined}
@@ -215,7 +226,7 @@ export const PlanDetailsV2LeftSidebar = ({
               <button
                 type="button"
                 data-test={`sidebar-add-${item.id}`}
-                className="flex items-center justify-center rounded-r-lg px-1 py-2.5 hover:bg-grey-300"
+                className="flex items-center justify-center rounded-r-lg px-1 py-2.5 hover:bg-grey-300 focus-visible:ring focus-visible:ring-inset"
                 onClick={() => onAddClick?.(item.id)}
               >
                 <Icon name="plus" size="small" color="dark" />
@@ -242,7 +253,10 @@ export const PlanDetailsV2LeftSidebar = ({
 
   return (
     <nav
-      className="sticky top-0 flex h-screen w-64 flex-col gap-1 border-r border-grey-300 pr-4 pt-4"
+      className={tw(
+        'sticky top-0 flex h-screen w-64 flex-shrink-0 flex-col gap-1 border-r border-grey-300 pr-4 pt-4',
+        className,
+      )}
       aria-label="Plan sections"
     >
       {sections.map((item) => renderItem(item))}

--- a/src/components/plans/details-v2/PlanDetailsV2PlanSettingsSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2PlanSettingsSection.tsx
@@ -9,6 +9,7 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
+import { useSubscriptionPremiumGate } from '~/hooks/plans/useSubscriptionPremiumGate'
 
 import { PLAN_SETTINGS_ACCORDION_TEST_ID, PLAN_SETTINGS_EDIT_TEST_ID } from './detailsV2TestIds'
 import { SectionAccordion } from './shared/SectionAccordion'
@@ -40,6 +41,7 @@ export const PlanDetailsV2PlanSettingsSection = ({
 }: PlanDetailsV2PlanSettingsSectionProps) => {
   const { translate } = useInternationalization()
   const { canUpdate } = useAccordionPermissions(isInSubscriptionForm)
+  const { gateOnClick, premiumIcon } = useSubscriptionPremiumGate(isInSubscriptionForm)
   const { openDrawer } = usePlanSettingsDrawer(plan, subscriptionId)
 
   return (
@@ -55,7 +57,8 @@ export const PlanDetailsV2PlanSettingsSection = ({
           {
             label: translate('text_63e51ef4985f0ebd75c212fc'),
             startIcon: 'pen',
-            onClick: openDrawer,
+            endIcon: premiumIcon,
+            onClick: gateOnClick(openDrawer),
             hidden: !canUpdate,
             dataTest: PLAN_SETTINGS_EDIT_TEST_ID,
           },

--- a/src/components/plans/details-v2/PlanDetailsV2PlanSettingsSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2PlanSettingsSection.tsx
@@ -10,6 +10,7 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
 
+import { PLAN_SETTINGS_ACCORDION_TEST_ID, PLAN_SETTINGS_EDIT_TEST_ID } from './detailsV2TestIds'
 import { SectionAccordion } from './shared/SectionAccordion'
 import { SectionHeader } from './shared/SectionHeader'
 import { PlanDetailsV2SectionId } from './sidebarSections'
@@ -49,12 +50,14 @@ export const PlanDetailsV2PlanSettingsSection = ({
       />
       <SectionAccordion
         title={translate('text_642d5eb2783a2ad10d67031a')}
+        dataTest={PLAN_SETTINGS_ACCORDION_TEST_ID}
         actions={[
           {
             label: translate('text_63e51ef4985f0ebd75c212fc'),
             startIcon: 'pen',
             onClick: openDrawer,
             hidden: !canUpdate,
+            dataTest: PLAN_SETTINGS_EDIT_TEST_ID,
           },
         ]}
       >

--- a/src/components/plans/details-v2/PlanDetailsV2UsageChargesSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2UsageChargesSection.tsx
@@ -35,6 +35,11 @@ import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
 import { useCustomPricingUnits } from '~/hooks/plans/useCustomPricingUnits'
 import { toLocalUsageChargeInput } from '~/hooks/plans/utils'
 
+import {
+  DETAILS_ADD_USAGE_CHARGE_TEST_ID,
+  USAGE_CHARGE_ACCORDION_TEST_ID_PREFIX,
+  USAGE_CHARGE_EDIT_TEST_ID_PREFIX,
+} from './detailsV2TestIds'
 import { SectionAccordion } from './shared/SectionAccordion'
 import { SectionHeader } from './shared/SectionHeader'
 import { PlanDetailsV2SectionId } from './sidebarSections'
@@ -235,6 +240,7 @@ export const PlanDetailsV2UsageChargesSection = forwardRef<
                 label: translate('text_1772133285142oouequiz2t2'),
                 onClick: openCreate,
                 startIcon: 'plus',
+                dataTest: DETAILS_ADD_USAGE_CHARGE_TEST_ID,
               }
             : undefined
         }
@@ -253,6 +259,7 @@ export const PlanDetailsV2UsageChargesSection = forwardRef<
           icon="pulse"
           title={charge.invoiceDisplayName || charge.billableMetric.name}
           subtitle={charge.code}
+          dataTest={`${USAGE_CHARGE_ACCORDION_TEST_ID_PREFIX}${index}`}
           actions={[
             {
               label: translate('text_63e51ef4985f0ebd75c212fc'),
@@ -263,6 +270,7 @@ export const PlanDetailsV2UsageChargesSection = forwardRef<
                   index,
                 ),
               hidden: !canUpdate,
+              dataTest: `${USAGE_CHARGE_EDIT_TEST_ID_PREFIX}${index}`,
             },
             {
               label: translate('text_63ea0f84f400488553caa786'),

--- a/src/components/plans/details-v2/PlanDetailsV2UsageChargesSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2UsageChargesSection.tsx
@@ -33,6 +33,7 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
 import { useCustomPricingUnits } from '~/hooks/plans/useCustomPricingUnits'
+import { useSubscriptionPremiumGate } from '~/hooks/plans/useSubscriptionPremiumGate'
 import { toLocalUsageChargeInput } from '~/hooks/plans/utils'
 
 import {
@@ -171,6 +172,7 @@ export const PlanDetailsV2UsageChargesSection = forwardRef<
 >(({ plan, isInSubscriptionForm = false, chargeMutations }, ref) => {
   const { translate } = useInternationalization()
   const { canCreate, canUpdate, canDelete } = useAccordionPermissions(isInSubscriptionForm)
+  const { gateOnClick, premiumIcon } = useSubscriptionPremiumGate(isInSubscriptionForm)
   const { hasAnyPricingUnitConfigured } = useCustomPricingUnits()
   const drawerRef = useRef<UsageChargeDrawerRef>(null)
   const removeChargeWarningDialogRef = useRef<RemoveChargeWarningDialogRef>(null)
@@ -264,11 +266,13 @@ export const PlanDetailsV2UsageChargesSection = forwardRef<
             {
               label: translate('text_63e51ef4985f0ebd75c212fc'),
               startIcon: 'pen',
-              onClick: () =>
+              endIcon: premiumIcon,
+              onClick: gateOnClick(() =>
                 openEdit(
                   toLocalUsageChargeInput(charge, planCurrency, hasAnyPricingUnitConfigured),
                   index,
                 ),
+              ),
               hidden: !canUpdate,
               dataTest: `${USAGE_CHARGE_EDIT_TEST_ID_PREFIX}${index}`,
             },

--- a/src/components/plans/details-v2/SubscriptionFeeAccordion.tsx
+++ b/src/components/plans/details-v2/SubscriptionFeeAccordion.tsx
@@ -22,6 +22,10 @@ import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
 import { useUpdatePlanWithCascade } from '~/hooks/plans/useUpdatePlanWithCascade'
 import { useUpdateSubscriptionPlanOverride } from '~/hooks/plans/useUpdateSubscriptionPlanOverride'
 
+import {
+  SUBSCRIPTION_FEE_ACCORDION_TEST_ID,
+  SUBSCRIPTION_FEE_EDIT_TEST_ID,
+} from './detailsV2TestIds'
 import { SectionAccordion } from './shared/SectionAccordion'
 import { PlanDetailsV2SectionId } from './sidebarSections'
 
@@ -115,12 +119,14 @@ export const SubscriptionFeeAccordion = ({
         title={plan.invoiceDisplayName || translate('text_642d5eb2783a2ad10d670336')}
         subtitle={formattedAmount}
         badge={intervalBadge}
+        dataTest={SUBSCRIPTION_FEE_ACCORDION_TEST_ID}
         actions={[
           {
             label: translate('text_63e51ef4985f0ebd75c212fc'),
             startIcon: 'pen',
             onClick: openDrawer,
             hidden: !canUpdate,
+            dataTest: SUBSCRIPTION_FEE_EDIT_TEST_ID,
           },
         ]}
       >

--- a/src/components/plans/details-v2/SubscriptionFeeAccordion.tsx
+++ b/src/components/plans/details-v2/SubscriptionFeeAccordion.tsx
@@ -19,6 +19,7 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
+import { useSubscriptionPremiumGate } from '~/hooks/plans/useSubscriptionPremiumGate'
 import { useUpdatePlanWithCascade } from '~/hooks/plans/useUpdatePlanWithCascade'
 import { useUpdateSubscriptionPlanOverride } from '~/hooks/plans/useUpdateSubscriptionPlanOverride'
 
@@ -57,6 +58,7 @@ export const SubscriptionFeeAccordion = ({
 }: SubscriptionFeeAccordionProps) => {
   const { translate } = useInternationalization()
   const { canUpdate } = useAccordionPermissions(isInSubscriptionForm)
+  const { gateOnClick, premiumIcon } = useSubscriptionPremiumGate(isInSubscriptionForm)
   const drawerRef = useRef<SubscriptionFeeDrawerRef>(null)
 
   // ISO with the plan form: payInAdvance + trialPeriod lock once the plan has
@@ -124,7 +126,8 @@ export const SubscriptionFeeAccordion = ({
           {
             label: translate('text_63e51ef4985f0ebd75c212fc'),
             startIcon: 'pen',
-            onClick: openDrawer,
+            endIcon: premiumIcon,
+            onClick: gateOnClick(openDrawer),
             hidden: !canUpdate,
             dataTest: SUBSCRIPTION_FEE_EDIT_TEST_ID,
           },

--- a/src/components/plans/details-v2/__tests__/EntitlementAccordion.test.tsx
+++ b/src/components/plans/details-v2/__tests__/EntitlementAccordion.test.tsx
@@ -46,6 +46,7 @@ jest.mock('~/hooks/plans/useUpdatePlanWithCascade', () => ({
 }))
 
 const mockHasPermissions = jest.fn().mockReturnValue(true)
+
 jest.mock('~/hooks/usePermissions', () => ({
   usePermissions: () => ({ hasPermissions: mockHasPermissions }),
 }))

--- a/src/components/plans/details-v2/__tests__/MinimumCommitmentAccordion.test.tsx
+++ b/src/components/plans/details-v2/__tests__/MinimumCommitmentAccordion.test.tsx
@@ -44,11 +44,13 @@ jest.mock('~/hooks/plans/useUpdatePlanWithCascade', () => ({
 }))
 
 const mockIsPremium = jest.fn().mockReturnValue(true)
+
 jest.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({ isPremium: mockIsPremium() }),
 }))
 
 const mockHasPermissions = jest.fn().mockReturnValue(true)
+
 jest.mock('~/hooks/usePermissions', () => ({
   usePermissions: () => ({ hasPermissions: mockHasPermissions }),
 }))

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2FixedChargesSection.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2FixedChargesSection.test.tsx
@@ -37,6 +37,7 @@ const mockHasPermissions = jest.fn((perms?: string[]) => {
   if (!perms) return true
   return !perms.includes('none')
 })
+
 jest.mock('~/hooks/usePermissions', () => ({
   usePermissions: () => ({ hasPermissions: mockHasPermissions }),
 }))
@@ -147,6 +148,7 @@ describe('PlanDetailsV2FixedChargesSection', () => {
 
     await waitFor(() => expect(mockOpenDrawer).toHaveBeenCalledTimes(1))
     const [chargeArg, indexArg] = mockOpenDrawer.mock.calls[0]
+
     expect(chargeArg.id).toBe('fc_1')
     expect(indexArg).toBe(0)
   })
@@ -178,6 +180,7 @@ describe('PlanDetailsV2FixedChargesSection', () => {
 
     await waitFor(() => expect(mockOpenDrawer).toHaveBeenCalledTimes(1))
     const [, , options] = mockOpenDrawer.mock.calls[0]
+
     expect(options?.alreadyUsedChargeAlertMessage).toBe('text_1760729707268h378x60alri')
   })
 
@@ -205,6 +208,7 @@ describe('PlanDetailsV2FixedChargesSection', () => {
 
     await waitFor(() => expect(mockOpenDrawer).toHaveBeenCalledTimes(1))
     const [, , options] = mockOpenDrawer.mock.calls[0]
+
     expect(options?.alreadyUsedChargeAlertMessage).toBeUndefined()
   })
 

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2PlanSettingsSection.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2PlanSettingsSection.test.tsx
@@ -41,6 +41,16 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
   }),
 }))
 
+let mockIsPremium = true
+jest.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ isPremium: mockIsPremium }),
+}))
+
+const mockOpenPremiumDialog = jest.fn()
+jest.mock('~/components/dialogs/PremiumWarningDialog', () => ({
+  usePremiumWarningDialog: () => ({ open: mockOpenPremiumDialog, close: jest.fn() }),
+}))
+
 const Wrapper = ({ children }: { children: ReactNode }) => (
   <MockedProvider mocks={[]} addTypename={false}>
     <NiceModal.Provider>{children}</NiceModal.Provider>
@@ -50,7 +60,9 @@ const Wrapper = ({ children }: { children: ReactNode }) => (
 describe('PlanDetailsV2PlanSettingsSection', () => {
   beforeEach(() => {
     mockOpenDrawer.mockClear()
+    mockOpenPremiumDialog.mockClear()
     mockHasPermissions.mockReset().mockReturnValue(true)
+    mockIsPremium = true
   })
 
   it('renders the section header and accordion summary', () => {
@@ -101,6 +113,29 @@ describe('PlanDetailsV2PlanSettingsSection', () => {
     )
 
     await waitFor(() => expect(mockOpenDrawer).toHaveBeenCalledTimes(1))
+  })
+
+  // Drift test: sub plan-override editing is premium-gated. A freemium user's
+  // Edit click opens the upsell modal instead of the drawer.
+  it('opens the premium upsell instead of the drawer in subscription context for freemium users', async () => {
+    mockIsPremium = false
+
+    render(
+      <PlanDetailsV2PlanSettingsSection
+        plan={planDetailsV2Fixture}
+        isInSubscriptionForm
+        subscriptionId="sub_1"
+      />,
+      { wrapper: Wrapper },
+    )
+
+    await userEvent.click(await screen.findByRole('button', { name: /actions/i }))
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'text_63e51ef4985f0ebd75c212fc' }),
+    )
+
+    await waitFor(() => expect(mockOpenPremiumDialog).toHaveBeenCalledTimes(1))
+    expect(mockOpenDrawer).not.toHaveBeenCalled()
   })
 
   it('hides the Edit action when plansUpdate permission is missing', () => {

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2UsageChargesSection.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2UsageChargesSection.test.tsx
@@ -42,6 +42,7 @@ const mockHasPermissions = jest.fn((perms?: string[]) => {
   if (!perms) return true
   return !perms.includes('none')
 })
+
 jest.mock('~/hooks/usePermissions', () => ({
   usePermissions: () => ({ hasPermissions: mockHasPermissions }),
 }))
@@ -157,6 +158,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
       ...planDetailsV2Fixture,
       charges: [buildUsageChargeFixture({ id: 'ch_1' })],
     }
+
     render(<PlanDetailsV2UsageChargesSection plan={plan} chargeMutations={chargeMutations} />, {
       wrapper: Wrapper,
     })
@@ -166,6 +168,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
     )
     await waitFor(() => expect(mockOpenDrawer).toHaveBeenCalledTimes(1))
     const [chargeArg, indexArg] = mockOpenDrawer.mock.calls[0]
+
     expect(chargeArg.id).toBe('ch_1')
     expect(indexArg).toBe(0)
   })
@@ -175,6 +178,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
       ...planDetailsV2Fixture,
       charges: [buildUsageChargeFixture({ id: 'ch_1' }), buildUsageChargeFixture({ id: 'ch_2' })],
     }
+
     render(<PlanDetailsV2UsageChargesSection plan={plan} chargeMutations={chargeMutations} />, {
       wrapper: Wrapper,
     })
@@ -184,6 +188,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
     )
     await waitFor(() => expect(mockOpenDrawer).toHaveBeenCalledTimes(1))
     const [, , options] = mockOpenDrawer.mock.calls[0]
+
     expect(options?.alreadyUsedChargeAlertMessage).toBe('text_6435895831d323008a47911f')
   })
 
@@ -192,6 +197,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
       ...planDetailsV2Fixture,
       charges: [buildUsageChargeFixture({ id: 'ch_1' })],
     }
+
     render(<PlanDetailsV2UsageChargesSection plan={plan} chargeMutations={chargeMutations} />, {
       wrapper: Wrapper,
     })
@@ -201,6 +207,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
     )
     await waitFor(() => expect(mockOpenDrawer).toHaveBeenCalledTimes(1))
     const [, , options] = mockOpenDrawer.mock.calls[0]
+
     expect(options?.alreadyUsedChargeAlertMessage).toBeUndefined()
   })
 
@@ -209,6 +216,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
       ...planDetailsV2Fixture,
       charges: [buildUsageChargeFixture({ id: 'ch_to_delete' })],
     }
+
     render(<PlanDetailsV2UsageChargesSection plan={plan} chargeMutations={chargeMutations} />, {
       wrapper: Wrapper,
     })
@@ -225,6 +233,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
       subscriptionsCount: 3,
       charges: [buildUsageChargeFixture({ id: 'ch_used' })],
     }
+
     render(<PlanDetailsV2UsageChargesSection plan={plan} chargeMutations={chargeMutations} />, {
       wrapper: Wrapper,
     })
@@ -275,6 +284,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
       ...planDetailsV2Fixture,
       charges: [buildUsageChargeFixture({ id: 'ch_sub' })],
     }
+
     render(
       <PlanDetailsV2UsageChargesSection
         plan={plan}
@@ -301,6 +311,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
       ...planDetailsV2Fixture,
       charges: [buildUsageChargeFixture({ id: 'ch_no_perm' })],
     }
+
     render(<PlanDetailsV2UsageChargesSection plan={plan} chargeMutations={chargeMutations} />, {
       wrapper: Wrapper,
     })
@@ -316,6 +327,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
       ...planDetailsV2Fixture,
       charges: [buildUsageChargeFixture({ id: 'ch_no_update' })],
     }
+
     render(<PlanDetailsV2UsageChargesSection plan={plan} chargeMutations={chargeMutations} />, {
       wrapper: Wrapper,
     })
@@ -342,6 +354,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
         }),
       ],
     }
+
     render(<PlanDetailsV2UsageChargesSection plan={plan} chargeMutations={chargeMutations} />, {
       wrapper: Wrapper,
     })
@@ -351,6 +364,7 @@ describe('PlanDetailsV2UsageChargesSection', () => {
 
   it('exposes openCreate via ref', async () => {
     const ref = createRef<PlanDetailsV2UsageChargesSectionRef>()
+
     render(
       <PlanDetailsV2UsageChargesSection
         ref={ref}

--- a/src/components/plans/details-v2/__tests__/ProgressiveBillingAccordion.test.tsx
+++ b/src/components/plans/details-v2/__tests__/ProgressiveBillingAccordion.test.tsx
@@ -45,6 +45,7 @@ jest.mock('~/hooks/plans/useUpdatePlanWithCascade', () => ({
 const mockPremiumIntegrations = jest
   .fn()
   .mockReturnValue([PremiumIntegrationTypeEnum.ProgressiveBilling])
+
 jest.mock('~/hooks/useOrganizationInfos', () => ({
   useOrganizationInfos: () => ({
     organization: { premiumIntegrations: mockPremiumIntegrations() },
@@ -52,6 +53,7 @@ jest.mock('~/hooks/useOrganizationInfos', () => ({
 }))
 
 const mockHasPermissions = jest.fn().mockReturnValue(true)
+
 jest.mock('~/hooks/usePermissions', () => ({
   usePermissions: () => ({ hasPermissions: mockHasPermissions }),
 }))

--- a/src/components/plans/details-v2/__tests__/SubscriptionFeeAccordion.test.tsx
+++ b/src/components/plans/details-v2/__tests__/SubscriptionFeeAccordion.test.tsx
@@ -42,6 +42,7 @@ const mockHasPermissions = jest.fn((perms?: string[]) => {
   if (!perms) return true
   return !perms.includes('none')
 })
+
 jest.mock('~/hooks/usePermissions', () => ({
   usePermissions: () => ({ hasPermissions: mockHasPermissions }),
 }))

--- a/src/components/plans/details-v2/accordions/MinimumCommitmentAccordion.tsx
+++ b/src/components/plans/details-v2/accordions/MinimumCommitmentAccordion.tsx
@@ -16,6 +16,7 @@ import { serializeMinimumCommitment } from '~/core/serializers/serializePlanInpu
 import { CommitmentTypeEnum, CurrencyEnum, PlanDetailsV2Fragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAccordionPermissions } from '~/hooks/plans/useAccordionPermissions'
+import { useSubscriptionPremiumGate } from '~/hooks/plans/useSubscriptionPremiumGate'
 import { useUpdatePlanWithCascade } from '~/hooks/plans/useUpdatePlanWithCascade'
 import { useUpdateSubscriptionPlanOverride } from '~/hooks/plans/useUpdateSubscriptionPlanOverride'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
@@ -38,6 +39,7 @@ export const MinimumCommitmentAccordion = ({
   const { translate } = useInternationalization()
   const { isPremium } = useCurrentUser()
   const { canUpdate, canDelete } = useAccordionPermissions(isInSubscriptionForm)
+  const { gateOnClick, premiumIcon } = useSubscriptionPremiumGate(isInSubscriptionForm)
   const drawerRef = useRef<MinimumCommitmentDrawerRef>(null)
 
   const currency = plan.amountCurrency || CurrencyEnum.Usd
@@ -120,7 +122,8 @@ export const MinimumCommitmentAccordion = ({
             {
               label: translate('text_63e51ef4985f0ebd75c212fc'),
               startIcon: 'pen',
-              onClick: openEditDrawer,
+              endIcon: premiumIcon,
+              onClick: gateOnClick(openEditDrawer),
               hidden: !canUpdate,
             },
             {

--- a/src/components/plans/details-v2/detailsV2TestIds.ts
+++ b/src/components/plans/details-v2/detailsV2TestIds.ts
@@ -1,0 +1,15 @@
+// Standalone test-id constants for the plan/subscription details v2 layouts.
+// Imported by Cypress specs — keep this file free of React/JSX imports.
+
+// PlanDetailsV2PlanSettingsSection
+export const PLAN_SETTINGS_ACCORDION_TEST_ID = 'plan-settings-accordion'
+export const PLAN_SETTINGS_EDIT_TEST_ID = 'plan-settings-edit'
+
+// SubscriptionFeeAccordion
+export const SUBSCRIPTION_FEE_ACCORDION_TEST_ID = 'subscription-fee-accordion'
+export const SUBSCRIPTION_FEE_EDIT_TEST_ID = 'subscription-fee-edit'
+
+// PlanDetailsV2UsageChargesSection
+export const DETAILS_ADD_USAGE_CHARGE_TEST_ID = 'details-add-usage-charge'
+export const USAGE_CHARGE_ACCORDION_TEST_ID_PREFIX = 'usage-charge-accordion-'
+export const USAGE_CHARGE_EDIT_TEST_ID_PREFIX = 'usage-charge-edit-'

--- a/src/components/plans/details-v2/shared/SectionAccordion.tsx
+++ b/src/components/plans/details-v2/shared/SectionAccordion.tsx
@@ -14,6 +14,7 @@ export type SectionAccordionAction = {
   onClick: () => void
   hidden?: boolean
   startIcon?: IconName
+  dataTest?: string
 }
 
 export type SectionAccordionProps = {
@@ -25,6 +26,7 @@ export type SectionAccordionProps = {
   actions?: SectionAccordionAction[]
   initiallyOpen?: boolean
   noContentMargin?: boolean
+  dataTest?: string
   children: ReactNode
 }
 
@@ -37,12 +39,13 @@ export const SectionAccordion = ({
   actions,
   initiallyOpen,
   noContentMargin,
+  dataTest,
   children,
 }: SectionAccordionProps) => {
   const visibleActions = (actions ?? []).filter((a) => !a.hidden)
 
   return (
-    <div id={id} className="scroll-mt-12">
+    <div id={id} data-test={dataTest} className="scroll-mt-12">
       {/* content-visibility lives on the card itself, not this wrapper: a contain:paint
           element clips its descendants' overflow but not its OWN box-shadow, so the focus
           ring on the card is no longer cropped.
@@ -82,6 +85,7 @@ export const SectionAccordion = ({
                   opener={({ onClick: openPopper }) => (
                     <Button
                       aria-label="actions"
+                      data-test={dataTest ? `${dataTest}-actions` : undefined}
                       variant="quaternary"
                       icon="dots-horizontal"
                       onClick={(e) => {
@@ -96,6 +100,7 @@ export const SectionAccordion = ({
                       {visibleActions.map((action) => (
                         <Button
                           key={action.label}
+                          data-test={action.dataTest}
                           variant="quaternary"
                           align="left"
                           fullWidth

--- a/src/components/plans/details-v2/shared/SectionAccordion.tsx
+++ b/src/components/plans/details-v2/shared/SectionAccordion.tsx
@@ -14,6 +14,7 @@ export type SectionAccordionAction = {
   onClick: () => void
   hidden?: boolean
   startIcon?: IconName
+  endIcon?: IconName
   dataTest?: string
 }
 
@@ -105,6 +106,7 @@ export const SectionAccordion = ({
                           align="left"
                           fullWidth
                           startIcon={action.startIcon}
+                          endIcon={action.endIcon}
                           onClick={(e) => {
                             e.stopPropagation()
                             e.preventDefault()

--- a/src/components/plans/details-v2/shared/SectionHeader.tsx
+++ b/src/components/plans/details-v2/shared/SectionHeader.tsx
@@ -9,6 +9,7 @@ export type SectionHeaderAction = {
   hidden?: boolean
   disabled?: boolean
   startIcon?: IconName
+  dataTest?: string
 }
 
 export type SectionHeaderProps = {
@@ -35,6 +36,7 @@ export const SectionHeader = ({ title, description, action }: SectionHeaderProps
       {showAction && (
         <Button
           variant="inline"
+          data-test={action.dataTest}
           onClick={action.onClick}
           disabled={action.disabled}
           startIcon={action.startIcon}

--- a/src/components/plans/details-v2/shared/SectionHeader.tsx
+++ b/src/components/plans/details-v2/shared/SectionHeader.tsx
@@ -9,6 +9,7 @@ export type SectionHeaderAction = {
   hidden?: boolean
   disabled?: boolean
   startIcon?: IconName
+  endIcon?: IconName
   dataTest?: string
 }
 
@@ -40,6 +41,7 @@ export const SectionHeader = ({ title, description, action }: SectionHeaderProps
           onClick={action.onClick}
           disabled={action.disabled}
           startIcon={action.startIcon}
+          endIcon={action.endIcon}
         >
           {action.label}
         </Button>

--- a/src/components/plans/drawers/fixedCharge/FixedChargeDrawerContent.tsx
+++ b/src/components/plans/drawers/fixedCharge/FixedChargeDrawerContent.tsx
@@ -4,6 +4,7 @@ import { useStore } from '@tanstack/react-form'
 import { useCallback, useMemo } from 'react'
 
 import { Selector } from '~/components/designSystem/Selector'
+import { Typography } from '~/components/designSystem/Typography'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { ChargeModelSelector } from '~/components/plans/chargeAccordion/ChargeModelSelector'
 import { ChargeWrapperSwitch } from '~/components/plans/chargeAccordion/ChargeWrapperSwitch'
@@ -311,26 +312,26 @@ export const FixedChargeDrawerContent = withForm({
               <PlanBillingPeriodInfoSection />
 
               <ChargePayInAdvanceOption
-                chargePayInAdvanceDescription={undefined}
+                form={form}
+                fields={{ payInAdvance: 'payInAdvance' }}
                 disabled={isInSubscriptionForm || isExistingChargeDisabled}
                 isPayInAdvanceOptionDisabled={isPayInAdvanceOptionDisabled}
-                payInAdvance={formValues.payInAdvance}
-                handleUpdate={({ payInAdvance }) => {
-                  form.setFieldValue('payInAdvance', payInAdvance)
-                }}
               />
 
               <div className="flex flex-col gap-4">
                 <div className="flex flex-col gap-1">
-                  <CenteredPage.PageSectionTitle
-                    title={translate('text_17607297072670cl4jl071yy')}
-                  />
+                  <Typography variant="captionHl" color="grey700">
+                    {translate('text_177488074309762bkd4znl3p')}
+                  </Typography>
+                  <Typography variant="caption" color="grey600">
+                    {translate('text_1774880743098ioxd3oxanxo')}
+                  </Typography>
                 </div>
 
                 <form.AppField name="prorated">
                   {(field) => (
                     <field.SwitchField
-                      label={translate('text_17607297072670cl4jl071yy')}
+                      label={translate('text_177488074309762bkd4znl3p')}
                       disabled={
                         isInSubscriptionForm || isExistingChargeDisabled || isProratedOptionDisabled
                       }

--- a/src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx
+++ b/src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx
@@ -701,16 +701,14 @@ export const UsageChargeDrawerContent = withForm({
               <PlanBillingPeriodInfoSection />
 
               <ChargePayInAdvanceOption
-                chargePayInAdvanceDescription={chargePayInAdvanceDescription}
+                form={form}
+                fields={{ payInAdvance: 'payInAdvance' }}
+                description={chargePayInAdvanceDescription}
                 disabled={isInSubscriptionForm || isExistingChargeDisabled}
                 isPayInAdvanceOptionDisabled={isPayInAdvanceOptionDisabled}
-                payInAdvance={formValues.payInAdvance}
-                handleUpdate={({ invoiceable, payInAdvance, regroupPaidFees }) => {
-                  form.setFieldValue('payInAdvance', payInAdvance)
-                  if (invoiceable !== undefined) {
-                    form.setFieldValue('invoiceable', invoiceable)
-                  }
-                  if (regroupPaidFees === null) {
+                onPayInAdvanceChange={(payInAdvance) => {
+                  if (!payInAdvance) {
+                    form.setFieldValue('invoiceable', true)
                     form.setFieldValue('regroupPaidFees', null)
                   }
                 }}
@@ -730,7 +728,7 @@ export const UsageChargeDrawerContent = withForm({
 
               {!!formValues.billableMetric.recurring && (
                 <div className="flex flex-col gap-4">
-                  <div>
+                  <div className="flex flex-col gap-1">
                     <Typography variant="captionHl" color="grey700">
                       {translate('text_177488074309762bkd4znl3p')}
                     </Typography>

--- a/src/components/subscriptions/SubscriptionsList.tsx
+++ b/src/components/subscriptions/SubscriptionsList.tsx
@@ -178,7 +178,7 @@ const generateActionColumn = ({
             generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
               customerId: subscription.customer.id,
               subscriptionId: subscription.id,
-              tab: CustomerSubscriptionDetailsTabsOptionsEnum.editOverview,
+              tab: CustomerSubscriptionDetailsTabsOptionsEnum.overview,
             }),
           ),
       },

--- a/src/components/subscriptions/SubscriptionsList.tsx
+++ b/src/components/subscriptions/SubscriptionsList.tsx
@@ -10,7 +10,6 @@ import { subscriptionStatusMapping } from '~/core/constants/statusSubscriptionMa
 import { CustomerSubscriptionDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import {
   CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE,
-  UPDATE_SUBSCRIPTION,
   UPGRADE_DOWNGRADE_SUBSCRIPTION,
   useNavigate,
 } from '~/core/router'
@@ -176,9 +175,22 @@ const generateActionColumn = ({
         title: translate('text_62d7f6178ec94cd09370e63c'),
         onAction: () =>
           navigate(
-            generatePath(UPDATE_SUBSCRIPTION, {
+            generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
               customerId: subscription.customer.id,
               subscriptionId: subscription.id,
+              tab: CustomerSubscriptionDetailsTabsOptionsEnum.editOverview,
+            }),
+          ),
+      },
+      {
+        startIcon: 'board',
+        title: translate('text_17810297639135ya0hmsldpi'),
+        onAction: () =>
+          navigate(
+            generatePath(CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE, {
+              customerId: subscription.customer.id,
+              subscriptionId: subscription.id,
+              tab: CustomerSubscriptionDetailsTabsOptionsEnum.subscriptionPlan,
             }),
           ),
       },

--- a/src/components/subscriptions/details-v2/SubscriptionDetailsV2Plan.tsx
+++ b/src/components/subscriptions/details-v2/SubscriptionDetailsV2Plan.tsx
@@ -1,4 +1,5 @@
 import { gql } from '@apollo/client'
+import { useMemo } from 'react'
 
 import { Alert } from '~/components/designSystem/Alert'
 import { PlanDetailsV2 } from '~/components/plans/details-v2/PlanDetailsV2'
@@ -11,7 +12,6 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
-import { tw } from '~/styles/utils'
 
 gql`
   query getSubscriptionForDetailsV2Plan($subscriptionId: ID!) {
@@ -45,6 +45,24 @@ export const SubscriptionDetailsV2Plan = ({ subscriptionId }: Props) => {
 
   const plan = data?.subscription?.plan
 
+  const banner = useMemo(() => {
+    if (!isPremium) {
+      return (
+        <PremiumFeature
+          feature={translate('text_65118a52df984447c18694d1')}
+          title={translate('text_65118a52df984447c18694d0')}
+          description={translate('text_65118a52df984447c18694da')}
+        />
+      )
+    }
+
+    if (!plan?.parent) {
+      return <Alert type="info">{translate('text_652525609f420d00b83dd602')}</Alert>
+    }
+
+    return undefined
+  }, [isPremium, plan?.parent, translate])
+
   if (loading && !plan) {
     return <PlanDetailsV2Skeleton />
   }
@@ -54,40 +72,11 @@ export const SubscriptionDetailsV2Plan = ({ subscriptionId }: Props) => {
   }
 
   return (
-    <>
-      {/* Editing a subscription's plan overrides is a premium feature (the BE
-          override services are premium-gated). Mirror the masked upsell from the
-          subscription edit form: non-premium users see the upsell + a faded,
-          inert (non-interactive) preview of the whole scrolling area. */}
-      {!isPremium && (
-        <PremiumFeature
-          className="mt-12"
-          feature={translate('text_65118a52df984447c18694d0')}
-          title={translate('text_65118a52df984447c18694d0')}
-          description={translate('text_65118a52df984447c18694da')}
-        />
-      )}
-
-      <div
-        className={tw(
-          'flex flex-col',
-          !isPremium && '[mask-image:linear-gradient(to_bottom,black_0%,transparent_100%)]',
-        )}
-        {...(!isPremium && { inert: '' })}
-      >
-        <PlanDetailsV2
-          planId={plan.id}
-          isInSubscriptionForm
-          subscriptionId={subscriptionId}
-          banner={
-            !plan.parent ? (
-              <Alert className="pl-[-4px]" type="info" fullWidth>
-                {translate('text_652525609f420d00b83dd602')}
-              </Alert>
-            ) : undefined
-          }
-        />
-      </div>
-    </>
+    <PlanDetailsV2
+      planId={plan.id}
+      isInSubscriptionForm
+      subscriptionId={subscriptionId}
+      banner={banner}
+    />
   )
 }

--- a/src/components/subscriptions/details-v2/__tests__/SubscriptionDetailsV2Plan.test.tsx
+++ b/src/components/subscriptions/details-v2/__tests__/SubscriptionDetailsV2Plan.test.tsx
@@ -1,5 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { screen, waitFor } from '@testing-library/react'
+import { isValidElement, ReactElement } from 'react'
 
 import { GetSubscriptionForDetailsV2PlanDocument } from '~/generated/graphql'
 import { render } from '~/test-utils'
@@ -67,16 +68,20 @@ describe('SubscriptionDetailsV2Plan', () => {
 
     await waitFor(() => expect(capturedProps.length).toBeGreaterThan(0))
     const props = capturedProps[capturedProps.length - 1]
+
     expect(props.planId).toBe('plan_override_1')
     expect(props.isInSubscriptionForm).toBe(true)
     expect(props.subscriptionId).toBe(SUB_ID)
-    // Premium users see no upsell.
+    // Premium users see no upsell: the banner is never the PremiumFeature.
+    if (isValidElement(props.banner)) {
+      render(props.banner as ReactElement)
+    }
     expect(screen.queryByTestId('premium-feature')).not.toBeInTheDocument()
   })
 
   // Drift test: subscription plan overrides are premium-gated — non-premium users
-  // get the upsell over a gated preview, mirroring the subscription edit form.
-  it('shows the premium upsell for non-premium users', async () => {
+  // get the upsell as the PlanDetailsV2 banner over a gated (clickable) preview.
+  it('passes the premium upsell as the PlanDetailsV2 banner for non-premium users', async () => {
     mockIsPremium = false
 
     render(
@@ -85,6 +90,11 @@ describe('SubscriptionDetailsV2Plan', () => {
       </MockedProvider>,
     )
 
+    await waitFor(() => expect(capturedProps.length).toBeGreaterThan(0))
+    const props = capturedProps[capturedProps.length - 1]
+
+    expect(isValidElement(props.banner)).toBe(true)
+    render(props.banner as ReactElement)
     expect(await screen.findByTestId('premium-feature')).toBeInTheDocument()
   })
 })

--- a/src/core/constants/tabsOptions.ts
+++ b/src/core/constants/tabsOptions.ts
@@ -25,7 +25,6 @@ export enum CustomerInvoiceDetailsTabsOptionsEnum {
 export enum CustomerSubscriptionDetailsTabsOptionsEnum {
   activityLogs = 'activity-logs',
   alerts = 'alerts',
-  editOverview = 'edit-overview',
   entitlements = 'entitlements',
   overview = 'overview',
   progressiveBilling = 'progressive-billing',
@@ -40,7 +39,6 @@ export enum IntegrationsTabsOptionsEnum {
 
 export enum PlanDetailsTabsOptionsEnum {
   activityLogs = 'activity-logs',
-  editOverview = 'edit-overview',
   overview = 'overview',
   subscriptions = 'subscriptions',
 }

--- a/src/core/router/__tests__/utils.test.tsx
+++ b/src/core/router/__tests__/utils.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { act } from '@testing-library/react'
 
 import { lazyLoad } from '../utils'

--- a/src/core/utils/featureFlags.ts
+++ b/src/core/utils/featureFlags.ts
@@ -2,7 +2,6 @@
 export enum FeatureFlags {
   FTR_ENABLED = 'ftr_enabled',
   SUPERSET_PERSISTENT_FILTERS = 'superset_persistent_filters',
-  EDIT_DETAILS_PAGE = 'edit_details_page',
 }
 
 const FF_KEY = 'featureFlags'

--- a/src/formValidation/__tests__/zodChargePropertiesCustom.test.ts
+++ b/src/formValidation/__tests__/zodChargePropertiesCustom.test.ts
@@ -12,9 +12,8 @@ function validate(
   props: Partial<PropertiesZodInput>,
   pathPrefix: string[],
 ) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const issues: any[] = []
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   const ctx = { addIssue: (issue: any) => issues.push(issue), path: [] } as any as z.RefinementCtx
 
   validateChargeProperties(chargeModel, props as PropertiesZodInput, ctx, pathPrefix)

--- a/src/formValidation/__tests__/zodChargePropertiesGraduated.test.ts
+++ b/src/formValidation/__tests__/zodChargePropertiesGraduated.test.ts
@@ -11,9 +11,8 @@ function validate(
   props: Partial<PropertiesZodInput>,
   pathPrefix: string[],
 ) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const issues: any[] = []
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   const ctx = { addIssue: (issue: any) => issues.push(issue), path: [] } as any as z.RefinementCtx
 
   validateChargeProperties(chargeModel, props as PropertiesZodInput, ctx, pathPrefix)

--- a/src/formValidation/__tests__/zodChargePropertiesGraduatedPercentage.test.ts
+++ b/src/formValidation/__tests__/zodChargePropertiesGraduatedPercentage.test.ts
@@ -12,7 +12,7 @@ function validate(
   pathPrefix: string[],
 ) {
   const issues: any[] = []
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   const ctx = { addIssue: (issue: any) => issues.push(issue), path: [] } as any as z.RefinementCtx
 
   validateChargeProperties(chargeModel, props as PropertiesZodInput, ctx, pathPrefix)

--- a/src/formValidation/__tests__/zodChargePropertiesPackage.test.ts
+++ b/src/formValidation/__tests__/zodChargePropertiesPackage.test.ts
@@ -11,9 +11,8 @@ function validate(
   props: Partial<PropertiesZodInput>,
   pathPrefix: string[],
 ) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const issues: any[] = []
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   const ctx = { addIssue: (issue: any) => issues.push(issue), path: [] } as any as z.RefinementCtx
 
   validateChargeProperties(chargeModel, props as PropertiesZodInput, ctx, pathPrefix)

--- a/src/formValidation/__tests__/zodChargePropertiesPercentage.test.ts
+++ b/src/formValidation/__tests__/zodChargePropertiesPercentage.test.ts
@@ -11,9 +11,8 @@ function validate(
   props: Partial<PropertiesZodInput>,
   pathPrefix: string[],
 ) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const issues: any[] = []
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   const ctx = { addIssue: (issue: any) => issues.push(issue), path: [] } as any as z.RefinementCtx
 
   validateChargeProperties(chargeModel, props as PropertiesZodInput, ctx, pathPrefix)

--- a/src/formValidation/__tests__/zodChargePropertiesStandard.test.ts
+++ b/src/formValidation/__tests__/zodChargePropertiesStandard.test.ts
@@ -11,9 +11,8 @@ function validate(
   props: Partial<PropertiesZodInput>,
   pathPrefix: string[],
 ) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const issues: any[] = []
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   const ctx = { addIssue: (issue: any) => issues.push(issue), path: [] } as any as z.RefinementCtx
 
   validateChargeProperties(chargeModel, props as PropertiesZodInput, ctx, pathPrefix)

--- a/src/formValidation/__tests__/zodChargePropertiesVolume.test.ts
+++ b/src/formValidation/__tests__/zodChargePropertiesVolume.test.ts
@@ -11,9 +11,8 @@ function validate(
   props: Partial<PropertiesZodInput>,
   pathPrefix: string[],
 ) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const issues: any[] = []
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   const ctx = { addIssue: (issue: any) => issues.push(issue), path: [] } as any as z.RefinementCtx
 
   validateChargeProperties(chargeModel, props as PropertiesZodInput, ctx, pathPrefix)

--- a/src/hooks/plans/__tests__/usePlanUpdate.test.tsx
+++ b/src/hooks/plans/__tests__/usePlanUpdate.test.tsx
@@ -9,6 +9,7 @@ import { usePlanUpdate } from '../usePlanUpdate'
 
 jest.mock('~/core/apolloClient', () => {
   const actual = jest.requireActual('~/core/apolloClient')
+
   return { ...actual, addToast: jest.fn() }
 })
 

--- a/src/hooks/plans/useSubscriptionPremiumGate.ts
+++ b/src/hooks/plans/useSubscriptionPremiumGate.ts
@@ -1,0 +1,37 @@
+import { IconName } from 'lago-design-system'
+
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useCurrentUser } from '~/hooks/useCurrentUser'
+
+// Editing a subscription's plan overrides is a premium feature (the BE override
+// services are premium-gated). On the subscription plan tab a non-premium user
+// still sees the (faded) sections, so every edit action must open the upsell
+// modal instead of running its real handler. The modal copy mirrors the masked
+// PremiumFeature banner shown at the top of the same tab.
+export const useSubscriptionPremiumGate = (isInSubscriptionForm: boolean) => {
+  const { isPremium } = useCurrentUser()
+  const { translate } = useInternationalization()
+  const premiumWarningDialog = usePremiumWarningDialog()
+
+  const isGated = isInSubscriptionForm && !isPremium
+
+  const openPremiumDialog = () => {
+    const feature = translate('text_65118a52df984447c18694d1')
+
+    premiumWarningDialog.open({
+      title: translate('text_65118a52df984447c18694d0'),
+      description: translate('text_65118a52df984447c18694da'),
+      mailtoSubject: translate('text_1759493418045b173t4qhktb', { feature }),
+      mailtoBody: translate('text_1759493745332hiuejhksn15', { feature }),
+    })
+  }
+
+  // Wrap an action handler: gated callers get the upsell modal, everyone else
+  // gets the real handler untouched.
+  const gateOnClick = (handler: () => void): (() => void) => (isGated ? openPremiumDialog : handler)
+
+  const premiumIcon: IconName | undefined = isGated ? 'sparkles' : undefined
+
+  return { isGated, gateOnClick, premiumIcon, openPremiumDialog }
+}

--- a/src/pages/PlanDetails.tsx
+++ b/src/pages/PlanDetails.tsx
@@ -9,7 +9,6 @@ import { useMainHeaderTabContent } from '~/components/MainHeader/useMainHeaderTa
 import { DeletePlanDialog, DeletePlanDialogRef } from '~/components/plans/DeletePlanDialog'
 import { PlanDetailsV2 } from '~/components/plans/details-v2/PlanDetailsV2'
 import { PlanDetailsActivityLogs } from '~/components/plans/details/PlanDetailsActivityLogs'
-import { PlanDetailsOverview } from '~/components/plans/details/PlanDetailsOverview'
 import PlanSubscriptionList from '~/components/plans/details/PlanSubscriptionList'
 import { updateDuplicatePlanVar } from '~/core/apolloClient'
 import { PlanDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
@@ -21,7 +20,6 @@ import {
   UPDATE_PLAN_ROUTE,
   useNavigate,
 } from '~/core/router'
-import { FeatureFlags, isFeatureFlagActive } from '~/core/utils/featureFlags'
 import {
   DeletePlanDialogFragment,
   DeletePlanDialogFragmentDoc,
@@ -141,55 +139,30 @@ const PlanDetails = () => {
         }}
         actions={{ items: actions, loading: isPlanLoading }}
         tabs={[
-          isFeatureFlagActive(FeatureFlags.EDIT_DETAILS_PAGE)
-            ? {
-                title: translate('text_628cf761cbe6820138b8f2e4'),
-                link: generatePath(PLAN_DETAILS_ROUTE, {
-                  planId: planId as string,
-                  tab: PlanDetailsTabsOptionsEnum.editOverview,
-                }),
-                match: [
-                  generatePath(PLAN_DETAILS_ROUTE, {
-                    planId: planId as string,
-                    tab: PlanDetailsTabsOptionsEnum.editOverview,
-                  }),
-                  generatePath(CUSTOMER_SUBSCRIPTION_PLAN_DETAILS, {
-                    customerId: customerId || '',
-                    subscriptionId: subscriptionId || '',
-                    planId: planId as string,
-                    tab: PlanDetailsTabsOptionsEnum.editOverview,
-                  }),
-                ],
-                content: (
-                  <DetailsPage.Container className="pb-0">
-                    <PlanDetailsV2 planId={planId as string} />
-                  </DetailsPage.Container>
-                ),
-              }
-            : {
-                title: translate('text_628cf761cbe6820138b8f2e4'),
-                link: generatePath(PLAN_DETAILS_ROUTE, {
-                  planId: planId as string,
-                  tab: PlanDetailsTabsOptionsEnum.overview,
-                }),
-                match: [
-                  generatePath(PLAN_DETAILS_ROUTE, {
-                    planId: planId as string,
-                    tab: PlanDetailsTabsOptionsEnum.overview,
-                  }),
-                  generatePath(CUSTOMER_SUBSCRIPTION_PLAN_DETAILS, {
-                    customerId: customerId || '',
-                    subscriptionId: subscriptionId || '',
-                    planId: planId as string,
-                    tab: PlanDetailsTabsOptionsEnum.overview,
-                  }),
-                ],
-                content: (
-                  <DetailsPage.Container>
-                    <PlanDetailsOverview planId={planId} />
-                  </DetailsPage.Container>
-                ),
-              },
+          {
+            title: translate('text_628cf761cbe6820138b8f2e4'),
+            link: generatePath(PLAN_DETAILS_ROUTE, {
+              planId: planId as string,
+              tab: PlanDetailsTabsOptionsEnum.overview,
+            }),
+            match: [
+              generatePath(PLAN_DETAILS_ROUTE, {
+                planId: planId as string,
+                tab: PlanDetailsTabsOptionsEnum.overview,
+              }),
+              generatePath(CUSTOMER_SUBSCRIPTION_PLAN_DETAILS, {
+                customerId: customerId || '',
+                subscriptionId: subscriptionId || '',
+                planId: planId as string,
+                tab: PlanDetailsTabsOptionsEnum.overview,
+              }),
+            ],
+            content: (
+              <DetailsPage.Container className="pb-0">
+                <PlanDetailsV2 planId={planId as string} />
+              </DetailsPage.Container>
+            ),
+          },
           {
             title: translate('text_6250304370f0f700a8fdc28d'),
             link: generatePath(PLAN_DETAILS_ROUTE, {

--- a/src/pages/PlanDetails.tsx
+++ b/src/pages/PlanDetails.tsx
@@ -87,10 +87,12 @@ const PlanDetails = () => {
     {
       type: 'dropdown',
       label: translate('text_626162c62f790600f850b6fe'),
+      dataTest: 'plan-details-actions',
       items: [
         {
           label: translate('text_65281f686a80b400c8e2f6b3'),
           hidden: !hasPermissions(['plansUpdate']),
+          dataTest: 'plan-details-edit',
           onClick: (closePopper) => {
             navigate(generatePath(UPDATE_PLAN_ROUTE, { planId: plan?.id as string }))
             closePopper()

--- a/src/pages/PlansList.tsx
+++ b/src/pages/PlansList.tsx
@@ -15,12 +15,7 @@ import { DeletePlanDialog, DeletePlanDialogRef } from '~/components/plans/Delete
 import { SearchInput } from '~/components/SearchInput'
 import { updateDuplicatePlanVar } from '~/core/apolloClient/reactiveVars/duplicatePlanVar'
 import { PlanDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
-import {
-  CREATE_PLAN_ROUTE,
-  PLAN_DETAILS_ROUTE,
-  UPDATE_PLAN_ROUTE,
-  useNavigate,
-} from '~/core/router'
+import { CREATE_PLAN_ROUTE, PLAN_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import { DeletePlanDialogFragmentDoc, usePlansLazyQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useDebouncedSearch } from '~/hooks/useDebouncedSearch'
@@ -217,12 +212,13 @@ const PlansList = () => {
             if (canUpdatePlans) {
               actions.push({
                 startIcon: 'pen',
-                title: translate('text_625fd39a15394c0117e7d792'),
+                title: translate('text_17810296077545fp2y0ulzko'),
                 dataTest: 'tab-internal-button-link-update-plan',
                 onAction: () =>
                   navigate(
-                    generatePath(UPDATE_PLAN_ROUTE, {
+                    generatePath(PLAN_DETAILS_ROUTE, {
                       planId: plan.id,
+                      tab: PlanDetailsTabsOptionsEnum.overview,
                     }),
                   ),
               })

--- a/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
+++ b/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
@@ -141,7 +141,7 @@ const mockSyncSalesforceIntegrationInvoice = jest.fn()
 const mockUseIntegrationsListQuery = jest.fn().mockReturnValue({ data: null })
 
 // Capture mutation options to test onError/onCompleted callbacks
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 const mockMutationOptions: Record<string, any> = {}
 
 jest.mock('~/generated/graphql', () => ({
@@ -150,32 +150,32 @@ jest.mock('~/generated/graphql', () => ({
   useGetInvoiceFeesQuery: () => mockUseGetInvoiceFeesQuery(),
   useGetInvoiceCustomerQuery: () => mockUseGetInvoiceCustomerQuery(),
   useIntegrationsListForCustomerInvoiceDetailsQuery: () => mockUseIntegrationsListQuery(),
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   useRefreshInvoiceMutation: (options: any) => {
     mockMutationOptions.refreshInvoice = options || {}
     return [mockRefreshInvoice, { loading: false }]
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   useRetryInvoiceMutation: (options: any) => {
     mockMutationOptions.retryInvoice = options || {}
     return [mockRetryInvoice, { loading: false }]
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   useRetryTaxProviderVoidingMutation: (options: any) => {
     mockMutationOptions.retryTaxProviderVoiding = options || {}
     return [mockRetryTaxProviderVoiding, { loading: false }]
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   useSyncIntegrationInvoiceMutation: (options: any) => {
     mockMutationOptions.syncIntegration = options || {}
     return [mockSyncIntegrationInvoice, { loading: false }]
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   useSyncHubspotIntegrationInvoiceMutation: (options: any) => {
     mockMutationOptions.syncHubspot = options || {}
     return [mockSyncHubspotIntegrationInvoice, { loading: false }]
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   useSyncSalesforceInvoiceMutation: (options: any) => {
     mockMutationOptions.syncSalesforce = options || {}
     return [mockSyncSalesforceIntegrationInvoice, { loading: false }]

--- a/src/pages/__tests__/PlanDetails.test.tsx
+++ b/src/pages/__tests__/PlanDetails.test.tsx
@@ -27,10 +27,6 @@ jest.mock('~/components/layouts/DetailsPage', () => ({
   },
 }))
 
-jest.mock('~/components/plans/details/PlanDetailsOverview', () => ({
-  PlanDetailsOverview: () => null,
-}))
-
 jest.mock('~/components/plans/details-v2/PlanDetailsV2', () => ({
   PlanDetailsV2: () => null,
 }))
@@ -71,13 +67,6 @@ jest.mock('~/generated/graphql', () => ({
     mockUseGetPlanForDetailsQuery(options),
 }))
 
-const mockIsFeatureFlagActive = jest.fn().mockReturnValue(false)
-
-jest.mock('~/core/utils/featureFlags', () => ({
-  ...jest.requireActual('~/core/utils/featureFlags'),
-  isFeatureFlagActive: (flag: string) => mockIsFeatureFlagActive(flag),
-}))
-
 interface MainHeaderDropdownAction {
   type: string
   items: { hidden?: boolean; label: string }[]
@@ -90,7 +79,6 @@ describe('PlanDetails', () => {
 
     useParamsMock.mockReturnValue({ planId: 'plan-123' })
     mockIsPremium.mockReturnValue(true)
-    mockIsFeatureFlagActive.mockReturnValue(false)
     mockUseGetPlanForDetailsQuery.mockReturnValue({
       data: {
         plan: {
@@ -253,39 +241,19 @@ describe('PlanDetails', () => {
     })
   })
 
-  describe('GIVEN the EDIT_DETAILS_PAGE feature flag', () => {
-    describe('WHEN the flag is off', () => {
-      it('THEN should render the legacy overview tab', () => {
+  describe('GIVEN the v2 overview tab', () => {
+    describe('WHEN the component renders', () => {
+      it('THEN should always serve the v2 overview at /overview', () => {
         mockHasPermissions.mockReturnValue(true)
-        mockIsFeatureFlagActive.mockReturnValue(false)
 
         render(<PlanDetails />)
 
         const tabs = mockMainHeaderConfigure.mock.calls[0]?.[0]?.tabs as MainHeaderTab[]
         const overviewTab = tabs.find((t) => t.title === 'text_628cf761cbe6820138b8f2e4')
 
-        // The overview tab is always visible; the flag only swaps its content
-        // (legacy overview) and route (`/overview`).
         expect(overviewTab).toBeDefined()
         expect(overviewTab?.hidden).toBeFalsy()
         expect(overviewTab?.link).toContain('/overview')
-      })
-    })
-
-    describe('WHEN the flag is on', () => {
-      it('THEN should render the v2 edit overview tab', () => {
-        mockHasPermissions.mockReturnValue(true)
-        mockIsFeatureFlagActive.mockReturnValue(true)
-
-        render(<PlanDetails />)
-
-        const tabs = mockMainHeaderConfigure.mock.calls[0]?.[0]?.tabs as MainHeaderTab[]
-        const overviewTab = tabs.find((t) => t.title === 'text_628cf761cbe6820138b8f2e4')
-
-        // Flag on routes the overview tab to the v2 edit page (`/edit-overview`).
-        expect(overviewTab).toBeDefined()
-        expect(overviewTab?.hidden).toBeFalsy()
-        expect(overviewTab?.link).toContain('edit-overview')
       })
     })
   })

--- a/src/pages/subscriptions/CreateSubscription.tsx
+++ b/src/pages/subscriptions/CreateSubscription.tsx
@@ -516,11 +516,11 @@ const CreateSubscription = () => {
                 {!!subscriptionPlanId && (
                   <>
                     {/* Premium "Override plan" full-width divider */}
-                    <div className="relative my-20 flex flex-col items-center gap-3">
+                    <div className="relative mb-8 mt-20 flex flex-col items-center gap-3">
                       <div className="absolute left-1/2 top-0 h-[2px] w-[100vw] -translate-x-1/2 bg-purple-100" />
                       <div className="rounded-b bg-purple-100 px-4 py-1">
                         <Typography variant="captionHl" color="info600">
-                          {translate('text_65118a52df984447c18694d0')}
+                          {translate('text_65118a52df984447c18694d1')}
                         </Typography>
                       </div>
                     </div>
@@ -528,7 +528,7 @@ const CreateSubscription = () => {
                     {/* Premium upsell (non-premium users) */}
                     {!isPremium && (
                       <PremiumFeature
-                        feature={translate('text_65118a52df984447c18694d0')}
+                        feature={translate('text_65118a52df984447c18694d1')}
                         title={translate('text_65118a52df984447c18694d0')}
                         description={translate('text_65118a52df984447c18694da')}
                       />

--- a/src/pages/subscriptions/SubscriptionDetails.tsx
+++ b/src/pages/subscriptions/SubscriptionDetails.tsx
@@ -11,7 +11,6 @@ import { SubscriptionDetailsV2Overview } from '~/components/subscriptions/detail
 import { SubscriptionDetailsV2Plan } from '~/components/subscriptions/details-v2/SubscriptionDetailsV2Plan'
 import { SubscriptionActivityLogs } from '~/components/subscriptions/SubscriptionActivityLogs'
 import { SubscriptionAlertsList } from '~/components/subscriptions/SubscriptionAlertsList'
-import { SubscriptionDetailsOverview } from '~/components/subscriptions/SubscriptionDetailsOverview'
 import { SubscriptionEntitlementsTabContent } from '~/components/subscriptions/SubscriptionEntitlementsTabContent'
 import { SubscriptionProgressiveBillingTab } from '~/components/subscriptions/SubscriptionProgressiveBillingTab/SubscriptionProgressiveBillingTab'
 import { SubscriptionUsageTabContent } from '~/components/subscriptions/SubscriptionUsageTabContent'
@@ -29,7 +28,6 @@ import {
   useNavigate,
 } from '~/core/router'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
-import { FeatureFlags, isFeatureFlagActive } from '~/core/utils/featureFlags'
 import {
   LagoApiError,
   StatusTypeEnum,
@@ -146,53 +144,21 @@ const SubscriptionDetails = () => {
     }
 
     return [
-      isFeatureFlagActive(FeatureFlags.EDIT_DETAILS_PAGE)
-        ? {
-            title: translate('text_628cf761cbe6820138b8f2e4'),
-            link: !!customerId
-              ? getCustomerSubscriptionDetailsRoute(
-                  CustomerSubscriptionDetailsTabsOptionsEnum.editOverview,
-                )
-              : getPlanSubscriptionDetailsRoute(
-                  CustomerSubscriptionDetailsTabsOptionsEnum.editOverview,
-                ),
-            match: [
-              getCustomerSubscriptionDetailsRoute(
-                CustomerSubscriptionDetailsTabsOptionsEnum.editOverview,
-              ),
-              getPlanSubscriptionDetailsRoute(
-                CustomerSubscriptionDetailsTabsOptionsEnum.editOverview,
-              ),
-            ],
-            content: (
-              <DetailsPage.Container>
-                <SubscriptionDetailsV2Overview subscriptionId={subscriptionId as string} />
-              </DetailsPage.Container>
-            ),
-            hidden: !isFeatureFlagActive(FeatureFlags.EDIT_DETAILS_PAGE),
-          }
-        : {
-            title: translate('text_628cf761cbe6820138b8f2e4'),
-            link: !!customerId
-              ? getCustomerSubscriptionDetailsRoute(
-                  CustomerSubscriptionDetailsTabsOptionsEnum.overview,
-                )
-              : getPlanSubscriptionDetailsRoute(
-                  CustomerSubscriptionDetailsTabsOptionsEnum.overview,
-                ),
-            match: [
-              getCustomerSubscriptionDetailsRoute(
-                CustomerSubscriptionDetailsTabsOptionsEnum.overview,
-              ),
-              getPlanSubscriptionDetailsRoute(CustomerSubscriptionDetailsTabsOptionsEnum.overview),
-            ],
-            content: (
-              <DetailsPage.Container>
-                <SubscriptionDetailsOverview />
-              </DetailsPage.Container>
-            ),
-          },
-
+      {
+        title: translate('text_628cf761cbe6820138b8f2e4'),
+        link: !!customerId
+          ? getCustomerSubscriptionDetailsRoute(CustomerSubscriptionDetailsTabsOptionsEnum.overview)
+          : getPlanSubscriptionDetailsRoute(CustomerSubscriptionDetailsTabsOptionsEnum.overview),
+        match: [
+          getCustomerSubscriptionDetailsRoute(CustomerSubscriptionDetailsTabsOptionsEnum.overview),
+          getPlanSubscriptionDetailsRoute(CustomerSubscriptionDetailsTabsOptionsEnum.overview),
+        ],
+        content: (
+          <DetailsPage.Container>
+            <SubscriptionDetailsV2Overview subscriptionId={subscriptionId as string} />
+          </DetailsPage.Container>
+        ),
+      },
       {
         title: translate('text_17792001643316pbexygvpu2'),
         link: !!customerId
@@ -215,7 +181,6 @@ const SubscriptionDetails = () => {
             <SubscriptionDetailsV2Plan subscriptionId={subscriptionId as string} />
           </DetailsPage.Container>
         ),
-        hidden: !isFeatureFlagActive(FeatureFlags.EDIT_DETAILS_PAGE),
       },
       {
         title: translate('text_1724179887722baucvj7bvc1'),

--- a/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
+++ b/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
@@ -118,13 +118,6 @@ jest.mock('~/hooks/useSubscriptionPermissionsActions', () => ({
   }),
 }))
 
-const mockIsFeatureFlagActive = jest.fn().mockReturnValue(false)
-
-jest.mock('~/core/utils/featureFlags', () => ({
-  ...jest.requireActual('~/core/utils/featureFlags'),
-  isFeatureFlagActive: (flag: string) => mockIsFeatureFlagActive(flag),
-}))
-
 describe('SubscriptionDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -133,7 +126,6 @@ describe('SubscriptionDetails', () => {
     mockCanEditSubscription.mockReturnValue(true)
     mockIsStatusEditable.mockReturnValue(true)
     mockUseCurrentUser.mockReturnValue({ isPremium: true })
-    mockIsFeatureFlagActive.mockReturnValue(false)
 
     const useParamsMock = jest.requireMock('react-router-dom').useParams as jest.Mock
 
@@ -511,15 +503,11 @@ describe('SubscriptionDetails', () => {
     })
   })
 
-  describe('GIVEN the EDIT_DETAILS_PAGE feature flag', () => {
-    describe('WHEN the flag is off', () => {
-      it('THEN should keep the overview tab visible (legacy overview)', () => {
-        mockIsFeatureFlagActive.mockReturnValue(false)
-
+  describe('GIVEN the v2 tabs', () => {
+    describe('WHEN the component renders', () => {
+      it('THEN should render the v2 overview tab as visible', () => {
         render(<SubscriptionDetails />)
 
-        // When the flag is off the overview tab renders the legacy overview and
-        // stays visible; only the subscription plan tab is gated (next test).
         const overviewTab = capturedConfig?.tabs?.find(
           (t) => t.title === 'text_628cf761cbe6820138b8f2e4',
         )
@@ -528,36 +516,7 @@ describe('SubscriptionDetails', () => {
         expect(overviewTab?.hidden).toBeFalsy()
       })
 
-      it('THEN should hide the subscription plan tab', () => {
-        mockIsFeatureFlagActive.mockReturnValue(false)
-
-        render(<SubscriptionDetails />)
-
-        const subPlanTab = capturedConfig?.tabs?.find(
-          (t) => t.title === 'text_17792001643316pbexygvpu2',
-        )
-
-        expect(subPlanTab?.hidden).toBe(true)
-      })
-    })
-
-    describe('WHEN the flag is on', () => {
-      it('THEN should render the edit overview tab as visible', () => {
-        mockIsFeatureFlagActive.mockReturnValue(true)
-
-        render(<SubscriptionDetails />)
-
-        const editOverviewTab = capturedConfig?.tabs?.find(
-          (t) => t.title === 'text_628cf761cbe6820138b8f2e4',
-        )
-
-        expect(editOverviewTab).toBeDefined()
-        expect(editOverviewTab?.hidden).toBe(false)
-      })
-
       it('THEN should render the subscription plan tab as visible', () => {
-        mockIsFeatureFlagActive.mockReturnValue(true)
-
         render(<SubscriptionDetails />)
 
         const subPlanTab = capturedConfig?.tabs?.find(
@@ -565,7 +524,7 @@ describe('SubscriptionDetails', () => {
         )
 
         expect(subPlanTab).toBeDefined()
-        expect(subPlanTab?.hidden).toBe(false)
+        expect(subPlanTab?.hidden).toBeFalsy()
       })
     })
   })

--- a/translations/base.json
+++ b/translations/base.json
@@ -4290,5 +4290,7 @@
   "text_1780498504241avgm5sugii4": "Units",
   "text_1780498504241di3s12o655k": "Price",
   "text_1780498504241eo24fnc6s9u": "From {{fromDate}} to {{toDate}}",
-  "text_17804985042422iw5hwj0u2v": "All prices exclude any applicable taxes"
+  "text_17804985042422iw5hwj0u2v": "All prices exclude any applicable taxes",
+  "text_17810296077545fp2y0ulzko": "View and edit",
+  "text_17810297639135ya0hmsldpi": "Edit subscription's plan"
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -4,7 +4,8 @@
   "text_65118a52df984447c186940f": "Assign a plan to {{customerName}}",
   "text_65118a52df984447c1869472": "Add an external id",
   "text_65118a52df984447c186947c": "Add a subscription name",
-  "text_65118a52df984447c18694d0": "Override plan",
+  "text_65118a52df984447c18694d1": "Override plan",
+  "text_65118a52df984447c18694d0": "Unlock plan overrides",
   "text_65118a52df984447c18694da": "Customize certain aspects of the initially selected plan for flexibility.",
   "text_65118a52df984447c18694ee": "Leaving deletes your choices",
   "text_65118a52df984447c18694fe": "By clicking ‘Leave’, the subscription and data you’re creating will be deleted. Are you sure you want to leave?",
@@ -35,7 +36,7 @@
   "text_65201c5a175a4b0238abf2a0": "End date",
   "text_65201c5a175a4b0238abf2a2": "Overridden from",
   "text_6529666e71f6ce006d2bf011": "{{planName}} -  subscription details",
-  "text_652525609f420d00b83dd602": "This subscription is presently associated with a plan that has no overrides. Updating the charges will result in the creation of an overridden plan",
+  "text_652525609f420d00b83dd602": "This subscription is presently associated with a plan that has no overrides. Updating the charges will result in the creation of an overridden plan.",
   "text_65281f686a80b400c8e2f6ad": "{{planName}} - plan details",
   "text_65281f686a80b400c8e2f6b3": "Edit plan",
   "text_65281f686a80b400c8e2f6b6": "Duplicate plan",
@@ -285,7 +286,6 @@
   "text_6682c52081acea90520743aa": "Indicate when this subscription fee is generated and invoiced",
   "text_6682c52081acea90520743ac": "At the end of each billing period (in arrears)",
   "text_6682c52081acea90520743ae": "At the start of each billing period and on event (in advance)",
-  "text_6682c52081acea90520744c8": "Immediately at the event reception (in advance)",
   "text_6682c52081acea90520744ca": "Invoicing strategy",
   "text_6687b0081931407697975943": "Invoice each fee upon event reception",
   "text_6682c52081acea90520744d0": "Unlock all invoicing strategies",
@@ -3385,7 +3385,6 @@
   "text_1761554090907c9n5qyilqow": "Search or select a billable metric",
   "text_1761560753771d6ppz3evqxc": "Unlock Forecasts",
   "text_1761560714509hv9325ywuzq": "Lago requires sufficient usage and revenue data to run its AI model effectively. Contact us to check if you're eligible.",
-  "text_17607297072670cl4jl071yy": "Prorate fixed charge amount",
   "text_1760729707267seik64l67k8": "Tax rates (optional)",
   "text_17607297072672w5hid8gl1i": "Set specific tax rates to apply to this fee.",
   "text_176072970726728iw4tc8ucl": "Fixed charges",
@@ -4292,5 +4291,6 @@
   "text_1780498504241eo24fnc6s9u": "From {{fromDate}} to {{toDate}}",
   "text_17804985042422iw5hwj0u2v": "All prices exclude any applicable taxes",
   "text_17810296077545fp2y0ulzko": "View and edit",
-  "text_17810297639135ya0hmsldpi": "Edit subscription's plan"
+  "text_17810297639135ya0hmsldpi": "Edit subscription's plan",
+  "text_1781703119230q5zam349txb": "Indicate when this fee is generated and invoiced"
 }


### PR DESCRIPTION
Fixes BIL-165

Releases the v2 plan/subscription details layouts:

- Removes the `edit_details_page` feature flag; the v2 edit overview is now served on the `overview` tab for both plan and subscription details, and the Subscription plan tab is always visible.
- Plans-list and subscriptions-list actions now redirect to the details layouts ("View and edit" wording) instead of the legacy edit forms.
- Adds data-test hooks to the v2 section accordions/headers (standalone `detailsV2TestIds.ts`).
- Rewrites the `t50-edit-plan` e2e spec to drive the v2 layout: plan settings drawer (open/close, code update, locked code on used plan) and granular usage-charge creation from the details page.

Stacked on `bil-159-160-164-v2-sidebar` (merge order: main < sidebar < this PR).