### PR TITLE
fix(deps): patch ws, brace-expansion, qs CVEs (>=3 weeks old)

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,10 @@
       "flatted": "3.4.2",
       "svgo": "4.0.1",
       "follow-redirects": "1.16.0",
-      "uuid": "14.0.0"
+      "uuid": "14.0.0",
+      "ws": ">=8.20.1",
+      "brace-expansion@5": ">=5.0.6",
+      "qs@6": ">=6.15.2"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ overrides:
   svgo: 4.0.1
   follow-redirects: 1.16.0
   uuid: 14.0.0
+  ws: '>=8.20.1'
+  brace-expansion@5: '>=5.0.6'
+  qs@6: '>=6.15.2'
 
 importers:
 
@@ -17,7 +20,7 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 3.14.1
-        version: 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ebay/nice-modal-react':
         specifier: 1.2.13
         version: 1.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -146,13 +149,13 @@ importers:
         version: 5.2.8-1
       apollo-link-timeout:
         specifier: 4.0.0
-        version: 4.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       apollo-upload-client:
         specifier: 17.0.0
-        version: 17.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.1)
+        version: 17.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.1)
       apollo3-cache-persist:
         specifier: 0.15.0
-        version: 0.15.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 0.15.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       decimal.js:
         specifier: 10.6.0
         version: 10.6.0
@@ -164,7 +167,7 @@ importers:
         version: 16.14.1
       graphql-ruby-client:
         specifier: 1.15.1
-        version: 1.15.1(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.1)
+        version: 1.15.1(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.1)
       html-react-parser:
         specifier: 6.1.3
         version: 6.1.3(@types/react@18.3.29)(react@18.3.1)
@@ -303,7 +306,7 @@ importers:
         version: 5.2.11
       '@types/apollo-upload-client':
         specifier: 17.0.5
-        version: 17.0.5(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 17.0.5(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -4571,8 +4574,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5745,7 +5748,7 @@ packages:
       crossws: ~0.3
       graphql: ^15.10.1 || ^16
       uWebSockets.js: ^20
-      ws: ^8
+      ws: '>=8.20.1'
     peerDependenciesMeta:
       '@fastify/websocket':
         optional: true
@@ -6151,12 +6154,12 @@ packages:
   isomorphic-ws@5.0.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
     peerDependencies:
-      ws: '*'
+      ws: '>=8.20.1'
 
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
-      ws: '*'
+      ws: '>=8.20.1'
 
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -7791,8 +7794,8 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -8816,8 +8819,8 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -8899,7 +8902,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.1)
       '@wry/caches': 1.0.1
@@ -8916,7 +8919,7 @@ snapshots:
       tslib: 2.8.1
       zen-observable-ts: 1.2.5
     optionalDependencies:
-      graphql-ws: 6.0.6(graphql@16.14.1)(ws@8.19.0)
+      graphql-ws: 6.0.6(graphql@16.14.1)(ws@8.21.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -10530,7 +10533,7 @@ snapshots:
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       performance-now: 2.1.0
-      qs: 6.14.2
+      qs: 6.15.2
       safe-buffer: 5.2.1
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
@@ -11033,10 +11036,10 @@ snapshots:
       '@graphql-tools/utils': 10.10.3(graphql@16.14.1)
       '@whatwg-node/disposablestack': 0.0.6
       graphql: 16.14.1
-      graphql-ws: 6.0.6(graphql@16.14.1)(ws@8.19.0)
-      isows: 1.0.7(ws@8.19.0)
+      graphql-ws: 6.0.6(graphql@16.14.1)(ws@8.21.0)
+      isows: 1.0.7(ws@8.21.0)
       tslib: 2.8.1
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - '@fastify/websocket'
       - bufferutil
@@ -11064,9 +11067,9 @@ snapshots:
       '@graphql-tools/utils': 11.0.0(graphql@16.14.1)
       '@types/ws': 8.5.13
       graphql: 16.14.1
-      isomorphic-ws: 5.0.0(ws@8.19.0)
+      isomorphic-ws: 5.0.0(ws@8.21.0)
       tslib: 2.8.1
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11188,10 +11191,10 @@ snapshots:
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.14.1
-      isomorphic-ws: 5.0.0(ws@8.19.0)
+      isomorphic-ws: 5.0.0(ws@8.21.0)
       sync-fetch: 0.6.0
       tslib: 2.8.1
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - '@fastify/websocket'
       - '@types/node'
@@ -12679,9 +12682,9 @@ snapshots:
 
   '@types/actioncable@5.2.11': {}
 
-  '@types/apollo-upload-client@17.0.5(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@types/apollo-upload-client@17.0.5(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/extract-files': 13.0.1
       graphql: 16.14.1
     transitivePeerDependencies:
@@ -13152,19 +13155,19 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  apollo-link-timeout@4.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  apollo-link-timeout@4.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
-      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  apollo-upload-client@17.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.1):
+  apollo-upload-client@17.0.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.1):
     dependencies:
