### PR TITLE
fix(portal): scope auth headers by route

### DIFF
--- a/src/core/apolloClient/__tests__/authHeaders.test.ts
+++ b/src/core/apolloClient/__tests__/authHeaders.test.ts
@@ -1,0 +1,113 @@
+import { buildAuthHeaders } from '../authHeaders'
+
+const mockGetCurrentOrganizationId = jest.fn()
+
+jest.mock('../reactiveVars', () => ({
+  AUTH_TOKEN_LS_KEY: 'auth_token',
+  TMP_AUTH_TOKEN_LS_KEY: 'tmp_auth_token',
+  CUSTOMER_PORTAL_TOKEN_LS_KEY: 'customer_portal_token',
+  getCurrentOrganizationId: (...args: unknown[]) => mockGetCurrentOrganizationId(...args),
+}))
+
+jest.mock('~/hooks/useDeveloperTool', () => ({
+  DEVTOOL_AUTO_SAVE_KEY: 'devtool_auto_save',
+  resetDevtoolsNavigation: jest.fn(),
+}))
+
+const PORTAL_PATH = '/customer-portal/portal-token-abc'
+const ADMIN_PATH = '/acme/customers'
+
+describe('buildAuthHeaders', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+    mockGetCurrentOrganizationId.mockReturnValue(null)
+  })
+
+  describe('GIVEN a customer portal route', () => {
+    describe('WHEN both an admin token and a portal token exist in localStorage', () => {
+      it('THEN should send only the customer-portal-token header', () => {
+        localStorage.setItem('auth_token', 'expired-admin-jwt')
+        localStorage.setItem('customer_portal_token', 'valid-portal-token')
+        mockGetCurrentOrganizationId.mockReturnValue('org-123')
+
+        const headers = buildAuthHeaders(PORTAL_PATH)
+
+        expect(headers).toEqual({ 'customer-portal-token': 'valid-portal-token' })
+      })
+    })
+
+    describe('WHEN the path is a portal sub-route', () => {
+      it('THEN should still resolve as a portal route', () => {
+        localStorage.setItem('auth_token', 'expired-admin-jwt')
+        localStorage.setItem('customer_portal_token', 'valid-portal-token')
+
+        expect(buildAuthHeaders(`${PORTAL_PATH}/usage/item-1`)).toEqual({
+          'customer-portal-token': 'valid-portal-token',
+        })
+        expect(buildAuthHeaders(`${PORTAL_PATH}/wallet/wallet-1`)).toEqual({
+          'customer-portal-token': 'valid-portal-token',
+        })
+      })
+    })
+
+    describe('WHEN no portal token exists in localStorage', () => {
+      it('THEN should send no headers at all (no admin token fallback)', () => {
+        localStorage.setItem('auth_token', 'expired-admin-jwt')
+        mockGetCurrentOrganizationId.mockReturnValue('org-123')
+
+        expect(buildAuthHeaders(PORTAL_PATH)).toEqual({})
+      })
+    })
+  })
+
+  describe('GIVEN an admin route', () => {
+    describe('WHEN both an admin token and a portal token exist in localStorage', () => {
+      it('THEN should send authorization and organization headers but never the portal token', () => {
+        localStorage.setItem('auth_token', 'admin-jwt')
+        localStorage.setItem('customer_portal_token', 'stale-portal-token')
+        mockGetCurrentOrganizationId.mockReturnValue('org-123')
+
+        expect(buildAuthHeaders(ADMIN_PATH)).toEqual({
+          authorization: 'Bearer admin-jwt',
+          'x-lago-organization': 'org-123',
+        })
+      })
+    })
+
+    describe('WHEN only the temporary auth token exists (login flow)', () => {
+      it('THEN should use the temporary token as Bearer', () => {
+        localStorage.setItem('tmp_auth_token', 'tmp-jwt')
+
+        expect(buildAuthHeaders('/login')).toEqual({ authorization: 'Bearer tmp-jwt' })
+      })
+    })
+
+    describe('WHEN both the auth token and the temporary token exist', () => {
+      it('THEN should prefer the auth token', () => {
+        localStorage.setItem('auth_token', 'admin-jwt')
+        localStorage.setItem('tmp_auth_token', 'tmp-jwt')
+
+        expect(buildAuthHeaders(ADMIN_PATH)).toEqual({ authorization: 'Bearer admin-jwt' })
+      })
+    })
+
+    describe('WHEN no organization id is resolved', () => {
+      it('THEN should omit the x-lago-organization header', () => {
+        localStorage.setItem('auth_token', 'admin-jwt')
+        mockGetCurrentOrganizationId.mockReturnValue(null)
+
+        const headers = buildAuthHeaders(ADMIN_PATH)
+
+        expect(headers).toEqual({ authorization: 'Bearer admin-jwt' })
+        expect(headers).not.toHaveProperty('x-lago-organization')
+      })
+    })
+
+    describe('WHEN no token exists at all', () => {
+      it('THEN should send no headers', () => {
+        expect(buildAuthHeaders(ADMIN_PATH)).toEqual({})
+      })
+    })
+  })
+})

