### PR TITLE
refactor(wallet): migrate WalletAccordion to new PremiumWarningDialog

### DIFF
--- a/src/components/wallets/WalletAccordion.tsx
+++ b/src/components/wallets/WalletAccordion.tsx
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 import { Icon } from 'lago-design-system'
 import { DateTime } from 'luxon'
-import { FC, PropsWithChildren, RefObject, useMemo, useRef } from 'react'
+import { FC, PropsWithChildren, useMemo, useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { buildLinkToActivityLog } from '~/components/activityLogs/utils'
@@ -14,7 +14,7 @@ import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Status, StatusProps, StatusType } from '~/components/designSystem/Status'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { TimezoneDate } from '~/components/TimezoneDate'
 import {
   TerminateCustomerWalletDialog,
@@ -87,7 +87,6 @@ const TODAY = DateTime.now().toISODate()
 
 interface WalletAccordionProps {
   wallet: WalletAccordionFragment
-  premiumWarningDialogRef: RefObject<PremiumWarningDialogRef>
   customerTimezone?: TimezoneEnum
   initiallyOpen?: boolean
   selectedTransaction?: string | null
@@ -110,7 +109,6 @@ const mapStatus = (type?: WalletStatusEnum | undefined): StatusProps => {
 
 export const WalletAccordion: FC<WalletAccordionProps> = ({
   customerTimezone,
-  premiumWarningDialogRef,
   wallet,
   initiallyOpen,
   selectedTransaction,
@@ -140,6 +138,7 @@ export const WalletAccordion: FC<WalletAccordionProps> = ({
   const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
   const { setUrl, openPanel: open } = useDeveloperTool()
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
 
   const terminateCustomerWalletDialogRef = useRef<TerminateCustomerWalletDialogRef>(null)
   const voidWalletDialogRef = useRef<VoidWalletDialogRef>(null)
@@ -382,7 +381,7 @@ export const WalletAccordion: FC<WalletAccordionProps> = ({
                 <Button
                   variant="tertiary"
                   endIcon="sparkles"
-                  onClick={() => premiumWarningDialogRef.current?.openDialog()}
+                  onClick={() => openPremiumWarningDialog()}
                 >
                   {translate('text_65ae73ebe3a66bec2b91d72d')}
                 </Button>


### PR DESCRIPTION
## Summary

Migrates `src/components/wallets/WalletAccordion.tsx` off the deprecated ref-based `PremiumWarningDialog` and onto the new hook-based `usePremiumWarningDialog` from `~/components/dialogs/PremiumWarningDialog`. This clears the corresponding `no-restricted-imports` ESLint warning on that file.

## Changes

- Replace `import { PremiumWarningDialogRef } from '~/components/PremiumWarningDialog'` with `import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'`.
- Drop the `premiumWarningDialogRef: RefObject<PremiumWarningDialogRef>` prop from `WalletAccordionProps` — the dialog is now opened internally via the hook.
- Call `const { open: openPremiumWarningDialog } = usePremiumWarningDialog()` inside the component.
- Update the upgrade-CTA `onClick` to call `openPremiumWarningDialog()` instead of `premiumWarningDialogRef.current?.openDialog()`.
- Drop the no-longer-needed `RefObject` import from `react`.

## Scope

Scoped strictly to the `PremiumWarningDialog` migration. The other deprecated-dialog warnings in this file (`TerminateCustomerWalletDialog`, `VoidWalletDialog`) require their own dialog definitions to be migrated first and are intentionally left for a follow-up.

## Test plan

- [ ] `pnpm code:style` shows no PremiumWarningDialog warning in `WalletAccordion.tsx`
- [ ] No type errors introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_01485ibMBz3oysptgW3NWR4p)_