-      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       extract-files: 11.0.0
       graphql: 16.14.1
 
-  apollo3-cache-persist@0.15.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  apollo3-cache-persist@0.15.0(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
-      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   arch@2.2.0: {}
 
@@ -13417,7 +13420,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.3
 
@@ -14804,9 +14807,9 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  graphql-ruby-client@1.15.1(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.1):
+  graphql-ruby-client@1.15.1(@apollo/client@3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.14.1):
     dependencies:
-      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@apollo/client': 3.14.1(@types/react@18.3.29)(graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0))(graphql@16.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       glob: 13.0.6
       graphql: 16.14.1
       minimist: 1.2.8
@@ -14816,11 +14819,11 @@ snapshots:
       graphql: 16.14.1
       tslib: 2.8.1
 
-  graphql-ws@6.0.6(graphql@16.14.1)(ws@8.19.0):
+  graphql-ws@6.0.6(graphql@16.14.1)(ws@8.21.0):
     dependencies:
       graphql: 16.14.1
     optionalDependencies:
-      ws: 8.19.0
+      ws: 8.21.0
 
   graphql@16.14.1: {}
 
@@ -15224,13 +15227,13 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isomorphic-ws@5.0.0(ws@8.19.0):
+  isomorphic-ws@5.0.0(ws@8.21.0):
     dependencies:
-      ws: 8.19.0
+      ws: 8.21.0
 
-  isows@1.0.7(ws@8.19.0):
+  isows@1.0.7(ws@8.21.0):
     dependencies:
-      ws: 8.19.0
+      ws: 8.21.0
 
   isstream@0.1.2: {}
 
@@ -15727,7 +15730,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.19.0
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -16383,7 +16386,7 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.4:
     dependencies:
@@ -16399,7 +16402,7 @@ snapshots:
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 
@@ -17310,7 +17313,7 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  qs@6.14.2:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -18565,7 +18568,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@8.19.0: {}
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
## Summary

Fixes three transitive devDependency CVEs that have been open for ≥3 weeks, following the established `pnpm.overrides` pattern already used in this project (axios, follow-redirects, uuid, etc.).

| Package | Before | After | CVE | Severity | Age |
|---|---|---|---|---|---|
| `ws` | 8.19.0 | **8.21.0** | CVE-2026-45736 / [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) | Moderate | 28 days |
| `brace-expansion` (v5 only) | 5.0.5 | **5.0.6** | CVE-2026-45149 / [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) | Moderate | 28 days |
| `qs` | 6.14.2 | **6.15.2** | CVE-2026-8723 / [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) | Moderate | 24 days |

Two alerts (`tmp` CVE-2026-44705, opened 19 days ago, and `esbuild` GHSA-gv7w-rqvm-qjhr, opened 3 days ago) were intentionally skipped — they are under the 3-week threshold.

## Dependency chains

- `ws` via `@graphql-codegen/cli > @graphql-tools/url-loader > ws` and `jest-environment-jsdom > jsdom > ws`
- `brace-expansion@5` via `@typescript-eslint > minimatch@10` and `graphql-config > minimatch@10` (v1/v2 are unaffected and untouched)
- `qs` via `cypress > @cypress/request@4.0.0` — `@cypress/request@4.0.0` pins `qs: ~6.14.1`; upgrading to 4.0.1 (which declares `^6.15.2`) would fix it, but `pnpm update` doesn't re-resolve peer-dep-baked lockfile strings, so an override is the least-invasive option

## Why overrides and not `pnpm update`

pnpm v9/v10 bakes the transitive `ws` version into peer-dependency resolution strings throughout the lockfile (e.g. `@apollo/client@3.14.1(...)(ws@8.19.0)`). Running `pnpm update --depth Infinity ws` returns "Already up to date" because 8.19.0 already satisfies all declared ranges. Adding a `pnpm.overrides` entry forces re-resolution and follows the project's existing pattern.

## Test plan

- [ ] CI passes (lint, types, unit tests)
- [ ] `pnpm audit` shows no findings for the three patched packages
- [ ] No runtime regressions — all three are devDependencies (codegen toolchain, Cypress, Jest/jsdom)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMG3b5NTJZx8nW5YBoAQVa)_