### PR TITLE
refactor(quotes): extract usePlanFormSetup from usePlanForm

### DIFF
--- a/src/hooks/plans/__tests__/usePlanFormSetup.test.ts
+++ b/src/hooks/plans/__tests__/usePlanFormSetup.test.ts
@@ -1,0 +1,408 @@
+import { renderHook } from '@testing-library/react'
+
+import { FORM_TYPE_ENUM } from '~/core/constants/form'
+import { CurrencyEnum } from '~/generated/graphql'
+
+import { usePlanFormSetup } from '../usePlanFormSetup'
+
+// --- Mocks ---
+
+const mockReset = jest.fn()
+const mockSetFieldValue = jest.fn()
+
+const mockForm = {
+  reset: mockReset,
+  setFieldValue: mockSetFieldValue,
+  store: {
+    subscribe: jest.fn(() => jest.fn()),
+    getState: () => ({ values: { charges: [], billChargesMonthly: false, interval: 'monthly' } }),
+  },
+}
+
+jest.mock('~/hooks/forms/useAppform', () => ({
+  useAppForm: (config: Record<string, unknown>) => {
+    // Capture defaultValues for assertions
+    capturedDefaultValues = config.defaultValues as Record<string, unknown>
+    capturedOnSubmit = config.onSubmit as (() => void) | undefined
+
+    return mockForm
+  },
+}))
+
+let capturedDefaultValues: Record<string, unknown> | undefined
+let capturedOnSubmit: (() => void) | undefined
+
+const mockBuildDefaultValues = jest.fn().mockReturnValue({ name: 'default-plan' })
+
+jest.mock('../usePlanForm', () => ({
+  buildDefaultValues: (...args: unknown[]) => mockBuildDefaultValues(...args),
+}))
+
+const mockFromPlanBillingItems = jest.fn()
+
+jest.mock('~/core/serializers/serializeQuotePlanBillingItems', () => ({
+  fromPlanBillingItems: (...args: unknown[]) => mockFromPlanBillingItems(...args),
+}))
+
+const mockUseGetSinglePlanQuery = jest.fn()
+const mockUseGetSubscriptionForQuotePricingQuery = jest.fn()
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useGetSinglePlanQuery: (...args: unknown[]) => mockUseGetSinglePlanQuery(...args),
+  useGetSubscriptionForQuotePricingQuery: (...args: unknown[]) =>
+    mockUseGetSubscriptionForQuotePricingQuery(...args),
+  LagoApiError: { NotFound: 'not_found' },
+  CurrencyEnum: { Usd: 'USD', Eur: 'EUR' },
+}))
+
+jest.mock('~/formValidation/planFormSchema', () => ({
+  planFormSchema: jest.fn(),
+}))
+
+jest.mock('@tanstack/react-form', () => ({
+  revalidateLogic: jest.fn(() => ({})),
+  useStore: (_store: unknown, selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ values: { charges: [], billChargesMonthly: false, interval: 'monthly' } }),
+}))
+
+jest.mock('~/components/plans/utils', () => ({
+  isPlanIntervalAnnual: jest.fn(() => false),
+}))
+
+// --- Helpers ---
+
+const mockPlan = {
+  id: 'plan-123',
+  amountCurrency: 'USD',
+  parent: null,
+}
+
+const mockSubscription = {
+  id: 'sub-1',
+  name: 'My Subscription',
+  externalId: 'ext-sub-1',
+  subscriptionAt: '2026-01-01',
+  endingAt: '2026-12-31',
+  billingTime: 'anniversary',
+  plan: {
+    id: 'child-plan-1',
+    parent: { id: 'parent-plan-1' },
+  },
+}
+
+// --- Tests ---
+
+describe('usePlanFormSetup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    capturedDefaultValues = undefined
+    capturedOnSubmit = undefined
+
+    mockUseGetSinglePlanQuery.mockReturnValue({ data: undefined, loading: false, error: undefined })
+    mockUseGetSubscriptionForQuotePricingQuery.mockReturnValue({ data: undefined })
+  })
+
+  describe('GIVEN no initialization source is provided', () => {
+    describe('WHEN the hook is rendered', () => {
+      it('THEN should return the form and loading as false', () => {
+        const { result } = renderHook(() => usePlanFormSetup({}))
+
+        expect(result.current.form).toBe(mockForm)
+        expect(result.current.loading).toBe(false)
+        expect(result.current.formReady).toBe(false)
+      })
+
+      it('THEN should skip both GraphQL queries', () => {
+        renderHook(() => usePlanFormSetup({}))
+
+        expect(mockUseGetSinglePlanQuery).toHaveBeenCalledWith(
+          expect.objectContaining({ skip: true }),
+        )
+        expect(mockUseGetSubscriptionForQuotePricingQuery).toHaveBeenCalledWith(
+          expect.objectContaining({ skip: true }),
+        )
+      })
+    })
+  })
+
+  describe('GIVEN a planIdToFetch (case 4)', () => {
+    describe('WHEN the plan query returns data', () => {
+      it('THEN should use the fetched plan and mark formReady', () => {
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: { plan: mockPlan },
+          loading: false,
+          error: undefined,
+        })
+
+        const { result } = renderHook(() => usePlanFormSetup({ planIdToFetch: 'plan-123' }))
+
+        expect(result.current.plan).toEqual(mockPlan)
+        expect(result.current.formReady).toBe(true)
+        expect(result.current.resolvedPlanId).toBe('plan-123')
+      })
+
+      it('THEN should call buildDefaultValues with the plan', () => {
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: { plan: mockPlan },
+          loading: false,
+          error: undefined,
+        })
+
+        renderHook(() =>
+          usePlanFormSetup({
+            planIdToFetch: 'plan-123',
+            initialCurrency: CurrencyEnum.Eur,
+            formType: FORM_TYPE_ENUM.edition,
+          }),
+        )
+
+        expect(mockBuildDefaultValues).toHaveBeenCalledWith(
+          mockPlan,
+          FORM_TYPE_ENUM.edition,
+          CurrencyEnum.Eur,
+          false,
+        )
+      })
+    })
+
+    describe('WHEN the plan query is loading', () => {
+      it('THEN should return loading as true', () => {
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: undefined,
+          loading: true,
+          error: undefined,
+        })
+
+        const { result } = renderHook(() => usePlanFormSetup({ planIdToFetch: 'plan-123' }))
+
+        expect(result.current.loading).toBe(true)
+      })
+    })
+  })
+
+  describe('GIVEN a billingItemPlan (case 2)', () => {
+    const billingItemPlan = {
+      id: 'plan-from-billing',
+      payload: { plan_name: 'Test Plan', plan_code: 'test' },
+      overrides: {},
+    }
+
+    describe('WHEN deserialized billing data has form values', () => {
+      it('THEN should use formValues from billing items and skip plan query', () => {
+        const mockDeserialized = {
+          formValues: { name: 'Deserialized Plan' },
+          subscriptionSettings: { externalId: 'ext-1' },
+          invoicingSettings: { paymentMethodId: 'pm-1' },
+        }
+
+        mockFromPlanBillingItems.mockReturnValue(mockDeserialized)
+
+        const { result } = renderHook(() =>
+          usePlanFormSetup({ billingItemPlan: billingItemPlan as never }),
+        )
+
+        expect(mockFromPlanBillingItems).toHaveBeenCalledWith([billingItemPlan])
+        expect(result.current.formReady).toBe(true)
+        expect(result.current.subscriptionSettings).toEqual(mockDeserialized.subscriptionSettings)
+        expect(result.current.invoicingSettings).toEqual(mockDeserialized.invoicingSettings)
+        expect(capturedDefaultValues).toEqual(mockDeserialized.formValues)
+      })
+
+      it('THEN should skip the plan query', () => {
+        mockFromPlanBillingItems.mockReturnValue({
+          formValues: { name: 'Plan' },
+          subscriptionSettings: {},
+          invoicingSettings: {},
+        })
+
+        renderHook(() => usePlanFormSetup({ billingItemPlan: billingItemPlan as never }))
+
+        expect(mockUseGetSinglePlanQuery).toHaveBeenCalledWith(
+          expect.objectContaining({ skip: true }),
+        )
+      })
+    })
+  })
+
+  describe('GIVEN a subscriptionId (case 3)', () => {
+    describe('WHEN the subscription query returns data with a parent plan', () => {
+      it('THEN should resolve to the parent plan ID', () => {
+        mockUseGetSubscriptionForQuotePricingQuery.mockReturnValue({
+          data: { subscription: mockSubscription },
+        })
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: undefined,
+          loading: false,
+          error: undefined,
+        })
+
+        const { result } = renderHook(() => usePlanFormSetup({ subscriptionId: 'sub-1' }))
+
+        expect(result.current.resolvedPlanId).toBe('parent-plan-1')
+      })
+
+      it('THEN should extract subscription settings from the query', () => {
+        mockUseGetSubscriptionForQuotePricingQuery.mockReturnValue({
+          data: { subscription: mockSubscription },
+        })
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: undefined,
+          loading: false,
+          error: undefined,
+        })
+
+        const { result } = renderHook(() => usePlanFormSetup({ subscriptionId: 'sub-1' }))
+
+        expect(result.current.subscriptionSettings).toEqual({
+          externalId: 'ext-sub-1',
+          subscriptionName: 'My Subscription',
+          billingTime: 'anniversary',
+          startDate: '2026-01-01',
+          endDate: '2026-12-31',
+        })
+      })
+
+      it('THEN should skip the plan query since subscriptionPlan is available', () => {
+        mockUseGetSubscriptionForQuotePricingQuery.mockReturnValue({
+          data: { subscription: mockSubscription },
+        })
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: undefined,
+          loading: false,
+          error: undefined,
+        })
+
+        renderHook(() => usePlanFormSetup({ subscriptionId: 'sub-1' }))
+
+        expect(mockUseGetSinglePlanQuery).toHaveBeenCalledWith(
+          expect.objectContaining({ skip: true }),
+        )
+      })
+    })
+
+    describe('WHEN the subscription has no parent plan (no overrides)', () => {
+      it('THEN should use the plan own ID as resolvedPlanId', () => {
+        const subscriptionWithoutParent = {
+          ...mockSubscription,
+          plan: { id: 'direct-plan', parent: null },
+        }
+
+        mockUseGetSubscriptionForQuotePricingQuery.mockReturnValue({
+          data: { subscription: subscriptionWithoutParent },
+        })
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: undefined,
+          loading: false,
+          error: undefined,
+        })
+
+        const { result } = renderHook(() => usePlanFormSetup({ subscriptionId: 'sub-1' }))
+
+        expect(result.current.resolvedPlanId).toBe('direct-plan')
+      })
+    })
+
+    describe('WHEN the subscription query has not loaded yet', () => {
+      it('THEN should return loading as true', () => {
+        mockUseGetSubscriptionForQuotePricingQuery.mockReturnValue({ data: undefined })
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: undefined,
+          loading: false,
+          error: undefined,
+        })
+
+        const { result } = renderHook(() => usePlanFormSetup({ subscriptionId: 'sub-1' }))
+
+        expect(result.current.loading).toBe(true)
+      })
+    })
+  })
+
+  describe('GIVEN billingItemPlan takes priority over subscriptionId', () => {
+    describe('WHEN both billingItemPlan and subscriptionId are provided', () => {
+      it('THEN should skip the subscription query', () => {
+        const billingItemPlan = {
+          id: 'plan-billing',
+          payload: {},
+          overrides: {},
+        }
+
+        mockFromPlanBillingItems.mockReturnValue({
+          formValues: { name: 'From Billing' },
+          subscriptionSettings: {},
+          invoicingSettings: {},
+        })
+
+        renderHook(() =>
+          usePlanFormSetup({
+            billingItemPlan: billingItemPlan as never,
+            subscriptionId: 'sub-1',
+          }),
+        )
+
+        expect(mockUseGetSubscriptionForQuotePricingQuery).toHaveBeenCalledWith(
+          expect.objectContaining({ skip: true }),
+        )
+      })
+    })
+  })
+
+  describe('GIVEN an onSubmit callback', () => {
+    describe('WHEN the hook initializes', () => {
+      it('THEN should pass onSubmit to useAppForm', () => {
+        const mockOnSubmit = jest.fn()
+
+        renderHook(() => usePlanFormSetup({ onSubmit: mockOnSubmit }))
+
+        expect(capturedOnSubmit).toBeDefined()
+      })
+    })
+  })
+
+  describe('GIVEN default currency resolution', () => {
+    describe('WHEN initialCurrency is provided', () => {
+      it('THEN should use initialCurrency', () => {
+        renderHook(() => usePlanFormSetup({ initialCurrency: CurrencyEnum.Eur }))
+
+        expect(mockBuildDefaultValues).toHaveBeenCalledWith(
+          undefined,
+          FORM_TYPE_ENUM.creation,
+          CurrencyEnum.Eur,
+          false,
+        )
+      })
+    })
+
+    describe('WHEN no initialCurrency and no plan data', () => {
+      it('THEN should default to USD', () => {
+        renderHook(() => usePlanFormSetup({}))
+
+        expect(mockBuildDefaultValues).toHaveBeenCalledWith(
+          undefined,
+          FORM_TYPE_ENUM.creation,
+          CurrencyEnum.Usd,
+          false,
+        )
+      })
+    })
+  })
+
+  describe('GIVEN the hook returns error from plan query', () => {
+    describe('WHEN the plan query errors', () => {
+      it('THEN should expose the error', () => {
+        const queryError = new Error('Plan not found')
+
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: undefined,
+          loading: false,
+          error: queryError,
+        })
+
+        const { result } = renderHook(() => usePlanFormSetup({ planIdToFetch: 'bad-id' }))
+
+        expect(result.current.error).toBe(queryError)
+      })
+    })
+  })
+})

