### PR TITLE
fix(auth): purge persisted Apollo cache on logout

### DIFF
--- a/src/core/apolloClient/__tests__/cachePersistor.test.ts
+++ b/src/core/apolloClient/__tests__/cachePersistor.test.ts
@@ -1,0 +1,138 @@
+import { ApolloClient } from '@apollo/client'
+
+const mockCtor = jest.fn()
+const mockRestore = jest.fn()
+const mockPurge = jest.fn()
+const mockPause = jest.fn()
+const mockKeys = jest.fn()
+const mockRemoveItem = jest.fn()
+
+jest.mock('apollo3-cache-persist', () => ({
+  CachePersistor: function CachePersistorMock(options: unknown) {
+    mockCtor(options)
+
+    return { restore: mockRestore, purge: mockPurge, pause: mockPause }
+  },
+  LocalForageWrapper: function LocalForageWrapperMock(storage: unknown) {
+    return { storage }
+  },
+}))
+
+jest.mock('localforage', () => ({
+  __esModule: true,
+  default: {
+    keys: (...args: unknown[]) => mockKeys(...args),
+    removeItem: (...args: unknown[]) => mockRemoveItem(...args),
+  },
+}))
+
+jest.mock('../cache', () => ({ cache: { id: 'mock-cache' } }))
+
+const CURRENT_KEY = 'apollo-cache-persist-lago-1.0.0'
+const STALE_KEY = 'apollo-cache-persist-lago-0.9.0'
+const UNRELATED_KEY = 'some-other-localforage-key'
+
+const loadModule = () => import('../cachePersistor')
+
+describe('cachePersistor', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+    mockRestore.mockResolvedValue(undefined)
+    mockPurge.mockResolvedValue(undefined)
+    mockRemoveItem.mockResolvedValue(undefined)
+    mockKeys.mockResolvedValue([])
+    window.history.pushState({}, '', '/')
+  })
+
+  describe('setupCachePersistor', () => {
+    describe('GIVEN a customer-portal URL', () => {
+      it('THEN should skip persistence entirely (no persistor, no restore)', async () => {
+        window.history.pushState({}, '', '/customer-portal/some-token')
+
+        const { setupCachePersistor } = await loadModule()
+        const result = await setupCachePersistor('1.0.0')
+
+        expect(result).toBeNull()
+        expect(mockCtor).not.toHaveBeenCalled()
+        expect(mockRestore).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('GIVEN a non-portal URL', () => {
+      it('THEN should purge only stale version-keyed blobs, keep the current and unrelated keys, then restore', async () => {
+        mockKeys.mockResolvedValue([CURRENT_KEY, STALE_KEY, UNRELATED_KEY])
+
+        const { setupCachePersistor } = await loadModule()
+        const result = await setupCachePersistor('1.0.0')
+
+        expect(mockRemoveItem).toHaveBeenCalledTimes(1)
+        expect(mockRemoveItem).toHaveBeenCalledWith(STALE_KEY)
+        expect(mockRemoveItem).not.toHaveBeenCalledWith(CURRENT_KEY)
+        expect(mockRemoveItem).not.toHaveBeenCalledWith(UNRELATED_KEY)
+
+        expect(mockCtor).toHaveBeenCalledWith(expect.objectContaining({ key: CURRENT_KEY }))
+        expect(mockRestore).toHaveBeenCalledTimes(1)
+        expect(result).not.toBeNull()
+      })
+
+      it('THEN should still set up the persistor when stale-cache cleanup fails', async () => {
+        mockKeys.mockRejectedValue(new Error('IndexedDB unavailable'))
+
+        const { setupCachePersistor } = await loadModule()
+        const result = await setupCachePersistor('1.0.0')
+
+        expect(result).not.toBeNull()
+        expect(mockRestore).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('resetPersistedCache', () => {
+    it('THEN should clear the in-memory store BEFORE purging the persisted blob', async () => {
+      const { setupCachePersistor, resetPersistedCache } = await loadModule()
+
+      await setupCachePersistor('1.0.0')
+
+      const callOrder: string[] = []
+
+      mockPurge.mockImplementation(async () => {
+        callOrder.push('purge')
+      })
+
+      const client = {
+        clearStore: jest.fn().mockImplementation(async () => {
+          callOrder.push('clearStore')
+        }),
+      } as unknown as ApolloClient<object>
+
+      await resetPersistedCache(client)
+
+      expect(callOrder).toEqual(['clearStore', 'purge'])
+    })
+  })
+
+  describe('purgePersistedCache', () => {
+    it('THEN should be a no-op when persistence was skipped (portal context)', async () => {
+      window.history.pushState({}, '', '/customer-portal/some-token')
+
+      const { setupCachePersistor, purgePersistedCache } = await loadModule()
+
+      await setupCachePersistor('1.0.0')
+      await purgePersistedCache()
+
+      expect(mockPurge).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pausePersistence', () => {
+    it('THEN should pause the persistor write trigger', async () => {
+      const { setupCachePersistor, pausePersistence } = await loadModule()
+
+      await setupCachePersistor('1.0.0')
+      pausePersistence()
+
+      expect(mockPause).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/core/apolloClient/__tests__/cacheUtils.test.ts
+++ b/src/core/apolloClient/__tests__/cacheUtils.test.ts
@@ -1,11 +1,18 @@
 import { ApolloClient } from '@apollo/client'
 
-import { onLogIn, switchCurrentOrganization } from '../cacheUtils'
+import { logOut, onLogIn, switchCurrentOrganization } from '../cacheUtils'
 
 const mockGetCurrentOrganizationId = jest.fn()
 const mockSetCurrentOrganizationId = jest.fn()
 const mockUpdateAuthTokenVar = jest.fn()
 const mockAddToast = jest.fn()
+const mockResetPersistedCache = jest.fn().mockResolvedValue(undefined)
+const mockPurgePersistedCache = jest.fn().mockResolvedValue(undefined)
+
+jest.mock('../cachePersistor', () => ({
+  resetPersistedCache: (...args: unknown[]) => mockResetPersistedCache(...args),
+  purgePersistedCache: (...args: unknown[]) => mockPurgePersistedCache(...args),
+}))
 
 jest.mock('../reactiveVars', () => ({
   addToast: (...args: unknown[]) => mockAddToast(...args),
@@ -88,6 +95,14 @@ describe('switchCurrentOrganization', () => {
           'setCurrentOrganizationId',
           'reFetchObservableQueries',
         ])
+      })
+
+      it('THEN should purge the persisted blob without awaiting it (fire-and-forget keeps switch timing flash-free)', async () => {
+        const client = createMockClient()
+
+        await switchCurrentOrganization(client, 'org-456')
+
+        expect(mockPurgePersistedCache).toHaveBeenCalledTimes(1)
       })
     })
   })
@@ -187,6 +202,40 @@ describe('onLogIn', () => {
         expect(mockSetCurrentOrganizationId).toHaveBeenCalledWith(null)
         expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'danger' }))
       })
+    })
+  })
+})
+
+describe('logOut', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+  })
+
+  describe('WHEN logging out', () => {
+    it('THEN should reset both the in-memory and the persisted cache, then clear the auth token', async () => {
+      const client = createMockClient()
+
+      await logOut(client)
+
+      expect(mockResetPersistedCache).toHaveBeenCalledWith(client)
+      expect(mockUpdateAuthTokenVar).toHaveBeenCalled()
+    })
+
+    it('THEN should stop the client BEFORE resetting the cache', async () => {
+      const client = createMockClient()
+      const callOrder: string[] = []
+
+      ;(client.stop as jest.Mock).mockImplementation(() => {
+        callOrder.push('stop')
+      })
+      mockResetPersistedCache.mockImplementation(async () => {
+        callOrder.push('resetPersistedCache')
+      })
+
+      await logOut(client)
+
+      expect(callOrder).toEqual(['stop', 'resetPersistedCache'])
     })
   })
 })

--- a/src/core/apolloClient/cachePersistor.ts
+++ b/src/core/apolloClient/cachePersistor.ts
@@ -1,0 +1,78 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+import { CachePersistor, LocalForageWrapper } from 'apollo3-cache-persist'
+import localForage from 'localforage'
+import { matchPath } from 'react-router-dom'
+
+import { CUSTOMER_PORTAL_ROUTE } from '~/core/router/paths/customerPortal'
+
+import { cache } from './cache'
+
+const KEY_PREFIX = 'apollo-cache-persist-lago-'
+
+let persistor: CachePersistor<NormalizedCacheObject> | null = null
+
+const isCustomerPortalContext = () =>
+  !!matchPath(`${CUSTOMER_PORTAL_ROUTE}/*`, window.location.pathname)
+
+// storage.purge() only removes the current key. Blobs left by previous app
+// versions (different version suffix) must be cleaned manually so old deploys
+// don't leave org data at rest forever. Best-effort — never block boot on it.
+const purgeStaleVersionedCaches = async (currentKey: string) => {
+  try {
+    const keys = await localForage.keys()
+
+    await Promise.all(
+      keys
+        .filter((key) => key.startsWith(KEY_PREFIX) && key !== currentKey)
+        .map((key) => localForage.removeItem(key)),
+    )
+  } catch {
+    // ignore — stale-cache cleanup must never prevent the app from starting
+  }
+}
+
+// Called once at client init. In customer-portal context we skip persistence
+// entirely: the portal is public, token-scoped and single-customer, and must
+// never restore the shared admin blob into memory nor write into it. The
+// in-memory cache still works normally for the portal session.
+export const setupCachePersistor = async (appVersion: string) => {
+  if (isCustomerPortalContext()) {
+    return null
+  }
+
+  const currentKey = `${KEY_PREFIX}${appVersion}`
+
+  await purgeStaleVersionedCaches(currentKey)
+
+  persistor = new CachePersistor({
+    cache,
+    storage: new LocalForageWrapper(localForage),
+    key: currentKey,
+  })
+
+  // The constructor does not restore (unlike the persistCache helper), so we
+  // restore explicitly.
+  await persistor.restore()
+
+  return persistor
+}
+
+// Wipe the persisted blob from IndexedDB. No-op if setup was skipped (portal).
+export const purgePersistedCache = async () => {
+  await persistor?.purge()
+}
+
+// Full teardown for authenticated contexts (logout, org switch): empty the
+// in-memory cache, then wipe the at-rest blob — in that order.
+export const resetPersistedCache = async (client: ApolloClient<object>) => {
+  await client.clearStore()
+  await purgePersistedCache()
+}
+
+// Stop persisting without deleting the blob. Used when a portal is entered via
+// same-tab client-side navigation (persistor already live with the admin key):
+// prevents portal data from leaking into the admin blob while leaving that blob
+// intact.
+export const pausePersistence = () => {
+  persistor?.pause()
+}

--- a/src/core/apolloClient/cacheUtils.ts
+++ b/src/core/apolloClient/cacheUtils.ts
@@ -7,6 +7,7 @@ import {
 } from '~/generated/graphql'
 import { DEVTOOL_AUTO_SAVE_KEY, resetDevtoolsNavigation } from '~/hooks/useDeveloperTool'
 
+import { purgePersistedCache, resetPersistedCache } from './cachePersistor'
 import {
   addToast,
   AUTH_TOKEN_LS_KEY,
@@ -61,8 +62,9 @@ export const logOut = async (client: ApolloClient<object>, resetLocationHistory?
   resetDevtoolsNavigation()
   // Cancels active operations
   client.stop()
-  // Removes cached data and prevents active queries re-fetch
-  await client.clearStore()
+  // Removes cached data (in-memory + IndexedDB-persisted blob) and prevents
+  // active queries re-fetch
+  await resetPersistedCache(client)
   updateAuthTokenVar()
 
   resetLocationHistory && resetLocationHistoryVar()
@@ -163,15 +165,27 @@ export const switchCurrentOrganization = async (
   // 1. Reset devtools navigation to prevent stale queries with old transactionIds
   resetDevtoolsNavigation()
 
-  // 2. Cancel in-flight queries scoped to the previous org. If we let them
+  // 2. Purge the previous org's IndexedDB-persisted blob so its data isn't left
+  //    at rest. Fire-and-forget on purpose: `OrganizationLayout`'s effect
+  //    re-enters this function during the slug↔var mismatch window around the
+  //    post-switch `navigate`, so the switch path is timing-sensitive. Awaiting
+  //    an IndexedDB op here adds latency that stretches that mismatch window and
+  //    lets React paint a blank Error404 frame. Backgrounding it keeps the
+  //    teardown→resync timing identical to the pre-persistence behaviour (only
+  //    `clearStore` awaited). The new org's refetch (step 5) repersists a fresh
+  //    blob; `removeItem` resolves long before the network round-trip, so it
+  //    won't delete that fresh blob.
+  purgePersistedCache().catch(() => {})
+
+  // 3. Cancel in-flight queries scoped to the previous org. If we let them
   //    return after the var change, they'd write old-org data into a cache
   //    that we're about to repopulate for the new org → race.
   client.stop()
 
-  // 3. Clear the cache before updating the org context.
+  // 4. Clear the cache before updating the org context.
   await client.clearStore()
 
-  // 4. Update the org id (and LS). The auth link reads from the var, so any
+  // 4b. Update the org id (and LS). The auth link reads from the var, so any
   //    request fired AFTER this line carries the new `x-lago-organization`
   //    header.
   setCurrentOrganizationId(organizationId)
@@ -181,7 +195,7 @@ export const switchCurrentOrganization = async (
   //    `OrganizationLayout`'s gate keeps `Outlet` unmounted, so children
   //    never get a fresh mount that would create new observers — the
   //    observers in `OrganizationLayout` itself (e.g. `useCurrentUser`)
-  //    were stopped at step 2 and would otherwise sit dead, leaving the
+  //    were stopped at step 3 and would otherwise sit dead, leaving the
   //    UI stuck on `loading: true` until a second hard refresh.
   //
   //    Fire-and-forget on purpose: callers (e.g. `OrganizationSwitcher`)
@@ -191,7 +205,7 @@ export const switchCurrentOrganization = async (
   //    the brief window where the cache is empty / refetch in flight.
   client.reFetchObservableQueries()
 
-  // 6. Clear other org-specific state
+  // 7. Clear other org-specific state
   removeItemFromLS(DEVTOOL_AUTO_SAVE_KEY)
 }
 

--- a/src/core/apolloClient/index.ts
+++ b/src/core/apolloClient/index.ts
@@ -1,5 +1,6 @@
 export * from './init'
 export * from './cache'
+export * from './cachePersistor'
 export * from './cacheUtils'
 export * from './errorUtils'
 export * from './reactiveVars'

--- a/src/core/apolloClient/init.ts
+++ b/src/core/apolloClient/init.ts
@@ -4,11 +4,9 @@ import { RetryLink } from '@apollo/client/link/retry'
 import { getMainDefinition } from '@apollo/client/utilities'
 import { captureException, captureMessage } from '@sentry/react'
 import ActionCable from 'actioncable'
-import { LocalForageWrapper, persistCache } from 'apollo3-cache-persist'
 import ApolloLinkTimeout from 'apollo-link-timeout'
 import { createUploadLink } from 'apollo-upload-client'
 import ActionCableLink from 'graphql-ruby-client/subscriptions/ActionCableLink'
-import localForage from 'localforage'
 // IMPORTANT: Keep reactiveVars import before cacheUtils
 import { matchPath } from 'react-router-dom'
 
@@ -25,6 +23,7 @@ import { LagoApiError } from '~/generated/graphql'
 
 import { buildAuthHeaders } from './authHeaders'
 import { cache } from './cache'
+import { setupCachePersistor } from './cachePersistor'
 import { getItemFromLS, omitDeep } from './cacheUtils'
 import { resolvers, typeDefs } from './graphqlResolvers'
 
@@ -272,11 +271,7 @@ export const initializeApolloClient = async () => {
 
   const splitLink = split(hasSubscriptionOperation, subscriptionLink, httpLink)
 
-  await persistCache({
-    cache,
-    storage: new LocalForageWrapper(localForage),
-    key: `apollo-cache-persist-lago-${appVersion}`,
-  })
+  await setupCachePersistor(appVersion)
 
   const link = ApolloLink.from([
     authLink,

--- a/src/pages/auth/PortalInit.tsx
+++ b/src/pages/auth/PortalInit.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { Spinner } from '~/components/designSystem/Spinner'
-import { onAccessCustomerPortal } from '~/core/apolloClient'
+import { onAccessCustomerPortal, pausePersistence } from '~/core/apolloClient'
 import CustomerPortal from '~/pages/customerPortal/CustomerPortal'
 
 const PortalInit = () => {
@@ -12,15 +12,28 @@ const PortalInit = () => {
   const [isReady, setIsReady] = useState(false)
 
   useEffect(() => {
-    if (token) {
-      client
-        .clearStore()
-        .catch(() => {})
-        .finally(() => {
-          onAccessCustomerPortal(token)
-          setIsReady(true)
-        })
+    if (!token) {
+      return
     }
+
+    const init = async () => {
+      // Stop persisting to the shared admin blob (no-op on a fresh portal load
+      // where persistence was skipped at setup; stops writes on same-tab
+      // admin → portal nav). Do NOT purge — that would delete the admin's
+      // at-rest cache, which a different tab may still rely on.
+      pausePersistence()
+
+      try {
+        await client.clearStore()
+      } catch {
+        // proceed to grant portal access regardless
+      }
+
+      onAccessCustomerPortal(token)
+      setIsReady(true)
+    }
+
+    init()
   }, [client, token])
 
   if (!token || !isReady) {

--- a/src/pages/auth/__tests__/PortalInit.test.tsx
+++ b/src/pages/auth/__tests__/PortalInit.test.tsx
@@ -15,9 +15,13 @@ jest.mock('@apollo/client', () => ({
 }))
 
 const mockOnAccessCustomerPortal = jest.fn()
+const mockPausePersistence = jest.fn()
+const mockPurgePersistedCache = jest.fn()
 
 jest.mock('~/core/apolloClient', () => ({
   onAccessCustomerPortal: (...args: unknown[]) => mockOnAccessCustomerPortal(...args),
+  pausePersistence: (...args: unknown[]) => mockPausePersistence(...args),
+  purgePersistedCache: (...args: unknown[]) => mockPurgePersistedCache(...args),
 }))
 
 jest.mock('~/pages/customerPortal/CustomerPortal', () => ({
@@ -84,10 +88,19 @@ describe('PortalInit', () => {
           expect(mockOnAccessCustomerPortal).toHaveBeenCalledWith('test-token')
         })
       })
+
+      it('THEN should pause persistence and never purge the admin blob', async () => {
+        renderWithToken()
+
+        await waitFor(() => {
+          expect(mockPausePersistence).toHaveBeenCalled()
+        })
+        expect(mockPurgePersistedCache).not.toHaveBeenCalled()
+      })
     })
 
     describe('WHEN the store clear fails', () => {
-      it('THEN should still render CustomerPortal via .finally()', async () => {
+      it('THEN should still render CustomerPortal', async () => {
         mockClearStore.mockRejectedValue(new Error('Store clear failed'))
 
         renderWithToken()


### PR DESCRIPTION
Fixes LAGO-1550

## Problem

`logOut()` only tore down the **in-memory** Apollo cache (`client.stop()` → `client.clearStore()` → `updateAuthTokenVar()`). The full cache is persisted to IndexedDB via the `persistCache()` helper (key `apollo-cache-persist-lago-${appVersion}`).

`apollo3-cache-persist@0.15.0` uses the default `trigger: 'write'`, which only patches `cache.write/evict/modify/gc`. `clearStore()` → `InMemoryCache.reset()` never hits a patched method, so the persist trigger never fires — and because the app used the convenience helper (which hides the persistor) and never instantiated `CachePersistor`, there was no `.purge()` anywhere.

Result: every customer/invoice/plan/membership payload the previous session wrote stayed in IndexedDB after logout. On the next load `persistCache` restored it into memory **before** any auth check, so a different user on the same browser could read prior org data — at rest and via cache-first paint. The version-suffixed key also orphaned each deploy's blob permanently.

## Fix

- New `src/core/apolloClient/cachePersistor.ts`: a singleton `CachePersistor` with explicit `restore()` (the helper did this internally; the class does not), plus stale version-keyed blob cleanup on startup.
- `resetPersistedCache(client)` = `clearStore()` + `purge()`, used by `logOut`.
- **Customer portal isolation**: the portal shares the single app-wide persist key, so it previously restored the admin blob into its own memory and persisted portal data back into it. `setupCachePersistor` now skips persistence entirely in portal context (no restore, no persist), and `PortalInit` pauses persistence + clears memory without purging the admin's at-rest blob. In-memory caching for the portal session is unchanged.
- **Org switch**: `switchCurrentOrganization` purges the previous org's blob fire-and-forget. Awaiting it added latency to a path that `OrganizationLayout`'s effect re-enters during the slug↔var mismatch window, which stretched that window enough for React to paint a blank Error404 frame (a flash). Backgrounding the purge keeps the switch timing identical to before, so no flash.

## Tests

- New `cachePersistor.test.ts`: portal skip, stale-key purge (keeps current + unrelated keys), restore, reset ordering, pause.
- `cacheUtils.test.ts`: logout teardown + ordering, switch path stays `clearStore → setOrgId → reFetch` with purge fire-and-forget.
- `PortalInit.test.tsx`: pause called, admin blob never purged, ready even when `clearStore` rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
