### PR TITLE
chore(sonar): suppress S6679 isNaN rule project-wide

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -35,7 +35,7 @@ sonar.exclusions+=**/node_modules/**,**/dist/**,**/cypress/**,**/packages/design
 # Ignore "Do not add then to an object" rule for entire project
 # This is a false positive - Yup's .when() API and other libraries legitimately use 'then' for conditional logic
 # Configured for both JavaScript and TypeScript analyzers
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6
 sonar.issue.ignore.multicriteria.e1.ruleKey=javascript:S6643
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.{js,jsx,ts,tsx}
 sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S6643
@@ -47,4 +47,11 @@ sonar.issue.ignore.multicriteria.e3.ruleKey=javascript:S7764
 sonar.issue.ignore.multicriteria.e3.resourceKey=**/*.{js,jsx,ts,tsx}
 sonar.issue.ignore.multicriteria.e4.ruleKey=typescript:S7764
 sonar.issue.ignore.multicriteria.e4.resourceKey=**/*.{js,jsx,ts,tsx}
+
+# Ignore "Prefer Number.isNaN over isNaN" rule
+# Global isNaN is intentional in this codebase
+sonar.issue.ignore.multicriteria.e5.ruleKey=javascript:S6679
+sonar.issue.ignore.multicriteria.e5.resourceKey=**/*.{js,jsx,ts,tsx}
+sonar.issue.ignore.multicriteria.e6.ruleKey=typescript:S6679
+sonar.issue.ignore.multicriteria.e6.resourceKey=**/*.{js,jsx,ts,tsx}
 


### PR DESCRIPTION
Adds `javascript:S6679` and `typescript:S6679` to the SonarCloud ignore list so the \"Number.isNaN() should be used\" warning no longer fires across the codebase.