### PR TITLE
chore: prevent pre-push hook for branch deletion

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,12 @@
-pnpm run code:style
+# Run lint only if a real ref is being pushed. Branch deletions send an
+# all-zeros local SHA on stdin — skip code:style for those (instant action).
+while read -r local_ref local_sha remote_ref remote_sha; do
+  case "$local_sha" in
+    *[!0]*)
+      pnpm run code:style
+      exit $?
+      ;;
+  esac
+done
 
+exit 0


### PR DESCRIPTION
No need to run this hook when deleting a branch.

Still work otherwise