### PR TITLE
feat(quotes): add download and approve button on edit

### DIFF
--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -297,6 +297,7 @@ const EditQuote = () => {
         aside={
           <EditQuoteAside
             quote={quote}
+            isSaving={saveStatus === 'saving'}
             onSaveStart={() => setSaveStatus('saving')}
             onSaveFinished={onUpdateFinished}
             onSaveError={(payload) => {

--- a/src/pages/quotes/__tests__/EditQuote.test.tsx
+++ b/src/pages/quotes/__tests__/EditQuote.test.tsx
@@ -100,6 +100,7 @@ jest.mock('../editQuote/EditQuoteAside', () => {
   return {
     __esModule: true,
     default: (props: {
+      isSaving?: boolean
       onSaveStart?: () => void
       onSaveFinished?: () => void
       onSaveError?: (payload: unknown) => void
@@ -110,7 +111,7 @@ jest.mock('../editQuote/EditQuoteAside', () => {
         onSaveError: props.onSaveError,
       }
 
-      return <div data-test="mock-edit-quote-aside" />
+      return <div data-test="mock-edit-quote-aside" data-is-saving={String(!!props.isSaving)} />
     },
   }
 })
@@ -547,6 +548,76 @@ describe('EditQuote', () => {
             expect.objectContaining({ id: 'version-1', startDate: '2026-06-01' }),
             false,
           )
+        })
+      })
+    })
+  })
+
+  describe('GIVEN the isSaving prop passed to the aside', () => {
+    const getAside = () => screen.getByTestId('mock-edit-quote-aside')
+
+    describe('WHEN the save status is idle', () => {
+      it('THEN should pass isSaving=false to the aside', () => {
+        render(<EditQuote />)
+
+        expect(getAside()).toHaveAttribute('data-is-saving', 'false')
+      })
+    })
+
+    describe('WHEN a save starts', () => {
+      it('THEN should pass isSaving=true to the aside', async () => {
+        render(<EditQuote />)
+
+        act(() => {
+          capturedAsideCallbacks.onSaveStart?.()
+        })
+
+        await waitFor(() => {
+          expect(getAside()).toHaveAttribute('data-is-saving', 'true')
+        })
+      })
+    })
+
+    describe('WHEN a save finishes successfully', () => {
+      it('THEN should pass isSaving=false back to the aside', async () => {
+        render(<EditQuote />)
+
+        act(() => {
+          capturedAsideCallbacks.onSaveStart?.()
+        })
+
+        await waitFor(() => {
+          expect(getAside()).toHaveAttribute('data-is-saving', 'true')
+        })
+
+        act(() => {
+          capturedAsideCallbacks.onSaveFinished?.()
+        })
+
+        await waitFor(() => {
+          expect(getAside()).toHaveAttribute('data-is-saving', 'false')
+        })
+      })
+    })
+
+    describe('WHEN a save errors', () => {
+      it('THEN should pass isSaving=false back to the aside', async () => {
+        render(<EditQuote />)
+
+        act(() => {
+          capturedAsideCallbacks.onSaveStart?.()
+        })
+
+        await waitFor(() => {
+          expect(getAside()).toHaveAttribute('data-is-saving', 'true')
+        })
+
+        act(() => {
+          capturedAsideCallbacks.onSaveError?.({ id: 'version-1' })
+        })
+
+        await waitFor(() => {
+          expect(getAside()).toHaveAttribute('data-is-saving', 'false')
         })
       })
     })

--- a/src/pages/quotes/editQuote/EditQuoteAside.tsx
+++ b/src/pages/quotes/editQuote/EditQuoteAside.tsx
@@ -194,6 +194,12 @@ const EditQuoteAsideForm = ({
 
   const gridClassName = 'grid grid-cols-[7.5rem_1fr] items-center gap-0 gap-y-2'
 
+  const handleDownloadPdf = () => {
+    download(buildQuotePreviewProps(quote.currentVersion, quote.customer, pdfHeader)).catch(
+      () => undefined,
+    )
+  }
+
   return (
     <div className="flex min-h-full flex-col">
       <div className="flex flex-col gap-3 px-3 py-4">
@@ -337,11 +343,7 @@ const EditQuoteAsideForm = ({
           data-test={EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID}
           loading={isSaving}
           disabled={!!isSaving}
-          onClick={() =>
-            download(buildQuotePreviewProps(quote.currentVersion, quote.customer, pdfHeader)).catch(
-              () => undefined,
-            )
-          }
+          onClick={handleDownloadPdf}
         >
           {translate('text_17797156485850t8yms6hf7z')}
         </Button>

--- a/src/pages/quotes/editQuote/EditQuoteAside.tsx
+++ b/src/pages/quotes/editQuote/EditQuoteAside.tsx
@@ -335,6 +335,7 @@ const EditQuoteAsideForm = ({
         <Button
           variant="secondary"
           data-test={EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID}
+          loading={isSaving}
           disabled={!!isSaving}
           onClick={() =>
             download(buildQuotePreviewProps(quote.currentVersion, quote.customer, pdfHeader)).catch(
@@ -348,6 +349,7 @@ const EditQuoteAsideForm = ({
           <Button
             variant="primary"
             data-test={EDIT_QUOTE_ASIDE_APPROVE_TEST_ID}
+            loading={isSaving}
             disabled={!!isSaving}
             onClick={() => goToApproveQuote(quote.id, quote.currentVersion.id)}
           >

--- a/src/pages/quotes/editQuote/EditQuoteAside.tsx
+++ b/src/pages/quotes/editQuote/EditQuoteAside.tsx
@@ -2,6 +2,7 @@ import { revalidateLogic, useStore } from '@tanstack/react-form'
 import { debounce } from 'lodash'
 import { useEffect, useMemo, useRef } from 'react'
 
+import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
 import {
   type CurrencyEnum,
@@ -11,6 +12,13 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm } from '~/hooks/forms/useAppform'
+import { usePermissions } from '~/hooks/usePermissions'
+import {
+  buildQuotePreviewProps,
+  type QuotePdfHeaderData,
+} from '~/pages/quotes/common/buildQuotePreviewProps'
+import { useDownloadQuotePdf } from '~/pages/quotes/common/QuotePdfProvider'
+import { useApproveQuote } from '~/pages/quotes/hooks/useApproveQuote'
 import { useUpdateQuote } from '~/pages/quotes/hooks/useUpdateQuote'
 
 import { type EditQuoteAsideFormValues, editQuoteAsideSchema } from './validationSchema'
@@ -27,9 +35,12 @@ export const EDIT_QUOTE_ASIDE_CURRENCY_INPUT_TEST_ID = 'edit-quote-aside-currenc
 export const EDIT_QUOTE_ASIDE_START_DATE_TEST_ID = 'edit-quote-aside-start-date'
 export const EDIT_QUOTE_ASIDE_END_DATE_TEST_ID = 'edit-quote-aside-end-date'
 export const EDIT_QUOTE_ASIDE_PAYMENT_TERM_TEST_ID = 'edit-quote-aside-payment-term'
+export const EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID = 'edit-quote-aside-download-pdf'
+export const EDIT_QUOTE_ASIDE_APPROVE_TEST_ID = 'edit-quote-aside-approve'
 
 interface EditQuoteAsideProps {
   quote: QuoteDetailItemFragment | null | undefined
+  isSaving?: boolean
   onSaveStart?: () => void
   onSaveFinished?: () => void
   onSaveError?: (payload: UpdateQuoteVersionInput) => void
@@ -37,6 +48,7 @@ interface EditQuoteAsideProps {
 
 const EditQuoteAside = ({
   quote,
+  isSaving,
   onSaveStart,
   onSaveFinished,
   onSaveError,
@@ -46,6 +58,7 @@ const EditQuoteAside = ({
   return (
     <EditQuoteAsideForm
       quote={quote}
+      isSaving={isSaving}
       onSaveStart={onSaveStart}
       onSaveFinished={onSaveFinished}
       onSaveError={onSaveError}
@@ -65,17 +78,31 @@ const formatNetPaymentTerm = (
 
 const EditQuoteAsideForm = ({
   quote,
+  isSaving,
   onSaveStart,
   onSaveFinished,
   onSaveError,
 }: {
   quote: QuoteDetailItemFragment
+  isSaving?: boolean
   onSaveStart?: () => void
   onSaveFinished?: () => void
   onSaveError?: (payload: UpdateQuoteVersionInput) => void
 }) => {
   const { translate } = useInternationalization()
   const { updateQuoteVersion } = useUpdateQuote({ onUpdateFinished: onSaveFinished })
+  const { hasPermissions } = usePermissions()
+  const { download } = useDownloadQuotePdf()
+  const { goToApproveQuote } = useApproveQuote()
+
+  const canApprove = hasPermissions(['quotesApprove'])
+  const pdfHeader: QuotePdfHeaderData = {
+    documentNumber: quote.number,
+    title: translate('text_1781883445506576p2jigfpx', {
+      numberWithVersion: `${quote.number} - v${quote.currentVersion.version}`,
+    }),
+    rows: [],
+  }
 
   const hasSubscription = !!quote.subscription
   const isOneOff = quote.orderType === OrderTypeEnum.OneOff
@@ -168,7 +195,7 @@ const EditQuoteAsideForm = ({
   const gridClassName = 'grid grid-cols-[7.5rem_1fr] items-center gap-0 gap-y-2'
 
   return (
-    <>
+    <div className="flex min-h-full flex-col">
       <div className="flex flex-col gap-3 px-3 py-4">
         <Typography variant="bodyHl" color="grey700">
           {translate('text_1777540287773ez178bggf4h')}
@@ -304,7 +331,31 @@ const EditQuoteAsideForm = ({
           </form.AppField>
         </div>
       </div>
-    </>
+      <div className="sticky bottom-0 mt-auto flex justify-end gap-3 border-t border-grey-200 bg-white p-4">
+        <Button
+          variant="secondary"
+          data-test={EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID}
+          disabled={!!isSaving}
+          onClick={() =>
+            download(buildQuotePreviewProps(quote.currentVersion, quote.customer, pdfHeader)).catch(
+              () => undefined,
+            )
+          }
+        >
+          {translate('text_17797156485850t8yms6hf7z')}
+        </Button>
+        {canApprove && (
+          <Button
+            variant="primary"
+            data-test={EDIT_QUOTE_ASIDE_APPROVE_TEST_ID}
+            disabled={!!isSaving}
+            onClick={() => goToApproveQuote(quote.id, quote.currentVersion.id)}
+          >
+            {translate('text_1776848720529vv5zmyyq94k')}
+          </Button>
+        )}
+      </div>
+    </div>
   )
 }
 

--- a/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
+++ b/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 
 import {
   CurrencyEnum,
@@ -9,9 +9,11 @@ import {
 import { render } from '~/test-utils'
 
 import EditQuoteAside, {
+  EDIT_QUOTE_ASIDE_APPROVE_TEST_ID,
   EDIT_QUOTE_ASIDE_BILLING_ENTITY_INPUT_TEST_ID,
   EDIT_QUOTE_ASIDE_CURRENCY_INPUT_TEST_ID,
   EDIT_QUOTE_ASIDE_CUSTOMER_INPUT_TEST_ID,
+  EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID,
   EDIT_QUOTE_ASIDE_END_DATE_TEST_ID,
   EDIT_QUOTE_ASIDE_PAYMENT_TERM_TEST_ID,
   EDIT_QUOTE_ASIDE_QUOTE_TYPE_COMBOBOX_TEST_ID,
@@ -42,6 +44,22 @@ jest.mock('~/pages/quotes/hooks/useUpdateQuote', () => ({
     updateQuote: jest.fn(),
     isUpdatingQuote: false,
   }),
+}))
+
+const mockDownload = jest.fn().mockResolvedValue(undefined)
+const mockGoToApproveQuote = jest.fn()
+const mockHasPermissions = jest.fn().mockReturnValue(true)
+
+jest.mock('~/pages/quotes/common/QuotePdfProvider', () => ({
+  useDownloadQuotePdf: () => ({ download: mockDownload }),
+}))
+
+jest.mock('~/pages/quotes/hooks/useApproveQuote', () => ({
+  useApproveQuote: () => ({ goToApproveQuote: mockGoToApproveQuote }),
+}))
+
+jest.mock('~/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasPermissions: mockHasPermissions }),
 }))
 
 const mockQuote: QuoteDetailItemFragment = {
@@ -92,6 +110,7 @@ const mockQuote: QuoteDetailItemFragment = {
 describe('EditQuoteAside', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockHasPermissions.mockReturnValue(true)
   })
 
   describe('GIVEN a quote is provided', () => {
@@ -403,6 +422,59 @@ describe('EditQuoteAside', () => {
         render(<EditQuoteAside quote={amendmentQuote} />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_END_DATE_TEST_ID)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN the footer actions', () => {
+    describe('WHEN the component renders', () => {
+      it('THEN should render the Download PDF button', () => {
+        render(<EditQuoteAside quote={mockQuote} />)
+
+        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID)).toBeInTheDocument()
+      })
+
+      it('THEN should render the Approve button when the user has the quotesApprove permission', () => {
+        mockHasPermissions.mockReturnValue(true)
+        render(<EditQuoteAside quote={mockQuote} />)
+
+        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID)).toBeInTheDocument()
+      })
+
+      it('THEN should NOT render the Approve button without the quotesApprove permission', () => {
+        mockHasPermissions.mockReturnValue(false)
+        render(<EditQuoteAside quote={mockQuote} />)
+
+        expect(screen.queryByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the Download PDF button is clicked', () => {
+      it('THEN should trigger a PDF download', () => {
+        render(<EditQuoteAside quote={mockQuote} />)
+
+        fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID))
+
+        expect(mockDownload).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('WHEN the Approve button is clicked', () => {
+      it('THEN should navigate to the approve quote page', () => {
+        render(<EditQuoteAside quote={mockQuote} />)
+
+        fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID))
+
+        expect(mockGoToApproveQuote).toHaveBeenCalledWith('quote-1', 'version-1')
+      })
+    })
+
+    describe('WHEN the quote is saving', () => {
+      it('THEN should disable both action buttons', () => {
+        render(<EditQuoteAside quote={mockQuote} isSaving />)
+
+        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID)).toBeDisabled()
+        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID)).toBeDisabled()
       })
     })
   })

--- a/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
+++ b/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
@@ -27,6 +27,8 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
       if (key === 'text_64c7a89b6c67eb6c98898125') return '0 days (at issuing date)'
       if (key === 'text_64c7a89b6c67eb6c9889815f' && params?.days)
         return `${params.days} day${Number(params.days) !== 1 ? 's' : ''}`
+      if (key === 'text_1781883445506576p2jigfpx' && params?.numberWithVersion)
+        return `Quote #${params.numberWithVersion}`
 
       return key
     },
@@ -434,6 +436,13 @@ describe('EditQuoteAside', () => {
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID)).toBeInTheDocument()
       })
 
+      it('THEN should still render the Download PDF button without the quotesApprove permission', () => {
+        mockHasPermissions.mockReturnValue(false)
+        render(<EditQuoteAside quote={mockQuote} />)
+
+        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID)).toBeInTheDocument()
+      })
+
       it('THEN should render the Approve button when the user has the quotesApprove permission', () => {
         mockHasPermissions.mockReturnValue(true)
         render(<EditQuoteAside quote={mockQuote} />)
@@ -457,6 +466,21 @@ describe('EditQuoteAside', () => {
 
         expect(mockDownload).toHaveBeenCalledTimes(1)
       })
+
+      it('THEN should build the PDF header from the quote number and version', () => {
+        render(<EditQuoteAside quote={mockQuote} />)
+
+        fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID))
+
+        expect(mockDownload).toHaveBeenCalledWith(
+          expect.objectContaining({
+            header: expect.objectContaining({
+              documentNumber: 'Q-001',
+              title: 'Quote #Q-001 - v1',
+            }),
+          }),
+        )
+      })
     })
 
     describe('WHEN the Approve button is clicked', () => {
@@ -476,6 +500,22 @@ describe('EditQuoteAside', () => {
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID)).toBeDisabled()
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID)).toBeDisabled()
         expect(screen.getAllByTestId(/processing/)).toHaveLength(2)
+      })
+
+      it('THEN should not trigger a PDF download while saving', () => {
+        render(<EditQuoteAside quote={mockQuote} isSaving />)
+
+        fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID))
+
+        expect(mockDownload).not.toHaveBeenCalled()
+      })
+
+      it('THEN should not navigate to approve while saving', () => {
+        render(<EditQuoteAside quote={mockQuote} isSaving />)
+
+        fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID))
+
+        expect(mockGoToApproveQuote).not.toHaveBeenCalled()
       })
     })
 

--- a/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
+++ b/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
@@ -470,11 +470,20 @@ describe('EditQuoteAside', () => {
     })
 
     describe('WHEN the quote is saving', () => {
-      it('THEN should disable both action buttons', () => {
+      it('THEN should disable both action buttons and show loading spinners', () => {
         render(<EditQuoteAside quote={mockQuote} isSaving />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID)).toBeDisabled()
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID)).toBeDisabled()
+        expect(screen.getAllByTestId(/processing/)).toHaveLength(2)
+      })
+    })
+
+    describe('WHEN the quote is NOT saving', () => {
+      it('THEN should not show any loading spinners', () => {
+        render(<EditQuoteAside quote={mockQuote} />)
+
+        expect(screen.queryAllByTestId(/processing/)).toHaveLength(0)
       })
     })
   })

--- a/translations/base.json
+++ b/translations/base.json
@@ -4356,5 +4356,6 @@
   "text_17817078224635v32b58mejt": "Lago provisions subscriptions and related billing records.",
   "text_17817078224637p2veq3bqwe": "Record the order that will be executed in another tool.",
   "text_1781707828627t3f7vohqvq8": "Ensure your document are in good condition and readable",
-  "text_1781859135627z59hpfpa8pt": "Billing anchor date"
+  "text_1781859135627z59hpfpa8pt": "Billing anchor date",
+  "text_1781883445506576p2jigfpx": "Quote #{{numberWithVersion}}"
 }


### PR DESCRIPTION
## Context

While testing, we decided to add other action buttons on the edit quote flow

## Description

This PR adds download pdf and approve quote button on the edit quote flow

<!-- Linear link -->
Fixes LAGO-1574