### PR TITLE
feat(order-forms): filter on order forms list

### DIFF
--- a/src/components/designSystem/Filters/FiltersPanelItemTypeSwitch.tsx
+++ b/src/components/designSystem/Filters/FiltersPanelItemTypeSwitch.tsx
@@ -32,6 +32,7 @@ import { FiltersItemLogEventsAndTypes } from '~/components/designSystem/Filters/
 import { FiltersItemLoggedDate } from '~/components/designSystem/Filters/filtersElements/FiltersItemLoggedDate'
 import { FiltersItemMetadata } from '~/components/designSystem/Filters/filtersElements/FiltersItemMetadata'
 import { FiltersItemMultipleCustomers } from '~/components/designSystem/Filters/filtersElements/FiltersItemMultipleCustomers'
+import { FiltersItemOrderFormNumber } from '~/components/designSystem/Filters/filtersElements/FiltersItemOrderFormNumber'
 import { FiltersItemOrderFormStatus } from '~/components/designSystem/Filters/filtersElements/FiltersItemOrderFormStatus'
 import { FiltersItemOverridden } from '~/components/designSystem/Filters/filtersElements/FiltersItemOverridden'
 import { FiltersItemPartiallyPaid } from '~/components/designSystem/Filters/filtersElements/FiltersItemPartiallyPaid'
@@ -143,6 +144,7 @@ export const FiltersPanelItemTypeSwitch = ({
     [AvailableFiltersEnum.userIds]: <FiltersItemUserIds {...props} />,
     [AvailableFiltersEnum.multipleCustomers]: <FiltersItemMultipleCustomers {...props} />,
     [AvailableFiltersEnum.orderFormCreatedAt]: <FiltersItemDate {...props} />,
+    [AvailableFiltersEnum.orderFormNumber]: <FiltersItemOrderFormNumber {...props} />,
     [AvailableFiltersEnum.orderFormStatus]: <FiltersItemOrderFormStatus {...props} />,
     [AvailableFiltersEnum.quoteCreatedAt]: <FiltersItemDate {...props} />,
     [AvailableFiltersEnum.quoteNumber]: <FiltersItemQuoteNumber {...props} />,

--- a/src/components/designSystem/Filters/FiltersPanelItemTypeSwitch.tsx
+++ b/src/components/designSystem/Filters/FiltersPanelItemTypeSwitch.tsx
@@ -32,6 +32,7 @@ import { FiltersItemLogEventsAndTypes } from '~/components/designSystem/Filters/
 import { FiltersItemLoggedDate } from '~/components/designSystem/Filters/filtersElements/FiltersItemLoggedDate'
 import { FiltersItemMetadata } from '~/components/designSystem/Filters/filtersElements/FiltersItemMetadata'
 import { FiltersItemMultipleCustomers } from '~/components/designSystem/Filters/filtersElements/FiltersItemMultipleCustomers'
+import { FiltersItemOrderFormStatus } from '~/components/designSystem/Filters/filtersElements/FiltersItemOrderFormStatus'
 import { FiltersItemOverridden } from '~/components/designSystem/Filters/filtersElements/FiltersItemOverridden'
 import { FiltersItemPartiallyPaid } from '~/components/designSystem/Filters/filtersElements/FiltersItemPartiallyPaid'
 import { FiltersItemPaymentDisputeLost } from '~/components/designSystem/Filters/filtersElements/FiltersItemPaymentDisputeLost'
@@ -141,6 +142,8 @@ export const FiltersPanelItemTypeSwitch = ({
     [AvailableFiltersEnum.webhookHttpStatuses]: <FiltersItemWebhookHttpStatuses {...props} />,
     [AvailableFiltersEnum.userIds]: <FiltersItemUserIds {...props} />,
     [AvailableFiltersEnum.multipleCustomers]: <FiltersItemMultipleCustomers {...props} />,
+    [AvailableFiltersEnum.orderFormCreatedAt]: <FiltersItemDate {...props} />,
+    [AvailableFiltersEnum.orderFormStatus]: <FiltersItemOrderFormStatus {...props} />,
     [AvailableFiltersEnum.quoteCreatedAt]: <FiltersItemDate {...props} />,
     [AvailableFiltersEnum.quoteNumber]: <FiltersItemQuoteNumber {...props} />,
     [AvailableFiltersEnum.quoteOrderType]: <FiltersItemQuoteOrderType {...props} />,

--- a/src/components/designSystem/Filters/__tests__/utils.test.ts
+++ b/src/components/designSystem/Filters/__tests__/utils.test.ts
@@ -9,6 +9,7 @@ import {
   formatFiltersForCustomerQuery,
   formatFiltersForInvoiceQuery,
   formatFiltersForMrrQuery,
+  formatFiltersForOrderFormsQuery,
   formatFiltersForQuery,
   formatFiltersForQuotesQuery,
   formatFiltersForRevenueStreamsQuery,
@@ -1405,6 +1406,87 @@ describe('Filters utils', () => {
         }),
       )
       expect(result).not.toHaveProperty('logTypes')
+    })
+  })
+
+  describe('formatFiltersForOrderFormsQuery', () => {
+    it('should format order form status filter with prefix', () => {
+      const searchParams = new URLSearchParams()
+
+      searchParams.set('of_orderFormStatus', 'generated,signed')
+
+      const result = formatFiltersForOrderFormsQuery(searchParams)
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          status: ['generated', 'signed'],
+        }),
+      )
+    })
+
+    it('should format multipleCustomers filter as customerId extracting ids', () => {
+      const searchParams = new URLSearchParams()
+
+      searchParams.set(
+        'of_multipleCustomers',
+        `cust-1${filterDataInlineSeparator}Acme Corp,cust-2${filterDataInlineSeparator}Beta Inc`,
+      )
+
+      const result = formatFiltersForOrderFormsQuery(searchParams)
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          customerId: ['cust-1', 'cust-2'],
+        }),
+      )
+    })
+
+    it('should format orderFormCreatedAt into createdAtFrom and createdAtTo', () => {
+      const searchParams = new URLSearchParams()
+
+      searchParams.set('of_orderFormCreatedAt', '2026-01-01,2026-01-31')
+
+      const result = formatFiltersForOrderFormsQuery(searchParams)
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          createdAtFrom: '2026-01-01',
+          createdAtTo: '2026-01-31',
+        }),
+      )
+    })
+
+    it('should format userIds filter as ownerId', () => {
+      const searchParams = new URLSearchParams()
+
+      searchParams.set(
+        'of_userIds',
+        `user-1${filterDataInlineSeparator}alice@example.com,user-2${filterDataInlineSeparator}bob@example.com`,
+      )
+
+      const result = formatFiltersForOrderFormsQuery(searchParams)
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          ownerId: ['user-1', 'user-2'],
+        }),
+      )
+    })
+
+    it('should ignore filters with a different prefix', () => {
+      const searchParams = new URLSearchParams()
+
+      searchParams.set('qu_quoteStatus', 'draft')
+      searchParams.set('of_orderFormStatus', 'signed')
+
+      const result = formatFiltersForOrderFormsQuery(searchParams)
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          status: ['signed'],
+        }),
+      )
+      expect(result).not.toHaveProperty('statuses')
     })
   })
 })

