### PR TITLE
fix(members): wrap refetch in error placeholder

### DIFF
--- a/src/pages/settings/teamAndSecurity/members/MembersInvitationList.tsx
+++ b/src/pages/settings/teamAndSecurity/members/MembersInvitationList.tsx
@@ -166,7 +166,9 @@ const MembersInvitationList = () => {
         title: translate('text_6321a076b94bd1b32494e9ee'),
         subtitle: translate('text_6321a076b94bd1b32494e9e8'),
         buttonTitle: translate('text_6321a076b94bd1b32494e9f2'),
-        buttonAction: invitesRefetch,
+        buttonAction: () => {
+          invitesRefetch()
+        },
       },
     }
 

--- a/src/pages/settings/teamAndSecurity/members/MembersList.tsx
+++ b/src/pages/settings/teamAndSecurity/members/MembersList.tsx
@@ -157,7 +157,9 @@ const MemberList = () => {
       title: translate('text_6321a076b94bd1b32494e9ee'),
       subtitle: translate('text_6321a076b94bd1b32494e9f0'),
       buttonTitle: translate('text_6321a076b94bd1b32494e9f2'),
-      buttonAction: membersRefetch,
+      buttonAction: () => {
+        membersRefetch()
+      },
     },
   }
 


### PR DESCRIPTION
Fixes [FRONT-EU-BS](https://lago-eu.sentry.io/issues/126560117/)

Passing Apollo `refetch` directly as `buttonAction` made the error-placeholder button's click `MouseEvent` land in `refetch(variables)`. Apollo's `canonicalStringify` then threw `TypeError: Converting circular structure to JSON` on the DOM event (React fiber circular ref), surfacing as an unhandled rejection on `/settings/team-and-security/members`.

Wrapped both call sites (`MembersList`, `MembersInvitationList`) in an arrow function so `refetch` is called without arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)