### PR TITLE
fix(search): enforce 3-char minimum before triggering search

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -37,6 +37,7 @@ export const SearchInput = ({
       InputProps={{
         startAdornment: <Icon className="ml-4" name="magnifying-glass" />,
       }}
+      inputProps={{ maxLength: 255 }}
       {...props}
     />
   )

--- a/src/components/__tests__/SearchInput.test.tsx
+++ b/src/components/__tests__/SearchInput.test.tsx
@@ -1,0 +1,13 @@
+import { screen } from '@testing-library/react'
+import { debounce } from 'lodash'
+
+import { SearchInput } from '~/components/SearchInput'
+import { render } from '~/test-utils'
+
+describe('SearchInput', () => {
+  it('caps the input value at 255 characters', async () => {
+    render(<SearchInput onChange={debounce(jest.fn(), 0)} placeholder="Search" />)
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('maxlength', '255')
+  })
+})

--- a/src/hooks/__tests__/useDebouncedSearch.test.ts
+++ b/src/hooks/__tests__/useDebouncedSearch.test.ts
@@ -79,6 +79,76 @@ describe('useDebouncedSearch', () => {
     expect(result.current.isLoading).toBe(false)
   })
 
+  describe('minimum search characters', () => {
+    it('does not trigger the search query when typing less than 3 characters', async () => {
+      const { result, callback } = await prepare({ initialLoadingState: false })
+
+      // Initial query on mount
+      expect(callback).toHaveBeenCalledTimes(1)
+
+      result?.current?.debouncedSearch?.('a')
+      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+      result?.current?.debouncedSearch?.('ab')
+      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+
+      expect(callback).toHaveBeenCalledTimes(1)
+    })
+
+    it('triggers the search query with 3 characters or more', async () => {
+      const { result, callback } = await prepare({ initialLoadingState: false })
+
+      result?.current?.debouncedSearch?.('abc')
+      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+
+      expect(callback).toHaveBeenCalledTimes(2)
+      expect(callback).toHaveBeenLastCalledWith({ variables: { searchTerm: 'abc' } })
+    })
+
+    it('restores the unfiltered list when going back under 3 characters after a search', async () => {
+      const { result, callback } = await prepare({ initialLoadingState: false })
+
+      result?.current?.debouncedSearch?.('abc')
+      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+      result?.current?.debouncedSearch?.('ab')
+      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+
+      expect(callback).toHaveBeenCalledTimes(3)
+      expect(callback).toHaveBeenLastCalledWith({ variables: { searchTerm: undefined } })
+    })
+
+    it('restores the unfiltered list when the search is cleared after a search', async () => {
+      const { result, callback } = await prepare({ initialLoadingState: false })
+
+      result?.current?.debouncedSearch?.('abc')
+      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+      result?.current?.debouncedSearch?.('')
+      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+
+      expect(callback).toHaveBeenCalledTimes(3)
+      expect(callback).toHaveBeenLastCalledWith({ variables: { searchTerm: undefined } })
+    })
+
+    it('ignores surrounding whitespace when counting characters', async () => {
+      const { result, callback } = await prepare({ initialLoadingState: false })
+
+      result?.current?.debouncedSearch?.('  ab  ')
+      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+
+      expect(callback).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not re-trigger the search query for the same term', async () => {
+      const { result, callback } = await prepare({ initialLoadingState: false })
+
+      result?.current?.debouncedSearch?.('abc')
+      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+      result?.current?.debouncedSearch?.('abc')
+      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+
+      expect(callback).toHaveBeenCalledTimes(2)
+    })
+  })
+
   describe('anti-regression', () => {
     // Fixes https://github.com/getlago/lago-front/pull/1272
     it('should fallback loading to initial if debounce timer is passed', async () => {

--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 export const DEBOUNCE_SEARCH_MS = window.Cypress ? 0 : 500
+export const MIN_SEARCH_CHARS = 3
 
 export type UseDebouncedSearch = (
   searchQuery?: LazyQueryExecFunction<
@@ -21,14 +22,23 @@ export type UseDebouncedSearch = (
 export const useDebouncedSearch: UseDebouncedSearch = (searchQuery, loading) => {
   const [isLoading, setIsLoading] = useState(true)
   const startLoading = useRef<DateTime | null>(null)
+  const lastSearchTerm = useRef<string | undefined>(undefined)
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedSearch = useCallback(
     // We want to delay the query execution, to prevent sending a query on every key down
     debounce((value: string) => {
+      // Terms under MIN_SEARCH_CHARS are treated as "no search" so the unfiltered list is restored
+      const searchTerm = (value || '').trim().length >= MIN_SEARCH_CHARS ? value : undefined
+
+      // Prevent firing the same query again (e.g. typing 1-2 chars while the list is unfiltered)
+      if (searchTerm === lastSearchTerm.current) return
+
+      lastSearchTerm.current = searchTerm
+
       searchQuery &&
         searchQuery({
-          variables: { searchTerm: value },
+          variables: { searchTerm },
         })
     }, DEBOUNCE_SEARCH_MS),
     [],


### PR DESCRIPTION
## Context

List view search inputs fired a query on every keystroke, including single-character terms. Short queries are rarely meaningful, return near-unfiltered result sets and add load on the API.

## Description

- Treat search terms shorter than 3 characters as "no search" in `useDebouncedSearch`, restoring the unfiltered list instead of querying with a 1-2 char term.
- Skip re-firing the same query when the resolved search term hasn't changed, so typing/erasing short terms doesn't trigger redundant requests.
- Cap `SearchInput` value at 255 characters to prevent oversized payloads.
- Add unit tests covering the threshold behavior, deduping and the input length cap.

<!-- Linear link -->
Fixes LAGO-1545