### PR TITLE
feat(copy): inline click-to-copy in list cells

### DIFF
--- a/src/components/MainHeader/EntitySection.tsx
+++ b/src/components/MainHeader/EntitySection.tsx
@@ -61,9 +61,13 @@ export const EntitySection: FC<{ entity?: MainHeaderEntityConfig }> = ({ entity 
           )}
         </div>
         {entity.metadataLoading && <Skeleton variant="text" className="w-24" />}
-        {!entity.metadataLoading && entity.metadata && (
-          <Typography data-test={ENTITY_SECTION_METADATA_TEST_ID}>{entity.metadata}</Typography>
-        )}
+        {!entity.metadataLoading &&
+          entity.metadata &&
+          (typeof entity.metadata === 'string' ? (
+            <Typography data-test={ENTITY_SECTION_METADATA_TEST_ID}>{entity.metadata}</Typography>
+          ) : (
+            <div data-test={ENTITY_SECTION_METADATA_TEST_ID}>{entity.metadata}</div>
+          ))}
       </div>
     </div>
   )

--- a/src/components/MainHeader/MainHeaderConfigure.tsx
+++ b/src/components/MainHeader/MainHeaderConfigure.tsx
@@ -18,6 +18,12 @@ function configSnapshot(config: MainHeaderConfig): string {
     if (key === 'icon' && typeof value !== 'string') return undefined
     if (key === 'snapshotKey') return value
 
+    // ReactNode values (e.g. a node passed as `metadata`) are non-serializable:
+    // dev-mode React elements carry a circular `_owner` Fiber that links back to
+    // a DOM node, which crashes JSON.stringify. Strip any React element/portal,
+    // mirroring how `content` and non-string `icon` nodes are already dropped.
+    if (value && typeof value === 'object' && '$$typeof' in value) return undefined
+
     return value
   })
 }

--- a/src/components/MainHeader/__tests__/EntitySection.test.tsx
+++ b/src/components/MainHeader/__tests__/EntitySection.test.tsx
@@ -139,6 +139,25 @@ describe('EntitySection', () => {
     })
   })
 
+  describe('GIVEN an entity with a ReactNode metadata', () => {
+    const NODE_METADATA_TEST_ID = 'node-metadata-content'
+    const entity: MainHeaderEntityConfig = {
+      viewName: 'Customer',
+      metadata: <span data-test={NODE_METADATA_TEST_ID}>copyable-ext-id</span>,
+    }
+
+    describe('WHEN the component renders', () => {
+      it('THEN should render the node as-is inside the metadata slot', () => {
+        render(<EntitySection entity={entity} />)
+
+        const metadata = screen.getByTestId(ENTITY_SECTION_METADATA_TEST_ID)
+
+        expect(metadata).toBeInTheDocument()
+        expect(screen.getByTestId(NODE_METADATA_TEST_ID)).toHaveTextContent('copyable-ext-id')
+      })
+    })
+  })
+
   describe('GIVEN an entity with badges', () => {
     const entity: MainHeaderEntityConfig = {
       viewName: 'Customer',

--- a/src/components/MainHeader/__tests__/MainHeaderConfigure.test.tsx
+++ b/src/components/MainHeader/__tests__/MainHeaderConfigure.test.tsx
@@ -196,4 +196,40 @@ describe('MainHeaderConfigure', () => {
       })
     })
   })
+
+  describe('GIVEN an entity whose metadata is a ReactNode', () => {
+    describe('WHEN computing the change-detection snapshot', () => {
+      it('THEN should not crash on the non-serializable element and should push the node to context', () => {
+        const ReadConfigSpy: FC<{ onConfig: (config: MainHeaderConfig | null) => void }> = ({
+          onConfig,
+        }) => {
+          const { config } = useMainHeaderReader()
+
+          onConfig(config)
+
+          return null
+        }
+
+        let capturedConfig: MainHeaderConfig | null = null
+        const metadataNode = <span>ext-id-copyable</span>
+
+        // Before the snapshot fix, JSON.stringify on the element's circular
+        // _owner Fiber threw "Converting circular structure to JSON".
+        expect(() =>
+          render(
+            <MainHeaderProvider>
+              <MainHeaderConfigure entity={{ viewName: 'Customer', metadata: metadataNode }} />
+              <ReadConfigSpy onConfig={(c) => (capturedConfig = c)} />
+            </MainHeaderProvider>,
+          ),
+        ).not.toThrow()
+
+        expect(capturedConfig).toEqual(
+          expect.objectContaining({
+            entity: expect.objectContaining({ metadata: metadataNode }),
+          }),
+        )
+      })
+    })
+  })
 })

