### PR TITLE
fix(rte): fix rich text editor behaviour

### DIFF
--- a/src/components/designSystem/RichTextEditor/BlockControls/BlockToolbar.tsx
+++ b/src/components/designSystem/RichTextEditor/BlockControls/BlockToolbar.tsx
@@ -80,6 +80,7 @@ const BlockToolbar = ({ editor }: BlockToolbarProps) => {
     editor,
     selector: ({ editor: e }) => {
       if (!e || e.isDestroyed) return null
+      if (getDragHandleStorage(e).hideMenu) return null
 
       return getNodeSelectionBlock(e) ?? getDragHandleTableBlock(e)
     },

--- a/src/components/designSystem/RichTextEditor/BlockControls/__tests__/BlockToolbar.test.tsx
+++ b/src/components/designSystem/RichTextEditor/BlockControls/__tests__/BlockToolbar.test.tsx
@@ -537,6 +537,36 @@ describe('BlockToolbar', () => {
         expect(result).toBeNull()
       })
     })
+
+    describe('WHEN hideMenu is true in DragHandle storage', () => {
+      it('THEN should return null even with a node selected', () => {
+        captureSelectorAndRender()
+
+        const { NodeSelection } = jest.requireActual('@tiptap/pm/state')
+        const mockNode = { attrs: { backgroundColor: '#dbeafe', textColor: '#1d4ed8' } }
+        const mockSelection = Object.create(NodeSelection.prototype, {
+          from: { value: 5 },
+          node: { value: mockNode },
+        })
+
+        const result = capturedSelector?.({
+          editor: {
+            isDestroyed: false,
+            state: {
+              selection: mockSelection,
+              doc: {
+                resolve: () => ({ index: () => 0 }),
+                childCount: 3,
+              },
+            },
+            view: { dragging: null },
+            storage: { dragHandle: { selectedBlock: null, hideMenu: true } },
+          },
+        })
+
+        expect(result).toBeNull()
+      })
+    })
   })
 
   describe('GIVEN the color picker interactions', () => {

--- a/src/components/designSystem/RichTextEditor/Toolbar/Toolbar.tsx
+++ b/src/components/designSystem/RichTextEditor/Toolbar/Toolbar.tsx
@@ -253,6 +253,10 @@ const Toolbar = ({ editor }: ToolbarProps) => {
     },
   ]
 
+  const activeTextStyle = textStylings.find((s) => s.isActive)
+  const hasNoActiveStyle = !activeTextStyle // selection spans mixed styles
+  const isTextStyleActive = !editorState.isParagraph && !!activeTextStyle
+
   const renderGroup = (name: GroupName) => {
     switch (name) {
       case 'undoRedo':
@@ -289,7 +293,8 @@ const Toolbar = ({ editor }: ToolbarProps) => {
                 <ToolbarButton
                   testId={TOOLBAR_TEXT_STYLING_DROPDOWN_TEST_ID}
                   tooltip={translate('text_1774862470019c5cxqnwghwv')}
-                  isActive={false}
+                  isActive={isTextStyleActive}
+                  isDisabled={hasNoActiveStyle}
                 >
                   <Icon name="h1" />
                 </ToolbarButton>

--- a/src/components/designSystem/RichTextEditor/Toolbar/__tests__/Toolbar.test.tsx
+++ b/src/components/designSystem/RichTextEditor/Toolbar/__tests__/Toolbar.test.tsx
@@ -308,6 +308,44 @@ describe('Toolbar', () => {
       expect(editor.chain).toHaveBeenCalled()
       expect(runMock).toHaveBeenCalled()
     })
+
+    describe('WHEN a heading is active', () => {
+      it('THEN should show the text style button with secondary variant (active)', async () => {
+        const { editor } = createMockEditor({ 'heading-1': true, paragraph: false })
+
+        await act(() => render(<Toolbar editor={editor} />))
+
+        const button = screen.getByTestId(TOOLBAR_TEXT_STYLING_DROPDOWN_TEST_ID)
+
+        // secondary variant maps to MUI contained
+        expect(button.classList.contains('MuiButton-contained')).toBe(true)
+      })
+    })
+
+    describe('WHEN paragraph is active (default text)', () => {
+      it('THEN should show the text style button with quaternary variant (inactive)', async () => {
+        const { editor } = createMockEditor({ paragraph: true })
+
+        await act(() => render(<Toolbar editor={editor} />))
+
+        const button = screen.getByTestId(TOOLBAR_TEXT_STYLING_DROPDOWN_TEST_ID)
+
+        // quaternary variant maps to MUI text
+        expect(button.classList.contains('MuiButton-text')).toBe(true)
+      })
+    })
+
+    describe('WHEN no text style is active (mixed selection)', () => {
+      it('THEN should disable the text style button', async () => {
+        const { editor } = createMockEditor({ paragraph: false })
+
+        await act(() => render(<Toolbar editor={editor} />))
+
+        const button = screen.getByTestId(TOOLBAR_TEXT_STYLING_DROPDOWN_TEST_ID)
+
+        expect(button).toBeDisabled()
+      })
+    })
   })
 
   describe('GIVEN tooltips on toolbar buttons', () => {

--- a/src/components/designSystem/RichTextEditor/extensions/DragHandle.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/DragHandle.ts
@@ -199,6 +199,38 @@ export const DragHandle = Extension.create({
     return [
       new Plugin({
         key: dragHandlePluginKey,
+        view(editorView) {
+          const handleOutsideClick = (event: MouseEvent) => {
+            const target = event.target as HTMLElement
+            const editorContainer = editorView.dom.closest('.rich-text-editor')
+
+            if (!editorContainer || editorContainer.contains(target)) return
+
+            const { selection } = editorView.state
+            const isNodeSelected = selection instanceof NodeSelection
+            const isTableSelected = storage.selectedBlock !== null
+
+            if (!isNodeSelected && !isTableSelected) return
+
+            storage.selectedBlock = null
+            storage.hideMenu = false
+
+            const $pos = editorView.state.doc.resolve(
+              Math.min(selection.from, editorView.state.doc.content.size),
+            )
+            const textSel = TextSelection.near($pos)
+
+            editorView.dispatch(editorView.state.tr.setSelection(textSel))
+          }
+
+          document.addEventListener('mousedown', handleOutsideClick)
+
+          return {
+            destroy() {
+              document.removeEventListener('mousedown', handleOutsideClick)
+            },
+          }
+        },
         state: {
           init(_, state) {
             return buildDecorations(state.doc)

--- a/src/components/designSystem/RichTextEditor/extensions/DragHandle.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/DragHandle.ts
@@ -20,6 +20,7 @@ const renderIcon = (container: HTMLElement, icon: keyof typeof ALL_ICONS): void 
 
 export type DragHandleStorage = {
   selectedBlock: { pos: number } | null
+  hideMenu: boolean
 }
 
 const isDragHandleStorage = (value: unknown): value is DragHandleStorage =>
@@ -30,7 +31,7 @@ export const getDragHandleStorage = (editor: Editor): DragHandleStorage => {
     return editor.storage.dragHandle
   }
 
-  return { selectedBlock: null }
+  return { selectedBlock: null, hideMenu: false }
 }
 
 export const DragHandle = Extension.create({
@@ -42,6 +43,7 @@ export const DragHandle = Extension.create({
        *  to CellSelection, so BlockToolbar can't detect it. We store the selected block
        *  info here so BlockToolbar can fall back to it. */
       selectedBlock: null as { pos: number } | null,
+      hideMenu: false,
     }
   },
 
@@ -74,6 +76,7 @@ export const DragHandle = Extension.create({
     const storage = getDragHandleStorage(editor)
 
     function selectBlock(pos: number) {
+      storage.hideMenu = false
       const node = editor.view.state.doc.nodeAt(pos)
 
       // For tables, avoid NodeSelection entirely — prosemirror-tables converts it
@@ -265,6 +268,38 @@ export const DragHandle = Extension.create({
             storage.selectedBlock = null
 
             return false // don't consume the event
+          },
+          handleKeyDown(view, event) {
+            if (event.key !== 'Escape') return false
+
+            const { selection } = view.state
+            const isNodeSelected = selection instanceof NodeSelection
+            const isTableSelected = storage.selectedBlock !== null
+
+            if (!isNodeSelected && !isTableSelected) return false
+
+            // First ESC: hide the block menu (BlockToolbar)
+            if (!storage.hideMenu) {
+              storage.hideMenu = true
+              view.dispatch(view.state.tr.setMeta('hideBlockMenu', true))
+
+              return true
+            }
+
+            // Second ESC: deselect the block
+            storage.hideMenu = false
+
+            if (isNodeSelected) {
+              const $pos = view.state.doc.resolve(selection.to)
+              const textSel = TextSelection.near($pos)
+
+              view.dispatch(view.state.tr.setSelection(textSel))
+            } else if (isTableSelected) {
+              storage.selectedBlock = null
+              view.dispatch(view.state.tr.setMeta('clearBlockSelection', true))
+            }
+
+            return true
           },
         },
       }),

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
@@ -3,6 +3,7 @@ import { Table } from '@tiptap/extension-table'
 import TableCell from '@tiptap/extension-table-cell'
 import TableHeader from '@tiptap/extension-table-header'
 import TableRow from '@tiptap/extension-table-row'
+import { NodeSelection } from '@tiptap/pm/state'
 import StarterKit from '@tiptap/starter-kit'
 import { act } from 'react'
 
@@ -307,6 +308,15 @@ describe('DragHandle', () => {
 
         editor.destroy()
       })
+
+      it('THEN should have hideMenu as false', () => {
+        const editor = createEditor()
+        const storage = getDragHandleStorage(editor)
+
+        expect(storage.hideMenu).toBe(false)
+
+        editor.destroy()
+      })
     })
   })
 
@@ -542,6 +552,356 @@ describe('DragHandle', () => {
         expect(() => plusButton.click()).not.toThrow()
 
         editor.destroy()
+      })
+    })
+  })
+
+  describe('GIVEN the selectBlock function resets hideMenu', () => {
+    describe('WHEN a block is selected via grip click after hideMenu was true', () => {
+      it('THEN should reset hideMenu to false', () => {
+        const editor = createEditor('<p>First</p><p>Second</p>')
+        const storage = getDragHandleStorage(editor)
+
+        // Manually set hideMenu to true (simulating a prior ESC press)
+        storage.hideMenu = true
+
+        // Click a grip to select a block
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const firstGrip = grips[0] as HTMLElement
+
+        firstGrip.click()
+
+        expect(storage.hideMenu).toBe(false)
+
+        editor.destroy()
+      })
+    })
+  })
+
+  describe('GIVEN the ESC key handler', () => {
+    describe('WHEN ESC is pressed with no block selected', () => {
+      it('THEN should not consume the event', () => {
+        const editor = createEditor('<p>First</p><p>Second</p>')
+
+        // Place a normal text cursor
+        editor.commands.setTextSelection(1)
+
+        const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+        const prevented = !editor.view.dom.dispatchEvent(event)
+
+        editor.destroy()
+
+        // The handler returns false so the event is not consumed
+        expect(prevented).toBe(false)
+      })
+    })
+
+    describe('WHEN a non-Escape key is pressed with a block selected', () => {
+      it('THEN should not consume the event', () => {
+        const editor = createEditor('<p>First</p><p>Second</p>')
+
+        // Select the first block
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        ;(grips[0] as HTMLElement).click()
+
+        const event = new KeyboardEvent('keydown', {
+          key: 'a',
+          bubbles: true,
+          cancelable: true,
+        })
+
+        // handleKeyDown returns false for non-Escape keys
+        let result: boolean | void = undefined
+
+        editor.view.someProp('handleKeyDown', (f) => {
+          result = f(editor.view, event)
+        })
+
+        editor.destroy()
+
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('WHEN ESC is pressed once with a node selected', () => {
+      it('THEN should set hideMenu to true and keep the selection', () => {
+        const editor = createEditor('<p>First</p><p>Second</p>')
+        const storage = getDragHandleStorage(editor)
+
+        // Select first block via grip
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        ;(grips[0] as HTMLElement).click()
+
+        expect(storage.hideMenu).toBe(false)
+
+        // Simulate ESC keydown through ProseMirror's handleKeyDown
+        const escEvent = new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        })
+
+        editor.view.someProp('handleKeyDown', (f) => f(editor.view, escEvent))
+
+        expect(storage.hideMenu).toBe(true)
+
+        // Block should still be selected (NodeSelection)
+
+        const isStillNodeSelected = editor.state.selection instanceof NodeSelection
+
+        editor.destroy()
+
+        expect(isStillNodeSelected).toBe(true)
+      })
+    })
+
+    describe('WHEN ESC is pressed twice with a node selected', () => {
+      it('THEN should deselect the block and reset hideMenu', () => {
+        const editor = createEditor('<p>First</p><p>Second</p>')
+        const storage = getDragHandleStorage(editor)
+
+        // Select first block
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        ;(grips[0] as HTMLElement).click()
+
+        // First ESC — hides menu
+        const esc1 = new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        })
+
+        editor.view.someProp('handleKeyDown', (f) => f(editor.view, esc1))
+
+        expect(storage.hideMenu).toBe(true)
+
+        // Second ESC — deselects block
+        const esc2 = new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        })
+
+        editor.view.someProp('handleKeyDown', (f) => f(editor.view, esc2))
+
+        expect(storage.hideMenu).toBe(false)
+
+        const isNodeSelected = editor.state.selection instanceof NodeSelection
+
+        editor.destroy()
+
+        expect(isNodeSelected).toBe(false)
+      })
+    })
+
+    describe('WHEN ESC is pressed once with a table selected', () => {
+      it('THEN should set hideMenu to true and keep the table selection', () => {
+        const editor = createEditor(TABLE_CONTENT)
+        const storage = getDragHandleStorage(editor)
+
+        // Select table via grip
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        ;(grips[1] as HTMLElement).click()
+
+        expect(storage.selectedBlock).not.toBeNull()
+        expect(storage.hideMenu).toBe(false)
+
+        const escEvent = new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        })
+
+        editor.view.someProp('handleKeyDown', (f) => f(editor.view, escEvent))
+
+        expect(storage.hideMenu).toBe(true)
+        expect(storage.selectedBlock).not.toBeNull()
+
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN ESC is pressed twice with a table selected', () => {
+      it('THEN should clear the table selection and reset hideMenu', () => {
+        const editor = createEditor(TABLE_CONTENT)
+        const storage = getDragHandleStorage(editor)
+
+        // Select table via grip
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        ;(grips[1] as HTMLElement).click()
+
+        // First ESC
+        const esc1 = new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        })
+
+        editor.view.someProp('handleKeyDown', (f) => f(editor.view, esc1))
+
+        expect(storage.hideMenu).toBe(true)
+
+        // Second ESC
+        const esc2 = new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        })
+
+        editor.view.someProp('handleKeyDown', (f) => f(editor.view, esc2))
+
+        expect(storage.hideMenu).toBe(false)
+        expect(storage.selectedBlock).toBeNull()
+
+        editor.destroy()
+      })
+    })
+  })
+
+  describe('GIVEN the outside-click handler', () => {
+    const wrapEditorInContainer = (editor: Editor) => {
+      const container = document.createElement('div')
+
+      container.className = 'rich-text-editor'
+      document.body.appendChild(container)
+      container.appendChild(editor.view.dom)
+
+      return container
+    }
+
+    describe('WHEN clicking outside the editor with a node selected', () => {
+      it('THEN should deselect the block', () => {
+        const editor = createEditor('<p>First</p><p>Second</p>')
+        const container = wrapEditorInContainer(editor)
+
+        // Select first block
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        ;(grips[0] as HTMLElement).click()
+
+        expect(editor.state.selection instanceof NodeSelection).toBe(true)
+
+        // Simulate outside click on an element outside .rich-text-editor
+        const outsideEl = document.createElement('div')
+
+        document.body.appendChild(outsideEl)
+
+        const mousedown = new MouseEvent('mousedown', { bubbles: true })
+
+        outsideEl.dispatchEvent(mousedown)
+
+        const isStillNodeSelected = editor.state.selection instanceof NodeSelection
+
+        document.body.removeChild(outsideEl)
+        document.body.removeChild(container)
+        editor.destroy()
+
+        expect(isStillNodeSelected).toBe(false)
+      })
+    })
+
+    describe('WHEN clicking outside the editor with a table selected', () => {
+      it('THEN should clear the table selection', () => {
+        const editor = createEditor(TABLE_CONTENT)
+        const container = wrapEditorInContainer(editor)
+        const storage = getDragHandleStorage(editor)
+
+        // Select table via grip
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        ;(grips[1] as HTMLElement).click()
+
+        expect(storage.selectedBlock).not.toBeNull()
+
+        // Simulate outside click
+        const outsideEl = document.createElement('div')
+
+        document.body.appendChild(outsideEl)
+
+        const mousedown = new MouseEvent('mousedown', { bubbles: true })
+
+        outsideEl.dispatchEvent(mousedown)
+
+        const selectedBlockAfter = storage.selectedBlock
+
+        document.body.removeChild(outsideEl)
+        document.body.removeChild(container)
+        editor.destroy()
+
+        expect(selectedBlockAfter).toBeNull()
+      })
+    })
+
+    describe('WHEN clicking inside the editor with a node selected', () => {
+      it('THEN should not trigger outside-click deselection', () => {
+        const editor = createEditor('<p>First</p><p>Second</p>')
+        const container = wrapEditorInContainer(editor)
+
+        // Select first block
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        ;(grips[0] as HTMLElement).click()
+
+        expect(editor.state.selection instanceof NodeSelection).toBe(true)
+
+        // Create a child element inside the container and click it
+        // (avoid dispatching mousedown on editor.view.dom directly — ProseMirror
+        //  needs elementFromPoint which jsdom doesn't support)
+        const insideEl = document.createElement('span')
+
+        container.appendChild(insideEl)
+
+        const mousedown = new MouseEvent('mousedown', { bubbles: true })
+
+        insideEl.dispatchEvent(mousedown)
+
+        // The outside-click handler should see the target is inside .rich-text-editor
+        // and return early — the NodeSelection should remain intact
+        const isStillNodeSelected = editor.state.selection instanceof NodeSelection
+
+        document.body.removeChild(container)
+        editor.destroy()
+
+        expect(isStillNodeSelected).toBe(true)
+      })
+    })
+
+    describe('WHEN clicking outside with no block selected', () => {
+      it('THEN should not change the selection', () => {
+        const editor = createEditor('<p>First</p><p>Second</p>')
+
+        wrapEditorInContainer(editor)
+
+        // Place a normal text cursor
+        editor.commands.setTextSelection(1)
+
+        const selBefore = editor.state.selection.from
+
+        // Simulate outside click
+        const outsideEl = document.createElement('div')
+
+        document.body.appendChild(outsideEl)
+
+        const mousedown = new MouseEvent('mousedown', { bubbles: true })
+
+        outsideEl.dispatchEvent(mousedown)
+
+        const selAfter = editor.state.selection.from
+
+        document.body.removeChild(outsideEl)
+        editor.destroy()
+
+        expect(selAfter).toBe(selBefore)
+      })
+    })
+
+    describe('WHEN the editor is destroyed', () => {
+      it('THEN should remove the mousedown listener', () => {
+        const removeSpy = jest.spyOn(document, 'removeEventListener')
+        const editor = createEditor('<p>Hello</p>')
+
+        editor.destroy()
+
+        expect(removeSpy).toHaveBeenCalledWith('mousedown', expect.any(Function))
+
+        removeSpy.mockRestore()
       })
     })
   })


### PR DESCRIPTION
## Context

QA has been done and showcased 3 behaviour issues on the RichTextEditor

## Description

This PR fixes the three behaviours:
- Display active on the text style button
- Remove selection using ESC button
- Remove selection on click outside

<!-- Linear link -->
Fixes LAGO-1536
Fixes LAGO-1537
Fixes LAGO-1546