### PR TITLE
chore(wallet): remove unused PremiumWarningDialog from WalletDetails

### DIFF
--- a/src/components/wallets/WalletTransactions.tsx
+++ b/src/components/wallets/WalletTransactions.tsx
@@ -1,12 +1,11 @@
 import { Icon } from 'lago-design-system'
 import { DateTime } from 'luxon'
-import { FC, PropsWithChildren, RefObject, useMemo } from 'react'
+import { FC, PropsWithChildren, useMemo } from 'react'
 
 import { Card } from '~/components/designSystem/Card'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { TimezoneDate } from '~/components/TimezoneDate'
 import { WalletTransactionList } from '~/components/wallets/WalletTransactionList'
 import { WalletTransactionListItem } from '~/components/wallets/WalletTransactionListItem'
@@ -32,7 +31,6 @@ const TODAY = DateTime.now().toISODate()
 
 interface WalletTransactionsProps {
   wallet: WalletDetailsFragment
-  premiumWarningDialogRef: RefObject<PremiumWarningDialogRef>
   customerTimezone?: TimezoneEnum
   initiallyOpen?: boolean
   selectedTransaction?: string | null

--- a/src/components/wallets/__tests__/WalletTransactions.test.tsx
+++ b/src/components/wallets/__tests__/WalletTransactions.test.tsx
@@ -1,6 +1,5 @@
 import { screen } from '@testing-library/react'
 import { Settings } from 'luxon'
-import { createRef } from 'react'
 
 import { CurrencyEnum, WalletStatusEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
@@ -54,8 +53,6 @@ const createMockWallet = (overrides = {}) =>
     ...overrides,
   }) as any
 
-const premiumWarningDialogRef = createRef<any>()
-
 describe('WalletTransactions', () => {
   beforeAll(() => {
     Settings.defaultZone = 'UTC'
@@ -68,7 +65,7 @@ describe('WalletTransactions', () => {
   it('GIVEN active wallet WHEN rendered THEN should show transactions container', () => {
     const wallet = createMockWallet({ status: WalletStatusEnum.Active })
 
-    render(<WalletTransactions wallet={wallet} premiumWarningDialogRef={premiumWarningDialogRef} />)
+    render(<WalletTransactions wallet={wallet} />)
 
     const container = screen.getByTestId(WALLET_TRANSACTIONS_CONTAINER_TEST_ID)
 
@@ -87,7 +84,7 @@ describe('WalletTransactions', () => {
       terminatedAt: '2024-06-01T00:00:00Z',
     })
 
-    render(<WalletTransactions wallet={wallet} premiumWarningDialogRef={premiumWarningDialogRef} />)
+    render(<WalletTransactions wallet={wallet} />)
 
     const container = screen.getByTestId(WALLET_TRANSACTIONS_CONTAINER_TEST_ID)
 

--- a/src/pages/wallet/WalletDetails.tsx
+++ b/src/pages/wallet/WalletDetails.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { ButtonLink } from '~/components/designSystem/ButtonLink'
@@ -9,7 +9,6 @@ import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { MainHeaderAction } from '~/components/MainHeader/types'
 import { useMainHeaderTabContent } from '~/components/MainHeader/useMainHeaderTabContent'
-import { PremiumWarningDialog, PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
 import { TerminateCustomerWalletDialog } from '~/components/wallets/TerminateCustomerWalletDialog'
 import { VoidWalletDialog } from '~/components/wallets/VoidWalletDialog'
 import WalletAlerts from '~/components/wallets/WalletAlerts'
@@ -138,7 +137,6 @@ const WalletDetails = () => {
   const { translate } = useInternationalization()
   const { walletId, customerId } = useParams()
   const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
-  const premiumWarningDialogRef = useRef<PremiumWarningDialogRef>(null)
   const { hasPermissions } = usePermissions()
   const activeTabContent = useMainHeaderTabContent()
 
@@ -236,13 +234,7 @@ const WalletDetails = () => {
               description={translate('text_1773043324342ka1zcxto0pg')}
             />
 
-            {!!wallet && (
-              <WalletTransactions
-                wallet={wallet}
-                premiumWarningDialogRef={premiumWarningDialogRef}
-                loading={loading}
-              />
-            )}
+            {!!wallet && <WalletTransactions wallet={wallet} loading={loading} />}
           </DetailsPage.Container>
         ),
       },
@@ -284,7 +276,7 @@ const WalletDetails = () => {
         ),
       },
     ]
-  }, [translate, walletId, customerId, wallet, loading, hasPermissions, premiumWarningDialogRef])
+  }, [translate, walletId, customerId, wallet, loading, hasPermissions])
 
   const headerActions: MainHeaderAction[] = [
     {
@@ -342,7 +334,6 @@ const WalletDetails = () => {
 
       <>{activeTabContent}</>
 
-      <PremiumWarningDialog ref={premiumWarningDialogRef} />
       <TerminateCustomerWalletDialog ref={terminateDialogRef} />
       <VoidWalletDialog ref={voidDialogRef} />
     </>


### PR DESCRIPTION
## Context

`pnpm eslint` flags `~/components/PremiumWarningDialog` as deprecated — the canonical entry point is now the hook-based dialog system in `~/components/dialogs/` (already registered via NiceModal in `src/core/overlays/registeredDialogs.ts`).

This PR addresses the warning in `src/pages/wallet/WalletDetails.tsx`.

## What changed

While preparing the migration, the `PremiumWarningDialog` mounted in `WalletDetails.tsx` turned out to be **dead code**:

- `WalletDetails` created `premiumWarningDialogRef`, rendered the dialog, and passed the ref down to `WalletTransactions`.
- `WalletTransactions` declared `premiumWarningDialogRef` in its props interface but **never destructured or used it** in the body.

So the dialog was mounted but had no opener in this flow. The fix is to remove the dead wiring rather than re-mount a fresh hook-based version no one calls. If a premium gate ever needs to be opened from this path, the new `usePremiumWarningDialog()` hook (in `~/components/dialogs/PremiumWarningDialog.tsx`) is the entry point — no JSX mount required, it's registered through NiceModal.

Concretely:

- `src/pages/wallet/WalletDetails.tsx` — drop the deprecated import, the `useRef`, the JSX mount, the prop passed to `<WalletTransactions>`, and the now-unused `useMemo` dep.
- `src/components/wallets/WalletTransactions.tsx` — drop the unused `premiumWarningDialogRef` prop and the deprecated `PremiumWarningDialogRef` / `RefObject` imports.
- `src/components/wallets/__tests__/WalletTransactions.test.tsx` — drop the now-unused `createRef` and prop wiring.

Scope kept tight per the routine: other deprecated dialog imports in `WalletDetails.tsx` (`TerminateCustomerWalletDialog`, `VoidWalletDialog`) are non-warning dialogs and are intentionally left for separate migrations.

## Verification

- `pnpm eslint` warning count: **494 → 492** (the two `PremiumWarningDialog` warnings in `WalletDetails.tsx` and `WalletTransactions.tsx` are gone).
- `pnpm test src/components/wallets/__tests__/WalletTransactions.test.tsx` — passes (2/2).
- `pnpm code:style` — no new errors.

## Test plan

- [ ] Open a wallet detail page, switch to the Transactions tab, confirm rendering is unchanged.
- [ ] Confirm no premium-gated CTA on this page expects the old ref-based dialog (none did).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXxanqnMiAjezw71W5uNsE)_