### PR TITLE
fix(filters): comma in customer/entity names splits a single filter selection

### DIFF
--- a/src/components/designSystem/Filters/__tests__/utils.test.ts
+++ b/src/components/designSystem/Filters/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import { AvailableFiltersEnum, filterDataInlineSeparator } from '../types'
 import {
   defineDefaultToDateValue,
+  escapeFilterLabel,
   FILTER_VALUE_MAP,
   formatActiveFilterValueDisplay,
   formatFiltersForCreditNotesQuery,
@@ -22,6 +23,7 @@ import {
   keyWithPrefix,
   parseFromToValue,
   parseMetadataFilter,
+  unescapeFilterLabel,
 } from '../utils'
 
 describe('Filters utils', () => {
@@ -1606,6 +1608,46 @@ describe('Filters utils', () => {
       const result = formatFiltersForOrdersQuery(searchParams)
 
       expect(result).toEqual({ status: ['created'] })
+    })
+  })
+
+  describe('comma-safe filter labels (escapeFilterLabel / unescapeFilterLabel)', () => {
+    it('escapes and unescapes a label containing commas, round-tripping exactly', () => {
+      const label = 'Bernhard, Strosin & Rolfson'
+      const escaped = escapeFilterLabel(label)
+
+      expect(escaped).not.toContain(',')
+      expect(unescapeFilterLabel(escaped)).toBe(label)
+    })
+
+    it('is a no-op for labels without commas', () => {
+      expect(escapeFilterLabel('Acme Corp')).toBe('Acme Corp')
+      expect(unescapeFilterLabel('Acme Corp')).toBe('Acme Corp')
+    })
+
+    it('keeps a comma-named customer as a single multipleCustomers chip with the real name', () => {
+      const value = `cust-1${filterDataInlineSeparator}${escapeFilterLabel('Bernhard, Strosin & Rolfson')}`
+
+      expect(formatActiveFilterValueDisplay(AvailableFiltersEnum.multipleCustomers, value)).toBe(
+        'Bernhard, Strosin & Rolfson',
+      )
+    })
+
+    it('extracts a single customer id from a comma-named customer in the query filters', () => {
+      const searchParams = new URLSearchParams()
+
+      searchParams.set(
+        'qu_multipleCustomers',
+        `cust-1${filterDataInlineSeparator}${escapeFilterLabel('Bernhard, Strosin & Rolfson')}`,
+      )
+
+      const result = formatFiltersForQuotesQuery(searchParams)
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          customers: ['cust-1'],
+        }),
+      )
     })
   })
 })

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemApiKeyIds.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemApiKeyIds.tsx
@@ -7,6 +7,7 @@ import { useGetApiKeyIdsForFilterItemApiKeyIdsQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 import { filterDataInlineSeparator, FiltersFormValues } from '../types'
+import { escapeFilterLabel, unescapeFilterLabel } from '../utils'
 
 gql`
   query getApiKeyIdsForFilterItemApiKeyIds {
@@ -34,7 +35,7 @@ export const FiltersItemApiKeyIds = ({ value, setFilterValue }: FiltersItemApiKe
 
     return data.apiKeys.collection.map((apiKey) => ({
       label: apiKey.value,
-      value: `${apiKey.id}${filterDataInlineSeparator}${apiKey.value}`,
+      value: `${apiKey.id}${filterDataInlineSeparator}${escapeFilterLabel(apiKey.value)}`,
     }))
   }, [data?.apiKeys?.collection])
 
@@ -52,7 +53,7 @@ export const FiltersItemApiKeyIds = ({ value, setFilterValue }: FiltersItemApiKe
         ?.split(',')
         .filter((v) => !!v)
         .map((v) => ({
-          label: v.split(filterDataInlineSeparator)[1],
+          label: unescapeFilterLabel(v.split(filterDataInlineSeparator)[1] ?? ''),
           value: v,
         }))}
     />

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemBillingEntity.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemBillingEntity.tsx
@@ -5,6 +5,7 @@ import { useGetBillingEntitiesQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 import { filterDataInlineSeparator, FiltersFormValues } from '../types'
+import { escapeFilterLabel, unescapeFilterLabel } from '../utils'
 
 type FiltersItemBillingEntityProps = {
   value: FiltersFormValues['filters'][0]['value']
@@ -23,7 +24,9 @@ export const FiltersItemBillingEntity = ({
 
     return data.billingEntities.collection.map((billingEntity) => ({
       label: billingEntity.name || billingEntity.code,
-      value: `${billingEntity.id}${filterDataInlineSeparator}${billingEntity.name || billingEntity.code}`,
+      value: `${billingEntity.id}${filterDataInlineSeparator}${escapeFilterLabel(
+        billingEntity.name || billingEntity.code,
+      )}`,
     }))
   }, [data])
 
@@ -39,7 +42,9 @@ export const FiltersItemBillingEntity = ({
         ?.split(',')
         .filter((v) => !!v)
         .map((v) => ({
-          label: v.split(filterDataInlineSeparator)[1] || v.split(filterDataInlineSeparator)[0],
+          label: unescapeFilterLabel(
+            v.split(filterDataInlineSeparator)[1] || v.split(filterDataInlineSeparator)[0],
+          ),
           value: v,
         }))}
     />

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemBillingEntityId.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemBillingEntityId.tsx
@@ -5,6 +5,7 @@ import { useGetBillingEntitiesQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 import { filterDataInlineSeparator, FiltersFormValues } from '../types'
+import { escapeFilterLabel } from '../utils'
 
 type FiltersItemBillingEntityIdProps = {
   value: FiltersFormValues['filters'][0]['value']
@@ -31,7 +32,9 @@ export const FiltersItemBillingEntityId = ({
 
     return data.billingEntities.collection.map((billingEntity) => ({
       label: billingEntity.name || billingEntity.code,
-      value: `${billingEntity.id}${filterDataInlineSeparator}${billingEntity.name || billingEntity.code}`,
+      value: `${billingEntity.id}${filterDataInlineSeparator}${escapeFilterLabel(
+        billingEntity.name || billingEntity.code,
+      )}`,
     }))
   }, [data])
 

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemCustomer.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemCustomer.tsx
@@ -8,6 +8,7 @@ import { useGetCustomersForFilterItemCustomerLazyQuery } from '~/generated/graph
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 import { filterDataInlineSeparator, FiltersFormValues } from '../types'
+import { escapeFilterLabel } from '../utils'
 
 gql`
   query getCustomersForFilterItemCustomer($page: Int, $limit: Int, $searchTerm: String) {
@@ -61,7 +62,7 @@ export const FiltersItemCustomer = ({ value, setFilterValue }: FiltersItemCustom
             )}
           </ComboboxItem>
         ),