--- a/src/components/designSystem/Filters/__tests__/utils.test.ts
+++ b/src/components/designSystem/Filters/__tests__/utils.test.ts
@@ -1424,6 +1424,20 @@ describe('Filters utils', () => {
       )
     })
 
+    it('should format order form number filter as number', () => {
+      const searchParams = new URLSearchParams()
+
+      searchParams.set('of_orderFormNumber', 'OF-001,OF-002')
+
+      const result = formatFiltersForOrderFormsQuery(searchParams)
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          number: ['OF-001', 'OF-002'],
+        }),
+      )
+    })
+
     it('should format multipleCustomers filter as customerId extracting ids', () => {
       const searchParams = new URLSearchParams()
 

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemOrderFormNumber.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemOrderFormNumber.tsx
@@ -1,0 +1,32 @@
+import { MultipleComboBox } from '~/components/form'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+import { FiltersFormValues } from '../types'
+
+type FiltersItemOrderFormNumberProps = {
+  value: FiltersFormValues['filters'][0]['value']
+  setFilterValue: (value: string) => void
+}
+
+export const FiltersItemOrderFormNumber = ({
+  value,
+  setFilterValue,
+}: FiltersItemOrderFormNumberProps) => {
+  const { translate } = useInternationalization()
+
+  return (
+    <MultipleComboBox
+      freeSolo
+      disableClearable
+      placeholder={translate('text_66ab42d4ece7e6b7078993b1')}
+      data={[]}
+      onChange={(numbers) => {
+        setFilterValue(String(numbers.map((v) => v.value).join(',')))
+      }}
+      value={value
+        ?.split(',')
+        .filter((v) => !!v)
+        .map((v) => ({ value: v }))}
+    />
+  )
+}

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemOrderFormStatus.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemOrderFormStatus.tsx
@@ -1,0 +1,50 @@
+import { MultipleComboBox } from '~/components/form'
+import { OrderFormStatusEnum } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+import { FiltersFormValues } from '../types'
+
+type FiltersItemOrderFormStatusProps = {
+  value: FiltersFormValues['filters'][0]['value']
+  setFilterValue: (value: string) => void
+}
+
+export const FiltersItemOrderFormStatus = ({
+  value,
+  setFilterValue,
+}: FiltersItemOrderFormStatusProps) => {
+  const { translate } = useInternationalization()
+
+  return (
+    <MultipleComboBox
+      disableClearable
+      disableCloseOnSelect
+      placeholder={translate('text_66ab42d4ece7e6b7078993b1')}
+      data={[
+        {
+          label: translate('text_17766979384805q6wx9it6wa'),
+          value: OrderFormStatusEnum.Generated,
+        },
+        {
+          label: translate('text_1776697938480b1fi7wqtzyi'),
+          value: OrderFormStatusEnum.Signed,
+        },
+        {
+          label: translate('text_1776697938480ap28ussl837'),
+          value: OrderFormStatusEnum.Expired,
+        },
+        {
+          label: translate('text_1776697938480hzc1xsmmpez'),
+          value: OrderFormStatusEnum.Voided,
+        },
+      ]}
+      onChange={(statuses) => {
+        setFilterValue(String(statuses.map((v) => v.value).join(',')))
+      }}
+      value={value
+        ?.split(',')
+        .filter((v) => !!v)
+        .map((v) => ({ value: v }))}
+    />
+  )
+}

--- a/src/components/designSystem/Filters/filtersElements/__tests__/FiltersItemOrderFormNumber.test.tsx
+++ b/src/components/designSystem/Filters/filtersElements/__tests__/FiltersItemOrderFormNumber.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from '@testing-library/react'
+
+import { AllTheProviders } from '~/test-utils'
+
+import { FiltersItemOrderFormNumber } from '../FiltersItemOrderFormNumber'
+
+const mockSetFilterValue = jest.fn()
+
+const renderComponent = (value?: string) => {
+  return render(<FiltersItemOrderFormNumber value={value} setFilterValue={mockSetFilterValue} />, {
+    wrapper: AllTheProviders,
+  })
+}
+
+describe('FiltersItemOrderFormNumber', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN no initial value', () => {
+    it('THEN displays the combobox', async () => {
+      renderComponent()
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN undefined value', () => {
+    it('THEN should not crash and displays the combobox', async () => {
+      renderComponent(undefined)
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a single order form number', () => {
+    it('THEN displays the number as a chip', async () => {
+      renderComponent('OF-001')
+
+      await waitFor(() => {
+        expect(screen.getByText('OF-001')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN multiple order form numbers', () => {
+    it('THEN displays all number chips', async () => {
+      renderComponent('OF-001,OF-002')
+
+      await waitFor(() => {
+        expect(screen.getByText('OF-001')).toBeInTheDocument()
+        expect(screen.getByText('OF-002')).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/components/designSystem/Filters/filtersElements/__tests__/FiltersItemOrderFormStatus.test.tsx
+++ b/src/components/designSystem/Filters/filtersElements/__tests__/FiltersItemOrderFormStatus.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/react'
+
+import { OrderFormStatusEnum } from '~/generated/graphql'
+import { AllTheProviders } from '~/test-utils'
+
+import { FiltersItemOrderFormStatus } from '../FiltersItemOrderFormStatus'
+
+const mockSetFilterValue = jest.fn()
+
+const renderComponent = (value?: string) => {
+  return render(<FiltersItemOrderFormStatus value={value} setFilterValue={mockSetFilterValue} />, {
+    wrapper: AllTheProviders,
+  })
+}
+
+describe('FiltersItemOrderFormStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN no initial value', () => {
+    it('THEN displays the combobox', async () => {
+      renderComponent()
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a single value', () => {
+    it.each([
+      ['generated', OrderFormStatusEnum.Generated],
+      ['signed', OrderFormStatusEnum.Signed],
+      ['expired', OrderFormStatusEnum.Expired],
+      ['voided', OrderFormStatusEnum.Voided],
+    ])('THEN displays chip for %s', async (_, enumValue) => {
+      renderComponent(enumValue)
+
+      await waitFor(() => {
+        expect(screen.getByText(enumValue)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN multiple values', () => {
+    it('THEN displays all chips', async () => {
+      const multipleValues = `${OrderFormStatusEnum.Generated},${OrderFormStatusEnum.Signed}`
+
+      renderComponent(multipleValues)
+
+      await waitFor(() => {
+        expect(screen.getByText(OrderFormStatusEnum.Generated)).toBeInTheDocument()
+        expect(screen.getByText(OrderFormStatusEnum.Signed)).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/components/designSystem/Filters/types.ts
+++ b/src/components/designSystem/Filters/types.ts
@@ -82,6 +82,7 @@ export enum AvailableFiltersEnum {
   paymentStatus = 'paymentStatus',
   planCode = 'planCode',
   orderFormCreatedAt = 'orderFormCreatedAt',
+  orderFormNumber = 'orderFormNumber',
   orderFormStatus = 'orderFormStatus',
   quoteCreatedAt = 'quoteCreatedAt',
   quoteNumber = 'quoteNumber',
@@ -330,6 +331,7 @@ export const QuoteAvailableFilters = [
 export const OrderFormAvailableFilters = [
   AvailableFiltersEnum.orderFormStatus,
   AvailableFiltersEnum.multipleCustomers,
+  AvailableFiltersEnum.orderFormNumber,
   AvailableFiltersEnum.orderFormCreatedAt,
   AvailableFiltersEnum.userIds,
 ]
@@ -377,6 +379,7 @@ const translationMap: Record<AvailableFiltersEnum, string> = {
   [AvailableFiltersEnum.paymentStatus]: 'text_63eba8c65a6c8043feee2a0f',
   [AvailableFiltersEnum.planCode]: 'text_642d5eb2783a2ad10d670320',
   [AvailableFiltersEnum.orderFormCreatedAt]: 'text_1776870266380s3zbpmnfrhj',
+  [AvailableFiltersEnum.orderFormNumber]: 'text_1781624189693d7zcv2vog4c',
   [AvailableFiltersEnum.orderFormStatus]: 'text_63ac86d797f728a87b2f9fa7',
   [AvailableFiltersEnum.quoteCreatedAt]: 'text_1776870266380s3zbpmnfrhj',
   [AvailableFiltersEnum.quoteNumber]: 'text_1776870266380lnc721e4opb',

--- a/src/components/designSystem/Filters/types.ts
+++ b/src/components/designSystem/Filters/types.ts
@@ -81,6 +81,8 @@ export enum AvailableFiltersEnum {
   paymentOverdue = 'paymentOverdue',
   paymentStatus = 'paymentStatus',
   planCode = 'planCode',
+  orderFormCreatedAt = 'orderFormCreatedAt',
+  orderFormStatus = 'orderFormStatus',
   quoteCreatedAt = 'quoteCreatedAt',
   quoteNumber = 'quoteNumber',
   quoteOrderType = 'quoteOrderType',
@@ -325,6 +327,13 @@ export const QuoteAvailableFilters = [
   AvailableFiltersEnum.userIds,
 ]
 
+export const OrderFormAvailableFilters = [
+  AvailableFiltersEnum.orderFormStatus,
+  AvailableFiltersEnum.multipleCustomers,
+  AvailableFiltersEnum.orderFormCreatedAt,
+  AvailableFiltersEnum.userIds,
+]
+
 const translationMap: Record<AvailableFiltersEnum, string> = {
   [AvailableFiltersEnum.activityIds]: 'text_1747666154075d10admbnf16',
   [AvailableFiltersEnum.activitySources]: 'text_1747666154075g4ceq9ii0xm',
@@ -367,6 +376,8 @@ const translationMap: Record<AvailableFiltersEnum, string> = {
   [AvailableFiltersEnum.paymentOverdue]: 'text_666c5b12fea4aa1e1b26bf55',
   [AvailableFiltersEnum.paymentStatus]: 'text_63eba8c65a6c8043feee2a0f',
   [AvailableFiltersEnum.planCode]: 'text_642d5eb2783a2ad10d670320',
+  [AvailableFiltersEnum.orderFormCreatedAt]: 'text_1776870266380s3zbpmnfrhj',
+  [AvailableFiltersEnum.orderFormStatus]: 'text_63ac86d797f728a87b2f9fa7',
   [AvailableFiltersEnum.quoteCreatedAt]: 'text_1776870266380s3zbpmnfrhj',
   [AvailableFiltersEnum.quoteNumber]: 'text_1776870266380lnc721e4opb',
   [AvailableFiltersEnum.quoteOrderType]: 'text_1776870266380ydi5pjfjcqq',

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -24,6 +24,7 @@ import {
   INVOICE_LIST_FILTER_PREFIX,
   MRR_BREAKDOWN_OVERVIEW_FILTER_PREFIX,
   MRR_BREAKDOWN_PLANS_FILTER_PREFIX,
+  ORDER_FORM_LIST_FILTER_PREFIX,
   PREPAID_CREDITS_OVERVIEW_FILTER_PREFIX,
   QUOTE_LIST_FILTER_PREFIX,
   REVENUE_STREAMS_BREAKDOWN_CUSTOMER_FILTER_PREFIX,
@@ -47,6 +48,7 @@ import {
   type GetInvoiceCollectionsForAnalyticsQueryVariables,
   type GetInvoicesListQueryVariables,
   type GetMrrsQueryVariables,
+  type GetOrderFormsQueryVariables,
   type GetPrepaidCreditsQueryVariables,
   type GetQuotesQueryVariables,
   type GetRevenueStreamsQueryVariables,
@@ -81,6 +83,7 @@ import {
   InvoiceAvailableFilters,
   MrrBreakdownPlansAvailableFilters,
   MrrOverviewAvailableFilters,
+  OrderFormAvailableFilters,
   QuoteAvailableFilters,
   RevenueStreamsAvailablePopperFilters,
   RevenueStreamsCustomersAvailableFilters,
@@ -160,6 +163,7 @@ export const FiltersItemDates = [
   AvailableFiltersEnum.loggedDate,
   AvailableFiltersEnum.webhookDate,
   AvailableFiltersEnum.quoteCreatedAt,
+  AvailableFiltersEnum.orderFormCreatedAt,
 ]
 
 // TODO: Fix this type
@@ -227,6 +231,13 @@ export const FILTER_VALUE_MAP: Record<AvailableFiltersEnum, Function> = {
   [AvailableFiltersEnum.paymentOverdue]: (value: string) => value === 'true',
   [AvailableFiltersEnum.paymentStatus]: (value: string) => (value as string).split(','),
   [AvailableFiltersEnum.planCode]: (value: string) => value,
+  [AvailableFiltersEnum.orderFormCreatedAt]: (value: string) => {
+    return {
+      createdAtFrom: value.split(',')[0],
+      createdAtTo: value.split(',')[1],
+    }
+  },
+  [AvailableFiltersEnum.orderFormStatus]: (value: string) => value.split(','),
   [AvailableFiltersEnum.quoteCreatedAt]: (value: string) => {
     return {
       fromDate: value.split(',')[0],
@@ -976,6 +987,7 @@ export const formatActiveFilterValueDisplay = (
     case AvailableFiltersEnum.loggedDate:
     case AvailableFiltersEnum.webhookDate:
     case AvailableFiltersEnum.quoteCreatedAt:
+    case AvailableFiltersEnum.orderFormCreatedAt:
       return value
         .split(',')
         .map((v) => {
@@ -1044,6 +1056,27 @@ export const formatFiltersForQuotesQuery = (searchParams: URLSearchParams): Quot
       [AvailableFiltersEnum.quoteNumber]: 'numbers',
       [AvailableFiltersEnum.quoteOrderType]: 'orderTypes',
       [AvailableFiltersEnum.userIds]: 'owners',
+    },
+  })
+
+type OrderFormsQueryFilters = Partial<
+  Pick<
+    GetOrderFormsQueryVariables,
+    'status' | 'customerId' | 'ownerId' | 'createdAtFrom' | 'createdAtTo'
+  >
+>
+
+export const formatFiltersForOrderFormsQuery = (
+  searchParams: URLSearchParams,
+): OrderFormsQueryFilters =>
+  formatFiltersForQuery<OrderFormsQueryFilters>({
+    searchParams,
+    availableFilters: OrderFormAvailableFilters,
+    filtersNamePrefix: ORDER_FORM_LIST_FILTER_PREFIX,
+    keyMap: {
+      [AvailableFiltersEnum.orderFormStatus]: 'status',
+      [AvailableFiltersEnum.multipleCustomers]: 'customerId',
+      [AvailableFiltersEnum.userIds]: 'ownerId',
     },
   })
 

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -237,6 +237,7 @@ export const FILTER_VALUE_MAP: Record<AvailableFiltersEnum, Function> = {
       createdAtTo: value.split(',')[1],
     }
   },
+  [AvailableFiltersEnum.orderFormNumber]: (value: string) => value.split(','),
   [AvailableFiltersEnum.orderFormStatus]: (value: string) => value.split(','),
   [AvailableFiltersEnum.quoteCreatedAt]: (value: string) => {
     return {
@@ -1062,7 +1063,7 @@ export const formatFiltersForQuotesQuery = (searchParams: URLSearchParams): Quot
 type OrderFormsQueryFilters = Partial<
   Pick<
     GetOrderFormsQueryVariables,
-    'status' | 'customerId' | 'ownerId' | 'createdAtFrom' | 'createdAtTo'
+    'status' | 'number' | 'customerId' | 'ownerId' | 'createdAtFrom' | 'createdAtTo'
   >
 >
 
@@ -1075,6 +1076,7 @@ export const formatFiltersForOrderFormsQuery = (
     filtersNamePrefix: ORDER_FORM_LIST_FILTER_PREFIX,
     keyMap: {
       [AvailableFiltersEnum.orderFormStatus]: 'status',
+      [AvailableFiltersEnum.orderFormNumber]: 'number',
       [AvailableFiltersEnum.multipleCustomers]: 'customerId',
       [AvailableFiltersEnum.userIds]: 'ownerId',
     },

--- a/src/core/constants/filters.ts
+++ b/src/core/constants/filters.ts
@@ -34,6 +34,8 @@ export const SECURITY_LOGS_FILTER_PREFIX = 'secul'
 
 export const QUOTE_LIST_FILTER_PREFIX = 'qu'
 
+export const ORDER_FORM_LIST_FILTER_PREFIX = 'of'
+
 export const CUSTOMER_ANALYTICS_FILTER_PREFIX = 'cua'
 
 export const CUSTOMER_INVOICES_DRAFT_FILTER_PREFIX = 'cid'

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -14398,6 +14398,10 @@ export type GetOrderFormsQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
   status?: InputMaybe<Array<OrderFormStatusEnum> | OrderFormStatusEnum>;
   quoteNumber?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
+  customerId?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
+  ownerId?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
+  createdAtFrom?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
+  createdAtTo?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
 }>;
 
 
@@ -39320,12 +39324,16 @@ export type UpdateCustomerCurrencyForQuoteMutationHookResult = ReturnType<typeof
 export type UpdateCustomerCurrencyForQuoteMutationResult = Apollo.MutationResult<UpdateCustomerCurrencyForQuoteMutation>;
 export type UpdateCustomerCurrencyForQuoteMutationOptions = Apollo.BaseMutationOptions<UpdateCustomerCurrencyForQuoteMutation, UpdateCustomerCurrencyForQuoteMutationVariables>;
 export const GetOrderFormsDocument = gql`
-    query getOrderForms($page: Int, $limit: Int, $status: [OrderFormStatusEnum!], $quoteNumber: [String!]) {
+    query getOrderForms($page: Int, $limit: Int, $status: [OrderFormStatusEnum!], $quoteNumber: [String!], $customerId: [ID!], $ownerId: [ID!], $createdAtFrom: ISO8601DateTime, $createdAtTo: ISO8601DateTime) {
   orderForms(
     page: $page
     limit: $limit
     status: $status
     quoteNumber: $quoteNumber
+    customerId: $customerId
+    ownerId: $ownerId
+    createdAtFrom: $createdAtFrom
+    createdAtTo: $createdAtTo
   ) {
     metadata {
       currentPage
@@ -39355,6 +39363,10 @@ export const GetOrderFormsDocument = gql`
  *      limit: // value for 'limit'
  *      status: // value for 'status'
  *      quoteNumber: // value for 'quoteNumber'
+ *      customerId: // value for 'customerId'
+ *      ownerId: // value for 'ownerId'
+ *      createdAtFrom: // value for 'createdAtFrom'
+ *      createdAtTo: // value for 'createdAtTo'
  *   },
  * });
  */

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -14398,6 +14398,7 @@ export type GetOrderFormsQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
   status?: InputMaybe<Array<OrderFormStatusEnum> | OrderFormStatusEnum>;
   quoteNumber?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
+  number?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
   customerId?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
   ownerId?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
   createdAtFrom?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
@@ -39324,12 +39325,13 @@ export type UpdateCustomerCurrencyForQuoteMutationHookResult = ReturnType<typeof
 export type UpdateCustomerCurrencyForQuoteMutationResult = Apollo.MutationResult<UpdateCustomerCurrencyForQuoteMutation>;
 export type UpdateCustomerCurrencyForQuoteMutationOptions = Apollo.BaseMutationOptions<UpdateCustomerCurrencyForQuoteMutation, UpdateCustomerCurrencyForQuoteMutationVariables>;
 export const GetOrderFormsDocument = gql`
-    query getOrderForms($page: Int, $limit: Int, $status: [OrderFormStatusEnum!], $quoteNumber: [String!], $customerId: [ID!], $ownerId: [ID!], $createdAtFrom: ISO8601DateTime, $createdAtTo: ISO8601DateTime) {
+    query getOrderForms($page: Int, $limit: Int, $status: [OrderFormStatusEnum!], $quoteNumber: [String!], $number: [String!], $customerId: [ID!], $ownerId: [ID!], $createdAtFrom: ISO8601DateTime, $createdAtTo: ISO8601DateTime) {
   orderForms(
     page: $page
     limit: $limit
     status: $status
     quoteNumber: $quoteNumber
+    number: $number
     customerId: $customerId
     ownerId: $ownerId
     createdAtFrom: $createdAtFrom
@@ -39363,6 +39365,7 @@ export const GetOrderFormsDocument = gql`
  *      limit: // value for 'limit'
  *      status: // value for 'status'
  *      quoteNumber: // value for 'quoteNumber'
+ *      number: // value for 'number'
  *      customerId: // value for 'customerId'
  *      ownerId: // value for 'ownerId'
  *      createdAtFrom: // value for 'createdAtFrom'

--- a/src/pages/quotes/OrderFormsList.tsx
+++ b/src/pages/quotes/OrderFormsList.tsx
@@ -1,3 +1,7 @@
+import { useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+import { formatFiltersForOrderFormsQuery } from '~/components/designSystem/Filters'
 import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Table, TableColumn } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
@@ -22,9 +26,17 @@ interface OrderFormsListProps {
 const OrderFormsList = ({ quoteNumber }: OrderFormsListProps): JSX.Element => {
   const { translate } = useInternationalization()
   const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
-  const { orderForms, loading, error, fetchMore, metadata } = useOrderForms(
-    quoteNumber ? { quoteNumber: [quoteNumber] } : undefined,
+  const [searchParams] = useSearchParams()
+
+  const filtersForOrderFormsQuery = useMemo(
+    () => formatFiltersForOrderFormsQuery(searchParams),
+    [searchParams],
   )
+
+  const { orderForms, loading, error, fetchMore, metadata } = useOrderForms({
+    ...filtersForOrderFormsQuery,
+    ...(quoteNumber ? { quoteNumber: [quoteNumber] } : {}),
+  })
   const { getActions } = useOrderFormActions()
 
   const columns: Array<TableColumn<OrderFormListItemFragment>> = [

--- a/src/pages/quotes/Quotes.tsx
+++ b/src/pages/quotes/Quotes.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useMemo } from 'react'
-import { generatePath } from 'react-router-dom'
+import { generatePath, useParams } from 'react-router-dom'
 
-import { AvailableFiltersEnum, Filters } from '~/components/designSystem/Filters'
+import {
+  Filters,
+  OrderFormAvailableFilters,
+  QuoteAvailableFilters,
+} from '~/components/designSystem/Filters'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { useMainHeaderTabContent } from '~/components/MainHeader/useMainHeaderTabContent'
 import PremiumFeature from '~/components/premium/PremiumFeature'
-import { QUOTE_LIST_FILTER_PREFIX } from '~/core/constants/filters'
+import { ORDER_FORM_LIST_FILTER_PREFIX, QUOTE_LIST_FILTER_PREFIX } from '~/core/constants/filters'
 import { QuotesTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import {
   CREATE_QUOTE_ROUTE,
@@ -31,6 +35,8 @@ const Quotes = (): JSX.Element => {
   const { hasPermissions } = usePermissions()
   const canCreateQuotes = hasPermissions(['quotesCreate'])
   const { isPremium } = useCurrentUser()
+  const { tab } = useParams()
+  const isOrderFormsTab = tab === QuotesTabsOptionsEnum.orderForms
 
   useEffect(() => {
     if (pathname === QUOTES_LIST_ROUTE) {
@@ -95,15 +101,13 @@ const Quotes = (): JSX.Element => {
               filtersSection: (
                 <div className="pt-4">
                   <Filters.Provider
-                    filtersNamePrefix={QUOTE_LIST_FILTER_PREFIX}
-                    availableFilters={[
-                      AvailableFiltersEnum.quoteStatus,
-                      AvailableFiltersEnum.multipleCustomers,
-                      AvailableFiltersEnum.quoteNumber,
-                      AvailableFiltersEnum.quoteCreatedAt,
-                      AvailableFiltersEnum.quoteOrderType,
-                      AvailableFiltersEnum.userIds,
-                    ]}
+                    key={isOrderFormsTab ? 'order-forms' : 'quotes'}
+                    filtersNamePrefix={
+                      isOrderFormsTab ? ORDER_FORM_LIST_FILTER_PREFIX : QUOTE_LIST_FILTER_PREFIX
+                    }
+                    availableFilters={
+                      isOrderFormsTab ? OrderFormAvailableFilters : QuoteAvailableFilters
+                    }
                   >
                     <Filters.Component />
                   </Filters.Provider>

--- a/src/pages/quotes/Quotes.tsx
+++ b/src/pages/quotes/Quotes.tsx
@@ -86,6 +86,10 @@ const Quotes = (): JSX.Element => {
         {...(isPremium
           ? {
               tabs,
+              // The filtersSection is tab-dependent but stripped from the config snapshot
+              // (it's a ReactNode). Bump snapshotKey per tab so switching tabs re-pushes the
+              // matching filter panel instead of leaving the previous tab's panel in context.
+              snapshotKey: isOrderFormsTab ? 'order-forms' : 'quotes',
               actions: {
                 items: [
                   {

--- a/src/pages/quotes/__tests__/OrderFormsList.test.tsx
+++ b/src/pages/quotes/__tests__/OrderFormsList.test.tsx
@@ -46,6 +46,13 @@ jest.mock('~/pages/quotes/common/QuotePdfProvider', () => ({
   useDownloadQuotePdf: () => ({ download: jest.fn() }),
 }))
 
+let mockSearchParams = new URLSearchParams()
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useSearchParams: () => [mockSearchParams, jest.fn()],
+}))
+
 const mockUseOrderForms = useOrderForms as jest.MockedFunction<typeof useOrderForms>
 
 const mockOrderForms = [
@@ -90,6 +97,7 @@ const mockOrderForms = [
 describe('OrderFormsList', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockSearchParams = new URLSearchParams()
     mockHasPermissions.mockReturnValue(true)
     mockUseOrderForms.mockReturnValue({
       orderForms: mockOrderForms,
@@ -174,6 +182,77 @@ describe('OrderFormsList', () => {
         const actionButtons = screen.getAllByTestId('open-action-button')
 
         expect(actionButtons.length).toBeGreaterThan(0)
+      })
+    })
+  })
+
+  describe('GIVEN no URL filters and no quoteNumber prop', () => {
+    describe('WHEN the component renders', () => {
+      it('THEN should call useOrderForms with no filter variables', () => {
+        render(<OrderFormsList />)
+
+        expect(mockUseOrderForms).toHaveBeenCalledWith({})
+      })
+    })
+  })
+
+  describe('GIVEN of_-prefixed URL filters are present', () => {
+    describe('WHEN the component renders', () => {
+      it('THEN should pass the formatted status filter to useOrderForms', () => {
+        mockSearchParams = new URLSearchParams()
+        mockSearchParams.set('of_orderFormStatus', 'generated,signed')
+
+        render(<OrderFormsList />)
+
+        expect(mockUseOrderForms).toHaveBeenCalledWith(
+          expect.objectContaining({ status: ['generated', 'signed'] }),
+        )
+      })
+
+      it('THEN should pass the formatted number filter to useOrderForms', () => {
+        mockSearchParams = new URLSearchParams()
+        mockSearchParams.set('of_orderFormNumber', 'OF-001,OF-002')
+
+        render(<OrderFormsList />)
+
+        expect(mockUseOrderForms).toHaveBeenCalledWith(
+          expect.objectContaining({ number: ['OF-001', 'OF-002'] }),
+        )
+      })
+
+      it('THEN should ignore filters with a different prefix', () => {
+        mockSearchParams = new URLSearchParams()
+        mockSearchParams.set('qu_quoteStatus', 'draft')
+
+        render(<OrderFormsList />)
+
+        expect(mockUseOrderForms).toHaveBeenCalledWith({})
+      })
+    })
+  })
+
+  describe('GIVEN the quoteNumber prop is provided', () => {
+    describe('WHEN the component renders', () => {
+      it('THEN should pass the quoteNumber to useOrderForms', () => {
+        render(<OrderFormsList quoteNumber="QUO-001" />)
+
+        expect(mockUseOrderForms).toHaveBeenCalledWith(
+          expect.objectContaining({ quoteNumber: ['QUO-001'] }),
+        )
+      })
+
+      it('THEN should merge the quoteNumber prop with URL filters', () => {
+        mockSearchParams = new URLSearchParams()
+        mockSearchParams.set('of_orderFormStatus', 'signed')
+
+        render(<OrderFormsList quoteNumber="QUO-001" />)
+
+        expect(mockUseOrderForms).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: ['signed'],
+            quoteNumber: ['QUO-001'],
+          }),
+        )
       })
     })
   })

--- a/src/pages/quotes/__tests__/Quotes.test.tsx
+++ b/src/pages/quotes/__tests__/Quotes.test.tsx
@@ -27,11 +27,13 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 }))
 
 const mockNavigate = jest.fn()
+const mockUseParams = jest.fn()
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
   useLocation: () => ({ pathname: '/quotes/quotes' }),
+  useParams: () => mockUseParams(),
 }))
 
 const mockHasPermissions = jest.fn()
@@ -51,6 +53,7 @@ describe('Quotes', () => {
     jest.clearAllMocks()
     capturedConfig = null
     mockIsPremium.mockReturnValue(true)
+    mockUseParams.mockReturnValue({})
   })
 
   describe('GIVEN the page is rendered', () => {
@@ -172,6 +175,48 @@ describe('Quotes', () => {
         render(<Quotes />)
 
         expect(screen.getByTestId('quotes-premium-feature')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN the user is on the Quotes tab', () => {
+    beforeEach(() => {
+      mockHasPermissions.mockReturnValue(true)
+      mockUseParams.mockReturnValue({ tab: 'quotes' })
+    })
+
+    describe('WHEN the page renders', () => {
+      it('THEN should configure MainHeader with the quotes snapshotKey', () => {
+        render(<Quotes />)
+
+        expect(capturedConfig?.snapshotKey).toBe('quotes')
+      })
+
+      it('THEN should configure MainHeader with a filters section', () => {
+        render(<Quotes />)
+
+        expect(capturedConfig?.filtersSection).toBeDefined()
+      })
+    })
+  })
+
+  describe('GIVEN the user is on the Order Forms tab', () => {
+    beforeEach(() => {
+      mockHasPermissions.mockReturnValue(true)
+      mockUseParams.mockReturnValue({ tab: 'order-forms' })
+    })
+
+    describe('WHEN the page renders', () => {
+      it('THEN should configure MainHeader with the order-forms snapshotKey', () => {
+        render(<Quotes />)
+
+        expect(capturedConfig?.snapshotKey).toBe('order-forms')
+      })
+
+      it('THEN should configure MainHeader with a filters section', () => {
+        render(<Quotes />)
+
+        expect(capturedConfig?.filtersSection).toBeDefined()
       })
     })
   })

--- a/src/pages/quotes/hooks/useOrderForms.ts
+++ b/src/pages/quotes/hooks/useOrderForms.ts
@@ -35,8 +35,21 @@ gql`
     $limit: Int
     $status: [OrderFormStatusEnum!]
     $quoteNumber: [String!]
+    $customerId: [ID!]
+    $ownerId: [ID!]
+    $createdAtFrom: ISO8601DateTime
+    $createdAtTo: ISO8601DateTime
   ) {
-    orderForms(page: $page, limit: $limit, status: $status, quoteNumber: $quoteNumber) {
+    orderForms(
+      page: $page
+      limit: $limit
+      status: $status
+      quoteNumber: $quoteNumber
+      customerId: $customerId
+      ownerId: $ownerId
+      createdAtFrom: $createdAtFrom
+      createdAtTo: $createdAtTo
+    ) {
       metadata {
         currentPage
         totalPages

--- a/src/pages/quotes/hooks/useOrderForms.ts
+++ b/src/pages/quotes/hooks/useOrderForms.ts
@@ -35,6 +35,7 @@ gql`
     $limit: Int
     $status: [OrderFormStatusEnum!]
     $quoteNumber: [String!]
+    $number: [String!]
     $customerId: [ID!]
     $ownerId: [ID!]
     $createdAtFrom: ISO8601DateTime
@@ -45,6 +46,7 @@ gql`
       limit: $limit
       status: $status
       quoteNumber: $quoteNumber
+      number: $number
       customerId: $customerId
       ownerId: $ownerId
       createdAtFrom: $createdAtFrom


### PR DESCRIPTION
## Context

We want to add filters on order form list

## Description

Adds a dedicated filter set to the **Order Forms** tab of the Quotes page, distinct from the Quotes tab.

The `MainHeader` `filtersSection` is now tab-aware: on the Order Forms tab it renders an Order Forms `Filters.Provider` (own `of_` URL prefix); on the Quotes tab it keeps the existing quote filters (`qu_`). `OrderFormsList` reads the `of_`-prefixed filters and merges them with its optional `quoteNumber` prop (the prop always wins, so the shared QuoteDetails usage is unaffected).

Fixes LAGO-1429

🤖 Generated with [Claude Code](https://claude.com/claude-code)