### PR TITLE
refactor(type filters): return query-specific types from formatFiltersForQuery

### DIFF
--- a/src/components/analytics/mrr/useMrrAnalyticsOverview.ts
+++ b/src/components/analytics/mrr/useMrrAnalyticsOverview.ts
@@ -102,7 +102,7 @@ export const useMrrAnalyticsOverview = (): MrrAnalyticsOverviewReturn => {
     return `${now.minus({ month: 12 }).startOf('day').toISO()},${now.endOf('day').toISO()}`
   }, [hasAccessToAnalyticsDashboardsFeature])
 
-  const getDefaultStaticTimeGranularityFilter = useCallback((): string => {
+  const getDefaultStaticTimeGranularityFilter = useCallback((): TimeGranularityEnum => {
     if (!hasAccessToAnalyticsDashboardsFeature) {
       return TimeGranularityEnum.Daily
     }

--- a/src/components/analytics/prepaidCredits/usePrepaidCreditsAnalyticsOverview.ts
+++ b/src/components/analytics/prepaidCredits/usePrepaidCreditsAnalyticsOverview.ts
@@ -99,7 +99,7 @@ export const usePrepaidCreditsAnalyticsOverview = (): PrepaidCreditsAnalyticsOve
     return `${now.minus({ month: 12 }).startOf('day').toISO()},${now.endOf('day').toISO()}`
   }, [hasAccessToAnalyticsDashboardsFeature])
 
-  const getDefaultStaticTimeGranularityFilter = useCallback((): string => {
+  const getDefaultStaticTimeGranularityFilter = useCallback((): TimeGranularityEnum => {
     if (!hasAccessToAnalyticsDashboardsFeature) {
       return TimeGranularityEnum.Daily
     }

--- a/src/components/analytics/revenueStreams/useRevenueAnalyticsOverview.ts
+++ b/src/components/analytics/revenueStreams/useRevenueAnalyticsOverview.ts
@@ -101,7 +101,7 @@ export const useRevenueAnalyticsOverview = (): RevenueAnalyticsOverviewReturn =>
     return `${now.minus({ month: 12 }).startOf('day').toISO()},${now.endOf('day').toISO()}`
   }, [hasAccessToAnalyticsDashboardsFeature])
 
-  const getDefaultStaticTimeGranularityFilter = useCallback((): string => {
+  const getDefaultStaticTimeGranularityFilter = useCallback((): TimeGranularityEnum => {
     if (!hasAccessToAnalyticsDashboardsFeature) {
       return TimeGranularityEnum.Daily
     }

--- a/src/components/analytics/usage/useUsageAnalyticsBillableMetric.ts
+++ b/src/components/analytics/usage/useUsageAnalyticsBillableMetric.ts
@@ -85,7 +85,7 @@ export const useUsageAnalyticsBillableMetric = ({
     return `${now.minus({ days: 30 }).startOf('day').toISO()},${now.endOf('day').toISO()}`
   }, [hasAccessToAnalyticsDashboardsFeature])
 
-  const getDefaultStaticTimeGranularityFilter = useCallback((): string => {
+  const getDefaultStaticTimeGranularityFilter = useCallback((): TimeGranularityEnum => {
     return TimeGranularityEnum.Daily
   }, [])
 

--- a/src/components/analytics/usage/useUsageAnalyticsOverview.ts
+++ b/src/components/analytics/usage/useUsageAnalyticsOverview.ts
@@ -89,7 +89,7 @@ export const useUsageAnalyticsOverview = () => {
     return `${now.minus({ days: 30 }).startOf('day').toISO()},${now.endOf('day').toISO()}`
   }, [hasAccessToAnalyticsDashboardsFeature])
 
-  const getDefaultStaticTimeGranularityFilter = useCallback((): string => {
+  const getDefaultStaticTimeGranularityFilter = useCallback((): TimeGranularityEnum => {
     return TimeGranularityEnum.Daily
   }, [])
 

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -36,8 +36,26 @@ import {
 import { INVOICES_ROUTE } from '~/core/router'
 import { DateFormat, intlFormatDateTime } from '~/core/timezone'
 import {
+  type ActivityLogsQueryVariables,
   ActivityTypeEnum,
   CurrencyEnum,
+  type CustomerAccountTypeEnum,
+  type CustomersQueryVariables,
+  type GetApiLogsQueryVariables,
+  type GetCreditNotesListQueryVariables,
+  type GetForecastsQueryVariables,
+  type GetInvoiceCollectionsForAnalyticsQueryVariables,
+  type GetInvoicesListQueryVariables,
+  type GetMrrsQueryVariables,
+  type GetPrepaidCreditsQueryVariables,
+  type GetQuotesQueryVariables,
+  type GetRevenueStreamsQueryVariables,
+  type GetSecurityLogsQueryVariables,
+  type GetSubscriptionsListQueryVariables,
+  type GetUsageBillableMetricQueryVariables,
+  type GetUsageBreakdownQueryVariables,
+  type GetUsageOverviewQueryVariables,
+  type GetWebhookLogQueryVariables,
   InvoicePaymentStatusTypeEnum,
   InvoiceStatusTypeEnum,
 } from '~/generated/graphql'
@@ -287,62 +305,86 @@ export const defineDefaultToDateValue = (
   return searchParamsCopy
 }
 
-type TformatFiltersForQueryReturn = {
+export type TformatFiltersForQueryReturn = {
   [key: string]: string | string[] | boolean
 }
 
-export const formatFiltersForQuery = ({
+export const formatFiltersForQuery = <T = TformatFiltersForQueryReturn>({
   searchParams,
   keyMap,
   availableFilters,
   filtersNamePrefix,
 }: {
   searchParams: URLSearchParams
-  keyMap?: Record<string, string>
+  keyMap?: Partial<Record<AvailableFiltersEnum, keyof T & string>>
   availableFilters: AvailableFiltersEnum[]
   filtersNamePrefix: string
-}): TformatFiltersForQueryReturn => {
+}): T => {
   const filtersSetInUrl = Object.fromEntries(searchParams.entries())
 
-  return Object.entries(filtersSetInUrl).reduce((acc, cur) => {
-    const current = cur as [AvailableFiltersEnum, string | string[] | boolean]
-    const _key = current[0]
+  return Object.entries(filtersSetInUrl).reduce(
+    (acc, cur) => {
+      const current = cur as [AvailableFiltersEnum, string | string[] | boolean]
+      const _key = current[0]
 
-    const key = (
-      filtersNamePrefix ? _key.replace(`${filtersNamePrefix}_`, '') : _key
-    ) as AvailableFiltersEnum
+      const key = (
+        filtersNamePrefix ? _key.replace(`${filtersNamePrefix}_`, '') : _key
+      ) as AvailableFiltersEnum
 
-    if (!availableFilters.includes(key)) {
-      return acc
-    }
+      if (!availableFilters.includes(key)) {
+        return acc
+      }
 
-    const filterFunction = FILTER_VALUE_MAP[key]
+      const filterFunction = FILTER_VALUE_MAP[key]
 
-    const value = filterFunction ? filterFunction(current[1]) : current[1]
+      const value = filterFunction ? filterFunction(current[1]) : current[1]
 
-    if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
+      if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
+        return {
+          ...acc,
+          ...value,
+        }
+      }
+
       return {
         ...acc,
-        ...value,
+        [keyMap?.[key] || key]: value,
       }
-    }
-
-    return {
-      ...acc,
-      [keyMap?.[key] || key]: value,
-    }
-  }, {} as TformatFiltersForQueryReturn)
+    },
+    {} as Record<string, unknown>,
+  ) as T
 }
 
-export const formatFiltersForCreditNotesQuery = (searchParams: URLSearchParams) => {
-  const keyMap: Partial<Record<AvailableFiltersEnum, string>> = {
+type CreditNotesQueryFilters = Partial<
+  Pick<
+    GetCreditNotesListQueryVariables,
+    | 'amountFrom'
+    | 'amountTo'
+    | 'creditStatus'
+    | 'currency'
+    | 'customerExternalId'
+    | 'invoiceNumber'
+    | 'issuingDateFrom'
+    | 'issuingDateTo'
+    | 'reason'
+    | 'refundStatus'
+    | 'types'
+    | 'selfBilled'
+    | 'billingEntityIds'
+  >
+>
+
+export const formatFiltersForCreditNotesQuery = (
+  searchParams: URLSearchParams,
+): CreditNotesQueryFilters => {
+  const keyMap: Partial<Record<AvailableFiltersEnum, keyof CreditNotesQueryFilters & string>> = {
     [AvailableFiltersEnum.creditNoteReason]: 'reason',
     [AvailableFiltersEnum.creditNoteCreditStatus]: 'creditStatus',
     [AvailableFiltersEnum.creditNoteRefundStatus]: 'refundStatus',
     [AvailableFiltersEnum.creditNoteType]: 'types',
   }
 
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<CreditNotesQueryFilters>({
     searchParams,
     keyMap,
     availableFilters: CreditNoteAvailableFilters,
@@ -350,12 +392,35 @@ export const formatFiltersForCreditNotesQuery = (searchParams: URLSearchParams) 
   })
 }
 
-export const formatFiltersForInvoiceQuery = (searchParams: URLSearchParams) => {
-  const keyMap: Partial<Record<AvailableFiltersEnum, string>> = {
+type InvoiceQueryFilters = Partial<
+  Pick<
+    GetInvoicesListQueryVariables,
+    | 'currency'
+    | 'customerExternalId'
+    | 'invoiceType'
+    | 'issuingDateFrom'
+    | 'issuingDateTo'
+    | 'partiallyPaid'
+    | 'paymentDisputeLost'
+    | 'paymentOverdue'
+    | 'paymentStatus'
+    | 'settlements'
+    | 'status'
+    | 'amountFrom'
+    | 'amountTo'
+    | 'selfBilled'
+    | 'billingEntityIds'
+  >
+>
+
+export const formatFiltersForInvoiceQuery = (
+  searchParams: URLSearchParams,
+): InvoiceQueryFilters => {
+  const keyMap: Partial<Record<AvailableFiltersEnum, keyof InvoiceQueryFilters & string>> = {
     [AvailableFiltersEnum.settlementType]: 'settlements',
   }
 
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<InvoiceQueryFilters>({
     searchParams,
     keyMap,
     availableFilters: InvoiceAvailableFilters,
@@ -363,8 +428,34 @@ export const formatFiltersForInvoiceQuery = (searchParams: URLSearchParams) => {
   })
 }
 
-export const formatFiltersForCustomerQuery = (searchParams: URLSearchParams) => {
-  const formatted = formatFiltersForQuery({
+type CustomerQueryFilters = Partial<
+  Pick<
+    CustomersQueryVariables,
+    | 'billingEntityIds'
+    | 'activeSubscriptionsCountFrom'
+    | 'activeSubscriptionsCountTo'
+    | 'customerType'
+    | 'countries'
+    | 'currencies'
+    | 'externalId'
+    | 'states'
+    | 'zipcodes'
+    | 'hasTaxIdentificationNumber'
+    | 'hasCustomerType'
+    | 'metadata'
+  >
+> & { accountType?: CustomerAccountTypeEnum }
+
+export const formatFiltersForCustomerQuery = (
+  searchParams: URLSearchParams,
+): CustomerQueryFilters => {
+  const formatted = formatFiltersForQuery<
+    CustomerQueryFilters & {
+      activeSubscriptionsFrom?: number | null
+      activeSubscriptionsTo?: number | null
+      isCustomerTinEmpty?: boolean
+    }
+  >({
     searchParams,
     availableFilters: CustomerAvailableFilters,
     filtersNamePrefix: CUSTOMER_LIST_FILTER_PREFIX,
@@ -392,13 +483,22 @@ export const formatFiltersForCustomerQuery = (searchParams: URLSearchParams) => 
   return formatted
 }
 
-export const formatFiltersForSubscriptionQuery = (searchParams: URLSearchParams) => {
-  const keyMap: Partial<Record<AvailableFiltersEnum, string>> = {
+type SubscriptionQueryFilters = Partial<
+  Pick<
+    GetSubscriptionsListQueryVariables,
+    'status' | 'externalCustomerId' | 'externalId' | 'overriden' | 'planCode' | 'billingEntityIds'
+  >
+>
+
+export const formatFiltersForSubscriptionQuery = (
+  searchParams: URLSearchParams,
+): SubscriptionQueryFilters => {
+  const keyMap: Partial<Record<AvailableFiltersEnum, keyof SubscriptionQueryFilters & string>> = {
     [AvailableFiltersEnum.subscriptionStatus]: 'status',
     [AvailableFiltersEnum.customerExternalId]: 'externalCustomerId',
   }
 
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<SubscriptionQueryFilters>({
     keyMap,
     searchParams,
     availableFilters: SubscriptionAvailableFilters,
@@ -409,53 +509,72 @@ export const formatFiltersForSubscriptionQuery = (searchParams: URLSearchParams)
 export const formatFiltersForCustomerAnalyticsQuery = (
   searchParams: URLSearchParams,
 ): { currency?: CurrencyEnum; billingEntityId?: string } => {
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<{ currency?: CurrencyEnum; billingEntityId?: string }>({
     searchParams,
     availableFilters: CustomerAnalyticsAvailableFilters,
     filtersNamePrefix: CUSTOMER_ANALYTICS_FILTER_PREFIX,
-  }) as { currency?: CurrencyEnum; billingEntityId?: string }
+  })
 }
 
 export const formatFiltersForCustomerInvoicesQuery = (
   searchParams: URLSearchParams,
   filtersNamePrefix: string,
 ): { currency?: CurrencyEnum; billingEntityId?: string } => {
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<{ currency?: CurrencyEnum; billingEntityId?: string }>({
     searchParams,
     availableFilters: CustomerInvoicesAvailableFilters,
     filtersNamePrefix,
-  }) as { currency?: CurrencyEnum; billingEntityId?: string }
+  })
 }
 
 export const formatFiltersForCustomerPaymentsQuery = (
   searchParams: URLSearchParams,
 ): { currency?: CurrencyEnum } => {
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<{ currency?: CurrencyEnum }>({
     searchParams,
     availableFilters: CustomerPaymentsAvailableFilters,
     filtersNamePrefix: CUSTOMER_PAYMENTS_FILTER_PREFIX,
-  }) as { currency?: CurrencyEnum }
+  })
 }
 
 export const formatFiltersForCustomerCreditNotesQuery = (
   searchParams: URLSearchParams,
 ): { currency?: CurrencyEnum; billingEntityId?: string } => {
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<{ currency?: CurrencyEnum; billingEntityId?: string }>({
     searchParams,
     availableFilters: CustomerCreditNotesAvailableFilters,
     filtersNamePrefix: CUSTOMER_CREDIT_NOTES_FILTER_PREFIX,
-  }) as { currency?: CurrencyEnum; billingEntityId?: string }
+  })
 }
 
-export const formatFiltersForRevenueStreamsQuery = (searchParams: URLSearchParams) => {
-  const keyMap: Partial<Record<AvailableFiltersEnum, string>> = {
+type RevenueStreamsQueryFilters = Partial<
+  Pick<
+    GetRevenueStreamsQueryVariables,
+    | 'currency'
+    | 'customerCountry'
+    | 'customerType'
+    | 'isCustomerTinEmpty'
+    | 'externalCustomerId'
+    | 'externalSubscriptionId'
+    | 'fromDate'
+    | 'toDate'
+    | 'planCode'
+    | 'timeGranularity'
+    | 'billingEntityCode'
+  >
+>
+
+export const formatFiltersForRevenueStreamsQuery = (
+  searchParams: URLSearchParams,
+): RevenueStreamsQueryFilters => {
+  const keyMap: Partial<Record<AvailableFiltersEnum, keyof RevenueStreamsQueryFilters & string>> = {
     [AvailableFiltersEnum.country]: 'customerCountry',
     [AvailableFiltersEnum.customerType]: 'customerType',
     [AvailableFiltersEnum.customerExternalId]: 'externalCustomerId',
     [AvailableFiltersEnum.subscriptionExternalId]: 'externalSubscriptionId',
   }
 
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<RevenueStreamsQueryFilters>({
     keyMap,
     searchParams,
     availableFilters: [
@@ -466,23 +585,39 @@ export const formatFiltersForRevenueStreamsQuery = (searchParams: URLSearchParam
   })
 }
 
-export const formatFiltersForRevenueStreamsPlansQuery = (searchParams: URLSearchParams) => {
-  return formatFiltersForQuery({
+export const formatFiltersForRevenueStreamsPlansQuery = (
+  searchParams: URLSearchParams,
+): { currency?: CurrencyEnum } => {
+  return formatFiltersForQuery<{ currency?: CurrencyEnum }>({
     searchParams,
     availableFilters: RevenueStreamsPlansAvailableFilters,
     filtersNamePrefix: REVENUE_STREAMS_BREAKDOWN_PLAN_FILTER_PREFIX,
   })
 }
 
-export const formatFiltersForMrrQuery = (searchParams: URLSearchParams) => {
-  const keyMap: Partial<Record<AvailableFiltersEnum, string>> = {
+type MrrQueryFilters = Partial<
+  Pick<
+    GetMrrsQueryVariables,
+    | 'currency'
+    | 'customerCountry'
+    | 'customerType'
+    | 'isCustomerTinEmpty'
+    | 'externalCustomerId'
+    | 'fromDate'
+    | 'toDate'
+    | 'timeGranularity'
+    | 'billingEntityCode'
+  >
+>
+
+export const formatFiltersForMrrQuery = (searchParams: URLSearchParams): MrrQueryFilters => {
+  const keyMap: Partial<Record<AvailableFiltersEnum, keyof MrrQueryFilters & string>> = {
     [AvailableFiltersEnum.country]: 'customerCountry',
     [AvailableFiltersEnum.customerType]: 'customerType',
     [AvailableFiltersEnum.customerExternalId]: 'externalCustomerId',
-    [AvailableFiltersEnum.subscriptionExternalId]: 'externalSubscriptionId',
   }
 
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<MrrQueryFilters>({
     keyMap,
     searchParams,
     availableFilters: [...MrrOverviewAvailableFilters, AvailableFiltersEnum.timeGranularity],
@@ -490,31 +625,51 @@ export const formatFiltersForMrrQuery = (searchParams: URLSearchParams) => {
   })
 }
 
-export const formatFiltersForMrrPlansQuery = (searchParams: URLSearchParams) => {
-  return formatFiltersForQuery({
+export const formatFiltersForMrrPlansQuery = (
+  searchParams: URLSearchParams,
+): { currency?: CurrencyEnum } => {
+  return formatFiltersForQuery<{ currency?: CurrencyEnum }>({
     searchParams,
     availableFilters: MrrBreakdownPlansAvailableFilters,
     filtersNamePrefix: MRR_BREAKDOWN_PLANS_FILTER_PREFIX,
   })
 }
 
-export const formatFiltersForRevenueStreamsCustomersQuery = (searchParams: URLSearchParams) => {
-  return formatFiltersForQuery({
+export const formatFiltersForRevenueStreamsCustomersQuery = (
+  searchParams: URLSearchParams,
+): { currency?: CurrencyEnum } => {
+  return formatFiltersForQuery<{ currency?: CurrencyEnum }>({
     searchParams,
     availableFilters: RevenueStreamsCustomersAvailableFilters,
     filtersNamePrefix: REVENUE_STREAMS_BREAKDOWN_CUSTOMER_FILTER_PREFIX,
   })
 }
 
-export const formatFiltersForPrepaidCreditsQuery = (searchParams: URLSearchParams) => {
-  const keyMap: Partial<Record<AvailableFiltersEnum, string>> = {
+type PrepaidCreditsQueryFilters = Partial<
+  Pick<
+    GetPrepaidCreditsQueryVariables,
+    | 'currency'
+    | 'customerCountry'
+    | 'customerType'
+    | 'isCustomerTinEmpty'
+    | 'externalCustomerId'
+    | 'fromDate'
+    | 'toDate'
+    | 'timeGranularity'
+    | 'billingEntityCode'
+  >
+>
+
+export const formatFiltersForPrepaidCreditsQuery = (
+  searchParams: URLSearchParams,
+): PrepaidCreditsQueryFilters => {
+  const keyMap: Partial<Record<AvailableFiltersEnum, keyof PrepaidCreditsQueryFilters & string>> = {
     [AvailableFiltersEnum.country]: 'customerCountry',
     [AvailableFiltersEnum.customerAccountType]: 'customerType',
     [AvailableFiltersEnum.customerExternalId]: 'externalCustomerId',
-    [AvailableFiltersEnum.subscriptionExternalId]: 'externalSubscriptionId',
   }
 
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<PrepaidCreditsQueryFilters>({
     keyMap,
     searchParams,
     availableFilters: [...MrrOverviewAvailableFilters, AvailableFiltersEnum.timeGranularity],
@@ -522,22 +677,40 @@ export const formatFiltersForPrepaidCreditsQuery = (searchParams: URLSearchParam
   })
 }
 
-export const formatFiltersForAnalyticsInvoicesQuery = (searchParams: URLSearchParams) => {
-  return formatFiltersForQuery({
+type AnalyticsInvoicesQueryFilters = Partial<
+  Pick<
+    GetInvoiceCollectionsForAnalyticsQueryVariables,
+    'currency' | 'billingEntityCode' | 'isCustomerTinEmpty'
+  >
+> & { period?: string }
+
+export const formatFiltersForAnalyticsInvoicesQuery = (
+  searchParams: URLSearchParams,
+): AnalyticsInvoicesQueryFilters => {
+  return formatFiltersForQuery<AnalyticsInvoicesQueryFilters>({
     searchParams,
     availableFilters: AnalyticsInvoicesAvailableFilters,
     filtersNamePrefix: ANALYTICS_INVOICES_FILTER_PREFIX,
   })
 }
 
-export const formatFiltersForWebhookLogsQuery = (searchParams: URLSearchParams) => {
-  const keyMap: Partial<Record<AvailableFiltersEnum, string>> = {
+type WebhookLogsQueryFilters = Partial<
+  Pick<
+    GetWebhookLogQueryVariables,
+    'statuses' | 'eventTypes' | 'httpStatuses' | 'fromDate' | 'toDate'
+  >
+>
+
+export const formatFiltersForWebhookLogsQuery = (
+  searchParams: URLSearchParams,
+): WebhookLogsQueryFilters => {
+  const keyMap: Partial<Record<AvailableFiltersEnum, keyof WebhookLogsQueryFilters & string>> = {
     [AvailableFiltersEnum.webhookStatus]: 'statuses',
     [AvailableFiltersEnum.webhookEventTypes]: 'eventTypes',
     [AvailableFiltersEnum.webhookHttpStatuses]: 'httpStatuses',
   }
 
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<WebhookLogsQueryFilters>({
     searchParams: defineDefaultToDateValue(
       searchParams,
       WEBHOOK_LOGS_FILTER_PREFIX,
@@ -549,15 +722,34 @@ export const formatFiltersForWebhookLogsQuery = (searchParams: URLSearchParams) 
   })
 }
 
-export const formatFiltersForUsageOverviewQuery = (searchParams: URLSearchParams) => {
-  const keyMap: Partial<Record<AvailableFiltersEnum, string>> = {
+type UsageOverviewQueryFilters = Partial<
+  Pick<
+    GetUsageOverviewQueryVariables,
+    | 'currency'
+    | 'customerCountry'
+    | 'customerType'
+    | 'isCustomerTinEmpty'
+    | 'externalCustomerId'
+    | 'externalSubscriptionId'
+    | 'fromDate'
+    | 'toDate'
+    | 'planCode'
+    | 'timeGranularity'
+    | 'billingEntityCode'
+  >
+>
+
+export const formatFiltersForUsageOverviewQuery = (
+  searchParams: URLSearchParams,
+): UsageOverviewQueryFilters => {
+  const keyMap: Partial<Record<AvailableFiltersEnum, keyof UsageOverviewQueryFilters & string>> = {
     [AvailableFiltersEnum.country]: 'customerCountry',
     [AvailableFiltersEnum.customerAccountType]: 'customerType',
     [AvailableFiltersEnum.customerExternalId]: 'externalCustomerId',
     [AvailableFiltersEnum.subscriptionExternalId]: 'externalSubscriptionId',
   }
 
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<UsageOverviewQueryFilters>({
     keyMap,
     searchParams,
     availableFilters: [...UsageOverviewAvailableFilters, AvailableFiltersEnum.timeGranularity],
@@ -565,15 +757,31 @@ export const formatFiltersForUsageOverviewQuery = (searchParams: URLSearchParams
   })
 }
 
-export const formatFiltersForUsageBreakdownQuery = (searchParams: URLSearchParams) => {
-  const keyMap: Partial<Record<AvailableFiltersEnum, string>> = {
+type UsageBreakdownQueryFilters = Partial<
+  Pick<
+    GetUsageBreakdownQueryVariables,
+    | 'currency'
+    | 'customerCountry'
+    | 'customerType'
+    | 'externalCustomerId'
+    | 'externalSubscriptionId'
+    | 'fromDate'
+    | 'toDate'
+    | 'planCode'
+  >
+>
+
+export const formatFiltersForUsageBreakdownQuery = (
+  searchParams: URLSearchParams,
+): UsageBreakdownQueryFilters => {
+  const keyMap: Partial<Record<AvailableFiltersEnum, keyof UsageBreakdownQueryFilters & string>> = {
     [AvailableFiltersEnum.country]: 'customerCountry',
     [AvailableFiltersEnum.customerAccountType]: 'customerType',
     [AvailableFiltersEnum.customerExternalId]: 'externalCustomerId',
     [AvailableFiltersEnum.subscriptionExternalId]: 'externalSubscriptionId',
   }
 
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<UsageBreakdownQueryFilters>({
     keyMap,
     searchParams,
     availableFilters: UsageBreakdownAvailableFilters,
@@ -597,8 +805,14 @@ export const formatFiltersForUsageBreakdownRecurringQuery = (searchParams: URLSe
   })
 }
 
-export const formatFiltersForUsageBillableMetricQuery = (searchParams: URLSearchParams) => {
-  return formatFiltersForQuery({
+type UsageBillableMetricQueryFilters = Partial<
+  Pick<GetUsageBillableMetricQueryVariables, 'currency' | 'timeGranularity' | 'fromDate' | 'toDate'>
+>
+
+export const formatFiltersForUsageBillableMetricQuery = (
+  searchParams: URLSearchParams,
+): UsageBillableMetricQueryFilters => {
+  return formatFiltersForQuery<UsageBillableMetricQueryFilters>({
     searchParams,
     availableFilters: [
       ...UsageBillableMetricAvailableFilters,
@@ -608,15 +822,33 @@ export const formatFiltersForUsageBillableMetricQuery = (searchParams: URLSearch
   })
 }
 
-export const formatFiltersForForecastsQuery = (searchParams: URLSearchParams) => {
-  const keyMap: Partial<Record<AvailableFiltersEnum, string>> = {
+type ForecastsQueryFilters = Partial<
+  Pick<
+    GetForecastsQueryVariables,
+    | 'billableMetricCode'
+    | 'billingEntityCode'
+    | 'currency'
+    | 'customerCountry'
+    | 'customerType'
+    | 'externalCustomerId'
+    | 'externalSubscriptionId'
+    | 'isCustomerTinEmpty'
+    | 'planCode'
+    | 'timeGranularity'
+  >
+>
+
+export const formatFiltersForForecastsQuery = (
+  searchParams: URLSearchParams,
+): ForecastsQueryFilters => {
+  const keyMap: Partial<Record<AvailableFiltersEnum, keyof ForecastsQueryFilters & string>> = {
     [AvailableFiltersEnum.country]: 'customerCountry',
     [AvailableFiltersEnum.customerType]: 'customerType',
     [AvailableFiltersEnum.customerExternalId]: 'externalCustomerId',
     [AvailableFiltersEnum.subscriptionExternalId]: 'externalSubscriptionId',
   }
 
-  return formatFiltersForQuery({
+  return formatFiltersForQuery<ForecastsQueryFilters>({
     keyMap,
     searchParams,
     availableFilters: [...ForecastsAvailableFilters, AvailableFiltersEnum.timeGranularity],
@@ -624,8 +856,32 @@ export const formatFiltersForForecastsQuery = (searchParams: URLSearchParams) =>
   })
 }
 
-export const formatFiltersForActivityLogsQuery = (searchParams: URLSearchParams) => {
-  const formatted = formatFiltersForQuery({
+type ActivityLogsQueryFilters = Partial<
+  Pick<
+    ActivityLogsQueryVariables,
+    | 'activityIds'
+    | 'activitySources'
+    | 'activityTypes'
+    | 'apiKeyIds'
+    | 'externalCustomerId'
+    | 'externalSubscriptionId'
+    | 'fromDate'
+    | 'toDate'
+    | 'resourceIds'
+    | 'resourceTypes'
+    | 'userEmails'
+  >
+>
+
+export const formatFiltersForActivityLogsQuery = (
+  searchParams: URLSearchParams,
+): ActivityLogsQueryFilters => {
+  const formatted = formatFiltersForQuery<
+    ActivityLogsQueryFilters & {
+      customerExternalId?: string
+      subscriptionExternalId?: string
+    }
+  >({
     searchParams: defineDefaultToDateValue(searchParams, ACTIVITY_LOG_FILTER_PREFIX),
     availableFilters: ActivityLogsAvailableFilters,
     filtersNamePrefix: ACTIVITY_LOG_FILTER_PREFIX,
@@ -643,8 +899,17 @@ export const formatFiltersForActivityLogsQuery = (searchParams: URLSearchParams)
   return formatted
 }
 
-export const formatFiltersForApiLogsQuery = (searchParams: URLSearchParams) => {
-  return formatFiltersForQuery({
+type ApiLogsQueryFilters = Partial<
+  Pick<
+    GetApiLogsQueryVariables,
+    'fromDate' | 'toDate' | 'apiKeyIds' | 'httpMethods' | 'httpStatuses' | 'requestPaths'
+  >
+>
+
+export const formatFiltersForApiLogsQuery = (
+  searchParams: URLSearchParams,
+): ApiLogsQueryFilters => {
+  return formatFiltersForQuery<ApiLogsQueryFilters>({
     searchParams: defineDefaultToDateValue(searchParams, API_LOGS_FILTER_PREFIX),
     availableFilters: ApiLogsAvailableFilters,
     filtersNamePrefix: API_LOGS_FILTER_PREFIX,
@@ -747,25 +1012,38 @@ export const formatActiveFilterValueDisplay = (
   }
 }
 
-export const formatFiltersForSecurityLogsQuery = (searchParams: URLSearchParams) => {
-  return formatFiltersForQuery({
+type SecurityLogsQueryFilters = Partial<
+  Pick<GetSecurityLogsQueryVariables, 'logEvents' | 'logTypes' | 'userIds' | 'fromDate' | 'toDate'>
+>
+
+export const formatFiltersForSecurityLogsQuery = (
+  searchParams: URLSearchParams,
+): SecurityLogsQueryFilters => {
+  return formatFiltersForQuery<SecurityLogsQueryFilters>({
     searchParams: defineDefaultToDateValue(searchParams, SECURITY_LOGS_FILTER_PREFIX),
     availableFilters: SecurityLogsAvailableFilters,
     filtersNamePrefix: SECURITY_LOGS_FILTER_PREFIX,
   })
 }
 
-export const formatFiltersForQuotesQuery = (searchParams: URLSearchParams) =>
-  formatFiltersForQuery({
+type QuotesQueryFilters = Partial<
+  Pick<
+    GetQuotesQueryVariables,
+    'statuses' | 'customers' | 'numbers' | 'orderTypes' | 'owners' | 'fromDate' | 'toDate'
+  >
+>
+
+export const formatFiltersForQuotesQuery = (searchParams: URLSearchParams): QuotesQueryFilters =>
+  formatFiltersForQuery<QuotesQueryFilters>({
     searchParams,
     availableFilters: QuoteAvailableFilters,
     filtersNamePrefix: QUOTE_LIST_FILTER_PREFIX,
     keyMap: {
-      multipleCustomers: 'customers',
-      quoteStatus: 'statuses',
-      quoteNumber: 'numbers',
-      quoteOrderType: 'orderTypes',
-      userIds: 'owners',
+      [AvailableFiltersEnum.multipleCustomers]: 'customers',
+      [AvailableFiltersEnum.quoteStatus]: 'statuses',
+      [AvailableFiltersEnum.quoteNumber]: 'numbers',
+      [AvailableFiltersEnum.quoteOrderType]: 'orderTypes',
+      [AvailableFiltersEnum.userIds]: 'owners',
     },
   })
 

--- a/src/pages/CreditNotesPage.tsx
+++ b/src/pages/CreditNotesPage.tsx
@@ -20,6 +20,7 @@ import {
   CreditNotesForTableFragmentDoc,
   CreditNoteTableItemFragmentDoc,
   CurrencyEnum,
+  type DataExportCreditNoteFiltersInput,
   PremiumIntegrationTypeEnum,
   useCreateCreditNotesDataExportMutation,
   useGetCreditNotesListLazyQuery,
@@ -80,26 +81,24 @@ gql`
 `
 
 // TODO: This is a temporary workaround
-const formatAmountCurrency = (
-  filters: Record<string, string | string[] | boolean | number>,
+const formatAmountCurrency = <T extends { amountFrom?: unknown; amountTo?: unknown }>(
+  filters: T,
   amountCurrency?: CurrencyEnum | null,
-) => {
-  const _filters = {
-    ...filters,
-  }
+): T => {
+  const _filters = { ...filters } as T
 
   if (_filters.amountFrom) {
     _filters.amountFrom = serializeAmount(
       Number(_filters.amountFrom),
       amountCurrency || CurrencyEnum.Usd,
-    )
+    ) as T['amountFrom']
   }
 
   if (_filters.amountTo) {
     _filters.amountTo = serializeAmount(
       Number(_filters.amountTo),
       amountCurrency || CurrencyEnum.Usd,
-    )
+    ) as T['amountTo']
   }
 
   return _filters
@@ -158,7 +157,7 @@ const CreditNotesPage = () => {
     const filters = {
       ...formatAmountCurrency(formatFiltersForCreditNotesQuery(searchParams), amountCurrency),
       searchTerm: variableCreditNotes?.searchTerm,
-    }
+    } as DataExportCreditNoteFiltersInput
 
     const res = await triggerCreateCreditNotesDataExport({
       variables: {

--- a/src/pages/InvoicesPage.tsx
+++ b/src/pages/InvoicesPage.tsx
@@ -28,6 +28,7 @@ import { INVOICE_LIST_FILTER_PREFIX } from '~/core/constants/filters'
 import { serializeAmount } from '~/core/serializers/serializeAmount'
 import {
   CurrencyEnum,
+  type DataExportInvoiceFiltersInput,
   InvoiceExportTypeEnum,
   InvoiceListItemFragmentDoc,
   InvoiceStatusTypeEnum,
@@ -113,26 +114,24 @@ gql`
 `
 
 // TODO: This is a temporary workaround
-const formatAmountCurrency = (
-  filters: Record<string, string | string[] | boolean | number>,
+const formatAmountCurrency = <T extends { amountFrom?: unknown; amountTo?: unknown }>(
+  filters: T,
   amountCurrency?: CurrencyEnum | null,
-) => {
-  const _filters = {
-    ...filters,
-  }
+): T => {
+  const _filters = { ...filters } as T
 
   if (_filters.amountFrom) {
     _filters.amountFrom = serializeAmount(
       Number(_filters.amountFrom),
       amountCurrency || CurrencyEnum.Usd,
-    )
+    ) as T['amountFrom']
   }
 
   if (_filters.amountTo) {
     _filters.amountTo = serializeAmount(
       Number(_filters.amountTo),
       amountCurrency || CurrencyEnum.Usd,
-    )
+    ) as T['amountTo']
   }
 
   return _filters
@@ -196,7 +195,7 @@ const InvoicesPage = () => {
     const filters = {
       ...formatAmountCurrency(formatFiltersForInvoiceQuery(searchParams), amountCurrency),
       searchTerm: variables?.searchTerm,
-    }
+    } as DataExportInvoiceFiltersInput
 
     const res = await triggerCreateInvoicesDataExport({
       variables: {

--- a/src/pages/settings/teamAndSecurity/securityLogs/hooks/useSecurityLogs.ts
+++ b/src/pages/settings/teamAndSecurity/securityLogs/hooks/useSecurityLogs.ts
@@ -48,20 +48,8 @@ gql`
   }
 `
 
-type FilterForSecurityLogsQuery = {
-  [key: string]: string | string[] | boolean
-  toDate: string
-}
-
 export const formatSecurityLogs = (securityLogs: SecurityLogs): Array<SecurityLogWithId> => {
   return securityLogs.map((securityLog) => ({ id: securityLog.logId, ...securityLog }))
-}
-
-const isFilterForSecurityLogsQuery = (
-  filter: Record<string, string | string[] | boolean>,
-): filter is FilterForSecurityLogsQuery => {
-  if (!filter.toDate || typeof filter.toDate !== 'string') return false
-  return true
 }
 
 export const useSecurityLogs = () => {
@@ -71,14 +59,11 @@ export const useSecurityLogs = () => {
   const filtersForSecurityLogsQuery = useMemo(() => {
     const formattedFilters = formatFiltersForSecurityLogsQuery(searchParams)
 
-    if (!isFilterForSecurityLogsQuery(formattedFilters)) {
-      return {
-        ...formattedFilters,
-        toDate: defaultToDateTime,
-      }
+    // The security logs query requires a toDate; fall back to the default when none is set.
+    return {
+      ...formattedFilters,
+      toDate: formattedFilters.toDate ?? defaultToDateTime,
     }
-
-    return formattedFilters
   }, [defaultToDateTime, searchParams])
 
   const {


### PR DESCRIPTION
## Context

`formatFiltersForQuery` returned a loose `Record`, agnostic of its target query, so it never warned when a filter (or `keyMap` remap) produced a key the query doesn't accept. This hid a bug: Forecasts emitted `accountType`, absent from its query, silently dropping the customer-account-type filter.

## Description

- Make `formatFiltersForQuery<T>` generic (default keeps old callers/tests working) and constrain `keyMap` targets to `keyof T` → invalid keys are now compile errors.
- Type each wrapper's return as `Pick<…QueryVariables>` of its query.
- Fix the surfaced bug: remap `customerAccountType → customerType` in Forecasts (only runtime change).
- Consumer touch-ups: generic `formatAmountCurrency` + export cast, align `getDefaultStaticTimeGranularityFilter` to `TimeGranularityEnum`, drop the redundant security-logs guard.

No behavioral change except the Forecasts fix; types, tests and lint pass.

<!-- Linear link -->
Fixes LAGO-1559