### PR TITLE
refactor(addons): migrate DeleteAddOnDialog to new dialog system

### DIFF
--- a/src/components/addOns/DeleteAddOnDialog.tsx
+++ b/src/components/addOns/DeleteAddOnDialog.tsx
@@ -1,9 +1,7 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import { DeleteAddOnFragment, useDeleteAddOnMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -21,62 +19,41 @@ gql`
   }
 `
 
-interface DeleteAddOnDialogProps {
+type DeleteAddOnDialogData = {
   addOn: DeleteAddOnFragment
   callback?: () => void
 }
 
-export interface DeleteAddOnDialogRef {
-  openDialog: ({ addOn, callback }: DeleteAddOnDialogProps) => unknown
-  closeDialog: () => unknown
-}
-
-export const DeleteAddOnDialog = forwardRef<DeleteAddOnDialogRef>((_, ref) => {
+export const useDeleteAddOnDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
-  const [localData, setLocalData] = useState<DeleteAddOnDialogProps | undefined>(undefined)
-
-  const { id = '', name = '' } = localData?.addOn || {}
 
   const [deleteAddOn] = useDeleteAddOnMutation({
-    onCompleted(data) {
-      if (data && data.destroyAddOn) {
-        addToast({
-          message: translate('text_629728388c4d2300e2d3815f'),
-          severity: 'success',
-        })
-
-        localData?.callback && localData.callback()
-      }
-    },
     refetchQueries: ['addOns'],
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => {
-      dialogRef.current?.closeDialog()
-    },
-  }))
-
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_629728388c4d2300e2d380ad', {
-        addOnName: name,
-      })}
-      description={<Typography html={translate('text_629728388c4d2300e2d380c5')} />}
-      onContinue={async () =>
-        await deleteAddOn({
-          variables: { input: { id: id || '' } },
+  const openDeleteAddOnDialog = ({ addOn, callback }: DeleteAddOnDialogData) => {
+    centralizedDialog.open({
+      title: translate('text_629728388c4d2300e2d380ad', { addOnName: addOn.name }),
+      description: <Typography html={translate('text_629728388c4d2300e2d380c5')} />,
+      colorVariant: 'danger',
+      actionText: translate('text_629728388c4d2300e2d380f5'),
+      onAction: async () => {
+        const result = await deleteAddOn({
+          variables: { input: { id: addOn.id } },
         })
-      }
-      continueText={translate('text_629728388c4d2300e2d380f5')}
-    />
-  )
-})
 
-DeleteAddOnDialog.displayName = 'DeleteAddOnDialog'
+        if (result.data?.destroyAddOn) {
+          addToast({
+            message: translate('text_629728388c4d2300e2d3815f'),
+            severity: 'success',
+          })
+
+          callback?.()
+        }
+      },
+    })
+  }
+
+  return { openDeleteAddOnDialog }
+}

--- a/src/pages/AddOnDetails.tsx
+++ b/src/pages/AddOnDetails.tsx
@@ -1,8 +1,7 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
-import { DeleteAddOnDialog, DeleteAddOnDialogRef } from '~/components/addOns/DeleteAddOnDialog'
+import { useDeleteAddOnDialog } from '~/components/addOns/DeleteAddOnDialog'
 import { Card } from '~/components/designSystem/Card'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
