### PR TITLE
refactor(dialog): migrate RemoveTaxDialog to CentralizedDialog hook

### DIFF
--- a/src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx
@@ -27,10 +27,7 @@ import {
   ApplyTaxDialogRef,
 } from '~/pages/settings/BillingEntity/sections/taxes/ApplyTaxDialog'
 import { APPLY_TAX_BUTTON_TEST_ID } from '~/pages/settings/BillingEntity/sections/taxes/dataTestConstants'
-import {
-  RemoveTaxDialog,
-  RemoveTaxDialogRef,
-} from '~/pages/settings/BillingEntity/sections/taxes/RemoveTaxDialog'
+import { useRemoveTaxDialog } from '~/pages/settings/BillingEntity/sections/taxes/RemoveTaxDialog'
 import ErrorImage from '~/public/images/maneki/error.svg'
 
 gql`
@@ -51,7 +48,7 @@ const BillingEntityTaxesSettings = () => {
   const { translate } = useInternationalization()
 
   const applyTaxDialogRef = useRef<ApplyTaxDialogRef>(null)
-  const removeTaxDialogRef = useRef<RemoveTaxDialogRef>(null)
+  const { openRemoveTaxDialog } = useRemoveTaxDialog()
 
   const { billingEntityCode } = useParams()
 
@@ -192,10 +189,10 @@ const BillingEntityTaxesSettings = () => {
                             variant="quaternary"
                             onClick={() => {
                               if (billingEntity?.id && tax) {
-                                removeTaxDialogRef?.current?.openDialog(
-                                  billingEntity?.id,
-                                  tax as Tax,
-                                )
+                                openRemoveTaxDialog({
+                                  billingEntityId: billingEntity.id,
+                                  tax: tax as Tax,
+                                })
                               }
                             }}
                           />
@@ -211,7 +208,6 @@ const BillingEntityTaxesSettings = () => {
       </SettingsPaddedContainer>
 
       <ApplyTaxDialog ref={applyTaxDialogRef} />
-      <RemoveTaxDialog ref={removeTaxDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/BillingEntity/sections/taxes/RemoveTaxDialog.tsx
+++ b/src/pages/settings/BillingEntity/sections/taxes/RemoveTaxDialog.tsx
@@ -1,8 +1,7 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import { Tax, useRemoveBillingEntityTaxesMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -15,17 +14,14 @@ gql`
   }
 `
 
-export type RemoveTaxDialogRef = {
-  openDialog: (billingEntityId: string, tax: Tax) => unknown
-  closeDialog: () => unknown
+type RemoveTaxDialogInfos = {
+  billingEntityId: string
+  tax: Tax
 }
 
-export const RemoveTaxDialog = forwardRef<RemoveTaxDialogRef>((_, ref) => {
+export const useRemoveTaxDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<WarningDialogRef>(null)
-
-  const [tax, setTax] = useState<Tax | null>(null)
-  const [billingEntityId, setBillingEntityId] = useState<string | null>(null)
 
   const [removeTax] = useRemoveBillingEntityTaxesMutation({
     onCompleted(data) {
@@ -39,38 +35,24 @@ export const RemoveTaxDialog = forwardRef<RemoveTaxDialogRef>((_, ref) => {
     refetchQueries: ['getBillingEntityTaxes'],
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (_billingEntityId, _tax) => {
-      setBillingEntityId(_billingEntityId)
-      setTax(_tax)
-
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => {
-      dialogRef.current?.closeDialog()
-    },
-  }))
-
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_1743241419871l3utqcy1e3h')}
-      description={<Typography>{translate('text_1743241419871xs0wuhvffq9')}</Typography>}
-      onContinue={async () => {
-        if (billingEntityId && tax) {
-          await removeTax({
-            variables: {
-              input: {
-                billingEntityId,
-                taxCodes: [tax.code],
-              },
+  const openRemoveTaxDialog = ({ billingEntityId, tax }: RemoveTaxDialogInfos) => {
+    centralizedDialog.open({
+      title: translate('text_1743241419871l3utqcy1e3h'),
+      description: <Typography>{translate('text_1743241419871xs0wuhvffq9')}</Typography>,
+      colorVariant: 'danger',
+      actionText: translate('text_645bb193927b375079d28b34'),
+      onAction: async () => {
+        await removeTax({
+          variables: {
+            input: {
+              billingEntityId,
+              taxCodes: [tax.code],
             },
-          })
-        }
-      }}
-      continueText={translate('text_645bb193927b375079d28b34')}
-    />
-  )
-})
+          },
+        })
+      },
+    })
+  }
 
-RemoveTaxDialog.displayName = 'RemoveTaxDialog'
+  return { openRemoveTaxDialog }
+}


### PR DESCRIPTION
## Summary

Migrates `RemoveTaxDialog` from the legacy imperative ref-based `WarningDialog` (deprecated) to the new hook-based `useCentralizedDialog` system, addressing one of the `no-restricted-imports` ESLint warnings about `~/components/designSystem/WarningDialog`.

## Changes

- **`src/pages/settings/BillingEntity/sections/taxes/RemoveTaxDialog.tsx`**
  - Replaced `forwardRef` + `useImperativeHandle` + `useState` + `WarningDialog` boilerplate with a thin `useRemoveTaxDialog` hook backed by `useCentralizedDialog`.
  - Local data (`tax`, `billingEntityId`) is now captured directly via the open-function parameter — no more `useState` plumbing.
  - Preserved the existing `removeBillingEntityTaxes` GraphQL mutation, the success toast, the `getBillingEntityTaxes` refetch, and the danger color variant.

- **`src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx`**
  - Dropped the `removeTaxDialogRef` `useRef` and the `<RemoveTaxDialog ref={…} />` JSX (the dialog is rendered via NiceModal now).
  - Calls `openRemoveTaxDialog({ billingEntityId, tax })` directly from the table's trash action.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. No form/Formik changes are involved (the dialog is purely a confirmation), so no TanStack Form migration was required here.

## Test plan

- [ ] Open *Settings → Billing entity → Taxes* on an entity with at least one applied tax.
- [ ] Click the trash icon on a tax row → the confirmation dialog opens with the danger styling and correct title/description.
- [ ] Confirm → the tax is removed, the success toast appears, and the table refetches.
- [ ] Cancel / close → no mutation runs, the dialog closes cleanly.
- [ ] `pnpm exec tsc --noEmit` and `pnpm exec eslint` on the two changed files pass with no errors (verified locally).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MNGpuhJTeQDgEhP9YvGd)_