-        value: `${externalId}${filterDataInlineSeparator}${customerName}`,
+        value: `${externalId}${filterDataInlineSeparator}${escapeFilterLabel(customerName ?? '')}`,
       }
     })
   }, [data?.customers?.collection, translate])

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemMultipleCustomers.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemMultipleCustomers.tsx
@@ -8,6 +8,7 @@ import { useGetCustomersForFilterItemMultipleCustomersQuery } from '~/generated/
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 import { filterDataInlineSeparator, FiltersFormValues } from '../types'
+import { escapeFilterLabel, unescapeFilterLabel } from '../utils'
 
 gql`
   query getCustomersForFilterItemMultipleCustomers($page: Int, $limit: Int) {
@@ -67,7 +68,7 @@ export const FiltersItemMultipleCustomers = ({
             )}
           </ComboboxItem>
         ),
-        value: `${customer.id}${filterDataInlineSeparator}${customerName}`,
+        value: `${customer.id}${filterDataInlineSeparator}${escapeFilterLabel(customerName ?? '')}`,
       }
     })
   }, [data?.customers?.collection, translate])
@@ -86,7 +87,9 @@ export const FiltersItemMultipleCustomers = ({
         .split(',')
         .filter((v) => !!v)
         .map((v) => ({
-          label: v.split(filterDataInlineSeparator)[1] || v.split(filterDataInlineSeparator)[0],
+          label: unescapeFilterLabel(
+            v.split(filterDataInlineSeparator)[1] || v.split(filterDataInlineSeparator)[0],
+          ),
           value: v,
         }))}
     />

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemUserIds.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemUserIds.tsx
@@ -6,6 +6,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useGetAllMembers } from '~/hooks/useGetAllMembers'
 
 import { filterDataInlineSeparator, FiltersFormValues } from '../types'
+import { escapeFilterLabel, unescapeFilterLabel } from '../utils'
 
 type FiltersItemUserIdsProps = {
   value: FiltersFormValues['filters'][0]['value']
@@ -24,7 +25,9 @@ export const FiltersItemUserIds = ({ value, setFilterValue }: FiltersItemUserIds
       .filter((membership) => !!membership.user.email)
       .map((membership) => ({
         label: membership.user.email as string,
-        value: `${membership.user.id}${filterDataInlineSeparator}${membership.user.email}`,
+        value: `${membership.user.id}${filterDataInlineSeparator}${escapeFilterLabel(
+          membership.user.email ?? '',
+        )}`,
       }))
   }, [memberships])
 
@@ -42,7 +45,9 @@ export const FiltersItemUserIds = ({ value, setFilterValue }: FiltersItemUserIds
         .split(',')
         .filter((v) => !!v)
         .map((v) => ({
-          label: v.split(filterDataInlineSeparator)[1] || v.split(filterDataInlineSeparator)[0],
+          label: unescapeFilterLabel(
+            v.split(filterDataInlineSeparator)[1] || v.split(filterDataInlineSeparator)[0],
+          ),
           value: v,
         }))}
     />

--- a/src/components/designSystem/Filters/types.ts
+++ b/src/components/designSystem/Filters/types.ts
@@ -1,6 +1,12 @@
 // By convention, we use value then metadata (usually display value) on each side of the separator.
 export const filterDataInlineSeparator = '|-_-|'
 
+// Multiple-value filters join their selections with a comma. Display labels (customer/entity
+// names, emails) embedded after the separator can themselves contain commas, which would
+// over-split a single selection into several. Encode such commas with this placeholder and
+// decode them back only for display — see escapeFilterLabel / unescapeFilterLabel in utils.
+export const filterDataLabelCommaPlaceholder = '|-COMMA-|'
+
 export enum AvailableQuickFilters {
   invoiceStatus = 'invoiceStatus',
   customerAccountType = 'customerAccountType',

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -81,6 +81,7 @@ import {
   CustomerInvoicesAvailableFilters,
   CustomerPaymentsAvailableFilters,
   filterDataInlineSeparator,
+  filterDataLabelCommaPlaceholder,
   ForecastsAvailableFilters,
   InvoiceAvailableFilters,
   MrrBreakdownPlansAvailableFilters,
@@ -159,6 +160,19 @@ export const formatMetadataFilter = (metadata: { key: string; value: string }[])
     .map((item) => (item.value ? `${item.key}=${item.value}` : `${item.key}=`))
     .join(METADATA_SPLITTER)
 }
+
+/**
+ * Multiple-value filters join selections with a comma; the display label embedded after
+ * `filterDataInlineSeparator` (a customer/entity name, an email) can itself contain commas.
+ * escapeFilterLabel encodes those commas at storage time so a single selection never
+ * over-splits; unescapeFilterLabel restores them for display. The id portion (before the
+ * separator) is never escaped, so query decoding is unaffected.
+ */
+export const escapeFilterLabel = (label: string): string =>
+  label.split(',').join(filterDataLabelCommaPlaceholder)
+
+export const unescapeFilterLabel = (label: string): string =>
+  label.split(filterDataLabelCommaPlaceholder).join(',')
 
 export const FiltersItemDates = [
   AvailableFiltersEnum.date,
@@ -987,7 +1001,9 @@ export const formatActiveFilterValueDisplay = (
         .map((v) => formatActivityType(v as ActivityTypeEnum))
         .join(', ')
     case AvailableFiltersEnum.customerExternalId:
-      return value.split(filterDataInlineSeparator)[1] || value.split(filterDataInlineSeparator)[0]
+      return unescapeFilterLabel(
+        value.split(filterDataInlineSeparator)[1] || value.split(filterDataInlineSeparator)[0],
+      )
     case AvailableFiltersEnum.isCustomerTinEmpty:
       return (
         translate?.(
@@ -1019,10 +1035,16 @@ export const formatActiveFilterValueDisplay = (
     case AvailableFiltersEnum.multipleCustomers:
       return value
         .split(',')
-        .map((v) => v.split(filterDataInlineSeparator)[1] || v.split(filterDataInlineSeparator)[0])
+        .map((v) =>
+          unescapeFilterLabel(
+            v.split(filterDataInlineSeparator)[1] || v.split(filterDataInlineSeparator)[0],
+          ),
+        )
         .join(', ')
     case AvailableFiltersEnum.billingEntityId:
-      return value.split(filterDataInlineSeparator)[1] || value.split(filterDataInlineSeparator)[0]
+      return unescapeFilterLabel(
+        value.split(filterDataInlineSeparator)[1] || value.split(filterDataInlineSeparator)[0],
+      )
     case AvailableFiltersEnum.userEmails:
       return value.toLocaleLowerCase()
     case AvailableFiltersEnum.billableMetricCode:

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -1001,6 +1001,7 @@ export const formatActiveFilterValueDisplay = (
         .map((v) => formatActivityType(v as ActivityTypeEnum))
         .join(', ')
     case AvailableFiltersEnum.customerExternalId:
+    case AvailableFiltersEnum.billingEntityId:
       return unescapeFilterLabel(
         value.split(filterDataInlineSeparator)[1] || value.split(filterDataInlineSeparator)[0],
       )
@@ -1041,10 +1042,6 @@ export const formatActiveFilterValueDisplay = (
           ),
         )
         .join(', ')
-    case AvailableFiltersEnum.billingEntityId:
-      return unescapeFilterLabel(
-        value.split(filterDataInlineSeparator)[1] || value.split(filterDataInlineSeparator)[0],
-      )
     case AvailableFiltersEnum.userEmails:
       return value.toLocaleLowerCase()
     case AvailableFiltersEnum.billableMetricCode:


### PR DESCRIPTION
## Context

Selecting a customer whose name contains a comma — e.g. **"Bernhard, Strosin & Rolfson"** — created **two** chips in the filter and sent a malformed `customerId` to the query.

## Description

This PR changes the way we escape the filters containing commas

🤖 Generated with [Claude Code](https://claude.com/claude-code)