### PR TITLE
fix(security logs): handle new webhook_endpoint_updated resource shapes

### DIFF
--- a/src/pages/settings/teamAndSecurity/securityLogs/common/securityLogsTypes.ts
+++ b/src/pages/settings/teamAndSecurity/securityLogs/common/securityLogsTypes.ts
@@ -69,10 +69,13 @@ export const webhookResourceSchema = z.object({
 })
 export type WebhookResource = z.infer<typeof webhookResourceSchema>
 
+const stringDiffSchema = z.object({
+  deleted: z.string(),
+  added: z.string(),
+})
+
 export const webhookEditedResourceSchema = z.object({
-  webhook_url: z.object({
-    deleted: z.string(),
-    added: z.string(),
-  }),
+  webhook_url: z.union([z.string(), stringDiffSchema]),
+  signature_algo: stringDiffSchema.optional(),
 })
 export type WebhookEditedResource = z.infer<typeof webhookEditedResourceSchema>

--- a/src/pages/settings/teamAndSecurity/securityLogs/hooks/__tests__/useSecurityLogsFormatting.test.ts
+++ b/src/pages/settings/teamAndSecurity/securityLogs/hooks/__tests__/useSecurityLogsFormatting.test.ts
@@ -447,6 +447,79 @@ describe('useSecurityLogsFormatting', () => {
           }),
         )
       })
