### PR TITLE
feat: Fixed charge units override

### DIFF
--- a/cypress/e2e/10-resources/t90-subscription-fixed-charge-override.cy.ts
+++ b/cypress/e2e/10-resources/t90-subscription-fixed-charge-override.cy.ts
@@ -1,5 +1,5 @@
 import { ACTIONS_BLOCK_TEST_ID } from '~/components/MainHeader/mainHeaderTestIds'
-import { FIXED_CHARGES_ADD_BUTTON_TEST_ID } from '~/components/plans/form/FixedChargesSection'
+import { FIXED_CHARGES_ADD_BUTTON_TEST_ID } from '~/components/plans/chargeTestIds'
 
 import { customerName } from '../../support/reusableConstants'
 

--- a/cypress/e2e/10-resources/t90-subscription-fixed-charge-override.cy.ts
+++ b/cypress/e2e/10-resources/t90-subscription-fixed-charge-override.cy.ts
@@ -1,0 +1,123 @@
+import { ACTIONS_BLOCK_TEST_ID } from '~/components/MainHeader/mainHeaderTestIds'
+import { FIXED_CHARGES_ADD_BUTTON_TEST_ID } from '~/components/plans/form/FixedChargesSection'
+
+import { customerName } from '../../support/reusableConstants'
+
+/**
+ * E2E coverage for the per-subscription fixed-charge units override.
+ *
+ * Verifies that:
+ *   1. After editing units on a subscription's fixed charge, the subscription
+ *      detail page displays the override value (read from
+ *      `Subscription.fixedCharges[*].units`).
+ *   2. The override survives a full page reload (Apollo cache reads from the
+ *      no-cache `getSubscriptionFixedChargeUnitsOverrides` query each time).
+ *
+ * The test sets up its full state inline (add-on → plan with fixed charge →
+ * subscription against an existing customer) so it has no implicit dependency
+ * on other specs. Skipped until the BE override endpoint is deployed in the
+ * CI environment — flip `describe.skip` to `describe` to enable.
+ */
+describe.skip('Subscription fixed charge units override', () => {
+  const randomId = Math.round(Math.random() * 100000)
+  const addOnName = `Fixed Charge AddOn ${randomId}`
+  const addOnCode = `fc_addon_${randomId}`
+  const planName = `Plan FC ${randomId}`
+  const planCode = `plan_fc_${randomId}`
+  const subscriptionName = `Sub FC ${randomId}`
+  const baseUnits = '10'
+  const overrideUnits = '25'
+
+  before(() => {
+    cy.login()
+
+    // 1. Create an add-on to back the plan's fixed charge.
+    cy.visitApp('/add-ons')
+    cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-addon-cta"]`).click({
+      force: true,
+    })
+    cy.get('input[name="name"]').type(addOnName)
+    cy.get('input[name="code"]').clear().type(addOnCode)
+    cy.get('input[name="amountCents"]').type('30')
+    cy.get('[data-test="submit"]').should('be.enabled').click()
+    cy.url().should('include', '/overview')
+
+    // 2. Create a plan, attach the add-on as a fixed charge with baseUnits.
+    cy.visitApp('/plans')
+    cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-plan"]`).click({
+      force: true,
+    })
+    cy.url().should('match', /\/[^/]+\/create\/plans$/)
+    cy.get('input[name="name"]').type(planName)
+    cy.get('input[name="code"]').clear().type(planCode)
+    cy.get('input[name="amountCents"]').type('5000')
+
+    cy.get(`[data-test="${FIXED_CHARGES_ADD_BUTTON_TEST_ID}"]`).scrollIntoView().click({
+      force: true,
+    })
+
+    // Pick the add-on we just created (combobox is searchable).
+    cy.get('input[name="addOnId"]').click({ force: true })
+    cy.contains('[role="option"]', addOnName).click({ force: true })
+    cy.get('input[name="units"]').clear().type(baseUnits)
+    cy.get('[data-test="fixed-charge-drawer-save"]').should('not.be.disabled').click()
+    cy.get('[data-test="base-drawer-paper"]', { timeout: 10000 }).should('not.exist')
+
+    cy.get('[data-test="submit"]').click({ force: true })
+    cy.url().should('include', '/overview')
+
+    // 3. Subscribe an existing customer to the new plan.
+    cy.visitApp('/customers')
+    cy.get('[data-test="table-customers-list"] tr').contains(customerName).click({ force: true })
+    cy.get('[data-test="add-subscription"]').click({ force: true })
+    cy.url().should('include', '/create/subscription')
+
+    cy.get('input[name="planId"]').click({ force: true })
+    cy.contains('[role="option"]', planName).click({ force: true })
+
+    cy.get('[data-test="create-subscription-form-wrapper"]').within(() => {
+      cy.get('[data-test="show-name"]').click({ force: true })
+      cy.get('input[name="name"]').first().type(subscriptionName)
+    })
+    cy.get('[data-test="submit"]').should('not.be.disabled').click({ force: true })
+    cy.get(`[data-test="${subscriptionName}"]`, { timeout: 15000 }).should('exist')
+  })
+
+  it('displays the override units after editing units on the subscription, and persists across reload', () => {
+    cy.login().visitApp('/customers')
+    cy.get('[data-test="table-customers-list"] tr').contains(customerName).click({ force: true })
+    cy.get(`[data-test="${subscriptionName}"]`, { timeout: 15000 }).click({ force: true })
+
+    // Open the Plan tab on the subscription detail page.
+    cy.contains('[role="tab"]', /plan/i).click({ force: true })
+
+    // The base units (plan default) should appear first.
+    cy.contains(addOnCode).should('exist')
+    cy.contains(addOnCode).parents('[role="button"]').first().click({ force: true })
+    cy.contains(baseUnits).should('exist')
+
+    // Open the edit drawer via the actions menu and update units.
+    cy.get('button[aria-label="actions"]').first().click({ force: true })
+    cy.contains('button', /edit/i).click({ force: true })
+    cy.get('input[name="units"]').clear().type(overrideUnits)
+    cy.get('[data-test="fixed-charge-drawer-save"]').should('not.be.disabled').click()
+    cy.get('[data-test="base-drawer-paper"]', { timeout: 10000 }).should('not.exist')
+
+    // After the mutation, the override units should be displayed.
+    cy.contains(overrideUnits, { timeout: 10000 }).should('exist')
+
+    // Reload — the override is read from Subscription.fixedCharges (no-cache),
+    // so the displayed value must still be the override, not the plan default.
+    cy.reload()
+    cy.contains('[role="tab"]', /plan/i).click({ force: true })
+    cy.contains(addOnCode).parents('[role="button"]').first().click({ force: true })
+    cy.contains(overrideUnits, { timeout: 10000 }).should('exist')
+
+    // And the plan-scope page must keep showing the plan default (no cache
+    // bleed from the per-subscription override). Navigate to the plan view.
+    cy.visitApp('/plans')
+    cy.contains('tr', planName).click({ force: true })
+    cy.contains(addOnCode).parents('[role="button"]').first().click({ force: true })
+    cy.contains(baseUnits).should('exist')
+  })
+})

--- a/src/components/plans/chargeTestIds.ts
+++ b/src/components/plans/chargeTestIds.ts
@@ -14,3 +14,6 @@ export const GRADUATED_PERCENTAGE_CHARGE_TABLE_ADD_TIER_TEST_ID = 'add-tier'
 
 // VolumeChargeTable
 export const VOLUME_CHARGE_TABLE_ADD_TIER_TEST_ID = 'add-tier'
+
+// FixedChargesSection
+export const FIXED_CHARGES_ADD_BUTTON_TEST_ID = 'add-fixed-charge'

--- a/src/components/plans/details-v2/PlanDetailsV2.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2.tsx
@@ -76,6 +76,10 @@ type PlanDetailsV2Props = {
   planId: string
   isInSubscriptionForm?: boolean
   subscriptionId?: string
+  // Override units keyed by FixedCharge id. Populated only in subscription
+  // mode by SubscriptionDetailsV2Plan, which fetches Subscription.fixedCharges
+  // with fetchPolicy: 'no-cache' so plan-scope cache entries keep plan defaults.
+  subscriptionFixedChargeUnitsById?: Record<string, string>
   banner?: ReactNode
 }
 
