### PR TITLE
refactor(EditInvoicePaymentStatusDialog): Migrate to TanStack Form + new dialog system

### DIFF
--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -12,10 +12,7 @@ import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { buildInvoiceDocumentData } from '~/components/emails/buildDocumentData'
-import {
-  UpdateInvoicePaymentStatusDialog,
-  UpdateInvoicePaymentStatusDialogRef,
-} from '~/components/invoices/EditInvoicePaymentStatusDialog'
+import { useUpdateInvoicePaymentStatusDialog } from '~/components/invoices/EditInvoicePaymentStatusDialog'
 import {
   FinalizeInvoiceDialog,
   FinalizeInvoiceDialogRef,
@@ -216,7 +213,7 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
   const { generatePaymentUrl } = useGeneratePaymentUrl()
 
   const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
-  const updateInvoicePaymentStatusDialog = useRef<UpdateInvoicePaymentStatusDialogRef>(null)
+  const { openUpdateInvoicePaymentStatusDialog } = useUpdateInvoicePaymentStatusDialog()
   const voidInvoiceDialogRef = useRef<VoidInvoiceDialogRef>(null)
 
   return (
@@ -573,7 +570,7 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
                     startIcon: 'coin-dollar',
                     title: translate('text_63eba8c65a6c8043feee2a01'),
                     onAction: () => {
-                      updateInvoicePaymentStatusDialog?.current?.openDialog(invoice)
+                      openUpdateInvoicePaymentStatusDialog(invoice)
                     },
                   }
                 : null,
@@ -626,7 +623,6 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
         />
       </InfiniteScroll>
       <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
-      <UpdateInvoicePaymentStatusDialog ref={updateInvoicePaymentStatusDialog} />
       <VoidInvoiceDialog ref={voidInvoiceDialogRef} />
       <ResendInvoiceForCollectionDialog ref={resendInvoiceForCollectionDialogRef} />
     </>

--- a/src/components/invoices/EditInvoicePaymentStatusDialog.tsx
+++ b/src/components/invoices/EditInvoicePaymentStatusDialog.tsx
@@ -1,21 +1,20 @@
 import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
-import { object, string } from 'yup'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { ComboBoxField } from '~/components/form'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
 import { addToast } from '~/core/apolloClient'
 import {
   AllInvoiceDetailsForCustomerInvoiceDetailsFragmentDoc,
   InvoiceForUpdateInvoicePaymentStatusFragment,
   InvoiceListItemFragmentDoc,
   InvoicePaymentStatusTypeEnum,
-  UpdateInvoiceInput,
   useUpdateInvoicePaymentStatusMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 gql`
   fragment InvoiceForUpdateInvoicePaymentStatus on Invoice {
@@ -36,105 +35,119 @@ gql`
   ${InvoiceListItemFragmentDoc}
 `
 
-export interface UpdateInvoicePaymentStatusDialogRef {
-  openDialog: (invoice: InvoiceForUpdateInvoicePaymentStatusFragment) => unknown
-  closeDialog: () => unknown
-}
+export const UPDATE_INVOICE_PAYMENT_STATUS_FORM_ID = 'update-invoice-payment-status-form'
 
-export const UpdateInvoicePaymentStatusDialog = forwardRef<UpdateInvoicePaymentStatusDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
-    const dialogRef = useRef<DialogRef>(null)
-    const [invoice, setInvoice] = useState<InvoiceForUpdateInvoicePaymentStatusFragment>()
-    const [updateInvoice] = useUpdateInvoicePaymentStatusMutation({
-      onCompleted({ updateInvoice: updateInvoiceRes }) {
-        if (updateInvoiceRes?.id) {
-          addToast({
-            message: translate('text_63eba8c65a6c8043feee2a02'),
-            severity: 'success',
-          })
-        }
-      },
-    })
-    const formikProps = useFormik<Omit<UpdateInvoiceInput, 'id'>>({
-      initialValues: {
-        paymentStatus: invoice?.paymentStatus || undefined,
-      },
-      validationSchema: object().shape({
-        paymentStatus: string().required(''),
-      }),
-      validateOnMount: true,
-      enableReinitialize: true,
-      onSubmit: async (values, formikBag) => {
-        if (!invoice?.id) return
+const updateInvoicePaymentStatusValidationSchema = z.object({
+  paymentStatus: z
+    .string({ message: 'text_624ea7c29103fd010732ab7d' })
+    .min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+})
 
-        const res = await updateInvoice({
-          variables: {
-            input: {
-              id: invoice.id,
-              ...values,
-            },
-          },
+export const useUpdateInvoicePaymentStatusDialog = () => {
+  const formDialog = useFormDialog()
+  const { translate } = useInternationalization()
+  const invoiceRef = useRef<InvoiceForUpdateInvoicePaymentStatusFragment | null>(null)
+  const successRef = useRef(false)
+
+  const [updateInvoice] = useUpdateInvoicePaymentStatusMutation({
+    onCompleted({ updateInvoice: updateInvoiceRes }) {
+      if (updateInvoiceRes?.id) {
+        addToast({
+          message: translate('text_63eba8c65a6c8043feee2a02'),
+          severity: 'success',
         })
+      }
+    },
+  })
 
-        if (res.data?.updateInvoice) {
-          dialogRef?.current?.closeDialog()
-          formikBag.resetForm()
+  const form = useAppForm({
+    defaultValues: {
+      paymentStatus: '' as string,
+    },
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: updateInvoicePaymentStatusValidationSchema,
+    },
+    onSubmit: async ({ value }) => {
+      const invoice = invoiceRef.current
+
+      if (!invoice?.id) {
+        return
+      }
+
+      const res = await updateInvoice({
+        variables: {
+          input: {
+            id: invoice.id,
+            paymentStatus: value.paymentStatus as InvoicePaymentStatusTypeEnum,
+          },
+        },
+      })
+
+      if (res.data?.updateInvoice) {
+        successRef.current = true
+      }
+    },
+  })
+
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
+
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openUpdateInvoicePaymentStatusDialog = (
+    invoice: InvoiceForUpdateInvoicePaymentStatusFragment,
+  ) => {
+    invoiceRef.current = invoice
+    form.reset()
+    form.setFieldValue('paymentStatus', invoice.paymentStatus ?? '')
+
+    formDialog
+      .open({
+        title: translate('text_63eba8c65a6c8043feee2a0d'),
+        description: translate('text_63eba8c65a6c8043feee2a0e'),
+        cancelOrCloseText: 'cancel',
+        children: (
+          <div className="p-8">
+            <form.AppField name="paymentStatus">
+              {(field) => (
+                <field.ComboBoxField
+                  disableClearable
+                  label={translate('text_63eba8c65a6c8043feee2a0f')}
+                  data={Object.values(InvoicePaymentStatusTypeEnum).map((status) => ({
+                    label: status.charAt(0).toUpperCase() + status.slice(1),
+                    value: status,
+                  }))}
+                  PopperProps={{ displayInDialog: true }}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        closeOnError: false,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>{translate('text_63eba8c65a6c8043feee2a15')}</form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: UPDATE_INVOICE_PAYMENT_STATUS_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close') {
+          form.reset()
+          invoiceRef.current = null
         }
-      },
-    })
+      })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setInvoice(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => dialogRef.current?.closeDialog(),
-    }))
-
-    return (
-      <Dialog
-        ref={dialogRef}
-        title={translate('text_63eba8c65a6c8043feee2a0d')}
-        description={translate('text_63eba8c65a6c8043feee2a0e')}
-        onClose={() => {
-          formikProps.resetForm()
-          formikProps.validateForm()
-        }}
-        actions={({ closeDialog }) => (
-          <>
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_63eba8c65a6c8043feee2a14')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!formikProps.isValid || !formikProps.dirty}
-              onClick={async () => {
-                await formikProps.submitForm()
-                closeDialog()
-              }}
-            >
-              {translate('text_63eba8c65a6c8043feee2a15')}
-            </Button>
-          </>
-        )}
-      >
-        <ComboBoxField
-          className="mb-8"
-          name="paymentStatus"
-          label={translate('text_63eba8c65a6c8043feee2a0f')}
-          data={Object.values(InvoicePaymentStatusTypeEnum).map((status) => ({
-            label: status.charAt(0).toUpperCase() + status.slice(1),
-            value: status,
-          }))}
-          isEmptyNull={false}
-          disableClearable
-          formikProps={formikProps}
-          PopperProps={{ displayInDialog: true }}
-        />
-      </Dialog>
-    )
-  },
-)
-
-UpdateInvoicePaymentStatusDialog.displayName = 'forwardRef'
+  return { openUpdateInvoicePaymentStatusDialog }
+}

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -13,10 +13,7 @@ import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { buildInvoiceDocumentData } from '~/components/emails/buildDocumentData'
-import {
-  UpdateInvoicePaymentStatusDialog,
-  UpdateInvoicePaymentStatusDialogRef,
-} from '~/components/invoices/EditInvoicePaymentStatusDialog'
+import { useUpdateInvoicePaymentStatusDialog } from '~/components/invoices/EditInvoicePaymentStatusDialog'
 import {
   FinalizeInvoiceDialog,
   FinalizeInvoiceDialogRef,
@@ -101,7 +98,7 @@ const InvoicesList = ({
   const hasAccessToMultiPaymentFlow = hasFeatureFlag(FeatureFlagEnum.MultiplePaymentMethods)
 
   const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
-  const updateInvoicePaymentStatusDialog = useRef<UpdateInvoicePaymentStatusDialogRef>(null)
+  const { openUpdateInvoicePaymentStatusDialog } = useUpdateInvoicePaymentStatusDialog()
   const voidInvoiceDialogRef = useRef<VoidInvoiceDialogRef>(null)
   const resendInvoiceForCollectionDialogRef = useRef<ResendInvoiceForCollectionDialogRef>(null)
 
@@ -320,7 +317,7 @@ const InvoicesList = ({
             startIcon: 'coin-dollar',
             title: translate('text_63eba8c65a6c8043feee2a01'),
             onAction: () => {
-              updateInvoicePaymentStatusDialog?.current?.openDialog(invoice)
+              openUpdateInvoicePaymentStatusDialog(invoice)
             },
           }
         : null
@@ -596,7 +593,6 @@ const InvoicesList = ({
       </InfiniteScroll>
 
       <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
-      <UpdateInvoicePaymentStatusDialog ref={updateInvoicePaymentStatusDialog} />
       <VoidInvoiceDialog ref={voidInvoiceDialogRef} />
       <ResendInvoiceForCollectionDialog ref={resendInvoiceForCollectionDialogRef} />
     </div>

--- a/src/components/invoices/__tests__/EditInvoicePaymentStatusDialog.test.tsx
+++ b/src/components/invoices/__tests__/EditInvoicePaymentStatusDialog.test.tsx
@@ -1,0 +1,290 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { addToast } from '~/core/apolloClient'
+import {
+  InvoiceForUpdateInvoicePaymentStatusFragment,
+  InvoicePaymentStatusTypeEnum,
+} from '~/generated/graphql'
+import { AllTheProviders } from '~/test-utils'
+
+import {
+  UPDATE_INVOICE_PAYMENT_STATUS_FORM_ID,
+  useUpdateInvoicePaymentStatusDialog,
+} from '../EditInvoicePaymentStatusDialog'
+
+const mockFormDialogOpen = jest.fn()
+const mockUpdateInvoice = jest.fn()
+
+jest.mock('~/components/dialogs/FormDialog', () => ({
+  ...jest.requireActual('~/components/dialogs/FormDialog'),
+  useFormDialog: () => ({
+    open: mockFormDialogOpen,
+    close: jest.fn(),
+  }),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: jest.fn(),
+}))
+
+jest.mock('~/generated/graphql', () => {
+  const actual = jest.requireActual('~/generated/graphql')
+
+  return {
+    ...actual,
+    useUpdateInvoicePaymentStatusMutation: (options?: {
+      onCompleted?: (data: unknown) => void
+    }) => [
+      async (variables: unknown) => {
+        const result = await mockUpdateInvoice(variables)
+
+        if (result?.data) {
+          options?.onCompleted?.(result.data)
+        }
+
+        return result
+      },
+    ],
+  }
+})
+
+const INVOICE_ID = 'invoice-1'
+
+const buildInvoice = (
+  overrides: Partial<InvoiceForUpdateInvoicePaymentStatusFragment> = {},
+): InvoiceForUpdateInvoicePaymentStatusFragment => ({
+  __typename: 'Invoice',
+  id: INVOICE_ID,
+  paymentStatus: InvoicePaymentStatusTypeEnum.Pending,
+  ...overrides,
+})
+
+const buildSuccessResult = () => ({
+  data: {
+    updateInvoice: {
+      __typename: 'Invoice',
+      id: INVOICE_ID,
+      paymentStatus: InvoicePaymentStatusTypeEnum.Succeeded,
+    },
+  },
+  errors: undefined,
+})
+
+describe('useUpdateInvoicePaymentStatusDialog', () => {
+  const customWrapper = ({ children }: { children: React.ReactNode }) =>
+    AllTheProviders({ children })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+  })
+
+  describe('GIVEN the hook is initialized', () => {
+    describe('WHEN rendered', () => {
+      it('THEN should return openUpdateInvoicePaymentStatusDialog function', () => {
+        const { result } = renderHook(() => useUpdateInvoicePaymentStatusDialog(), {
+          wrapper: customWrapper,
+        })
+
+        expect(typeof result.current.openUpdateInvoicePaymentStatusDialog).toBe('function')
+      })
+    })
+  })
+
+  describe('GIVEN openUpdateInvoicePaymentStatusDialog is called', () => {
+    describe('WHEN opening the dialog', () => {
+      it('THEN should call formDialog.open once', () => {
+        const { result } = renderHook(() => useUpdateInvoicePaymentStatusDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openUpdateInvoicePaymentStatusDialog(buildInvoice())
+        })
+
+        expect(mockFormDialogOpen).toHaveBeenCalledTimes(1)
+      })
+
+      it('THEN should include closeOnError false', () => {
+        const { result } = renderHook(() => useUpdateInvoicePaymentStatusDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openUpdateInvoicePaymentStatusDialog(buildInvoice())
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs.closeOnError).toBe(false)
+      })
+
+      it('THEN should pass cancelOrCloseText as cancel', () => {
+        const { result } = renderHook(() => useUpdateInvoicePaymentStatusDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openUpdateInvoicePaymentStatusDialog(buildInvoice())
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs.cancelOrCloseText).toBe('cancel')
+      })
+
+      it.each([
+        ['title', 'string'],
+        ['description', 'string'],
+        ['children', 'object'],
+        ['mainAction', 'object'],
+      ])('THEN should include %s', (prop, expectedType) => {
+        const { result } = renderHook(() => useUpdateInvoicePaymentStatusDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openUpdateInvoicePaymentStatusDialog(buildInvoice())
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs[prop]).toBeDefined()
+        expect(typeof callArgs[prop]).toBe(expectedType)
+      })
+
+      it('THEN should include form with the expected id and a submit function', () => {
+        const { result } = renderHook(() => useUpdateInvoicePaymentStatusDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openUpdateInvoicePaymentStatusDialog(buildInvoice())
+        })
+
+        const callArgs = mockFormDialogOpen.mock.calls[0][0]
+
+        expect(callArgs.form).toBeDefined()
+        expect(callArgs.form.id).toBe(UPDATE_INVOICE_PAYMENT_STATUS_FORM_ID)
+        expect(typeof callArgs.form.submit).toBe('function')
+      })
+    })
+  })
+
+  describe('GIVEN the form is submitted', () => {
+    describe('WHEN a payment status is provided', () => {
+      it('THEN should call the mutation with the invoice id and payment status', async () => {
+        mockUpdateInvoice.mockResolvedValue(buildSuccessResult())
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useUpdateInvoicePaymentStatusDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openUpdateInvoicePaymentStatusDialog(
+            buildInvoice({ paymentStatus: InvoicePaymentStatusTypeEnum.Succeeded }),
+          )
+        })
+
+        expect(mockUpdateInvoice).toHaveBeenCalledWith({
+          variables: {
+            input: {
+              id: INVOICE_ID,
+              paymentStatus: InvoicePaymentStatusTypeEnum.Succeeded,
+            },
+          },
+        })
+      })
+    })
+
+    describe('WHEN the mutation succeeds', () => {
+      it('THEN should show a success toast', async () => {
+        mockUpdateInvoice.mockResolvedValue(buildSuccessResult())
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useUpdateInvoicePaymentStatusDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openUpdateInvoicePaymentStatusDialog(buildInvoice())
+        })
+
+        expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+      })
+    })
+
+    describe('WHEN the mutation returns no data', () => {
+      it('THEN handleSubmit should throw Submit failed', async () => {
+        mockUpdateInvoice.mockResolvedValue({ data: null, errors: undefined })
+
+        let submitError: unknown = null
+
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          try {
+            await config.form.submit()
+          } catch (err) {
+            submitError = err
+          }
+
+          return { reason: 'close' }
+        })
+
+        const { result } = renderHook(() => useUpdateInvoicePaymentStatusDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openUpdateInvoicePaymentStatusDialog(buildInvoice())
+        })
+
+        expect(submitError).toBeInstanceOf(Error)
+        expect((submitError as Error).message).toBe('Submit failed')
+      })
+    })
+  })
+
+  describe('GIVEN the dialog resolves with close', () => {
+    describe('WHEN the dialog is cancelled before submit', () => {
+      it('THEN should not call the mutation', async () => {
+        mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+
+        const { result } = renderHook(() => useUpdateInvoicePaymentStatusDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openUpdateInvoicePaymentStatusDialog(buildInvoice())
+        })
+
+        expect(mockUpdateInvoice).not.toHaveBeenCalled()
+      })
+
+      it('THEN should not show a toast', async () => {
+        mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+
+        const { result } = renderHook(() => useUpdateInvoicePaymentStatusDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openUpdateInvoicePaymentStatusDialog(buildInvoice())
+        })
+
+        expect(addToast).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/components/invoices/__tests__/InvoicesList.test.tsx
+++ b/src/components/invoices/__tests__/InvoicesList.test.tsx
@@ -129,6 +129,14 @@ jest.mock('~/components/dialogs/PremiumWarningDialog', () => ({
   }),
 }))
 
+const mockOpenUpdateInvoicePaymentStatusDialog = jest.fn()
+
+jest.mock('~/components/invoices/EditInvoicePaymentStatusDialog', () => ({
+  useUpdateInvoicePaymentStatusDialog: () => ({
+    openUpdateInvoicePaymentStatusDialog: mockOpenUpdateInvoicePaymentStatusDialog,
+  }),
+}))
+
 jest.mock('~/generated/graphql', () => ({
   ...jest.requireActual('~/generated/graphql'),
   useDownloadInvoiceItemMutation: (options: typeof downloadInvoiceCallbacks) => {
@@ -1503,10 +1511,10 @@ describe('InvoicesList', () => {
         name: 'text_63eba8c65a6c8043feee2a01',
       })
 
-      // Click triggers dialog - this tests line 291
+      // Click triggers the update payment status dialog
       await user.click(updateStatusButton)
 
-      expect(mockCanUpdatePaymentStatus).toHaveBeenCalled()
+      expect(mockOpenUpdateInvoicePaymentStatusDialog).toHaveBeenCalled()
     })
   })
 

--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -14,10 +14,7 @@ import {
   DisputeInvoiceDialog,
   DisputeInvoiceDialogRef,
 } from '~/components/invoices/DisputeInvoiceDialog'
-import {
-  UpdateInvoicePaymentStatusDialog,
-  UpdateInvoicePaymentStatusDialogRef,
-} from '~/components/invoices/EditInvoicePaymentStatusDialog'
+import { useUpdateInvoicePaymentStatusDialog } from '~/components/invoices/EditInvoicePaymentStatusDialog'
 import {
   FinalizeInvoiceDialog,
   FinalizeInvoiceDialogRef,
@@ -322,7 +319,7 @@ const CustomerInvoiceDetails = () => {
   const { hasPermissions } = usePermissions()
   const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
   const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
-  const updateInvoicePaymentStatusDialog = useRef<UpdateInvoicePaymentStatusDialogRef>(null)
+  const { openUpdateInvoicePaymentStatusDialog } = useUpdateInvoicePaymentStatusDialog()
   const addMetadataDrawerDialogRef = useRef<AddMetadataDrawerRef>(null)
   const voidInvoiceDialogRef = useRef<VoidInvoiceDialogRef>(null)
   const disputeInvoiceDialogRef = useRef<DisputeInvoiceDialogRef>(null)
@@ -904,7 +901,7 @@ const CustomerInvoiceDetails = () => {
           hidden: !authorizations.canUpdatePaymentStatus,
           onClick: (closePopper: () => void) => {
             if (invoice) {
-              updateInvoicePaymentStatusDialog?.current?.openDialog(invoice)
+              openUpdateInvoicePaymentStatusDialog(invoice)
             }
             closePopper()
           },
@@ -1040,7 +1037,6 @@ const CustomerInvoiceDetails = () => {
       )}
 
       <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
-      <UpdateInvoicePaymentStatusDialog ref={updateInvoicePaymentStatusDialog} />
       <VoidInvoiceDialog ref={voidInvoiceDialogRef} />
       <DisputeInvoiceDialog ref={disputeInvoiceDialogRef} />
       {!!invoice && <AddMetadataDrawer ref={addMetadataDrawerDialogRef} invoiceId={invoice.id} />}

--- a/src/pages/InvoicesPage.tsx
+++ b/src/pages/InvoicesPage.tsx
@@ -11,10 +11,6 @@ import {
 } from '~/components/designSystem/Filters'
 import { ExportDialog, ExportDialogRef, ExportValues } from '~/components/exports/ExportDialog'
 import {
-  UpdateInvoicePaymentStatusDialog,
-  UpdateInvoicePaymentStatusDialogRef,
-} from '~/components/invoices/EditInvoicePaymentStatusDialog'
-import {
   FinalizeInvoiceDialog,
   FinalizeInvoiceDialogRef,
 } from '~/components/invoices/FinalizeInvoiceDialog'
@@ -149,7 +145,6 @@ const InvoicesPage = () => {
   )
 
   const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
-  const updateInvoicePaymentStatusDialog = useRef<UpdateInvoicePaymentStatusDialogRef>(null)
   const voidInvoiceDialogRef = useRef<VoidInvoiceDialogRef>(null)
   const exportInvoicesDialogRef = useRef<ExportDialogRef>(null)
 
@@ -306,7 +301,6 @@ const InvoicesPage = () => {
       />
 
       <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
-      <UpdateInvoicePaymentStatusDialog ref={updateInvoicePaymentStatusDialog} />
       <VoidInvoiceDialog ref={voidInvoiceDialogRef} />
       <ExportDialog
         ref={exportInvoicesDialogRef}

--- a/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
+++ b/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
@@ -235,7 +235,9 @@ jest.mock('~/components/invoices/FinalizeInvoiceDialog', () => ({
 }))
 
 jest.mock('~/components/invoices/EditInvoicePaymentStatusDialog', () => ({
-  UpdateInvoicePaymentStatusDialog: () => null,
+  useUpdateInvoicePaymentStatusDialog: () => ({
+    openUpdateInvoicePaymentStatusDialog: jest.fn(),
+  }),
 }))
 
 jest.mock('~/components/invoices/VoidInvoiceDialog', () => ({

--- a/src/pages/__tests__/InvoicesPage.test.tsx
+++ b/src/pages/__tests__/InvoicesPage.test.tsx
@@ -83,10 +83,6 @@ jest.mock('~/components/invoices/FinalizeInvoiceDialog', () => ({
   FinalizeInvoiceDialog: () => null,
 }))
 
-jest.mock('~/components/invoices/EditInvoicePaymentStatusDialog', () => ({
-  UpdateInvoicePaymentStatusDialog: () => null,
-}))
-
 jest.mock('~/components/invoices/VoidInvoiceDialog', () => ({
   VoidInvoiceDialog: () => null,
 }))


### PR DESCRIPTION
## Context

The dialog still used the deprecated Formik/Yup stack and the legacy ref-based `Dialog`. Both are being phased out in favor of TanStack Form (+ Zod) and the hook-based dialog system in `~/components/dialogs`.

## Description

- Migrate the form from Formik/Yup to `useAppForm` + Zod.
- Replace the ref-based `Dialog` with a `useUpdateInvoicePaymentStatusDialog()` hook backed by `useFormDialog`; the dialog now closes only on a successful mutation.
- Update the 3 callers (InvoicesList, CustomerInvoicesList, CustomerInvoiceDetails) to call the hook; remove a dead, never-triggered dialog instance from InvoicesPage.
- Update tests accordingly (new hook test + fix the parents' stale mocks).

<!-- Linear link -->
Fixes LAGO-1212