+
+      it('THEN should call translate for WebhookEndpointUpdated with the algorithm copy when only the signature algorithm changed', () => {
+        // Regression test for FRONT-15Y: the backend sends webhook_url as a
+        // plain string when unchanged, alongside a signature_algo diff.
+        const { result } = renderHook(() => useSecurityLogsFormatting())
+        const log = createMockSecurityLog({
+          logEvent: LogEventEnum.WebhookEndpointUpdated,
+          resources: {
+            webhook_url: 'https://example.com/webhook',
+            signature_algo: { deleted: 'hmac', added: 'jwt' },
+          },
+        })
+
+        result.current.getSecurityLogDescription(log)
+
+        expect(mockTranslate).toHaveBeenCalledWith('text_17810792697743rdztc0hzsn', {
+          algoFrom: 'hmac',
+          algoTo: 'jwt',
+        })
+      })
+
+      it('THEN should call translate for WebhookEndpointUpdated with the combined copy when both url and signature algorithm changed', () => {
+        const { result } = renderHook(() => useSecurityLogsFormatting())
+        const log = createMockSecurityLog({
+          logEvent: LogEventEnum.WebhookEndpointUpdated,
+          resources: {
+            webhook_url: {
+              deleted: 'https://old.example.com/webhook',
+              added: 'https://new.example.com/webhook',
+            },
+            signature_algo: { deleted: 'hmac', added: 'jwt' },
+          },
+        })
+
+        result.current.getSecurityLogDescription(log)
+
+        expect(mockTranslate).toHaveBeenCalledWith('text_1781079269774kur4mhrgipy', {
+          urlFrom: 'https://old.example.com/webhook',
+          urlTo: 'https://new.example.com/webhook',
+          algoFrom: 'hmac',
+          algoTo: 'jwt',
+        })
+      })
+
+      it('THEN falls back to unknown for WebhookEndpointUpdated when the url is unchanged and no algorithm change is present', () => {
+        const { result } = renderHook(() => useSecurityLogsFormatting())
+        const log = createMockSecurityLog({
+          logEvent: LogEventEnum.WebhookEndpointUpdated,
+          resources: { webhook_url: 'https://example.com/webhook' },
+        })
+
+        result.current.getSecurityLogDescription(log)
+
+        expect(mockTranslate).toHaveBeenCalledWith('text_1771937987062rw8agotc8gs', {
+          urlFrom: 'unknown',
+          urlTo: 'unknown',
+        })
+      })
+
+      it('THEN falls back to unknown for WebhookEndpointUpdated when the payload shape is not recognized', () => {
+        const { result } = renderHook(() => useSecurityLogsFormatting())
+        const log = createMockSecurityLog({
+          logEvent: LogEventEnum.WebhookEndpointUpdated,
+          resources: { webhook_url: 123 },
+        })
+
+        result.current.getSecurityLogDescription(log)
+
+        expect(mockTranslate).toHaveBeenCalledWith('text_1771937987062rw8agotc8gs', {
+          urlFrom: 'unknown',
+          urlTo: 'unknown',
+        })
+      })
     })
 
     describe('GIVEN an unknown event', () => {

--- a/src/pages/settings/teamAndSecurity/securityLogs/hooks/useSecurityLogsFormatting.ts
+++ b/src/pages/settings/teamAndSecurity/securityLogs/hooks/useSecurityLogsFormatting.ts
@@ -151,15 +151,40 @@ export const useSecurityLogsFormatting = () => {
     }
   }
 
-  const getWebhookEditedResources = (securityLog: SecurityLogWithId) => {
+  const getWebhookEditedDescription = (securityLog: SecurityLogWithId) => {
     const parsed = parseSecurityLogResource(webhookEditedResourceSchema, securityLog)
 
-    if (!parsed) return { urlFrom: 'unknown', urlTo: 'unknown' }
+    if (!parsed)
+      return translate('text_1771937987062rw8agotc8gs', { urlFrom: 'unknown', urlTo: 'unknown' })
 
-    return {
-      urlFrom: parsed.webhook_url.deleted,
-      urlTo: parsed.webhook_url.added,
+    const { webhook_url, signature_algo } = parsed
+    const urlDiff = typeof webhook_url === 'object' ? webhook_url : null
+
+    if (urlDiff && signature_algo) {
+      return translate('text_1781079269774kur4mhrgipy', {
+        urlFrom: urlDiff.deleted,
+        urlTo: urlDiff.added,
+        algoFrom: signature_algo.deleted,
+        algoTo: signature_algo.added,
+      })
     }
+
+    if (signature_algo) {
+      return translate('text_17810792697743rdztc0hzsn', {
+        algoFrom: signature_algo.deleted,
+        algoTo: signature_algo.added,
+      })
+    }
+
+    if (urlDiff) {
+      return translate('text_1771937987062rw8agotc8gs', {
+        urlFrom: urlDiff.deleted,
+        urlTo: urlDiff.added,
+      })
+    }
+
+    // webhook_url is a string and no signature_algo change — nothing meaningful to show
+    return translate('text_1771937987062rw8agotc8gs', { urlFrom: 'unknown', urlTo: 'unknown' })
   }
 
   const getSecurityLogDescription = (securityLog: SecurityLogWithId) => {
@@ -217,7 +242,7 @@ export const useSecurityLogsFormatting = () => {
       case LogEventEnum.WebhookEndpointDeleted:
         return translate('text_177193798706284nfb2tmxkb', getWebhookResources(securityLog))
       case LogEventEnum.WebhookEndpointUpdated:
-        return translate('text_1771937987062rw8agotc8gs', getWebhookEditedResources(securityLog))
+        return getWebhookEditedDescription(securityLog)
       case LogEventEnum.UserNewDeviceLoggedIn:
         return translate('text_1773415705134l01iamqr6fk', {
           email: securityLog.userEmail,

--- a/translations/base.json
+++ b/translations/base.json
@@ -4285,5 +4285,7 @@
   "text_1780329442633n0oe3prszsw": "Click to edit",
   "text_1780604419477p7xvwx52oad": "Subscription status",
   "text_1780604419477ujb85w6pk81": "Subscription name",
-  "text_178060441947738s33pstvzp": "Subscription external ID"
+  "text_178060441947738s33pstvzp": "Subscription external ID",
+  "text_17810792697743rdztc0hzsn": "A webhook endpoint signature algorithm was changed from {{algoFrom}} to {{algoTo}}",
+  "text_1781079269774kur4mhrgipy": "A webhook endpoint {{urlFrom}} was updated to {{urlTo}} and signature algorithm was changed from {{algoFrom}} to {{algoTo}}"
 }


### PR DESCRIPTION
## Context

The backend now sends `webhook_url` as a plain string when unchanged and can include a `signature_algo` diff, which failed the Zod schema and made rows render as "unknown"

## Description

- widen webhookEditedResourceSchema: webhook_url as string | diff, optional signature_algo diff
- add copies for algo-only and url+algo changes
- add regression tests for the new shapes

<!-- Linear link -->
Fixes LAGO-1517