--- a/src/hooks/plans/usePlanForm.tsx
+++ b/src/hooks/plans/usePlanForm.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
-import { revalidateLogic, useStore } from '@tanstack/react-form'
-import { useEffect, useMemo, useRef } from 'react'
+import { useStore } from '@tanstack/react-form'
+import { useEffect, useMemo } from 'react'
 import { generatePath, useParams, useSearchParams } from 'react-router-dom'
 
 import {
@@ -8,7 +8,7 @@ import {
   LocalUsageChargeInput,
   PlanFormInput,
 } from '~/components/plans/types'
-import { isPlanIntervalAnnual, transformFilterObjectToString } from '~/components/plans/utils'
+import { transformFilterObjectToString } from '~/components/plans/utils'
 import { REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE } from '~/components/subscriptions/SubscriptionUsageLifetimeGraph'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import {
@@ -32,7 +32,6 @@ import { serializePlanInput } from '~/core/serializers'
 import getPropertyShape from '~/core/serializers/getPropertyShape'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { scrollToTop } from '~/core/utils/domUtils'
-import { planFormSchema } from '~/formValidation/planFormSchema'
 import {
   CurrencyEnum,
   DeletePlanDialogFragmentDoc,
@@ -42,10 +41,9 @@ import {
   PlanDetailsV2FragmentDoc,
   PlanItemFragmentDoc,
   useCreatePlanMutation,
-  useGetSinglePlanQuery,
 } from '~/generated/graphql'
-import { useAppForm } from '~/hooks/forms/useAppform'
 import { useCustomPricingUnits } from '~/hooks/plans/useCustomPricingUnits'
+import { usePlanFormSetup } from '~/hooks/plans/usePlanFormSetup'
 import { usePlanUpdate } from '~/hooks/plans/usePlanUpdate'
 import { buildPlanSettingsValues } from '~/hooks/plans/utils'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
@@ -80,7 +78,7 @@ gql`
 
 export type PlanFormType = ReturnType<typeof usePlanForm>['form']
 
-const buildDefaultValues = (
+export const buildDefaultValues = (
   plan: EditPlanFragment | undefined | null,
   type: PLAN_FORM_TYPE,
   initialCurrency: CurrencyEnum,
@@ -216,11 +214,7 @@ export const usePlanForm = ({
   const { planId: id = '' } = useParams()
   const { hasAnyPricingUnitConfigured } = useCustomPricingUnits()
   const { parentId, type: actionType } = useDuplicatePlanVar()
-  const { data, loading, error } = useGetSinglePlanQuery({
-    context: { silentError: LagoApiError.NotFound },
-    variables: { id: id || (parentId as string) || (planIdToFetch as string) },
-    skip: !id && !parentId && !planIdToFetch,
-  })
+
   const isDuplicate = actionType === 'duplicate' && !!parentId
   const type = useMemo(() => {
     if (!!id) return FORM_TYPE_ENUM.edition
@@ -229,11 +223,13 @@ export const usePlanForm = ({
   }, [id, isDuplicate])
 
   const isEdition = type === FORM_TYPE_ENUM.edition
-  const plan = data?.plan
+
   const initialCurrency =
     type === FORM_TYPE_ENUM.creation && !isUsedInSubscriptionForm
       ? organization?.defaultCurrency || CurrencyEnum.Usd
-      : plan?.amountCurrency || CurrencyEnum.Usd
+      : undefined // let usePlanFormSetup derive from plan data
+
+  // --- Mutations (CRUD layer) ---
 
   const [create, { error: createError }] = useCreatePlanMutation({
     context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
@@ -301,13 +297,14 @@ export const usePlanForm = ({
     },
   })
 
-  const form = useAppForm({
-    defaultValues: buildDefaultValues(plan, type, initialCurrency, hasAnyPricingUnitConfigured),
-    validationLogic: revalidateLogic(),
-    validators: {
-      onDynamic: planFormSchema,
-    },
-    onSubmit: ({ value }) => {
+  // --- Delegate form setup to usePlanFormSetup ---
+
+  const { form, plan, loading, error } = usePlanFormSetup({
+    planIdToFetch: id || (parentId as string) || planIdToFetch,
+    initialCurrency,
+    formType: type,
+    hasAnyPricingUnitConfigured,
+    onSubmit: (value) => {
       const serializedInput = serializePlanInput(value)
 
       if (type === FORM_TYPE_ENUM.edition) {
@@ -326,6 +323,8 @@ export const usePlanForm = ({
     },
   })
 
+  // --- CRUD-specific effects (Router-dependent) ---
+
   const errorCode = useMemo(() => {
     if (hasDefinedGQLError('ValueAlreadyExist', createError || updateError)) {
       return FORM_ERRORS_ENUM.existingCode
@@ -333,18 +332,6 @@ export const usePlanForm = ({
 
     return undefined
   }, [createError, updateError])
-
-  // Re-initialize form when plan data loads (replaces enableReinitialize)
-  const prevPlanRef = useRef(plan)
-
-  useEffect(() => {
-    if (plan && plan !== prevPlanRef.current) {
-      form.reset(buildDefaultValues(plan, type, initialCurrency, hasAnyPricingUnitConfigured), {
-        keepDefaultValues: false,
-      })
-      prevPlanRef.current = plan
-    }
-  }, [plan, type, initialCurrency, hasAnyPricingUnitConfigured, form])
 
   // Clear duplicate plan var when leaving the page
   useEffect(() => {
@@ -363,7 +350,7 @@ export const usePlanForm = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [error])
 
-  // Propagate server-side code error to TanStack form (same pattern as CreateCoupon)
+  // Propagate server-side code error to TanStack form
   useEffect(() => {
     if (errorCode === FORM_ERRORS_ENUM.existingCode) {
       form.setFieldMeta('code', (meta) => ({
@@ -389,19 +376,6 @@ export const usePlanForm = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [codeValue])
-
-  // Auto-reset billChargesMonthly when conditions aren't met
-  const charges = useStore(form.store, (s) => s.values.charges)
-  const billChargesMonthly = useStore(form.store, (s) => s.values.billChargesMonthly)
-  const interval = useStore(form.store, (s) => s.values.interval)
-  const isAnnual = isPlanIntervalAnnual(interval)
-
-  useEffect(() => {
-    if ((!charges || !charges.length || !isAnnual) && !!billChargesMonthly) {
-      form.setFieldValue('billChargesMonthly', false)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [charges, billChargesMonthly, interval])
 
   return useMemo(
     () => ({

--- a/src/hooks/plans/usePlanFormSetup.ts
+++ b/src/hooks/plans/usePlanFormSetup.ts
@@ -1,0 +1,180 @@
+import { gql } from '@apollo/client'
+import { revalidateLogic, useStore } from '@tanstack/react-form'
+import { useEffect, useMemo, useRef } from 'react'
+
+import type { PlanFormInput } from '~/components/plans/types'
+import { isPlanIntervalAnnual } from '~/components/plans/utils'
+import { type PLAN_FORM_TYPE } from '~/core/apolloClient/reactiveVars/duplicatePlanVar'
+import { FORM_TYPE_ENUM } from '~/core/constants/form'
+import {
+  BillingItemPlan,
+  fromPlanBillingItems,
+} from '~/core/serializers/serializeQuotePlanBillingItems'
+import { planFormSchema } from '~/formValidation/planFormSchema'
+import {
+  CurrencyEnum,
+  type EditPlanFragment,
+  LagoApiError,
+  useGetSinglePlanQuery,
+  useGetSubscriptionForQuotePricingQuery,
+} from '~/generated/graphql'
+import { useAppForm } from '~/hooks/forms/useAppform'
+
+import { buildDefaultValues } from './usePlanForm'
+
+gql`
+  query getSubscriptionForQuotePricing($subscriptionId: ID!) {
+    subscription(id: $subscriptionId) {
+      id
+      name
+      externalId
+      subscriptionAt
+      endingAt
+      billingTime
+      plan {
+        id
+        parent {
+          id
+        }
+        ...EditPlan
+      }
+    }
+  }
+`
+
+/**
+ * Lightweight hook that fetches a plan by ID and creates a TanStack form.
+ * No Router, no mutations, no navigation — safe to use in drawers and other
+ * non-routed contexts.
+ *
+ * `usePlanForm` calls this internally and layers CRUD on top via `onSubmit`.
+ *
+ * Three initialization paths:
+ *  Case 2: billingItemPlan — form values come from deserialized billing items
+ *  Case 3: subscriptionId — fetch subscription's plan (override child plan → parent)
+ *  Case 4: planIdToFetch — existing behavior (fetch plan by id directly)
+ */
+export const usePlanFormSetup = ({
+  planIdToFetch,
+  initialCurrency,
+  formType = FORM_TYPE_ENUM.creation,
+  hasAnyPricingUnitConfigured = false,
+  onSubmit,
+  billingItemPlan,
+  subscriptionId,
+}: {
+  planIdToFetch?: string
+  initialCurrency?: CurrencyEnum
+  formType?: PLAN_FORM_TYPE
+  hasAnyPricingUnitConfigured?: boolean
+  onSubmit?: (value: PlanFormInput) => void
+  billingItemPlan?: BillingItemPlan
+  subscriptionId?: string
+}) => {
+  // Case 2: billing item deserialization
+  const billingItemData = useMemo(
+    () => (billingItemPlan ? fromPlanBillingItems([billingItemPlan]) : null),
+    [billingItemPlan],
+  )
+
+  // Case 3: subscription query
+  const { data: subscriptionData } = useGetSubscriptionForQuotePricingQuery({
+    variables: { subscriptionId: subscriptionId as string },
+    skip: !subscriptionId || !!billingItemPlan,
+  })
+  const subscription = subscriptionData?.subscription
+  const subscriptionPlan = subscription?.plan
+  // If the subscription has overrides, plan.parent is the original plan.
+  // If no overrides, plan IS the original — use its own ID.
+  const parentPlanId = subscriptionPlan?.parent?.id ?? subscriptionPlan?.id
+
+  // Extract subscription settings from case 3 subscription query
+  const subscriptionQuerySettings = subscription
+    ? {
+        externalId: subscription.externalId ?? '',
+        subscriptionName: subscription.name ?? '',
+        billingTime: (subscription.billingTime ?? 'anniversary') as 'anniversary' | 'calendar',
+        startDate: subscription.subscriptionAt ?? '',
+        endDate: subscription.endingAt ?? '',
+      }
+    : undefined
+
+  // Resolve which plan ID to fetch (case 4 / case 3 fallback)
+  const resolvedPlanId = billingItemPlan?.id ?? parentPlanId ?? planIdToFetch
+
+  // Cases 2 & 3 don't need a separate plan query
+  const skipPlanQuery = !!billingItemPlan || !!subscriptionPlan
+  const {
+    data,
+    loading: planLoading,
+    error,
+  } = useGetSinglePlanQuery({
+    context: { silentError: LagoApiError.NotFound },
+    variables: { id: resolvedPlanId as string },
+    skip: !resolvedPlanId || skipPlanQuery,
+  })
+
+  const plan = skipPlanQuery ? undefined : data?.plan
+  const effectivePlan = plan ?? (subscriptionPlan as EditPlanFragment | undefined)
+  const currency =
+    initialCurrency || (effectivePlan?.amountCurrency as CurrencyEnum) || CurrencyEnum.Usd
+
+  const form = useAppForm({
+    defaultValues:
+      billingItemData?.formValues ??
+      buildDefaultValues(effectivePlan, formType, currency, hasAnyPricingUnitConfigured),
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: planFormSchema,
+    },
+    onSubmit: onSubmit ? ({ value }) => onSubmit(value) : undefined,
+  })
+
+  // Re-initialize form when plan data or billing item data loads
+  const prevPlanRef = useRef(effectivePlan)
+  const prevBillingItemRef = useRef(billingItemData)
+
+  useEffect(() => {
+    if (billingItemData?.formValues && billingItemData !== prevBillingItemRef.current) {
+      form.reset(billingItemData.formValues, { keepDefaultValues: false })
+      prevBillingItemRef.current = billingItemData
+      return
+    }
+    if (effectivePlan && effectivePlan !== prevPlanRef.current) {
+      form.reset(
+        buildDefaultValues(effectivePlan, formType, currency, hasAnyPricingUnitConfigured),
+        { keepDefaultValues: false },
+      )
+      prevPlanRef.current = effectivePlan
+    }
+  }, [effectivePlan, billingItemData, formType, currency, hasAnyPricingUnitConfigured, form])
+
+  // Auto-reset billChargesMonthly when conditions aren't met
+  const charges = useStore(form.store, (s) => s.values.charges)
+  const billChargesMonthly = useStore(form.store, (s) => s.values.billChargesMonthly)
+  const interval = useStore(form.store, (s) => s.values.interval)
+  const isAnnual = isPlanIntervalAnnual(interval)
+
+  useEffect(() => {
+    if ((!charges || !charges.length || !isAnnual) && !!billChargesMonthly) {
+      form.setFieldValue('billChargesMonthly', false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [charges, billChargesMonthly, interval])
+
+  const loading = planLoading || (!!subscriptionId && !subscriptionData && !billingItemPlan)
+
+  // Form is ready when we have data from any source
+  const formReady = !!billingItemData?.formValues || !!effectivePlan
+
+  return {
+    form,
+    plan: effectivePlan as EditPlanFragment | undefined,
+    formReady,
+    loading,
+    error,
+    resolvedPlanId,
+    subscriptionSettings: billingItemData?.subscriptionSettings ?? subscriptionQuerySettings,
+    invoicingSettings: billingItemData?.invoicingSettings,
+  }
+}


### PR DESCRIPTION
## Summary
**PR 2 of 4** in the subscription pricing drawer stack (split from #3653).

- Extract plan form initialization logic into a dedicated `usePlanFormSetup` hook
- Three initialization paths: empty plan, existing plan, and subscription-based
- Comprehensive GIVEN/WHEN/THEN tests for all paths

## Stack
1. #3677 — Types + Serializer
2. **This PR** — Plan form refactor
3. #3679 — Settings drawer hooks
4. #3680 — UI wiring

## Test plan
- [x] `usePlanFormSetup` tests pass
- [ ] Existing `usePlanForm` behavior unchanged
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)