### PR TITLE
refactor(EditCustomerDocumentLocaleDialog): Migrate to TanStack Form + new dialog system

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -22,10 +22,7 @@ import {
   DeleteCustomerVatRateDialog,
   DeleteCustomerVatRateDialogRef,
 } from '~/components/customers/DeleteCustomerVatRateDialog'
-import {
-  EditCustomerDocumentLocaleDialog,
-  EditCustomerDocumentLocaleDialogRef,
-} from '~/components/customers/EditCustomerDocumentLocaleDialog'
+import { useEditCustomerDocumentLocaleDialog } from '~/components/customers/EditCustomerDocumentLocaleDialog'
 import {
   EditCustomerDunningCampaignDialog,
   EditCustomerDunningCampaignDialogRef,
@@ -222,7 +219,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
   const deleteVatRateDialogRef = useRef<DeleteCustomerVatRateDialogRef>(null)
   const editInvoiceGracePeriodDialogRef = useRef<EditCustomerInvoiceGracePeriodDialogRef>(null)
   const deleteGracePeriodDialogRef = useRef<DeleteCustomerGracePeriodeDialogRef>(null)
-  const editCustomerDocumentLocale = useRef<EditCustomerDocumentLocaleDialogRef>(null)
+  const { openEditCustomerDocumentLocaleDialog } = useEditCustomerDocumentLocaleDialog()
   const editCustomerDunningCampaignDialogRef = useRef<EditCustomerDunningCampaignDialogRef>(null)
   const editCustomerInvoiceCustomSectionsDialogRef =
     useRef<EditCustomerInvoiceCustomSectionsDialogRef>(null)
@@ -426,7 +423,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                             endIcon={isPremium ? undefined : 'sparkles'}
                             onClick={() =>
                               isPremium
-                                ? editCustomerDocumentLocale?.current?.openDialog()
+                                ? customer && openEditCustomerDocumentLocaleDialog(customer)
                                 : openPremiumWarningDialog()
                             }
                           >
@@ -451,7 +448,9 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                                   variant="quaternary"
                                   align="left"
                                   onClick={() => {
-                                    editCustomerDocumentLocale.current?.openDialog()
+                                    if (customer) {
+                                      openEditCustomerDocumentLocaleDialog(customer)
+                                    }
                                     closePopper()
                                   }}
                                 >
@@ -952,7 +951,6 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
             ref={editInvoiceGracePeriodDialogRef}
             invoiceGracePeriod={customer?.invoiceGracePeriod}
           />
-          <EditCustomerDocumentLocaleDialog ref={editCustomerDocumentLocale} customer={customer} />
           <EditCustomerDunningCampaignDialog
             ref={editCustomerDunningCampaignDialogRef}
             customer={customer}

--- a/src/components/customers/EditCustomerDocumentLocaleDialog.tsx
+++ b/src/components/customers/EditCustomerDocumentLocaleDialog.tsx
@@ -1,20 +1,19 @@
 import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
-import { forwardRef } from 'react'
-import { object, string } from 'yup'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { ComboBoxField } from '~/components/form'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
 import { addToast } from '~/core/apolloClient'
 import { documentLocalesDataForComboBox } from '~/core/translations/documentLocales'
 import {
   EditCustomerDocumentLocaleFragment,
-  UpdateCustomerInput,
   useUpdateCustomerDocumentLocaleMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 gql`
   fragment EditCustomerDocumentLocale on Customer {
@@ -38,50 +37,56 @@ gql`
     }
   }
 `
-export type EditCustomerDocumentLocaleDialogRef = DialogRef
 
-interface EditCustomerDocumentLocaleDialogProps {
-  customer: EditCustomerDocumentLocaleFragment
-}
+export const EDIT_CUSTOMER_DOCUMENT_LOCALE_FORM_ID = 'edit-customer-document-locale-form'
 
-export const EditCustomerDocumentLocaleDialog = forwardRef<
-  DialogRef,
-  EditCustomerDocumentLocaleDialogProps
->(({ customer }: EditCustomerDocumentLocaleDialogProps, ref) => {
+const editCustomerDocumentLocaleValidationSchema = z.object({
+  documentLocale: z
+    .string({ message: 'text_624ea7c29103fd010732ab7d' })
+    .min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+})
+
+export const useEditCustomerDocumentLocaleDialog = () => {
+  const formDialog = useFormDialog()
   const { translate } = useInternationalization()
-  const isEdition = !!customer.billingConfiguration?.documentLocale
-  const customerName = customer?.displayName
+  const customerRef = useRef<EditCustomerDocumentLocaleFragment | null>(null)
+  const successRef = useRef(false)
+
   const [updateDocumentLocale] = useUpdateCustomerDocumentLocaleMutation({
     onCompleted(res) {
       if (res.updateCustomer) {
         addToast({
           severity: 'success',
-          translateKey: isEdition
+          translateKey: !!customerRef.current?.billingConfiguration?.documentLocale
             ? 'text_63ea0f84f400488553caa76f'
             : 'text_63ea0f84f400488553caa77b',
         })
       }
     },
   })
-  const formikProps = useFormik<Pick<UpdateCustomerInput, 'billingConfiguration'>>({
-    initialValues: {
-      billingConfiguration: {
-        documentLocale: customer.billingConfiguration?.documentLocale,
-      },
+
+  const form = useAppForm({
+    defaultValues: {
+      documentLocale: '' as string,
     },
-    validationSchema: object().shape({
-      billingConfiguration: object().shape({
-        documentLocale: string().required(''),
-      }),
-    }),
-    enableReinitialize: true,
-    validateOnMount: true,
-    onSubmit: async (values) => {
-      await updateDocumentLocale({
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: editCustomerDocumentLocaleValidationSchema,
+    },
+    onSubmit: async ({ value }) => {
+      const customer = customerRef.current
+
+      if (!customer) {
+        return
+      }
+
+      const result = await updateDocumentLocale({
         variables: {
           input: {
             id: customer.id,
-            ...values,
+            billingConfiguration: {
+              documentLocale: value.documentLocale,
+            },
             // NOTE: API should not require those fields on customer update
             // To be tackled as improvement
             externalId: customer.externalId,
@@ -89,62 +94,86 @@ export const EditCustomerDocumentLocaleDialog = forwardRef<
           },
         },
       })
+
+      if (result.data?.updateCustomer) {
+        successRef.current = true
+      }
     },
   })
 
-  return (
-    <Dialog
-      ref={ref}
-      title={translate(
-        isEdition ? 'text_63ea0f84f400488553caa65c' : 'text_63ea0f84f400488553caa678',
-      )}
-      description={
-        <Typography
-          html={translate('text_63ea0f84f400488553caa680', {
-            customerName: `<span class="line-break-anywhere">${customerName}</span>`,
-          })}
-        />
-      }
-      onClose={() => {
-        formikProps.resetForm()
-        formikProps.validateForm()
-      }}
-      actions={({ closeDialog }) => (
-        <>
-          <Button variant="quaternary" onClick={closeDialog}>
-            {translate('text_63ea0f84f400488553caa6a5')}
-          </Button>
-          <Button
-            variant="primary"
-            disabled={!formikProps.isValid || !formikProps.dirty}
-            onClick={async () => {
-              await formikProps.submitForm()
-              closeDialog()
-            }}
-          >
-            {isEdition
-              ? translate('text_63ea0f84f400488553caa681')
-              : translate('text_63ea0f84f400488553caa6ad')}
-          </Button>
-        </>
-      )}
-    >
-      <div className="mb-8">
-        <ComboBoxField
-          disableClearable
-          name="billingConfiguration.documentLocale"
-          label={translate('text_63ea0f84f400488553caa687')}
-          placeholder={translate('text_63ea0f84f400488553caa68f')}
-          helperText={
-            <Typography variant="caption" html={translate('text_63e51ef4985f0ebd75c21312')} />
-          }
-          formikProps={formikProps}
-          data={documentLocalesDataForComboBox}
-          PopperProps={{ displayInDialog: true }}
-        />
-      </div>
-    </Dialog>
-  )
-})
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-EditCustomerDocumentLocaleDialog.displayName = 'forwardRef'
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openEditCustomerDocumentLocaleDialog = (customer: EditCustomerDocumentLocaleFragment) => {
+    customerRef.current = customer
+    const isEdition = !!customer.billingConfiguration?.documentLocale
+
+    form.reset()
+    form.setFieldValue('documentLocale', customer.billingConfiguration?.documentLocale ?? '')
+
+    formDialog
+      .open({
+        title: translate(
+          isEdition ? 'text_63ea0f84f400488553caa65c' : 'text_63ea0f84f400488553caa678',
+        ),
+        description: (
+          <Typography
+            html={translate('text_63ea0f84f400488553caa680', {
+              customerName: `<span class="line-break-anywhere">${customer.displayName}</span>`,
+            })}
+          />
+        ),
+        children: (
+          <div className="p-8">
+            <form.AppField name="documentLocale">
+              {(field) => (
+                <field.ComboBoxField
+                  disableClearable
+                  label={translate('text_63ea0f84f400488553caa687')}
+                  placeholder={translate('text_63ea0f84f400488553caa68f')}
+                  helperText={
+                    <Typography
+                      variant="caption"
+                      html={translate('text_63e51ef4985f0ebd75c21312')}
+                    />
+                  }
+                  data={documentLocalesDataForComboBox}
+                  PopperProps={{ displayInDialog: true }}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        closeOnError: false,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>
+              {translate(
+                isEdition ? 'text_63ea0f84f400488553caa681' : 'text_63ea0f84f400488553caa6ad',
+              )}
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: EDIT_CUSTOMER_DOCUMENT_LOCALE_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close') {
+          form.reset()
+          customerRef.current = null
+        }
+      })
+  }
+
+  return { openEditCustomerDocumentLocaleDialog }
+}

--- a/src/components/customers/__tests__/CustomerSettings.test.tsx
+++ b/src/components/customers/__tests__/CustomerSettings.test.tsx
@@ -56,13 +56,11 @@ jest.mock('~/components/customers/DeleteCustomerGracePeriodeDialog', () => {
   return { DeleteCustomerGracePeriodeDialog: MockDialog }
 })
 
-jest.mock('~/components/customers/EditCustomerDocumentLocaleDialog', () => {
-  const React = jest.requireActual('react')
-  const MockDialog = React.forwardRef(() => null)
-
-  MockDialog.displayName = 'EditCustomerDocumentLocaleDialog'
-  return { EditCustomerDocumentLocaleDialog: MockDialog }
-})
+jest.mock('~/components/customers/EditCustomerDocumentLocaleDialog', () => ({
+  useEditCustomerDocumentLocaleDialog: () => ({
+    openEditCustomerDocumentLocaleDialog: jest.fn(),
+  }),
+}))
 
 jest.mock('~/components/customers/DeleteCustomerDocumentLocaleDialog', () => {
   const React = jest.requireActual('react')

--- a/src/components/customers/__tests__/EditCustomerDocumentLocaleDialog.test.tsx
+++ b/src/components/customers/__tests__/EditCustomerDocumentLocaleDialog.test.tsx
@@ -1,0 +1,282 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { addToast } from '~/core/apolloClient'
+import { EditCustomerDocumentLocaleFragment } from '~/generated/graphql'
+import { AllTheProviders } from '~/test-utils'
+
+import {
+  EDIT_CUSTOMER_DOCUMENT_LOCALE_FORM_ID,
+  useEditCustomerDocumentLocaleDialog,
+} from '../EditCustomerDocumentLocaleDialog'
+
+const mockFormDialogOpen = jest.fn()
+const mockUpdateDocumentLocale = jest.fn()
+
+jest.mock('~/components/dialogs/FormDialog', () => ({
+  ...jest.requireActual('~/components/dialogs/FormDialog'),
+  useFormDialog: () => ({
+    open: mockFormDialogOpen,
+    close: jest.fn(),
+  }),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: jest.fn(),
+}))
+
+jest.mock('~/generated/graphql', () => {
+  const actual = jest.requireActual('~/generated/graphql')
+
+  return {
+    ...actual,
+    useUpdateCustomerDocumentLocaleMutation: (options?: {
+      onCompleted?: (data: unknown) => void
+    }) => [
+      async (variables: unknown) => {
+        const result = await mockUpdateDocumentLocale(variables)
+
+        if (result?.data) {
+          options?.onCompleted?.(result.data)
+        }
+
+        return result
+      },
+    ],
+  }
+})
+
+const buildCustomer = (
+  overrides: Partial<EditCustomerDocumentLocaleFragment> = {},
+): EditCustomerDocumentLocaleFragment => ({
+  __typename: 'Customer',
+  id: 'customer-1',
+  name: 'Test Customer',
+  displayName: 'Test Customer',
+  externalId: 'external-1',
+  billingConfiguration: {
+    __typename: 'CustomerBillingConfiguration',
+    id: 'billing-config-1',
+    documentLocale: 'en',
+  },
+  ...overrides,
+})
+
+const buildSuccessResult = () => ({
+  data: {
+    updateCustomer: {
+      __typename: 'Customer',
+      id: 'customer-1',
+      billingConfiguration: {
+        __typename: 'CustomerBillingConfiguration',
+        id: 'billing-config-1',
+        documentLocale: 'en',
+      },
+    },
+  },
+  errors: undefined,
+})
+
+describe('useEditCustomerDocumentLocaleDialog', () => {
+  const customWrapper = ({ children }: { children: React.ReactNode }) =>
+    AllTheProviders({ children })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+  })
+
+  describe('GIVEN the hook is initialized', () => {
+    describe('WHEN rendered', () => {
+      it('THEN should return openEditCustomerDocumentLocaleDialog function', () => {
+        const { result } = renderHook(() => useEditCustomerDocumentLocaleDialog(), {
+          wrapper: customWrapper,
+        })
+
+        expect(typeof result.current.openEditCustomerDocumentLocaleDialog).toBe('function')
+      })
+    })
+  })
+
+  describe('GIVEN openEditCustomerDocumentLocaleDialog is called', () => {
+    describe('WHEN opening the dialog', () => {
+      it('THEN should call formDialog.open once', () => {
+        const { result } = renderHook(() => useEditCustomerDocumentLocaleDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditCustomerDocumentLocaleDialog(buildCustomer())
+        })
+
+        expect(mockFormDialogOpen).toHaveBeenCalledTimes(1)
+      })
+
+      it('THEN should include closeOnError false', () => {
+        const { result } = renderHook(() => useEditCustomerDocumentLocaleDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditCustomerDocumentLocaleDialog(buildCustomer())
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs.closeOnError).toBe(false)
+      })
+
+      it.each([
+        ['title', 'string'],
+        ['description', 'object'],
+        ['children', 'object'],
+        ['mainAction', 'object'],
+      ])('THEN should include %s', (prop, expectedType) => {
+        const { result } = renderHook(() => useEditCustomerDocumentLocaleDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditCustomerDocumentLocaleDialog(buildCustomer())
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs[prop]).toBeDefined()
+        expect(typeof callArgs[prop]).toBe(expectedType)
+      })
+
+      it('THEN should include form with the expected id and a submit function', () => {
+        const { result } = renderHook(() => useEditCustomerDocumentLocaleDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditCustomerDocumentLocaleDialog(buildCustomer())
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs.form).toBeDefined()
+        expect(callArgs.form.id).toBe(EDIT_CUSTOMER_DOCUMENT_LOCALE_FORM_ID)
+        expect(typeof callArgs.form.submit).toBe('function')
+      })
+    })
+  })
+
+  describe('GIVEN the form is submitted', () => {
+    describe('WHEN a document locale is provided', () => {
+      it('THEN should call the mutation with id, billingConfiguration and required customer fields', async () => {
+        mockUpdateDocumentLocale.mockResolvedValue(buildSuccessResult())
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useEditCustomerDocumentLocaleDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditCustomerDocumentLocaleDialog(buildCustomer())
+        })
+
+        expect(mockUpdateDocumentLocale).toHaveBeenCalledWith({
+          variables: {
+            input: {
+              id: 'customer-1',
+              billingConfiguration: { documentLocale: 'en' },
+              externalId: 'external-1',
+              name: 'Test Customer',
+            },
+          },
+        })
+      })
+    })
+
+    describe('WHEN the mutation succeeds', () => {
+      it('THEN should show a success toast', async () => {
+        mockUpdateDocumentLocale.mockResolvedValue(buildSuccessResult())
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useEditCustomerDocumentLocaleDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditCustomerDocumentLocaleDialog(buildCustomer())
+        })
+
+        expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+      })
+    })
+
+    describe('WHEN the mutation returns no data', () => {
+      it('THEN handleSubmit should throw Submit failed', async () => {
+        mockUpdateDocumentLocale.mockResolvedValue({ data: null, errors: undefined })
+
+        let submitError: unknown = null
+
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          try {
+            await config.form.submit()
+          } catch (err) {
+            submitError = err
+          }
+
+          return { reason: 'close' }
+        })
+
+        const { result } = renderHook(() => useEditCustomerDocumentLocaleDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditCustomerDocumentLocaleDialog(buildCustomer())
+        })
+
+        expect(submitError).toBeInstanceOf(Error)
+        expect((submitError as Error).message).toBe('Submit failed')
+      })
+    })
+  })
+
+  describe('GIVEN the dialog resolves with close', () => {
+    describe('WHEN the dialog is cancelled before submit', () => {
+      it('THEN should not call the mutation', async () => {
+        mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+
+        const { result } = renderHook(() => useEditCustomerDocumentLocaleDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditCustomerDocumentLocaleDialog(buildCustomer())
+        })
+
+        expect(mockUpdateDocumentLocale).not.toHaveBeenCalled()
+      })
+
+      it('THEN should not show a toast', async () => {
+        mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+
+        const { result } = renderHook(() => useEditCustomerDocumentLocaleDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditCustomerDocumentLocaleDialog(buildCustomer())
+        })
+
+        expect(addToast).not.toHaveBeenCalled()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Context

The dialog still used the deprecated Formik/Yup stack and the legacy ref-based `Dialog`. Both are being phased out in favor of TanStack Form (+ Zod) and the hook-based dialog system in `~/components/dialogs`.

## Description

- Migrate the form from Formik/Yup to `useAppForm` + Zod.
- Replace the ref-based `Dialog` with a `useEditCustomerDocumentLocaleDialog()` hook backed by `useFormDialog`; the dialog now closes only on a successful mutation.
- Update `CustomerSettings` to call the hook instead of rendering the dialog via ref.
- Update tests accordingly (new hook test + fix the parent's stale mock).

<!-- Linear link -->
Fixes ISSUE-1482