### PR TITLE
refactor(taxes): migrate RemoveTaxDialog to new dialog system

### DIFF
--- a/src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx
@@ -27,10 +27,7 @@ import {
   ApplyTaxDialogRef,
 } from '~/pages/settings/BillingEntity/sections/taxes/ApplyTaxDialog'
 import { APPLY_TAX_BUTTON_TEST_ID } from '~/pages/settings/BillingEntity/sections/taxes/dataTestConstants'
-import {
-  RemoveTaxDialog,
-  RemoveTaxDialogRef,
-} from '~/pages/settings/BillingEntity/sections/taxes/RemoveTaxDialog'
+import { useRemoveTaxDialog } from '~/pages/settings/BillingEntity/sections/taxes/RemoveTaxDialog'
 import ErrorImage from '~/public/images/maneki/error.svg'
 
 gql`
@@ -51,7 +48,7 @@ const BillingEntityTaxesSettings = () => {
   const { translate } = useInternationalization()
 
   const applyTaxDialogRef = useRef<ApplyTaxDialogRef>(null)
-  const removeTaxDialogRef = useRef<RemoveTaxDialogRef>(null)
+  const { openRemoveTaxDialog } = useRemoveTaxDialog()
 
   const { billingEntityCode } = useParams()
 
@@ -192,10 +189,10 @@ const BillingEntityTaxesSettings = () => {
                             variant="quaternary"
                             onClick={() => {
                               if (billingEntity?.id && tax) {
-                                removeTaxDialogRef?.current?.openDialog(
-                                  billingEntity?.id,
-                                  tax as Tax,
-                                )
+                                openRemoveTaxDialog({
+                                  billingEntityId: billingEntity.id,
+                                  tax: tax as Tax,
+                                })
                               }
                             }}
                           />
@@ -211,7 +208,6 @@ const BillingEntityTaxesSettings = () => {
       </SettingsPaddedContainer>
 
       <ApplyTaxDialog ref={applyTaxDialogRef} />
-      <RemoveTaxDialog ref={removeTaxDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/BillingEntity/sections/taxes/RemoveTaxDialog.tsx
+++ b/src/pages/settings/BillingEntity/sections/taxes/RemoveTaxDialog.tsx
@@ -1,8 +1,7 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import { Tax, useRemoveBillingEntityTaxesMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -15,17 +14,14 @@ gql`
   }
 `
 
-export type RemoveTaxDialogRef = {
-  openDialog: (billingEntityId: string, tax: Tax) => unknown
-  closeDialog: () => unknown
+type RemoveTaxDialogData = {
+  billingEntityId: string
+  tax: Tax
 }
 
-export const RemoveTaxDialog = forwardRef<RemoveTaxDialogRef>((_, ref) => {
+export const useRemoveTaxDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<WarningDialogRef>(null)
-
-  const [tax, setTax] = useState<Tax | null>(null)
-  const [billingEntityId, setBillingEntityId] = useState<string | null>(null)
 
   const [removeTax] = useRemoveBillingEntityTaxesMutation({
     onCompleted(data) {
@@ -39,38 +35,24 @@ export const RemoveTaxDialog = forwardRef<RemoveTaxDialogRef>((_, ref) => {
     refetchQueries: ['getBillingEntityTaxes'],
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (_billingEntityId, _tax) => {
-      setBillingEntityId(_billingEntityId)
-      setTax(_tax)
-
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => {
-      dialogRef.current?.closeDialog()
-    },
-  }))
-
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_1743241419871l3utqcy1e3h')}
-      description={<Typography>{translate('text_1743241419871xs0wuhvffq9')}</Typography>}
-      onContinue={async () => {
-        if (billingEntityId && tax) {
-          await removeTax({
-            variables: {
-              input: {
-                billingEntityId,
-                taxCodes: [tax.code],
-              },
+  const openRemoveTaxDialog = ({ billingEntityId, tax }: RemoveTaxDialogData) => {
+    centralizedDialog.open({
+      title: translate('text_1743241419871l3utqcy1e3h'),
+      description: <Typography>{translate('text_1743241419871xs0wuhvffq9')}</Typography>,
+      colorVariant: 'danger',
+      actionText: translate('text_645bb193927b375079d28b34'),
+      onAction: async () => {
+        await removeTax({
+          variables: {
+            input: {
+              billingEntityId,
+              taxCodes: [tax.code],
             },
-          })
-        }
-      }}
-      continueText={translate('text_645bb193927b375079d28b34')}
-    />
-  )
-})
+          },
+        })
+      },
+    })
+  }
 
-RemoveTaxDialog.displayName = 'RemoveTaxDialog'
+  return { openRemoveTaxDialog }
+}


### PR DESCRIPTION
## Summary

Migrates the legacy `WarningDialog`-based `RemoveTaxDialog` to the new hook-based `useCentralizedDialog` system, addressing the ESLint warning about the deprecated `~/components/designSystem/WarningDialog` import in `src/pages/settings/BillingEntity/sections/taxes/RemoveTaxDialog.tsx`.

## Changes

- **`src/pages/settings/BillingEntity/sections/taxes/RemoveTaxDialog.tsx`**
  - Converted the `forwardRef` component (`RemoveTaxDialog` + `RemoveTaxDialogRef`) into a custom hook `useRemoveTaxDialog` exposing `openRemoveTaxDialog`.
  - Replaced internal `useState` / `useImperativeHandle` / `WarningDialog` plumbing with a single `centralizedDialog.open(...)` call (`colorVariant: 'danger'`).
  - Data (`billingEntityId`, `tax`) is now passed as an argument to the open function instead of via `setState` + ref.
  - Same translations, mutation behavior and toast retained.

- **`src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx`**
  - Replaced the `useRef<RemoveTaxDialogRef>` + JSX `<RemoveTaxDialog ref={...} />` with `const { openRemoveTaxDialog } = useRemoveTaxDialog()`.
  - Updated the trash-action callback to call `openRemoveTaxDialog({ billingEntityId, tax })` directly.

## Scope

The migration is intentionally scoped to the single ESLint warning for `RemoveTaxDialog`. The sibling `ApplyTaxDialog` (still on the legacy `Dialog` ref-based pattern but already form-driven) is left untouched to keep this PR focused — it can be migrated in a follow-up.

## Verification

- `pnpm tsc --noEmit` ✅
- `pnpm eslint` — no new warnings/errors, and the `WarningDialog` warning for `RemoveTaxDialog.tsx` no longer appears in the list.

## Test plan

- [ ] Open `Settings → Billing entity → Taxes`.
- [ ] Apply a tax to the billing entity (existing flow, unchanged).
- [ ] Click the trash icon on a tax row → confirm the new centralized confirmation dialog opens with the same title/description/danger styling.
- [ ] Click Cancel → dialog closes, tax unchanged.
- [ ] Click the destructive action → mutation fires, success toast appears, taxes list refetches.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KJ8k84rKGaTiuR1Nxs2GoH)_