### PR TITLE
feat(subs): display per-subscription fixed-charge units override

### DIFF
--- a/cypress/e2e/10-resources/t90-subscription-fixed-charge-override.cy.ts
+++ b/cypress/e2e/10-resources/t90-subscription-fixed-charge-override.cy.ts
@@ -1,0 +1,123 @@
+import { ACTIONS_BLOCK_TEST_ID } from '~/components/MainHeader/mainHeaderTestIds'
+import { FIXED_CHARGES_ADD_BUTTON_TEST_ID } from '~/components/plans/form/FixedChargesSection'
+
+import { customerName } from '../../support/reusableConstants'
+
+/**
+ * E2E coverage for the per-subscription fixed-charge units override.
+ *
+ * Verifies that:
+ *   1. After editing units on a subscription's fixed charge, the subscription
+ *      detail page displays the override value (read from
+ *      `Subscription.fixedCharges[*].units`).
+ *   2. The override survives a full page reload (Apollo cache reads from the
+ *      no-cache `getSubscriptionFixedChargeUnitsOverrides` query each time).
+ *
+ * The test sets up its full state inline (add-on → plan with fixed charge →
+ * subscription against an existing customer) so it has no implicit dependency
+ * on other specs. Skipped until the BE override endpoint is deployed in the
+ * CI environment — flip `describe.skip` to `describe` to enable.
+ */
+describe.skip('Subscription fixed charge units override', () => {
+  const randomId = Math.round(Math.random() * 100000)
+  const addOnName = `Fixed Charge AddOn ${randomId}`
+  const addOnCode = `fc_addon_${randomId}`
+  const planName = `Plan FC ${randomId}`
+  const planCode = `plan_fc_${randomId}`
+  const subscriptionName = `Sub FC ${randomId}`
+  const baseUnits = '10'
+  const overrideUnits = '25'
+
+  before(() => {
+    cy.login()
+
+    // 1. Create an add-on to back the plan's fixed charge.
+    cy.visitApp('/add-ons')
+    cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-addon-cta"]`).click({
+      force: true,
+    })
+    cy.get('input[name="name"]').type(addOnName)
+    cy.get('input[name="code"]').clear().type(addOnCode)
+    cy.get('input[name="amountCents"]').type('30')
+    cy.get('[data-test="submit"]').should('be.enabled').click()
+    cy.url().should('include', '/overview')
+
+    // 2. Create a plan, attach the add-on as a fixed charge with baseUnits.
+    cy.visitApp('/plans')
+    cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-plan"]`).click({
+      force: true,
+    })
+    cy.url().should('match', /\/[^/]+\/create\/plans$/)
+    cy.get('input[name="name"]').type(planName)
+    cy.get('input[name="code"]').clear().type(planCode)
+    cy.get('input[name="amountCents"]').type('5000')
+
+    cy.get(`[data-test="${FIXED_CHARGES_ADD_BUTTON_TEST_ID}"]`).scrollIntoView().click({
+      force: true,
+    })
+
+    // Pick the add-on we just created (combobox is searchable).
+    cy.get('input[name="addOnId"]').click({ force: true })
+    cy.contains('[role="option"]', addOnName).click({ force: true })
+    cy.get('input[name="units"]').clear().type(baseUnits)
+    cy.get('[data-test="fixed-charge-drawer-save"]').should('not.be.disabled').click()
+    cy.get('[data-test="base-drawer-paper"]', { timeout: 10000 }).should('not.exist')
+
+    cy.get('[data-test="submit"]').click({ force: true })
+    cy.url().should('include', '/overview')
+
+    // 3. Subscribe an existing customer to the new plan.
+    cy.visitApp('/customers')
+    cy.get('[data-test="table-customers-list"] tr').contains(customerName).click({ force: true })
+    cy.get('[data-test="add-subscription"]').click({ force: true })
+    cy.url().should('include', '/create/subscription')
+
+    cy.get('input[name="planId"]').click({ force: true })
+    cy.contains('[role="option"]', planName).click({ force: true })
+
+    cy.get('[data-test="create-subscription-form-wrapper"]').within(() => {
+      cy.get('[data-test="show-name"]').click({ force: true })
+      cy.get('input[name="name"]').first().type(subscriptionName)
+    })
+    cy.get('[data-test="submit"]').should('not.be.disabled').click({ force: true })
+    cy.get(`[data-test="${subscriptionName}"]`, { timeout: 15000 }).should('exist')
+  })
+
+  it('displays the override units after editing units on the subscription, and persists across reload', () => {
+    cy.login().visitApp('/customers')
+    cy.get('[data-test="table-customers-list"] tr').contains(customerName).click({ force: true })
+    cy.get(`[data-test="${subscriptionName}"]`, { timeout: 15000 }).click({ force: true })
+
+    // Open the Plan tab on the subscription detail page.
+    cy.contains('[role="tab"]', /plan/i).click({ force: true })
+
+    // The base units (plan default) should appear first.
+    cy.contains(addOnCode).should('exist')
+    cy.contains(addOnCode).parents('[role="button"]').first().click({ force: true })
+    cy.contains(baseUnits).should('exist')
+
+    // Open the edit drawer via the actions menu and update units.
+    cy.get('button[aria-label="actions"]').first().click({ force: true })
+    cy.contains('button', /edit/i).click({ force: true })
+    cy.get('input[name="units"]').clear().type(overrideUnits)
+    cy.get('[data-test="fixed-charge-drawer-save"]').should('not.be.disabled').click()
+    cy.get('[data-test="base-drawer-paper"]', { timeout: 10000 }).should('not.exist')
+
+    // After the mutation, the override units should be displayed.
+    cy.contains(overrideUnits, { timeout: 10000 }).should('exist')
+
+    // Reload — the override is read from Subscription.fixedCharges (no-cache),
+    // so the displayed value must still be the override, not the plan default.
+    cy.reload()
+    cy.contains('[role="tab"]', /plan/i).click({ force: true })
+    cy.contains(addOnCode).parents('[role="button"]').first().click({ force: true })
+    cy.contains(overrideUnits, { timeout: 10000 }).should('exist')
+
+    // And the plan-scope page must keep showing the plan default (no cache
+    // bleed from the per-subscription override). Navigate to the plan view.
+    cy.visitApp('/plans')
+    cy.contains('tr', planName).click({ force: true })
+    cy.contains(addOnCode).parents('[role="button"]').first().click({ force: true })
+    cy.contains(baseUnits).should('exist')
+  })
+})