--- a/src/core/apolloClient/authHeaders.ts
+++ b/src/core/apolloClient/authHeaders.ts
@@ -1,0 +1,36 @@
+import { matchPath } from 'react-router-dom'
+
+// IMPORTANT: Keep reactiveVars import before cacheUtils
+import {
+  AUTH_TOKEN_LS_KEY,
+  CUSTOMER_PORTAL_TOKEN_LS_KEY,
+  getCurrentOrganizationId,
+  TMP_AUTH_TOKEN_LS_KEY,
+} from '~/core/apolloClient/reactiveVars'
+import { CUSTOMER_PORTAL_ROUTE } from '~/core/router/paths/customerPortal'
+
+import { getItemFromLS } from './cacheUtils'
+
+// Credentials are scoped by route: a logged-in admin previewing a customer
+// portal keeps both tokens in localStorage, and only the URL tells which
+// context the request belongs to. Sending the admin Bearer on portal routes
+// breaks the portal when that token is expired (the API rejects it before
+// reading customer-portal-token), and sending the portal token on admin
+// routes leaks it on every request after visiting any portal link.
+export const buildAuthHeaders = (pathname: string): Record<string, string> => {
+  const isCustomerPortal = !!matchPath(`${CUSTOMER_PORTAL_ROUTE}/*`, pathname)
+
+  if (isCustomerPortal) {
+    const customerPortalToken = getItemFromLS(CUSTOMER_PORTAL_TOKEN_LS_KEY)
+
+    return customerPortalToken ? { 'customer-portal-token': customerPortalToken } : {}
+  }
+
+  const token = getItemFromLS(AUTH_TOKEN_LS_KEY) || getItemFromLS(TMP_AUTH_TOKEN_LS_KEY)
+  const currentOrganizationId = getCurrentOrganizationId()
+
+  return {
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+    ...(currentOrganizationId ? { 'x-lago-organization': currentOrganizationId } : {}),
+  }
+}

--- a/src/core/apolloClient/init.ts
+++ b/src/core/apolloClient/init.ts
@@ -15,10 +15,8 @@ import { matchPath } from 'react-router-dom'
 import {
   addToast,
   AUTH_TOKEN_LS_KEY,
-  CUSTOMER_PORTAL_TOKEN_LS_KEY,
   envGlobalVar,
   getCurrentOrganizationId,
-  TMP_AUTH_TOKEN_LS_KEY,
   updateAuthTokenVar,
 } from '~/core/apolloClient/reactiveVars'
 import { buildWebSocketUrl } from '~/core/apolloClient/websocketUrl'
@@ -26,6 +24,7 @@ import { CUSTOMER_PORTAL_ROUTE } from '~/core/router/paths/customerPortal'
 import { generateRandomHexId } from '~/core/utils/generateRandomHexId'
 import { LagoApiError } from '~/generated/graphql'
 
+import { buildAuthHeaders } from './authHeaders'
 import { cache } from './cache'
 import { getItemFromLS, omitDeep } from './cacheUtils'
 import { resolvers, typeDefs } from './graphqlResolvers'
@@ -67,16 +66,11 @@ export const setAuthErrorHandler = (handler: () => void) => {
 export const initializeApolloClient = async () => {
   const authLink = new ApolloLink((operation, forward) => {
     const { headers } = operation.getContext()
-    const token = getItemFromLS(AUTH_TOKEN_LS_KEY) || getItemFromLS(TMP_AUTH_TOKEN_LS_KEY)
-    const customerPortalToken = getItemFromLS(CUSTOMER_PORTAL_TOKEN_LS_KEY)
-    const currentOrganizationId = getCurrentOrganizationId()
 
     operation.setContext({
       headers: {
         ...headers,
-        ...(!token ? {} : { authorization: `Bearer ${token}` }),
-        ...(!customerPortalToken ? {} : { 'customer-portal-token': customerPortalToken }),
-        'x-lago-organization': currentOrganizationId,
+        ...buildAuthHeaders(window.location.pathname),
       },
     })
 


### PR DESCRIPTION
## Context

Customer report: opening a valid `/customer-portal/<token>` URL while an expired admin JWT sits in localStorage renders the portal full of errors. The Apollo authLink attached every credential found in localStorage to every request, so portal queries carried `authorization: Bearer <expired token>` and the API rejected them with `expired_jwt_token` before reading the valid `customer-portal-token`. The errorLink intentionally skips logout on portal routes, so the stale token never cleared and the portal stayed broken.

The converse leak also existed: `customerPortalToken` is never removed from localStorage, so admin requests carried a stale `customer-portal-token` header after visiting any portal link.

## Fix

Auth headers are now scoped by route, keyed on the same `matchPath(\`${CUSTOMER_PORTAL_ROUTE}/*\`)` pattern the errorLink already uses:

- Portal routes send only `customer-portal-token`
- All other routes send `authorization` + `x-lago-organization`, never the portal token

The header construction is extracted into a pure `buildAuthHeaders(pathname)` in `src/core/apolloClient/authHeaders.ts` (importing `init.ts` in Jest triggers module side effects), with unit tests covering both leaks, portal sub-routes, the `tmpAuthToken` login flow, and token precedence.

A complementary hardening on lago-api (prefer the portal token over a bystander expired Bearer) is worth filing separately, but this fix is sufficient on its own.

Fixes INT-85