@@ -40,7 +39,7 @@ const AddOnDetails = () => {
   const { translate } = useInternationalization()
   const { addOnId } = useParams()
 
-  const deleteDialogRef = useRef<DeleteAddOnDialogRef>(null)
+  const { openDeleteAddOnDialog } = useDeleteAddOnDialog()
 
   const {
     data: addOnResult,
@@ -93,7 +92,7 @@ const AddOnDetails = () => {
           hidden: !addOn || !hasPermissions(['addonsDelete']),
           onClick: (closePopper) => {
             if (!addOn) return
-            deleteDialogRef.current?.openDialog({
+            openDeleteAddOnDialog({
               addOn,
               callback: () => {
                 navigate(ADD_ONS_ROUTE)
@@ -182,8 +181,6 @@ const AddOnDetails = () => {
           </Card>
         </section>
       </DetailsPage.Container>
-
-      <DeleteAddOnDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/pages/AddOnsList.tsx
+++ b/src/pages/AddOnsList.tsx
@@ -1,9 +1,8 @@
 import { gql } from '@apollo/client'
 import { Icon, tw } from 'lago-design-system'
-import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
 
-import { DeleteAddOnDialog, DeleteAddOnDialogRef } from '~/components/addOns/DeleteAddOnDialog'
+import { useDeleteAddOnDialog } from '~/components/addOns/DeleteAddOnDialog'
 import { Avatar } from '~/components/designSystem/Avatar'
 import { GenericPlaceholderProps } from '~/components/designSystem/GenericPlaceholder'
 import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
@@ -58,7 +57,7 @@ const AddOnsList = () => {
   const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
   const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
-  const deleteDialogRef = useRef<DeleteAddOnDialogRef>(null)
+  const { openDeleteAddOnDialog } = useDeleteAddOnDialog()
   const [getAddOns, { data, error, loading, fetchMore, variables }] = useAddOnsLazyQuery({
     variables: { limit: 20 },
     notifyOnNetworkStatusChange: true,
@@ -221,7 +220,7 @@ const AddOnsList = () => {
                 startIcon: 'trash',
                 title: translate('text_629728388c4d2300e2d38182'),
                 onAction: () => {
-                  deleteDialogRef.current?.openDialog({
+                  openDeleteAddOnDialog({
                     addOn,
                     callback: () => {
                       navigate(ADD_ONS_ROUTE)
@@ -251,8 +250,6 @@ const AddOnsList = () => {
           }}
         />
       </InfiniteScroll>
-
-      <DeleteAddOnDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/pages/__tests__/AddOnDetails.test.tsx
+++ b/src/pages/__tests__/AddOnDetails.test.tsx
@@ -29,7 +29,7 @@ jest.mock('~/components/designSystem/Card', () => ({
 }))
 
 jest.mock('~/components/addOns/DeleteAddOnDialog', () => ({
-  DeleteAddOnDialog: () => null,
+  useDeleteAddOnDialog: () => ({ openDeleteAddOnDialog: jest.fn() }),
 }))
 
 jest.mock('~/hooks/usePermissions', () => ({

--- a/src/pages/__tests__/AddOnsList.test.tsx
+++ b/src/pages/__tests__/AddOnsList.test.tsx
@@ -31,7 +31,7 @@ jest.mock('~/components/SearchInput', () => ({
 }))
 
 jest.mock('~/components/addOns/DeleteAddOnDialog', () => ({
-  DeleteAddOnDialog: () => null,
+  useDeleteAddOnDialog: () => ({ openDeleteAddOnDialog: jest.fn() }),
 }))
 
 jest.mock('react-router-dom', () => ({


### PR DESCRIPTION
## Summary

Migrate `DeleteAddOnDialog` from the legacy imperative ref-based `WarningDialog` system to the new hook-based NiceModal dialog system, using `useCentralizedDialog` (no form involved, just a danger confirmation).

This addresses one of the ESLint `no-restricted-imports` warnings about the deprecated `~/components/designSystem/WarningDialog`.

## Changes

- **`src/components/addOns/DeleteAddOnDialog.tsx`**
  - Replace the `forwardRef` component + `DeleteAddOnDialogRef` interface with a `useDeleteAddOnDialog` custom hook.
  - Drop `useImperativeHandle`, `useRef`, `useState`, and the legacy `WarningDialog` / `Dialog` imports.
  - Use `useCentralizedDialog().open(...)` with `colorVariant: 'danger'`, threading the mutation, success toast, and parent `callback` through `onAction`.
  - Keep the existing GraphQL fragment, mutation, and translation keys unchanged.

- **`src/pages/AddOnsList.tsx`** and **`src/pages/AddOnDetails.tsx`**
  - Replace `useRef<DeleteAddOnDialogRef>(null)` + JSX render of `<DeleteAddOnDialog ref={...} />` with `const { openDeleteAddOnDialog } = useDeleteAddOnDialog()`.
  - Call `openDeleteAddOnDialog({ addOn, callback })` directly from the row/action handlers.
  - Remove now-unused `useRef` imports.

- **`src/pages/__tests__/AddOnDetails.test.tsx`** and **`src/pages/__tests__/AddOnsList.test.tsx`**
  - Update the `jest.mock` to export `useDeleteAddOnDialog: () => ({ openDeleteAddOnDialog: jest.fn() })` to match the new hook contract.

## Notes

- The scope was intentionally kept to the single warning targeted. The parent files (`AddOnsList.tsx`, `AddOnDetails.tsx`) still trigger the path-based `no-restricted-imports` warning on `~/components/addOns/*Dialog*`, but this matches the pre-existing behavior of already-migrated dialogs in the codebase (e.g. `useDeleteWalletAlertDialog` in `~/components/wallets/WalletAlerts.tsx`).
- No form elements were involved, so no Formik → TanStack migration was required here.

## Test plan

- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm exec eslint` no longer reports the `WarningDialog` warning for `DeleteAddOnDialog.tsx`
- [x] `pnpm exec jest src/pages/__tests__/AddOnDetails.test.tsx src/pages/__tests__/AddOnsList.test.tsx` — 15/15 pass
- [ ] Manually verify: delete an add-on from the add-ons list — danger confirmation appears, action triggers mutation, success toast shows, and navigation to `ADD_ONS_ROUTE` occurs
- [ ] Manually verify: delete an add-on from the add-on details page — same flow, returns to the list

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYepVzR5iPJUZGJNMZbpoN)_