### PR TITLE
refactor(dialogs): migrate DeleteAdjustedFeeDialog to NiceModal hook

### DIFF
--- a/src/components/invoices/details/DeleteAdjustedFeeDialog.tsx
+++ b/src/components/invoices/details/DeleteAdjustedFeeDialog.tsx
@@ -1,11 +1,10 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import { TExtendedRemainingFee } from '~/core/formats/formatInvoiceItemsMap'
-import { useDestroyAdjustedFeeMutation, useGetInvoiceDetailsQuery } from '~/generated/graphql'
+import { useDestroyAdjustedFeeMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 gql`
@@ -21,32 +20,18 @@ gql`
   }
 `
 
-interface DeleteAdjustedFeeDialogProps {
+interface DeleteAdjustedFeeDialogData {
   fee: TExtendedRemainingFee | undefined
   onDelete?: (id: string) => void
 }
 
-export interface DeleteAdjustedFeeDialogRef {
-  openDialog: (dialogData: DeleteAdjustedFeeDialogProps) => unknown
-  closeDialog: () => unknown
-}
-
-export const DeleteAdjustedFeeDialog = forwardRef<DeleteAdjustedFeeDialogRef>((_, ref) => {
+export const useDeleteAdjustedFeeDialog = () => {
   const { translate } = useInternationalization()
-  const dialogRef = useRef<WarningDialogRef>(null)
-  const [dialogData, setDialogData] = useState<DeleteAdjustedFeeDialogProps | undefined>(undefined)
-
-  // Skip this query in regenerate mode (when onDelete is provided) since we manage local state
-  useGetInvoiceDetailsQuery({
-    variables: { id: dialogData?.fee?.invoiceId || '' },
-    skip: !dialogData?.fee?.invoiceId || !!dialogData?.onDelete,
-  })
+  const centralizedDialog = useCentralizedDialog()
 
   const [destroyFee] = useDestroyAdjustedFeeMutation({
     onCompleted({ destroyAdjustedFee }) {
       if (destroyAdjustedFee?.id) {
-        dialogRef.current?.closeDialog()
-
         addToast({
           message: translate('text_1738084927595tzdnuy6oxyu'),
           severity: 'success',
@@ -56,38 +41,28 @@ export const DeleteAdjustedFeeDialog = forwardRef<DeleteAdjustedFeeDialogRef>((_
     refetchQueries: ['getInvoiceDetails', 'getInvoiceFees'],
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setDialogData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
-
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_65a6b4e2cb38d9b70ec54035')}
-      description={<Typography>{translate('text_65a6b4e2cb38d9b70ec53c55')}</Typography>}
-      onContinue={async () => {
-        if (dialogData?.onDelete) {
-          dialogData.onDelete(dialogData?.fee?.id || '')
-          dialogRef.current?.closeDialog()
-          setDialogData(undefined)
+  const openDeleteAdjustedFeeDialog = (data: DeleteAdjustedFeeDialogData) => {
+    centralizedDialog.open({
+      title: translate('text_65a6b4e2cb38d9b70ec54035'),
+      description: <Typography>{translate('text_65a6b4e2cb38d9b70ec53c55')}</Typography>,
+      colorVariant: 'danger',
+      actionText: translate('text_65a6b4e2cb38d9b70ec54035'),
+      onAction: async () => {
+        if (data.onDelete) {
+          data.onDelete(data.fee?.id || '')
           return
         }
 
         await destroyFee({
           variables: {
             input: {
-              id: dialogData?.fee?.id || '',
+              id: data.fee?.id || '',
             },
           },
         })
-      }}
-      continueText={translate('text_65a6b4e2cb38d9b70ec54035')}
-    />
-  )
-})
+      },
+    })
+  }
 
-DeleteAdjustedFeeDialog.displayName = 'DeleteAdjustedFeeDialog'
+  return { openDeleteAdjustedFeeDialog }
+}

--- a/src/components/invoices/details/InvoiceDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTable.tsx
@@ -4,7 +4,6 @@ import { DateTime } from 'luxon'
 import { FC, Fragment, memo, ReactNode, RefObject } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
-import { DeleteAdjustedFeeDialogRef } from '~/components/invoices/details/DeleteAdjustedFeeDialog'
 import { EditFeeDrawerRef } from '~/components/invoices/details/EditFeeDrawer'
 import {
   getRegenerateModeProps,
@@ -176,7 +175,6 @@ interface InvoiceDetailsTableProps {
   customer: Pick<Customer, 'id' | 'applicableTimezone'> | null | undefined
   invoice: InvoiceForDetailsTableFragment | null | undefined
   editFeeDrawerRef: RefObject<EditFeeDrawerRef>
-  deleteAdjustedFeeDialogRef: RefObject<DeleteAdjustedFeeDialogRef>
   isDraftOverride?: boolean
   fees: FeeDetailsForInvoiceOverviewFragment[] | null | undefined
   onAdd?: OnRegeneratedFeeAdd
@@ -256,7 +254,6 @@ export const InvoiceDetailsTable = memo(
   ({
     customer,
     editFeeDrawerRef,
-    deleteAdjustedFeeDialogRef,
     invoice,
     isDraftOverride,
     fees,
@@ -323,7 +320,6 @@ export const InvoiceDetailsTable = memo(
                         : undefined
                     }
                     editFeeDrawerRef={editFeeDrawerRef}
-                    deleteAdjustedFeeDialogRef={deleteAdjustedFeeDialogRef}
                     isDraftInvoice={isDraftInvoice}
                     fee={
                       feeWithMetadata as FeeForInvoiceDetailsTableBodyLineFragment & {
@@ -390,7 +386,6 @@ export const InvoiceDetailsTable = memo(
                       currency={currency}
                       displayName={subscription.name || subscription.plan.name}
                       editFeeDrawerRef={editFeeDrawerRef}
-                      deleteAdjustedFeeDialogRef={deleteAdjustedFeeDialogRef}
                       fee={undefined}
                       isDraftInvoice={false}
                       hasTaxProviderError={hasTaxProviderError}
@@ -482,7 +477,6 @@ export const InvoiceDetailsTable = memo(
                                 displayName={fee.metadata.displayName}
                                 succeededDate={succeededDate}
                                 editFeeDrawerRef={editFeeDrawerRef}
-                                deleteAdjustedFeeDialogRef={deleteAdjustedFeeDialogRef}
                                 isDraftInvoice={isDraftInvoice}
                                 fee={fee}
                                 hasTaxProviderError={hasTaxProviderError}

--- a/src/components/invoices/details/InvoiceDetailsTableBodyLine.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableBodyLine.tsx
@@ -33,7 +33,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { OnRegeneratedFeeAdd } from '~/pages/CustomerInvoiceRegenerate'
 import { MenuPopper, PopperOpener } from '~/styles'
 
-import { DeleteAdjustedFeeDialogRef } from './DeleteAdjustedFeeDialog'
+import { useDeleteAdjustedFeeDialog } from './DeleteAdjustedFeeDialog'
 import { EditFeeDrawerRef } from './EditFeeDrawer'
 import { CopyFeeIdButton, FeeActionsCell, ViewFeeDetailsButton } from './FeeActionsCell'
 import { InvoiceDetailsTableBodyLineGraduated } from './InvoiceDetailsTableBodyLineGraduated'
@@ -133,7 +133,6 @@ type InvoiceDetailsTableBodyLineBaseProps = {
   hideVat?: boolean
   displayFeeBoundaries?: boolean
   editFeeDrawerRef?: RefObject<EditFeeDrawerRef>
-  deleteAdjustedFeeDialogRef?: RefObject<DeleteAdjustedFeeDialogRef>
   succeededDate?: string
   hasTaxProviderError?: boolean
 }
@@ -229,7 +228,6 @@ export const InvoiceDetailsTableBodyLine = memo(
   ({
     canHaveUnitPrice,
     currency,
-    deleteAdjustedFeeDialogRef,
     displayName,
     editFeeDrawerRef,
     fee,
@@ -246,6 +244,7 @@ export const InvoiceDetailsTableBodyLine = memo(
     const { invoiceId = '' } = useParams()
     const { translate } = useInternationalization()
     const viewFeeDetails = useViewFeeDetailsDrawer()
+    const { openDeleteAdjustedFeeDialog } = useDeleteAdjustedFeeDialog()
     const chargeModel = fee?.charge?.chargeModel
     const isTrueUpFee = !!fee?.metadata?.isTrueUpFee
     const isCommitmentFee = !!fee?.metadata?.isCommitmentFee
@@ -441,7 +440,7 @@ export const InvoiceDetailsTableBodyLine = memo(
                         align="left"
                         onClick={() => {
                           if (isAdjustedFee) {
-                            deleteAdjustedFeeDialogRef?.current?.openDialog({ fee, onDelete })
+                            openDeleteAdjustedFeeDialog({ fee, onDelete })
                           } else if (fee) {
                             if (onAdd && invoiceSubscriptionId) {
                               editFeeDrawerRef?.current?.openDrawer({

--- a/src/components/invoices/details/__tests__/DeleteAdjustedFeeDialog.test.tsx
+++ b/src/components/invoices/details/__tests__/DeleteAdjustedFeeDialog.test.tsx
@@ -1,0 +1,261 @@
+import { act, renderHook } from '@testing-library/react'
+import { ReactNode } from 'react'
+
+import { TExtendedRemainingFee } from '~/core/formats/formatInvoiceItemsMap'
+import { AllTheProviders } from '~/test-utils'
+
+import { useDeleteAdjustedFeeDialog } from '../DeleteAdjustedFeeDialog'
+
+const mockDialogOpen = jest.fn()
+
+jest.mock('~/components/dialogs/CentralizedDialog', () => ({
+  useCentralizedDialog: () => ({
+    open: mockDialogOpen,
+  }),
+}))
+
+const mockDestroyFee = jest.fn()
+let mockMutationConfig: { onCompleted: (data: unknown) => void } | undefined
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useDestroyAdjustedFeeMutation: (config: { onCompleted: (data: unknown) => void }) => {
+    mockMutationConfig = config
+    return [mockDestroyFee]
+  },
+}))
+
+const mockAddToast = jest.fn()
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: (...args: unknown[]) => mockAddToast(...args),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <AllTheProviders>{children}</AllTheProviders>
+)
+
+const buildFee = (overrides = {}) =>
+  ({
+    id: 'fee-1',
+    invoiceId: 'invoice-1',
+    ...overrides,
+  }) as TExtendedRemainingFee
+
+describe('useDeleteAdjustedFeeDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockMutationConfig = undefined
+  })
+
+  describe('GIVEN the hook is called', () => {
+    describe('WHEN it returns', () => {
+      it('THEN should return openDeleteAdjustedFeeDialog function', () => {
+        const { result } = renderHook(() => useDeleteAdjustedFeeDialog(), { wrapper })
+
+        expect(result.current.openDeleteAdjustedFeeDialog).toBeDefined()
+        expect(typeof result.current.openDeleteAdjustedFeeDialog).toBe('function')
+      })
+    })
+  })
+
+  describe('GIVEN openDeleteAdjustedFeeDialog is called', () => {
+    describe('WHEN called with a fee', () => {
+      it('THEN should open the dialog with danger variant', () => {
+        const { result } = renderHook(() => useDeleteAdjustedFeeDialog(), { wrapper })
+
+        act(() => {
+          result.current.openDeleteAdjustedFeeDialog({ fee: buildFee() })
+        })
+
+        expect(mockDialogOpen).toHaveBeenCalledWith(
+          expect.objectContaining({
+            colorVariant: 'danger',
+          }),
+        )
+      })
+
+      it('THEN should pass title, description and actionText', () => {
+        const { result } = renderHook(() => useDeleteAdjustedFeeDialog(), { wrapper })
+
+        act(() => {
+          result.current.openDeleteAdjustedFeeDialog({ fee: buildFee() })
+        })
+
+        expect(mockDialogOpen).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: expect.any(String),
+            description: expect.anything(),
+            actionText: expect.any(String),
+          }),
+        )
+      })
+    })
+  })
+
+  describe('GIVEN onAction is triggered in default flow', () => {
+    describe('WHEN onDelete is not provided', () => {
+      it('THEN should call destroyFee mutation with the fee id', async () => {
+        mockDestroyFee.mockResolvedValueOnce({})
+
+        const { result } = renderHook(() => useDeleteAdjustedFeeDialog(), { wrapper })
+
+        act(() => {
+          result.current.openDeleteAdjustedFeeDialog({ fee: buildFee({ id: 'fee-42' }) })
+        })
+
+        const onAction = mockDialogOpen.mock.calls[0][0].onAction
+
+        await act(async () => {
+          await onAction()
+        })
+
+        expect(mockDestroyFee).toHaveBeenCalledWith({
+          variables: { input: { id: 'fee-42' } },
+        })
+      })
+
+      it('THEN should call destroyFee with empty id when fee is undefined', async () => {
+        mockDestroyFee.mockResolvedValueOnce({})
+
+        const { result } = renderHook(() => useDeleteAdjustedFeeDialog(), { wrapper })
+
+        act(() => {
+          result.current.openDeleteAdjustedFeeDialog({ fee: undefined })
+        })
+
+        const onAction = mockDialogOpen.mock.calls[0][0].onAction
+
+        await act(async () => {
+          await onAction()
+        })
+
+        expect(mockDestroyFee).toHaveBeenCalledWith({
+          variables: { input: { id: '' } },
+        })
+      })
+    })
+  })
+
+  describe('GIVEN onAction is triggered in regenerate flow', () => {
+    describe('WHEN onDelete is provided', () => {
+      it('THEN should call onDelete with the fee id', async () => {
+        const onDelete = jest.fn()
+
+        const { result } = renderHook(() => useDeleteAdjustedFeeDialog(), { wrapper })
+
+        act(() => {
+          result.current.openDeleteAdjustedFeeDialog({ fee: buildFee({ id: 'fee-7' }), onDelete })
+        })
+
+        const onAction = mockDialogOpen.mock.calls[0][0].onAction
+
+        await act(async () => {
+          await onAction()
+        })
+
+        expect(onDelete).toHaveBeenCalledWith('fee-7')
+      })
+
+      it('THEN should not call destroyFee mutation', async () => {
+        const onDelete = jest.fn()
+
+        const { result } = renderHook(() => useDeleteAdjustedFeeDialog(), { wrapper })
+
+        act(() => {
+          result.current.openDeleteAdjustedFeeDialog({ fee: buildFee(), onDelete })
+        })
+
+        const onAction = mockDialogOpen.mock.calls[0][0].onAction
+
+        await act(async () => {
+          await onAction()
+        })
+
+        expect(mockDestroyFee).not.toHaveBeenCalled()
+      })
+
+      it('THEN should call onDelete with empty id when fee is undefined', async () => {
+        const onDelete = jest.fn()
+
+        const { result } = renderHook(() => useDeleteAdjustedFeeDialog(), { wrapper })
+
+        act(() => {
+          result.current.openDeleteAdjustedFeeDialog({ fee: undefined, onDelete })
+        })
+
+        const onAction = mockDialogOpen.mock.calls[0][0].onAction
+
+        await act(async () => {
+          await onAction()
+        })
+
+        expect(onDelete).toHaveBeenCalledWith('')
+      })
+    })
+  })
+
+  describe('GIVEN the destroy mutation completes', () => {
+    describe('WHEN destroyAdjustedFee returns an id', () => {
+      it('THEN should display a success toast', () => {
+        renderHook(() => useDeleteAdjustedFeeDialog(), { wrapper })
+
+        act(() => {
+          mockMutationConfig?.onCompleted({ destroyAdjustedFee: { id: 'fee-1' } })
+        })
+
+        expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+      })
+    })
+
+    describe('WHEN destroyAdjustedFee returns no id', () => {
+      it('THEN should not display a toast', () => {
+        renderHook(() => useDeleteAdjustedFeeDialog(), { wrapper })
+
+        act(() => {
+          mockMutationConfig?.onCompleted({ destroyAdjustedFee: null })
+        })
+
+        expect(mockAddToast).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN the dialog is opened multiple times', () => {
+    describe('WHEN openDeleteAdjustedFeeDialog is called with different fees', () => {
+      it('THEN should use the correct fee id for each call', async () => {
+        mockDestroyFee.mockResolvedValue({})
+
+        const { result } = renderHook(() => useDeleteAdjustedFeeDialog(), { wrapper })
+
+        act(() => {
+          result.current.openDeleteAdjustedFeeDialog({ fee: buildFee({ id: 'fee-a' }) })
+        })
+        await act(async () => {
+          await mockDialogOpen.mock.calls[0][0].onAction()
+        })
+
+        act(() => {
+          result.current.openDeleteAdjustedFeeDialog({ fee: buildFee({ id: 'fee-b' }) })
+        })
+        await act(async () => {
+          await mockDialogOpen.mock.calls[1][0].onAction()
+        })
+
+        expect(mockDestroyFee).toHaveBeenNthCalledWith(1, {
+          variables: { input: { id: 'fee-a' } },
+        })
+        expect(mockDestroyFee).toHaveBeenNthCalledWith(2, {
+          variables: { input: { id: 'fee-b' } },
+        })
+      })
+    })
+  })
+})

--- a/src/components/invoices/details/__tests__/InvoiceDetailsTable.integration.test.tsx
+++ b/src/components/invoices/details/__tests__/InvoiceDetailsTable.integration.test.tsx
@@ -23,6 +23,10 @@ jest.mock('~/components/invoices/details/ViewFeeDetailsDrawer', () => ({
   useViewFeeDetailsDrawer: () => ({ open: jest.fn(), close: jest.fn() }),
 }))
 
+jest.mock('~/components/invoices/details/DeleteAdjustedFeeDialog', () => ({
+  useDeleteAdjustedFeeDialog: () => ({ openDeleteAdjustedFeeDialog: jest.fn() }),
+}))
+
 describe('InvoiceDetailsTable - Integration Tests', () => {
   const mockCustomer = {
     id: 'customer-1',
@@ -30,7 +34,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
   }
 
   const mockEditFeeDrawerRef = { current: null }
-  const mockDeleteAdjustedFeeDialogRef = { current: null }
 
   describe('Invoice with 1 subscription', () => {
     it('should render invoice with single subscription and fees correctly', () => {
@@ -114,7 +117,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -224,7 +226,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -328,7 +329,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -477,7 +477,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -603,7 +602,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -666,7 +664,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={[]}
         />,
       )
@@ -699,7 +696,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={[]}
         />,
       )
@@ -776,7 +772,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -854,7 +849,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -926,7 +920,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -946,7 +939,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={null}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={[]}
         />,
       )
@@ -961,7 +953,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={undefined}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={[]}
         />,
       )
@@ -1038,7 +1029,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -1115,7 +1105,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -1192,7 +1181,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -1286,7 +1274,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -1426,7 +1413,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={mockInvoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
         />,
       )
@@ -1457,7 +1443,6 @@ describe('InvoiceDetailsTable - Integration Tests', () => {
           customer={mockCustomer}
           invoice={mockInvoice}
           editFeeDrawerRef={mockEditFeeDrawerRef}
-          deleteAdjustedFeeDialogRef={mockDeleteAdjustedFeeDialogRef}
           fees={[]}
         />,
       )

--- a/src/components/invoices/details/__tests__/InvoiceDetailsTableBodyLine.clickable.integration.test.tsx
+++ b/src/components/invoices/details/__tests__/InvoiceDetailsTableBodyLine.clickable.integration.test.tsx
@@ -1,7 +1,6 @@
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { DeleteAdjustedFeeDialogRef } from '~/components/invoices/details/DeleteAdjustedFeeDialog'
 import { EditFeeDrawerRef } from '~/components/invoices/details/EditFeeDrawer'
 import { InvoiceDetailsTable } from '~/components/invoices/details/InvoiceDetailsTable'
 import {
@@ -36,6 +35,10 @@ jest.mock('~/components/invoices/details/ViewFeeDetailsDrawer', () => ({
     open: mockHookOpen,
     close: mockHookClose,
   }),
+}))
+
+jest.mock('~/components/invoices/details/DeleteAdjustedFeeDialog', () => ({
+  useDeleteAdjustedFeeDialog: () => ({ openDeleteAdjustedFeeDialog: jest.fn() }),
 }))
 
 const buildFinalizedInvoice = (): InvoiceForDetailsTableFragment =>
@@ -103,9 +106,6 @@ const renderTable = (invoice: InvoiceForDetailsTableFragment) =>
       customer={{ id: 'customer-1', applicableTimezone: TimezoneEnum.TzAmericaNewYork }}
       invoice={invoice}
       editFeeDrawerRef={{ current: null } as unknown as React.RefObject<EditFeeDrawerRef>}
-      deleteAdjustedFeeDialogRef={
-        { current: null } as unknown as React.RefObject<DeleteAdjustedFeeDialogRef>
-      }
       fees={invoice.fees as FeeDetailsForInvoiceOverviewFragment[]}
     />,
   )

--- a/src/pages/CustomerInvoiceRegenerate.tsx
+++ b/src/pages/CustomerInvoiceRegenerate.tsx
@@ -6,10 +6,6 @@ import { Alert } from '~/components/designSystem/Alert'
 import { Button } from '~/components/designSystem/Button'
 import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder'
 import { Typography } from '~/components/designSystem/Typography'
-import {
-  DeleteAdjustedFeeDialog,
-  DeleteAdjustedFeeDialogRef,
-} from '~/components/invoices/details/DeleteAdjustedFeeDialog'
 import { EditFeeDrawer, EditFeeDrawerRef } from '~/components/invoices/details/EditFeeDrawer'
 import { InvoiceDetailsTable } from '~/components/invoices/details/InvoiceDetailsTable'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
@@ -106,7 +102,6 @@ const CustomerInvoiceRegenerate = () => {
   const { customerId, invoiceId } = useParams()
   const navigate = useNavigate()
 
-  const deleteAdjustedFeeDialogRef = useRef<DeleteAdjustedFeeDialogRef>(null)
   const editFeeDrawerRef = useRef<EditFeeDrawerRef>(null)
 
   const {
@@ -392,7 +387,6 @@ const CustomerInvoiceRegenerate = () => {
                 customer={customer}
                 invoice={invoice}
                 editFeeDrawerRef={editFeeDrawerRef}
-                deleteAdjustedFeeDialogRef={deleteAdjustedFeeDialogRef}
                 isDraftOverride={true}
                 onAdd={onAdd}
                 onDelete={onDelete}
@@ -547,7 +541,6 @@ const CustomerInvoiceRegenerate = () => {
         </Button>
       </CenteredPage.StickyFooter>
 
-      <DeleteAdjustedFeeDialog ref={deleteAdjustedFeeDialogRef} />
       <EditFeeDrawer ref={editFeeDrawerRef} />
     </CenteredPage.Wrapper>
   )

--- a/src/pages/InvoiceOverview.tsx
+++ b/src/pages/InvoiceOverview.tsx
@@ -8,10 +8,6 @@ import { Alert } from '~/components/designSystem/Alert'
 import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Typography } from '~/components/designSystem/Typography'
-import {
-  DeleteAdjustedFeeDialog,
-  DeleteAdjustedFeeDialogRef,
-} from '~/components/invoices/details/DeleteAdjustedFeeDialog'
 import { EditFeeDrawer, EditFeeDrawerRef } from '~/components/invoices/details/EditFeeDrawer'
 import {
   InvoiceDetailsTable,
@@ -385,7 +381,6 @@ const InvoiceOverview = memo(
     const { invoiceId } = useParams()
 
     const billingEntity = invoice?.billingEntity
-    const deleteAdjustedFeeDialogRef = useRef<DeleteAdjustedFeeDialogRef>(null)
     const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
     const editFeeDrawerRef = useRef<EditFeeDrawerRef>(null)
 
@@ -559,7 +554,6 @@ const InvoiceOverview = memo(
                 customer={customer}
                 invoice={invoice}
                 editFeeDrawerRef={editFeeDrawerRef}
-                deleteAdjustedFeeDialogRef={deleteAdjustedFeeDialogRef}
                 fees={fees}
               />
               {showExternalAppsSection && (
@@ -821,7 +815,6 @@ const InvoiceOverview = memo(
             </>
           )}
         </>
-        <DeleteAdjustedFeeDialog ref={deleteAdjustedFeeDialogRef} />
         <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
         <EditFeeDrawer ref={editFeeDrawerRef} />
       </ViewFeeDetailsDrawerProvider>

--- a/src/pages/__tests__/CustomerInvoiceRegenerate.test.tsx
+++ b/src/pages/__tests__/CustomerInvoiceRegenerate.test.tsx
@@ -39,7 +39,7 @@ jest.mock('~/generated/graphql', () => {
 })
 
 jest.mock('~/components/invoices/details/DeleteAdjustedFeeDialog', () => ({
-  DeleteAdjustedFeeDialog: jest.fn(() => null),
+  useDeleteAdjustedFeeDialog: () => ({ openDeleteAdjustedFeeDialog: jest.fn() }),
 }))
 
 jest.mock('~/components/invoices/details/EditFeeDrawer', () => ({


### PR DESCRIPTION
## Summary

Migrates `DeleteAdjustedFeeDialog` off the deprecated imperative `WarningDialog` (ref-based) onto the new `useCentralizedDialog` hook from `~/components/dialogs`. This removes one of the remaining `no-restricted-imports` ESLint warnings about `~/components/designSystem/WarningDialog`.

## Changes

- **`src/components/invoices/details/DeleteAdjustedFeeDialog.tsx`**: Rewrite the file as a `useDeleteAdjustedFeeDialog` hook returning `openDeleteAdjustedFeeDialog`. It now wraps `useCentralizedDialog` with `colorVariant: 'danger'` and dispatches either the `onDelete` callback (regenerate flow) or the `destroyAdjustedFee` mutation (default flow). The dialog is no longer rendered explicitly — it lives in the NiceModal registry.
- **`src/components/invoices/details/InvoiceDetailsTableBodyLine.tsx`**: Call the hook directly instead of receiving `deleteAdjustedFeeDialogRef` as a prop. Drops the prop from `InvoiceDetailsTableBodyLineBaseProps`.
- **`src/components/invoices/details/InvoiceDetailsTable.tsx`**: Removes the `deleteAdjustedFeeDialogRef` prop and forwarding to body lines.
- **`src/pages/CustomerInvoiceRegenerate.tsx` & `src/pages/InvoiceOverview.tsx`**: Remove the `useRef<DeleteAdjustedFeeDialogRef>` declarations, the JSX `<DeleteAdjustedFeeDialog ref=... />` mounting, and the prop forwarding to `InvoiceDetailsTable`.
- **Tests** (`InvoiceDetailsTable.integration.test.tsx`, `InvoiceDetailsTableBodyLine.clickable.integration.test.tsx`, `CustomerInvoiceRegenerate.test.tsx`): Replace the `mockDeleteAdjustedFeeDialogRef` shim with a `jest.mock` of `useDeleteAdjustedFeeDialog`.

The `destroyAdjustedFee` mutation still refetches `getInvoiceDetails` / `getInvoiceFees`, so the parent invoice view refreshes the same way it used to. The internal `useGetInvoiceDetailsQuery` lazy-subscribe trick from the old dialog has been dropped — the active subscription lives in `CustomerInvoiceDetails.tsx`, which is what the refetch was actually targeting.

## Test plan

- [x] `pnpm exec tsc --noEmit` — passes
- [x] `pnpm exec eslint` on touched files — no new errors, one fewer `WarningDialog` warning (68 → 67)
- [x] `pnpm exec jest` on the three impacted test files — 45 / 45 pass
- [ ] Smoke test: open a draft invoice, edit a fee, then revert it via the row menu — confirm the danger dialog opens and the destroy mutation runs.
- [ ] Smoke test: in the invoice regenerate flow, revert an adjusted fee — confirm the row is removed locally via `onDelete` without a network call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NE5CkQUbFk2WdUCexE32T2)_