### PR TITLE
refactor(form & modal): migrate timezone dialog to TanStack Form & NiceModal

### DIFF
--- a/src/pages/settings/BillingEntity/sections/general/EditBillingEntityTimezoneDialog.tsx
+++ b/src/pages/settings/BillingEntity/sections/general/EditBillingEntityTimezoneDialog.tsx
@@ -1,16 +1,16 @@
 import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
+import { revalidateLogic } from '@tanstack/react-form'
 import { Settings } from 'luxon'
-import { forwardRef } from 'react'
-import { object, string } from 'yup'
+import { useRef } from 'react'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { ComboBoxField } from '~/components/form'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
 import { addToast } from '~/core/apolloClient'
 import { getTimezoneConfig } from '~/core/timezone'
 import { TimezoneEnum, useUpdateBillingEntityTimezoneMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 gql`
   mutation updateBillingEntityTimezone($input: UpdateBillingEntityInput!) {
@@ -21,18 +21,32 @@ gql`
   }
 `
 
-export type EditBillingEntityTimezoneDialogRef = DialogRef
+const editBillingEntityTimezoneValidationSchema = z.object({
+  timezone: z.enum(TimezoneEnum).optional(),
+})
 
-interface EditBillingEntityTimezoneProps {
+type EditBillingEntityTimezoneFormValues = z.infer<typeof editBillingEntityTimezoneValidationSchema>
+
+export const EDIT_BILLING_ENTITY_TIMEZONE_FORM_ID = 'edit-billing-entity-timezone-form'
+export const EDIT_BILLING_ENTITY_TIMEZONE_COMBOBOX_TEST_ID = 'edit-billing-entity-timezone-combobox'
+export const EDIT_BILLING_ENTITY_TIMEZONE_SUBMIT_BUTTON_TEST_ID =
+  'edit-billing-entity-timezone-submit-button'
+
+const initialValues: EditBillingEntityTimezoneFormValues = {
+  timezone: undefined,
+}
+
+type EditBillingEntityTimezoneData = {
   id?: string
   timezone?: TimezoneEnum | null
 }
 
-export const EditBillingEntityTimezoneDialog = forwardRef<
-  EditBillingEntityTimezoneDialogRef,
-  EditBillingEntityTimezoneProps
->(({ id, timezone }: EditBillingEntityTimezoneProps, ref) => {
+export const useEditBillingEntityTimezoneDialog = () => {
+  const formDialog = useFormDialog()
   const { translate } = useInternationalization()
+  const dataRef = useRef<EditBillingEntityTimezoneData | null>(null)
+  const successRef = useRef(false)
+
   const [update] = useUpdateBillingEntityTimezoneMutation({
     onCompleted(res) {
       if (res?.updateBillingEntity) {
@@ -44,75 +58,93 @@ export const EditBillingEntityTimezoneDialog = forwardRef<
       }
     },
   })
-  const formikProps = useFormik({
-    initialValues: {
-      timezone,
-    },
-    validationSchema: object().shape({
-      timezone: string().nullable(),
-    }),
-    enableReinitialize: true,
-    validateOnMount: true,
-    onSubmit: async ({ timezone: tzFromFormik, ...values }) => {
-      const selectedTimezone = tzFromFormik || TimezoneEnum.TzUtc
 
-      await update({
+  const form = useAppForm({
+    defaultValues: initialValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: editBillingEntityTimezoneValidationSchema,
+    },
+    onSubmit: async ({ value }) => {
+      const selectedTimezone = value.timezone || TimezoneEnum.TzUtc
+
+      const result = await update({
         variables: {
           input: {
-            id: id as string,
+            id: dataRef.current?.id as string,
             timezone: selectedTimezone,
-            ...values,
           },
         },
       })
+
+      if (result.data?.updateBillingEntity) {
+        successRef.current = true
+      }
     },
   })
 
-  return (
-    <Dialog
-      ref={ref}
-      title={translate('text_63890710eb171a76814a0c0d')}
-      description={translate('text_63890710eb171a76814a0c0f')}
-      onClose={() => {
-        formikProps.resetForm()
-        formikProps.validateForm()
-      }}
-      actions={({ closeDialog }) => (
-        <>
-          <Button variant="quaternary" onClick={closeDialog}>
-            {translate('text_63890710eb171a76814a0c15')}
-          </Button>
-          <Button
-            variant="primary"
-            disabled={!formikProps.isValid || !formikProps.dirty}
-            onClick={async () => {
-              await formikProps.submitForm()
-              closeDialog()
-            }}
-          >
-            {translate('text_63890710eb171a76814a0c17')}
-          </Button>
-        </>
-      )}
-    >
-      <div className="mb-8">
-        <ComboBoxField
-          name="timezone"
-          label={translate('text_63890710eb171a76814a0c11')}
-          formikProps={formikProps}
-          PopperProps={{ displayInDialog: true }}
-          placeholder={translate('text_6390a4ffef9227ba45daca92')}
-          data={Object.values(TimezoneEnum).map((timezoneValue) => ({
-            value: timezoneValue,
-            label: translate('text_638f743fa9a2a9545ee6409a', {
-              zone: translate(timezoneValue),
-              offset: getTimezoneConfig(timezoneValue).offset,
-            }),
-          }))}
-        />
-      </div>
-    </Dialog>
-  )
-})
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-EditBillingEntityTimezoneDialog.displayName = 'EditBillingEntityTimezoneDialog'
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openEditBillingEntityTimezoneDialog = (data: EditBillingEntityTimezoneData) => {
+    dataRef.current = data
+    form.reset()
+    form.setFieldValue('timezone', data.timezone ?? undefined)
+
+    formDialog
+      .open({
+        title: translate('text_63890710eb171a76814a0c0d'),
+        description: translate('text_63890710eb171a76814a0c0f'),
+        cancelOrCloseText: 'cancel',
+        closeOnError: false,
+        children: (
+          <div className="p-8">
+            <form.AppField name="timezone">
+              {(field) => (
+                <field.ComboBoxField
+                  dataTest={EDIT_BILLING_ENTITY_TIMEZONE_COMBOBOX_TEST_ID}
+                  label={translate('text_63890710eb171a76814a0c11')}
+                  PopperProps={{ displayInDialog: true }}
+                  placeholder={translate('text_6390a4ffef9227ba45daca92')}
+                  data={Object.values(TimezoneEnum).map((timezoneValue) => ({
+                    value: timezoneValue,
+                    label: translate('text_638f743fa9a2a9545ee6409a', {
+                      zone: translate(timezoneValue),
+                      offset: getTimezoneConfig(timezoneValue).offset,
+                    }),
+                  }))}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton dataTest={EDIT_BILLING_ENTITY_TIMEZONE_SUBMIT_BUTTON_TEST_ID}>
+              {translate('text_63890710eb171a76814a0c17')}
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: EDIT_BILLING_ENTITY_TIMEZONE_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close') {
+          form.reset()
+          dataRef.current = null
+        }
+      })
+  }
+
+  return { openEditBillingEntityTimezoneDialog }
+}

--- a/src/pages/settings/BillingEntity/sections/general/TimezoneBlock.tsx
+++ b/src/pages/settings/BillingEntity/sections/general/TimezoneBlock.tsx
@@ -1,5 +1,3 @@
-import { useRef } from 'react'
-
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
 import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
@@ -9,10 +7,7 @@ import { BillingEntity, TimezoneEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { usePermissions } from '~/hooks/usePermissions'
-import {
-  EditBillingEntityTimezoneDialog,
-  EditBillingEntityTimezoneDialogRef,
-} from '~/pages/settings/BillingEntity/sections/general/EditBillingEntityTimezoneDialog'
+import { useEditBillingEntityTimezoneDialog } from '~/pages/settings/BillingEntity/sections/general/EditBillingEntityTimezoneDialog'
 
 type TimezoneBlockProps = {
   billingEntity: BillingEntity
@@ -26,7 +21,7 @@ const TimezoneBlock = ({ billingEntity }: TimezoneBlockProps) => {
   const { id, timezone } = billingEntity
   const timezoneConfig = getTimezoneConfig(timezone)
 
-  const editTimezoneDialogRef = useRef<EditBillingEntityTimezoneDialogRef>(null)
+  const { openEditBillingEntityTimezoneDialog } = useEditBillingEntityTimezoneDialog()
   const premiumWarningDialog = usePremiumWarningDialog()
 
   return (
@@ -42,7 +37,7 @@ const TimezoneBlock = ({ billingEntity }: TimezoneBlockProps) => {
                 endIcon={isPremium ? undefined : 'sparkles'}
                 onClick={() => {
                   isPremium
-                    ? editTimezoneDialogRef?.current?.openDialog()
+                    ? openEditBillingEntityTimezoneDialog({ id, timezone })
                     : premiumWarningDialog.open()
                 }}
               >
@@ -59,8 +54,6 @@ const TimezoneBlock = ({ billingEntity }: TimezoneBlockProps) => {
           offset: timezoneConfig.offset,
         })}
       </Typography>
-
-      <EditBillingEntityTimezoneDialog ref={editTimezoneDialogRef} id={id} timezone={timezone} />
     </SettingsListItem>
   )
 }

--- a/src/pages/settings/BillingEntity/sections/general/__tests__/EditBillingEntityTimezoneDialog.test.tsx
+++ b/src/pages/settings/BillingEntity/sections/general/__tests__/EditBillingEntityTimezoneDialog.test.tsx
@@ -1,0 +1,336 @@
+import { act, renderHook } from '@testing-library/react'
+import { Settings } from 'luxon'
+
+import { addToast } from '~/core/apolloClient'
+import { TimezoneEnum } from '~/generated/graphql'
+import { AllTheProviders } from '~/test-utils'
+
+import {
+  EDIT_BILLING_ENTITY_TIMEZONE_FORM_ID,
+  useEditBillingEntityTimezoneDialog,
+} from '../EditBillingEntityTimezoneDialog'
+
+const mockFormDialogOpen = jest.fn()
+const mockUpdate = jest.fn()
+
+jest.mock('~/components/dialogs/FormDialog', () => ({
+  ...jest.requireActual('~/components/dialogs/FormDialog'),
+  useFormDialog: () => ({
+    open: mockFormDialogOpen,
+    close: jest.fn(),
+  }),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: jest.fn(),
+}))
+
+jest.mock('~/generated/graphql', () => {
+  const actual = jest.requireActual('~/generated/graphql')
+
+  return {
+    ...actual,
+    useUpdateBillingEntityTimezoneMutation: (options?: {
+      onCompleted?: (data: unknown) => void
+    }) => [
+      async (variables: unknown) => {
+        const result = await mockUpdate(variables)
+
+        if (result?.data) {
+          options?.onCompleted?.(result.data)
+        }
+
+        return result
+      },
+    ],
+  }
+})
+
+describe('useEditBillingEntityTimezoneDialog', () => {
+  const originalDefaultZone = Settings.defaultZone
+  const customWrapper = ({ children }: { children: React.ReactNode }) =>
+    AllTheProviders({ children })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+  })
+
+  afterEach(() => {
+    Settings.defaultZone = originalDefaultZone
+  })
+
+  describe('GIVEN the hook is initialized', () => {
+    describe('WHEN rendered', () => {
+      it('THEN should return openEditBillingEntityTimezoneDialog function', () => {
+        const { result } = renderHook(() => useEditBillingEntityTimezoneDialog(), {
+          wrapper: customWrapper,
+        })
+
+        expect(typeof result.current.openEditBillingEntityTimezoneDialog).toBe('function')
+      })
+    })
+  })
+
+  describe('GIVEN openEditBillingEntityTimezoneDialog is called', () => {
+    describe('WHEN opening the dialog', () => {
+      it('THEN should call formDialog.open once', () => {
+        const { result } = renderHook(() => useEditBillingEntityTimezoneDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditBillingEntityTimezoneDialog({
+            id: 'be-1',
+            timezone: TimezoneEnum.TzEuropeParis,
+          })
+        })
+
+        expect(mockFormDialogOpen).toHaveBeenCalledTimes(1)
+      })
+
+      it('THEN should include closeOnError false', () => {
+        const { result } = renderHook(() => useEditBillingEntityTimezoneDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditBillingEntityTimezoneDialog({
+            id: 'be-1',
+            timezone: TimezoneEnum.TzEuropeParis,
+          })
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs.closeOnError).toBe(false)
+      })
+
+      it('THEN should pass cancelOrCloseText as cancel', () => {
+        const { result } = renderHook(() => useEditBillingEntityTimezoneDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditBillingEntityTimezoneDialog({
+            id: 'be-1',
+            timezone: TimezoneEnum.TzEuropeParis,
+          })
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs.cancelOrCloseText).toBe('cancel')
+      })
+
+      it.each([
+        ['title', 'string'],
+        ['description', 'string'],
+        ['children', 'object'],
+        ['mainAction', 'object'],
+      ])('THEN should include %s', (prop, expectedType) => {
+        const { result } = renderHook(() => useEditBillingEntityTimezoneDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditBillingEntityTimezoneDialog({
+            id: 'be-1',
+            timezone: TimezoneEnum.TzEuropeParis,
+          })
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs[prop]).toBeDefined()
+        expect(typeof callArgs[prop]).toBe(expectedType)
+      })
+
+      it('THEN should include form with id and submit function', () => {
+        const { result } = renderHook(() => useEditBillingEntityTimezoneDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditBillingEntityTimezoneDialog({
+            id: 'be-1',
+            timezone: TimezoneEnum.TzEuropeParis,
+          })
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs.form).toBeDefined()
+        expect(callArgs.form.id).toBe(EDIT_BILLING_ENTITY_TIMEZONE_FORM_ID)
+        expect(typeof callArgs.form.submit).toBe('function')
+      })
+    })
+  })
+
+  describe('GIVEN the form is submitted', () => {
+    describe('WHEN a timezone is provided', () => {
+      it('THEN should call the mutation with that timezone and id', async () => {
+        mockUpdate.mockResolvedValue({
+          data: {
+            updateBillingEntity: { id: 'be-1', timezone: TimezoneEnum.TzEuropeParis },
+          },
+          errors: undefined,
+        })
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useEditBillingEntityTimezoneDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditBillingEntityTimezoneDialog({
+            id: 'be-1',
+            timezone: TimezoneEnum.TzEuropeParis,
+          })
+        })
+
+        expect(mockUpdate).toHaveBeenCalledWith({
+          variables: {
+            input: { id: 'be-1', timezone: TimezoneEnum.TzEuropeParis },
+          },
+        })
+      })
+    })
+
+    describe('WHEN no timezone is provided', () => {
+      it('THEN should fall back to TzUtc', async () => {
+        mockUpdate.mockResolvedValue({
+          data: { updateBillingEntity: { id: 'be-1', timezone: TimezoneEnum.TzUtc } },
+          errors: undefined,
+        })
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useEditBillingEntityTimezoneDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditBillingEntityTimezoneDialog({
+            id: 'be-1',
+            timezone: null,
+          })
+        })
+
+        expect(mockUpdate).toHaveBeenCalledWith({
+          variables: {
+            input: { id: 'be-1', timezone: TimezoneEnum.TzUtc },
+          },
+        })
+      })
+    })
+
+    describe('WHEN the mutation succeeds', () => {
+      it('THEN should show success toast', async () => {
+        mockUpdate.mockResolvedValue({
+          data: {
+            updateBillingEntity: { id: 'be-1', timezone: TimezoneEnum.TzEuropeParis },
+          },
+          errors: undefined,
+        })
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useEditBillingEntityTimezoneDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditBillingEntityTimezoneDialog({
+            id: 'be-1',
+            timezone: TimezoneEnum.TzEuropeParis,
+          })
+        })
+
+        expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+      })
+    })
+
+    describe('WHEN the mutation returns no data', () => {
+      it('THEN handleSubmit should throw Submit failed', async () => {
+        mockUpdate.mockResolvedValue({ data: null, errors: undefined })
+
+        let submitError: unknown = null
+
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          try {
+            await config.form.submit()
+          } catch (err) {
+            submitError = err
+          }
+
+          return { reason: 'close' }
+        })
+
+        const { result } = renderHook(() => useEditBillingEntityTimezoneDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditBillingEntityTimezoneDialog({
+            id: 'be-1',
+            timezone: TimezoneEnum.TzEuropeParis,
+          })
+        })
+
+        expect(submitError).toBeInstanceOf(Error)
+        expect((submitError as Error).message).toBe('Submit failed')
+      })
+    })
+  })
+
+  describe('GIVEN the dialog resolves with close', () => {
+    describe('WHEN dialog is cancelled before submit', () => {
+      it('THEN should not call the mutation', async () => {
+        mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+
+        const { result } = renderHook(() => useEditBillingEntityTimezoneDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditBillingEntityTimezoneDialog({
+            id: 'be-1',
+            timezone: TimezoneEnum.TzEuropeParis,
+          })
+        })
+
+        expect(mockUpdate).not.toHaveBeenCalled()
+      })
+
+      it('THEN should not show a toast', async () => {
+        mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+
+        const { result } = renderHook(() => useEditBillingEntityTimezoneDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditBillingEntityTimezoneDialog({
+            id: 'be-1',
+            timezone: TimezoneEnum.TzEuropeParis,
+          })
+        })
+
+        expect(addToast).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/translations/base.json
+++ b/translations/base.json
@@ -1519,7 +1519,6 @@
   "text_63890710eb171a76814a0c0d": "Edit billing entity's timezone",
   "text_63890710eb171a76814a0c0f": "Set the timezone for your entity. This timezone will be used for invoicing and boundary calculations unless overridden at the customer level.",
   "text_63890710eb171a76814a0c11": "Timezone",
-  "text_63890710eb171a76814a0c15": "Cancel",
   "text_63890710eb171a76814a0c17": "Save timezone",
   "text_63891ad3dd238c657ea00954": "Billing entity’s timezone successfully edited",
   "text_638f743fa9a2a9545ee6409a": "{{zone}}, UTC {{offset}}",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -1547,7 +1547,6 @@
   "text_63890710eb171a76814a0c0d": "Editar fuso horário da entidade de faturamento",
   "text_63890710eb171a76814a0c0f": "Defina o fuso horário para sua entidade. Este fuso horário será usado para faturamento e cálculos de limites, a menos que seja substituído no nível do cliente.",
   "text_63890710eb171a76814a0c11": "Fuso horário",
-  "text_63890710eb171a76814a0c15": "Cancelar",
   "text_63890710eb171a76814a0c17": "Salvar fuso horário",
   "text_63891ad3dd238c657ea00954": "Fuso horário da entidade de faturamento editado com sucesso",
   "text_638f743fa9a2a9545ee6409a": "{{zone}}, UTC {{offset}}",


### PR DESCRIPTION
## Context

The EditBillingEntityTimezoneDialog relied on Formik and the deprecated
imperative ref-based Dialog component, both being phased out in favour of
TanStack Form and the hook-based NiceModal dialog system.

## Description

- Migrate the form from Formik/Yup to TanStack Form (`useAppForm`) with a Zod
  schema, preserving the optional timezone validation, the `enableReinitialize`
  behaviour, and the UTC fallback on submit.
- Convert the dialog from `forwardRef`/`useImperativeHandle` + legacy `Dialog`
  to a `useEditBillingEntityTimezoneDialog` hook built on `useFormDialog`
  (NiceModal); `id`/`timezone` now flow through the open function rather than
  props, and submit/close are handled via `DialogResult`.
- Update `TimezoneBlock` to call the hook directly and drop the imperative ref
  and JSX rendering of the dialog.

Fixes [ISSUE-1478](https://linear.app/getlago/issue/ISSUE-1478)