### PR TITLE
fix(nginx): add CSP script-src + security headers

### DIFF
--- a/nginx/csp.conf
+++ b/nginx/csp.conf
@@ -1,1 +1,33 @@
-add_header Content-Security-Policy "frame-ancestors *.force.com *.localhost *.ojin.ai *.ojin.foo *.web.app *.hubspot.com *.hubspotusercontent.com *.foxglove-app-party.pages.dev app.foxglove.party app.foxglove.dev *.gladia.io localhost;" always;
+# Security headers (included from every location in nginx.conf).
+#
+# Design constraint: lago-front ships as a single static image used by both
+# Lago Cloud and self-hosted users. The hosts the app talks to at runtime
+# (the API + its `wss://` ActionCable subscriptions, the Sentry DSN, Nango,
+# the embedded Superset URL) are injected per-deployment via env-config.js and
+# are NOT known at build time. So directives that gate *network egress* or
+# *embedding remote frames/images* (connect-src, frame-src, img-src) are kept
+# permissive on purpose: pinning them statically would break every
+# self-hosted deployment that uses a different API/Sentry/Superset host.
+#
+# The defense-in-depth that DOES apply universally is locking down where
+# *scripts* execute: script-src 'self' (the app only loads its own hashed
+# /assets bundles + env-config.js, with no inline scripts and no eval),
+# object-src 'none', and base-uri 'self'. That is the XSS mitigation this
+# header buys.
+
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https: http: wss: ws: blob: data:; worker-src 'self' blob:; frame-src 'self' https: http:; object-src 'none'; base-uri 'self'; frame-ancestors *.force.com *.localhost *.ojin.ai *.ojin.foo *.web.app *.hubspot.com *.hubspotusercontent.com *.foxglove-app-party.pages.dev app.foxglove.party app.foxglove.dev *.gladia.io localhost;" always;
+
+# Stop browsers MIME-sniffing a response into an unexpected (e.g. executable)
+# content type.
+add_header X-Content-Type-Options "nosniff" always;
+
+# Don't leak full URLs (which can carry org slugs / ids) to third-party
+# origins; send only the origin on cross-origin requests, nothing on downgrade.
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+# NOTE: deliberately NO X-Frame-Options header. Lago is intentionally embedded
+# by partner origins (see the frame-ancestors allowlist above), and X-Frame-
+# Options has no allowlist value: SAMEORIGIN/DENY would break those embedders
+# in browsers that honor XFO, and the deprecated ALLOW-FROM is unsupported.
+# CSP frame-ancestors is the modern, allowlist-capable clickjacking control
+# and already covers this case, so XFO would only regress behaviour.


### PR DESCRIPTION
Fixes LAGO-1526

Replaces the `frame-ancestors`-only CSP in `nginx/csp.conf` with a real policy plus the two missing static headers, while deliberately keeping the deployment-variable directives open so no self-hosted install breaks.

### Done (from ticket remediation)
- [x] **Real CSP with `default-src 'self'` and a tight `script-src`** — `script-src 'self' 'wasm-unsafe-eval'`, `object-src 'none'`, `base-uri 'self'`. This is the XSS defense-in-depth the ticket asks for. Safe because the app loads only its own hashed `/assets` bundles + `env-config.js` (no inline scripts, no eval).
- [x] **`X-Content-Type-Options: nosniff`**
- [x] **`Referrer-Policy: strict-origin-when-cross-origin`**

Supporting directives so the app keeps rendering: `style-src 'unsafe-inline' https://fonts.googleapis.com` (MUI/emotion + Google Fonts), `font-src https://fonts.gstatic.com`, `worker-src blob:` (Sentry replay).

### Intentionally NOT done, and why
- **`connect-src` / `frame-src` / `img-src` left permissive (not `'self'`).** The hosts the app talks to at runtime — API + its `wss://` ActionCable subscriptions, Sentry DSN, Nango, embedded Superset URL — are injected per deployment via `env-config.js` and are unknown at build time. lago-front ships as one static image for Lago Cloud *and* self-hosted users, so pinning these would break every install on a different host. The XSS value of CSP lives in `script-src`, which is tight.
- **`X-Frame-Options` omitted** (ticket listed it as missing). Lago is intentionally embedded by partner origins in the `frame-ancestors` allowlist (force.com, hubspot, gladia, foxglove, ...). XFO has no allowlist value, so `SAMEORIGIN`/`DENY` would block those legit embedders in browsers that honor XFO. `frame-ancestors` is the modern, allowlist-capable clickjacking control and already covers this; adding XFO would only regress behaviour.
- **`localhost` kept in `frame-ancestors`** (ticket suggested dropping it in prod) — still needed for now.

### Outcome
Smoke-tested against the real `nginx:1.31-alpine` image serving the built app with the actual `nginx.conf` + `csp.conf`. Under the enforced policy: React mounts, the login page renders fully, `self` bundles + both Google Fonts stylesheets load, and there are **zero CSP violations** in the console. Authenticated flows (integrations OAuth, Superset embed, PDF, logo upload) ride on the permissive `connect-src`/`frame-src`/`img-src`, so they cannot be CSP-blocked by construction.

