### PR TITLE
feat(quotes): wire subscription pricing UI and drawer routing

### DIFF
--- a/src/components/designSystem/RichTextEditor/PricingBlock/PricingDrawerContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/PricingDrawerContent.tsx
@@ -1,22 +1,15 @@
-import {
-  type AddOnForPricingSectionFragment,
-  CurrencyEnum,
-  OrderTypeEnum,
-} from '~/generated/graphql'
+import { type AddOnForPricingSectionFragment, CurrencyEnum } from '~/generated/graphql'
 import { withForm } from '~/hooks/forms/useAppform'
 
 import AddOnSelectionContent from './AddOnSelectionContent'
 import { pricingDrawerDefaultValues } from './constants'
-import PlanSelectionContent from './PlanSelectionContent'
 
 interface PricingDrawerContentExtraProps {
-  quoteType: OrderTypeEnum
   currency: CurrencyEnum
   onAddOnPayloadCapture?: (localId: string, addOn: AddOnForPricingSectionFragment) => void
 }
 
 const pricingDrawerContentDefaultProps: PricingDrawerContentExtraProps = {
-  quoteType: OrderTypeEnum.OneOff,
   currency: CurrencyEnum.Usd,
   onAddOnPayloadCapture: undefined,
 }
@@ -24,15 +17,7 @@ const pricingDrawerContentDefaultProps: PricingDrawerContentExtraProps = {
 const PricingDrawerContent = withForm({
   defaultValues: pricingDrawerDefaultValues,
   props: pricingDrawerContentDefaultProps,
-  render: function PricingDrawerContent({ form, quoteType, currency, onAddOnPayloadCapture }) {
-    const isPlanSelection =
-      quoteType === OrderTypeEnum.SubscriptionCreation ||
-      quoteType === OrderTypeEnum.SubscriptionAmendment
-
-    if (isPlanSelection) {
-      return <PlanSelectionContent form={form} />
-    }
-
+  render: function PricingDrawerContent({ form, currency, onAddOnPayloadCapture }) {
     return (
       <AddOnSelectionContent
         form={form}

--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
@@ -1,0 +1,424 @@
+import { useStore } from '@tanstack/react-form'
+import { type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { Button } from '~/components/designSystem/Button'
+import { Chip } from '~/components/designSystem/Chip'
+import { Selector, SelectorActions } from '~/components/designSystem/Selector'
+import { Tooltip } from '~/components/designSystem/Tooltip'
+import { Typography } from '~/components/designSystem/Typography'
+import { ComboBox } from '~/components/form/ComboBox/ComboBox'
+import { CenteredPage } from '~/components/layouts/CenteredPage'
+import { CommitmentsSection } from '~/components/plans/CommitmentsSection'
+import {
+  SubscriptionFeeDrawer,
+  type SubscriptionFeeDrawerRef,
+  type SubscriptionFeeFormValues,
+} from '~/components/plans/drawers/subscriptionFee/SubscriptionFeeDrawer'
+import { FixedChargesSection } from '~/components/plans/form/FixedChargesSection'
+import { ProgressiveBillingSection } from '~/components/plans/ProgressiveBillingSection'
+import type { LocalUsageChargeInput, PlanFormInput } from '~/components/plans/types'
+import { UsageChargesSection } from '~/components/plans/UsageChargesSection'
+import { PlanFormProvider } from '~/contexts/PlanFormContext'
+import { getIntervalTranslationKey } from '~/core/constants/form'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import {
+  type BillingItemPlan,
+  DEFAULT_INVOICING_SETTINGS,
+  DEFAULT_SUBSCRIPTION_SETTINGS,
+  type PlanOverrides,
+  type SubscriptionPricingState,
+} from '~/core/serializers/serializeQuotePlanBillingItems'
+import { CurrencyEnum, PlanInterval, usePlansQuery } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { usePlanFormSetup } from '~/hooks/plans/usePlanFormSetup'
+import type { QuoteCustomer } from '~/pages/quotes/hooks/useSubscriptionPricingDrawer'
+
+import { useInvoicingPaymentsSettingsDrawer } from './useInvoicingPaymentsSettingsDrawer'
+import { useQuotePlanSettingsDrawer } from './useQuotePlanSettingsDrawer'
+import { useSubscriptionSettingsDrawer } from './useSubscriptionSettingsDrawer'
+
+interface SubscriptionPricingContentProps {
+  stateRef: MutableRefObject<SubscriptionPricingState | null>
+  formValuesRef: MutableRefObject<PlanFormInput | null>
+  initialState?: SubscriptionPricingState | null
+  quoteDates?: { startDate?: string; endDate?: string }
+  customer?: QuoteCustomer | null
+  billingItemPlan?: BillingItemPlan
+  subscriptionId?: string
+}
+
+export function SubscriptionPricingContent({
+  stateRef,
+  formValuesRef,
+  initialState,
+  quoteDates,
+  customer,
+  billingItemPlan,
+  subscriptionId,
+}: SubscriptionPricingContentProps) {
+  const { translate } = useInternationalization()
+
+  // Plan selection
+  const [selectedPlanId, setSelectedPlanId] = useState(initialState?.planId || '')
+
+  const { data: plansData, loading: plansLoading } = usePlansQuery({
+    variables: { limit: 100 },
+  })
+
+  // Plan form — fetches plan by ID and creates TanStack form (no Router needed)
+  const {
+    form: planForm,
+    plan: planData,
+    formReady,
+    resolvedPlanId,
+    subscriptionSettings: billingItemSubscriptionSettings,
+    invoicingSettings: billingItemInvoicingSettings,
+  } = usePlanFormSetup({
+    planIdToFetch: selectedPlanId || undefined,
+    billingItemPlan,
+    subscriptionId,
+  })
+
+  // Sync selectedPlanId from resolvedPlanId when billing items or subscription data arrives
+  useEffect(() => {
+    if (resolvedPlanId && !selectedPlanId) {
+      setSelectedPlanId(resolvedPlanId)
+    }
+  }, [resolvedPlanId, selectedPlanId])
+
+  // Quote-specific state
+  const [subscriptionSettings, setSubscriptionSettings] = useState(() => {
+    if (initialState?.subscriptionSettings) return initialState.subscriptionSettings
+    if (billingItemSubscriptionSettings) return billingItemSubscriptionSettings
+
+    return {
+      ...DEFAULT_SUBSCRIPTION_SETTINGS,
+      startDate: quoteDates?.startDate ?? '',
+      endDate: quoteDates?.endDate ?? '',
+    }
+  })
+  const [invoicingSettings, setInvoicingSettings] = useState(
+    initialState?.invoicingSettings ?? billingItemInvoicingSettings ?? DEFAULT_INVOICING_SETTINGS,
+  )
+
+  // Hook-based drawers for settings
+  const subscriptionSettingsDrawer = useSubscriptionSettingsDrawer(
+    (values) => setSubscriptionSettings(values),
+    !!subscriptionId,
+  )
+  const invoicingSettingsDrawer = useInvoicingPaymentsSettingsDrawer(
+    (values) => setInvoicingSettings(values),
+    customer,
+  )
+  const showInvoicingSection = invoicingSettingsDrawer.showSection
+  const planSettingsDrawer = useQuotePlanSettingsDrawer(planForm)
+
+  // Subscription fee drawer (grouped with plan settings section)
+  const subscriptionFeeDrawerRef = useRef<SubscriptionFeeDrawerRef>(null)
+
+  const handleSubscriptionFeeSave = useCallback(
+    (values: SubscriptionFeeFormValues) => {
+      planForm.setFieldValue('amountCents', values.amountCents)
+      planForm.setFieldValue('payInAdvance', values.payInAdvance)
+      planForm.setFieldValue('trialPeriod', values.trialPeriod)
+      planForm.setFieldValue('invoiceDisplayName', values.invoiceDisplayName)
+    },
+    [planForm],
+  )
+
+  // Watch form values for override computation and display
+  const formAmountCents = useStore(planForm.store, (s) => s.values.amountCents)
+  const formInvoiceDisplayName = useStore(planForm.store, (s) => s.values.invoiceDisplayName)
+  const formPayInAdvance = useStore(planForm.store, (s) => s.values.payInAdvance)
+  const formTrialPeriod = useStore(planForm.store, (s) => s.values.trialPeriod)
+  const formName = useStore(planForm.store, (s) => s.values.name)
+  const formDescription = useStore(planForm.store, (s) => s.values.description)
+  const formCode = useStore(planForm.store, (s) => s.values.code)
+  const formCurrency = useStore(planForm.store, (s) => s.values.amountCurrency)
+  const formInterval = useStore(planForm.store, (s) => s.values.interval)
+  const formFixedCharges = useStore(planForm.store, (s) => s.values.fixedCharges)
+  const formCharges = useStore(planForm.store, (s) => s.values.charges)
+  const formMinimumCommitment = useStore(planForm.store, (s) => s.values.minimumCommitment)
+  const formNonRecurringThresholds = useStore(
+    planForm.store,
+    (s) => s.values.nonRecurringUsageThresholds,
+  )
+  const formRecurringThreshold = useStore(planForm.store, (s) => s.values.recurringUsageThreshold)
+
+  const displayCurrency = (formCurrency as CurrencyEnum) || CurrencyEnum.Usd
+  const displayInterval = formInterval || PlanInterval.Monthly
+
+  // Sync to stateRef — compute overrides from form state vs original plan
+  useEffect(() => {
+    if (!formReady || !selectedPlanId) {
+      stateRef.current = null
+      return
+    }
+
+    // Always serialize the full form state as overrides — the backend applies them on top of the plan
+    const overrides: PlanOverrides = {}
+
+    // Subscription fee
+    overrides.amount_cents = Number(formAmountCents) || undefined
+    if (formInvoiceDisplayName) {
+      overrides.invoice_display_name = formInvoiceDisplayName || undefined
+    }
+
+    // Fixed charges
+    if (formFixedCharges?.length) {
+      overrides.charges = [
+        ...formFixedCharges.map((c) => ({
+          billable_metric_code: c.addOn?.code ?? '',
+          charge_model: c.chargeModel,
+          properties: (c.properties ?? {}) as Record<string, unknown>,
+        })),
+      ]
+    }
+
+    // Usage charges
+    if (formCharges?.length) {
+      overrides.charges = [
+        ...(overrides.charges ?? []),
+        ...formCharges.map((c) => ({
+          billable_metric_code: c.billableMetric?.code ?? '',
+          charge_model: c.chargeModel,
+          properties: (c.properties ?? {}) as Record<string, unknown>,
+        })),
+      ]
+    }
+
+    // Minimum commitment
+    const mcAmount = formMinimumCommitment?.amountCents
+
+    if (mcAmount && !isNaN(Number(mcAmount)) && Number(mcAmount) > 0) {
+      overrides.minimum_commitment = {
+        amount_cents: Number(mcAmount),
+        invoice_display_name: formMinimumCommitment?.invoiceDisplayName || undefined,
+      }
+    }
+
+    // Progressive billing (usage thresholds)
+    const thresholds = [
+      ...(formNonRecurringThresholds ?? []).map((t) => ({
+        amount_cents: Number(t.amountCents),
+        recurring: false as const,
+        threshold_display_name: t.thresholdDisplayName ?? undefined,
+      })),
+      ...(formRecurringThreshold
+        ? [
+            {
+              amount_cents: Number(formRecurringThreshold.amountCents),
+              recurring: true as const,
+              threshold_display_name: formRecurringThreshold.thresholdDisplayName ?? undefined,
+            },
+          ]
+        : []),
+    ]
+
+    if (thresholds.length) {
+      overrides.usage_thresholds = thresholds
+    }
+
+    stateRef.current = {
+      planId: planData?.id ?? selectedPlanId,
+      planCode: formCode,
+      planName: formName,
+      planDescription: formDescription ?? '',
+      subscriptionSettings,
+      invoicingSettings,
+      overrides,
+    }
+
+    formValuesRef.current = planForm.state.values
+  }, [
+    formReady,
+    planData,
+    selectedPlanId,
+    subscriptionSettings,
+    invoicingSettings,
+    formAmountCents,
+    formInvoiceDisplayName,
+    formName,
+    formDescription,
+    formCode,
+    formFixedCharges,
+    formCharges,
+    formMinimumCommitment,
+    formNonRecurringThresholds,
+    formRecurringThreshold,
+    stateRef,
+    formValuesRef,
+    planForm,
+  ])
+
+  // ComboBox data
+  const comboBoxData = useMemo(() => {
+    const plans = plansData?.plans?.collection ?? []
+
+    return plans.map((p) => ({
+      value: p.id,
+      label: `${p.name} (${p.code})`,
+    }))
+  }, [plansData])
+
+  // Shared selector helpers for custom sections
+  const buildEndContent = (showInterval = false) => (
+    <div className="flex items-center gap-3">
+      {showInterval && <Chip label={translate(getIntervalTranslationKey[displayInterval])} />}
+      <Tooltip placement="top-end" title={translate('text_17719630334671lxunwzo7ae')}>
+        <Button icon="chevron-right-filled" variant="quaternary" tabIndex={-1} />
+      </Tooltip>
+    </div>
+  )
+
+  const buildHoverActions = (onEdit: () => void) => (
+    <SelectorActions
+      actions={[
+        {
+          icon: 'pen',
+          tooltipCopy: translate('text_63e51ef4985f0ebd75c212fc'),
+          onClick: (e) => {
+            e.stopPropagation()
+            onEdit()
+          },
+        },
+      ]}
+    />
+  )
+
+  // Drawer open handlers
+  const openSubscriptionSettings = () => subscriptionSettingsDrawer.openDrawer(subscriptionSettings)
+
+  const openInvoicingSettings = () => invoicingSettingsDrawer.openDrawer(invoicingSettings)
+
+  const openPlanSettings = () => planSettingsDrawer.openDrawer()
+
+  const openSubscriptionFeeDrawer = () =>
+    subscriptionFeeDrawerRef.current?.openDrawer({
+      amountCents: formAmountCents || '',
+      payInAdvance: formPayInAdvance || false,
+      trialPeriod: formTrialPeriod ?? 0,
+      invoiceDisplayName: formInvoiceDisplayName || undefined,
+    })
+
+  const formattedFee = intlFormatNumber(Number(formAmountCents || 0), {
+    style: 'currency',
+    currency: displayCurrency,
+  })
+
+  return (
+    <CenteredPage.SubsectionWrapper>
+      {/* 1. Plan selection */}
+      <div className="flex flex-col gap-12">
+        <div className="flex flex-col gap-1">
+          <Typography variant="headline">{translate('text_17791987800302plb0guzxzv')}</Typography>
+          <Typography variant="body" color="grey600">
+            {translate('text_1781191156548mkw3alklhhh')}
+          </Typography>
+        </div>
+        <CenteredPage.PageSection>
+          <CenteredPage.PageSectionTitle
+            title={translate('text_65118a52df984447c186940f', {
+              customerName: customer?.name,
+            })}
+            description={translate('text_1781099100337s3ou7wd0l4z')}
+          />
+          <ComboBox
+            data={comboBoxData}
+            loading={plansLoading}
+            disabled={!!subscriptionId}
+            label={translate('text_17810991003371jgudmuzk6a')}
+            placeholder={translate('text_1781099100337xeyy7omuzp8')}
+            value={selectedPlanId}
+            onChange={(value) => {
+              if (value) setSelectedPlanId(value)
+            }}
+          />
+        </CenteredPage.PageSection>
+      </div>
+
+      {!!selectedPlanId && formReady && (
+        <>
+          {/* 2. Subscription settings */}
+          <CenteredPage.PageSection>
+            <CenteredPage.PageSectionTitle
+              title={translate('text_17791987800304a3fihrighy')}
+              description={translate('text_17810991003377o8vcthggta')}
+            />
+            <Selector
+              icon="settings"
+              title={translate('text_17791987800304a3fihrighy')}
+              endContent={buildEndContent()}
+              hoverActions={buildHoverActions(openSubscriptionSettings)}
+              onClick={openSubscriptionSettings}
+            />
+          </CenteredPage.PageSection>
+
+          {/* 3. Invoicing & payments settings (feature-flagged) */}
+          {showInvoicingSection && (
+            <CenteredPage.PageSection>
+              <CenteredPage.PageSectionTitle
+                title={translate('text_17791987800309g2j0x3t2n0')}
+                description={translate('text_1781099100337xfqzt0jxvj5')}
+              />
+              <Selector
+                icon="receipt"
+                title={translate('text_17791987800309g2j0x3t2n0')}
+                endContent={buildEndContent()}
+                hoverActions={buildHoverActions(openInvoicingSettings)}
+                onClick={openInvoicingSettings}
+              />
+            </CenteredPage.PageSection>
+          )}
+
+          {/* 4. Plan settings + Subscription fee */}
+          <CenteredPage.PageSection>
+            <CenteredPage.PageSectionTitle
+              title={translate('text_177928991586601f21f0x87c')}
+              description={translate('text_1781099100338qnx3kgjyv14')}
+            />
+            <Selector
+              icon="board"
+              title={translate('text_177928991586601f21f0x87c')}
+              endContent={buildEndContent()}
+              hoverActions={buildHoverActions(openPlanSettings)}
+              onClick={openPlanSettings}
+            />
+            <Selector
+              icon="coin-dollar"
+              title={formInvoiceDisplayName || translate('text_1779289915866etwoweh1syv')}
+              subtitle={formattedFee}
+              endContent={buildEndContent(true)}
+              hoverActions={buildHoverActions(openSubscriptionFeeDrawer)}
+              onClick={openSubscriptionFeeDrawer}
+            />
+          </CenteredPage.PageSection>
+
+          {/* 5-9. Reused plan form sections */}
+          <PlanFormProvider currency={displayCurrency} interval={displayInterval}>
+            <FixedChargesSection
+              form={planForm}
+              alreadyExistingFixedChargesIds={planData?.fixedCharges?.map((c) => c.id) || []}
+              isEdition={false}
+            />
+
+            <UsageChargesSection
+              form={planForm}
+              alreadyExistingCharges={(planData?.charges ?? []) as LocalUsageChargeInput[]}
+              isEdition={false}
+            />
+
+            <CommitmentsSection form={planForm} />
+
+            <ProgressiveBillingSection form={planForm} />
+
+            <SubscriptionFeeDrawer
+              ref={subscriptionFeeDrawerRef}
+              onSave={handleSubscriptionFeeSave}
+            />
+          </PlanFormProvider>
+        </>
+      )}
+    </CenteredPage.SubsectionWrapper>
+  )
+}

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/PricingDrawerContent.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/PricingDrawerContent.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { CurrencyEnum, OrderTypeEnum } from '~/generated/graphql'
+import { CurrencyEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
 import { type AddOnItem, pricingDrawerDefaultValues } from '../constants'
@@ -31,14 +31,12 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 
 // Helper to render with a form wrapper
 const renderWithForm = ({
-  quoteType,
   currency = CurrencyEnum.Usd,
   initialValues,
 }: {
-  quoteType: OrderTypeEnum
   currency?: CurrencyEnum
   initialValues?: { planId?: string; addOnItems?: AddOnItem[] }
-}) => {
+} = {}) => {
   // We use a wrapper component that creates the form via useAppForm
   // and passes it to PricingDrawerContent
   const { useAppForm: useAppFormHook } = jest.requireActual('~/hooks/forms/useAppform')
@@ -52,7 +50,7 @@ const renderWithForm = ({
       },
     })
 
-    return <PricingDrawerContent form={form} quoteType={quoteType} currency={currency} />
+    return <PricingDrawerContent form={form} currency={currency} />
   }
 
   return render(<Wrapper />)
@@ -73,47 +71,6 @@ describe('PricingDrawerContent', () => {
     })
   })
 
-  describe('GIVEN the quote type is SubscriptionCreation', () => {
-    describe('WHEN plans data is loaded', () => {
-      it('THEN should render a plan combobox', () => {
-        mockUsePlansQuery.mockReturnValue({
-          data: {
-            plans: {
-              collection: [
-                { id: 'plan-1', name: 'Basic', code: 'basic' },
-                { id: 'plan-2', name: 'Pro', code: 'pro' },
-              ],
-            },
-          },
-          loading: false,
-        })
-
-        renderWithForm({ quoteType: OrderTypeEnum.SubscriptionCreation })
-
-        expect(screen.getByRole('combobox')).toBeInTheDocument()
-      })
-    })
-  })
-
-  describe('GIVEN the quote type is SubscriptionAmendment', () => {
-    describe('WHEN plans data is loaded', () => {
-      it('THEN should render a plan combobox', () => {
-        mockUsePlansQuery.mockReturnValue({
-          data: {
-            plans: {
-              collection: [{ id: 'plan-1', name: 'Starter', code: 'starter' }],
-            },
-          },
-          loading: false,
-        })
-
-        renderWithForm({ quoteType: OrderTypeEnum.SubscriptionAmendment })
-
-        expect(screen.getByRole('combobox')).toBeInTheDocument()
-      })
-    })
-  })
-
   describe('GIVEN the quote type is OneOff', () => {
     describe('WHEN add-ons data is loaded', () => {
       it('THEN should render an add-on button', () => {
@@ -129,7 +86,7 @@ describe('PricingDrawerContent', () => {
           loading: false,
         })
 
-        renderWithForm({ quoteType: OrderTypeEnum.OneOff })
+        renderWithForm()
 
         expect(screen.getByTestId('add-add-on-button')).toBeInTheDocument()
       })
@@ -143,7 +100,6 @@ describe('PricingDrawerContent', () => {
         })
 
         renderWithForm({
-          quoteType: OrderTypeEnum.OneOff,
           initialValues: {
             addOnItems: [
               {
@@ -176,7 +132,6 @@ describe('PricingDrawerContent', () => {
         })
 
         renderWithForm({
-          quoteType: OrderTypeEnum.OneOff,
           initialValues: {
             addOnItems: [
               {
@@ -209,30 +164,13 @@ describe('PricingDrawerContent', () => {
   })
 
   describe('GIVEN the query configuration', () => {
-    it('THEN should fetch plans with correct options for subscription creation', () => {
-      mockUsePlansQuery.mockReturnValue({
-        data: { plans: { collection: [] } },
-        loading: false,
-      })
-
-      renderWithForm({ quoteType: OrderTypeEnum.SubscriptionCreation })
-
-      expect(mockUsePlansQuery).toHaveBeenCalledWith(
-        expect.objectContaining({
-          variables: { limit: 100 },
-          fetchPolicy: 'network-only',
-          nextFetchPolicy: 'network-only',
-        }),
-      )
-    })
-
     it('THEN should not call plans query for one-off quote type', () => {
       mockUseGetAddOnsForPricingSectionQuery.mockReturnValue({
         data: { addOns: { collection: [] } },
         loading: false,
       })
 
-      renderWithForm({ quoteType: OrderTypeEnum.OneOff })
+      renderWithForm()
 
       expect(mockUsePlansQuery).not.toHaveBeenCalled()
     })
@@ -243,7 +181,7 @@ describe('PricingDrawerContent', () => {
         loading: false,
       })
 
-      renderWithForm({ quoteType: OrderTypeEnum.OneOff })
+      renderWithForm()
 
       expect(mockUseGetAddOnsForPricingSectionQuery).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -252,17 +190,6 @@ describe('PricingDrawerContent', () => {
           nextFetchPolicy: 'network-only',
         }),
       )
-    })
-
-    it('THEN should not call add-ons query for subscription creation quote type', () => {
-      mockUsePlansQuery.mockReturnValue({
-        data: { plans: { collection: [] } },
-        loading: false,
-      })
-
-      renderWithForm({ quoteType: OrderTypeEnum.SubscriptionCreation })
-
-      expect(mockUseGetAddOnsForPricingSectionQuery).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
@@ -1,0 +1,176 @@
+import { act, screen } from '@testing-library/react'
+
+import type { PlanFormInput } from '~/components/plans/types'
+import {
+  DEFAULT_INVOICING_SETTINGS,
+  DEFAULT_SUBSCRIPTION_SETTINGS,
+  type SubscriptionPricingState,
+} from '~/core/serializers/serializeQuotePlanBillingItems'
+import { CurrencyEnum, PlanInterval } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import { SubscriptionPricingContent } from '../SubscriptionPricingContent'
+
+const mockPlan = {
+  id: 'plan_1',
+  name: 'Starter',
+  code: 'starter',
+  description: '',
+  interval: PlanInterval.Monthly,
+  amountCents: '5000',
+  amountCurrency: CurrencyEnum.Usd,
+  payInAdvance: false,
+  invoiceDisplayName: '',
+  trialPeriod: 0,
+  fixedCharges: [],
+  charges: [],
+  minimumCommitment: null,
+  usageThresholds: [],
+  subscriptionsCount: 0,
+  billChargesMonthly: false,
+  hasOverriddenPlans: false,
+  billFixedChargesMonthly: false,
+  taxes: [],
+  entitlements: [],
+}
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  usePlansQuery: jest.fn(() => ({
+    data: {
+      plans: {
+        collection: [{ id: 'plan_1', name: 'Starter', code: 'starter' }],
+      },
+    },
+    loading: false,
+  })),
+}))
+
+// Mock usePlanFormSetup — returns a mock form + plan when planIdToFetch is set
+jest.mock('~/hooks/plans/usePlanFormSetup', () => {
+  const { createMockPlanForm } = jest.requireActual('~/test-utils/createMockPlanForm')
+
+  return {
+    usePlanFormSetup: jest.fn(({ planIdToFetch }: { planIdToFetch?: string }) => ({
+      form: createMockPlanForm(),
+      plan: planIdToFetch ? mockPlan : undefined,
+      formReady: !!planIdToFetch,
+      loading: false,
+      resolvedPlanId: planIdToFetch,
+      subscriptionSettings: undefined,
+      invoicingSettings: undefined,
+    })),
+  }
+})
+
+// Mock hook-based drawers
+jest.mock('../useSubscriptionSettingsDrawer', () => ({
+  useSubscriptionSettingsDrawer: () => ({ openDrawer: jest.fn() }),
+}))
+
+jest.mock('../useInvoicingPaymentsSettingsDrawer', () => ({
+  useInvoicingPaymentsSettingsDrawer: () => ({ openDrawer: jest.fn() }),
+}))
+
+jest.mock('../useQuotePlanSettingsDrawer', () => ({
+  useQuotePlanSettingsDrawer: () => ({ openDrawer: jest.fn() }),
+}))
+
+// Mock reused section components
+jest.mock('~/components/plans/form/FixedChargesSection', () => ({
+  FixedChargesSection: () => <div data-test="fixed-charges-section">Fixed Charges</div>,
+}))
+
+jest.mock('~/components/plans/UsageChargesSection', () => ({
+  UsageChargesSection: () => <div data-test="usage-charges-section">Usage Charges</div>,
+}))
+
+jest.mock('~/components/plans/CommitmentsSection', () => ({
+  CommitmentsSection: () => <div data-test="commitments-section">Commitments</div>,
+}))
+
+jest.mock('~/components/plans/ProgressiveBillingSection', () => ({
+  ProgressiveBillingSection: () => (
+    <div data-test="progressive-billing-section">Progressive Billing</div>
+  ),
+}))
+
+jest.mock('~/components/plans/drawers/subscriptionFee/SubscriptionFeeDrawer', () => ({
+  SubscriptionFeeDrawer: () => null,
+}))
+
+describe('SubscriptionPricingContent', () => {
+  it('shows plan selection ComboBox without initial data', async () => {
+    const stateRef = { current: null as SubscriptionPricingState | null }
+    const formValuesRef = { current: null as PlanFormInput | null }
+
+    await act(() =>
+      render(<SubscriptionPricingContent stateRef={stateRef} formValuesRef={formValuesRef} />),
+    )
+
+    // Should show ComboBox for plan selection
+    expect(screen.getByText('Plan')).toBeInTheDocument()
+    // Should not show sections since no plan is selected
+    expect(screen.queryByTestId('fixed-charges-section')).not.toBeInTheDocument()
+  })
+
+  it('shows sections when initial plan is provided', async () => {
+    const stateRef = { current: null as SubscriptionPricingState | null }
+    const formValuesRef = { current: null as PlanFormInput | null }
+
+    const initialState: SubscriptionPricingState = {
+      planId: 'plan_1',
+      planCode: 'starter',
+      planName: 'Starter',
+      planDescription: '',
+      subscriptionSettings: DEFAULT_SUBSCRIPTION_SETTINGS,
+      invoicingSettings: DEFAULT_INVOICING_SETTINGS,
+      overrides: {},
+    }
+
+    await act(() =>
+      render(
+        <SubscriptionPricingContent
+          stateRef={stateRef}
+          formValuesRef={formValuesRef}
+          initialState={initialState}
+        />,
+      ),
+    )
+
+    // Should show both the ComboBox and the sections
+    expect(screen.getByText('Plan')).toBeInTheDocument()
+    expect(screen.getByTestId('fixed-charges-section')).toBeInTheDocument()
+    expect(screen.getByTestId('usage-charges-section')).toBeInTheDocument()
+    expect(screen.getByTestId('commitments-section')).toBeInTheDocument()
+    expect(screen.getByTestId('progressive-billing-section')).toBeInTheDocument()
+  })
+
+  it('syncs state to stateRef when plan is selected', async () => {
+    const stateRef = { current: null as SubscriptionPricingState | null }
+    const formValuesRef = { current: null as PlanFormInput | null }
+
+    const initialState: SubscriptionPricingState = {
+      planId: 'plan_1',
+      planCode: 'starter',
+      planName: 'Starter',
+      planDescription: '',
+      subscriptionSettings: DEFAULT_SUBSCRIPTION_SETTINGS,
+      invoicingSettings: DEFAULT_INVOICING_SETTINGS,
+      overrides: {},
+    }
+
+    await act(() =>
+      render(
+        <SubscriptionPricingContent
+          stateRef={stateRef}
+          formValuesRef={formValuesRef}
+          initialState={initialState}
+        />,
+      ),
+    )
+
+    expect(stateRef.current).not.toBeNull()
+    expect(stateRef.current?.planId).toBe('plan_1')
+  })
+})

--- a/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
@@ -77,9 +77,13 @@ const RichTextEditor = ({
   const { translate } = useInternationalization()
   const onChangeRef = useRef(onChange)
   const onPricingBlocksChangeRef = useRef(onPricingBlocksChange)
+  const onPricingCommandRef = useRef(onPricingCommand)
+  const isPricingDisabledRef = useRef(isPricingDisabled)
 
   onChangeRef.current = onChange
   onPricingBlocksChangeRef.current = onPricingBlocksChange
+  onPricingCommandRef.current = onPricingCommand
+  isPricingDisabledRef.current = isPricingDisabled
 
   const variableItems = [
     { id: 'customerName', label: 'Customer Name' },
@@ -154,7 +158,15 @@ const RichTextEditor = ({
         },
       } as MentionSchemaOptions),
       PricingBlock.configure({ entities: entitiesFromProps }),
-      SlashCommands.configure({ translate, onPricingCommand, isPricingDisabled }),
+      SlashCommands.configure({
+        translate,
+        onPricingCommand: onPricingCommand
+          ? (params) => onPricingCommandRef.current?.(params)
+          : undefined,
+        isPricingDisabled: isPricingDisabled
+          ? () => isPricingDisabledRef.current?.() ?? false
+          : undefined,
+      }),
       LinkPasteHandler,
       TemplateSelectorExtension.configure({ templates: templates ?? [] }),
       DragHandle,

--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -16,12 +16,13 @@ import { QuoteDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { QUOTE_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBillingItems'
 import type { Locale } from '~/core/translations'
-import { type UpdateQuoteVersionInput } from '~/generated/graphql'
+import { OrderTypeEnum, type UpdateQuoteVersionInput } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 import EditQuoteAside from './editQuote/EditQuoteAside'
-import { usePricingDrawer } from './hooks/usePricingDrawer'
+import { useOneOffPricingDrawer } from './hooks/useOneOffPricingDrawer'
 import { useQuote } from './hooks/useQuote'
+import { useSubscriptionPricingDrawer } from './hooks/useSubscriptionPricingDrawer'
 import { useUpdateQuote } from './hooks/useUpdateQuote'
 
 const AUTO_SAVE_DELAY_MS = 2000
@@ -64,12 +65,33 @@ const EditQuote = () => {
 
   const isUpdating = isUpdatingQuote || isUpdatingQuoteVersion
 
+  const handleSubscriptionDatesChange = useCallback(
+    async (startDate?: string, endDate?: string) => {
+      if (!versionId) return
+
+      await updateQuoteVersionRef.current({ id: versionId, startDate, endDate }, false)
+    },
+    [versionId],
+  )
+
+  const isSubscriptionOrder =
+    quote?.orderType === OrderTypeEnum.SubscriptionCreation ||
+    quote?.orderType === OrderTypeEnum.SubscriptionAmendment
+
+  const subscriptionPricing = useSubscriptionPricingDrawer(quote?.currentVersion?.billingItems, {
+    quoteDates: {
+      startDate:
+        quote?.subscription?.subscriptionAt ?? quote?.currentVersion?.startDate ?? undefined,
+      endDate: quote?.currentVersion?.endDate ?? undefined,
+    },
+    onDatesChange: handleSubscriptionDatesChange,
+    customer: quote?.customer,
+    subscriptionId: quote?.subscription?.id,
+  })
+  const oneOffPricing = useOneOffPricingDrawer(quote?.currentVersion?.billingItems)
+
   const { onPricingCommand, isPricingDisabled, entities, syncEntitiesWithBlocks } =
-    usePricingDrawer(
-      quote?.orderType,
-      quote?.currentVersion?.billingItems,
-      quote?.customer?.currency,
-    )
+    isSubscriptionOrder ? subscriptionPricing : oneOffPricing
 
   const customerLocale = (quote?.customer?.billingConfiguration?.documentLocale ?? 'en') as Locale
 
@@ -284,18 +306,26 @@ const EditQuote = () => {
           />
         }
       >
-        <RichTextEditor
-          content={quote?.currentVersion?.content ?? ''}
-          getMarkdownRef={getMarkdownRef}
-          onChange={handleChange}
-          mode={editorMode}
-          onPricingCommand={handlePricingCommand}
-          isPricingDisabled={isPricingDisabled}
-          entities={entities}
-          onPricingBlocksChange={handlePricingBlocksChange}
-          customerLocale={customerLocale}
-          customerCurrency={quote?.customer?.currency ?? undefined}
-        />
+        {loading ? (
+          <div className="mx-auto my-4 flex max-w-4xl flex-col gap-4 px-10">
+            <Skeleton variant="text" className="w-3/4" />
+            <Skeleton variant="text" className="w-1/2" />
+            <Skeleton variant="text" className="w-5/6" />
+          </div>
+        ) : (
+          <RichTextEditor
+            content={quote?.currentVersion?.content ?? ''}
+            getMarkdownRef={getMarkdownRef}
+            onChange={handleChange}
+            mode={editorMode}
+            onPricingCommand={handlePricingCommand}
+            isPricingDisabled={isPricingDisabled}
+            entities={entities}
+            onPricingBlocksChange={handlePricingBlocksChange}
+            customerLocale={customerLocale}
+            customerCurrency={quote?.customer?.currency ?? undefined}
+          />
+        )}
       </RightAsidePage.Content>
     </RightAsidePage.Wrapper>
   )

--- a/src/pages/quotes/__tests__/EditQuote.test.tsx
+++ b/src/pages/quotes/__tests__/EditQuote.test.tsx
@@ -190,16 +190,22 @@ const mockDrawerOnPricingCommand = jest.fn()
 const mockSyncEntitiesWithBlocks = jest.fn().mockReturnValue(null)
 let capturedPricingDrawerArgs: unknown[] = []
 
-jest.mock('../hooks/usePricingDrawer', () => ({
-  usePricingDrawer: (...args: unknown[]) => {
-    capturedPricingDrawerArgs = args
+jest.mock('../hooks/useSubscriptionPricingDrawer', () => ({
+  useSubscriptionPricingDrawer: () => ({
+    onPricingCommand: mockDrawerOnPricingCommand,
+    isPricingDisabled: () => false,
+    entities: {},
+    syncEntitiesWithBlocks: mockSyncEntitiesWithBlocks,
+  }),
+}))
 
-    return {
-      onPricingCommand: mockDrawerOnPricingCommand,
-      entities: {},
-      syncEntitiesWithBlocks: mockSyncEntitiesWithBlocks,
-    }
-  },
+jest.mock('../hooks/useOneOffPricingDrawer', () => ({
+  useOneOffPricingDrawer: () => ({
+    onPricingCommand: jest.fn(),
+    isPricingDisabled: () => false,
+    entities: {},
+    syncEntitiesWithBlocks: jest.fn().mockReturnValue(null),
+  }),
 }))
 
 jest.mock('../common/getQuoteStatusMapping', () => ({

--- a/src/pages/quotes/__tests__/EditQuote.test.tsx
+++ b/src/pages/quotes/__tests__/EditQuote.test.tsx
@@ -191,12 +191,16 @@ const mockSyncEntitiesWithBlocks = jest.fn().mockReturnValue(null)
 let capturedPricingDrawerArgs: unknown[] = []
 
 jest.mock('../hooks/useSubscriptionPricingDrawer', () => ({
-  useSubscriptionPricingDrawer: () => ({
-    onPricingCommand: mockDrawerOnPricingCommand,
-    isPricingDisabled: () => false,
-    entities: {},
-    syncEntitiesWithBlocks: mockSyncEntitiesWithBlocks,
-  }),
+  useSubscriptionPricingDrawer: (...args: unknown[]) => {
+    capturedPricingDrawerArgs = args
+
+    return {
+      onPricingCommand: mockDrawerOnPricingCommand,
+      isPricingDisabled: () => false,
+      entities: {},
+      syncEntitiesWithBlocks: mockSyncEntitiesWithBlocks,
+    }
+  },
 }))
 
 jest.mock('../hooks/useOneOffPricingDrawer', () => ({
@@ -778,7 +782,7 @@ describe('EditQuote', () => {
     })
 
     describe('WHEN the customer has a currency', () => {
-      it('THEN should pass it as the third argument to usePricingDrawer', () => {
+      it('THEN should pass the customer to useSubscriptionPricingDrawer options', () => {
         mockUseQuote.mockReturnValue({
           quote: {
             ...mockQuote,
@@ -793,7 +797,9 @@ describe('EditQuote', () => {
 
         render(<EditQuote />)
 
-        expect(capturedPricingDrawerArgs[2]).toBe('EUR')
+        const options = capturedPricingDrawerArgs[1] as { customer?: { currency?: string } }
+
+        expect(options.customer?.currency).toBe('EUR')
       })
     })
   })

--- a/src/pages/quotes/hooks/__tests__/useOneOffPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useOneOffPricingDrawer.test.tsx
@@ -3,10 +3,10 @@ import { ReactNode } from 'react'
 import { z } from 'zod'
 
 import { fromBillingItems } from '~/core/serializers/serializeQuoteBillingItems'
-import { CurrencyEnum, OrderTypeEnum } from '~/generated/graphql'
+import { CurrencyEnum } from '~/generated/graphql'
 import { AllTheProviders } from '~/test-utils'
 
-import { usePricingDrawer } from '../usePricingDrawer'
+import { useOneOffPricingDrawer } from '../useOneOffPricingDrawer'
 
 // --- Mocks ---
 
@@ -116,6 +116,15 @@ jest.mock('~/components/designSystem/RichTextEditor/PricingBlock/PricingDrawerCo
   default: () => null,
 }))
 
+jest.mock('../useSubscriptionPricingDrawer', () => ({
+  useSubscriptionPricingDrawer: () => ({
+    onPricingCommand: jest.fn(),
+    isPricingDisabled: jest.fn(() => false),
+    entities: {},
+    syncEntitiesWithBlocks: jest.fn(() => null),
+  }),
+}))
+
 const mockedFromBillingItems = fromBillingItems as jest.Mock
 
 const wrapper = ({ children }: { children: ReactNode }) => (
@@ -151,7 +160,7 @@ const mockBillingItemsPayload = {
 
 // --- Tests ---
 
-describe('usePricingDrawer', () => {
+describe('useOneOffPricingDrawer', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     capturedOnSubmit = null
@@ -162,7 +171,7 @@ describe('usePricingDrawer', () => {
   describe('GIVEN the hook is called', () => {
     describe('WHEN it returns', () => {
       it('THEN should return onPricingCommand, entities, and syncEntitiesWithBlocks', () => {
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.OneOff), { wrapper })
+        const { result } = renderHook(() => useOneOffPricingDrawer(), { wrapper })
 
         expect(typeof result.current.onPricingCommand).toBe('function')
         expect(result.current.entities).toBeDefined()
@@ -172,7 +181,7 @@ describe('usePricingDrawer', () => {
 
     describe('WHEN no initialBillingItems is provided', () => {
       it('THEN entities should be an empty object', () => {
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.OneOff), { wrapper })
+        const { result } = renderHook(() => useOneOffPricingDrawer(), { wrapper })
 
         expect(result.current.entities).toEqual({})
       })
@@ -218,10 +227,9 @@ describe('usePricingDrawer', () => {
           ],
         })
 
-        const { result } = renderHook(
-          () => usePricingDrawer(OrderTypeEnum.OneOff, mockBillingItemsPayload),
-          { wrapper },
-        )
+        const { result } = renderHook(() => useOneOffPricingDrawer(mockBillingItemsPayload), {
+          wrapper,
+        })
 
         expect(mockedFromBillingItems).toHaveBeenCalledWith(mockBillingItemsPayload)
         // Entities should include both localId-keyed and backward-compat catalog-keyed entries
@@ -246,7 +254,7 @@ describe('usePricingDrawer', () => {
       it('THEN should not call fromBillingItems', () => {
         const emptyPayload = { addons: [] }
 
-        renderHook(() => usePricingDrawer(OrderTypeEnum.OneOff, emptyPayload), { wrapper })
+        renderHook(() => useOneOffPricingDrawer(emptyPayload), { wrapper })
 
         expect(mockedFromBillingItems).not.toHaveBeenCalled()
       })
@@ -256,7 +264,7 @@ describe('usePricingDrawer', () => {
   describe('GIVEN onPricingCommand is called', () => {
     describe('WHEN called with an onSave callback and no editData', () => {
       it('THEN should open the form drawer', () => {
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.OneOff), { wrapper })
+        const { result } = renderHook(() => useOneOffPricingDrawer(), { wrapper })
 
         act(() => {
           result.current.onPricingCommand({
@@ -278,30 +286,9 @@ describe('usePricingDrawer', () => {
       })
     })
 
-    describe('WHEN called for a subscription creation order type', () => {
-      it('THEN should open the form drawer with the plan selection title', () => {
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.SubscriptionCreation), {
-          wrapper,
-        })
-
-        act(() => {
-          result.current.onPricingCommand({
-            onSave: jest.fn(),
-            editData: undefined,
-          })
-        })
-
-        expect(mockFormDrawerOpen).toHaveBeenCalledTimes(1)
-        const callArgs = mockFormDrawerOpen.mock.calls[0][0]
-
-        // The title for subscription types should be the plan selection key
-        expect(callArgs.title).toBe('text_17799586575628qyl2jk1tbn')
-      })
-    })
-
     describe('WHEN called for a one-off order type', () => {
       it('THEN should open the form drawer with the add-on selection title', () => {
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.OneOff), { wrapper })
+        const { result } = renderHook(() => useOneOffPricingDrawer(), { wrapper })
 
         act(() => {
           result.current.onPricingCommand({
@@ -339,10 +326,9 @@ describe('usePricingDrawer', () => {
           ],
         })
 
-        const { result } = renderHook(
-          () => usePricingDrawer(OrderTypeEnum.OneOff, mockBillingItemsPayload),
-          { wrapper },
-        )
+        const { result } = renderHook(() => useOneOffPricingDrawer(mockBillingItemsPayload), {
+          wrapper,
+        })
 
         expect(result.current.isPricingDisabled()).toBe(true)
       })
@@ -350,35 +336,7 @@ describe('usePricingDrawer', () => {
 
     describe('WHEN order type is one-off and no entities exist', () => {
       it('THEN should return false', () => {
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.OneOff), { wrapper })
-
-        expect(result.current.isPricingDisabled()).toBe(false)
-      })
-    })
-
-    describe('WHEN order type is subscription creation and entities exist', () => {
-      it('THEN should return false', () => {
-        mockedFromBillingItems.mockReturnValue({
-          entities: {
-            'local-uuid-1': {
-              entityId: 'local-uuid-1',
-              entityType: 'addOn',
-              name: 'Setup Fee',
-              code: 'setup',
-            },
-          },
-          originalPayloads: {
-            'local-uuid-1': mockAddOnPayload,
-          },
-          addOnItems: [
-            { localId: 'local-uuid-1', addOnId: 'addon-1', name: 'Setup Fee', code: 'setup' },
-          ],
-        })
-
-        const { result } = renderHook(
-          () => usePricingDrawer(OrderTypeEnum.SubscriptionCreation, mockBillingItemsPayload),
-          { wrapper },
-        )
+        const { result } = renderHook(() => useOneOffPricingDrawer(), { wrapper })
 
         expect(result.current.isPricingDisabled()).toBe(false)
       })
@@ -405,10 +363,9 @@ describe('usePricingDrawer', () => {
           ],
         })
 
-        const { result } = renderHook(
-          () => usePricingDrawer(OrderTypeEnum.OneOff, mockBillingItemsPayload),
-          { wrapper },
-        )
+        const { result } = renderHook(() => useOneOffPricingDrawer(mockBillingItemsPayload), {
+          wrapper,
+        })
 
         act(() => {
           result.current.onPricingCommand({
@@ -441,10 +398,9 @@ describe('usePricingDrawer', () => {
           addOnItems: [],
         })
 
-        const { result } = renderHook(
-          () => usePricingDrawer(OrderTypeEnum.OneOff, mockBillingItemsPayload),
-          { wrapper },
-        )
+        const { result } = renderHook(() => useOneOffPricingDrawer(mockBillingItemsPayload), {
+          wrapper,
+        })
 
         const blocks = [
           {
@@ -484,10 +440,9 @@ describe('usePricingDrawer', () => {
           ],
         })
 
-        const { result } = renderHook(
-          () => usePricingDrawer(OrderTypeEnum.OneOff, mockBillingItemsPayload),
-          { wrapper },
-        )
+        const { result } = renderHook(() => useOneOffPricingDrawer(mockBillingItemsPayload), {
+          wrapper,
+        })
 
         // After hydration, entities has both 'local-uuid-1' and 'addon-1' (backward-compat)
         expect(result.current.entities).toHaveProperty('local-uuid-1')
@@ -570,10 +525,9 @@ describe('usePricingDrawer', () => {
           ],
         }
 
-        const { result } = renderHook(
-          () => usePricingDrawer(OrderTypeEnum.OneOff, billingItemsWithTwo),
-          { wrapper },
-        )
+        const { result } = renderHook(() => useOneOffPricingDrawer(billingItemsWithTwo), {
+          wrapper,
+        })
 
         // Blocks only reference local-uuid-1, so local-uuid-2 becomes orphaned
         const blocks = [
@@ -606,7 +560,7 @@ describe('usePricingDrawer', () => {
 
     describe('WHEN there are no entities at all', () => {
       it('THEN should return null', () => {
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.OneOff), { wrapper })
+        const { result } = renderHook(() => useOneOffPricingDrawer(), { wrapper })
 
         const blocks = [{ pricingType: 'addOns' as const, entityIds: [], localEntityIds: [] }]
 
@@ -622,27 +576,6 @@ describe('usePricingDrawer', () => {
   })
 
   describe('GIVEN onPricingCommand is called with editData', () => {
-    describe('WHEN it is a subscription creation with pricingType plan', () => {
-      it('THEN should reset the form with the plan ID as initialPlanId', () => {
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.SubscriptionCreation), {
-          wrapper,
-        })
-
-        act(() => {
-          result.current.onPricingCommand({
-            onSave: jest.fn(),
-            editData: { pricingType: 'plan', entityIds: ['plan-abc'] },
-          })
-        })
-
-        expect(mockFormReset).toHaveBeenCalledWith(
-          { planId: 'plan-abc', addOnItems: [] },
-          { keepDefaultValues: true },
-        )
-        expect(mockFormDrawerOpen).toHaveBeenCalled()
-      })
-    })
-
     describe('WHEN it is a one-off order with pricingType addOns and existing entities', () => {
       it('THEN should reset the form with initialAddOnItems from entity data', () => {
         mockedFromBillingItems.mockReturnValue({
@@ -679,10 +612,9 @@ describe('usePricingDrawer', () => {
           ],
         })
 
-        const { result } = renderHook(
-          () => usePricingDrawer(OrderTypeEnum.OneOff, mockBillingItemsPayload),
-          { wrapper },
-        )
+        const { result } = renderHook(() => useOneOffPricingDrawer(mockBillingItemsPayload), {
+          wrapper,
+        })
 
         act(() => {
           result.current.onPricingCommand({
@@ -732,10 +664,9 @@ describe('usePricingDrawer', () => {
           ],
         })
 
-        const { result } = renderHook(
-          () => usePricingDrawer(OrderTypeEnum.OneOff, mockBillingItemsPayload),
-          { wrapper },
-        )
+        const { result } = renderHook(() => useOneOffPricingDrawer(mockBillingItemsPayload), {
+          wrapper,
+        })
 
         act(() => {
           result.current.onPricingCommand({
@@ -752,35 +683,14 @@ describe('usePricingDrawer', () => {
         expect(mockFormDrawerOpen).toHaveBeenCalled()
       })
     })
-
-    describe('WHEN it is a subscription creation with no editData planId', () => {
-      it('THEN should reset the form with an empty planId', () => {
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.SubscriptionCreation), {
-          wrapper,
-        })
-
-        act(() => {
-          result.current.onPricingCommand({
-            onSave: jest.fn(),
-            editData: undefined,
-          })
-        })
-
-        expect(mockFormReset).toHaveBeenCalledWith(
-          { planId: '', addOnItems: [] },
-          { keepDefaultValues: true },
-        )
-      })
-    })
   })
 
   describe('GIVEN customerCurrency is provided', () => {
     describe('WHEN onPricingCommand is called', () => {
       it('THEN should pass the customerCurrency to the drawer content instead of organization default', () => {
-        const { result } = renderHook(
-          () => usePricingDrawer(OrderTypeEnum.OneOff, undefined, CurrencyEnum.Eur),
-          { wrapper },
-        )
+        const { result } = renderHook(() => useOneOffPricingDrawer(undefined, CurrencyEnum.Eur), {
+          wrapper,
+        })
 
         act(() => {
           result.current.onPricingCommand({
@@ -798,10 +708,7 @@ describe('usePricingDrawer', () => {
 
     describe('WHEN customerCurrency is null', () => {
       it('THEN should fall back to organization defaultCurrency', () => {
-        const { result } = renderHook(
-          () => usePricingDrawer(OrderTypeEnum.OneOff, undefined, null),
-          { wrapper },
-        )
+        const { result } = renderHook(() => useOneOffPricingDrawer(undefined, null), { wrapper })
 
         act(() => {
           result.current.onPricingCommand({
@@ -819,7 +726,7 @@ describe('usePricingDrawer', () => {
 
     describe('WHEN customerCurrency is not provided', () => {
       it('THEN should use organization defaultCurrency', () => {
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.OneOff), { wrapper })
+        const { result } = renderHook(() => useOneOffPricingDrawer(), { wrapper })
 
         act(() => {
           result.current.onPricingCommand({
@@ -837,74 +744,11 @@ describe('usePricingDrawer', () => {
   })
 
   describe('GIVEN the form onSubmit handler is invoked', () => {
-    describe('WHEN submitting for a subscription creation with a planId', () => {
-      it('THEN should call onSave with plan entity data and update entities', () => {
-        const mockOnSave = jest.fn()
-
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.SubscriptionCreation), {
-          wrapper,
-        })
-
-        // Trigger onPricingCommand to capture onSaveRef and onSubmit
-        act(() => {
-          result.current.onPricingCommand({
-            onSave: mockOnSave,
-            editData: undefined,
-          })
-        })
-
-        // Simulate form values for a plan submission
-        mockFormValues = { planId: 'plan-123', addOnItems: [] }
-
-        // Invoke the captured onSubmit
-        expect(capturedOnSubmit).not.toBeNull()
-        act(() => {
-          capturedOnSubmit?.({ value: mockFormValues })
-        })
-
-        expect(mockOnSave).toHaveBeenCalledWith(
-          { pricingType: 'plan', entityIds: ['plan-123'] },
-          expect.objectContaining({
-            'plan-123': expect.objectContaining({
-              entityId: 'plan-123',
-              entityType: 'plan',
-            }),
-          }),
-        )
-      })
-    })
-
-    describe('WHEN submitting for a subscription creation with no planId', () => {
-      it('THEN should not call onSave', () => {
-        const mockOnSave = jest.fn()
-
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.SubscriptionCreation), {
-          wrapper,
-        })
-
-        act(() => {
-          result.current.onPricingCommand({
-            onSave: mockOnSave,
-            editData: undefined,
-          })
-        })
-
-        // Empty planId
-        mockFormValues = { planId: '', addOnItems: [] }
-
-        act(() => {
-          capturedOnSubmit?.({ value: mockFormValues })
-        })
-
-        expect(mockOnSave).not.toHaveBeenCalled()
-      })
-    })
-
     describe('WHEN submitting for a one-off with confirmed add-on items', () => {
       it('THEN should call onSave with add-on entity data and billing items', () => {
         const mockOnSave = jest.fn()
 
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.OneOff), {
+        const { result } = renderHook(() => useOneOffPricingDrawer(), {
           wrapper,
         })
 
@@ -965,7 +809,7 @@ describe('usePricingDrawer', () => {
       it('THEN should not call onSave', () => {
         const mockOnSave = jest.fn()
 
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.OneOff), {
+        const { result } = renderHook(() => useOneOffPricingDrawer(), {
           wrapper,
         })
 
@@ -994,7 +838,7 @@ describe('usePricingDrawer', () => {
   describe('GIVEN the captureAddOnPayload callback', () => {
     describe('WHEN an add-on is selected in the drawer', () => {
       it('THEN should store the add-on payload for later serialization', () => {
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.OneOff), { wrapper })
+        const { result } = renderHook(() => useOneOffPricingDrawer(), { wrapper })
 
         act(() => {
           result.current.onPricingCommand({
@@ -1079,7 +923,7 @@ describe('usePricingDrawer', () => {
   describe('GIVEN the handleSubmit function inside onPricingCommand', () => {
     describe('WHEN form.submit is invoked from the drawer', () => {
       it('THEN should call form.handleSubmit', async () => {
-        const { result } = renderHook(() => usePricingDrawer(OrderTypeEnum.OneOff), { wrapper })
+        const { result } = renderHook(() => useOneOffPricingDrawer(), { wrapper })
 
         act(() => {
           result.current.onPricingCommand({
@@ -1098,37 +942,9 @@ describe('usePricingDrawer', () => {
       })
     })
   })
-
-  describe('GIVEN isPricingDisabled is called for subscription amendment', () => {
-    describe('WHEN order type is subscription amendment and entities exist', () => {
-      it('THEN should return false', () => {
-        mockedFromBillingItems.mockReturnValue({
-          entities: {
-            'local-uuid-1': {
-              entityId: 'local-uuid-1',
-              entityType: 'addOn',
-              name: 'Setup Fee',
-              code: 'setup',
-            },
-          },
-          originalPayloads: { 'local-uuid-1': mockAddOnPayload },
-          addOnItems: [
-            { localId: 'local-uuid-1', addOnId: 'addon-1', name: 'Setup Fee', code: 'setup' },
-          ],
-        })
-
-        const { result } = renderHook(
-          () => usePricingDrawer(OrderTypeEnum.SubscriptionAmendment, mockBillingItemsPayload),
-          { wrapper },
-        )
-
-        expect(result.current.isPricingDisabled()).toBe(false)
-      })
-    })
-  })
 })
 
-// --- Standalone validation schema tests (mirrors the superRefine in usePricingDrawer) ---
+// --- Standalone validation schema tests (mirrors the superRefine in useOneOffPricingDrawer) ---
 
 const pricingDrawerValidationSchema = z
   .object({

--- a/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
@@ -1,0 +1,131 @@
+import { act, renderHook } from '@testing-library/react'
+
+import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBillingItems'
+
+import { useSubscriptionPricingDrawer } from '../useSubscriptionPricingDrawer'
+
+const mockDrawerOpen = jest.fn()
+const mockDrawerClose = jest.fn()
+
+jest.mock('~/components/drawers/useDrawer', () => ({
+  useFormDrawer: () => ({ open: mockDrawerOpen, close: mockDrawerClose }),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+// Mock SubscriptionPricingContent
+jest.mock(
+  '~/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent',
+  () => ({
+    SubscriptionPricingContent: () => null,
+  }),
+)
+
+describe('useSubscriptionPricingDrawer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns the expected interface', () => {
+    const { result } = renderHook(() => useSubscriptionPricingDrawer(undefined))
+
+    expect(result.current).toHaveProperty('onPricingCommand')
+    expect(result.current).toHaveProperty('isPricingDisabled')
+    expect(result.current).toHaveProperty('entities')
+    expect(result.current).toHaveProperty('syncEntitiesWithBlocks')
+  })
+
+  it('opens the drawer when onPricingCommand is called', () => {
+    const { result } = renderHook(() => useSubscriptionPricingDrawer(undefined))
+
+    const mockOnSave = jest.fn()
+
+    act(() => {
+      result.current.onPricingCommand({ onSave: mockOnSave })
+    })
+
+    expect(mockDrawerOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('isPricingDisabled returns false when no entities', () => {
+    const { result } = renderHook(() => useSubscriptionPricingDrawer(undefined))
+
+    expect(result.current.isPricingDisabled()).toBe(false)
+  })
+
+  it('hydrates entities from initial billingItems with plans', () => {
+    const initialBillingItems: BillingItemsPayload = {
+      addons: [],
+      plans: [
+        {
+          type: 'plan',
+          id: 'plan_123',
+          payload: {
+            position: 1,
+            plan_code: 'enterprise',
+            plan_name: 'Enterprise Plan',
+            plan_description: '',
+            subscription_external_id: null,
+            subscription_name: null,
+            billing_time: 'anniversary',
+            start_date: '2023-07-26',
+            end_date: null,
+            payment_method_id: null,
+            invoice_custom_footer: null,
+          },
+          overrides: {},
+        },
+      ],
+    }
+
+    const { result } = renderHook(() => useSubscriptionPricingDrawer(initialBillingItems))
+
+    expect(result.current.entities).toHaveProperty('plan_123')
+    expect(result.current.entities.plan_123.entityType).toBe('plan')
+    expect(result.current.entities.plan_123.name).toBe('Enterprise Plan')
+  })
+
+  it('syncEntitiesWithBlocks removes orphaned entities', () => {
+    const initialBillingItems: BillingItemsPayload = {
+      addons: [],
+      plans: [
+        {
+          type: 'plan',
+          id: 'plan_123',
+          payload: {
+            position: 1,
+            plan_code: 'enterprise',
+            plan_name: 'Enterprise Plan',
+            plan_description: '',
+            subscription_external_id: null,
+            subscription_name: null,
+            billing_time: 'anniversary',
+            start_date: '2023-07-26',
+            end_date: null,
+            payment_method_id: null,
+            invoice_custom_footer: null,
+          },
+          overrides: {},
+        },
+      ],
+    }
+
+    const { result } = renderHook(() => useSubscriptionPricingDrawer(initialBillingItems))
+
+    // Block with different entity — plan_123 becomes orphaned
+    let billingItems: BillingItemsPayload | null = null
+
+    act(() => {
+      billingItems = result.current.syncEntitiesWithBlocks([
+        { pricingType: 'plan', entityIds: ['plan_other'] },
+      ])
+    })
+
+    expect(billingItems).not.toBeNull()
+    expect(result.current.entities).not.toHaveProperty('plan_123')
+  })
+})

--- a/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
@@ -18,11 +18,7 @@ import {
   fromBillingItems,
   toBillingItems,
 } from '~/core/serializers/serializeQuoteBillingItems'
-import {
-  type AddOnForPricingSectionFragment,
-  CurrencyEnum,
-  OrderTypeEnum,
-} from '~/generated/graphql'
+import { type AddOnForPricingSectionFragment, CurrencyEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm } from '~/hooks/forms/useAppform'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
@@ -31,18 +27,17 @@ import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
 const PRICING_DRAWER_FORM_ID = 'pricing-drawer-form'
 
-interface UsePricingDrawerReturn {
+export interface UseOneOffPricingDrawerReturn {
   onPricingCommand: OnPricingCommand
   isPricingDisabled: () => boolean
   entities: Record<string, EntityData>
   syncEntitiesWithBlocks: (blocks: PricingBlockAttributes[]) => BillingItemsPayload | null
 }
 
-export const usePricingDrawer = (
-  quoteOrderType: OrderTypeEnum | undefined,
+export const useOneOffPricingDrawer = (
   initialBillingItems?: unknown,
   customerCurrency?: CurrencyEnum | null,
-): UsePricingDrawerReturn => {
+): UseOneOffPricingDrawerReturn => {
   const { translate } = useInternationalization()
   const { organization } = useOrganizationInfos()
   const formDrawer = useFormDrawer()
@@ -58,9 +53,6 @@ export const usePricingDrawer = (
       ) => void)
     | null
   >(null)
-  const quoteOrderTypeRef = useRef(quoteOrderType)
-
-  quoteOrderTypeRef.current = quoteOrderType
 
   // Hydrate from saved billingItems on mount / when quote data arrives
   useEffect(() => {
@@ -135,14 +127,7 @@ export const usePricingDrawer = (
           ),
         })
         .superRefine((data, ctx) => {
-          const orderType = quoteOrderTypeRef.current ?? OrderTypeEnum.SubscriptionCreation
-          const isPlanSelection =
-            orderType === OrderTypeEnum.SubscriptionCreation ||
-            orderType === OrderTypeEnum.SubscriptionAmendment
-
-          if (isPlanSelection) return
-
-          // One-off: at least one confirmed add-on
+          // At least one confirmed add-on
           const confirmed = data.addOnItems.filter((item) => item.addOnId)
 
           if (confirmed.length === 0) {
@@ -185,83 +170,50 @@ export const usePricingDrawer = (
       onDynamic: validationSchema,
     },
     onSubmit: ({ value }) => {
-      const orderType = quoteOrderTypeRef.current ?? OrderTypeEnum.SubscriptionCreation
-      const isPlanSelection =
-        orderType === OrderTypeEnum.SubscriptionCreation ||
-        orderType === OrderTypeEnum.SubscriptionAmendment
+      const confirmedItems = value.addOnItems.filter((item) => item.addOnId)
 
-      if (isPlanSelection) {
-        if (!value.planId) return
+      if (confirmedItems.length === 0) return
 
-        const entityData: Record<string, EntityData> = {
-          [value.planId]: {
-            entityId: value.planId,
-            entityType: 'plan',
-            name: value.planId,
-            code: '',
-          },
+      const entityData: Record<string, EntityData> = {}
+
+      confirmedItems.forEach((item) => {
+        entityData[item.localId] = {
+          entityId: item.localId,
+          entityType: 'addOn',
+          name: item.name,
+          invoiceDisplayName: item.invoiceDisplayName,
+          code: item.code,
+          description: item.description,
+          units: item.units,
+          unitAmountCents: item.unitAmountCents,
+          totalAmount: item.totalAmount,
+          fromDatetime: item.fromDatetime,
+          toDatetime: item.toDatetime,
         }
+      })
 
-        onSaveRef.current?.({ pricingType: 'plan' as const, entityIds: [value.planId] }, entityData)
-        const updatedPlan = { ...entitiesRef.current, ...entityData }
+      const billingItems = toBillingItems(confirmedItems, payloadsRef.current)
 
-        entitiesRef.current = updatedPlan
-        setEntities(updatedPlan)
-      } else {
-        const confirmedItems = value.addOnItems.filter((item) => item.addOnId)
+      onSaveRef.current?.(
+        {
+          pricingType: 'addOns' as const,
+          entityIds: confirmedItems.map((item) => item.addOnId),
+          localEntityIds: confirmedItems.map((item) => item.localId),
+        },
+        entityData,
+        billingItems,
+      )
+      const updatedAddOns = { ...entitiesRef.current, ...entityData }
 
-        if (confirmedItems.length === 0) return
-
-        const entityData: Record<string, EntityData> = {}
-
-        confirmedItems.forEach((item) => {
-          entityData[item.localId] = {
-            entityId: item.localId,
-            entityType: 'addOn',
-            name: item.name,
-            invoiceDisplayName: item.invoiceDisplayName,
-            code: item.code,
-            description: item.description,
-            units: item.units,
-            unitAmountCents: item.unitAmountCents,
-            totalAmount: item.totalAmount,
-            fromDatetime: item.fromDatetime,
-            toDatetime: item.toDatetime,
-          }
-        })
-
-        const billingItems = toBillingItems(confirmedItems, payloadsRef.current)
-
-        onSaveRef.current?.(
-          {
-            pricingType: 'addOns' as const,
-            entityIds: confirmedItems.map((item) => item.addOnId),
-            localEntityIds: confirmedItems.map((item) => item.localId),
-          },
-          entityData,
-          billingItems,
-        )
-        const updatedAddOns = { ...entitiesRef.current, ...entityData }
-
-        entitiesRef.current = updatedAddOns
-        setEntities(updatedAddOns)
-      }
+      entitiesRef.current = updatedAddOns
+      setEntities(updatedAddOns)
     },
   })
 
   const onPricingCommand: OnPricingCommand = useCallback(
     ({ onSave, editData }) => {
-      const orderType = quoteOrderTypeRef.current ?? OrderTypeEnum.SubscriptionCreation
-      const isPlanSelection =
-        orderType === OrderTypeEnum.SubscriptionCreation ||
-        orderType === OrderTypeEnum.SubscriptionAmendment
-
-      // One-off quotes: only allow one pricing block (new insertion only, not edits)
-      if (
-        orderType === OrderTypeEnum.OneOff &&
-        !editData &&
-        Object.keys(entitiesRef.current).length > 0
-      ) {
+      // Only allow one pricing block (new insertion only, not edits)
+      if (!editData && Object.keys(entitiesRef.current).length > 0) {
         return
       }
 
@@ -269,12 +221,8 @@ export const usePricingDrawer = (
 
       onSaveRef.current = onSave
 
-      // Build initial values from editData
-      const initialPlanId =
-        isPlanSelection && editData?.pricingType === 'plan' ? editData.entityIds[0] : ''
-
       const initialAddOnItems =
-        !isPlanSelection && editData?.pricingType === 'addOns'
+        editData?.pricingType === 'addOns'
           ? editData.entityIds.map((catalogId, i) => {
               const localId = editData.localEntityIds?.[i]
               const lookupId = localId ?? catalogId
@@ -300,7 +248,7 @@ export const usePricingDrawer = (
 
       form.reset(
         {
-          planId: initialPlanId,
+          planId: '',
           addOnItems: initialAddOnItems,
         },
         { keepDefaultValues: true },
@@ -315,10 +263,7 @@ export const usePricingDrawer = (
       }
 
       formDrawer.open({
-        title:
-          orderType === OrderTypeEnum.OneOff
-            ? translate('text_17799586575620rdqef1d7dq')
-            : translate('text_17799586575628qyl2jk1tbn'),
+        title: translate('text_17799586575620rdqef1d7dq'),
         form: {
           id: PRICING_DRAWER_FORM_ID,
           submit: handleSubmit,
@@ -333,7 +278,6 @@ export const usePricingDrawer = (
         children: (
           <PricingDrawerContent
             form={form}
-            quoteType={orderType}
             currency={currency}
             onAddOnPayloadCapture={captureAddOnPayload}
           />
@@ -381,11 +325,7 @@ export const usePricingDrawer = (
     [],
   )
 
-  const isPricingDisabled = useCallback(() => {
-    const orderType = quoteOrderTypeRef.current ?? OrderTypeEnum.SubscriptionCreation
-
-    return orderType === OrderTypeEnum.OneOff && Object.keys(entitiesRef.current).length > 0
-  }, [])
+  const isPricingDisabled = useCallback(() => Object.keys(entitiesRef.current).length > 0, [])
 
   return { onPricingCommand, isPricingDisabled, entities, syncEntitiesWithBlocks }
 }

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { Button } from '~/components/designSystem/Button'
+import type {
+  EntityData,
+  OnPricingCommand,
+} from '~/components/designSystem/RichTextEditor/common/RichTextEditorContext'
+import type { PricingBlockAttributes } from '~/components/designSystem/RichTextEditor/extensions/PricingBlock.schema'
+import { SubscriptionPricingContent } from '~/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent'
+import { useFormDrawer } from '~/components/drawers/useDrawer'
+import type { PlanFormInput } from '~/components/plans/types'
+import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBillingItems'
+import {
+  type BillingItemPlan,
+  fromPlanBillingItems,
+  type SubscriptionPricingState,
+  toPlanBillingItems,
+} from '~/core/serializers/serializeQuotePlanBillingItems'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+interface UseSubscriptionPricingDrawerReturn {
+  onPricingCommand: OnPricingCommand
+  isPricingDisabled: () => boolean
+  entities: Record<string, EntityData>
+  syncEntitiesWithBlocks: (blocks: PricingBlockAttributes[]) => BillingItemsPayload | null
+}
+
+export interface QuoteCustomer {
+  id: string
+  externalId: string
+  name?: string | null
+}
+
+export interface SubscriptionPricingDrawerOptions {
+  quoteDates?: { startDate?: string; endDate?: string }
+  onDatesChange?: (startDate?: string, endDate?: string) => void
+  customer?: QuoteCustomer | null
+  subscriptionId?: string
+}
+
+export const useSubscriptionPricingDrawer = (
+  initialBillingItems?: unknown,
+  options?: SubscriptionPricingDrawerOptions,
+): UseSubscriptionPricingDrawerReturn => {
+  const { translate } = useInternationalization()
+  const drawer = useFormDrawer()
+
+  const [entities, setEntities] = useState<Record<string, EntityData>>({})
+  const entitiesRef = useRef<Record<string, EntityData>>({})
+  const initialStateRef = useRef<SubscriptionPricingState | null>(null)
+  const subscriptionStateRef = useRef<SubscriptionPricingState | null>(null)
+  const formValuesRef = useRef<PlanFormInput | null>(null)
+
+  // Determine initialization case: extract billing item plan for case 2
+  const billingItemPlan = useMemo(() => {
+    if (!initialBillingItems) return undefined
+    const parsed = initialBillingItems as BillingItemsPayload
+
+    return parsed.plans?.[0] as BillingItemPlan | undefined
+  }, [initialBillingItems])
+  const onSaveRef = useRef<
+    | ((
+        attrs: PricingBlockAttributes,
+        entityData: Record<string, EntityData>,
+        billingItems?: BillingItemsPayload,
+      ) => void)
+    | null
+  >(null)
+
+  // Hydration: populate entities from saved billing items on mount
+  useEffect(() => {
+    if (!initialBillingItems) return
+
+    const parsed = initialBillingItems as BillingItemsPayload
+
+    if (!parsed.plans?.length) return
+
+    const result = fromPlanBillingItems(parsed.plans)
+
+    initialStateRef.current = {
+      planId: result.planId,
+      planCode: result.planCode,
+      planName: result.planName,
+      planDescription: result.planDescription,
+      subscriptionSettings: result.subscriptionSettings,
+      invoicingSettings: result.invoicingSettings,
+      overrides: result.overrides,
+    }
+
+    entitiesRef.current = { ...entitiesRef.current, ...result.entityData }
+    setEntities({ ...entitiesRef.current })
+  }, [initialBillingItems])
+
+  const onPricingCommand = useCallback<OnPricingCommand>(
+    ({ onSave }) => {
+      onSaveRef.current = onSave
+
+      const handleSave = () => {
+        const state = subscriptionStateRef.current
+        const formValues = formValuesRef.current
+
+        if (!state) return
+
+        const billingItems = toPlanBillingItems(state, formValues ?? undefined)
+        const entityData: Record<string, EntityData> = {
+          [state.planId]: {
+            entityId: state.planId,
+            entityType: 'plan',
+            name: state.planName,
+            code: state.planCode,
+          },
+        }
+
+        entitiesRef.current = { ...entitiesRef.current, ...entityData }
+        setEntities({ ...entitiesRef.current })
+
+        onSaveRef.current?.({ pricingType: 'plan', entityIds: [state.planId] }, entityData, {
+          addons: [],
+          ...billingItems,
+        })
+
+        // Propagate date changes to the quote level
+        options?.onDatesChange?.(
+          state.subscriptionSettings.startDate || undefined,
+          state.subscriptionSettings.endDate || undefined,
+        )
+
+        drawer.close()
+      }
+
+      drawer.open({
+        title: translate('text_17791987800302plb0guzxzv'),
+        form: {
+          id: 'subscription-pricing-drawer-form',
+          submit: handleSave,
+        },
+        mainAction: (
+          <Button data-test="subscription-pricing-drawer-submit" type="submit">
+            {translate('text_17295436903260tlyb1gp1i7')}
+          </Button>
+        ),
+        children: (
+          <SubscriptionPricingContent
+            stateRef={subscriptionStateRef}
+            formValuesRef={formValuesRef}
+            initialState={initialStateRef.current}
+            quoteDates={options?.quoteDates}
+            customer={options?.customer}
+            billingItemPlan={billingItemPlan}
+            subscriptionId={!billingItemPlan ? options?.subscriptionId : undefined}
+          />
+        ),
+      })
+    },
+    [translate, drawer, options, billingItemPlan],
+  )
+
+  const isPricingDisabled = useCallback(() => Object.keys(entitiesRef.current).length > 0, [])
+
+  const syncEntitiesWithBlocks = useCallback(
+    (blocks: PricingBlockAttributes[]): BillingItemsPayload | null => {
+      const activeEntityIds = new Set(blocks.flatMap((b) => b.entityIds))
+      const currentKeys = Object.keys(entitiesRef.current)
+      const orphanedKeys = currentKeys.filter((id) => !activeEntityIds.has(id))
+
+      if (orphanedKeys.length === 0) return null
+
+      const updatedEntities = { ...entitiesRef.current }
+
+      for (const key of orphanedKeys) {
+        delete updatedEntities[key]
+      }
+
+      entitiesRef.current = updatedEntities
+      setEntities(updatedEntities)
+
+      return { addons: [], plans: [] }
+    },
+    [],
+  )
+
+  return { onPricingCommand, isPricingDisabled, entities, syncEntitiesWithBlocks }
+}

--- a/translations/base.json
+++ b/translations/base.json
@@ -4256,7 +4256,6 @@
   "text_1779802343220xh5jm32or13": "Add an add-on",
   "text_17798023432203q6hytdp7om": "Select add-ons",
   "text_17799586575620rdqef1d7dq": "Pricing for one-off invoice",
-  "text_17799586575628qyl2jk1tbn": "Pricing for subscription",
   "text_1779958764076n5tclla792h": "You must add at least one add-on",
   "text_1779958764076e77b9cs2q5q": "Units is required",
   "text_1779958764076kncdf7nqbts": "Unit price is required",


### PR DESCRIPTION
## Summary
**PR 4 of 4** in the subscription pricing drawer stack (split from #3653).

- Add `SubscriptionPricingContent` component with two-step flow (plan selection → charge configuration)
- Add `useSubscriptionPricingDrawer` hook with ref-based state pattern
- Wire `EditQuote` to route pricing drawer by order type (one-off vs subscription)
- Rename `usePricingDrawer` → `useOneOffPricingDrawer` (scoped to one-off quotes)
- Update `PricingDrawerContent` to delegate to subscription path

## Stack
1. #3677 — Types + Serializer
2. #3678 — Plan form refactor
3. #3679 — Settings drawer hooks
4. **This PR** — UI wiring

## Test plan
- [x] `useSubscriptionPricingDrawer` tests pass
- [x] `SubscriptionPricingContent` tests pass
- [x] `useOneOffPricingDrawer` tests pass (renamed)
- [x] `EditQuote` tests pass
- [ ] Manual test: subscription pricing drawer opens and flows correctly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)