### PR TITLE
chore(details-v2): remove leftover edit plan/subscription actions

### DIFF
--- a/src/pages/PlanDetails.tsx
+++ b/src/pages/PlanDetails.tsx
@@ -17,7 +17,6 @@ import {
   CUSTOMER_SUBSCRIPTION_PLAN_DETAILS,
   PLAN_DETAILS_ROUTE,
   PLANS_ROUTE,
-  UPDATE_PLAN_ROUTE,
   useNavigate,
 } from '~/core/router'
 import {
@@ -87,15 +86,6 @@ const PlanDetails = () => {
       label: translate('text_626162c62f790600f850b6fe'),
       dataTest: 'plan-details-actions',
       items: [
-        {
-          label: translate('text_65281f686a80b400c8e2f6b3'),
-          hidden: !hasPermissions(['plansUpdate']),
-          dataTest: 'plan-details-edit',
-          onClick: (closePopper) => {
-            navigate(generatePath(UPDATE_PLAN_ROUTE, { planId: plan?.id as string }))
-            closePopper()
-          },
-        },
         {
           label: translate('text_65281f686a80b400c8e2f6b6'),
           hidden: !hasPermissions(['plansCreate']),

--- a/src/pages/__tests__/PlanDetails.test.tsx
+++ b/src/pages/__tests__/PlanDetails.test.tsx
@@ -152,7 +152,7 @@ describe('PlanDetails', () => {
 
   describe('GIVEN user has all permissions', () => {
     describe('WHEN actions are configured', () => {
-      it('THEN should include dropdown with edit, duplicate, and delete items', () => {
+      it('THEN should include dropdown with duplicate and delete items', () => {
         mockHasPermissions.mockReturnValue(true)
 
         render(<PlanDetails />)
@@ -165,23 +165,7 @@ describe('PlanDetails', () => {
 
         const visibleItems = actions[0]?.items.filter((i) => !i.hidden)
 
-        expect(visibleItems).toHaveLength(3)
-      })
-    })
-  })
-
-  describe('GIVEN user has no plansUpdate permission', () => {
-    describe('WHEN actions are configured', () => {
-      it('THEN should hide the edit action', () => {
-        mockHasPermissions.mockImplementation((perms: string[]) => !perms.includes('plansUpdate'))
-
-        render(<PlanDetails />)
-
-        const actions = mockMainHeaderConfigure.mock.calls[0]?.[0]?.actions
-          ?.items as MainHeaderDropdownAction[]
-        const editItem = actions[0]?.items[0]
-
-        expect(editItem?.hidden).toBe(true)
+        expect(visibleItems).toHaveLength(2)
       })
     })
   })
@@ -195,7 +179,7 @@ describe('PlanDetails', () => {
 
         const actions = mockMainHeaderConfigure.mock.calls[0]?.[0]?.actions
           ?.items as MainHeaderDropdownAction[]
-        const duplicateItem = actions[0]?.items[1]
+        const duplicateItem = actions[0]?.items[0]
 
         expect(duplicateItem?.hidden).toBe(true)
       })
@@ -211,7 +195,7 @@ describe('PlanDetails', () => {
 
         const actions = mockMainHeaderConfigure.mock.calls[0]?.[0]?.actions
           ?.items as MainHeaderDropdownAction[]
-        const deleteItem = actions[0]?.items[2]
+        const deleteItem = actions[0]?.items[1]
 
         expect(deleteItem?.hidden).toBe(true)
       })

--- a/src/pages/subscriptions/SubscriptionDetails.tsx
+++ b/src/pages/subscriptions/SubscriptionDetails.tsx
@@ -23,7 +23,6 @@ import {
   CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE,
   PLAN_SUBSCRIPTION_DETAILS_ROUTE,
   SUBSCRIPTIONS_ROUTE,
-  UPDATE_SUBSCRIPTION,
   UPGRADE_DOWNGRADE_SUBSCRIPTION,
   useNavigate,
 } from '~/core/router'
@@ -69,7 +68,6 @@ gql`
 `
 
 export const SUBSCRIPTION_DETAILS_ACTIONS_TEST_ID = 'subscription-details-actions'
-export const SUBSCRIPTION_DETAILS_UPDATE_TEST_ID = 'subscription-details-update'
 export const SUBSCRIPTION_DETAILS_UPGRADE_DOWNGRADE_TEST_ID =
   'subscription-details-upgrade-downgrade'
 export const SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID = 'subscription-details-terminate'
@@ -315,20 +313,6 @@ const SubscriptionDetails = () => {
       label: translate('text_626162c62f790600f850b6fe'),
       dataTest: SUBSCRIPTION_DETAILS_ACTIONS_TEST_ID,
       items: [
-        {
-          label: translate('text_62d7f6178ec94cd09370e63c'),
-          dataTest: SUBSCRIPTION_DETAILS_UPDATE_TEST_ID,
-          hidden: !canEditSubscription(subscription?.status),
-          onClick: (closePopper) => {
-            navigate(
-              generatePath(UPDATE_SUBSCRIPTION, {
-                customerId: subscription?.customer?.id as string,
-                subscriptionId: subscriptionId as string,
-              }),
-            )
-            closePopper()
-          },
-        },
         {
           label: translate('text_62d7f6178ec94cd09370e64a'),
           dataTest: SUBSCRIPTION_DETAILS_UPGRADE_DOWNGRADE_TEST_ID,

--- a/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
+++ b/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
@@ -5,7 +5,6 @@ import { addToast } from '~/core/apolloClient'
 import {
   CUSTOMER_DETAILS_ROUTE,
   SUBSCRIPTIONS_ROUTE,
-  UPDATE_SUBSCRIPTION,
   UPGRADE_DOWNGRADE_SUBSCRIPTION,
 } from '~/core/router'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
@@ -14,7 +13,6 @@ import { render, testMockNavigateFn } from '~/test-utils'
 
 import SubscriptionDetails, {
   SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID,
-  SUBSCRIPTION_DETAILS_UPDATE_TEST_ID,
   SUBSCRIPTION_DETAILS_UPGRADE_DOWNGRADE_TEST_ID,
 } from '../SubscriptionDetails'
 
@@ -178,10 +176,6 @@ describe('SubscriptionDetails', () => {
 
     it.each([
       {
-        buttonTestId: SUBSCRIPTION_DETAILS_UPDATE_TEST_ID,
-        buttonName: 'update',
-      },
-      {
         buttonTestId: SUBSCRIPTION_DETAILS_UPGRADE_DOWNGRADE_TEST_ID,
         buttonName: 'upgrade/downgrade',
       },
@@ -215,10 +209,6 @@ describe('SubscriptionDetails', () => {
     })
 
     it.each([
-      {
-        buttonTestId: SUBSCRIPTION_DETAILS_UPDATE_TEST_ID,
-        buttonName: 'update',
-      },
       {
         buttonTestId: SUBSCRIPTION_DETAILS_UPGRADE_DOWNGRADE_TEST_ID,
         buttonName: 'upgrade/downgrade',
@@ -406,29 +396,6 @@ describe('SubscriptionDetails', () => {
   })
 
   describe('GIVEN the dropdown actions', () => {
-    describe('WHEN clicking the update subscription item', () => {
-      it('THEN should navigate to the update subscription route', () => {
-        render(<SubscriptionDetails />)
-
-        const dropdownAction = capturedConfig?.actions?.items[0]
-
-        if (dropdownAction?.type === 'dropdown') {
-          const updateItem = dropdownAction.items.find(
-            (i) => i.dataTest === SUBSCRIPTION_DETAILS_UPDATE_TEST_ID,
-          )
-
-          updateItem?.onClick(jest.fn())
-
-          expect(testMockNavigateFn).toHaveBeenCalledWith(
-            UPDATE_SUBSCRIPTION.replace(':customerId', 'customer-1').replace(
-              ':subscriptionId',
-              'subscription-1',
-            ),
-          )
-        }
-      })
-    })
-
     describe('WHEN clicking the upgrade/downgrade item', () => {
       it('THEN should navigate to the upgrade/downgrade route', () => {
         render(<SubscriptionDetails />)

--- a/translations/base.json
+++ b/translations/base.json
@@ -38,7 +38,6 @@
   "text_6529666e71f6ce006d2bf011": "{{planName}} -  subscription details",
   "text_652525609f420d00b83dd602": "This subscription is presently associated with a plan that has no overrides. Updating the charges will result in the creation of an overridden plan.",
   "text_65281f686a80b400c8e2f6ad": "{{planName}} - plan details",
-  "text_65281f686a80b400c8e2f6b3": "Edit plan",
   "text_65281f686a80b400c8e2f6b6": "Duplicate plan",
   "text_65281f686a80b400c8e2f6be": "Active subscriptions",
   "text_65281f686a80b400c8e2f6c4": "Plan prices",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -35,7 +35,6 @@
   "text_6529666e71f6ce006d2bf011": "{{planName}} - detalhes da assinatura",
   "text_652525609f420d00b83dd602": "Esta assinatura está atualmente associada a um plano sem substituições. A atualização das taxas resultará na criação de um plano substituído",
   "text_65281f686a80b400c8e2f6ad": "{{planName}} - detalhes do plano",
-  "text_65281f686a80b400c8e2f6b3": "Editar plano",
   "text_65281f686a80b400c8e2f6b6": "Duplicar plano",
   "text_65281f686a80b400c8e2f6be": "Assinaturas ativas",
   "text_65281f686a80b400c8e2f6c4": "Preços do plano",


### PR DESCRIPTION
Removes the leftover **Edit plan** and **Edit subscription** items from the top-right action dropdown on the v2 plan and subscription details pages. With v2 inline editing these standalone edit entry points are no longer needed.

- `PlanDetails.tsx`: drop the Edit plan dropdown item (and its now-unused `UPDATE_PLAN_ROUTE` import)
- `SubscriptionDetails.tsx`: drop the Edit subscription item (and the now-unused `UPDATE_SUBSCRIPTION` import + `SUBSCRIPTION_DETAILS_UPDATE_TEST_ID`)
- Tests updated to match; removed the now-unused `text_65281f686a80b400c8e2f6b3` ("Edit plan") translation key

The Duplicate, Delete, Upgrade/Downgrade, Alerts, Copy ID and Terminate actions are untouched.
