### PR TITLE
fix(rte): parse pasted markdown into rich text

### DIFF
--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/baseExtensions.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/baseExtensions.test.ts
@@ -279,4 +279,21 @@ describe('getBaseExtensions', () => {
       })
     })
   })
+
+  describe('GIVEN the Markdown extension', () => {
+    const findMarkdown = () => getBaseExtensions().find((ext) => ext.name === 'markdown')
+
+    it('THEN is configured to transform pasted plain text as markdown', () => {
+      const markdown = findMarkdown()
+
+      expect(markdown).toBeDefined()
+      expect(markdown?.options.transformPastedText).toBe(true)
+    })
+
+    it('THEN still allows inline HTML (existing behavior preserved)', () => {
+      const markdown = findMarkdown()
+
+      expect(markdown?.options.html).toBe(true)
+    })
+  })
 })

--- a/src/components/designSystem/RichTextEditor/extensions/baseExtensions.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/baseExtensions.ts
@@ -252,5 +252,5 @@ export const getBaseExtensions = (options?: BaseExtensionsOptions): Extensions =
   LinkCard,
   BlockColors,
   BlockMove,
-  Markdown.configure({ html: true }),
+  Markdown.configure({ html: true, transformPastedText: true }),
 ]


### PR DESCRIPTION
## Context

When a user pastes plain text containing markdown syntax (e.g. `**bold**`, `# Heading`, `- list`, `[link](url)`, tables) into the quotes rich text editor, it's now parsed and inserted as real formatted rich text instead of literal markdown characters.

## Description

This PR activates TipTap own parsing for markdown. We kept the behavious for parse link too.

## Fixes

Fixes LAGO-1570

🤖 Generated with [Claude Code](https://claude.com/claude-code)