### PR TITLE
refactor(modal): migrate DeletePaymentMethodDialog to NiceModal CentralizedDialog

### DIFF
--- a/src/components/paymentMethodsList/DeletePaymentMethodDialog.tsx
+++ b/src/components/paymentMethodsList/DeletePaymentMethodDialog.tsx
@@ -1,57 +1,30 @@
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
-
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { DestroyPaymentMethodInput } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { PaymentMethodItem } from '~/hooks/customer/usePaymentMethodsList'
 
-interface DeletePaymentMethodDialogProps {
-  paymentMethod?: PaymentMethodItem
+type DeletePaymentMethodDialogInfos = {
+  paymentMethod: PaymentMethodItem
   onConfirm: (input: DestroyPaymentMethodInput) => Promise<void>
 }
 
-export interface DeletePaymentMethodDialogRef {
-  openDialog: (data: DeletePaymentMethodDialogProps) => void
-  closeDialog: () => void
+export const useDeletePaymentMethodDialog = (): {
+  openDeletePaymentMethodDialog: (infos: DeletePaymentMethodDialogInfos) => void
+} => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+
+  const openDeletePaymentMethodDialog = (infos: DeletePaymentMethodDialogInfos): void => {
+    centralizedDialog.open({
+      title: translate('text_1762437511802sg9jrl46lkb'),
+      description: translate('text_17625350067233oa8biywazm'),
+      actionText: translate('text_1762437511802sg9jrl46lkb'),
+      colorVariant: 'danger',
+      onAction: async () => {
+        await infos.onConfirm({ id: infos.paymentMethod.id })
+      },
+    })
+  }
+
+  return { openDeletePaymentMethodDialog }
 }
-
-export const DeletePaymentMethodDialog = forwardRef<DeletePaymentMethodDialogRef, unknown>(
-  (_props, ref) => {
-    const { translate } = useInternationalization()
-    const dialogRef = useRef<WarningDialogRef>(null)
-    const [localData, setLocalData] = useState<DeletePaymentMethodDialogProps | undefined>(
-      undefined,
-    )
-
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setLocalData(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => {
-        dialogRef.current?.closeDialog()
-      },
-    }))
-
-    const handleConfirm = async (): Promise<void> => {
-      if (!localData?.paymentMethod) return
-
-      await localData.onConfirm({ id: localData.paymentMethod.id })
-
-      dialogRef.current?.closeDialog()
-    }
-
-    return (
-      <WarningDialog
-        ref={dialogRef}
-        title={translate('text_1762437511802sg9jrl46lkb')}
-        description={translate('text_17625350067233oa8biywazm')}
-        onContinue={handleConfirm}
-        continueText={translate('text_1762437511802sg9jrl46lkb')}
-        mode="danger"
-      />
-    )
-  },
-)
-
-DeletePaymentMethodDialog.displayName = 'DeletePaymentMethodDialog'

--- a/src/components/paymentMethodsList/PaymentMethodList.tsx
+++ b/src/components/paymentMethodsList/PaymentMethodList.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { useCallback, useRef } from 'react'
+import { useCallback } from 'react'
 
 import { Table } from '~/components/designSystem/Table'
 import { addToast } from '~/core/apolloClient'
@@ -12,10 +12,7 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { PaymentMethodItem, usePaymentMethodsList } from '~/hooks/customer/usePaymentMethodsList'
 
