### PR TITLE
refactor(form): migrate invoice document locale dialog to TanStack Form

### DIFF
--- a/.agents/skills/migrate-formik-to-tanstack/SKILL.md
+++ b/.agents/skills/migrate-formik-to-tanstack/SKILL.md
@@ -171,16 +171,16 @@ Before writing any code, create a plan document:
 
 Search for `setFieldError`, `setErrors`, `setStatus` in the onSubmit handler. These are server-side errors set AFTER a mutation response and must be migrated to `formApi.setErrorMap`.
 
-| Formik Call | GQL Error | Target Field | Error Message Key | TanStack `setErrorMap` |
-| ----------- | --------- | ------------ | ----------------- | ---------------------- |
-| `formikBag.setFieldError('email', ...)` | `NotFound` | `email` | `text_xxx` | See Pattern 4 below |
+| Formik Call                             | GQL Error  | Target Field | Error Message Key | TanStack `setErrorMap` |
+| --------------------------------------- | ---------- | ------------ | ----------------- | ---------------------- |
+| `formikBag.setFieldError('email', ...)` | `NotFound` | `email`      | `text_xxx`        | See Pattern 4 below    |
 
 **If no `setFieldError`/`setErrors`/`setStatus` calls are found, write "None" and move on.**
 
 ### Submit Button Disabled Logic
 
 Current: `disabled={!formikProps.isValid || !formikProps.dirty || loading}`
-TanStack: `form.SubmitButton` handles isValid + dirty automatically
+TanStack: `form.SubmitButton` handles validity + isSubmitting automatically. It does **not** subscribe to `isDirty` — if the original Formik logic gated on `dirty`, preserve that by passing `disabled={!isDirty}` explicitly (subscribe to `isDirty` via `useStore(form.store, (s) => s.isDirty)`).
 
 ### Validation Timing
 