--- a/src/components/MainHeader/types.ts
+++ b/src/components/MainHeader/types.ts
@@ -95,8 +95,12 @@ export interface MainHeaderEntityConfig {
   viewName: string
   /** Show a skeleton instead of the title + badges row */
   viewNameLoading?: boolean
-  /** Secondary text below the name (e.g. externalId, amount) */
-  metadata?: string
+  /**
+   * Secondary line below the name (e.g. externalId, amount). A plain string is
+   * wrapped in a Typography; pass a ReactNode to render custom content as-is
+   * (e.g. a TypographyWithCopy, or copy button composed next to text).
+   */
+  metadata?: ReactNode
   /** Show a skeleton instead of the metadata line */
   metadataLoading?: boolean
   /** Status badges displayed next to the entity name */

--- a/src/components/creditNote/CreditNotesTable.tsx
+++ b/src/components/creditNote/CreditNotesTable.tsx
@@ -11,6 +11,7 @@ import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Table, TableColumn, TableContainerSize } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { buildCreditNoteDocumentData } from '~/components/emails/buildDocumentData'
 import { addToast, envGlobalVar } from '~/core/apolloClient'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -301,9 +302,9 @@ const CreditNotesTable = ({
               title: translate('text_64188b3d9735d5007d71227f'),
               minWidth: 160,
               content: ({ number }) => (
-                <Typography variant="body" noWrap>
+                <TypographyWithCopy compact noWrap variant="body">
                   {number}
-                </Typography>
+                </TypographyWithCopy>
               ),
             },
             {

--- a/src/components/customers/CustomerAppliedCouponsList.tsx
+++ b/src/components/customers/CustomerAppliedCouponsList.tsx
@@ -15,6 +15,7 @@ import { Status } from '~/components/designSystem/Status'
 import { Table, TableColumn } from '~/components/designSystem/Table/Table'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import { CouponDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
@@ -104,9 +105,11 @@ export const CustomerAppliedCouponsList = ({
           <Typography variant="body" color="grey700" className="text-nowrap">
             {name}
           </Typography>
-          <Typography variant="body" noWrap>
-            {code || ''}
-          </Typography>
+          {code ? (
+            <TypographyWithCopy compact noWrap variant="body">
+              {code}
+            </TypographyWithCopy>
+          ) : null}
         </div>
       ),
     },

--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -10,6 +10,7 @@ import { ActionItem } from '~/components/designSystem/Table'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { buildInvoiceDocumentData } from '~/components/emails/buildDocumentData'
 import {
@@ -296,7 +297,14 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
               minWidth: 160,
               maxSpace: true,
               title: translate('text_63ac86d797f728a87b2f9fad'),
-              content: (invoice) => invoice.number || '-',
+              content: (invoice) =>
+                invoice.number ? (
+                  <TypographyWithCopy compact noWrap variant="body">
+                    {invoice.number}
+                  </TypographyWithCopy>
+                ) : (
+                  '-'
+                ),
             },
             {
               key: 'totalAmountCents',

--- a/src/components/customers/CustomerPaymentsList.tsx
+++ b/src/components/customers/CustomerPaymentsList.tsx
@@ -5,6 +5,7 @@ import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Status } from '~/components/designSystem/Status'
 import { Table, TableProps } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { buildPaymentDocumentData } from '~/components/emails/buildDocumentData'
 import { PaymentProviderChip } from '~/components/PaymentProviderChip'
 import { addToast } from '~/core/apolloClient'
@@ -162,7 +163,11 @@ export const CustomerPaymentsList: FC<CustomerPaymentsListProps> = ({
             maxSpace: true,
             content: ({ payable }) => {
               if (isInvoice(payable)) {
-                return payable.number
+                return payable.number ? (
+                  <TypographyWithCopy compact noWrap variant="body">
+                    {payable.number}
+                  </TypographyWithCopy>
+                ) : null
               }
               if (isPaymentRequest(payable)) {
                 if (payable.invoices.length > 1) {
@@ -170,7 +175,14 @@ export const CustomerPaymentsList: FC<CustomerPaymentsListProps> = ({
                     count: payable.invoices.length,
                   })
                 }
-                return payable.invoices[0]?.number
+
+                const firstNumber = payable.invoices[0]?.number
+
+                return firstNumber ? (
+                  <TypographyWithCopy compact noWrap variant="body">
+                    {firstNumber}
+                  </TypographyWithCopy>
+                ) : null
               }
             },
           },

--- a/src/components/customers/overview/CustomerSubscriptionsList.tsx
+++ b/src/components/customers/overview/CustomerSubscriptionsList.tsx
@@ -4,6 +4,7 @@ import { generatePath, useParams } from 'react-router-dom'
 
 import { Status, StatusProps, StatusType } from '~/components/designSystem/Status'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import { SubscriptionsList } from '~/components/subscriptions/SubscriptionsList'
 import { TimezoneDate } from '~/components/TimezoneDate'
@@ -117,6 +118,7 @@ export const CustomerSubscriptionsList = () => {
             customerId={data?.customer?.id}
             customerTimezone={data?.customer?.applicableTimezone}
             containerSize={4}
+            rowSize={72}
             isLoading={loading}
             actionColumnTooltip={() => translate('text_634687079be251fdb438338f')}
             onRowActionLink={({ id }) =>
@@ -136,13 +138,9 @@ export const CustomerSubscriptionsList = () => {
                 key: 'name',
                 maxSpace: true,
                 title: translate('text_6253f11816f710014600b9ed'),
-                content: ({ name, isDowngrade, isScheduled }) => (
-                  <>
-                    <div
-                      className={tw('relative flex items-center gap-3', {
-                        'pl-4': isDowngrade,
-                      })}
-                    >
+                content: ({ name, externalId, isDowngrade, isScheduled }) => (
+                  <div className={tw('flex flex-col gap-1', { 'pl-4': isDowngrade })}>
+                    <div className="relative flex items-center gap-3">
                       {isDowngrade && <Icon name="arrow-indent" />}
 
                       <Typography variant="bodyHl" color="grey700">
@@ -153,7 +151,13 @@ export const CustomerSubscriptionsList = () => {
 
                       {isScheduled && <Status type={StatusType.default} label="scheduled" />}
                     </div>
-                  </>
+
+                    {externalId && (
+                      <TypographyWithCopy compact noWrap variant="caption" color="grey600">
+                        {externalId}
+                      </TypographyWithCopy>
+                    )}
+                  </div>
                 ),
               },
               {

--- a/src/components/customers/overview/CustomerSubscriptionsList.tsx
+++ b/src/components/customers/overview/CustomerSubscriptionsList.tsx
@@ -4,7 +4,6 @@ import { generatePath, useParams } from 'react-router-dom'
 
 import { Status, StatusProps, StatusType } from '~/components/designSystem/Status'
 import { Typography } from '~/components/designSystem/Typography'
-import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import { SubscriptionsList } from '~/components/subscriptions/SubscriptionsList'
 import { TimezoneDate } from '~/components/TimezoneDate'
@@ -118,7 +117,6 @@ export const CustomerSubscriptionsList = () => {
             customerId={data?.customer?.id}
             customerTimezone={data?.customer?.applicableTimezone}
             containerSize={4}
-            rowSize={72}
             isLoading={loading}
             actionColumnTooltip={() => translate('text_634687079be251fdb438338f')}
             onRowActionLink={({ id }) =>
@@ -138,9 +136,13 @@ export const CustomerSubscriptionsList = () => {
                 key: 'name',
                 maxSpace: true,
                 title: translate('text_6253f11816f710014600b9ed'),
-                content: ({ name, externalId, isDowngrade, isScheduled }) => (
-                  <div className={tw('flex flex-col gap-1', { 'pl-4': isDowngrade })}>
-                    <div className="relative flex items-center gap-3">
+                content: ({ name, isDowngrade, isScheduled }) => (
+                  <>
+                    <div
+                      className={tw('relative flex items-center gap-3', {
+                        'pl-4': isDowngrade,
+                      })}
+                    >
                       {isDowngrade && <Icon name="arrow-indent" />}
 
                       <Typography variant="bodyHl" color="grey700">
@@ -151,13 +153,7 @@ export const CustomerSubscriptionsList = () => {
 
                       {isScheduled && <Status type={StatusType.default} label="scheduled" />}
                     </div>
-
-                    {externalId && (
-                      <TypographyWithCopy compact noWrap variant="caption" color="grey600">
-                        {externalId}
-                      </TypographyWithCopy>
-                    )}
-                  </div>
+                  </>
                 ),
               },
               {

--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -90,6 +90,27 @@ export interface TableProps<T> {
 const ACTION_COLUMN_ID = 'actionColumn'
 const LOADING_ROW_COUNT = 3
 
+const MIN_CONTAINER_PADDING_PX = 4
+
+// The outer columns' padding follows the table's exterior gutter
+// (`containerSize`), but never drops below 4px so both edges keep the same small
+// gutter even when `containerSize` is 0 (e.g. dialog/usage tables). On the left
+// this also keeps the inline copy button's -4px overhang clear of the boundary.
+const clampContainerPadding = (
+  value: ResponsiveStyleValue<TableContainerSize>,
+): ResponsiveStyleValue<number> => {
+  if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([breakpoint, size]) => [
+        breakpoint,
+        size === undefined ? size : Math.max(size, MIN_CONTAINER_PADDING_PX),
+      ]),
+    )
+  }
+
+  return Math.max(value, MIN_CONTAINER_PADDING_PX)
+}
+
 const countMaxSpaceColumns = <T,>(columns: TableColumn<T>[]) =>
   columns.reduce((acc, column) => {
     if (column.maxSpace) {
@@ -456,10 +477,10 @@ export const Table = <T extends DataItem>({
         ref={tableRef}
         sx={{
           '& .lago-table-cell:first-of-type .lago-table-inner-cell': {
-            ...setResponsiveProperty('paddingLeft', containerSize),
+            ...setResponsiveProperty('paddingLeft', clampContainerPadding(containerSize)),
           },
           '& .lago-table-cell:last-of-type .lago-table-inner-cell': {
-            ...setResponsiveProperty('paddingRight', containerSize),
+            ...setResponsiveProperty('paddingRight', clampContainerPadding(containerSize)),
           },
           '& tbody .lago-table-inner-cell': {
             minHeight: rowSize,
@@ -522,7 +543,9 @@ export const Table = <T extends DataItem>({
                         minWidth={column.minWidth}
                         truncateOverflow={column.truncateOverflow}
                       >
-                        <Typography noWrap>{column.content(item)}</Typography>
+                        <Typography className="-ml-1 pl-1" noWrap>
+                          {column.content(item)}
+                        </Typography>
                       </TableInnerCell>
                     </TableCell>
                   ))}

--- a/src/components/designSystem/Table/TableCell.tsx
+++ b/src/components/designSystem/Table/TableCell.tsx
@@ -32,10 +32,13 @@ const TableCell = ({
       }}
       sx={{
         '& > div': {
+          // Every column keeps a 4px left gutter so edge-aligned header titles and
+          // cell content (and the copy button's -4px overhang, see Table.tsx) clear
+          // the cell boundary. The first column's left padding is owned by the
+          // table's containerSize rule (clamped to a 4px min); last column drops
+          // its right padding.
+          paddingLeft: '4px',
           paddingRight: `${PADDING_SPACING_RIGHT_PX}px`,
-        },
-        '&:first-of-type > div': {
-          paddingLeft: 0,
         },
         '&:last-of-type > div': {
           paddingRight: 0,

--- a/src/components/designSystem/TypographyWithCopy.tsx
+++ b/src/components/designSystem/TypographyWithCopy.tsx
@@ -16,6 +16,12 @@ interface TypographyWithCopyProps extends TypographyProps {
   masked?: boolean
   maskOptions?: MaskOptions
   onCopy?: () => void
+  /**
+   * Shrinks the copy button so it hugs its content height and uses a smaller
+   * icon, to sit inline with caption/body text in dense lists. Defaults to
+   * `false`, preserving the original `size="small"` button look.
+   */
+  compact?: boolean
 }
 
 export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
@@ -24,6 +30,7 @@ export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
   masked,
   maskOptions,
   onCopy,
+  compact,
   ...typographyProps
 }) => {
   const { translate } = useInternationalization()
@@ -37,7 +44,14 @@ export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
         endIcon="duplicate"
         variant="quaternary"
         size="small"
-        className={tw('-ml-1 px-1 py-0', className)}
+        className={tw(
+          '-ml-1 px-1 py-0',
+          {
+            '!ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1':
+              compact,
+          },
+          className,
+        )}
         onClick={(e) => {
           e.stopPropagation()
           if (onCopy) {
@@ -51,7 +65,17 @@ export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
           }
         }}
       >
-        <Typography {...typographyProps}>{displayValue}</Typography>
+        <Typography
+          className={tw({
+            // Caption is 14px/24px; the copy button nudges the text baseline ~1px
+            // high, so the code in a `code • text` line misaligns with its plain
+            // sibling. +2px line-height drops the baseline back onto the sibling's.
+            '!leading-[26px]': compact,
+          })}
+          {...typographyProps}
+        >
+          {displayValue}
+        </Typography>
       </Button>
     </Tooltip>
   )

--- a/src/components/designSystem/TypographyWithCopy.tsx
+++ b/src/components/designSystem/TypographyWithCopy.tsx
@@ -47,7 +47,7 @@ export const TypographyWithCopy: FC<TypographyWithCopyProps> = ({
         className={tw(
           '-ml-1 px-1 py-0',
           {
-            '!ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1':
+            '!h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1':
               compact,
           },
           className,

--- a/src/components/designSystem/__tests__/TypographyWithCopy.test.tsx
+++ b/src/components/designSystem/__tests__/TypographyWithCopy.test.tsx
@@ -58,6 +58,53 @@ describe('TypographyWithCopy', () => {
     })
   })
 
+  describe('GIVEN the compact prop', () => {
+    describe('WHEN compact is not set', () => {
+      it('THEN should keep the default negative-margin button layout', () => {
+        render(<TypographyWithCopy>some-code</TypographyWithCopy>)
+
+        const button = screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID)
+
+        expect(button).toHaveClass('-ml-1')
+        expect(button).not.toHaveClass('!items-baseline')
+      })
+
+      it('THEN should not apply the baseline line-height nudge to the text', () => {
+        render(<TypographyWithCopy>some-code</TypographyWithCopy>)
+
+        expect(screen.getByText('some-code')).not.toHaveClass('!leading-[26px]')
+      })
+    })
+
+    describe('WHEN compact is set', () => {
+      it('THEN should hug its content and baseline-align via important utilities', () => {
+        render(<TypographyWithCopy compact>some-code</TypographyWithCopy>)
+
+        const button = screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID)
+
+        expect(button).toHaveClass('!ml-0')
+        expect(button).toHaveClass('!h-auto')
+        expect(button).toHaveClass('!items-baseline')
+      })
+
+      it('THEN should apply the line-height nudge to the text for baseline alignment', () => {
+        render(<TypographyWithCopy compact>some-code</TypographyWithCopy>)
+
+        expect(screen.getByText('some-code')).toHaveClass('!leading-[26px]')
+      })
+
+      it('THEN should still copy the value when clicked', async () => {
+        const user = userEvent.setup()
+
+        render(<TypographyWithCopy compact>compact-code</TypographyWithCopy>)
+
+        await user.click(screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID))
+
+        expect(copyToClipboard).toHaveBeenCalledWith('compact-code')
+      })
+    })
+  })
+
   describe('GIVEN the component is rendered with masked props', () => {
     describe('WHEN masked with maskOptions', () => {
       it('THEN should display the masked text', () => {

--- a/src/components/designSystem/__tests__/TypographyWithCopy.test.tsx
+++ b/src/components/designSystem/__tests__/TypographyWithCopy.test.tsx
@@ -82,7 +82,8 @@ describe('TypographyWithCopy', () => {
 
         const button = screen.getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID)
 
-        expect(button).toHaveClass('!ml-0')
+        expect(button).toHaveClass('-ml-1')
+        expect(button).not.toHaveClass('!ml-0')
         expect(button).toHaveClass('!h-auto')
         expect(button).toHaveClass('!items-baseline')
       })

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -11,6 +11,7 @@ import { Table } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { buildInvoiceDocumentData } from '~/components/emails/buildDocumentData'
 import {
@@ -458,11 +459,16 @@ const InvoicesList = ({
               key: 'number',
               title: translate('text_63ac86d797f728a87b2f9fad'),
               minWidth: 160,
-              content: ({ number }) => (
-                <Typography variant="body" noWrap>
-                  {number || '-'}
-                </Typography>
-              ),
+              content: ({ number }) =>
+                number ? (
+                  <TypographyWithCopy compact noWrap variant="body">
+                    {number}
+                  </TypographyWithCopy>
+                ) : (
+                  <Typography variant="body" noWrap>
+                    -
+                  </Typography>
+                ),
             },
             {
               key: 'totalAmountCents',

--- a/src/components/invoices/PaymentsList.tsx
+++ b/src/components/invoices/PaymentsList.tsx
@@ -6,6 +6,7 @@ import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Status } from '~/components/designSystem/Status'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { buildPaymentDocumentData } from '~/components/emails/buildDocumentData'
 import { PaymentProviderChip } from '~/components/PaymentProviderChip'
 import { addToast } from '~/core/apolloClient'
@@ -233,7 +234,11 @@ export const PaymentsList: FC<PaymentsListProps> = ({
               minWidth: 160,
               content: ({ payable }) => {
                 if (isInvoice(payable)) {
-                  return payable.number
+                  return payable.number ? (
+                    <TypographyWithCopy compact noWrap variant="body">
+                      {payable.number}
+                    </TypographyWithCopy>
+                  ) : null
                 }
                 if (isPaymentRequest(payable)) {
                   if (payable.invoices.length > 1) {
@@ -241,7 +246,14 @@ export const PaymentsList: FC<PaymentsListProps> = ({
                       count: payable.invoices.length,
                     })
                   }
-                  return payable.invoices[0]?.number
+
+                  const firstNumber = payable.invoices[0]?.number
+
+                  return firstNumber ? (
+                    <TypographyWithCopy compact noWrap variant="body">
+                      {firstNumber}
+                    </TypographyWithCopy>
+                  ) : null
                 }
               },
             },

--- a/src/components/invoices/__tests__/__snapshots__/InvoicesList.test.tsx.snap
+++ b/src/components/invoices/__tests__/__snapshots__/InvoicesList.test.tsx.snap
@@ -938,10 +938,43 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                     data-test="body"
                   >
                     <div
-                      class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
-                      data-test="body"
+                      class="w-fit"
                     >
-                      INV-DRAFT
+                      <div
+                        aria-label="text_623b42ff8ee4e000ba87d0c6"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          data-test="typography-with-copy-button"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class=MuiTypography-root MuiTypography-body MuiTypography-noWrap !leading-[26px] css-hash-MuiTypography-root
+                            data-test="body"
+                          >
+                            INV-DRAFT
+                          </div>
+                          <span
+                            class=MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-hash-MuiButton-endIcon
+                          >
+                            <svg
+                              class="text-inherit size-4 min-w-4"
+                              data-test="duplicate/medium"
+                              fill="currentColor"
+                              title="duplicate/medium"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M14 2H6V4H10C10.5304 4 11.0391 4.21071 11.4142 4.58579C11.7893 4.96086 12 5.46957 12 6V10H14V2ZM2 14H10V6H2V14ZM14 12H12V14C12 14.5304 11.7893 15.0391 11.4142 15.4142C11.0391 15.7893 10.5304 16 10 16H2C1.46957 16 0.960859 15.7893 0.585786 15.4142C0.210714 15.0391 0 14.5304 0 14V6C0 5.46957 0.210714 4.96086 0.585786 4.58579C0.960859 4.21071 1.46957 4 2 4H4V2C4 1.46957 4.21071 0.960859 4.58579 0.585786C4.96086 0.210714 5.46957 0 6 0L14 0C14.5304 0 15.0391 0.210714 15.4142 0.585786C15.7893 0.960859 16 1.46957 16 2V10C16 10.5304 15.7893 11.0391 15.4142 11.4142C15.0391 11.7893 14.5304 12 14 12Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1184,10 +1217,43 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                     data-test="body"
                   >
                     <div
-                      class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
-                      data-test="body"
+                      class="w-fit"
                     >
-                      INV-FINALIZED
+                      <div
+                        aria-label="text_623b42ff8ee4e000ba87d0c6"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          data-test="typography-with-copy-button"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class=MuiTypography-root MuiTypography-body MuiTypography-noWrap !leading-[26px] css-hash-MuiTypography-root
+                            data-test="body"
+                          >
+                            INV-FINALIZED
+                          </div>
+                          <span
+                            class=MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-hash-MuiButton-endIcon
+                          >
+                            <svg
+                              class="text-inherit size-4 min-w-4"
+                              data-test="duplicate/medium"
+                              fill="currentColor"
+                              title="duplicate/medium"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M14 2H6V4H10C10.5304 4 11.0391 4.21071 11.4142 4.58579C11.7893 4.96086 12 5.46957 12 6V10H14V2ZM2 14H10V6H2V14ZM14 12H12V14C12 14.5304 11.7893 15.0391 11.4142 15.4142C11.0391 15.7893 10.5304 16 10 16H2C1.46957 16 0.960859 15.7893 0.585786 15.4142C0.210714 15.0391 0 14.5304 0 14V6C0 5.46957 0.210714 4.96086 0.585786 4.58579C0.960859 4.21071 1.46957 4 2 4H4V2C4 1.46957 4.21071 0.960859 4.58579 0.585786C4.96086 0.210714 5.46957 0 6 0L14 0C14.5304 0 15.0391 0.210714 15.4142 0.585786C15.7893 0.960859 16 1.46957 16 2V10C16 10.5304 15.7893 11.0391 15.4142 11.4142C15.0391 11.7893 14.5304 12 14 12Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1451,10 +1517,43 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                     data-test="body"
                   >
                     <div
-                      class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
-                      data-test="body"
+                      class="w-fit"
                     >
-                      INV-VOIDED
+                      <div
+                        aria-label="text_623b42ff8ee4e000ba87d0c6"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          data-test="typography-with-copy-button"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class=MuiTypography-root MuiTypography-body MuiTypography-noWrap !leading-[26px] css-hash-MuiTypography-root
+                            data-test="body"
+                          >
+                            INV-VOIDED
+                          </div>
+                          <span
+                            class=MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-hash-MuiButton-endIcon
+                          >
+                            <svg
+                              class="text-inherit size-4 min-w-4"
+                              data-test="duplicate/medium"
+                              fill="currentColor"
+                              title="duplicate/medium"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M14 2H6V4H10C10.5304 4 11.0391 4.21071 11.4142 4.58579C11.7893 4.96086 12 5.46957 12 6V10H14V2ZM2 14H10V6H2V14ZM14 12H12V14C12 14.5304 11.7893 15.0391 11.4142 15.4142C11.0391 15.7893 10.5304 16 10 16H2C1.46957 16 0.960859 15.7893 0.585786 15.4142C0.210714 15.0391 0 14.5304 0 14V6C0 5.46957 0.210714 4.96086 0.585786 4.58579C0.960859 4.21071 1.46957 4 2 4H4V2C4 1.46957 4.21071 0.960859 4.58579 0.585786C4.96086 0.210714 5.46957 0 6 0L14 0C14.5304 0 15.0391 0.210714 15.4142 0.585786C15.7893 0.960859 16 1.46957 16 2V10C16 10.5304 15.7893 11.0391 15.4142 11.4142C15.0391 11.7893 14.5304 12 14 12Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1846,10 +1945,43 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                     data-test="body"
                   >
                     <div
-                      class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
-                      data-test="body"
+                      class="w-fit"
                     >
-                      INV-PENDING
+                      <div
+                        aria-label="text_623b42ff8ee4e000ba87d0c6"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          data-test="typography-with-copy-button"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class=MuiTypography-root MuiTypography-body MuiTypography-noWrap !leading-[26px] css-hash-MuiTypography-root
+                            data-test="body"
+                          >
+                            INV-PENDING
+                          </div>
+                          <span
+                            class=MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-hash-MuiButton-endIcon
+                          >
+                            <svg
+                              class="text-inherit size-4 min-w-4"
+                              data-test="duplicate/medium"
+                              fill="currentColor"
+                              title="duplicate/medium"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M14 2H6V4H10C10.5304 4 11.0391 4.21071 11.4142 4.58579C11.7893 4.96086 12 5.46957 12 6V10H14V2ZM2 14H10V6H2V14ZM14 12H12V14C12 14.5304 11.7893 15.0391 11.4142 15.4142C11.0391 15.7893 10.5304 16 10 16H2C1.46957 16 0.960859 15.7893 0.585786 15.4142C0.210714 15.0391 0 14.5304 0 14V6C0 5.46957 0.210714 4.96086 0.585786 4.58579C0.960859 4.21071 1.46957 4 2 4H4V2C4 1.46957 4.21071 0.960859 4.58579 0.585786C4.96086 0.210714 5.46957 0 6 0L14 0C14.5304 0 15.0391 0.210714 15.4142 0.585786C15.7893 0.960859 16 1.46957 16 2V10C16 10.5304 15.7893 11.0391 15.4142 11.4142C15.0391 11.7893 14.5304 12 14 12Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -2113,10 +2245,43 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                     data-test="body"
                   >
                     <div
-                      class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
-                      data-test="body"
+                      class="w-fit"
                     >
-                      INV-SUCCEEDED
+                      <div
+                        aria-label="text_623b42ff8ee4e000ba87d0c6"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          data-test="typography-with-copy-button"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class=MuiTypography-root MuiTypography-body MuiTypography-noWrap !leading-[26px] css-hash-MuiTypography-root
+                            data-test="body"
+                          >
+                            INV-SUCCEEDED
+                          </div>
+                          <span
+                            class=MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-hash-MuiButton-endIcon
+                          >
+                            <svg
+                              class="text-inherit size-4 min-w-4"
+                              data-test="duplicate/medium"
+                              fill="currentColor"
+                              title="duplicate/medium"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M14 2H6V4H10C10.5304 4 11.0391 4.21071 11.4142 4.58579C11.7893 4.96086 12 5.46957 12 6V10H14V2ZM2 14H10V6H2V14ZM14 12H12V14C12 14.5304 11.7893 15.0391 11.4142 15.4142C11.0391 15.7893 10.5304 16 10 16H2C1.46957 16 0.960859 15.7893 0.585786 15.4142C0.210714 15.0391 0 14.5304 0 14V6C0 5.46957 0.210714 4.96086 0.585786 4.58579C0.960859 4.21071 1.46957 4 2 4H4V2C4 1.46957 4.21071 0.960859 4.58579 0.585786C4.96086 0.210714 5.46957 0 6 0L14 0C14.5304 0 15.0391 0.210714 15.4142 0.585786C15.7893 0.960859 16 1.46957 16 2V10C16 10.5304 15.7893 11.0391 15.4142 11.4142C15.0391 11.7893 14.5304 12 14 12Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -2380,10 +2545,43 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                     data-test="body"
                   >
                     <div
-                      class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
-                      data-test="body"
+                      class="w-fit"
                     >
-                      INV-FAILED
+                      <div
+                        aria-label="text_623b42ff8ee4e000ba87d0c6"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          data-test="typography-with-copy-button"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class=MuiTypography-root MuiTypography-body MuiTypography-noWrap !leading-[26px] css-hash-MuiTypography-root
+                            data-test="body"
+                          >
+                            INV-FAILED
+                          </div>
+                          <span
+                            class=MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-hash-MuiButton-endIcon
+                          >
+                            <svg
+                              class="text-inherit size-4 min-w-4"
+                              data-test="duplicate/medium"
+                              fill="currentColor"
+                              title="duplicate/medium"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M14 2H6V4H10C10.5304 4 11.0391 4.21071 11.4142 4.58579C11.7893 4.96086 12 5.46957 12 6V10H14V2ZM2 14H10V6H2V14ZM14 12H12V14C12 14.5304 11.7893 15.0391 11.4142 15.4142C11.0391 15.7893 10.5304 16 10 16H2C1.46957 16 0.960859 15.7893 0.585786 15.4142C0.210714 15.0391 0 14.5304 0 14V6C0 5.46957 0.210714 4.96086 0.585786 4.58579C0.960859 4.21071 1.46957 4 2 4H4V2C4 1.46957 4.21071 0.960859 4.58579 0.585786C4.96086 0.210714 5.46957 0 6 0L14 0C14.5304 0 15.0391 0.210714 15.4142 0.585786C15.7893 0.960859 16 1.46957 16 2V10C16 10.5304 15.7893 11.0391 15.4142 11.4142C15.0391 11.7893 14.5304 12 14 12Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -3171,10 +3369,43 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                     data-test="body"
                   >
                     <div
-                      class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
-                      data-test="body"
+                      class="w-fit"
                     >
-                      INV-001
+                      <div
+                        aria-label="text_623b42ff8ee4e000ba87d0c6"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          data-test="typography-with-copy-button"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class=MuiTypography-root MuiTypography-body MuiTypography-noWrap !leading-[26px] css-hash-MuiTypography-root
+                            data-test="body"
+                          >
+                            INV-001
+                          </div>
+                          <span
+                            class=MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-hash-MuiButton-endIcon
+                          >
+                            <svg
+                              class="text-inherit size-4 min-w-4"
+                              data-test="duplicate/medium"
+                              fill="currentColor"
+                              title="duplicate/medium"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M14 2H6V4H10C10.5304 4 11.0391 4.21071 11.4142 4.58579C11.7893 4.96086 12 5.46957 12 6V10H14V2ZM2 14H10V6H2V14ZM14 12H12V14C12 14.5304 11.7893 15.0391 11.4142 15.4142C11.0391 15.7893 10.5304 16 10 16H2C1.46957 16 0.960859 15.7893 0.585786 15.4142C0.210714 15.0391 0 14.5304 0 14V6C0 5.46957 0.210714 4.96086 0.585786 4.58579C0.960859 4.21071 1.46957 4 2 4H4V2C4 1.46957 4.21071 0.960859 4.58579 0.585786C4.96086 0.210714 5.46957 0 6 0L14 0C14.5304 0 15.0391 0.210714 15.4142 0.585786C15.7893 0.960859 16 1.46957 16 2V10C16 10.5304 15.7893 11.0391 15.4142 11.4142C15.0391 11.7893 14.5304 12 14 12Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -3438,10 +3669,43 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                     data-test="body"
                   >
                     <div
-                      class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
-                      data-test="body"
+                      class="w-fit"
                     >
-                      INV-002
+                      <div
+                        aria-label="text_623b42ff8ee4e000ba87d0c6"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          data-test="typography-with-copy-button"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class=MuiTypography-root MuiTypography-body MuiTypography-noWrap !leading-[26px] css-hash-MuiTypography-root
+                            data-test="body"
+                          >
+                            INV-002
+                          </div>
+                          <span
+                            class=MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-hash-MuiButton-endIcon
+                          >
+                            <svg
+                              class="text-inherit size-4 min-w-4"
+                              data-test="duplicate/medium"
+                              fill="currentColor"
+                              title="duplicate/medium"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M14 2H6V4H10C10.5304 4 11.0391 4.21071 11.4142 4.58579C11.7893 4.96086 12 5.46957 12 6V10H14V2ZM2 14H10V6H2V14ZM14 12H12V14C12 14.5304 11.7893 15.0391 11.4142 15.4142C11.0391 15.7893 10.5304 16 10 16H2C1.46957 16 0.960859 15.7893 0.585786 15.4142C0.210714 15.0391 0 14.5304 0 14V6C0 5.46957 0.210714 4.96086 0.585786 4.58579C0.960859 4.21071 1.46957 4 2 4H4V2C4 1.46957 4.21071 0.960859 4.58579 0.585786C4.96086 0.210714 5.46957 0 6 0L14 0C14.5304 0 15.0391 0.210714 15.4142 0.585786C15.7893 0.960859 16 1.46957 16 2V10C16 10.5304 15.7893 11.0391 15.4142 11.4142C15.0391 11.7893 14.5304 12 14 12Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -3705,10 +3969,43 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                     data-test="body"
                   >
                     <div
-                      class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
-                      data-test="body"
+                      class="w-fit"
                     >
-                      INV-003
+                      <div
+                        aria-label="text_623b42ff8ee4e000ba87d0c6"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          data-test="typography-with-copy-button"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class=MuiTypography-root MuiTypography-body MuiTypography-noWrap !leading-[26px] css-hash-MuiTypography-root
+                            data-test="body"
+                          >
+                            INV-003
+                          </div>
+                          <span
+                            class=MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-hash-MuiButton-endIcon
+                          >
+                            <svg
+                              class="text-inherit size-4 min-w-4"
+                              data-test="duplicate/medium"
+                              fill="currentColor"
+                              title="duplicate/medium"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M14 2H6V4H10C10.5304 4 11.0391 4.21071 11.4142 4.58579C11.7893 4.96086 12 5.46957 12 6V10H14V2ZM2 14H10V6H2V14ZM14 12H12V14C12 14.5304 11.7893 15.0391 11.4142 15.4142C11.0391 15.7893 10.5304 16 10 16H2C1.46957 16 0.960859 15.7893 0.585786 15.4142C0.210714 15.0391 0 14.5304 0 14V6C0 5.46957 0.210714 4.96086 0.585786 4.58579C0.960859 4.21071 1.46957 4 2 4H4V2C4 1.46957 4.21071 0.960859 4.58579 0.585786C4.96086 0.210714 5.46957 0 6 0L14 0C14.5304 0 15.0391 0.210714 15.4142 0.585786C15.7893 0.960859 16 1.46957 16 2V10C16 10.5304 15.7893 11.0391 15.4142 11.4142C15.0391 11.7893 14.5304 12 14 12Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -4121,10 +4418,43 @@ exports[`InvoicesList Snapshot Tests matches snapshot with overdue invoice 1`] =
                     data-test="body"
                   >
                     <div
-                      class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
-                      data-test="body"
+                      class="w-fit"
                     >
-                      INV-001
+                      <div
+                        aria-label="text_623b42ff8ee4e000ba87d0c6"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          data-test="typography-with-copy-button"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class=MuiTypography-root MuiTypography-body MuiTypography-noWrap !leading-[26px] css-hash-MuiTypography-root
+                            data-test="body"
+                          >
+                            INV-001
+                          </div>
+                          <span
+                            class=MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-hash-MuiButton-endIcon
+                          >
+                            <svg
+                              class="text-inherit size-4 min-w-4"
+                              data-test="duplicate/medium"
+                              fill="currentColor"
+                              title="duplicate/medium"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M14 2H6V4H10C10.5304 4 11.0391 4.21071 11.4142 4.58579C11.7893 4.96086 12 5.46957 12 6V10H14V2ZM2 14H10V6H2V14ZM14 12H12V14C12 14.5304 11.7893 15.0391 11.4142 15.4142C11.0391 15.7893 10.5304 16 10 16H2C1.46957 16 0.960859 15.7893 0.585786 15.4142C0.210714 15.0391 0 14.5304 0 14V6C0 5.46957 0.210714 4.96086 0.585786 4.58579C0.960859 4.21071 1.46957 4 2 4H4V2C4 1.46957 4.21071 0.960859 4.58579 0.585786C4.96086 0.210714 5.46957 0 6 0L14 0C14.5304 0 15.0391 0.210714 15.4142 0.585786C15.7893 0.960859 16 1.46957 16 2V10C16 10.5304 15.7893 11.0391 15.4142 11.4142C15.0391 11.7893 14.5304 12 14 12Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -4549,10 +4879,43 @@ exports[`InvoicesList Snapshot Tests matches snapshot with partially paid invoic
                     data-test="body"
                   >
                     <div
-                      class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
-                      data-test="body"
+                      class="w-fit"
                     >
-                      INV-001
+                      <div
+                        aria-label="text_623b42ff8ee4e000ba87d0c6"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          data-test="typography-with-copy-button"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class=MuiTypography-root MuiTypography-body MuiTypography-noWrap !leading-[26px] css-hash-MuiTypography-root
+                            data-test="body"
+                          >
+                            INV-001
+                          </div>
+                          <span
+                            class=MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-hash-MuiButton-endIcon
+                          >
+                            <svg
+                              class="text-inherit size-4 min-w-4"
+                              data-test="duplicate/medium"
+                              fill="currentColor"
+                              title="duplicate/medium"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M14 2H6V4H10C10.5304 4 11.0391 4.21071 11.4142 4.58579C11.7893 4.96086 12 5.46957 12 6V10H14V2ZM2 14H10V6H2V14ZM14 12H12V14C12 14.5304 11.7893 15.0391 11.4142 15.4142C11.0391 15.7893 10.5304 16 10 16H2C1.46957 16 0.960859 15.7893 0.585786 15.4142C0.210714 15.0391 0 14.5304 0 14V6C0 5.46957 0.210714 4.96086 0.585786 4.58579C0.960859 4.21071 1.46957 4 2 4H4V2C4 1.46957 4.21071 0.960859 4.58579 0.585786C4.96086 0.210714 5.46957 0 6 0L14 0C14.5304 0 15.0391 0.210714 15.4142 0.585786C15.7893 0.960859 16 1.46957 16 2V10C16 10.5304 15.7893 11.0391 15.4142 11.4142C15.0391 11.7893 14.5304 12 14 12Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/components/invoices/__tests__/__snapshots__/InvoicesList.test.tsx.snap
+++ b/src/components/invoices/__tests__/__snapshots__/InvoicesList.test.tsx.snap
@@ -877,7 +877,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -913,7 +913,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -934,7 +934,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -946,7 +946,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                         data-mui-internal-clone-element="true"
                       >
                         <button
-                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
                           data-test="typography-with-copy-button"
                           tabindex="0"
                           type="button"
@@ -988,7 +988,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1009,7 +1009,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1030,7 +1030,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   />
                 </div>
@@ -1044,7 +1044,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   />
                 </div>
@@ -1058,7 +1058,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 160px; max-width: 600px;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1079,7 +1079,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 104px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1156,7 +1156,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1192,7 +1192,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1213,7 +1213,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1225,7 +1225,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                         data-mui-internal-clone-element="true"
                       >
                         <button
-                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
                           data-test="typography-with-copy-button"
                           tabindex="0"
                           type="button"
@@ -1267,7 +1267,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1288,7 +1288,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1309,7 +1309,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1344,7 +1344,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   />
                 </div>
@@ -1358,7 +1358,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 160px; max-width: 600px;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1379,7 +1379,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 104px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1456,7 +1456,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1492,7 +1492,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1513,7 +1513,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1525,7 +1525,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                         data-mui-internal-clone-element="true"
                       >
                         <button
-                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
                           data-test="typography-with-copy-button"
                           tabindex="0"
                           type="button"
@@ -1567,7 +1567,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1588,7 +1588,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1609,7 +1609,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   />
                 </div>
@@ -1623,7 +1623,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   />
                 </div>
@@ -1637,7 +1637,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 160px; max-width: 600px;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1658,7 +1658,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different invoice sta
                   style="min-width: 104px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1884,7 +1884,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1920,7 +1920,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1941,7 +1941,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -1953,7 +1953,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                         data-mui-internal-clone-element="true"
                       >
                         <button
-                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
                           data-test="typography-with-copy-button"
                           tabindex="0"
                           type="button"
@@ -1995,7 +1995,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2016,7 +2016,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2037,7 +2037,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2072,7 +2072,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   />
                 </div>
@@ -2086,7 +2086,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 160px; max-width: 600px;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2107,7 +2107,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 104px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2184,7 +2184,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2220,7 +2220,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2241,7 +2241,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2253,7 +2253,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                         data-mui-internal-clone-element="true"
                       >
                         <button
-                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
                           data-test="typography-with-copy-button"
                           tabindex="0"
                           type="button"
@@ -2295,7 +2295,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2316,7 +2316,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2337,7 +2337,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2372,7 +2372,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   />
                 </div>
@@ -2386,7 +2386,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 160px; max-width: 600px;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2407,7 +2407,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 104px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2484,7 +2484,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2520,7 +2520,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2541,7 +2541,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2553,7 +2553,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                         data-mui-internal-clone-element="true"
                       >
                         <button
-                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
                           data-test="typography-with-copy-button"
                           tabindex="0"
                           type="button"
@@ -2595,7 +2595,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2616,7 +2616,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2637,7 +2637,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2672,7 +2672,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   />
                 </div>
@@ -2686,7 +2686,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 160px; max-width: 600px;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -2707,7 +2707,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with different payment sta
                   style="min-width: 104px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3308,7 +3308,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3344,7 +3344,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3365,7 +3365,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3377,7 +3377,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                         data-mui-internal-clone-element="true"
                       >
                         <button
-                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
                           data-test="typography-with-copy-button"
                           tabindex="0"
                           type="button"
@@ -3419,7 +3419,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3440,7 +3440,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3461,7 +3461,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3496,7 +3496,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   />
                 </div>
@@ -3510,7 +3510,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 160px; max-width: 600px;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3531,7 +3531,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 104px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3608,7 +3608,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3644,7 +3644,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3665,7 +3665,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3677,7 +3677,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                         data-mui-internal-clone-element="true"
                       >
                         <button
-                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
                           data-test="typography-with-copy-button"
                           tabindex="0"
                           type="button"
@@ -3719,7 +3719,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3740,7 +3740,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3761,7 +3761,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3796,7 +3796,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   />
                 </div>
@@ -3810,7 +3810,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 160px; max-width: 600px;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3831,7 +3831,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 104px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3908,7 +3908,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3944,7 +3944,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3965,7 +3965,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -3977,7 +3977,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                         data-mui-internal-clone-element="true"
                       >
                         <button
-                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
                           data-test="typography-with-copy-button"
                           tabindex="0"
                           type="button"
@@ -4019,7 +4019,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4040,7 +4040,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4061,7 +4061,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4096,7 +4096,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   />
                 </div>
@@ -4110,7 +4110,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 160px; max-width: 600px;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4131,7 +4131,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with invoices 1`] = `
                   style="min-width: 104px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4357,7 +4357,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with overdue invoice 1`] =
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4393,7 +4393,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with overdue invoice 1`] =
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4414,7 +4414,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with overdue invoice 1`] =
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4426,7 +4426,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with overdue invoice 1`] =
                         data-mui-internal-clone-element="true"
                       >
                         <button
-                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
                           data-test="typography-with-copy-button"
                           tabindex="0"
                           type="button"
@@ -4468,7 +4468,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with overdue invoice 1`] =
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4489,7 +4489,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with overdue invoice 1`] =
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4510,7 +4510,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with overdue invoice 1`] =
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4545,7 +4545,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with overdue invoice 1`] =
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4571,7 +4571,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with overdue invoice 1`] =
                   style="min-width: 160px; max-width: 600px;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4592,7 +4592,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with overdue invoice 1`] =
                   style="min-width: 104px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4818,7 +4818,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with partially paid invoic
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4854,7 +4854,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with partially paid invoic
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4875,7 +4875,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with partially paid invoic
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4887,7 +4887,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with partially paid invoic
                         data-mui-internal-clone-element="true"
                       >
                         <button
-                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !ml-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
+                          class=MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation min-w-[unset] whitespace-nowrap [&>svg]:cursor-pointer justify-center -ml-1 px-1 py-0 !h-auto !min-h-0 !min-w-0 !items-baseline !py-0 [&_.MuiButton-endIcon>svg]:!size-3 [&_.MuiButton-endIcon]:!ml-1 css-hash-MuiButtonBase-root-MuiButton-root
                           data-test="typography-with-copy-button"
                           tabindex="0"
                           type="button"
@@ -4929,7 +4929,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with partially paid invoic
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4950,7 +4950,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with partially paid invoic
                   style="min-width: 160px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -4971,7 +4971,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with partially paid invoic
                   style="min-width: 80px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -5022,7 +5022,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with partially paid invoic
                   style="min-width: auto; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   />
                 </div>
@@ -5036,7 +5036,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with partially paid invoic
                   style="min-width: 160px; max-width: 600px;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div
@@ -5057,7 +5057,7 @@ exports[`InvoicesList Snapshot Tests matches snapshot with partially paid invoic
                   style="min-width: 104px; max-width: auto;"
                 >
                   <div
-                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap css-hash-MuiTypography-root
+                    class=MuiTypography-root MuiTypography-body MuiTypography-noWrap -ml-1 pl-1 css-hash-MuiTypography-root
                     data-test="body"
                   >
                     <div

--- a/src/components/wallets/CustomerWalletList.tsx
+++ b/src/components/wallets/CustomerWalletList.tsx
@@ -9,6 +9,7 @@ import { Status, StatusType } from '~/components/designSystem/Status'
 import { Table, TableColumn } from '~/components/designSystem/Table'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import { formatAmount, formatCredits } from '~/components/wallets/utils'
 import { CREATE_WALLET_DATA_TEST } from '~/components/wallets/utils/dataTestConstants'
@@ -100,29 +101,39 @@ export const CustomerWalletsList = ({ customerId }: CustomerWalletListProps) => 
       key: 'id',
       maxSpace: true,
       title: translate('text_1772536695408sddzumtfq2t'),
-      content: ({ code, createdAt, currency, name, rateAmount }) => (
-        <div className="flex flex-col">
-          <Typography variant="bodyHl" color="grey700">
-            {name ||
-              translate('text_62da6ec24a8e24e44f8128b2', {
-                createdAt: intlFormatDateTimeOrgaTZ(createdAt).date,
-              })}
-          </Typography>
-          <Typography variant="caption" color="grey600">
-            {[
-              code,
-              translate('text_62da6ec24a8e24e44f812872', {
-                rateAmount: intlFormatNumber(Number(rateAmount) || 0, {
-                  currencyDisplay: 'symbol',
-                  currency,
-                }),
-              }),
-            ]
-              .filter(Boolean)
-              .join(' • ')}
-          </Typography>
-        </div>
-      ),
+      content: ({ code, createdAt, currency, name, rateAmount }) => {
+        const rateLabel = translate('text_62da6ec24a8e24e44f812872', {
+          rateAmount: intlFormatNumber(Number(rateAmount) || 0, {
+            currencyDisplay: 'symbol',
+            currency,
+          }),
+        })
+
+        return (
+          <div className="flex flex-col">
+            <Typography variant="bodyHl" color="grey700">
+              {name ||
+                translate('text_62da6ec24a8e24e44f8128b2', {
+                  createdAt: intlFormatDateTimeOrgaTZ(createdAt).date,
+                })}
+            </Typography>
+            {code ? (
+              <div className="flex items-baseline gap-1">
+                <TypographyWithCopy className="shrink-0" compact noWrap variant="caption">
+                  {code}
+                </TypographyWithCopy>
+                <Typography className="min-w-0" variant="caption" color="grey600" noWrap>
+                  {`• ${rateLabel}`}
+                </Typography>
+              </div>
+            ) : (
+              <Typography variant="caption" color="grey600">
+                {rateLabel}
+              </Typography>
+            )}
+          </div>
+        )
+      },
     },
     {
       key: 'balanceCents',

--- a/src/components/wallets/WalletAccordion.tsx
+++ b/src/components/wallets/WalletAccordion.tsx
@@ -59,6 +59,7 @@ import { tw } from '~/styles/utils'
 gql`
   fragment WalletAccordion on Wallet {
     id
+    code
     balanceCents
     code
     consumedAmountCents

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -12861,7 +12861,7 @@ export type GetTaxesForTaxesSelectorSectionQueryVariables = Exact<{
 
 export type GetTaxesForTaxesSelectorSectionQuery = { __typename?: 'Query', taxes: { __typename?: 'TaxCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> } };
 
-export type CustomerWalletFragment = { __typename?: 'Wallet', id: string, billingEntityId?: string | null, currency: CurrencyEnum, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, paidTopUpMinAmountCents?: any | null, paidTopUpMaxAmountCents?: any | null, priority: number, paymentMethodType?: PaymentMethodTypeEnum | null, skipInvoiceCustomSections?: boolean | null, balanceCents: any, code?: string | null, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, code: string, name: string }> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', expirationAt?: any | null, grantedCredits: string, interval?: RecurringTransactionIntervalEnum | null, invoiceRequiresSuccessfulPayment: boolean, lagoId: string, method: RecurringTransactionMethodEnum, paidCredits: string, startedAt?: any | null, targetOngoingBalance?: string | null, thresholdCredits?: string | null, transactionName?: string | null, trigger: RecurringTransactionTriggerEnum, ignorePaidTopUpLimits: boolean, paymentMethodType?: PaymentMethodTypeEnum | null, skipInvoiceCustomSections?: boolean | null, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null };
+export type CustomerWalletFragment = { __typename?: 'Wallet', id: string, billingEntityId?: string | null, currency: CurrencyEnum, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, paidTopUpMinAmountCents?: any | null, paidTopUpMaxAmountCents?: any | null, priority: number, paymentMethodType?: PaymentMethodTypeEnum | null, skipInvoiceCustomSections?: boolean | null, code?: string | null, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, code: string, name: string }> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', expirationAt?: any | null, grantedCredits: string, interval?: RecurringTransactionIntervalEnum | null, invoiceRequiresSuccessfulPayment: boolean, lagoId: string, method: RecurringTransactionMethodEnum, paidCredits: string, startedAt?: any | null, targetOngoingBalance?: string | null, thresholdCredits?: string | null, transactionName?: string | null, trigger: RecurringTransactionTriggerEnum, ignorePaidTopUpLimits: boolean, paymentMethodType?: PaymentMethodTypeEnum | null, skipInvoiceCustomSections?: boolean | null, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null };
 
 export type GetCustomerWalletListQueryVariables = Exact<{
   customerId: Scalars['ID']['input'];
@@ -12870,7 +12870,7 @@ export type GetCustomerWalletListQueryVariables = Exact<{
 }>;
 
 
-export type GetCustomerWalletListQuery = { __typename?: 'Query', wallets: { __typename?: 'WalletCollection', metadata: { __typename?: 'WalletCollectionMetadata', currentPage: number, totalPages: number, customerActiveWalletsCount: number }, collection: Array<{ __typename?: 'Wallet', id: string, billingEntityId?: string | null, currency: CurrencyEnum, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, paidTopUpMinAmountCents?: any | null, paidTopUpMaxAmountCents?: any | null, priority: number, paymentMethodType?: PaymentMethodTypeEnum | null, skipInvoiceCustomSections?: boolean | null, balanceCents: any, code?: string | null, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, code: string, name: string }> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', expirationAt?: any | null, grantedCredits: string, interval?: RecurringTransactionIntervalEnum | null, invoiceRequiresSuccessfulPayment: boolean, lagoId: string, method: RecurringTransactionMethodEnum, paidCredits: string, startedAt?: any | null, targetOngoingBalance?: string | null, thresholdCredits?: string | null, transactionName?: string | null, trigger: RecurringTransactionTriggerEnum, ignorePaidTopUpLimits: boolean, paymentMethodType?: PaymentMethodTypeEnum | null, skipInvoiceCustomSections?: boolean | null, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null }> } };
+export type GetCustomerWalletListQuery = { __typename?: 'Query', wallets: { __typename?: 'WalletCollection', metadata: { __typename?: 'WalletCollectionMetadata', currentPage: number, totalPages: number, customerActiveWalletsCount: number }, collection: Array<{ __typename?: 'Wallet', id: string, billingEntityId?: string | null, currency: CurrencyEnum, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, paidTopUpMinAmountCents?: any | null, paidTopUpMaxAmountCents?: any | null, priority: number, paymentMethodType?: PaymentMethodTypeEnum | null, skipInvoiceCustomSections?: boolean | null, code?: string | null, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, code: string, name: string }> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', expirationAt?: any | null, grantedCredits: string, interval?: RecurringTransactionIntervalEnum | null, invoiceRequiresSuccessfulPayment: boolean, lagoId: string, method: RecurringTransactionMethodEnum, paidCredits: string, startedAt?: any | null, targetOngoingBalance?: string | null, thresholdCredits?: string | null, transactionName?: string | null, trigger: RecurringTransactionTriggerEnum, ignorePaidTopUpLimits: boolean, paymentMethodType?: PaymentMethodTypeEnum | null, skipInvoiceCustomSections?: boolean | null, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null }> } };
 
 export type DeleteWalletAlertDialogFragment = { __typename?: 'Alert', id: string };
 
@@ -12886,11 +12886,11 @@ export type TerminateCustomerWalletMutationVariables = Exact<{
 }>;
 
 
-export type TerminateCustomerWalletMutation = { __typename?: 'Mutation', terminateCustomerWallet?: { __typename?: 'Wallet', id: string, status: WalletStatusEnum, balanceCents: any, code?: string | null, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, expirationAt?: any | null, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, name?: string | null, rateAmount: number, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, priority: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean, customer?: { __typename?: 'Customer', id: string, hasActiveWallet: boolean } | null } | null };
+export type TerminateCustomerWalletMutation = { __typename?: 'Mutation', terminateCustomerWallet?: { __typename?: 'Wallet', id: string, status: WalletStatusEnum, code?: string | null, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, expirationAt?: any | null, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, name?: string | null, rateAmount: number, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, priority: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean, customer?: { __typename?: 'Customer', id: string, hasActiveWallet: boolean } | null } | null };
 
 export type WalletForVoidTransactionFragment = { __typename?: 'Wallet', id: string, currency: CurrencyEnum, rateAmount: number, creditsBalance: number };
 
-export type WalletAccordionFragment = { __typename?: 'Wallet', id: string, balanceCents: any, code?: string | null, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, expirationAt?: any | null, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, name?: string | null, rateAmount: number, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, priority: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean };
+export type WalletAccordionFragment = { __typename?: 'Wallet', id: string, code?: string | null, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, expirationAt?: any | null, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, name?: string | null, rateAmount: number, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, priority: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean };
 
 export type GetWalletAlertsQueryVariables = Exact<{
   walletId: Scalars['String']['input'];
@@ -13107,7 +13107,7 @@ export type UpdateAddOnMutationVariables = Exact<{
 }>;
 
 
-export type UpdateAddOnMutation = { __typename?: 'Mutation', updateAddOn?: { __typename?: 'AddOn', id: string, name: string, amountCurrency: CurrencyEnum, amountCents: any, customersCount: number, createdAt: any } | null };
+export type UpdateAddOnMutation = { __typename?: 'Mutation', updateAddOn?: { __typename?: 'AddOn', id: string, name: string, code: string, amountCurrency: CurrencyEnum, amountCents: any, customersCount: number, createdAt: any } | null };
 
 export type GetSingleBillableMetricQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -13179,7 +13179,7 @@ export type UpdateCouponMutationVariables = Exact<{
 }>;
 
 
-export type UpdateCouponMutation = { __typename?: 'Mutation', updateCoupon?: { __typename?: 'Coupon', id: string, name: string, customersCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null } | null };
+export type UpdateCouponMutation = { __typename?: 'Mutation', updateCoupon?: { __typename?: 'Coupon', id: string, name: string, code: string, customersCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null } | null };
 
 export type CustomerForExternalAppsAccordionFragment = { __typename?: 'Customer', id: string, customerType?: CustomerTypeEnum | null, currency?: CurrencyEnum | null, paymentProvider?: ProviderTypeEnum | null, paymentProviderCode?: string | null, netsuiteCustomer?: { __typename: 'NetsuiteCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, integrationCode?: string | null, integrationType?: IntegrationTypeEnum | null, subsidiaryId?: string | null, syncWithProvider?: boolean | null } | null, anrokCustomer?: { __typename: 'AnrokCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, integrationCode?: string | null, integrationType?: IntegrationTypeEnum | null, syncWithProvider?: boolean | null } | null, avalaraCustomer?: { __typename: 'AvalaraCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, integrationCode?: string | null, integrationType?: IntegrationTypeEnum | null, syncWithProvider?: boolean | null } | null, xeroCustomer?: { __typename: 'XeroCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, integrationCode?: string | null, integrationType?: IntegrationTypeEnum | null, syncWithProvider?: boolean | null } | null, hubspotCustomer?: { __typename: 'HubspotCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, integrationCode?: string | null, integrationType?: IntegrationTypeEnum | null, syncWithProvider?: boolean | null, targetedObject?: HubspotTargetedObjectsEnum | null } | null, salesforceCustomer?: { __typename: 'SalesforceCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, integrationCode?: string | null, integrationType?: IntegrationTypeEnum | null, syncWithProvider?: boolean | null } | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, syncWithProvider?: boolean | null, providerPaymentMethods?: Array<ProviderPaymentMethodsEnum> | null } | null };
 
@@ -13414,7 +13414,7 @@ export type GetAddOnForDetailsQueryVariables = Exact<{
 
 export type GetAddOnForDetailsQuery = { __typename?: 'Query', addOn?: { __typename?: 'AddOn', id: string, name: string, amountCents: any, amountCurrency: CurrencyEnum, code: string, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null } | null };
 
-export type AddOnItemFragment = { __typename?: 'AddOn', id: string, name: string, amountCurrency: CurrencyEnum, amountCents: any, customersCount: number, createdAt: any };
+export type AddOnItemFragment = { __typename?: 'AddOn', id: string, name: string, code: string, amountCurrency: CurrencyEnum, amountCents: any, customersCount: number, createdAt: any };
 
 export type AddOnsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -13423,7 +13423,7 @@ export type AddOnsQueryVariables = Exact<{
 }>;
 
 
-export type AddOnsQuery = { __typename?: 'Query', addOns: { __typename?: 'AddOnCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'AddOn', id: string, name: string, amountCurrency: CurrencyEnum, amountCents: any, customersCount: number, createdAt: any }> } };
+export type AddOnsQuery = { __typename?: 'Query', addOns: { __typename?: 'AddOnCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'AddOn', id: string, name: string, code: string, amountCurrency: CurrencyEnum, amountCents: any, customersCount: number, createdAt: any }> } };
 
 export type GetSubscriptionInfosQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -13498,7 +13498,7 @@ export type GetCouponForDetailsQueryVariables = Exact<{
 
 export type GetCouponForDetailsQuery = { __typename?: 'Query', coupon?: { __typename?: 'Coupon', id: string, name: string, code: string, status: CouponStatusEnum, couponType: CouponTypeEnum, percentageRate?: number | null, amountCents?: any | null, amountCurrency?: CurrencyEnum | null, frequency: CouponFrequency, appliedCouponsCount: number } | null };
 
-export type CouponItemFragment = { __typename?: 'Coupon', id: string, name: string, customersCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null };
+export type CouponItemFragment = { __typename?: 'Coupon', id: string, name: string, code: string, customersCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null };
 
 export type CouponsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -13507,7 +13507,7 @@ export type CouponsQueryVariables = Exact<{
 }>;
 
 
-export type CouponsQuery = { __typename?: 'Query', coupons: { __typename?: 'CouponCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Coupon', id: string, name: string, customersCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, appliedCouponsCount: number }> } };
+export type CouponsQuery = { __typename?: 'Query', coupons: { __typename?: 'CouponCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Coupon', id: string, name: string, code: string, customersCount: number, status: CouponStatusEnum, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, expiration: CouponExpiration, expirationAt?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, appliedCouponsCount: number }> } };
 
 export type EditBillableMetricFragment = { __typename?: 'BillableMetric', id: string, name: string, code: string, expression?: string | null, description?: string | null, aggregationType: AggregationTypeEnum, fieldName?: string | null, hasSubscriptions: boolean, hasPlans: boolean, recurring: boolean, roundingFunction?: RoundingFunctionEnum | null, roundingPrecision?: number | null, filters?: Array<{ __typename?: 'BillableMetricFilter', key: string, values: Array<string> }> | null };
 
@@ -18627,6 +18627,7 @@ export const WalletInfosForTransactionsFragmentDoc = gql`
 export const WalletAccordionFragmentDoc = gql`
     fragment WalletAccordion on Wallet {
   id
+  code
   balanceCents
   code
   consumedAmountCents
@@ -19084,6 +19085,7 @@ export const AddOnItemFragmentDoc = gql`
     fragment AddOnItem on AddOn {
   id
   name
+  code
   amountCurrency
   amountCents
   customersCount
@@ -19114,6 +19116,7 @@ export const CouponItemFragmentDoc = gql`
     fragment CouponItem on Coupon {
   id
   name
+  code
   customersCount
   status
   amountCurrency

--- a/src/hooks/customer/__tests__/useCustomerDetailsHeaderEntity.test.ts
+++ b/src/hooks/customer/__tests__/useCustomerDetailsHeaderEntity.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react'
+import { isValidElement, ReactElement } from 'react'
 
 import { CustomerAccountTypeEnum, CustomerDetailsFragment } from '~/generated/graphql'
 
@@ -32,9 +33,11 @@ describe('useCustomerDetailsHeaderEntity', () => {
         expect(result.current).toEqual(
           expect.objectContaining({
             viewName: 'Acme Corp',
-            metadata: 'ext-1',
           }),
         )
+        // metadata is now a click-to-copy element wrapping the externalId
+        expect(isValidElement(result.current?.metadata)).toBe(true)
+        expect((result.current?.metadata as ReactElement).props.children).toBe('ext-1')
       })
     })
 
@@ -47,9 +50,10 @@ describe('useCustomerDetailsHeaderEntity', () => {
         expect(result.current).toEqual(
           expect.objectContaining({
             viewName: expect.any(String),
-            metadata: 'ext-1',
           }),
         )
+        expect(isValidElement(result.current?.metadata)).toBe(true)
+        expect((result.current?.metadata as ReactElement).props.children).toBe('ext-1')
       })
     })
 

--- a/src/hooks/customer/useCustomerDetailsHeaderEntity.tsx
+++ b/src/hooks/customer/useCustomerDetailsHeaderEntity.tsx
@@ -1,4 +1,5 @@
 import { StatusType } from '~/components/designSystem/Status'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { MainHeaderEntityConfig } from '~/components/MainHeader/types'
 import { CustomerAccountTypeEnum, CustomerDetailsFragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -29,7 +30,9 @@ export function useCustomerDetailsHeaderEntity({
 
   return {
     viewName: customerName || translate('text_62f272a7a60b4d7fadad911a'),
-    metadata: customer.externalId,
+    metadata: customer.externalId ? (
+      <TypographyWithCopy>{customer.externalId}</TypographyWithCopy>
+    ) : undefined,
     badges: isPartner
       ? [{ label: translate('text_1738322099641hkzihmx9qyw'), type: StatusType.default }]
       : undefined,

--- a/src/pages/AddOnsList.tsx
+++ b/src/pages/AddOnsList.tsx
@@ -10,6 +10,7 @@ import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Table } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { SearchInput } from '~/components/SearchInput'
@@ -32,6 +33,7 @@ gql`
   fragment AddOnItem on AddOn {
     id
     name
+    code
     amountCurrency
     amountCents
     customersCount
@@ -154,7 +156,7 @@ const AddOnsList = () => {
               title: translate('text_629728388c4d2300e2d380bd'),
               minWidth: 200,
               maxSpace: true,
-              content: ({ name, amountCents, amountCurrency }) => (
+              content: ({ name, code, amountCents, amountCurrency }) => (
                 <div className="flex items-center gap-3">
                   <Avatar size="big" variant="connector">
                     <Icon name="puzzle" color="dark" />
@@ -163,17 +165,22 @@ const AddOnsList = () => {
                     <Typography color="textSecondary" variant="bodyHl" noWrap>
                       {name}
                     </Typography>
-                    <Typography variant="caption" noWrap>
-                      {translate('text_629728388c4d2300e2d3810b', {
-                        amountWithCurrency: intlFormatNumber(
-                          deserializeAmount(amountCents, amountCurrency) || 0,
-                          {
-                            currencyDisplay: 'symbol',
-                            currency: amountCurrency,
-                          },
-                        ),
-                      })}
-                    </Typography>
+                    <div className="flex items-baseline gap-1">
+                      <TypographyWithCopy className="shrink-0" compact noWrap variant="caption">
+                        {code}
+                      </TypographyWithCopy>
+                      <Typography className="min-w-0" variant="caption" noWrap>
+                        {`• ${translate('text_629728388c4d2300e2d3810b', {
+                          amountWithCurrency: intlFormatNumber(
+                            deserializeAmount(amountCents, amountCurrency) || 0,
+                            {
+                              currencyDisplay: 'symbol',
+                              currency: amountCurrency,
+                            },
+                          ),
+                        })}`}
+                      </Typography>
+                    </div>
                   </div>
                 </div>
               ),

--- a/src/pages/BillableMetricsList.tsx
+++ b/src/pages/BillableMetricsList.tsx
@@ -12,6 +12,7 @@ import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Table, TableColumn, TablePlaceholder } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { SearchInput } from '~/components/SearchInput'
@@ -136,9 +137,9 @@ const BillableMetricsList = () => {
             <Typography color="textSecondary" variant="bodyHl" noWrap>
               {name}
             </Typography>
-            <Typography variant="caption" noWrap>
+            <TypographyWithCopy compact noWrap variant="caption">
               {code}
-            </Typography>
+            </TypographyWithCopy>
           </div>
         </div>
       ),

--- a/src/pages/CouponsList.tsx
+++ b/src/pages/CouponsList.tsx
@@ -12,6 +12,7 @@ import { Status } from '~/components/designSystem/Status'
 import { Table } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { SearchInput } from '~/components/SearchInput'
@@ -39,6 +40,7 @@ gql`
   fragment CouponItem on Coupon {
     id
     name
+    code
     customersCount
     status
     amountCurrency
@@ -231,7 +233,15 @@ const CouponsList = () => {
                     <Typography color="textSecondary" variant="bodyHl" noWrap>
                       {coupon.name}
                     </Typography>
-                    <CouponCaption coupon={coupon} variant="caption" />
+                    <div className="flex items-baseline gap-1">
+                      <TypographyWithCopy className="shrink-0" compact noWrap variant="caption">
+                        {coupon.code}
+                      </TypographyWithCopy>
+                      <Typography className="shrink-0" variant="caption" noWrap>
+                        •
+                      </Typography>
+                      <CouponCaption coupon={coupon} variant="caption" />
+                    </div>
                   </div>
                 </div>
               ),

--- a/src/pages/CustomersList.tsx
+++ b/src/pages/CustomersList.tsx
@@ -12,6 +12,7 @@ import { formatFiltersForCustomerQuery } from '~/components/designSystem/Filters
 import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { PaymentProviderChip } from '~/components/PaymentProviderChip'
@@ -201,7 +202,14 @@ const CustomersList = () => {
               {
                 key: 'email',
                 title: translate('text_6419c64eace749372fc72b27'),
-                content: ({ email }) => email || '-',
+                content: ({ email }) =>
+                  email ? (
+                    <TypographyWithCopy compact noWrap variant="body">
+                      {email}
+                    </TypographyWithCopy>
+                  ) : (
+                    '-'
+                  ),
                 maxSpace: true,
                 minWidth: 200,
               },

--- a/src/pages/PlanDetails.tsx
+++ b/src/pages/PlanDetails.tsx
@@ -2,6 +2,7 @@ import { gql } from '@apollo/client'
 import { useEffect, useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { MainHeaderAction } from '~/components/MainHeader/types'
@@ -124,7 +125,7 @@ const PlanDetails = () => {
         entity={{
           viewName: translate('text_65281f686a80b400c8e2f6ad', { planName: plan?.name }),
           viewNameLoading: isPlanLoading,
-          metadata: plan?.code || '',
+          metadata: plan?.code ? <TypographyWithCopy>{plan.code}</TypographyWithCopy> : undefined,
           metadataLoading: isPlanLoading,
         }}
         actions={{ items: actions, loading: isPlanLoading }}

--- a/src/pages/PlansList.tsx
+++ b/src/pages/PlansList.tsx
@@ -9,6 +9,7 @@ import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Table } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { DeletePlanDialog, DeletePlanDialogRef } from '~/components/plans/DeletePlanDialog'
@@ -164,9 +165,9 @@ const PlansList = () => {
                     <Typography color="textSecondary" variant="bodyHl" noWrap>
                       {name}
                     </Typography>
-                    <Typography variant="caption" noWrap>
+                    <TypographyWithCopy compact noWrap variant="caption">
                       {code}
-                    </Typography>
+                    </TypographyWithCopy>
                   </div>
                 </div>
               ),

--- a/src/pages/SubscriptionsPage.tsx
+++ b/src/pages/SubscriptionsPage.tsx
@@ -13,7 +13,6 @@ import {
 import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Status, StatusType } from '~/components/designSystem/Status'
 import { Typography } from '~/components/designSystem/Typography'
-import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { SearchInput } from '~/components/SearchInput'
@@ -199,7 +198,6 @@ const SubscriptionsPage = () => {
             isLoading={isLoading}
             hasError={!!error}
             subscriptions={subscriptions}
-            rowSize={72}
             containerSize={{
               default: 16,
               md: 48,
@@ -208,9 +206,13 @@ const SubscriptionsPage = () => {
               {
                 key: 'name',
                 title: translate('text_6419c64eace749372fc72b0f'),
-                content: ({ name, externalId, isDowngrade, isScheduled }) => (
-                  <div className={tw('flex flex-col gap-1', { 'pl-4': isDowngrade })}>
-                    <div className="relative flex items-center gap-3">
+                content: ({ name, isDowngrade, isScheduled }) => (
+                  <>
+                    <div
+                      className={tw('relative flex items-center gap-3', {
+                        'pl-4': isDowngrade,
+                      })}
+                    >
                       {isDowngrade && <Icon name="arrow-indent" />}
                       <Typography variant="bodyHl" color="grey700" noWrap>
                         {name}
@@ -218,12 +220,7 @@ const SubscriptionsPage = () => {
                       {isDowngrade && <Status type={StatusType.default} label="downgrade" />}
                       {isScheduled && <Status type={StatusType.default} label="scheduled" />}
                     </div>
-                    {externalId && (
-                      <TypographyWithCopy compact noWrap variant="caption" color="grey600">
-                        {externalId}
-                      </TypographyWithCopy>
-                    )}
-                  </div>
+                  </>
                 ),
               },
               {

--- a/src/pages/SubscriptionsPage.tsx
+++ b/src/pages/SubscriptionsPage.tsx
@@ -13,6 +13,7 @@ import {
 import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Status, StatusType } from '~/components/designSystem/Status'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { SearchInput } from '~/components/SearchInput'
@@ -198,6 +199,7 @@ const SubscriptionsPage = () => {
             isLoading={isLoading}
             hasError={!!error}
             subscriptions={subscriptions}
+            rowSize={72}
             containerSize={{
               default: 16,
               md: 48,
@@ -206,13 +208,9 @@ const SubscriptionsPage = () => {
               {
                 key: 'name',
                 title: translate('text_6419c64eace749372fc72b0f'),
-                content: ({ name, isDowngrade, isScheduled }) => (
-                  <>
-                    <div
-                      className={tw('relative flex items-center gap-3', {
-                        'pl-4': isDowngrade,
-                      })}
-                    >
+                content: ({ name, externalId, isDowngrade, isScheduled }) => (
+                  <div className={tw('flex flex-col gap-1', { 'pl-4': isDowngrade })}>
+                    <div className="relative flex items-center gap-3">
                       {isDowngrade && <Icon name="arrow-indent" />}
                       <Typography variant="bodyHl" color="grey700" noWrap>
                         {name}
@@ -220,7 +218,12 @@ const SubscriptionsPage = () => {
                       {isDowngrade && <Status type={StatusType.default} label="downgrade" />}
                       {isScheduled && <Status type={StatusType.default} label="scheduled" />}
                     </div>
-                  </>
+                    {externalId && (
+                      <TypographyWithCopy compact noWrap variant="caption" color="grey600">
+                        {externalId}
+                      </TypographyWithCopy>
+                    )}
+                  </div>
                 ),
               },
               {

--- a/src/pages/__tests__/PlanDetails.test.tsx
+++ b/src/pages/__tests__/PlanDetails.test.tsx
@@ -120,7 +120,10 @@ describe('PlanDetails', () => {
           expect.objectContaining({
             entity: expect.objectContaining({
               viewName: expect.any(String),
-              metadata: 'test-plan',
+              // metadata is a click-to-copy element wrapping the plan code
+              metadata: expect.objectContaining({
+                props: expect.objectContaining({ children: 'test-plan' }),
+              }),
             }),
           }),
         )

--- a/src/pages/features/FeaturesList.tsx
+++ b/src/pages/features/FeaturesList.tsx
@@ -8,6 +8,7 @@ import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Table } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
 import { Typography } from '~/components/designSystem/Typography'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import {
   DeleteFeatureDialog,
   DeleteFeatureDialogRef,
@@ -189,9 +190,9 @@ const FeaturesList = () => {
                     <Typography variant="bodyHl" color="grey700">
                       {feature.name || '-'}
                     </Typography>
-                    <Typography variant="caption" color="grey600">
+                    <TypographyWithCopy compact variant="caption" color="grey600">
                       {feature.code}
-                    </Typography>
+                    </TypographyWithCopy>
                   </div>
                 </div>
               ),

--- a/src/pages/subscriptions/SubscriptionDetails.tsx
+++ b/src/pages/subscriptions/SubscriptionDetails.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { useTerminateCustomerSubscriptionDialog } from '~/components/customers/subscriptions/TerminateCustomerSubscriptionDialog'
+import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { MainHeaderAction } from '~/components/MainHeader/types'
@@ -303,7 +304,9 @@ const SubscriptionDetails = () => {
       planName: subscription?.plan.name,
     }),
     viewNameLoading: isSubscriptionLoading,
-    metadata: subscription?.plan.code || '',
+    metadata: subscription?.plan.code ? (
+      <TypographyWithCopy>{subscription.plan.code}</TypographyWithCopy>
+    ) : undefined,
     metadataLoading: isSubscriptionLoading,
   }
 

--- a/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
+++ b/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
@@ -151,7 +151,10 @@ describe('SubscriptionDetails', () => {
         render(<SubscriptionDetails />)
 
         expect(capturedConfig?.entity?.viewName).toBeDefined()
-        expect(capturedConfig?.entity?.metadata).toBe('test-plan')
+        // metadata is a click-to-copy element wrapping the plan code
+        expect(
+          (capturedConfig?.entity?.metadata as { props: { children: unknown } })?.props.children,
+        ).toBe('test-plan')
       })
 
       it('THEN should configure MainHeader with a dropdown action', () => {


### PR DESCRIPTION
Adds inline click-to-copy (`TypographyWithCopy`) on identifier values across list cells and the customer details header, so users can copy a code / number / external id without leaving the list. Clicking the copy button stops propagation, so it never triggers row navigation.

## Places touched

Main lists:
- Customers list > email
- Billable metrics list > code
- Plans list > code
- Features list > code
- Add-ons list > code (rendered as `code • amount`)
- Coupons list > code (rendered as `code • caption`)
- Subscriptions list > external id (under name, taller rows)
- Invoices list > invoice number
- Payments list > invoice number
- Credit notes list > credit note number

Customer details:
- Customer details > header > external id (below name, non-compact)
- Customer details > subscriptions > external id (under name, taller rows)
- Customer details > applied coupons > coupon code
- Customer details > wallets > wallet code (rendered as `code • rate`)
- Customer details > invoices > invoice number
- Customer details > payments > invoice number

Shared / infra:
- `TypographyWithCopy`: new `compact` prop (default off, keeps existing look e.g. API keys)
- `MainHeader` `metadata` now accepts `string | ReactNode`; snapshot now strips React elements
- Added `code` to `AddOnItem`, `CouponItem`, `WalletAccordion` fragments (+ codegen)

## Drawbacks / trade-offs

- ~4px left gap before the button text in tables: Table wraps cells in `<Typography noWrap>` (`overflow:hidden`), so the negative margin had to be dropped (`!ml-0` + `px-1`), otherwise the rounded hover corner was cropped.
- `compact` relies on several `!important` utilities to beat the MUI theme (fixed 32px height, padding, 80px min-width) - brittle if the button theme changes.
- Magic `!leading-[26px]` on the in-button text to fix baseline alignment in the `code • text` line (caption is 24px, +2px). Hardcoded in the shared component; also applies to body-variant standalone copies (harmless, single line, no sibling).
- `!items-baseline` on the compact button to expose the text baseline; the duplicate icon then baseline-aligns and sits slightly below center.
- In the flex `code • text` line the button needs `shrink-0` and the sibling `min-w-0`, else `noWrap` collapses the code to icon-only.
- `WalletAccordion` fragment is duplicated in `CustomerWalletList.tsx` and `WalletAccordion.tsx` (pre-existing); `code` had to be added to both or codegen fails on the name collision.
- Wallet `code` is nullable - the `code •` prefix only shows when a code exists.
- A `ReactNode` passed as header `metadata` is stripped from the change-detection snapshot, so it relies on `viewName` to detect changes. Edge case: two customers with no display name and different external ids, navigated without any other config change, could show a stale copy value.
- Payments: copy only on a single-invoice payment; a multi-invoice payment request still shows the plain "N invoices" count.
- Subscriptions / coupons / wallets list rows bumped to a taller row size (72px).

Fixes BIL-171