### PR TITLE
fix(i18n): add missing pt-BR translations

### DIFF
--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -3131,5 +3131,8 @@
   "text_1780498504241di3s12o655k": "Preço",
   "text_1780498504241eo24fnc6s9u": "De {{fromDate}} a {{toDate}}",
   "text_17804985042422iw5hwj0u2v": "Todos os preços não incluem os impostos aplicáveis",
-  "text_1779289915866etwoweh1syv": "Taxa de assinatura"
+  "text_1779289915866etwoweh1syv": "Taxa de assinatura",
+  "text_1778496527600gzfmf3x6r2q": "Dados de uso desta assinatura no período de faturamento atual em aberto.",
+  "text_17786802483174e1d300blik": "Uso vinculado aos filtros de cobrança e grupos de preços",
+  "text_177883198759933bb02ulslv": "preço por"
 }


### PR DESCRIPTION
Adds 3 missing pt-BR translation keys, translated from the en source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)