### PR TITLE
fix(graphql-ruby-client): prevent app crash on plain-HTTP origins (local)

### DIFF
--- a/src/core/apolloClient/init.ts
+++ b/src/core/apolloClient/init.ts
@@ -23,6 +23,7 @@ import {
 } from '~/core/apolloClient/reactiveVars'
 import { buildWebSocketUrl } from '~/core/apolloClient/websocketUrl'
 import { CUSTOMER_PORTAL_ROUTE } from '~/core/router/paths/customerPortal'
+import { generateRandomHexId } from '~/core/utils/generateRandomHexId'
 import { LagoApiError } from '~/generated/graphql'
 
 import { cache } from './cache'
@@ -45,6 +46,9 @@ const subscriptionLink = new ActionCableLink({
   cable: ActionCable.createConsumer(cableUrl),
   channelName: 'GraphqlChannel',
   actionName: 'execute',
+  // The default crypto.randomUUID is unavailable on plain-HTTP origins
+  // and would crash the app: https://github.com/getlago/lago/issues/752
+  createChannelId: () => generateRandomHexId(),
 })
 
 const hasSubscriptionOperation = ({ query }: Operation) => {

--- a/src/core/utils/__tests__/generateRandomHexId.test.ts
+++ b/src/core/utils/__tests__/generateRandomHexId.test.ts
@@ -1,0 +1,76 @@
+import { generateRandomHexId } from '~/core/utils/generateRandomHexId'
+
+describe('generateRandomHexId', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('GIVEN the default byte length', () => {
+    describe('WHEN generating an id', () => {
+      it('THEN should return a 32-character lowercase hex string (128 bits)', () => {
+        expect(generateRandomHexId()).toMatch(/^[0-9a-f]{32}$/)
+      })
+
+      it('THEN should return a different value on every call', () => {
+        const ids = new Set(Array.from({ length: 1000 }, () => generateRandomHexId()))
+
+        expect(ids.size).toBe(1000)
+      })
+    })
+  })
+
+  describe('GIVEN a custom byte length', () => {
+    describe('WHEN generating an id', () => {
+      it.each([
+        [1, 2],
+        [8, 16],
+        [32, 64],
+      ])('THEN should return %i bytes as %i hex characters', (byteLength, expectedLength) => {
+        const id = generateRandomHexId(byteLength)
+
+        expect(id).toHaveLength(expectedLength)
+        expect(id).toMatch(/^[0-9a-f]*$/)
+      })
+
+      it('THEN should return an empty string for a zero byte length', () => {
+        expect(generateRandomHexId(0)).toBe('')
+      })
+    })
+  })
+
+  describe('GIVEN bytes that encode to a single hex digit', () => {
+    describe('WHEN generating an id', () => {
+      it('THEN should pad each byte to two characters', () => {
+        jest.spyOn(crypto, 'getRandomValues').mockImplementation(((array: Uint8Array) => {
+          array.set([0, 1, 15, 255])
+
+          return array
+        }) as typeof crypto.getRandomValues)
+
+        expect(generateRandomHexId(4)).toBe('00010fff')
+      })
+    })
+  })
+
+  describe('GIVEN an insecure context where crypto.randomUUID is unavailable', () => {
+    describe('WHEN generating an id', () => {
+      it('THEN should keep working since it only relies on crypto.getRandomValues', () => {
+        const originalDescriptor = Object.getOwnPropertyDescriptor(crypto, 'randomUUID')
+
+        Object.defineProperty(crypto, 'randomUUID', {
+          value: undefined,
+          configurable: true,
+          writable: true,
+        })
+
+        try {
+          expect(generateRandomHexId()).toMatch(/^[0-9a-f]{32}$/)
+        } finally {
+          if (originalDescriptor) {
+            Object.defineProperty(crypto, 'randomUUID', originalDescriptor)
+          }
+        }
+      })
+    })
+  })
+})

--- a/src/core/utils/generateRandomHexId.ts
+++ b/src/core/utils/generateRandomHexId.ts
@@ -1,0 +1,13 @@
+/**
+ * Generates a cryptographically random, lowercase hex string (2 chars per byte).
+ *
+ * Built on `crypto.getRandomValues` instead of `crypto.randomUUID` so it also
+ * works on insecure origins (plain-HTTP self-hosted deployments), where
+ * `randomUUID` is not exposed (https://github.com/getlago/lago/issues/752).
+ * The default 16 bytes (128 bits) make collisions practically impossible.
+ */
+export const generateRandomHexId = (byteLength: number = 16): string => {
+  return Array.from(crypto.getRandomValues(new Uint8Array(byteLength)), (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('')
+}


### PR DESCRIPTION
## Context

`graphql-ruby-client` 1.15.0 generates ActionCable channel ids with `crypto.randomUUID`, which browsers only expose in secure contexts (HTTPS or localhost). On self-hosted deployments accessed over plain HTTP (e.g. a LAN IP), the ActionCableLink constructor throws at module evaluation and the whole app fails to load.
Downgrading is not an option: the new id generation fixed a cross-subscription payload leak.

## Description

- Configure ActionCableLink with a custom `createChannelId` so the library default relying on `crypto.randomUUID` is never evaluated
- Add `generateRandomHexId`, a 128-bit `crypto.getRandomValues`-based hex generator available in all contexts and collision-proof
- Add a regression test evaluating apolloClient/init without `crypto.randomUUID`, plus unit tests for the new util

<!-- Linear link -->
Fixes LAGO-1522