@@ -408,11 +408,11 @@ When you need to **react to a field value change** (e.g., propagate a selection,
 
 **When to use `listeners` vs `useStore`:**
 
-| Use case | Tool |
-|----------|------|
-| Read a value for conditional rendering in JSX | `useStore` |
-| Execute a side-effect when a value changes | `listeners.onChange` |
-| Derive another field's value from a change | `listeners.onChange` |
+| Use case                                      | Tool                 |
+| --------------------------------------------- | -------------------- |
+| Read a value for conditional rendering in JSX | `useStore`           |
+| Execute a side-effect when a value changes    | `listeners.onChange` |
+| Derive another field's value from a change    | `listeners.onChange` |
 
 > **Reference**: See `AddBillableMetricToCouponDialog.tsx` and `NameAndCodeGroup.tsx` for real-world examples of listeners.
 
@@ -428,6 +428,7 @@ import NameAndCodeGroup from '~/components/form/NameAndCodeGroup/NameAndCodeGrou
 ```
 
 This component:
+
 - Renders name and code fields in a 2-column grid
 - Auto-generates the `code` from `name` using `formatCodeFromName` (until the user manually edits the code field)
 - Uses the `withFieldGroup` HOC (different from `withForm` — see Advanced Patterns)
@@ -492,6 +493,8 @@ return (
 
 **Replace submit button:**
 
+Always prefer the registered `form.SubmitButton` over a manually-wired `<Button type="submit">` with `useStore` subscriptions — it internally subscribes to `canSubmit` + `isSubmitting` and adds a `loading` state for free.
+
 ```diff
 - <Button
 -   onClick={formikProps.submitForm}
@@ -504,7 +507,22 @@ return (
 + </form.AppForm>
 ```
 
-Note: `form.SubmitButton` handles `canSubmit` (validity + dirty state) automatically.
+Notes:
+
+- `form.SubmitButton` must be wrapped in `<form.AppForm>` — it reads the form via `useFormContext()`.
+- In TanStack, `canSubmit` = no validation errors + not submitting + not validating. **It does NOT include `isDirty`.** If the original Formik code disables on pristine forms (`!dirty`), preserve that by passing `disabled={!isDirty}` (and subscribing to `isDirty` via `useStore(form.store, (s) => s.isDirty)`).
+
+**Common mistake (do not do this):** hand-wiring a `<Button type="submit">` when the registered component already exists.
+
+```diff
+- const canSubmit = useStore(form.store, (s) => s.canSubmit)
+- <Button variant="primary" type="submit" disabled={!canSubmit}>
+-   {submitLabel}
+- </Button>
++ <form.AppForm>
++   <form.SubmitButton variant="primary">{submitLabel}</form.SubmitButton>
++ </form.AppForm>
+```
 
 #### Step 2.9: Update Field Value Changes
 
@@ -574,6 +592,7 @@ Go back to your Validation Migration Plan and verify:
 **CRITICAL: The UI before and after the migration MUST be visually identical** (unless changes are intentional UI/UX improvements).
 
 Verify:
+
 1. **Layout**: The `<form>` wrapper hasn't broken flex/grid layouts, sticky footers, or spacing
 2. **Field alignment**: All form fields maintain their original positioning and sizing
 3. **Error messages**: Error states display in the same position and style as before
@@ -753,9 +772,9 @@ Many forms set server-side errors on specific fields after a mutation fails (e.g
 
 **Formik → TanStack mapping:**
 
-| Formik | TanStack Form |
-|--------|---------------|
-| `formikBag.setFieldError('email', errorMsg)` | `formApi.setErrorMap({ onDynamic: { fields: { email: { message: errorMsg, path: ['email'] } } } })` |
+| Formik                                             | TanStack Form                                                                                                                            |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `formikBag.setFieldError('email', errorMsg)`       | `formApi.setErrorMap({ onDynamic: { fields: { email: { message: errorMsg, path: ['email'] } } } })`                                      |
 | `formikBag.setErrors({ email: msg1, name: msg2 })` | `formApi.setErrorMap({ onDynamic: { fields: { email: { message: msg1, path: ['email'] }, name: { message: msg2, path: ['name'] } } } })` |
 
 **⚠️ CRITICAL: Error value format**
@@ -915,12 +934,12 @@ Use `listeners` on `form.AppField` to react to field value changes. This is pref
 
 **When to use `listeners` vs `useStore`:**
 
-| Use case | Tool |
-|----------|------|
-| Read a value for conditional rendering in JSX | `useStore(form.store, ...)` |
-| Execute a side-effect when a value changes | `listeners={{ onChange }}` |
-| Derive another field's value from a change | `listeners={{ onChange }}` |
-| Update external state (refs, callbacks) on change | `listeners={{ onChange }}` |
+| Use case                                          | Tool                        |
+| ------------------------------------------------- | --------------------------- |
+| Read a value for conditional rendering in JSX     | `useStore(form.store, ...)` |
+| Execute a side-effect when a value changes        | `listeners={{ onChange }}`  |
+| Derive another field's value from a change        | `listeners={{ onChange }}`  |
+| Update external state (refs, callbacks) on change | `listeners={{ onChange }}`  |
 
 ### Pattern 8: `withFieldGroup` for Reusable Field Groups
 
@@ -990,12 +1009,12 @@ const NameAndCodeGroup = withFieldGroup({
 
 **Key differences: `withForm` vs `withFieldGroup`:**
 
-| Aspect | `withForm` | `withFieldGroup` |
-|--------|-----------|-----------------|
-| Purpose | Sub-component of a specific form | Reusable field group across multiple forms |
-| Receives | `form` prop | `group` prop |
-| Usage | `<MySection form={form} />` | `<NameAndCodeGroup group={form} />` |
-| Scope | Specific to one form's structure | Generic, works with any form that has matching fields |
+| Aspect   | `withForm`                       | `withFieldGroup`                                      |
+| -------- | -------------------------------- | ----------------------------------------------------- |
+| Purpose  | Sub-component of a specific form | Reusable field group across multiple forms            |
+| Receives | `form` prop                      | `group` prop                                          |
+| Usage    | `<MySection form={form} />`      | `<NameAndCodeGroup group={form} />`                   |
+| Scope    | Specific to one form's structure | Generic, works with any form that has matching fields |
 
 ### Pattern 9: Dialog with Independent Form
 
@@ -1079,6 +1098,7 @@ export const useAddItemDialog = () => {
 ```
 
 **Key points:**
+
 - The dialog has its own `useAppForm`, separate from the parent form
 - Data flows to the parent via callback (`onSelect` prop) and `useRef`
 - `useFormDialog` + `DialogActionButton` + `useSetDisabledRef` handle dialog UX

--- a/src/components/settings/invoices/EditBillingEntityDocumentLocaleDialog.tsx
+++ b/src/components/settings/invoices/EditBillingEntityDocumentLocaleDialog.tsx
@@ -90,7 +90,6 @@ export const EditBillingEntityDocumentLocaleDialog = forwardRef<
   })
 
   const isDirty = useStore(form.store, (state) => state.isDirty)
