### PR TITLE
fix(deps): patch tmp CVE and harden dependency security

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,11 +189,8 @@
   },
   "pnpm": {
     "overrides": {
-      "axios": "1.17.0",
-      "flatted": "3.4.2",
-      "svgo": "4.0.1",
-      "follow-redirects": "1.16.0",
-      "uuid": "14.0.0"
+      "uuid": ">=14.0.0",
+      "tmp": ">=0.2.6"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  axios: 1.17.0
-  flatted: 3.4.2
-  svgo: 4.0.1
-  follow-redirects: 1.16.0
-  uuid: 14.0.0
+  uuid: '>=14.0.0'
+  tmp: '>=0.2.6'
 
 importers:
 
@@ -4480,8 +4477,8 @@ packages:
     resolution: {integrity: sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==}
     engines: {node: '>=4'}
 
-  axios@1.17.0:
-    resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -4761,6 +4758,10 @@ packages:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -4866,6 +4867,10 @@ packages:
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  css-tree@2.3.1:
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
@@ -6755,6 +6760,9 @@ packages:
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
+  mdn-data@2.0.30:
+    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
@@ -8309,6 +8317,11 @@ packages:
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
+  svgo@3.3.3:
+    resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
@@ -8413,8 +8426,8 @@ packages:
     resolution: {integrity: sha512-LQIHmHnuzfZgZWAf2HzL83TIIrD8NhhI0DVxqo9/FdOd4ilec+NTNZOlDZf7EwrTNoutccbsHjvWHYXLAtvxjw==}
     hasBin: true
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -11804,7 +11817,7 @@ snapshots:
 
   '@nangohq/types@0.70.6(debug@4.4.3)':
     dependencies:
-      axios: 1.17.0(debug@4.4.3)
+      axios: 1.16.1(debug@4.4.3)
       json-schema: 0.4.0
       type-fest: 4.41.0
     transitivePeerDependencies:
@@ -12245,7 +12258,7 @@ snapshots:
       '@svgr/core': 8.1.0(typescript@6.0.3)
       cosmiconfig: 8.3.6(typescript@6.0.3)
       deepmerge: 4.3.1
-      svgo: 4.0.1
+      svgo: 3.3.3
     transitivePeerDependencies:
       - typescript
 
@@ -13292,7 +13305,7 @@ snapshots:
 
   axe-core@4.10.2: {}
 
-  axios@1.17.0(debug@4.4.3):
+  axios@1.16.1(debug@4.4.3):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
@@ -13624,6 +13637,8 @@ snapshots:
 
   commander@6.2.1: {}
 
+  commander@7.2.0: {}
+
   commander@8.3.0: {}
 
   common-tags@1.8.2: {}
@@ -13731,6 +13746,11 @@ snapshots:
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
+      source-map-js: 1.2.1
+
+  css-tree@2.3.1:
+    dependencies:
+      mdn-data: 2.0.30
       source-map-js: 1.2.1
 
   css-tree@3.1.0:
@@ -13844,7 +13864,7 @@ snapshots:
       request-progress: 3.0.0
       supports-color: 8.1.1
       systeminformation: 5.31.6
-      tmp: 0.2.5
+      tmp: 0.2.7
       tree-kill: 1.2.2
       tslib: 1.14.1
       untildify: 4.0.0
@@ -15700,7 +15720,7 @@ snapshots:
       neo-async: 2.6.2
       picocolors: 1.1.1
       recast: 0.23.11
-      tmp: 0.2.5
+      tmp: 0.2.7
       write-file-atomic: 5.0.1
     optionalDependencies:
       '@babel/preset-env': 7.29.7(@babel/core@7.29.0)
@@ -16158,6 +16178,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.0.28: {}
+
+  mdn-data@2.0.30: {}
 
   mdn-data@2.12.2: {}
 
@@ -17965,6 +17987,16 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
+  svgo@3.3.3:
+    dependencies:
+      commander: 7.2.0
+      css-select: 5.1.0
+      css-tree: 2.3.1
+      css-what: 6.1.0
+      csso: 5.0.5
+      picocolors: 1.1.1
+      sax: 1.5.0
+
   svgo@4.0.1:
     dependencies:
       commander: 11.1.0
@@ -18095,7 +18127,7 @@ snapshots:
     dependencies:
       tldts-core: 6.1.71
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   tmpl@1.0.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
 packages:
   - 'packages/configs/'
   - 'packages/design-system/'
+
+# Supply-chain quarantine: a published version must be at least 7 days old
+# (10080 minutes) before any resolution installs it. Applied at the package
+# manager level so it also covers Renovate's weekly lockFileMaintenance
+# regeneration, which bypasses Renovate's own minimumReleaseAge filter.
+minimumReleaseAge: 10080

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
   },
   "packageRules": [
     {
-      "matchDepTypes": ["overrides"],
+      "matchDepTypes": ["overrides", "pnpm.overrides"],
       "enabled": false,
       "description": "Disable updates for pnpm overrides used to pin transitive security patches"
     },


### PR DESCRIPTION
Resolves Dependabot alert [#231](https://github.com/getlago/lago-front/security/dependabot/231) — `tmp` path traversal (CVE-2026-44705 / GHSA-ph9p-34f9-6g65, High) — and hardens the dependency-security tooling while there.

## What changed and why

### 1. Patch the `tmp` CVE
`tmp` is a transitive-only dev dep (via `cypress` and `jscodeshift`). `pnpm update tmp` is a no-op on transitive-only packages (it only touches deps declared in an importer), so the fix is a `pnpm.overrides` entry. Both parents already declare ranges that admit the patch (`cypress ~0.2.4`, `jscodeshift ^0.2.3`), so the override just unsticks the stale lockfile. Resolves `tmp@0.2.5 → 0.2.7`.

**Choice: `>=` range, not an exact pin.** Exact pins mask future advisories and block patch bumps. `"tmp": ">=0.2.6"` keeps the alert closed (lockfile resolves 0.2.7) while letting future patched versions flow and future advisories still surface.

### 2. Prune 4 stale overrides
Audited every existing override by deleting it, re-resolving (`pnpm install --lockfile-only`), and checking the natural resolution against each CVE's vulnerable range:

| Override | Was | Natural resolve | Vulnerable | Decision |
|---|---|---|---|---|
| axios | `1.17.0` | `1.16.1` | `<1.16.0` | **Removed** — 1.16.1 is patched |
| flatted | `3.4.2` | `3.4.2` | `<=3.4.1` | **Removed** — flat-cache `^3.2.9` → latest-3.x patched |
| svgo | `4.0.1` | `3.3.3` + `4.0.1` | `2.1.0–<2.8.1` | **Removed** — both patched |
| follow-redirects | `1.16.0` | `1.16.0` | `<=1.15.11` | **Removed** — sole parent axios needs `^1.16.0` |
| uuid | `14.0.0` | `10.0.0` + `14.0.0` | `<14.0.0` | **Kept** — dropping it reintroduces vulnerable `10.0.0` |

**Choice on uuid:** kept the override but converted the exact pin `14.0.0 → >=14.0.0` for the same reason as `tmp` (don't mask future fixes).

**Choice on axios:** removing the override floats it `1.17.0 → 1.16.1` (the max `@nangohq/frontend` allows). Both are patched; accepted the minor downgrade rather than carry a redundant pin.

### 3. Fix the Renovate override-disable rule
The existing rule meant to leave overrides alone matched depType `overrides` — but Renovate extracts a `pnpm.overrides` block under depType **`pnpm.overrides`**. The rule was dead, so with the repo's global `"rangeStrategy": "pin"` Renovate would have pinned the new `>=` ranges. Rule now matches `["overrides", "pnpm.overrides"]`.

### 4. Quarantine lockfile regeneration at the pnpm level
The open `>=` ranges stay patched via Renovate's weekly `lockFileMaintenance` (resolves latest in-range) — but that regeneration bypasses Renovate's own `minimumReleaseAge` filter and branch-automerges to `main` with no PR review, so a compromised in-range transitive could land unquarantined. Added `minimumReleaseAge: 10080` (7 days) to `pnpm-workspace.yaml` so the cooldown applies to *every* resolution, including lockFileMaintenance.

**Choice: 7 days, kept alongside Renovate's `minimumReleaseAge`.** The two gates cover different layers (Renovate PR creation vs pnpm resolution) and are aligned at 7 days so Renovate never proposes a version pnpm would refuse. Trade-off: a brand-new legitimate release (security patches included) is delayed 7 days; the escape hatch for an urgent fix is `minimumReleaseAgeExclude: [pkg@version]`. Chose the audit's primary recommendation over `lockFileMaintenance.automerge: false` to preserve automerge convenience.

## Verification
All installed versions confirmed outside their vulnerable ranges after `pnpm install`: `tmp@0.2.7`, `uuid@14.0.0`, `axios@1.16.1`, `flatted@3.4.2`, `svgo@3.3.3`+`4.0.1`, `follow-redirects@1.16.0`.