--- a/src/components/plans/details-v2/PlanDetailsV2.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2.tsx
@@ -66,6 +66,10 @@ type PlanDetailsV2Props = {
   planId: string
   isInSubscriptionForm?: boolean
   subscriptionId?: string
+  // Override units keyed by FixedCharge id. Populated only in subscription
+  // mode by SubscriptionDetailsV2Plan, which fetches Subscription.fixedCharges
+  // with fetchPolicy: 'no-cache' so plan-scope cache entries keep plan defaults.
+  subscriptionFixedChargeUnitsById?: Record<string, string>
   banner?: ReactNode
 }
 
@@ -73,6 +77,7 @@ export const PlanDetailsV2 = ({
   planId,
   isInSubscriptionForm = false,
   subscriptionId,
+  subscriptionFixedChargeUnitsById,
   banner,
 }: PlanDetailsV2Props) => {
   const { data, loading } = useGetPlanForDetailsV2Query({
@@ -143,6 +148,7 @@ export const PlanDetailsV2 = ({
                   plan={plan}
                   isInSubscriptionForm={isInSubscriptionForm}
                   fixedChargeMutations={fixedChargeMutations}
+                  subscriptionFixedChargeUnitsById={subscriptionFixedChargeUnitsById}
                 />
               )
             }

--- a/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
@@ -96,11 +96,18 @@ type Props = {
   plan: PlanDetailsV2Fragment
   isInSubscriptionForm?: boolean
   fixedChargeMutations: FixedChargeMutations
+  // FixedCharge id → units to display when the row is rendered inside a
+  // subscription. Set by SubscriptionDetailsV2Plan from
+  // Subscription.fixedCharges. Absent in plan-scope rendering.
+  subscriptionFixedChargeUnitsById?: Record<string, string>
 }
 
 type FixedCharge = NonNullable<PlanDetailsV2Fragment['fixedCharges']>[number]
 
-const toLocalInput = (fixedCharge: FixedCharge): LocalFixedChargeInput => ({
+const toLocalInput = (
+  fixedCharge: FixedCharge,
+  effectiveUnits: string | null | undefined,
+): LocalFixedChargeInput => ({
   id: fixedCharge.id,
   code: fixedCharge.code,
   addOn: fixedCharge.addOn,
@@ -111,150 +118,165 @@ const toLocalInput = (fixedCharge: FixedCharge): LocalFixedChargeInput => ({
   properties: fixedCharge.properties ?? {},
   prorated: fixedCharge.prorated ?? false,
   taxes: fixedCharge.taxes ?? [],
-  units: fixedCharge.units ? String(fixedCharge.units) : '',
+  units: effectiveUnits ? String(effectiveUnits) : '',
 })
 
 export const PlanDetailsV2FixedChargesSection = forwardRef<
   PlanDetailsV2FixedChargesSectionRef,
   Props
->(({ plan, isInSubscriptionForm = false, fixedChargeMutations }, ref) => {
-  const { translate } = useInternationalization()
-  const { canCreate, canUpdate, canDelete } = useAccordionPermissions(isInSubscriptionForm)
-  const drawerRef = useRef<FixedChargeDrawerRef>(null)
-  const removeChargeWarningDialogRef = useRef<RemoveChargeWarningDialogRef>(null)
+>(
+  (
+    { plan, isInSubscriptionForm = false, fixedChargeMutations, subscriptionFixedChargeUnitsById },
+    ref,
+  ) => {
+    const { translate } = useInternationalization()
+    const { canCreate, canUpdate, canDelete } = useAccordionPermissions(isInSubscriptionForm)
+    const drawerRef = useRef<FixedChargeDrawerRef>(null)
+    const removeChargeWarningDialogRef = useRef<RemoveChargeWarningDialogRef>(null)
 
-  const { handleSaveCharge, handleDeleteCharge } = fixedChargeMutations
+    const { handleSaveCharge, handleDeleteCharge } = fixedChargeMutations
 
-  const fixedCharges = plan.fixedCharges ?? []
-  const isEmpty = fixedCharges.length === 0
-  // ISO with the plan form: existing charges lock once the plan has subscriptions.
-  // Sub mode keeps its own gating (driven by isInSubscriptionForm), so the
-  // subscription-count lock does not apply there.
-  const canBeEdited = isInSubscriptionForm ? true : !plan.subscriptionsCount
-  // ISO with the plan form: deleting a charge that is live on subscriptions
-  // prompts a confirmation. Every listed charge is persisted, so this reduces
-  // to "the plan has subscriptions" (canBeEdited === false).
-  const isUsedInSubscription = !canBeEdited
+    const fixedCharges = plan.fixedCharges ?? []
+    const isEmpty = fixedCharges.length === 0
+    // ISO with the plan form: existing charges lock once the plan has subscriptions.
+    // Sub mode keeps its own gating (driven by isInSubscriptionForm), so the
+    // subscription-count lock does not apply there.
+    const canBeEdited = isInSubscriptionForm ? true : !plan.subscriptionsCount
+    // ISO with the plan form: deleting a charge that is live on subscriptions
+    // prompts a confirmation. Every listed charge is persisted, so this reduces
+    // to "the plan has subscriptions" (canBeEdited === false).
+    const isUsedInSubscription = !canBeEdited
 
-  // ISO with the plan form: warn when the same add-on backs more than one fixed
-  // charge (count per add-on id, alert when > 1).
-  const fixedChargeCountByAddOnId = useMemo(() => {
-    const counts = new Map<string, number>()
+    // ISO with the plan form: warn when the same add-on backs more than one fixed
+    // charge (count per add-on id, alert when > 1).
+    const fixedChargeCountByAddOnId = useMemo(() => {
+      const counts = new Map<string, number>()
 
-    for (const fixedCharge of fixedCharges) {
-      counts.set(fixedCharge.addOn.id, (counts.get(fixedCharge.addOn.id) || 0) + 1)
-    }
+      for (const fixedCharge of fixedCharges) {
+        counts.set(fixedCharge.addOn.id, (counts.get(fixedCharge.addOn.id) || 0) + 1)
+      }
 
-    return counts
-  }, [fixedCharges])
+      return counts
+    }, [fixedCharges])
 
-  const openCreate = () => drawerRef.current?.openDrawer()
+    const openCreate = () => drawerRef.current?.openDrawer()
 
-  useImperativeHandle(ref, () => ({ openCreate }))
+    useImperativeHandle(ref, () => ({ openCreate }))
 
-  const openEdit = (charge: LocalFixedChargeInput, index: number) => {
-    const alreadyUsedChargeAlertMessage =
-      (fixedChargeCountByAddOnId.get(charge.addOn.id) || 0) > 1
-        ? translate('text_1760729707268h378x60alri')
-        : undefined
+    const openEdit = (charge: LocalFixedChargeInput, index: number) => {
+      const alreadyUsedChargeAlertMessage =
+        (fixedChargeCountByAddOnId.get(charge.addOn.id) || 0) > 1
+          ? translate('text_1760729707268h378x60alri')
+          : undefined
 
-    drawerRef.current?.openDrawer(charge, index, {
-      alreadyUsedChargeAlertMessage,
-      isUsedInSubscription,
-    })
-  }
-
-  // ISO with the plan form: confirm before deleting a charge that is live on
-  // subscriptions; delete directly otherwise.
-  const handleDelete = (chargeId: string) => {
-    if (isUsedInSubscription) {
-      removeChargeWarningDialogRef.current?.openDialog({
-        callback: () => handleDeleteCharge(chargeId),
+      drawerRef.current?.openDrawer(charge, index, {
+        alreadyUsedChargeAlertMessage,
+        isUsedInSubscription,
       })
-    } else {
-      handleDeleteCharge(chargeId)
     }
-  }
 
-  return (
-    <section id={PlanDetailsV2SectionId.FixedCharges} className="flex scroll-mt-12 flex-col gap-6">
-      <SectionHeader
-        title={translate('text_1779289915866aj39dyv1wps')}
-        description={translate('text_1760729707268c05r06ip8vg')}
-        action={
-          canCreate
-            ? {
-                label: translate('text_176072970726882uau5y69f1'),
-                onClick: openCreate,
-                startIcon: 'plus',
-              }
-            : undefined
-        }
-      />
+    // ISO with the plan form: confirm before deleting a charge that is live on
+    // subscriptions; delete directly otherwise.
+    const handleDelete = (chargeId: string) => {
+      if (isUsedInSubscription) {
+        removeChargeWarningDialogRef.current?.openDialog({
+          callback: () => handleDeleteCharge(chargeId),
+        })
+      } else {
+        handleDeleteCharge(chargeId)
+      }
+    }
 
-      {isEmpty && (
-        <Typography variant="body" color="grey600">
-          {translate('text_1779477955768bq18jsqhaom')}
-        </Typography>
-      )}
-
-      {fixedCharges.map((fixedCharge, index) => (
-        <SectionAccordion
-          key={fixedCharge.id}
-          id={fixedCharge.id}
-          icon="puzzle"
-          title={fixedCharge.invoiceDisplayName || fixedCharge.addOn.name}
-          subtitle={fixedCharge.code}
-          actions={[
-            {
-              label: translate('text_63e51ef4985f0ebd75c212fc'),
-              startIcon: 'pen',
-              onClick: () => openEdit(toLocalInput(fixedCharge), index),
-              hidden: !canUpdate,
-            },
-            {
-              label: translate('text_63ea0f84f400488553caa786'),
-              startIcon: 'trash',
-              onClick: () => handleDelete(fixedCharge.id),
-              hidden: !canDelete,
-            },
-          ]}
-          noContentMargin
-        >
-          <FixedChargeInfo
-            fixedCharge={fixedCharge}
-            currency={plan.amountCurrency as CurrencyEnum}
-            planInterval={plan.interval as PlanInterval}
-            billFixedChargesMonthly={plan.billFixedChargesMonthly}
-            planTaxes={plan.taxes}
-          />
-        </SectionAccordion>
-      ))}
-
-      <PlanFormProvider
-        currency={plan.amountCurrency as CurrencyEnum}
-        interval={(plan.interval as PlanInterval) ?? PlanInterval.Monthly}
+    return (
+      <section
+        id={PlanDetailsV2SectionId.FixedCharges}
+        className="flex scroll-mt-12 flex-col gap-6"
       >
-        <FixedChargeDrawer
-          ref={drawerRef}
-          isEdition
-          disabled={!canBeEdited}
-          isInSubscriptionForm={isInSubscriptionForm}
-          showCode
-          existingChargeCodes={fixedCharges.map((c) => c.code)}
-          onSave={handleSaveCharge}
-          onDelete={(index) => {
-            const target = fixedCharges[index]
-
-            if (target) handleDeleteCharge(target.id)
-          }}
-          removeChargeWarningDialogRef={removeChargeWarningDialogRef}
+        <SectionHeader
+          title={translate('text_1779289915866aj39dyv1wps')}
+          description={translate('text_1760729707268c05r06ip8vg')}
+          action={
+            canCreate
+              ? {
+                  label: translate('text_176072970726882uau5y69f1'),
+                  onClick: openCreate,
+                  startIcon: 'plus',
+                }
+              : undefined
+          }
         />
-      </PlanFormProvider>
 
-      <RemoveChargeWarningDialog ref={removeChargeWarningDialogRef} />
-    </section>
-  )
-})
+        {isEmpty && (
+          <Typography variant="body" color="grey600">
+            {translate('text_1779477955768bq18jsqhaom')}
+          </Typography>
+        )}
+
+        {fixedCharges.map((fixedCharge, index) => {
+          // In subscription mode, prefer the per-subscription override; otherwise
+          // fall back to the plan default carried on FixedCharge.units.
+          const effectiveUnits =
+            subscriptionFixedChargeUnitsById?.[fixedCharge.id] ?? fixedCharge.units
+
+          return (
+            <SectionAccordion
+              key={fixedCharge.id}
+              id={fixedCharge.id}
+              icon="puzzle"
+              title={fixedCharge.invoiceDisplayName || fixedCharge.addOn.name}
+              subtitle={fixedCharge.code}
+              actions={[
+                {
+                  label: translate('text_63e51ef4985f0ebd75c212fc'),
+                  startIcon: 'pen',
+                  onClick: () => openEdit(toLocalInput(fixedCharge, effectiveUnits), index),
+                  hidden: !canUpdate,
+                },
+                {
+                  label: translate('text_63ea0f84f400488553caa786'),
+                  startIcon: 'trash',
+                  onClick: () => handleDelete(fixedCharge.id),
+                  hidden: !canDelete,
+                },
+              ]}
+              noContentMargin
+            >
+              <FixedChargeInfo
+                fixedCharge={{ ...fixedCharge, units: effectiveUnits }}
+                currency={plan.amountCurrency as CurrencyEnum}
+                planInterval={plan.interval as PlanInterval}
+                billFixedChargesMonthly={plan.billFixedChargesMonthly}
+                planTaxes={plan.taxes}
+              />
+            </SectionAccordion>
+          )
+        })}
+
+        <PlanFormProvider
+          currency={plan.amountCurrency as CurrencyEnum}
+          interval={(plan.interval as PlanInterval) ?? PlanInterval.Monthly}
+        >
+          <FixedChargeDrawer
+            ref={drawerRef}
+            isEdition
+            disabled={!canBeEdited}
+            isInSubscriptionForm={isInSubscriptionForm}
+            showCode
+            existingChargeCodes={fixedCharges.map((c) => c.code)}
+            onSave={handleSaveCharge}
+            onDelete={(index) => {
+              const target = fixedCharges[index]
+
+              if (target) handleDeleteCharge(target.id)
+            }}
+            removeChargeWarningDialogRef={removeChargeWarningDialogRef}
+          />
+        </PlanFormProvider>
+
+        <RemoveChargeWarningDialog ref={removeChargeWarningDialogRef} />
+      </section>
+    )
+  },
+)
 
 PlanDetailsV2FixedChargesSection.displayName = 'PlanDetailsV2FixedChargesSection'

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2FixedChargesSection.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2FixedChargesSection.test.tsx
@@ -373,6 +373,69 @@ describe('PlanDetailsV2FixedChargesSection', () => {
     expect(screen.queryByText('text_63e51ef4985f0ebd75c212fc')).not.toBeInTheDocument()
   })
 
+  // Drift test: the subscription override map should take precedence over the
+  // plan-level units when displaying a row and when pre-filling the edit drawer.
+  it('uses subscriptionFixedChargeUnitsById to override displayed units', async () => {
+    const plan = {
+      ...planDetailsV2Fixture,
+      fixedCharges: [buildFixedChargeFixture({ id: 'fc_override', units: '5' })],
+    }
+
+    render(
+      <PlanDetailsV2FixedChargesSection
+        plan={plan}
+        isInSubscriptionForm
+        subscriptionFixedChargeUnitsById={{ fc_override: '42' }}
+        fixedChargeMutations={{
+          handleSaveCharge: mockHandleSaveCharge,
+          handleDeleteCharge: mockHandleDeleteCharge,
+        }}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    await userEvent.click(await screen.findByRole('button', { name: /actions/i }))
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'text_63e51ef4985f0ebd75c212fc' }),
+    )
+
+    await waitFor(() => expect(mockOpenDrawer).toHaveBeenCalledTimes(1))
+    const [chargeArg] = mockOpenDrawer.mock.calls[0]
+    // Drawer pre-fills with the override, not the plan default.
+    expect(chargeArg.units).toBe('42')
+  })
+
+  // Drift test: when no override is present for a charge, the plan-level value
+  // remains visible. Guards against accidental nullish display in sub mode.
+  it('falls back to plan units when no override is present', async () => {
+    const plan = {
+      ...planDetailsV2Fixture,
+      fixedCharges: [buildFixedChargeFixture({ id: 'fc_plain', units: '7' })],
+    }
+
+    render(
+      <PlanDetailsV2FixedChargesSection
+        plan={plan}
+        isInSubscriptionForm
+        subscriptionFixedChargeUnitsById={{}}
+        fixedChargeMutations={{
+          handleSaveCharge: mockHandleSaveCharge,
+          handleDeleteCharge: mockHandleDeleteCharge,
+        }}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    await userEvent.click(await screen.findByRole('button', { name: /actions/i }))
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'text_63e51ef4985f0ebd75c212fc' }),
+    )
+
+    await waitFor(() => expect(mockOpenDrawer).toHaveBeenCalledTimes(1))
+    const [chargeArg] = mockOpenDrawer.mock.calls[0]
+    expect(chargeArg.units).toBe('7')
+  })
+
   it('exposes openCreate via ref', async () => {
     const ref = createRef<PlanDetailsV2FixedChargesSectionRef>()
 

--- a/src/components/subscriptions/details-v2/SubscriptionDetailsV2Plan.tsx
+++ b/src/components/subscriptions/details-v2/SubscriptionDetailsV2Plan.tsx
@@ -1,4 +1,5 @@
 import { gql } from '@apollo/client'
+import { useMemo } from 'react'
 
 import { Alert } from '~/components/designSystem/Alert'
 import { PlanDetailsV2 } from '~/components/plans/details-v2/PlanDetailsV2'
@@ -7,6 +8,7 @@ import PremiumFeature from '~/components/premium/PremiumFeature'
 import {
   LagoApiError,
   PlanDetailsV2FragmentDoc,
+  useGetSubscriptionFixedChargeUnitsOverridesQuery,
   useGetSubscriptionForDetailsV2PlanQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -27,6 +29,20 @@ gql`
     }
   }
 
+  # Override-aware units come from Subscription.fixedCharges. FixedCharge is
+  # normalised by id in the Apollo cache, so this selection is fetched with
+  # fetchPolicy: 'no-cache' to avoid overwriting the plan-scoped units on the
+  # same FixedCharge entry — plan pages must keep showing plan defaults.
+  query getSubscriptionFixedChargeUnitsOverrides($subscriptionId: ID!) {
+    subscription(id: $subscriptionId) {
+      id
+      fixedCharges {
+        id
+        units
+      }
+    }
+  }
+
   ${PlanDetailsV2FragmentDoc}
 `
 
@@ -42,6 +58,23 @@ export const SubscriptionDetailsV2Plan = ({ subscriptionId }: Props) => {
     skip: !subscriptionId,
     context: { silentError: [LagoApiError.NotFound] },
   })
+
+  const { data: overridesData } = useGetSubscriptionFixedChargeUnitsOverridesQuery({
+    variables: { subscriptionId },
+    skip: !subscriptionId,
+    fetchPolicy: 'no-cache',
+    context: { silentError: [LagoApiError.NotFound] },
+  })
+
+  const subscriptionFixedChargeUnitsById = useMemo(() => {
+    const map: Record<string, string> = {}
+
+    for (const fixedCharge of overridesData?.subscription?.fixedCharges ?? []) {
+      map[fixedCharge.id] = fixedCharge.units
+    }
+
+    return map
+  }, [overridesData])
 
   const plan = data?.subscription?.plan
 
@@ -79,6 +112,7 @@ export const SubscriptionDetailsV2Plan = ({ subscriptionId }: Props) => {
           planId={plan.id}
           isInSubscriptionForm
           subscriptionId={subscriptionId}
+          subscriptionFixedChargeUnitsById={subscriptionFixedChargeUnitsById}
           banner={
             !plan.parent ? (
               <Alert className="pl-[-4px]" type="info" fullWidth>

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -12933,7 +12933,14 @@ export type UpdateSubscriptionFixedChargeMutationVariables = Exact<{
 }>;
 
 
-export type UpdateSubscriptionFixedChargeMutation = { __typename?: 'Mutation', updateSubscriptionFixedCharge?: { __typename?: 'FixedCharge', id: string, code?: string | null, invoiceDisplayName?: string | null, chargeModel: FixedChargeChargeModelEnum, units: string, payInAdvance: boolean, prorated: boolean, properties?: { __typename?: 'FixedChargeProperties', amount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, addOn: { __typename?: 'AddOn', id: string, name: string, code: string }, taxes?: Array<{ __typename?: 'Tax', id: string, name: string, rate: number, code: string }> | null } | null };
+export type UpdateSubscriptionFixedChargeMutation = { __typename?: 'Mutation', updateSubscriptionFixedCharge?: { __typename?: 'FixedCharge', id: string } | null };
+
+export type GetSubscriptionFixedChargeUnitsOverridesQueryVariables = Exact<{
+  subscriptionId: Scalars['ID']['input'];
+}>;
+
+
+export type GetSubscriptionFixedChargeUnitsOverridesQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string, units: string }> | null } | null };
 
 export type PlanForUpdateWithCascadeFragment = { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, amountCurrency: CurrencyEnum, billChargesMonthly?: boolean | null, billFixedChargesMonthly?: boolean | null, hasOverriddenPlans?: boolean | null, trialPeriod?: number | null, payInAdvance: boolean, amountCents: any, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string }> | null, charges?: Array<{ __typename?: 'Charge', id: string }> | null, minimumCommitment?: { __typename?: 'Commitment', amountCents: any, commitmentType: CommitmentTypeEnum, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null } | null, usageThresholds?: Array<{ __typename?: 'UsageThreshold', id: string, amountCents: any, recurring: boolean, thresholdDisplayName?: string | null }> | null, entitlements?: Array<{ __typename?: 'PlanEntitlement', code: string, name: string, privileges: Array<{ __typename?: 'PlanEntitlementPrivilegeObject', code: string, name?: string | null, value: string, valueType: PrivilegeValueTypeEnum, config: { __typename?: 'PrivilegeConfigObject', selectOptions?: Array<string> | null } }> }> | null };
 
@@ -32418,10 +32425,50 @@ export type UpdateSubscriptionChargeMutationOptions = Apollo.BaseMutationOptions
 export const UpdateSubscriptionFixedChargeDocument = gql`
     mutation updateSubscriptionFixedCharge($input: UpdateSubscriptionFixedChargeInput!) {
   updateSubscriptionFixedCharge(input: $input) {
-    ...FixedChargeForDetailsV2
+    id
   }
 }
-    ${FixedChargeForDetailsV2FragmentDoc}`;
+    `;
+export const GetSubscriptionFixedChargeUnitsOverridesDocument = gql`
+    query getSubscriptionFixedChargeUnitsOverrides($subscriptionId: ID!) {
+  subscription(id: $subscriptionId) {
+    id
+    fixedCharges {
+      id
+      units
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetSubscriptionFixedChargeUnitsOverridesQuery__
+ *
+ * To run a query within a React component, call `useGetSubscriptionFixedChargeUnitsOverridesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetSubscriptionFixedChargeUnitsOverridesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetSubscriptionFixedChargeUnitsOverridesQuery({
+ *   variables: {
+ *      subscriptionId: // value for 'subscriptionId'
+ *   },
+ * });
+ */
+export function useGetSubscriptionFixedChargeUnitsOverridesQuery(baseOptions: Apollo.QueryHookOptions<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables> & ({ variables: GetSubscriptionFixedChargeUnitsOverridesQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>(GetSubscriptionFixedChargeUnitsOverridesDocument, options);
+      }
+export function useGetSubscriptionFixedChargeUnitsOverridesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>(GetSubscriptionFixedChargeUnitsOverridesDocument, options);
+        }
+export type GetSubscriptionFixedChargeUnitsOverridesQueryHookResult = ReturnType<typeof useGetSubscriptionFixedChargeUnitsOverridesQuery>;
+export type GetSubscriptionFixedChargeUnitsOverridesLazyQueryHookResult = ReturnType<typeof useGetSubscriptionFixedChargeUnitsOverridesLazyQuery>;
+export type GetSubscriptionFixedChargeUnitsOverridesQueryResult = Apollo.QueryResult<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>;
+
 export type UpdateSubscriptionFixedChargeMutationFn = Apollo.MutationFunction<UpdateSubscriptionFixedChargeMutation, UpdateSubscriptionFixedChargeMutationVariables>;
 
 /**

--- a/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
+++ b/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
@@ -4,26 +4,29 @@ import { LocalFixedChargeInput } from '~/components/plans/types'
 import { addToast } from '~/core/apolloClient'
 import { serializeFixedChargeProperties } from '~/core/serializers/serializePlanInput'
 import {
-  FixedChargeForDetailsV2FragmentDoc,
   UpdateSubscriptionFixedChargeInput,
   useUpdateSubscriptionFixedChargeMutation,
 } from '~/generated/graphql'
 
+// Intentionally select only `id` on the mutation result. FixedCharge is
+// normalised by id in the Apollo cache, and the mutation returns the
+// subscription-scoped (override-aware) units. Writing that back would
+// overwrite the plan-default units that plan-scope pages read from the same
+// cache entry. Override-aware reads use the dedicated
+// getSubscriptionFixedChargeUnitsOverrides query (fetchPolicy: 'no-cache').
 gql`
   mutation updateSubscriptionFixedCharge($input: UpdateSubscriptionFixedChargeInput!) {
     updateSubscriptionFixedCharge(input: $input) {
-      ...FixedChargeForDetailsV2
+      id
     }
   }
-
-  ${FixedChargeForDetailsV2FragmentDoc}
 `
 
 type Args = { subscriptionId: string }
 
 export const useSubscriptionFixedChargeMutations = ({ subscriptionId }: Args) => {
   const [updateSubscriptionFixedCharge] = useUpdateSubscriptionFixedChargeMutation({
-    refetchQueries: ['getSubscriptionForDetailsV2Plan'],
+    refetchQueries: ['getSubscriptionForDetailsV2Plan', 'getSubscriptionFixedChargeUnitsOverrides'],
     awaitRefetchQueries: true,
     onCompleted(data) {
       if (data?.updateSubscriptionFixedCharge?.id) {


### PR DESCRIPTION
Subscription detail page now reads `units` via `Subscription.fixedCharges` (override-aware) instead of `Plan.fixedCharges`. A dedicated no-cache query isolates the override from the plan-scope cache entry, and the `updateSubscriptionFixedCharge` mutation result is narrowed to `id` to avoid polluting the same normalized FixedCharge.
