### PR TITLE
fix(api-keys): paginate list, scope reveal loading

### DIFF
--- a/src/components/developers/apiKeys/ApiKeys.tsx
+++ b/src/components/developers/apiKeys/ApiKeys.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
+import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Table } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
@@ -103,19 +104,53 @@ export const ApiKeys = () => {
   const premiumWarningDialog = usePremiumWarningDialog()
   const [showOrganizationId, setShowOrganizationId] = useState(false)
   const [shownApiKeysMap, setShownApiKeysMap] = useState<Map<string, string>>(new Map())
+  const [loadingKeyIds, setLoadingKeyIds] = useState<Set<string>>(new Set())
 
   const { data: organizationData, loading: organizationLoading } =
     useGetOrganizationInfosForApiKeyQuery()
-  const { data: apiKeysData, loading: apiKeysLoading } = useGetApiKeysQuery({
+  const {
+    data: apiKeysData,
+    loading: apiKeysLoading,
+    fetchMore: fetchMoreApiKeys,
+  } = useGetApiKeysQuery({
     variables: { page: 1, limit: 20 },
     notifyOnNetworkStatusChange: true,
   })
-  const [getApiKeyValue, { loading: revealKeyLoading }] = useGetApiKeyValueLazyQuery({
+  const [getApiKeyValue] = useGetApiKeyValueLazyQuery({
     fetchPolicy: 'network-only',
-    notifyOnNetworkStatusChange: true,
   })
 
   const showPremiumAddApiKeyState = !isPremium && !!apiKeysData?.apiKeys.collection.length
+
+  // Reveals a single key's value, tracking the loading state per row id (a Set, so
+  // several keys can reveal concurrently) and keeping the rest of the list as-is
+  // instead of flashing the whole list to loading.
+  const revealApiKey = async (id: string): Promise<string | undefined> => {
+    setLoadingKeyIds((prev) => new Set(prev).add(id))
+
+    try {
+      const res = await getApiKeyValue({ variables: { id } })
+      const fetchedValue = res?.data?.apiKey?.value
+
+      if (fetchedValue) {
+        setShownApiKeysMap((prev) => new Map(prev.set(id, fetchedValue)))
+      }
+
+      return fetchedValue
+    } catch {
+      addToast({
+        severity: 'danger',
+        translateKey: 'text_62b31e1f6a5b8b1b745ece48',
+      })
+    } finally {
+      setLoadingKeyIds((prev) => {
+        const next = new Set(prev)
+
+        next.delete(id)
+        return next
+      })
+    }
+  }
 
   useEffect(() => {
     const revealGivenKey = async () => {
@@ -277,246 +312,231 @@ export const ApiKeys = () => {
                   }
                 />
 
-                <Table
-                  tableInDialog
-                  name="api-keys"
-                  isLoading={apiKeysLoading}
-                  containerSize={{ default: 0 }}
-                  rowSize={48}
-                  data={apiKeysData?.apiKeys.collection || []}
-                  columns={[
-                    {
-                      key: 'id',
-                      title: translate('text_6419c64eace749372fc72b0f'),
-                      minWidth: 88,
-                      content: ({ name, expiresAt }) => (
-                        <Tooltip
-                          placement="top-start"
-                          title={translate('text_1732182455718np5v78j6dro', {
-                            date: DateTime.fromISO(expiresAt)
-                              .setLocale('en')
-                              .toLocaleString({ ...DateTime.DATETIME_FULL, second: 'numeric' }),
-                          })}
-                          disableHoverListener={!expiresAt}
-                        >
-                          <div className="flex items-center gap-2">
-                            <Typography color="grey700" variant="body" noWrap>
-                              {name || '-'}
-                            </Typography>
+                <InfiniteScroll
+                  onBottom={async () => {
+                    const { currentPage = 0, totalPages = 0 } = apiKeysData?.apiKeys.metadata || {}
 
-                            {!!expiresAt && (
-                              <Icon name="warning-filled" color="error" size="medium" />
-                            )}
-                          </div>
-                        </Tooltip>
-                      ),
-                    },
-                    {
-                      key: 'value',
-                      title: translate('text_1731079786592ksaixhj9ir9'),
-                      maxSpace: true,
-                      content: ({ id, value }) => {
-                        const apiKeyValue = shownApiKeysMap.get(id)
-
-                        if (revealKeyLoading) {
-                          return <Skeleton variant="text" textVariant="body" className="w-40" />
-                        }
-
-                        return (
-                          <div className="flex items-center gap-2 py-3">
-                            <TypographyWithCopy
-                              className="ml-0 line-break-auto [text-wrap:auto]"
-                              color="grey700"
-                              variant="captionCode"
-                              masked={!apiKeyValue}
-                              onCopy={
-                                apiKeyValue
-                                  ? undefined
-                                  : async () => {
-                                      try {
-                                        const res = await getApiKeyValue({ variables: { id } })
-                                        const fetchedValue = res?.data?.apiKey?.value
-
-                                        if (fetchedValue) {
-                                          copyToClipboard(fetchedValue)
-                                          addToast({
-                                            severity: 'info',
-                                            translateKey: 'text_6227a2e847fcd700e9038952',
-                                          })
-                                        }
-                                      } catch {
-                                        addToast({
-                                          severity: 'danger',
-                                          translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-                                        })
-                                      }
-                                    }
-                              }
-                            >
-                              {apiKeyValue || value}
-                            </TypographyWithCopy>
-
-                            <Tooltip
-                              placement="top-start"
-                              title={
-                                !!apiKeyValue
-                                  ? translate('text_1731082143943pr83kgzeh86')
-                                  : translate('text_1731082129536sv17ey4g0sk')
-                              }
-                            >
-                              <Button
-                                variant="quaternary"
-                                size="small"
-                                icon={!!apiKeyValue ? 'eye-hidden' : 'eye'}
-                                onClick={async () => {
-                                  if (!!apiKeyValue) {
-                                    setShownApiKeysMap((prev) => {
-                                      const newMap = new Map(prev)
-
-                                      newMap.delete(id)
-                                      return newMap
-                                    })
-                                  } else {
-                                    try {
-                                      const res = await getApiKeyValue({ variables: { id } })
-
-                                      if (!!res?.data?.apiKey?.value) {
-                                        setShownApiKeysMap(
-                                          (prev) =>
-                                            new Map(prev.set(id, res.data?.apiKey.value || '')),
-                                        )
-                                      }
-                                    } catch {
-                                      addToast({
-                                        severity: 'danger',
-                                        translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-                                      })
-                                    }
-                                  }
-                                }}
-                              />
-                            </Tooltip>
-                          </div>
-                        )
-                      },
-                    },
-                    {
-                      key: 'lastUsedAt',
-                      title: translate('text_1731515447290xbe4iqm5n6r'),
-                      minWidth: 140,
-                      content: ({ lastUsedAt }) => (
-                        <Typography color="grey700" variant="body">
-                          {!!lastUsedAt ? intlFormatDateTimeOrgaTZ(lastUsedAt).date : '-'}
-                        </Typography>
-                      ),
-                    },
-                    {
-                      key: 'createdAt',
-                      title: translate('text_1731080136186pvllfpt35on'),
-                      minWidth: 140,
-                      content: ({ createdAt }) => (
-                        <Typography color="grey700" variant="body">
-                          {intlFormatDateTimeOrgaTZ(createdAt).date}
-                        </Typography>
-                      ),
-                    },
-                  ]}
-                  actionColumnTooltip={() => translate('text_646e2d0cc536351b62ba6f01')}
-                  actionColumn={(item) => {
-                    const id = item.id
-                    const apiKeyValue = shownApiKeysMap.get(id)
-
-                    return [
-                      {
-                        startIcon: !!apiKeyValue ? 'eye-hidden' : 'eye',
-                        disabled: apiKeysLoading,
-                        title: !!apiKeyValue
-                          ? translate('text_1731085297554jks9n068fpp')
-                          : translate('text_1731085297554lu61x8djvcr'),
-                        onAction: async () => {
-                          if (!!apiKeyValue) {
-                            setShownApiKeysMap((prev) => {
-                              const newMap = new Map(prev)
-
-                              newMap.delete(id)
-                              return newMap
-                            })
-                          } else {
-                            try {
-                              const res = await getApiKeyValue({ variables: { id } })
-
-                              if (!!res?.data?.apiKey?.value) {
-                                setShownApiKeysMap(
-                                  (prev) => new Map(prev.set(id, res.data?.apiKey.value || '')),
-                                )
-                              }
-                            } catch {
-                              addToast({
-                                severity: 'danger',
-                                translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-                              })
-                            }
-                          }
-                        },
-                      },
-
-                      apiKeyValue
-                        ? {
-                            startIcon: 'duplicate',
-                            disabled: apiKeysLoading,
-                            title: translate('text_637f813d31381b1ed90ab30a'),
-                            onAction: () => {
-                              copyToClipboard(apiKeyValue)
-                              addToast({
-                                severity: 'info',
-                                translateKey: 'text_6227a2e847fcd700e9038952',
-                              })
-                            },
-                          }
-                        : null,
-
-                      {
-                        startIcon: 'pivot',
-                        disabled: apiKeysLoading,
-                        title: translate('text_17315063604211fznu9haor8'),
-                        onAction: () => {
-                          rotateApiKeyDialogRef.current?.openDialog({
-                            apiKey: item,
-                            callBack: (itemToReveal) => {
-                              setShownApiKeysMap(
-                                (prev) => new Map(prev.set(itemToReveal.id, itemToReveal.value)),
-                              )
-                            },
-                          })
-                        },
-                      },
-
-                      {
-                        startIcon: 'pen',
-                        disabled: apiKeysLoading,
-                        title: translate('text_1732286530467nu5f8jeg0ov'),
-                        onAction: () => {
-                          const path = generatePath(UPDATE_API_KEYS_ROUTE, { apiKeyId: id })
-
-                          // Navigate to BrowserRouter route from MemoryRouter without page reload
-                          setMainRouterUrl(path)
-                          close()
-                        },
-                      },
-
-                      (apiKeysData?.apiKeys.collection || []).length > 1
-                        ? {
-                            startIcon: 'trash',
-                            disabled: apiKeysLoading,
-                            title: translate('text_17322865304679l26k2dpiw2'),
-                            onAction: () => {
-                              deleteApiKeyDialogRef.current?.openDialog({ apiKey: item })
-                            },
-                          }
-                        : null,
-                    ]
+                    if (currentPage < totalPages && !apiKeysLoading) {
+                      await fetchMoreApiKeys({
+                        variables: { page: currentPage + 1 },
+                      })
+                    }
                   }}
-                />
+                >
+                  <Table
+                    tableInDialog
+                    name="api-keys"
+                    isLoading={apiKeysLoading}
+                    containerSize={{ default: 0 }}
+                    rowSize={48}
+                    data={apiKeysData?.apiKeys.collection || []}
+                    columns={[
+                      {
+                        key: 'id',
+                        title: translate('text_6419c64eace749372fc72b0f'),
+                        minWidth: 88,
+                        content: ({ name, expiresAt }) => (
+                          <Tooltip
+                            placement="top-start"
+                            title={translate('text_1732182455718np5v78j6dro', {
+                              date: DateTime.fromISO(expiresAt)
+                                .setLocale('en')
+                                .toLocaleString({ ...DateTime.DATETIME_FULL, second: 'numeric' }),
+                            })}
+                            disableHoverListener={!expiresAt}
+                          >
+                            <div className="flex items-center gap-2">
+                              <Typography color="grey700" variant="body" noWrap>
+                                {name || '-'}
+                              </Typography>
+
+                              {!!expiresAt && (
+                                <Icon name="warning-filled" color="error" size="medium" />
+                              )}
+                            </div>
+                          </Tooltip>
+                        ),
+                      },
+                      {
+                        key: 'value',
+                        title: translate('text_1731079786592ksaixhj9ir9'),
+                        maxSpace: true,
+                        content: ({ id, value }) => {
+                          const apiKeyValue = shownApiKeysMap.get(id)
+                          const isRevealing = loadingKeyIds.has(id)
+
+                          return (
+                            <div className="flex items-center gap-2 py-3">
+                              {isRevealing ? (
+                                <div className="flex h-8 items-center">
+                                  <Skeleton
+                                    variant="text"
+                                    textVariant="captionCode"
+                                    className="w-40"
+                                  />
+                                </div>
+                              ) : (
+                                <TypographyWithCopy
+                                  className="ml-0 line-break-auto [text-wrap:auto]"
+                                  color="grey700"
+                                  variant="captionCode"
+                                  masked={!apiKeyValue}
+                                  onCopy={
+                                    apiKeyValue
+                                      ? undefined
+                                      : async () => {
+                                          const fetchedValue = await revealApiKey(id)
+
+                                          if (fetchedValue) {
+                                            copyToClipboard(fetchedValue)
+                                            addToast({
+                                              severity: 'info',
+                                              translateKey: 'text_6227a2e847fcd700e9038952',
+                                            })
+                                          }
+                                        }
+                                  }
+                                >
+                                  {apiKeyValue || value}
+                                </TypographyWithCopy>
+                              )}
+
+                              <Tooltip
+                                placement="top-start"
+                                title={
+                                  !!apiKeyValue
+                                    ? translate('text_1731082143943pr83kgzeh86')
+                                    : translate('text_1731082129536sv17ey4g0sk')
+                                }
+                              >
+                                <Button
+                                  variant="quaternary"
+                                  size="small"
+                                  loading={isRevealing}
+                                  icon={!!apiKeyValue ? 'eye-hidden' : 'eye'}
+                                  onClick={async () => {
+                                    if (!!apiKeyValue) {
+                                      setShownApiKeysMap((prev) => {
+                                        const newMap = new Map(prev)
+
+                                        newMap.delete(id)
+                                        return newMap
+                                      })
+                                    } else {
+                                      await revealApiKey(id)
+                                    }
+                                  }}
+                                />
+                              </Tooltip>
+                            </div>
+                          )
+                        },
+                      },
+                      {
+                        key: 'lastUsedAt',
+                        title: translate('text_1731515447290xbe4iqm5n6r'),
+                        minWidth: 140,
+                        content: ({ lastUsedAt }) => (
+                          <Typography color="grey700" variant="body">
+                            {!!lastUsedAt ? intlFormatDateTimeOrgaTZ(lastUsedAt).date : '-'}
+                          </Typography>
+                        ),
+                      },
+                      {
+                        key: 'createdAt',
+                        title: translate('text_1731080136186pvllfpt35on'),
+                        minWidth: 140,
+                        content: ({ createdAt }) => (
+                          <Typography color="grey700" variant="body">
+                            {intlFormatDateTimeOrgaTZ(createdAt).date}
+                          </Typography>
+                        ),
+                      },
+                    ]}
+                    actionColumnTooltip={() => translate('text_646e2d0cc536351b62ba6f01')}
+                    actionColumn={(item) => {
+                      const id = item.id
+                      const apiKeyValue = shownApiKeysMap.get(id)
+
+                      return [
+                        {
+                          startIcon: !!apiKeyValue ? 'eye-hidden' : 'eye',
+                          disabled: apiKeysLoading,
+                          title: !!apiKeyValue
+                            ? translate('text_1731085297554jks9n068fpp')
+                            : translate('text_1731085297554lu61x8djvcr'),
+                          onAction: async () => {
+                            if (!!apiKeyValue) {
+                              setShownApiKeysMap((prev) => {
+                                const newMap = new Map(prev)
+
+                                newMap.delete(id)
+                                return newMap
+                              })
+                            } else {
+                              await revealApiKey(id)
+                            }
+                          },
+                        },
+
+                        apiKeyValue
+                          ? {
+                              startIcon: 'duplicate',
+                              disabled: apiKeysLoading,
+                              title: translate('text_637f813d31381b1ed90ab30a'),
+                              onAction: () => {
+                                copyToClipboard(apiKeyValue)
+                                addToast({
+                                  severity: 'info',
+                                  translateKey: 'text_6227a2e847fcd700e9038952',
+                                })
+                              },
+                            }
+                          : null,
+
+                        {
+                          startIcon: 'pivot',
+                          disabled: apiKeysLoading,
+                          title: translate('text_17315063604211fznu9haor8'),
+                          onAction: () => {
+                            rotateApiKeyDialogRef.current?.openDialog({
+                              apiKey: item,
+                              callBack: (itemToReveal) => {
+                                setShownApiKeysMap(
+                                  (prev) => new Map(prev.set(itemToReveal.id, itemToReveal.value)),
+                                )
+                              },
+                            })
+                          },
+                        },
+
+                        {
+                          startIcon: 'pen',
+                          disabled: apiKeysLoading,
+                          title: translate('text_1732286530467nu5f8jeg0ov'),
+                          onAction: () => {
+                            const path = generatePath(UPDATE_API_KEYS_ROUTE, { apiKeyId: id })
+
+                            // Navigate to BrowserRouter route from MemoryRouter without page reload
+                            setMainRouterUrl(path)
+                            close()
+                          },
+                        },
+
+                        (apiKeysData?.apiKeys.collection || []).length > 1
+                          ? {
+                              startIcon: 'trash',
+                              disabled: apiKeysLoading,
+                              title: translate('text_17322865304679l26k2dpiw2'),
+                              onAction: () => {
+                                deleteApiKeyDialogRef.current?.openDialog({ apiKey: item })
+                              },
+                            }
+                          : null,
+                      ]
+                    }}
+                  />
+                </InfiniteScroll>
               </SettingsListItem>
             </>
           )}

--- a/src/components/developers/apiKeys/__tests__/ApiKeys.test.tsx
+++ b/src/components/developers/apiKeys/__tests__/ApiKeys.test.tsx
@@ -6,6 +6,17 @@ import { AllTheProviders } from '~/test-utils'
 
 import { ApiKeys } from '../ApiKeys'
 
+// Mock IntersectionObserver (used by InfiniteScroll, undefined in jsdom)
+const mockIntersectionObserver = jest.fn()
+
+mockIntersectionObserver.mockReturnValue({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+})
+
+globalThis.IntersectionObserver = mockIntersectionObserver
+
 const MOCK_ORG_ID = 'org-12345-abcde-67890'
 const MOCK_API_KEY_ID = 'api-key-12345'
 const MOCK_API_KEY_VALUE = '••••••••xyz'

--- a/src/core/apolloClient/__tests__/cache.test.ts
+++ b/src/core/apolloClient/__tests__/cache.test.ts
@@ -14,9 +14,6 @@ const IGNORED_DIRECTORIES = new Set(['generated', '__tests__', '__mocks__', 'nod
 // these starts using fetchMore/InfiniteScroll, remove it from here and add a field
 // policy in cache.ts instead.
 const FIELDS_WITHOUT_FETCH_MORE = new Set([
-  // ApiKeys.tsx renders the whole collection, no InfiniteScroll - missing pagination
-  // tracked in LAGO-1524; remove from here when fixing it
-  'apiKeys',
   // XeroIntegrationMapItemDrawer combobox searchQuery, always a fresh page-1 lazy query
   'integrationItems',
 ])

--- a/src/core/apolloClient/cache.ts
+++ b/src/core/apolloClient/cache.ts
@@ -9,6 +9,7 @@ export const queryFieldPolicies: Record<string, FieldPolicy> = {
   // Standard paginated queries - automatically cache by all args except page/limit/offset
   activityLogs: createPaginatedFieldPolicy(),
   addOns: createPaginatedFieldPolicy(),
+  apiKeys: createPaginatedFieldPolicy(),
   appliedCoupons: createPaginatedFieldPolicy(),
   billableMetrics: createPaginatedFieldPolicy(),
   // billingEntity: createPaginatedFieldPolicy(),


### PR DESCRIPTION
Fixes LAGO-1524

The API keys list was hardcoded to `{ page: 1, limit: 20 }` with no `InfiniteScroll`/`fetchMore`, so orgs with more than 20 keys silently never saw keys 21+.

## Pagination
- Wrap the api-keys table in `InfiniteScroll`, wire `fetchMore` on bottom (same pattern as `ApiLogsTable`).
- Add `apiKeys: createPaginatedFieldPolicy()` in `cache.ts` so page-2 results merge into the watched query.
- Remove `apiKeys` from the `FIELDS_WITHOUT_FETCH_MORE` allowlist in `cache.test.ts`; the drift test now enforces the policy.

## Reveal loading UX
- Loading was a single shared boolean, so revealing one key flashed every row to a skeleton. Now tracked per row id via a `Set` (concurrent reveals supported).
- Skeleton is sized to match the `TypographyWithCopy` button height, so row height no longer jumps between masked / loading / revealed.
- Eye button spins while its row loads; dropped `notifyOnNetworkStatusChange` on the value query to cut redundant re-renders.