-  const canSubmit = useStore(form.store, (state) => state.canSubmit)
 
   const handleFormSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -102,9 +101,11 @@ export const EditBillingEntityDocumentLocaleDialog = forwardRef<
       <Button variant="quaternary" onClick={closeDialog}>
         {translate('text_63e51ef4985f0ebd75c21313')}
       </Button>
-      <Button variant="primary" type="submit" disabled={!canSubmit || !isDirty}>
-        {translate('text_17432414198706rdwf76ek3u')}
-      </Button>
+      <form.AppForm>
+        <form.SubmitButton variant="primary" disabled={!isDirty}>
+          {translate('text_17432414198706rdwf76ek3u')}
+        </form.SubmitButton>
+      </form.AppForm>
     </>
   )
 

--- a/src/components/settings/invoices/EditBillingEntityDocumentLocaleDialog.tsx
+++ b/src/components/settings/invoices/EditBillingEntityDocumentLocaleDialog.tsx
@@ -1,20 +1,16 @@
 import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
-import { forwardRef } from 'react'
-import { object, string } from 'yup'
+import { revalidateLogic, useStore } from '@tanstack/react-form'
+import { forwardRef, useImperativeHandle, useRef } from 'react'
+import { z } from 'zod'
 
 import { Button } from '~/components/designSystem/Button'
 import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { ComboBoxField } from '~/components/form'
 import { addToast } from '~/core/apolloClient'
 import { documentLocalesDataForComboBox } from '~/core/translations/documentLocales'