-import {
-  DeletePaymentMethodDialog,
-  DeletePaymentMethodDialogRef,
-} from './DeletePaymentMethodDialog'
+import { useDeletePaymentMethodDialog } from './DeletePaymentMethodDialog'
 import { usePaymentMethodsTableColumns } from './usePaymentMethodsTableColumns'
 
 gql`
@@ -38,7 +35,7 @@ interface Props {
 
 export const PaymentMethodsList = ({ externalCustomerId }: Props) => {
   const { translate } = useInternationalization()
-  const deletePaymentMethodDialogRef = useRef<DeletePaymentMethodDialogRef>(null)
+  const { openDeletePaymentMethodDialog } = useDeletePaymentMethodDialog()
 
   const [setPaymentMethodAsDefaultMutation, { error: errorSetAsDefault }] =
     useSetPaymentMethodAsDefaultMutation()
@@ -63,7 +60,7 @@ export const PaymentMethodsList = ({ externalCustomerId }: Props) => {
 
   const onDeletePaymentMethod = useCallback(
     (item: PaymentMethodItem) => {
-      deletePaymentMethodDialogRef.current?.openDialog({
+      openDeletePaymentMethodDialog({
         paymentMethod: item,
         onConfirm: async (input: DestroyPaymentMethodInput) => {
           const res = await destroyPaymentMethodMutation({ variables: { input } })
@@ -79,7 +76,7 @@ export const PaymentMethodsList = ({ externalCustomerId }: Props) => {
         },
       })
     },
-    [destroyPaymentMethodMutation, refetch, translate],
+    [destroyPaymentMethodMutation, refetch, translate, openDeletePaymentMethodDialog],
   )
 
   const { columns, actionColumn } = usePaymentMethodsTableColumns({
@@ -90,25 +87,22 @@ export const PaymentMethodsList = ({ externalCustomerId }: Props) => {
   const hasError = hasErrorPaymentMethods || errorSetAsDefault || errorDestroyPaymentMethod
 
   return (
-    <>
-      <Table
-        name="payment-methods-list"
-        containerSize={0}
-        rowSize={72}
-        data={paymentMethodsList}
-        placeholder={{
-          emptyState: {
-            title: translate('text_17624373282988xkhppid3at'),
-            subtitle: translate('text_1762437344178ud4kecr8cz9'),
-          },
-        }}
-        actionColumnTooltip={() => translate('text_634687079be251fdb438338f')}
-        actionColumn={actionColumn}
-        columns={columns}
-        isLoading={loading}
-        hasError={!!hasError}
-      />
-      <DeletePaymentMethodDialog ref={deletePaymentMethodDialogRef} />
-    </>
+    <Table
+      name="payment-methods-list"
+      containerSize={0}
+      rowSize={72}
+      data={paymentMethodsList}
+      placeholder={{
+        emptyState: {
+          title: translate('text_17624373282988xkhppid3at'),
+          subtitle: translate('text_1762437344178ud4kecr8cz9'),
+        },
+      }}
+      actionColumnTooltip={() => translate('text_634687079be251fdb438338f')}
+      actionColumn={actionColumn}
+      columns={columns}
+      isLoading={loading}
+      hasError={!!hasError}
+    />
   )
 }


### PR DESCRIPTION
## Summary

Migrate `DeletePaymentMethodDialog` from the legacy imperative ref-based `WarningDialog` system to the new hook-based NiceModal `CentralizedDialog` system, removing one of the deprecated `~/components/designSystem/WarningDialog` imports flagged by ESLint.

## Changes

- **`src/components/paymentMethodsList/DeletePaymentMethodDialog.tsx`**
  - Replaced the `forwardRef` / `useImperativeHandle` / `useState(localData)` pattern with a `useDeletePaymentMethodDialog` custom hook.
  - Replaced the deprecated `WarningDialog` (from `~/components/designSystem/WarningDialog`) with `useCentralizedDialog` (from `~/components/dialogs/CentralizedDialog`).
  - Kept the same UX: same title, description, danger color variant, and confirm callback wiring.
- **`src/components/paymentMethodsList/PaymentMethodList.tsx`**
  - Removed the `useRef<DeletePaymentMethodDialogRef>` boilerplate and the inline `<DeletePaymentMethodDialog ref={...} />` JSX node.
  - Wired the new `openDeletePaymentMethodDialog` hook return into the existing `onDeletePaymentMethod` callback, preserving the toast + refetch flow.

## Routine context

Picked as part of the scheduled "fix one deprecated dialog warning" routine. The legacy `~/components/PremiumWarningDialog` is no longer imported anywhere (only a single self-referential warning remains in the file itself), so the routine fell back to `WarningDialog`-import warnings (≈23 files) and randomly selected `DeletePaymentMethodDialog.tsx`. Total ESLint warnings dropped from **498 → 497**.

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm code:style` passes (no new errors; one fewer warning)
- [x] `pnpm test --testPathPatterns paymentMethodsList` — all 19 tests pass
- [ ] Manually verify in the app: open a customer with payment methods, click the trash action, confirm the dialog opens, has the correct title/description, danger button color, and that confirming actually deletes the payment method.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmoztDPRg1ay8NCucq2SCy)_