@@ -83,6 +87,7 @@ export const PlanDetailsV2 = ({
   planId,
   isInSubscriptionForm = false,
   subscriptionId,
+  subscriptionFixedChargeUnitsById,
   banner,
 }: PlanDetailsV2Props) => {
   const { isGated, openPremiumDialog } = useSubscriptionPremiumGate(isInSubscriptionForm)
@@ -189,6 +194,7 @@ export const PlanDetailsV2 = ({
                   plan={plan}
                   isInSubscriptionForm={isInSubscriptionForm}
                   fixedChargeMutations={fixedChargeMutations}
+                  subscriptionFixedChargeUnitsById={subscriptionFixedChargeUnitsById}
                 />
               )
             }

--- a/src/components/plans/details-v2/PlanDetailsV2.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2.tsx
@@ -80,6 +80,9 @@ type PlanDetailsV2Props = {
   // mode by SubscriptionDetailsV2Plan, which fetches Subscription.fixedCharges
   // with fetchPolicy: 'no-cache' so plan-scope cache entries keep plan defaults.
   subscriptionFixedChargeUnitsById?: Record<string, string>
+  // Refetch of that no-cache override query, so a sub-tab fixed-charge edit can
+  // reliably refresh the displayed override units (see useDetailsV2ChargeMutations).
+  refetchOverrides?: () => Promise<unknown>
   banner?: ReactNode
 }
 
@@ -88,6 +91,7 @@ export const PlanDetailsV2 = ({
   isInSubscriptionForm = false,
   subscriptionId,
   subscriptionFixedChargeUnitsById,
+  refetchOverrides,
   banner,
 }: PlanDetailsV2Props) => {
   const { isGated, openPremiumDialog } = useSubscriptionPremiumGate(isInSubscriptionForm)
@@ -104,6 +108,7 @@ export const PlanDetailsV2 = ({
   const { usageChargeMutations, fixedChargeMutations } = useDetailsV2ChargeMutations({
     plan: data?.plan,
     subscriptionId,
+    refetchOverrides,
   })
 
   // Usage charges are virtualized: a scrolled-out charge is unmounted, so the

--- a/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
@@ -97,11 +97,18 @@ type Props = {
   plan: PlanDetailsV2Fragment
   isInSubscriptionForm?: boolean
   fixedChargeMutations: FixedChargeMutations
+  // FixedCharge id → units to display when the row is rendered inside a
+  // subscription. Set by SubscriptionDetailsV2Plan from
+  // Subscription.fixedCharges. Absent in plan-scope rendering.
+  subscriptionFixedChargeUnitsById?: Record<string, string>
 }
 
 type FixedCharge = NonNullable<PlanDetailsV2Fragment['fixedCharges']>[number]
 
-const toLocalInput = (fixedCharge: FixedCharge): LocalFixedChargeInput => ({
+const toLocalInput = (
+  fixedCharge: FixedCharge,
+  effectiveUnits: string | null | undefined,
+): LocalFixedChargeInput => ({
   id: fixedCharge.id,
   code: fixedCharge.code,
   addOn: fixedCharge.addOn,
@@ -112,13 +119,19 @@ const toLocalInput = (fixedCharge: FixedCharge): LocalFixedChargeInput => ({
   properties: fixedCharge.properties ?? {},
   prorated: fixedCharge.prorated ?? false,
   taxes: fixedCharge.taxes ?? [],
-  units: fixedCharge.units ? String(fixedCharge.units) : '',
+  units: effectiveUnits ? String(effectiveUnits) : '',
 })
 
 export const PlanDetailsV2FixedChargesSection = forwardRef<
   PlanDetailsV2FixedChargesSectionRef,
   Props
->(({ plan, isInSubscriptionForm = false, fixedChargeMutations }, ref) => {
+>((props, ref) => {
+  const {
+    plan,
+    isInSubscriptionForm = false,
+    fixedChargeMutations,
+    subscriptionFixedChargeUnitsById,
+  } = props
   const { translate } = useInternationalization()
   const { canCreate, canUpdate, canDelete } = useAccordionPermissions(isInSubscriptionForm)
   const { gateOnClick, premiumIcon } = useSubscriptionPremiumGate(isInSubscriptionForm)
@@ -200,39 +213,46 @@ export const PlanDetailsV2FixedChargesSection = forwardRef<
         </Typography>
       )}
 
-      {fixedCharges.map((fixedCharge, index) => (
-        <SectionAccordion
-          key={fixedCharge.id}
-          id={fixedCharge.id}
-          icon="puzzle"
-          title={fixedCharge.invoiceDisplayName || fixedCharge.addOn.name}
-          subtitle={fixedCharge.code}
-          actions={[
-            {
-              label: translate('text_63e51ef4985f0ebd75c212fc'),
-              startIcon: 'pen',
-              endIcon: premiumIcon,
-              onClick: gateOnClick(() => openEdit(toLocalInput(fixedCharge), index)),
-              hidden: !canUpdate,
-            },
-            {
-              label: translate('text_63ea0f84f400488553caa786'),
-              startIcon: 'trash',
-              onClick: () => handleDelete(fixedCharge.id),
-              hidden: !canDelete,
-            },
-          ]}
-          noContentMargin
-        >
-          <FixedChargeInfo
-            fixedCharge={fixedCharge}
-            currency={plan.amountCurrency as CurrencyEnum}
-            planInterval={plan.interval as PlanInterval}
-            billFixedChargesMonthly={plan.billFixedChargesMonthly}
-            planTaxes={plan.taxes}
-          />
-        </SectionAccordion>
-      ))}
+      {fixedCharges.map((fixedCharge, index) => {
+        // In subscription mode, prefer the per-subscription override; otherwise
+        // fall back to the plan default carried on FixedCharge.units.
+        const effectiveUnits =
+          subscriptionFixedChargeUnitsById?.[fixedCharge.id] ?? fixedCharge.units
+
+        return (
+          <SectionAccordion
+            key={fixedCharge.id}
+            id={fixedCharge.id}
+            icon="puzzle"
+            title={fixedCharge.invoiceDisplayName || fixedCharge.addOn.name}
+            subtitle={fixedCharge.code}
+            actions={[
+              {
+                label: translate('text_63e51ef4985f0ebd75c212fc'),
+                startIcon: 'pen',
+                endIcon: premiumIcon,
+                onClick: gateOnClick(() => openEdit(toLocalInput(fixedCharge, effectiveUnits), index)),
+                hidden: !canUpdate,
+              },
+              {
+                label: translate('text_63ea0f84f400488553caa786'),
+                startIcon: 'trash',
+                onClick: () => handleDelete(fixedCharge.id),
+                hidden: !canDelete,
+              },
+            ]}
+            noContentMargin
+          >
+            <FixedChargeInfo
+              fixedCharge={{ ...fixedCharge, units: effectiveUnits }}
+              currency={plan.amountCurrency as CurrencyEnum}
+              planInterval={plan.interval as PlanInterval}
+              billFixedChargesMonthly={plan.billFixedChargesMonthly}
+              planTaxes={plan.taxes}
+            />
+          </SectionAccordion>
+        )
+      })}
 
       <PlanFormProvider
         currency={plan.amountCurrency as CurrencyEnum}

--- a/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
@@ -231,7 +231,9 @@ export const PlanDetailsV2FixedChargesSection = forwardRef<
                 label: translate('text_63e51ef4985f0ebd75c212fc'),
                 startIcon: 'pen',
                 endIcon: premiumIcon,
-                onClick: gateOnClick(() => openEdit(toLocalInput(fixedCharge, effectiveUnits), index)),
+                onClick: gateOnClick(() =>
+                  openEdit(toLocalInput(fixedCharge, effectiveUnits), index),
+                ),
                 hidden: !canUpdate,
               },
               {

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2FixedChargesSection.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2FixedChargesSection.test.tsx
@@ -46,6 +46,13 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({ translate: (k: string) => k }),
 }))
 
+// Editing in subscription mode is premium-gated (useSubscriptionPremiumGate):
+// a non-premium user gets the upsell modal instead of the edit drawer, so the
+// override-pre-fill assertions need a premium user.
+jest.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ isPremium: true }),
+}))
+
 const Wrapper = ({ children }: { children: ReactNode }) => (
   <MockedProvider mocks={[]} addTypename={false}>
     <NiceModal.Provider>{children}</NiceModal.Provider>
@@ -407,6 +414,34 @@ describe('PlanDetailsV2FixedChargesSection', () => {
     const [chargeArg] = mockOpenDrawer.mock.calls[0]
     // Drawer pre-fills with the override, not the plan default.
     expect(chargeArg.units).toBe('42')
+  })
+
+  // Reproduction: the VISIBLE units (FixedChargeInfo), not just the drawer
+  // pre-fill, must reflect the per-subscription override.
+  it('displays the override units in the accordion body, not the plan default', async () => {
+    const plan = {
+      ...planDetailsV2Fixture,
+      fixedCharges: [buildFixedChargeFixture({ id: 'fc_vis', units: '777' })],
+    }
+
+    render(
+      <PlanDetailsV2FixedChargesSection
+        plan={plan}
+        isInSubscriptionForm
+        subscriptionFixedChargeUnitsById={{ fc_vis: '222' }}
+        fixedChargeMutations={{
+          handleSaveCharge: mockHandleSaveCharge,
+          handleDeleteCharge: mockHandleDeleteCharge,
+        }}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    // Expand the accordion so its body (FixedChargeInfo) is visible.
+    await userEvent.click(await screen.findByText('Onboarding'))
+
+    expect(await screen.findByText('222')).toBeInTheDocument()
+    expect(screen.queryByText('777')).not.toBeInTheDocument()
   })
 
   // Drift test: when no override is present for a charge, the plan-level value

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2FixedChargesSection.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2FixedChargesSection.test.tsx
@@ -377,6 +377,69 @@ describe('PlanDetailsV2FixedChargesSection', () => {
     expect(screen.queryByText('text_63e51ef4985f0ebd75c212fc')).not.toBeInTheDocument()
   })
 
+  // Drift test: the subscription override map should take precedence over the
+  // plan-level units when displaying a row and when pre-filling the edit drawer.
+  it('uses subscriptionFixedChargeUnitsById to override displayed units', async () => {
+    const plan = {
+      ...planDetailsV2Fixture,
+      fixedCharges: [buildFixedChargeFixture({ id: 'fc_override', units: '5' })],
+    }
+
+    render(
+      <PlanDetailsV2FixedChargesSection
+        plan={plan}
+        isInSubscriptionForm
+        subscriptionFixedChargeUnitsById={{ fc_override: '42' }}
+        fixedChargeMutations={{
+          handleSaveCharge: mockHandleSaveCharge,
+          handleDeleteCharge: mockHandleDeleteCharge,
+        }}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    await userEvent.click(await screen.findByRole('button', { name: /actions/i }))
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'text_63e51ef4985f0ebd75c212fc' }),
+    )
+
+    await waitFor(() => expect(mockOpenDrawer).toHaveBeenCalledTimes(1))
+    const [chargeArg] = mockOpenDrawer.mock.calls[0]
+    // Drawer pre-fills with the override, not the plan default.
+    expect(chargeArg.units).toBe('42')
+  })
+
+  // Drift test: when no override is present for a charge, the plan-level value
+  // remains visible. Guards against accidental nullish display in sub mode.
+  it('falls back to plan units when no override is present', async () => {
+    const plan = {
+      ...planDetailsV2Fixture,
+      fixedCharges: [buildFixedChargeFixture({ id: 'fc_plain', units: '7' })],
+    }
+
+    render(
+      <PlanDetailsV2FixedChargesSection
+        plan={plan}
+        isInSubscriptionForm
+        subscriptionFixedChargeUnitsById={{}}
+        fixedChargeMutations={{
+          handleSaveCharge: mockHandleSaveCharge,
+          handleDeleteCharge: mockHandleDeleteCharge,
+        }}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    await userEvent.click(await screen.findByRole('button', { name: /actions/i }))
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'text_63e51ef4985f0ebd75c212fc' }),
+    )
+
+    await waitFor(() => expect(mockOpenDrawer).toHaveBeenCalledTimes(1))
+    const [chargeArg] = mockOpenDrawer.mock.calls[0]
+    expect(chargeArg.units).toBe('7')
+  })
+
   it('exposes openCreate via ref', async () => {
     const ref = createRef<PlanDetailsV2FixedChargesSectionRef>()
 

--- a/src/components/plans/drawers/fixedCharge/FixedChargeDrawerContent.tsx
+++ b/src/components/plans/drawers/fixedCharge/FixedChargeDrawerContent.tsx
@@ -3,6 +3,7 @@ import InputAdornment from '@mui/material/InputAdornment'
 import { useStore } from '@tanstack/react-form'
 import { useCallback, useMemo } from 'react'
 
+import { Alert } from '~/components/designSystem/Alert'
 import { Selector } from '~/components/designSystem/Selector'
 import { Typography } from '~/components/designSystem/Typography'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
@@ -265,6 +266,12 @@ export const FixedChargeDrawerContent = withForm({
                 localCharge={formValues as unknown as LocalFixedChargeInput}
                 propertyCursor="properties"
               />
+
+              <Alert type="info">
+                <Typography variant="body" color="grey700">
+                  {translate('text_1781789973520dpkwtttnk2m')}
+                </Typography>
+              </Alert>
 
               <form.AppField name="units">
                 {(field) => (

--- a/src/components/plans/form/FixedChargesSection.tsx
+++ b/src/components/plans/form/FixedChargesSection.tsx
@@ -7,6 +7,7 @@ import { Chip } from '~/components/designSystem/Chip'
 import { Selector, SelectorActions } from '~/components/designSystem/Selector'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
+import { FIXED_CHARGES_ADD_BUTTON_TEST_ID } from '~/components/plans/chargeTestIds'
 import {
   FixedChargeDrawer,
   FixedChargeDrawerRef,
@@ -64,9 +65,6 @@ gql`
   ${GraduatedChargeFragmentDoc}
   ${VolumeRangesFragmentDoc}
 `
-
-// Test ID constants
-export const FIXED_CHARGES_ADD_BUTTON_TEST_ID = 'add-fixed-charge'
 
 interface FixedChargesSectionProps {
   form: PlanFormType

--- a/src/components/plans/form/__tests__/FixedChargesSection.test.tsx
+++ b/src/components/plans/form/__tests__/FixedChargesSection.test.tsx
@@ -5,8 +5,9 @@ import { ChargeModelEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 import { createMockPlanForm } from '~/test-utils/createMockPlanForm'
 
+import { FIXED_CHARGES_ADD_BUTTON_TEST_ID } from '../../chargeTestIds'
 import { LocalFixedChargeInput, PlanFormInput } from '../../types'
-import { FIXED_CHARGES_ADD_BUTTON_TEST_ID, FixedChargesSection } from '../FixedChargesSection'
+import { FixedChargesSection } from '../FixedChargesSection'
 
 // --- Mocks ---
 

--- a/src/components/subscriptions/details-v2/SubscriptionDetailsV2Plan.tsx
+++ b/src/components/subscriptions/details-v2/SubscriptionDetailsV2Plan.tsx
@@ -8,6 +8,7 @@ import PremiumFeature from '~/components/premium/PremiumFeature'
 import {
   LagoApiError,
   PlanDetailsV2FragmentDoc,
+  useGetSubscriptionFixedChargeUnitsOverridesQuery,
   useGetSubscriptionForDetailsV2PlanQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -27,6 +28,20 @@ gql`
     }
   }
 
+  # Override-aware units come from Subscription.fixedCharges. FixedCharge is
+  # normalised by id in the Apollo cache, so this selection is fetched with
+  # fetchPolicy: 'no-cache' to avoid overwriting the plan-scoped units on the
+  # same FixedCharge entry — plan pages must keep showing plan defaults.
+  query getSubscriptionFixedChargeUnitsOverrides($subscriptionId: ID!) {
+    subscription(id: $subscriptionId) {
+      id
+      fixedCharges {
+        id
+        units
+      }
+    }
+  }
+
   ${PlanDetailsV2FragmentDoc}
 `
 
@@ -42,6 +57,23 @@ export const SubscriptionDetailsV2Plan = ({ subscriptionId }: Props) => {
     skip: !subscriptionId,
     context: { silentError: [LagoApiError.NotFound] },
   })
+
+  const { data: overridesData } = useGetSubscriptionFixedChargeUnitsOverridesQuery({
+    variables: { subscriptionId },
+    skip: !subscriptionId,
+    fetchPolicy: 'no-cache',
+    context: { silentError: [LagoApiError.NotFound] },
+  })
+
+  const subscriptionFixedChargeUnitsById = useMemo(() => {
+    const map: Record<string, string> = {}
+
+    for (const fixedCharge of overridesData?.subscription?.fixedCharges ?? []) {
+      map[fixedCharge.id] = fixedCharge.units
+    }
+
+    return map
+  }, [overridesData])
 
   const plan = data?.subscription?.plan
 
@@ -76,6 +108,7 @@ export const SubscriptionDetailsV2Plan = ({ subscriptionId }: Props) => {
       planId={plan.id}
       isInSubscriptionForm
       subscriptionId={subscriptionId}
+      subscriptionFixedChargeUnitsById={subscriptionFixedChargeUnitsById}
       banner={banner}
     />
   )

--- a/src/components/subscriptions/details-v2/SubscriptionDetailsV2Plan.tsx
+++ b/src/components/subscriptions/details-v2/SubscriptionDetailsV2Plan.tsx
@@ -58,13 +58,16 @@ export const SubscriptionDetailsV2Plan = ({ subscriptionId }: Props) => {
     context: { silentError: [LagoApiError.NotFound] },
   })
 
-  const { data: overridesData, loading: overridesLoading } =
-    useGetSubscriptionFixedChargeUnitsOverridesQuery({
-      variables: { subscriptionId },
-      skip: !subscriptionId,
-      fetchPolicy: 'no-cache',
-      context: { silentError: [LagoApiError.NotFound] },
-    })
+  const {
+    data: overridesData,
+    loading: overridesLoading,
+    refetch: refetchOverrides,
+  } = useGetSubscriptionFixedChargeUnitsOverridesQuery({
+    variables: { subscriptionId },
+    skip: !subscriptionId,
+    fetchPolicy: 'no-cache',
+    context: { silentError: [LagoApiError.NotFound] },
+  })
 
   const subscriptionFixedChargeUnitsById = useMemo(() => {
     const map: Record<string, string> = {}
@@ -119,6 +122,7 @@ export const SubscriptionDetailsV2Plan = ({ subscriptionId }: Props) => {
       isInSubscriptionForm
       subscriptionId={subscriptionId}
       subscriptionFixedChargeUnitsById={subscriptionFixedChargeUnitsById}
+      refetchOverrides={refetchOverrides}
       banner={banner}
     />
   )

--- a/src/components/subscriptions/details-v2/SubscriptionDetailsV2Plan.tsx
+++ b/src/components/subscriptions/details-v2/SubscriptionDetailsV2Plan.tsx
@@ -58,12 +58,13 @@ export const SubscriptionDetailsV2Plan = ({ subscriptionId }: Props) => {
     context: { silentError: [LagoApiError.NotFound] },
   })
 
-  const { data: overridesData } = useGetSubscriptionFixedChargeUnitsOverridesQuery({
-    variables: { subscriptionId },
-    skip: !subscriptionId,
-    fetchPolicy: 'no-cache',
-    context: { silentError: [LagoApiError.NotFound] },
-  })
+  const { data: overridesData, loading: overridesLoading } =
+    useGetSubscriptionFixedChargeUnitsOverridesQuery({
+      variables: { subscriptionId },
+      skip: !subscriptionId,
+      fetchPolicy: 'no-cache',
+      context: { silentError: [LagoApiError.NotFound] },
+    })
 
   const subscriptionFixedChargeUnitsById = useMemo(() => {
     const map: Record<string, string> = {}
@@ -101,6 +102,15 @@ export const SubscriptionDetailsV2Plan = ({ subscriptionId }: Props) => {
 
   if (!plan) {
     return null
+  }
+
+  // The fixed-charge rows derive their units from `override ?? planDefault`.
+  // Override units come from the separate no-cache overrides query, which
+  // resolves independently of the cached plan data. Holding the skeleton until
+  // it has settled avoids rendering the plan default first and then snapping to
+  // the override (or vice-versa) — the units flicker seen on initial load.
+  if (overridesLoading) {
+    return <PlanDetailsV2Skeleton />
   }
 
   return (

--- a/src/components/subscriptions/details-v2/SubscriptionDetailsV2Plan.tsx
+++ b/src/components/subscriptions/details-v2/SubscriptionDetailsV2Plan.tsx
@@ -1,14 +1,16 @@
-import { gql } from '@apollo/client'
-import { useMemo } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { Alert } from '~/components/designSystem/Alert'
 import { PlanDetailsV2 } from '~/components/plans/details-v2/PlanDetailsV2'
 import { PlanDetailsV2Skeleton } from '~/components/plans/details-v2/PlanDetailsV2Skeleton'
 import PremiumFeature from '~/components/premium/PremiumFeature'
 import {
+  GetSubscriptionFixedChargeUnitsOverridesDocument,
+  GetSubscriptionFixedChargeUnitsOverridesQuery,
+  GetSubscriptionFixedChargeUnitsOverridesQueryVariables,
   LagoApiError,
   PlanDetailsV2FragmentDoc,
-  useGetSubscriptionFixedChargeUnitsOverridesQuery,
   useGetSubscriptionForDetailsV2PlanQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -28,10 +30,14 @@ gql`
     }
   }
 
-  # Override-aware units come from Subscription.fixedCharges. FixedCharge is
-  # normalised by id in the Apollo cache, so this selection is fetched with
-  # fetchPolicy: 'no-cache' to avoid overwriting the plan-scoped units on the
-  # same FixedCharge entry — plan pages must keep showing plan defaults.
+  # Override-aware units come from Subscription.fixedCharges (the BE returns the
+  # effective units for every fixed charge: the override, or the plan default
+  # when there is no override). FixedCharge is normalised by id, and
+  # Subscription.fixedCharges shares that entity with Plan.fixedCharges, so this
+  # is fetched IMPERATIVELY (client.query, fetchPolicy: 'no-cache') and held in
+  # local state — see the component. A subscribed useQuery would have its result
+  # re-broadcast to the cached plan-default units when the plan queries write the
+  # shared FixedCharge; an imperative one-shot read keeps the override value.
   query getSubscriptionFixedChargeUnitsOverrides($subscriptionId: ID!) {
     subscription(id: $subscriptionId) {
       id
@@ -52,32 +58,54 @@ type Props = {
 export const SubscriptionDetailsV2Plan = ({ subscriptionId }: Props) => {
   const { translate } = useInternationalization()
   const { isPremium } = useCurrentUser()
+  const client = useApolloClient()
   const { data, loading } = useGetSubscriptionForDetailsV2PlanQuery({
     variables: { subscriptionId },
     skip: !subscriptionId,
     context: { silentError: [LagoApiError.NotFound] },
   })
 
-  const {
-    data: overridesData,
-    loading: overridesLoading,
-    refetch: refetchOverrides,
-  } = useGetSubscriptionFixedChargeUnitsOverridesQuery({
-    variables: { subscriptionId },
-    skip: !subscriptionId,
-    fetchPolicy: 'no-cache',
-    context: { silentError: [LagoApiError.NotFound] },
-  })
+  // Override units, keyed by FixedCharge id, kept in plain React state and
+  // fetched imperatively so the displayed value is fully decoupled from the
+  // Apollo cache (see the query comment). refetchOverrides is threaded to the
+  // edit mutation so a save re-reads the fresh override units.
+  const [subscriptionFixedChargeUnitsById, setSubscriptionFixedChargeUnitsById] = useState<
+    Record<string, string>
+  >({})
+  const [overridesLoaded, setOverridesLoaded] = useState(false)
 
-  const subscriptionFixedChargeUnitsById = useMemo(() => {
-    const map: Record<string, string> = {}
+  const refetchOverrides = useCallback(async () => {
+    if (!subscriptionId) return
 
-    for (const fixedCharge of overridesData?.subscription?.fixedCharges ?? []) {
-      map[fixedCharge.id] = fixedCharge.units
+    try {
+      const { data: overridesData } = await client.query<
+        GetSubscriptionFixedChargeUnitsOverridesQuery,
+        GetSubscriptionFixedChargeUnitsOverridesQueryVariables
+      >({
+        query: GetSubscriptionFixedChargeUnitsOverridesDocument,
+        variables: { subscriptionId },
+        fetchPolicy: 'no-cache',
+        context: { silentError: [LagoApiError.NotFound] },
+      })
+
+      const map: Record<string, string> = {}
+
+      for (const fixedCharge of overridesData?.subscription?.fixedCharges ?? []) {
+        map[fixedCharge.id] = fixedCharge.units
+      }
+
+      setSubscriptionFixedChargeUnitsById(map)
+    } catch {
+      // Silent (matches the NotFound handling): fall back to plan-default units.
+      setSubscriptionFixedChargeUnitsById({})
+    } finally {
+      setOverridesLoaded(true)
     }
+  }, [client, subscriptionId])
 
-    return map
-  }, [overridesData])
+  useEffect(() => {
+    refetchOverrides()
+  }, [refetchOverrides])
 
   const plan = data?.subscription?.plan
 
@@ -108,11 +136,11 @@ export const SubscriptionDetailsV2Plan = ({ subscriptionId }: Props) => {
   }
 
   // The fixed-charge rows derive their units from `override ?? planDefault`.
-  // Override units come from the separate no-cache overrides query, which
-  // resolves independently of the cached plan data. Holding the skeleton until
-  // it has settled avoids rendering the plan default first and then snapping to
-  // the override (or vice-versa) — the units flicker seen on initial load.
-  if (overridesLoading) {
+  // Override units come from the imperative overrides read, which resolves
+  // independently of the cached plan data. Holding the skeleton until it has
+  // settled avoids rendering the plan default first and then snapping to the
+  // override (or vice-versa) — the units flicker seen on initial load.
+  if (!overridesLoaded) {
     return <PlanDetailsV2Skeleton />
   }
 

--- a/src/components/subscriptions/details-v2/__tests__/SubscriptionDetailsV2Plan.integration.test.tsx
+++ b/src/components/subscriptions/details-v2/__tests__/SubscriptionDetailsV2Plan.integration.test.tsx
@@ -1,0 +1,137 @@
+import { MockedProvider } from '@apollo/client/testing'
+import NiceModal from '@ebay/nice-modal-react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { FORM_DIALOG_NAME } from '~/components/dialogs/const'
+import FormDialog from '~/components/dialogs/FormDialog'
+import {
+  GetPlanForDetailsV2Document,
+  GetSubscriptionFixedChargeUnitsOverridesDocument,
+  GetSubscriptionForDetailsV2PlanDocument,
+} from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import {
+  buildFixedChargeFixture,
+  PLAN_DETAILS_V2_FIXTURE_ID,
+  planDetailsV2Fixture,
+} from '../../../plans/details-v2/__tests__/fixtures'
+import { SubscriptionDetailsV2Plan } from '../SubscriptionDetailsV2Plan'
+
+NiceModal.register(FORM_DIALOG_NAME, FormDialog)
+
+// Drawers/accordions pull import.meta (drawerStack) which crashes Jest — stub them.
+jest.mock('~/components/plans/drawers/planSettings/usePlanSettingsDrawer', () => ({
+  usePlanSettingsDrawer: () => ({ openDrawer: jest.fn() }),
+}))
+const stubRefDrawer = () => {
+  const { forwardRef, useImperativeHandle } = jest.requireActual('react')
+
+  return forwardRef((_p: unknown, ref: unknown) => {
+    useImperativeHandle(ref, () => ({ openDrawer: jest.fn(), closeDrawer: jest.fn() }))
+    return null
+  })
+}
+jest.mock('~/components/plans/drawers/subscriptionFee/SubscriptionFeeDrawer', () => ({
+  __esModule: true,
+  SubscriptionFeeDrawer: stubRefDrawer(),
+}))
+jest.mock('~/components/plans/drawers/fixedCharge/FixedChargeDrawer', () => ({
+  __esModule: true,
+  FixedChargeDrawer: stubRefDrawer(),
+}))
+jest.mock('~/components/plans/drawers/usageCharge/UsageChargeDrawer', () => ({
+  __esModule: true,
+  UsageChargeDrawer: stubRefDrawer(),
+}))
+jest.mock('~/components/plans/details-v2/accordions/MinimumCommitmentAccordion', () => ({
+  __esModule: true,
+  MinimumCommitmentAccordion: () => null,
+}))
+jest.mock('~/components/plans/details-v2/accordions/ProgressiveBillingAccordion', () => ({
+  __esModule: true,
+  ProgressiveBillingAccordion: () => null,
+}))
+jest.mock('~/components/plans/details-v2/accordions/EntitlementAccordion', () => ({
+  __esModule: true,
+  EntitlementAccordion: () => null,
+}))
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (k: string) => k }),
+}))
+jest.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ isPremium: true }),
+}))
+jest.mock('~/components/premium/PremiumFeature', () => ({ __esModule: true, default: () => null }))
+
+const SUB_ID = 'sub_int_1'
+const FC_ID = 'fc_int_1'
+
+const planWithCharge = {
+  ...planDetailsV2Fixture,
+  id: PLAN_DETAILS_V2_FIXTURE_ID,
+  hasOverriddenPlans: true,
+  subscriptionsCount: 9,
+  fixedCharges: [
+    buildFixedChargeFixture({
+      id: FC_ID,
+      units: '5',
+      addOn: { __typename: 'AddOn', id: 'addon_int', name: 'JuiceTax', code: 'juicetax' },
+    }),
+  ],
+}
+
+const subscriptionPlanMock = {
+  request: {
+    query: GetSubscriptionForDetailsV2PlanDocument,
+    variables: { subscriptionId: SUB_ID },
+  },
+  result: {
+    data: { subscription: { id: SUB_ID, plan: { ...planWithCharge, parent: null } } },
+  },
+}
+
+const overridesMock = {
+  request: {
+    query: GetSubscriptionFixedChargeUnitsOverridesDocument,
+    variables: { subscriptionId: SUB_ID },
+  },
+  result: {
+    data: {
+      subscription: {
+        __typename: 'Subscription',
+        id: SUB_ID,
+        fixedCharges: [{ __typename: 'FixedCharge', id: FC_ID, units: '999' }],
+      },
+    },
+  },
+}
+
+const planMock = {
+  request: {
+    query: GetPlanForDetailsV2Document,
+    variables: { planId: PLAN_DETAILS_V2_FIXTURE_ID },
+  },
+  result: { data: { plan: planWithCharge } },
+}
+
+describe('SubscriptionDetailsV2Plan (integration)', () => {
+  // Wires the real PlanDetailsV2 → section → FixedChargeInfo so the override
+  // map is threaded and applied end-to-end (the row reads override ?? plan).
+  it('shows the per-subscription override units (999), not the plan default (5)', async () => {
+    render(
+      <MockedProvider mocks={[subscriptionPlanMock, overridesMock, planMock]} addTypename>
+        <NiceModal.Provider>
+          <SubscriptionDetailsV2Plan subscriptionId={SUB_ID} />
+        </NiceModal.Provider>
+      </MockedProvider>,
+    )
+
+    // Expand the fixed-charge accordion to reveal its body (FixedChargeInfo).
+    await userEvent.click(await screen.findByText('JuiceTax'))
+
+    expect(await screen.findByText('999')).toBeInTheDocument()
+    expect(screen.queryByText('5')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/subscriptions/details-v2/__tests__/SubscriptionDetailsV2Plan.test.tsx
+++ b/src/components/subscriptions/details-v2/__tests__/SubscriptionDetailsV2Plan.test.tsx
@@ -2,7 +2,10 @@ import { MockedProvider } from '@apollo/client/testing'
 import { screen, waitFor } from '@testing-library/react'
 import { isValidElement, ReactElement } from 'react'
 
-import { GetSubscriptionForDetailsV2PlanDocument } from '~/generated/graphql'
+import {
+  GetSubscriptionFixedChargeUnitsOverridesDocument,
+  GetSubscriptionForDetailsV2PlanDocument,
+} from '~/generated/graphql'
 import { render } from '~/test-utils'
 
 import { SubscriptionDetailsV2Plan } from '../SubscriptionDetailsV2Plan'
@@ -53,6 +56,21 @@ const queryMock = {
   },
 }
 
+const overridesMock = {
+  request: {
+    query: GetSubscriptionFixedChargeUnitsOverridesDocument,
+    variables: { subscriptionId: SUB_ID },
+  },
+  result: {
+    data: {
+      subscription: {
+        id: SUB_ID,
+        fixedCharges: [{ id: '05de03c3', units: '2' }],
+      },
+    },
+  },
+}
+
 describe('SubscriptionDetailsV2Plan', () => {
   beforeEach(() => {
     capturedProps.length = 0
@@ -77,6 +95,19 @@ describe('SubscriptionDetailsV2Plan', () => {
       render(props.banner as ReactElement)
     }
     expect(screen.queryByTestId('premium-feature')).not.toBeInTheDocument()
+  })
+
+  it('passes the per-subscription override units map to PlanDetailsV2', async () => {
+    render(
+      <MockedProvider mocks={[queryMock, overridesMock]} addTypename={false}>
+        <SubscriptionDetailsV2Plan subscriptionId={SUB_ID} />
+      </MockedProvider>,
+    )
+
+    await waitFor(() => expect(capturedProps.length).toBeGreaterThan(0))
+    const props = capturedProps[capturedProps.length - 1]
+
+    expect(props.subscriptionFixedChargeUnitsById).toEqual({ '05de03c3': '2' })
   })
 
   // Drift test: subscription plan overrides are premium-gated — non-premium users

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -12832,6 +12832,13 @@ export type GetSubscriptionForDetailsV2PlanQueryVariables = Exact<{
 
 export type GetSubscriptionForDetailsV2PlanQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, plan: { __typename?: 'Plan', id: string, subscriptionsCount: number, hasOverriddenPlans?: boolean | null, interval: PlanInterval, amountCurrency: CurrencyEnum, billFixedChargesMonthly?: boolean | null, billChargesMonthly?: boolean | null, name: string, code: string, description?: string | null, trialPeriod?: number | null, payInAdvance: boolean, amountCents: any, invoiceDisplayName?: string | null, parent?: { __typename?: 'Plan', id: string } | null, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string, invoiceDisplayName?: string | null, code?: string | null, chargeModel: FixedChargeChargeModelEnum, units: string, payInAdvance: boolean, prorated: boolean, addOn: { __typename?: 'AddOn', id: string, name: string, code: string }, properties?: { __typename?: 'FixedChargeProperties', amount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, taxes?: Array<{ __typename?: 'Tax', id: string, name: string, rate: number, code: string }> | null }> | null, charges?: Array<{ __typename?: 'Charge', id: string, invoiceDisplayName?: string | null, code?: string | null, chargeModel: ChargeModelEnum, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, prorated: boolean, regroupPaidFees?: RegroupPaidFeesEnum | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean, filters?: Array<{ __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> }> | null }, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, pricingGroupKeys?: Array<string> | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: number, rate: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, presentationGroupKeys?: Array<{ __typename?: 'PresentationGroupKey', value: string, options?: { __typename?: 'PresentationGroupKeyOptions', displayInInvoice?: boolean | null } | null }> | null } | null, filters?: Array<{ __typename?: 'ChargeFilter', id: string, invoiceDisplayName?: string | null, values: any, properties: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, pricingGroupKeys?: Array<string> | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: number, rate: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null, appliedPricingUnit?: { __typename?: 'AppliedPricingUnit', conversionRate: number, pricingUnit: { __typename?: 'PricingUnit', id: string, name: string, code: string, shortName: string } } | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null }> | null, entitlements?: Array<{ __typename?: 'PlanEntitlement', code: string, name: string, privileges: Array<{ __typename?: 'PlanEntitlementPrivilegeObject', code: string, name?: string | null, value: string, valueType: PrivilegeValueTypeEnum, config: { __typename?: 'PrivilegeConfigObject', selectOptions?: Array<string> | null } }> }> | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, minimumCommitment?: { __typename?: 'Commitment', amountCents: any, commitmentType: CommitmentTypeEnum, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null } | null, usageThresholds?: Array<{ __typename?: 'UsageThreshold', id: string, amountCents: any, recurring: boolean, thresholdDisplayName?: string | null }> | null } } | null };
 
+export type GetSubscriptionFixedChargeUnitsOverridesQueryVariables = Exact<{
+  subscriptionId: Scalars['ID']['input'];
+}>;
+
+
+export type GetSubscriptionFixedChargeUnitsOverridesQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string, units: string }> | null } | null };
+
 export type SubscriptionInformationSectionFragment = { __typename?: 'Subscription', id: string, externalId: string, name?: string | null, status?: StatusTypeEnum | null, startedAt?: any | null, subscriptionAt?: any | null, endingAt?: any | null, terminatedAt?: any | null, billingTime?: BillingTimeEnum | null, downgradePlanDate?: any | null, nextSubscriptionAt?: any | null, nextSubscriptionType?: NextSubscriptionTypeEnum | null, billingEntityId?: string | null, periodEndDate?: any | null, paymentMethodType?: PaymentMethodTypeEnum | null, consolidateInvoice: boolean, skipInvoiceCustomSections?: boolean | null, customer: { __typename?: 'Customer', id: string, applicableTimezone: TimezoneEnum, externalId: string, name?: string | null, displayName: string, deletedAt?: any | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string } }, nextPlan?: { __typename?: 'Plan', id: string, name: string } | null, previousPlan?: { __typename?: 'Plan', id: string, name: string } | null, previousSubscription?: { __typename?: 'Subscription', id: string, downgradePlanDate?: any | null } | null, plan: { __typename?: 'Plan', id: string, name: string, code: string, interval: PlanInterval, parent?: { __typename?: 'Plan', id: string, name: string } | null, entitlements?: Array<{ __typename?: 'PlanEntitlement', code: string, name: string, privileges: Array<{ __typename?: 'PlanEntitlementPrivilegeObject', code: string, name?: string | null, value: string, valueType: PrivilegeValueTypeEnum, config: { __typename?: 'PrivilegeConfigObject', selectOptions?: Array<string> | null } }> }> | null }, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string, code: string }> | null };
 
 export type SubscriptionForSubscriptionEditFormFragment = { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, endingAt?: any | null, billingTime?: BillingTimeEnum | null, billingEntityId?: string | null, periodEndDate?: any | null, status?: StatusTypeEnum | null, startedAt?: any | null, paymentMethodType?: PaymentMethodTypeEnum | null, consolidateInvoice: boolean, skipInvoiceCustomSections?: boolean | null, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string, code: string }> | null, plan: { __typename?: 'Plan', id: string, name: string, code: string, interval: PlanInterval, parent?: { __typename?: 'Plan', id: string } | null, entitlements?: Array<{ __typename?: 'PlanEntitlement', code: string, name: string, privileges: Array<{ __typename?: 'PlanEntitlementPrivilegeObject', code: string, name?: string | null, value: string, valueType: PrivilegeValueTypeEnum, config: { __typename?: 'PrivilegeConfigObject', selectOptions?: Array<string> | null } }> }> | null } };
@@ -13077,7 +13084,7 @@ export type UpdateSubscriptionFixedChargeMutationVariables = Exact<{
 }>;
 
 
-export type UpdateSubscriptionFixedChargeMutation = { __typename?: 'Mutation', updateSubscriptionFixedCharge?: { __typename?: 'FixedCharge', id: string, code?: string | null, invoiceDisplayName?: string | null, chargeModel: FixedChargeChargeModelEnum, units: string, payInAdvance: boolean, prorated: boolean, properties?: { __typename?: 'FixedChargeProperties', amount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, addOn: { __typename?: 'AddOn', id: string, name: string, code: string }, taxes?: Array<{ __typename?: 'Tax', id: string, name: string, rate: number, code: string }> | null } | null };
+export type UpdateSubscriptionFixedChargeMutation = { __typename?: 'Mutation', updateSubscriptionFixedCharge?: { __typename?: 'FixedCharge', id: string } | null };
 
 export type PlanForUpdateWithCascadeFragment = { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, amountCurrency: CurrencyEnum, billChargesMonthly?: boolean | null, billFixedChargesMonthly?: boolean | null, hasOverriddenPlans?: boolean | null, trialPeriod?: number | null, payInAdvance: boolean, amountCents: any, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string }> | null, charges?: Array<{ __typename?: 'Charge', id: string }> | null, minimumCommitment?: { __typename?: 'Commitment', amountCents: any, commitmentType: CommitmentTypeEnum, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null } | null, usageThresholds?: Array<{ __typename?: 'UsageThreshold', id: string, amountCents: any, recurring: boolean, thresholdDisplayName?: string | null }> | null, entitlements?: Array<{ __typename?: 'PlanEntitlement', code: string, name: string, privileges: Array<{ __typename?: 'PlanEntitlementPrivilegeObject', code: string, name?: string | null, value: string, valueType: PrivilegeValueTypeEnum, config: { __typename?: 'PrivilegeConfigObject', selectOptions?: Array<string> | null } }> }> | null };
 
@@ -31528,6 +31535,53 @@ export type GetSubscriptionForDetailsV2PlanQueryHookResult = ReturnType<typeof u
 export type GetSubscriptionForDetailsV2PlanLazyQueryHookResult = ReturnType<typeof useGetSubscriptionForDetailsV2PlanLazyQuery>;
 export type GetSubscriptionForDetailsV2PlanSuspenseQueryHookResult = ReturnType<typeof useGetSubscriptionForDetailsV2PlanSuspenseQuery>;
 export type GetSubscriptionForDetailsV2PlanQueryResult = Apollo.QueryResult<GetSubscriptionForDetailsV2PlanQuery, GetSubscriptionForDetailsV2PlanQueryVariables>;
+export const GetSubscriptionFixedChargeUnitsOverridesDocument = gql`
+    query getSubscriptionFixedChargeUnitsOverrides($subscriptionId: ID!) {
+  subscription(id: $subscriptionId) {
+    id
+    fixedCharges {
+      id
+      units
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetSubscriptionFixedChargeUnitsOverridesQuery__
+ *
+ * To run a query within a React component, call `useGetSubscriptionFixedChargeUnitsOverridesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetSubscriptionFixedChargeUnitsOverridesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetSubscriptionFixedChargeUnitsOverridesQuery({
+ *   variables: {
+ *      subscriptionId: // value for 'subscriptionId'
+ *   },
+ * });
+ */
+export function useGetSubscriptionFixedChargeUnitsOverridesQuery(baseOptions: Apollo.QueryHookOptions<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables> & ({ variables: GetSubscriptionFixedChargeUnitsOverridesQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>(GetSubscriptionFixedChargeUnitsOverridesDocument, options);
+      }
+export function useGetSubscriptionFixedChargeUnitsOverridesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>(GetSubscriptionFixedChargeUnitsOverridesDocument, options);
+        }
+// @ts-ignore
+export function useGetSubscriptionFixedChargeUnitsOverridesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>): Apollo.UseSuspenseQueryResult<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>;
+export function useGetSubscriptionFixedChargeUnitsOverridesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>): Apollo.UseSuspenseQueryResult<GetSubscriptionFixedChargeUnitsOverridesQuery | undefined, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>;
+export function useGetSubscriptionFixedChargeUnitsOverridesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>(GetSubscriptionFixedChargeUnitsOverridesDocument, options);
+        }
+export type GetSubscriptionFixedChargeUnitsOverridesQueryHookResult = ReturnType<typeof useGetSubscriptionFixedChargeUnitsOverridesQuery>;
+export type GetSubscriptionFixedChargeUnitsOverridesLazyQueryHookResult = ReturnType<typeof useGetSubscriptionFixedChargeUnitsOverridesLazyQuery>;
+export type GetSubscriptionFixedChargeUnitsOverridesSuspenseQueryHookResult = ReturnType<typeof useGetSubscriptionFixedChargeUnitsOverridesSuspenseQuery>;
+export type GetSubscriptionFixedChargeUnitsOverridesQueryResult = Apollo.QueryResult<GetSubscriptionFixedChargeUnitsOverridesQuery, GetSubscriptionFixedChargeUnitsOverridesQueryVariables>;
 export const DeleteTaxDocument = gql`
     mutation deleteTax($input: DestroyTaxInput!) {
   destroyTax(input: $input) {
@@ -32750,10 +32804,10 @@ export type UpdateSubscriptionChargeMutationOptions = Apollo.BaseMutationOptions
 export const UpdateSubscriptionFixedChargeDocument = gql`
     mutation updateSubscriptionFixedCharge($input: UpdateSubscriptionFixedChargeInput!) {
   updateSubscriptionFixedCharge(input: $input) {
-    ...FixedChargeForDetailsV2
+    id
   }
 }
-    ${FixedChargeForDetailsV2FragmentDoc}`;
+    `;
 export type UpdateSubscriptionFixedChargeMutationFn = Apollo.MutationFunction<UpdateSubscriptionFixedChargeMutation, UpdateSubscriptionFixedChargeMutationVariables>;
 
 /**

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3917,6 +3917,7 @@ export enum FeatureFlagEnum {
   MultiCurrency = 'multi_currency',
   MultiEntityBilling = 'multi_entity_billing',
   MultiplePaymentMethods = 'multiple_payment_methods',
+  NonPersistableChargeCacheOptimization = 'non_persistable_charge_cache_optimization',
   OrderForms = 'order_forms',
   PaymentGatedSubscriptions = 'payment_gated_subscriptions',
   PostgresEnrichedEvents = 'postgres_enriched_events',
@@ -10167,6 +10168,7 @@ export type VoidQuoteVersionInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   id: Scalars['ID']['input'];
+  reason: VoidReasonEnum;
 };
 
 export enum VoidReasonEnum {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3917,7 +3917,6 @@ export enum FeatureFlagEnum {
   MultiCurrency = 'multi_currency',
   MultiEntityBilling = 'multi_entity_billing',
   MultiplePaymentMethods = 'multiple_payment_methods',
-  NonPersistableChargeCacheOptimization = 'non_persistable_charge_cache_optimization',
   OrderForms = 'order_forms',
   PaymentGatedSubscriptions = 'payment_gated_subscriptions',
   PostgresEnrichedEvents = 'postgres_enriched_events',
@@ -10168,7 +10167,6 @@ export type VoidQuoteVersionInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   id: Scalars['ID']['input'];
-  reason: VoidReasonEnum;
 };
 
 export enum VoidReasonEnum {

--- a/src/hooks/__tests__/useAddSubscription.test.ts
+++ b/src/hooks/__tests__/useAddSubscription.test.ts
@@ -8,7 +8,7 @@ import {
   PlanOverridesInput,
   RegroupPaidFeesEnum,
 } from '~/generated/graphql'
-import { cleanPlanValues } from '~/hooks/customer/useAddSubscription'
+import { buildPlanOverridesInput, cleanPlanValues } from '~/hooks/customer/useAddSubscription'
 
 describe('cleanPlanValues', () => {
   // Mock plan form input with all the fields that exist in the form but should be cleaned
@@ -234,5 +234,153 @@ describe('cleanPlanValues', () => {
 
       expect(result.charges?.[0]?.appliedPricingUnit).toBeUndefined()
     })
+  })
+})
+
+describe('buildPlanOverridesInput', () => {
+  const buildBaseValues = (): PlanFormInput =>
+    ({
+      name: 'Standard with Fixed Charges',
+      code: 'PLAN_CODE',
+      description: '',
+      interval: PlanInterval.Monthly,
+      entitlements: [],
+      amountCents: '10',
+      amountCurrency: CurrencyEnum.Usd,
+      trialPeriod: 0,
+      payInAdvance: true,
+      billChargesMonthly: false,
+      billFixedChargesMonthly: false,
+      taxes: [],
+      minimumCommitment: {},
+      charges: [],
+      fixedCharges: [
+        {
+          id: 'fixed-charge-1',
+          units: '1',
+          invoiceDisplayName: 'Fixed Charge 1',
+          payInAdvance: false,
+          prorated: false,
+          chargeModel: FixedChargeChargeModelEnum.Standard,
+          properties: { amount: '12' },
+          taxes: [],
+          addOn: { id: 'add-on-1', name: 'Add On 1', code: 'ADD_ON_1' },
+        },
+        {
+          id: 'fixed-charge-2',
+          units: '5',
+          invoiceDisplayName: 'Fixed Charge 2',
+          payInAdvance: false,
+          prorated: false,
+          chargeModel: FixedChargeChargeModelEnum.Standard,
+          properties: { amount: '20' },
+          taxes: [],
+          addOn: { id: 'add-on-2', name: 'Add On 2', code: 'ADD_ON_2' },
+        },
+      ],
+    }) as unknown as PlanFormInput
+
+  const clone = (values: PlanFormInput): PlanFormInput =>
+    JSON.parse(JSON.stringify(values)) as PlanFormInput
+
+  it('sends only the changed fixed charge id + units when nothing else changed', () => {
+    const baseline = buildBaseValues()
+    const current = clone(baseline)
+
+    // Only the first fixed charge's units changed
+    ;(current.fixedCharges[0] as { units: string }).units = '3'
+
+    const result = buildPlanOverridesInput(current, baseline)
+
+    expect(result).toEqual({
+      fixedCharges: [{ id: 'fixed-charge-1', units: '3' }],
+    })
+  })
+
+  it('only includes the fixed charges whose units actually changed', () => {
+    const baseline = buildBaseValues()
+    const current = clone(baseline)
+
+    // Both still present, but only the second one's units moved
+    ;(current.fixedCharges[1] as { units: string }).units = '9'
+
+    const result = buildPlanOverridesInput(current, baseline)
+
+    expect(result).toEqual({
+      fixedCharges: [{ id: 'fixed-charge-2', units: '9' }],
+    })
+  })
+
+  it('treats drawer-added applyUnitsImmediately as noise, not a real change', () => {
+    // The edit drawer writes the whole charge back, augmenting it with
+    // `applyUnitsImmediately: false` — a field the untouched baseline charge
+    // (pulled raw from the plan) never has. That asymmetry must not be read as
+    // a non-units change.
+    const baseline = buildBaseValues()
+    const current = clone(baseline)
+
+    ;(current.fixedCharges[0] as { units: string }).units = '99'
+    ;(current.fixedCharges[0] as { applyUnitsImmediately: boolean }).applyUnitsImmediately = false
+
+    const result = buildPlanOverridesInput(current, baseline)
+
+    expect(result).toEqual({
+      fixedCharges: [{ id: 'fixed-charge-1', units: '99' }],
+    })
+  })
+
+  it('normalizes an empty invoiceDisplayName against an absent one', () => {
+    const baseline = buildBaseValues()
+    // Baseline charge has no invoiceDisplayName at all
+    delete (baseline.fixedCharges[0] as { invoiceDisplayName?: string }).invoiceDisplayName
+    const current = clone(baseline)
+
+    ;(current.fixedCharges[0] as { units: string }).units = '99'
+    // The drawer initializes the field to an empty string
+    ;(current.fixedCharges[0] as { invoiceDisplayName: string }).invoiceDisplayName = ''
+
+    const result = buildPlanOverridesInput(current, baseline)
+
+    expect(result).toEqual({
+      fixedCharges: [{ id: 'fixed-charge-1', units: '99' }],
+    })
+  })
+
+  it('sends the full payload when a non-fixed-charge field also changed', () => {
+    const baseline = buildBaseValues()
+    const current = clone(baseline)
+
+    ;(current.fixedCharges[0] as { units: string }).units = '3'
+    current.amountCents = '20'
+
+    const result = buildPlanOverridesInput(current, baseline)
+
+    // Falls back to the full cleaned payload, not the minimal units-only one
+    // (amountCents is serialized to cents: '20' USD → 2000)
+    expect(result.amountCents).toBe(2000)
+    expect(result.fixedCharges).toHaveLength(2)
+    expect(result.fixedCharges?.[0]).toMatchObject({ id: 'fixed-charge-1', units: '3' })
+  })
+
+  it('sends the full payload when a fixed charge field other than units changed', () => {
+    const baseline = buildBaseValues()
+    const current = clone(baseline)
+
+    ;(current.fixedCharges[0] as { units: string }).units = '3'
+    ;(current.fixedCharges[0] as { invoiceDisplayName: string }).invoiceDisplayName = 'Renamed'
+
+    const result = buildPlanOverridesInput(current, baseline)
+
+    expect(result.fixedCharges).toHaveLength(2)
+    expect(result.fixedCharges?.[0]).toMatchObject({ invoiceDisplayName: 'Renamed' })
+  })
+
+  it('sends the full payload when no baseline is available', () => {
+    const current = buildBaseValues()
+
+    const result = buildPlanOverridesInput(current, undefined)
+
+    expect(result.fixedCharges).toHaveLength(2)
+    expect(result.amountCents).toBe(1000)
   })
 })

--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -108,6 +108,9 @@ type UseAddSubscriptionReturn = {
     values: Omit<CreateSubscriptionInput, 'customerId'>,
     planValues: PlanFormInput,
     hasPlanBeingChangedFromInitial: boolean,
+    // The plan's baseline (unedited) values, used to send only the fields the
+    // user actually changed. See buildPlanOverridesInput.
+    planBaselineValues?: PlanFormInput | null,
   ) => Promise<string | undefined>
 }
 
@@ -116,6 +119,42 @@ type UseAddSubscription = (args: {
   billingTime?: BillingTimeEnum
   subscriptionAt?: string
 }) => UseAddSubscriptionReturn
+
+// Recursively drops __typename and sorts object keys so two values produced by
+// the same serialization compare equal regardless of key order / __typename.
+const sortedWithoutTypename = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(sortedWithoutTypename)
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => key !== '__typename')
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, entry]) => [key, sortedWithoutTypename(entry)]),
+    )
+  }
+
+  return value
+}
+
+const comparable = (value: unknown): string => JSON.stringify(sortedWithoutTypename(value))
+
+// The override-meaningful content of a (serialized + cleaned) fixed charge,
+// excluding `units` (compared separately) and identity fields. The edit drawer
+// writes the whole charge back and augments it with normalization-only fields
+// (e.g. `applyUnitsImmediately`) that the untouched baseline charge lacks, so we
+// compare an explicit whitelist instead of the whole object to avoid reading
+// that noise as a real change.
+const comparableChargeContent = (charge: {
+  invoiceDisplayName?: string | null
+  properties?: unknown
+  taxCodes?: Array<string> | null
+}): string =>
+  comparable({
+    invoiceDisplayName: charge.invoiceDisplayName || '',
+    properties: charge.properties ?? null,
+    taxCodes: [...(charge.taxCodes ?? [])].sort(),
+  })
 
 // Clean plan values (non editable fields not accepted by BE / Graph fails if they are sent)
 export const cleanPlanValues = (planValues: PlanOverridesInput) => {
@@ -152,6 +191,60 @@ export const cleanPlanValues = (planValues: PlanOverridesInput) => {
       prorated: undefined,
     })),
   }
+}
+
+// Builds the `planOverrides` payload from the edited plan values, diffed against
+// the original plan (the form's baseline values).
+//
+// When the only difference is fixed-charge units, returns a minimal
+// `{ fixedCharges: [{ id, units }] }` so the BE takes its per-subscription
+// units-override fast path instead of cloning the whole plan. Any other change
+// (a plan-level field, or a non-units field on a fixed charge) sends the full
+// cleaned payload, the existing behaviour.
+//
+// Fixed charges cannot be added or removed from the subscription form, so they
+// always match the baseline 1:1 by id.
+export const buildPlanOverridesInput = (
+  currentValues: PlanFormInput,
+  baselineValues?: PlanFormInput | null,
+): PlanOverridesInput => {
+  const current = cleanPlanValues(serializePlanInput(currentValues) as PlanOverridesInput)
+
+  // No baseline to diff against (plan still loading) → send the full payload.
+  if (!baselineValues) return current
+
+  const baseline = cleanPlanValues(serializePlanInput(baselineValues) as PlanOverridesInput)
+
+  const { fixedCharges: currentFixedCharges, ...currentRest } = current
+  const { fixedCharges: baselineFixedCharges, ...baselineRest } = baseline
+
+  // Any plan-level (non fixed-charge) field changed → full payload.
+  if (comparable(currentRest) !== comparable(baselineRest)) {
+    return current
+  }
+
+  const changedUnits: Array<{ id: string; units: string }> = []
+
+  for (const charge of currentFixedCharges ?? []) {
+    const original = baselineFixedCharges?.find((fixedCharge) => fixedCharge.id === charge.id)
+
+    // No baseline match → can't prove it's units-only, send the full payload.
+    if (!original) return current
+
+    // A non-units content field changed on this charge → full payload.
+    if (comparableChargeContent(charge) !== comparableChargeContent(original)) {
+      return current
+    }
+
+    if (String(charge.units ?? '') !== String(original.units ?? '')) {
+      changedUnits.push({ id: charge.id as string, units: String(charge.units ?? '') })
+    }
+  }
+
+  // Nothing units-related changed → keep the full payload behaviour.
+  if (changedUnits.length === 0) return current
+
+  return { fixedCharges: changedUnits }
 }
 
 export const useAddSubscription: UseAddSubscription = ({
@@ -280,8 +373,11 @@ export const useAddSubscription: UseAddSubscription = ({
       },
       { ...planValues },
       hasPlanBeingChangedFromInitial,
+      planBaselineValues,
     ) => {
-      const serializedPlanValues = serializePlanInput(planValues)
+      const planOverrides = hasPlanBeingChangedFromInitial
+        ? buildPlanOverridesInput(planValues, planBaselineValues)
+        : undefined
 
       const parsedPaymentMethod = paymentMethod
         ? {
@@ -327,9 +423,7 @@ export const useAddSubscription: UseAddSubscription = ({
                   externalId: externalId || undefined,
                   paymentMethod: parsedPaymentMethod,
                   ...values,
-                  planOverrides: hasPlanBeingChangedFromInitial
-                    ? { ...cleanPlanValues(serializedPlanValues as PlanOverridesInput) }
-                    : undefined,
+                  planOverrides,
                 },
               },
             })
@@ -345,9 +439,7 @@ export const useAddSubscription: UseAddSubscription = ({
                   // subscription column, meaning "inherit from customer".
                   billingEntityId: billingEntityId || null,
                   paymentMethod: parsedPaymentMethod,
-                  planOverrides: hasPlanBeingChangedFromInitial
-                    ? { ...cleanPlanValues(serializedPlanValues as PlanOverridesInput) }
-                    : undefined,
+                  planOverrides,
                 },
               },
             })

--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -153,7 +153,7 @@ const comparableChargeContent = (charge: {
   comparable({
     invoiceDisplayName: charge.invoiceDisplayName || '',
     properties: charge.properties ?? null,
-    taxCodes: [...(charge.taxCodes ?? [])].sort(),
+    taxCodes: [...(charge.taxCodes ?? [])].sort((a, b) => a.localeCompare(b)),
   })
 
 // Clean plan values (non editable fields not accepted by BE / Graph fails if they are sent)

--- a/src/hooks/plans/__tests__/useSubscriptionFixedChargeMutations.test.tsx
+++ b/src/hooks/plans/__tests__/useSubscriptionFixedChargeMutations.test.tsx
@@ -10,7 +10,10 @@ import {
   UpdateSubscriptionFixedChargeInput,
 } from '~/generated/graphql'
 
-import { useSubscriptionFixedChargeMutations } from '../useSubscriptionFixedChargeMutations'
+import {
+  BaselineFixedCharge,
+  useSubscriptionFixedChargeMutations,
+} from '../useSubscriptionFixedChargeMutations'
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({ translate: (k: string) => k }),
@@ -33,6 +36,18 @@ const buildCharge = (overrides: Partial<LocalFixedChargeInput> = {}): LocalFixed
     addOn: { __typename: 'AddOn', id: 'addon_1', name: 'Onboarding', code: 'onboarding' },
     ...overrides,
   }) as unknown as LocalFixedChargeInput
+
+// Plan-level baseline matching buildCharge()'s defaults, as it would come out
+// of the Apollo cache (__typename present, plan-default units).
+const buildBaseline = (overrides: Partial<BaselineFixedCharge> = {}): BaselineFixedCharge =>
+  ({
+    code: 'onboarding',
+    chargeModel: FixedChargeChargeModelEnum.Standard,
+    invoiceDisplayName: 'Onboarding',
+    properties: { __typename: 'FixedChargeProperties', amount: '10' },
+    taxes: [],
+    ...overrides,
+  }) as unknown as BaselineFixedCharge
 
 const wrapper = (mocks: MockedResponse[]) =>
   function W({ children }: { children: ReactNode }) {
@@ -110,5 +125,162 @@ describe('useSubscriptionFixedChargeMutations', () => {
 
     await waitFor(() => expect(capturedInput).toBeDefined())
     expect(capturedInput?.properties).toStrictEqual({ amount: '10' })
+  })
+
+  // The BE routes the request to the per-subscription override table ONLY when
+  // the params carry nothing but units (+ applyUnitsImmediately). These tests
+  // lock in the diff-based input so unchanged fields stay out of the payload.
+  describe('units-only fast path (diff against plan baseline)', () => {
+    const captureInput = () => {
+      let capturedInput: UpdateSubscriptionFixedChargeInput | undefined
+      const mock: MockedResponse = {
+        request: { query: UpdateSubscriptionFixedChargeDocument },
+        variableMatcher: (vars) => {
+          capturedInput = vars?.input
+
+          return true
+        },
+        result: {
+          data: {
+            updateSubscriptionFixedCharge: { __typename: 'FixedCharge', id: 'fc_override_1' },
+          },
+        },
+      }
+
+      return { mock, getInput: () => capturedInput }
+    }
+
+    it('sends only units + applyUnitsImmediately when nothing else changed', async () => {
+      const { mock, getInput } = captureInput()
+
+      const { result } = renderHook(
+        () =>
+          useSubscriptionFixedChargeMutations({
+            subscriptionId: SUB_ID,
+            fixedCharges: [buildBaseline()],
+          }),
+        { wrapper: wrapper([mock]) },
+      )
+
+      await act(async () => {
+        // Same display name, same (standard) properties, same taxes as the
+        // baseline — only units differ. The baseline carries __typename and the
+        // drawer value doesn't; the comparison must not be fooled by that.
+        await result.current.handleSaveCharge(
+          buildCharge({ units: '25', properties: { amount: '10' } }),
+        )
+      })
+
+      await waitFor(() => expect(getInput()).toBeDefined())
+      expect(getInput()).toStrictEqual({
+        subscriptionId: SUB_ID,
+        fixedChargeCode: 'onboarding',
+        units: '25',
+        applyUnitsImmediately: false,
+      })
+    })
+
+    it('includes properties when the amount changed', async () => {
+      const { mock, getInput } = captureInput()
+
+      const { result } = renderHook(
+        () =>
+          useSubscriptionFixedChargeMutations({
+            subscriptionId: SUB_ID,
+            fixedCharges: [buildBaseline()],
+          }),
+        { wrapper: wrapper([mock]) },
+      )
+
+      await act(async () => {
+        await result.current.handleSaveCharge(
+          buildCharge({ units: '25', properties: { amount: '99' } }),
+        )
+      })
+
+      await waitFor(() => expect(getInput()).toBeDefined())
+      expect(getInput()?.properties).toStrictEqual({ amount: '99' })
+      expect(getInput()?.taxCodes).toBeUndefined()
+      expect(getInput()?.invoiceDisplayName).toBeUndefined()
+    })
+
+    it('includes taxCodes when the taxes changed', async () => {
+      const { mock, getInput } = captureInput()
+
+      const { result } = renderHook(
+        () =>
+          useSubscriptionFixedChargeMutations({
+            subscriptionId: SUB_ID,
+            fixedCharges: [buildBaseline()],
+          }),
+        { wrapper: wrapper([mock]) },
+      )
+
+      await act(async () => {
+        await result.current.handleSaveCharge(
+          buildCharge({
+            units: '25',
+            properties: { amount: '10' },
+            taxes: [{ __typename: 'Tax', id: 'tax_1', name: 'VAT', rate: 20, code: 'vat' }],
+          }),
+        )
+      })
+
+      await waitFor(() => expect(getInput()).toBeDefined())
+      expect(getInput()?.taxCodes).toStrictEqual(['vat'])
+      expect(getInput()?.properties).toBeUndefined()
+    })
+
+    it('includes invoiceDisplayName when it changed', async () => {
+      const { mock, getInput } = captureInput()
+
+      const { result } = renderHook(
+        () =>
+          useSubscriptionFixedChargeMutations({
+            subscriptionId: SUB_ID,
+            fixedCharges: [buildBaseline()],
+          }),
+        { wrapper: wrapper([mock]) },
+      )
+
+      await act(async () => {
+        await result.current.handleSaveCharge(
+          buildCharge({
+            units: '25',
+            properties: { amount: '10' },
+            invoiceDisplayName: 'Custom name',
+          }),
+        )
+      })
+
+      await waitFor(() => expect(getInput()).toBeDefined())
+      expect(getInput()?.invoiceDisplayName).toBe('Custom name')
+      expect(getInput()?.properties).toBeUndefined()
+    })
+
+    it('sends the full payload when the charge has no plan baseline', async () => {
+      const { mock, getInput } = captureInput()
+
+      const { result } = renderHook(
+        () =>
+          useSubscriptionFixedChargeMutations({
+            subscriptionId: SUB_ID,
+            fixedCharges: [buildBaseline({ code: 'some_other_code' })],
+          }),
+        { wrapper: wrapper([mock]) },
+      )
+
+      await act(async () => {
+        await result.current.handleSaveCharge(
+          buildCharge({ units: '25', properties: { amount: '10' } }),
+        )
+      })
+
+      await waitFor(() => expect(getInput()).toBeDefined())
+      // No baseline to diff against → conservative full payload (clone path).
+      expect(getInput()?.properties).toStrictEqual({ amount: '10' })
+      expect(getInput()?.taxCodes).toStrictEqual([])
+      expect(getInput()?.invoiceDisplayName).toBe('Onboarding')
+    })
   })
 })

--- a/src/hooks/plans/__tests__/useSubscriptionFixedChargeMutations.test.tsx
+++ b/src/hooks/plans/__tests__/useSubscriptionFixedChargeMutations.test.tsx
@@ -87,6 +87,56 @@ describe('useSubscriptionFixedChargeMutations', () => {
     await waitFor(() => expect(called).toBe(true))
   })
 
+  // After a successful edit, the override-units row must refresh. The no-cache
+  // query's data is only reliably updated by calling its OWN refetch, so when
+  // one is supplied it is used (instead of the name-based client.refetchQueries).
+  it('calls the provided refetchOverrides after a successful save', async () => {
+    const updateMock: MockedResponse = {
+      request: { query: UpdateSubscriptionFixedChargeDocument },
+      variableMatcher: () => true,
+      result: {
+        data: { updateSubscriptionFixedCharge: { __typename: 'FixedCharge', id: 'fc_override_1' } },
+      },
+    }
+    const refetchOverrides = jest.fn().mockResolvedValue(undefined)
+
+    const { result } = renderHook(
+      () => useSubscriptionFixedChargeMutations({ subscriptionId: SUB_ID, refetchOverrides }),
+      { wrapper: wrapper([updateMock]) },
+    )
+
+    let saved: boolean | unknown
+    await act(async () => {
+      saved = await result.current.handleSaveCharge(buildCharge())
+    })
+
+    expect(saved).toBe(true)
+    await waitFor(() => expect(refetchOverrides).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not call refetchOverrides when the save fails', async () => {
+    const updateMock: MockedResponse = {
+      request: { query: UpdateSubscriptionFixedChargeDocument },
+      variableMatcher: () => true,
+      // Error link surfaces failures as a resolved result with data: null.
+      result: { data: { updateSubscriptionFixedCharge: null } },
+    }
+    const refetchOverrides = jest.fn().mockResolvedValue(undefined)
+
+    const { result } = renderHook(
+      () => useSubscriptionFixedChargeMutations({ subscriptionId: SUB_ID, refetchOverrides }),
+      { wrapper: wrapper([updateMock]) },
+    )
+
+    let saved: boolean | unknown
+    await act(async () => {
+      saved = await result.current.handleSaveCharge(buildCharge())
+    })
+
+    expect(saved).toBe(false)
+    expect(refetchOverrides).not.toHaveBeenCalled()
+  })
+
   it('prunes usage-only properties from the override input (standard)', async () => {
     let capturedInput: UpdateSubscriptionFixedChargeInput | undefined
 

--- a/src/hooks/plans/useDetailsV2ChargeMutations.ts
+++ b/src/hooks/plans/useDetailsV2ChargeMutations.ts
@@ -12,6 +12,10 @@ type Args = {
     | null
     | undefined
   subscriptionId?: string
+  // Refetch of the override-units query, threaded down so a sub-tab fixed-charge
+  // edit reliably refreshes the displayed override units. See
+  // useSubscriptionFixedChargeMutations.
+  refetchOverrides?: () => Promise<unknown>
 }
 
 type Result = {
@@ -19,7 +23,11 @@ type Result = {
   fixedChargeMutations: FixedChargeMutations
 }
 
-export const useDetailsV2ChargeMutations = ({ plan, subscriptionId }: Args): Result => {
+export const useDetailsV2ChargeMutations = ({
+  plan,
+  subscriptionId,
+  refetchOverrides,
+}: Args): Result => {
   const currency = (plan?.amountCurrency as CurrencyEnum) ?? CurrencyEnum.Usd
 
   // All four hooks run unconditionally (rules of hooks). The plan-mode hooks
@@ -40,6 +48,7 @@ export const useDetailsV2ChargeMutations = ({ plan, subscriptionId }: Args): Res
   const subFixed = useSubscriptionFixedChargeMutations({
     subscriptionId: subscriptionId ?? '',
     fixedCharges: plan?.fixedCharges,
+    refetchOverrides,
   })
 
   return subscriptionId

--- a/src/hooks/plans/useDetailsV2ChargeMutations.ts
+++ b/src/hooks/plans/useDetailsV2ChargeMutations.ts
@@ -8,7 +8,7 @@ import { useSubscriptionFixedChargeMutations } from '~/hooks/plans/useSubscripti
 
 type Args = {
   plan:
-    | Pick<PlanDetailsV2Fragment, 'id' | 'amountCurrency' | 'hasOverriddenPlans'>
+    | Pick<PlanDetailsV2Fragment, 'id' | 'amountCurrency' | 'hasOverriddenPlans' | 'fixedCharges'>
     | null
     | undefined
   subscriptionId?: string
@@ -37,7 +37,10 @@ export const useDetailsV2ChargeMutations = ({ plan, subscriptionId }: Args): Res
     subscriptionId: subscriptionId ?? '',
     currency,
   })
-  const subFixed = useSubscriptionFixedChargeMutations({ subscriptionId: subscriptionId ?? '' })
+  const subFixed = useSubscriptionFixedChargeMutations({
+    subscriptionId: subscriptionId ?? '',
+    fixedCharges: plan?.fixedCharges,
+  })
 
   return subscriptionId
     ? { usageChargeMutations: subUsage, fixedChargeMutations: subFixed }

--- a/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
+++ b/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
@@ -4,6 +4,7 @@ import { LocalFixedChargeInput } from '~/components/plans/types'
 import { addToast } from '~/core/apolloClient'
 import { serializeFixedChargeProperties } from '~/core/serializers/serializePlanInput'
 import {
+  FixedChargeForDetailsV2Fragment,
   UpdateSubscriptionFixedChargeInput,
   useUpdateSubscriptionFixedChargeMutation,
 } from '~/generated/graphql'
@@ -22,9 +23,49 @@ gql`
   }
 `
 
-type Args = { subscriptionId: string }
+// Baseline for diffing the drawer values against the plan-level fixed charge.
+export type BaselineFixedCharge = Pick<
+  FixedChargeForDetailsV2Fragment,
+  'code' | 'invoiceDisplayName' | 'chargeModel' | 'properties' | 'taxes'
+>
 
-export const useSubscriptionFixedChargeMutations = ({ subscriptionId }: Args) => {
+type Args = {
+  subscriptionId: string
+  // Plan-level fixed charges. Used to send only the fields the user actually
+  // changed (see buildInput). When absent, every field is sent.
+  fixedCharges?: BaselineFixedCharge[] | null
+}
+
+// Recursively drops __typename and sorts object keys, so cached values
+// (with __typename, selection-set key order) compare equal to drawer values
+// (no __typename, form key order) when nothing changed.
+const sortedWithoutTypename = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(sortedWithoutTypename)
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => key !== '__typename')
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, entry]) => [key, sortedWithoutTypename(entry)]),
+    )
+  }
+
+  return value
+}
+
+const comparableProperties = (
+  properties: LocalFixedChargeInput['properties'],
+  chargeModel: LocalFixedChargeInput['chargeModel'],
+): string =>
+  JSON.stringify(
+    sortedWithoutTypename(serializeFixedChargeProperties(properties ?? {}, chargeModel)),
+  )
+
+const comparableTaxCodes = (taxes: BaselineFixedCharge['taxes']): string =>
+  JSON.stringify((taxes ?? []).map((tax) => tax.code).sort())
+
+export const useSubscriptionFixedChargeMutations = ({ subscriptionId, fixedCharges }: Args) => {
   const [updateSubscriptionFixedCharge] = useUpdateSubscriptionFixedChargeMutation({
     refetchQueries: ['getSubscriptionForDetailsV2Plan', 'getSubscriptionFixedChargeUnitsOverrides'],
     awaitRefetchQueries: true,
@@ -35,17 +76,43 @@ export const useSubscriptionFixedChargeMutations = ({ subscriptionId }: Args) =>
     },
   })
 
-  const buildInput = (charge: LocalFixedChargeInput): UpdateSubscriptionFixedChargeInput => ({
-    subscriptionId,
-    fixedChargeCode: charge.code ?? '',
-    invoiceDisplayName: charge.invoiceDisplayName || undefined,
-    properties: charge.properties
-      ? serializeFixedChargeProperties(charge.properties, charge.chargeModel)
-      : undefined,
-    units: charge.units ? String(charge.units) : '0',
-    taxCodes: charge.taxes?.map((t) => t.code) ?? [],
-    applyUnitsImmediately: charge.applyUnitsImmediately ?? false,
-  })
+  // The BE only takes the per-subscription units-override fast path when the
+  // params carry nothing but `units` (+ `applyUnitsImmediately`) — any other
+  // key, even an unchanged one, falls through to legacy plan-cloning. So each
+  // optional field is included only when it differs from the plan-level value.
+  // `units` is always sent: on a mixed edit that does clone, it bakes the
+  // subscription's current units into the clone so the customer can't
+  // silently snap back to the plan default.
+  const buildInput = (charge: LocalFixedChargeInput): UpdateSubscriptionFixedChargeInput => {
+    const original = fixedCharges?.find((fixedCharge) => fixedCharge.code === charge.code)
+
+    const invoiceDisplayNameChanged =
+      !original || (charge.invoiceDisplayName ?? '') !== (original.invoiceDisplayName ?? '')
+    // The charge model is not editable in subscription mode, so the drawer's
+    // model is also the baseline's — serialize both sides through it.
+    const propertiesChanged =
+      !original ||
+      comparableProperties(charge.properties, charge.chargeModel) !==
+        comparableProperties(original.properties, charge.chargeModel)
+    const taxesChanged =
+      !original || comparableTaxCodes(charge.taxes) !== comparableTaxCodes(original.taxes)
+
+    return {
+      subscriptionId,
+      fixedChargeCode: charge.code ?? '',
+      units: charge.units ? String(charge.units) : '0',
+      applyUnitsImmediately: charge.applyUnitsImmediately ?? false,
+      ...(invoiceDisplayNameChanged && {
+        invoiceDisplayName: charge.invoiceDisplayName || undefined,
+      }),
+      ...(propertiesChanged && {
+        properties: charge.properties
+          ? serializeFixedChargeProperties(charge.properties, charge.chargeModel)
+          : undefined,
+      }),
+      ...(taxesChanged && { taxCodes: charge.taxes?.map((t) => t.code) ?? [] }),
+    }
+  }
 
   // Sub tab edits only (no create/delete), so the shared handler's index arg is
   // unused here - a narrower-arity fn stays assignable to FixedChargeMutations.

--- a/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
+++ b/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
@@ -4,26 +4,29 @@ import { LocalFixedChargeInput } from '~/components/plans/types'
 import { addToast } from '~/core/apolloClient'
 import { serializeFixedChargeProperties } from '~/core/serializers/serializePlanInput'
 import {
-  FixedChargeForDetailsV2FragmentDoc,
   UpdateSubscriptionFixedChargeInput,
   useUpdateSubscriptionFixedChargeMutation,
 } from '~/generated/graphql'
 
+// Intentionally select only `id` on the mutation result. FixedCharge is
+// normalised by id in the Apollo cache, and the mutation returns the
+// subscription-scoped (override-aware) units. Writing that back would
+// overwrite the plan-default units that plan-scope pages read from the same
+// cache entry. Override-aware reads use the dedicated
+// getSubscriptionFixedChargeUnitsOverrides query (fetchPolicy: 'no-cache').
 gql`
   mutation updateSubscriptionFixedCharge($input: UpdateSubscriptionFixedChargeInput!) {
     updateSubscriptionFixedCharge(input: $input) {
-      ...FixedChargeForDetailsV2
+      id
     }
   }
-
-  ${FixedChargeForDetailsV2FragmentDoc}
 `
 
 type Args = { subscriptionId: string }
 
 export const useSubscriptionFixedChargeMutations = ({ subscriptionId }: Args) => {
   const [updateSubscriptionFixedCharge] = useUpdateSubscriptionFixedChargeMutation({
-    refetchQueries: ['getSubscriptionForDetailsV2Plan'],
+    refetchQueries: ['getSubscriptionForDetailsV2Plan', 'getSubscriptionFixedChargeUnitsOverrides'],
     awaitRefetchQueries: true,
     onCompleted(data) {
       if (data?.updateSubscriptionFixedCharge?.id) {

--- a/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
+++ b/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql, useApolloClient } from '@apollo/client'
 
 import { LocalFixedChargeInput } from '~/components/plans/types'
 import { addToast } from '~/core/apolloClient'
@@ -66,8 +66,13 @@ const comparableTaxCodes = (taxes: BaselineFixedCharge['taxes']): string =>
   JSON.stringify((taxes ?? []).map((tax) => tax.code).sort())
 
 export const useSubscriptionFixedChargeMutations = ({ subscriptionId, fixedCharges }: Args) => {
+  const client = useApolloClient()
   const [updateSubscriptionFixedCharge] = useUpdateSubscriptionFixedChargeMutation({
-    refetchQueries: ['getSubscriptionForDetailsV2Plan', 'getSubscriptionFixedChargeUnitsOverrides'],
+    // Only the cached plan query is refreshed here. The override-aware units
+    // query is fetchPolicy: 'no-cache', and Apollo's name-based refetchQueries
+    // does not reliably re-run no-cache queries — it is refreshed explicitly in
+    // handleSaveCharge instead (see below).
+    refetchQueries: ['getSubscriptionForDetailsV2Plan'],
     awaitRefetchQueries: true,
     onCompleted(data) {
       if (data?.updateSubscriptionFixedCharge?.id) {
@@ -124,7 +129,19 @@ export const useSubscriptionFixedChargeMutations = ({ subscriptionId, fixedCharg
       variables: { input: buildInput(charge) },
     })
 
-    return !!data?.updateSubscriptionFixedCharge?.id
+    if (!data?.updateSubscriptionFixedCharge?.id) {
+      return false
+    }
+
+    // For a units-only override the plan is not cloned, so the cached plan
+    // query keeps showing plan defaults — the new units live only in the
+    // no-cache getSubscriptionFixedChargeUnitsOverrides query. Refresh it
+    // explicitly (client.refetchQueries calls refetch() directly, which honors
+    // no-cache) and await it so the list shows the new units once the drawer
+    // closes, instead of racing the stale plan default.
+    await client.refetchQueries({ include: ['getSubscriptionFixedChargeUnitsOverrides'] })
+
+    return true
   }
 
   // Delete is hidden on the sub tab; no-op to satisfy the shared handler shape.

--- a/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
+++ b/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
@@ -71,7 +71,7 @@ const comparableProperties = (
   )
 
 const comparableTaxCodes = (taxes: BaselineFixedCharge['taxes']): string =>
-  JSON.stringify((taxes ?? []).map((tax) => tax.code).sort())
+  JSON.stringify((taxes ?? []).map((tax) => tax.code).sort((a, b) => a.localeCompare(b)))
 
 export const useSubscriptionFixedChargeMutations = ({
   subscriptionId,

--- a/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
+++ b/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
@@ -34,6 +34,14 @@ type Args = {
   // Plan-level fixed charges. Used to send only the fields the user actually
   // changed (see buildInput). When absent, every field is sent.
   fixedCharges?: BaselineFixedCharge[] | null
+  // The `refetch` of the no-cache getSubscriptionFixedChargeUnitsOverrides query
+  // (owned by SubscriptionDetailsV2Plan). Calling the query's OWN refetch
+  // reliably pushes the fresh override units into its React hook; the
+  // name-based `client.refetchQueries({ include })` fires the network request
+  // but does not reliably update a no-cache query's rendered data, leaving the
+  // row showing the stale plan default. When absent, falls back to the
+  // name-based refresh.
+  refetchOverrides?: () => Promise<unknown>
 }
 
 // Recursively drops __typename and sorts object keys, so cached values
@@ -65,7 +73,11 @@ const comparableProperties = (
 const comparableTaxCodes = (taxes: BaselineFixedCharge['taxes']): string =>
   JSON.stringify((taxes ?? []).map((tax) => tax.code).sort())
 
-export const useSubscriptionFixedChargeMutations = ({ subscriptionId, fixedCharges }: Args) => {
+export const useSubscriptionFixedChargeMutations = ({
+  subscriptionId,
+  fixedCharges,
+  refetchOverrides,
+}: Args) => {
   const client = useApolloClient()
   const [updateSubscriptionFixedCharge] = useUpdateSubscriptionFixedChargeMutation({
     // Only the cached plan query is refreshed here. The override-aware units
@@ -135,11 +147,16 @@ export const useSubscriptionFixedChargeMutations = ({ subscriptionId, fixedCharg
 
     // For a units-only override the plan is not cloned, so the cached plan
     // query keeps showing plan defaults — the new units live only in the
-    // no-cache getSubscriptionFixedChargeUnitsOverrides query. Refresh it
-    // explicitly (client.refetchQueries calls refetch() directly, which honors
-    // no-cache) and await it so the list shows the new units once the drawer
-    // closes, instead of racing the stale plan default.
-    await client.refetchQueries({ include: ['getSubscriptionFixedChargeUnitsOverrides'] })
+    // no-cache getSubscriptionFixedChargeUnitsOverrides query. Refresh it and
+    // await it so the list shows the new units once the drawer closes, instead
+    // of racing the stale plan default. Prefer the query's OWN refetch (pushes
+    // the result into its hook); fall back to the name-based refresh when no
+    // refetcher was provided.
+    if (refetchOverrides) {
+      await refetchOverrides()
+    } else {
+      await client.refetchQueries({ include: ['getSubscriptionFixedChargeUnitsOverrides'] })
+    }
 
     return true
   }

--- a/src/pages/subscriptions/CreateSubscription.tsx
+++ b/src/pages/subscriptions/CreateSubscription.tsx
@@ -55,7 +55,8 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAddSubscription } from '~/hooks/customer/useAddSubscription'
 import { useAppForm } from '~/hooks/forms/useAppform'
-import { usePlanForm } from '~/hooks/plans/usePlanForm'
+import { useCustomPricingUnits } from '~/hooks/plans/useCustomPricingUnits'
+import { buildDefaultValues, usePlanForm } from '~/hooks/plans/usePlanForm'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { useIframeConfig } from '~/hooks/useIframeConfig'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
@@ -163,6 +164,7 @@ const CreateSubscription = () => {
         localValues,
         planForm.state.values,
         planFormIsDirty,
+        planBaselineValues,
       )
 
       if (errorsString === 'CurrenciesDoesNotMatch') {
@@ -238,6 +240,23 @@ const CreateSubscription = () => {
     planIdToFetch: subscriptionPlanId,
     isUsedInSubscriptionForm: true,
   })
+
+  const { hasAnyPricingUnitConfigured } = useCustomPricingUnits()
+
+  // The plan's unedited baseline, rebuilt the same way the plan form is
+  // initialized (usePlanFormSetup → buildDefaultValues). Diffed against the
+  // edited values in useAddSubscription so a units-only fixed-charge change
+  // sends a minimal planOverrides instead of cloning the whole plan.
+  const planBaselineValues = useMemo(
+    () =>
+      buildDefaultValues(
+        plan,
+        FORM_TYPE_ENUM.creation,
+        (plan?.amountCurrency as CurrencyEnum) || CurrencyEnum.Usd,
+        hasAnyPricingUnitConfigured,
+      ),
+    [plan, hasAnyPricingUnitConfigured],
+  )
 
   const alreadyExistingPlanFixedChargesIds =
     plan?.fixedCharges?.map((fixedCharge) => fixedCharge.id) || []

--- a/src/pages/subscriptions/__tests__/CreateSubscription.test.tsx
+++ b/src/pages/subscriptions/__tests__/CreateSubscription.test.tsx
@@ -78,6 +78,11 @@ jest.mock('~/hooks/plans/usePlanForm', () => ({
     loading: false,
     type: 'creation',
   }),
+  buildDefaultValues: jest.fn(() => ({})),
+}))
+
+jest.mock('~/hooks/plans/useCustomPricingUnits', () => ({
+  useCustomPricingUnits: () => ({ hasAnyPricingUnitConfigured: false }),
 }))
 
 const mockSubscriptionFormIsDirty = false

--- a/translations/base.json
+++ b/translations/base.json
@@ -4373,5 +4373,6 @@
   "text_1782392058759vsncvwa3829": "Execute in Lago",
   "text_1782392058759l2hdxjsbklc": "Order only",
   "text_1782392058759fvp6ye50x8g": "No order yet",
-  "text_1782392058759ee7h86svmtj": "Orders will appear here once their order forms are signed."
+  "text_1782392058759ee7h86svmtj": "Orders will appear here once their order forms are signed.",
+  "text_1781789973520dpkwtttnk2m": "Updating only units will not create a subscription override."
 }


### PR DESCRIPTION
## Context

  When a fixed charge is edited from a subscription, the backend exposes a lightweight "units override" fast path: if the mutation params carry only units (plus
  applyUnitsImmediately), the change is recorded as a per-subscription override against the shared plan. The moment any other field is present — even unchanged
  — the backend falls through to legacy plan-cloning, which is expensive and detaches the subscription from its plan.

  Two problems blocked us from using that fast path cleanly:

  1. Reads polluted the cache. FixedCharge is normalised by id in the Apollo cache and is not partitioned by subscription. Fetching subscription-scoped
  (override-aware) units through the normal cache would overwrite the plan-default units on the same FixedCharge entry, so plan-scope pages would start showing
  another subscription's overridden values.
  2. Writes always cloned. The existing updateSubscriptionFixedCharge mutation sent every field on every edit and wrote the override-aware result back into the
  cache, so a simple units change never hit the fast path and always triggered plan-cloning.

## Description

  Override-aware reads (display)
  - Added a dedicated getSubscriptionFixedChargeUnitsOverrides query selecting only subscription.fixedCharges { id, units }, fetched with fetchPolicy:
  'no-cache' so the normalised FixedCharge cache entry keeps its plan-default units intact.
  - SubscriptionDetailsV2Plan builds a subscriptionFixedChargeUnitsById map from that query and threads it through PlanDetailsV2 →
  PlanDetailsV2FixedChargesSection.
  - In the section, each row now prefers the per-subscription override (subscriptionFixedChargeUnitsById?.[id] ?? fixedCharge.units) for both the displayed info
  and the edit drawer. Plan-scope rendering passes no map and falls back to plan defaults unchanged.

  Fast-path writes (edit)
  - updateSubscriptionFixedCharge now selects only id on its result, so the mutation no longer writes subscription-scoped units back over the plan-default cache
  entry.
  - buildInput diffs the drawer values against the plan-level fixed charge and includes invoiceDisplayName, properties, and taxCodes only when they actually
  changed — keeping pure units edits on the BE's override fast path. units is always sent so that, if a mixed edit does clone, the subscription's current units
  are baked into the clone (no silent snap-back to the plan default).
  - Added sortedWithoutTypename / comparable-value helpers so cached values (with __typename, selection-set key order) compare equal to drawer values when
  nothing changed.
  - useSubscriptionFixedChargeMutations now receives the plan's fixedCharges as the diff baseline (threaded through useDetailsV2ChargeMutations) and refetches
  the new overrides query after a successful mutation.

  Tests
  - Unit coverage for buildInput (field-diffing / fast-path behaviour) and the fixed-charges section's override display, plus a
  t90-subscription-fixed-charge-override Cypress e2e spec.