-import {
-  LagoApiError,
-  UpdateBillingEntityInput,
-  useUpdateDocumentLocaleBillingEntityMutation,
-} from '~/generated/graphql'
+import { LagoApiError, useUpdateDocumentLocaleBillingEntityMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 gql`
   mutation updateDocumentLocaleBillingEntity($input: UpdateBillingEntityInput!) {
@@ -28,6 +24,14 @@ gql`
   }
 `
 
+const editBillingEntityDocumentLocaleValidationSchema = z.object({
+  // The combobox emits `undefined` when cleared, so cover both the missing
+  // (invalid_type) and empty-string cases with the same "required" message.
+  documentLocale: z
+    .string({ message: 'text_624ea7c29103fd010732ab7d' })
+    .min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+})
+
 export type EditBillingEntityDocumentLocaleDialogRef = DialogRef
 
 interface EditBillingEntityDocumentLocaleDialogProps {
@@ -35,11 +39,20 @@ interface EditBillingEntityDocumentLocaleDialogProps {
   documentLocale: string
 }
 
+const FORM_ID = 'edit-billing-entity-document-locale-form'
+
 export const EditBillingEntityDocumentLocaleDialog = forwardRef<
   DialogRef,
   EditBillingEntityDocumentLocaleDialogProps
 >(({ id, documentLocale }: EditBillingEntityDocumentLocaleDialogProps, ref) => {
   const { translate } = useInternationalization()
+  const dialogRef = useRef<DialogRef>(null)
+
+  useImperativeHandle(ref, () => ({
+    openDialog: () => dialogRef.current?.openDialog(),
+    closeDialog: () => dialogRef.current?.closeDialog(),
+  }))
+
   const [updateDocumentLocale] = useUpdateDocumentLocaleBillingEntityMutation({
     context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
     onCompleted(res) {
@@ -53,73 +66,76 @@ export const EditBillingEntityDocumentLocaleDialog = forwardRef<
     refetchQueries: ['getBillingEntitySettings'],
   })
 
-  const formikProps = useFormik<UpdateBillingEntityInput>({
-    initialValues: {
-      id,
-      billingConfiguration: {
-        documentLocale,
-      },
+  const form = useAppForm({
+    defaultValues: {
+      documentLocale,
     },
-    validationSchema: object().shape({
-      billingConfiguration: object().shape({
-        documentLocale: string().required(''),
-      }),
-    }),
-    enableReinitialize: true,
-    validateOnMount: true,
-    onSubmit: async (values) => {
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: editBillingEntityDocumentLocaleValidationSchema,
+    },
+    onSubmit: async ({ value }) => {
       await updateDocumentLocale({
         variables: {
           input: {
-            ...values,
+            id,
+            billingConfiguration: {
+              documentLocale: value.documentLocale,
+            },
           },
         },
       })
+      dialogRef.current?.closeDialog()
     },
   })
 
+  const isDirty = useStore(form.store, (state) => state.isDirty)
+  const canSubmit = useStore(form.store, (state) => state.canSubmit)
+
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    form.handleSubmit()
+  }
+
+  const actions = ({ closeDialog }: { closeDialog: () => void }) => (
+    <>
+      <Button variant="quaternary" onClick={closeDialog}>
+        {translate('text_63e51ef4985f0ebd75c21313')}
+      </Button>
+      <Button variant="primary" type="submit" disabled={!canSubmit || !isDirty}>
+        {translate('text_17432414198706rdwf76ek3u')}
+      </Button>
+    </>
+  )
+
   return (
     <Dialog
-      ref={ref}
+      ref={dialogRef}
       title={translate('text_63e51ef4985f0ebd75c2130e')}
       description={translate('text_63e51ef4985f0ebd75c2130f')}
-      onClose={() => {
-        formikProps.resetForm()
-        formikProps.validateForm()
-      }}
-      actions={({ closeDialog }) => (
-        <>
-          <Button variant="quaternary" onClick={closeDialog}>
-            {translate('text_63e51ef4985f0ebd75c21313')}
-          </Button>
-          <Button
-            variant="primary"
-            disabled={!formikProps.isValid || !formikProps.dirty}
-            onClick={async () => {
-              await formikProps.submitForm()
-              closeDialog()
-            }}
-          >
-            {translate('text_17432414198706rdwf76ek3u')}
-          </Button>
-        </>
-      )}
+      onOpen={() => form.reset()}
+      onClose={() => form.reset()}
+      formId={FORM_ID}
+      formSubmit={handleFormSubmit}
+      actions={actions}
     >
       <div className="mb-8">
-        <ComboBoxField
-          disableClearable
-          name="billingConfiguration.documentLocale"
-          label={translate('text_63e51ef4985f0ebd75c21310')}
-          helperText={
-            <Typography variant="caption" html={translate('text_63e51ef4985f0ebd75c21312')} />
-          }
-          formikProps={formikProps}
-          data={documentLocalesDataForComboBox}
-          PopperProps={{ displayInDialog: true }}
-        />
+        <form.AppField name="documentLocale">
+          {(field) => (
+            <field.ComboBoxField
+              disableClearable
+              label={translate('text_63e51ef4985f0ebd75c21310')}
+              helperText={
+                <Typography variant="caption" html={translate('text_63e51ef4985f0ebd75c21312')} />
+              }
+              data={documentLocalesDataForComboBox}
+              PopperProps={{ displayInDialog: true }}
+            />
+          )}
+        </form.AppField>
       </div>
     </Dialog>
   )
 })
 
-EditBillingEntityDocumentLocaleDialog.displayName = 'forwardRef'
+EditBillingEntityDocumentLocaleDialog.displayName = 'EditBillingEntityDocumentLocaleDialog'

--- a/src/components/settings/invoices/__tests__/EditBillingEntityDocumentLocaleDialog.test.tsx
+++ b/src/components/settings/invoices/__tests__/EditBillingEntityDocumentLocaleDialog.test.tsx
@@ -1,0 +1,345 @@
+import { act, cleanup, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createRef } from 'react'
+
+import {
+  EditBillingEntityDocumentLocaleDialog,
+  EditBillingEntityDocumentLocaleDialogRef,
+} from '~/components/settings/invoices/EditBillingEntityDocumentLocaleDialog'
+import { UpdateDocumentLocaleBillingEntityDocument } from '~/generated/graphql'
+import { render, TestMocksType } from '~/test-utils'
+
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 56,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, i) => ({
+        index: i,
+        key: String(i),
+        start: i * 56,
+        size: 56,
+      })),
+    scrollToIndex: jest.fn(),
+    measureElement: jest.fn(),
+  }),
+}))
+
+const BILLING_ENTITY_ID = 'billing-entity-1'
+
+const mockAddToast = jest.fn()
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: (params: unknown) => mockAddToast(params),
+}))
+
+const getActionButtons = () => screen.getAllByRole('button').filter((b) => !!b.textContent?.trim())
+
+const openLocaleOption = async (user: ReturnType<typeof userEvent.setup>, label: string) => {
+  await user.click(screen.getByRole('combobox'))
+
+  const optionWrapper = await screen.findByTestId(`combobox-item-${label}`)
+  const option = optionWrapper.querySelector('.MuiAutocomplete-option') as HTMLElement
+
+  await user.click(option)
+}
+
+async function prepare({
+  documentLocale = 'en',
+  mocks = [],
+}: {
+  documentLocale?: string
+  mocks?: TestMocksType
+} = {}) {
+  const ref = createRef<EditBillingEntityDocumentLocaleDialogRef>()
+
+  await act(() =>
+    render(
+      <EditBillingEntityDocumentLocaleDialog
+        ref={ref}
+        id={BILLING_ENTITY_ID}
+        documentLocale={documentLocale}
+      />,
+      { mocks },
+    ),
+  )
+
+  await act(() => {
+    ref.current?.openDialog()
+  })
+
+  return { ref }
+}
+
+describe('EditBillingEntityDocumentLocaleDialog', () => {
+  afterEach(() => {
+    cleanup()
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN the dialog ref API', () => {
+    describe('WHEN openDialog is called', () => {
+      it('THEN should show the dialog', async () => {
+        const ref = createRef<EditBillingEntityDocumentLocaleDialogRef>()
+
+        await act(() =>
+          render(
+            <EditBillingEntityDocumentLocaleDialog
+              ref={ref}
+              id={BILLING_ENTITY_ID}
+              documentLocale="en"
+            />,
+          ),
+        )
+
+        expect(screen.queryByTestId('dialog-title')).not.toBeInTheDocument()
+
+        await act(() => {
+          ref.current?.openDialog()
+        })
+
+        await waitFor(() => {
+          expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
+        })
+      })
+    })
+
+    describe('WHEN closeDialog is called', () => {
+      it('THEN should hide the dialog', async () => {
+        const { ref } = await prepare()
+
+        expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
+
+        await act(() => {
+          ref.current?.closeDialog()
+        })
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('dialog-title')).not.toBeInTheDocument()
+        })
+      })
+    })
+  })
+
+  describe('GIVEN the dialog is opened', () => {
+    describe('WHEN rendered with a documentLocale prop', () => {
+      it.each([
+        ['title', 'dialog-title'],
+        ['description', 'dialog-description'],
+      ])('THEN should display the %s', async (_, testId) => {
+        await prepare()
+
+        expect(screen.getByTestId(testId)).toBeInTheDocument()
+      })
+
+      it('THEN should render cancel and submit action buttons', async () => {
+        await prepare()
+
+        expect(getActionButtons()).toHaveLength(2)
+      })
+
+      it.each([
+        ['en', 'English'],
+        ['fr', 'French'],
+        ['de', 'German'],
+      ])(
+        'THEN should pre-fill the combobox with the %s locale label',
+        async (locale, expectedLabel) => {
+          await prepare({ documentLocale: locale })
+
+          const combobox = screen.getByRole('combobox') as HTMLInputElement
+
+          expect(combobox.value).toBe(expectedLabel)
+        },
+      )
+    })
+  })
+
+  describe('GIVEN the form validation', () => {
+    describe('WHEN the form is pristine', () => {
+      it('THEN should disable the submit button', async () => {
+        await prepare()
+
+        const [, submitButton] = getActionButtons()
+
+        expect(submitButton).toBeDisabled()
+      })
+    })
+
+    describe('WHEN the user selects a different locale', () => {
+      it('THEN should enable the submit button', async () => {
+        const user = userEvent.setup()
+
+        await prepare({ documentLocale: 'en' })
+
+        await openLocaleOption(user, 'French')
+
+        await waitFor(() => {
+          const [, submitButton] = getActionButtons()
+
+          expect(submitButton).not.toBeDisabled()
+        })
+      })
+    })
+  })
+
+  describe('GIVEN the form submission', () => {
+    const buildMutationMock = (resultFn?: jest.Mock) => ({
+      request: {
+        query: UpdateDocumentLocaleBillingEntityDocument,
+        variables: {
+          input: {
+            id: BILLING_ENTITY_ID,
+            billingConfiguration: {
+              documentLocale: 'fr',
+            },
+          },
+        },
+      },
+      result:
+        resultFn ??
+        (() => ({
+          data: {
+            updateBillingEntity: {
+              id: BILLING_ENTITY_ID,
+              billingConfiguration: {
+                id: 'billing-config-1',
+                documentLocale: 'fr',
+              },
+            },
+          },
+        })),
+    })
+
+    describe('WHEN the user submits a new locale', () => {
+      it('THEN should call the mutation with id and billingConfiguration', async () => {
+        const user = userEvent.setup()
+        const mutationResult = jest.fn(() => ({
+          data: {
+            updateBillingEntity: {
+              id: BILLING_ENTITY_ID,
+              billingConfiguration: {
+                id: 'billing-config-1',
+                documentLocale: 'fr',
+              },
+            },
+          },
+        }))
+
+        await prepare({
+          documentLocale: 'en',
+          mocks: [buildMutationMock(mutationResult)],
+        })
+
+        await openLocaleOption(user, 'French')
+
+        const [, submitButton] = getActionButtons()
+
+        await user.click(submitButton)
+
+        await waitFor(() => {
+          expect(mutationResult).toHaveBeenCalled()
+        })
+      })
+
+      it('THEN should show a success toast', async () => {
+        const user = userEvent.setup()
+
+        await prepare({
+          documentLocale: 'en',
+          mocks: [buildMutationMock()],
+        })
+
+        await openLocaleOption(user, 'French')
+
+        const [, submitButton] = getActionButtons()
+
+        await user.click(submitButton)
+
+        await waitFor(() => {
+          expect(mockAddToast).toHaveBeenCalledWith(
+            expect.objectContaining({ severity: 'success' }),
+          )
+        })
+      })
+
+      it('THEN should close the dialog after a successful submission', async () => {
+        const user = userEvent.setup()
+
+        await prepare({
+          documentLocale: 'en',
+          mocks: [buildMutationMock()],
+        })
+
+        await openLocaleOption(user, 'French')
+
+        const [, submitButton] = getActionButtons()
+
+        await user.click(submitButton)
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('dialog-title')).not.toBeInTheDocument()
+        })
+      })
+    })
+  })
+
+  describe('GIVEN the dialog actions', () => {
+    describe('WHEN the cancel button is clicked', () => {
+      it('THEN should close the dialog without calling the mutation', async () => {
+        const user = userEvent.setup()
+
+        await prepare()
+
+        expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
+
+        const [cancelButton] = getActionButtons()
+
+        await user.click(cancelButton)
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('dialog-title')).not.toBeInTheDocument()
+        })
+
+        expect(mockAddToast).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the dialog is closed and reopened', () => {
+      it('THEN should reset the form to its initial value', async () => {
+        const user = userEvent.setup()
+        const { ref } = await prepare({ documentLocale: 'en' })
+
+        await openLocaleOption(user, 'French')
+
+        await waitFor(() => {
+          const [, submitButton] = getActionButtons()
+
+          expect(submitButton).not.toBeDisabled()
+        })
+
+        await act(() => {
+          ref.current?.closeDialog()
+        })
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('dialog-title')).not.toBeInTheDocument()
+        })
+
+        await act(() => {
+          ref.current?.openDialog()
+        })
+
+        await waitFor(() => {
+          const combobox = screen.getByRole('combobox') as HTMLInputElement
+
+          expect(combobox.value).toBe('English')
+        })
+
+        const [, submitButton] = getActionButtons()
+
+        expect(submitButton).toBeDisabled()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Context

Migrate EditBillingEntityDocumentLocaleDialog from Formik + Yup to
TanStack Form + Zod. The legacy ref-based Dialog is retained and driven
via its native formId/formSubmit form wrapper.

Reuse the shared "Value is mandatory to move forward" key
(text_624ea7c29103fd010732ab7d) so submitting with the locale cleared
shows a proper required-field message instead of Zod's raw type error.