### PR TITLE
fix(quotes): use customer displayName in quote/order form displays

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -2128,6 +2128,7 @@ export type CreateQuoteInput = {
 export type CreateRecurringTransactionRuleInput = {
   expirationAt?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
   grantedCredits?: InputMaybe<Scalars['String']['input']>;
+  grantsTargetTopUp?: InputMaybe<Scalars['Boolean']['input']>;
   ignorePaidTopUpLimits?: InputMaybe<Scalars['Boolean']['input']>;
   interval?: InputMaybe<RecurringTransactionIntervalEnum>;
   invoiceCustomSection?: InputMaybe<InvoiceCustomSectionsReferenceInput>;
@@ -3912,6 +3913,7 @@ export enum EventsStoreEnum {
 /** Organization Feature Flag Values */
 export enum FeatureFlagEnum {
   EnrichedEventsAggregation = 'enriched_events_aggregation',
+  EventPropertyCombinations = 'event_property_combinations',
   MultiCurrency = 'multi_currency',
   MultiEntityBilling = 'multi_entity_billing',
   MultiplePaymentMethods = 'multiple_payment_methods',
@@ -8503,6 +8505,7 @@ export type RecurringTransactionRule = {
   createdAt: Scalars['ISO8601DateTime']['output'];
   expirationAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   grantedCredits: Scalars['String']['output'];
+  grantsTargetTopUp?: Maybe<Scalars['Boolean']['output']>;
   ignorePaidTopUpLimits: Scalars['Boolean']['output'];
   interval?: Maybe<RecurringTransactionIntervalEnum>;
   invoiceRequiresSuccessfulPayment: Scalars['Boolean']['output'];
@@ -9981,6 +9984,7 @@ export type UpdateQuoteVersionInput = {
 export type UpdateRecurringTransactionRuleInput = {
   expirationAt?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
   grantedCredits?: InputMaybe<Scalars['String']['input']>;
+  grantsTargetTopUp?: InputMaybe<Scalars['Boolean']['input']>;
   ignorePaidTopUpLimits?: InputMaybe<Scalars['Boolean']['input']>;
   interval?: InputMaybe<RecurringTransactionIntervalEnum>;
   invoiceCustomSection?: InputMaybe<InvoiceCustomSectionsReferenceInput>;
@@ -14329,7 +14333,7 @@ export type GetOrderFormForSignQueryVariables = Exact<{
 }>;
 
 
-export type GetOrderFormForSignQuery = { __typename?: 'Query', orderForm?: { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, quote: { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null } } } | null };
+export type GetOrderFormForSignQuery = { __typename?: 'Query', orderForm?: { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, quote: { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null } } } | null };
 
 export type MarkOrderFormAsSignedMutationVariables = Exact<{
   input: MarkOrderFormAsSignedInput;
@@ -14387,7 +14391,7 @@ export type UpdateCustomerCurrencyForQuoteMutationVariables = Exact<{
 
 export type UpdateCustomerCurrencyForQuoteMutation = { __typename?: 'Mutation', updateCustomer?: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null } | null };
 
-export type OrderFormListItemFragment = { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null } } };
+export type OrderFormListItemFragment = { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null } } };
 
 export type GetOrderFormsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -14397,22 +14401,22 @@ export type GetOrderFormsQueryVariables = Exact<{
 }>;
 
 
-export type GetOrderFormsQuery = { __typename?: 'Query', orderForms: { __typename?: 'OrderFormCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null } } }> } };
+export type GetOrderFormsQuery = { __typename?: 'Query', orderForms: { __typename?: 'OrderFormCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null } } }> } };
 
 export type QuotePreviewVersionFragment = { __typename?: 'QuoteVersion', content?: string | null, billingItems?: any | null };
 
 export type QuotePreviewCustomerFragment = { __typename?: 'Customer', currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null };
 
-export type QuoteDetailItemFragment = { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null } };
+export type QuoteDetailItemFragment = { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null } };
 
 export type GetQuoteQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetQuoteQuery = { __typename?: 'Query', quote?: { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null } } | null };
+export type GetQuoteQuery = { __typename?: 'Query', quote?: { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null } } | null };
 
-export type QuoteListItemFragment = { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number }>, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string } };
+export type QuoteListItemFragment = { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number }>, customer: { __typename?: 'Customer', id: string, displayName: string } };
 
 export type GetQuotesQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -14427,7 +14431,7 @@ export type GetQuotesQueryVariables = Exact<{
 }>;
 
 
-export type GetQuotesQuery = { __typename?: 'Query', quotes: { __typename?: 'QuoteCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number }>, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string } }> } };
+export type GetQuotesQuery = { __typename?: 'Query', quotes: { __typename?: 'QuoteCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number }>, customer: { __typename?: 'Customer', id: string, displayName: string } }> } };
 
 export type UpdateQuoteVersionMutationVariables = Exact<{
   input: UpdateQuoteVersionInput;
@@ -20364,7 +20368,6 @@ export const OrderFormListItemFragmentDoc = gql`
   expiresAt
   customer {
     id
-    name
     displayName
     ...QuotePreviewCustomer
   }
@@ -20394,7 +20397,6 @@ export const QuoteDetailItemFragmentDoc = gql`
   createdAt
   customer {
     id
-    name
     displayName
     externalId
     netPaymentTerm
@@ -20446,7 +20448,6 @@ export const QuoteListItemFragmentDoc = gql`
   createdAt
   customer {
     id
-    name
     displayName
   }
 }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -11909,15 +11909,6 @@ export type UsageChargeForDrawerFragment = { __typename?: 'Charge', id: string, 
 
 export type FixedChargesOnPlanFormFragment = { __typename?: 'Plan', id: string, billFixedChargesMonthly?: boolean | null, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string, prorated: boolean, units: string, chargeModel: FixedChargeChargeModelEnum, invoiceDisplayName?: string | null, payInAdvance: boolean, addOn: { __typename?: 'AddOn', id: string, name: string, code: string }, properties?: { __typename?: 'FixedChargeProperties', amount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null }> | null };
 
-export type DeleteCampaignFragment = { __typename?: 'DunningCampaign', id: string, appliedToOrganization: boolean };
-
-export type DeleteDunningCampaignMutationVariables = Exact<{
-  input: DestroyDunningCampaignInput;
-}>;
-
-
-export type DeleteDunningCampaignMutation = { __typename?: 'Mutation', destroyDunningCampaign?: { __typename?: 'DestroyDunningCampaignPayload', id?: string | null } | null };
-
 export type OrganizationInfoForPreviewDunningCampaignFragment = { __typename?: 'CurrentOrganization', name: string, email?: string | null, logoUrl?: string | null };
 
 export type GetOrganizationInfoForPreviewDunningCampaignQueryVariables = Exact<{ [key: string]: never; }>;
@@ -14338,7 +14329,7 @@ export type GetOrderFormForSignQueryVariables = Exact<{
 }>;
 
 
-export type GetOrderFormForSignQuery = { __typename?: 'Query', orderForm?: { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, name?: string | null }, quote: { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null } } } | null };
+export type GetOrderFormForSignQuery = { __typename?: 'Query', orderForm?: { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, quote: { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null } } } | null };
 
 export type MarkOrderFormAsSignedMutationVariables = Exact<{
   input: MarkOrderFormAsSignedInput;
@@ -14352,7 +14343,7 @@ export type GetOrderFormForVoidQueryVariables = Exact<{
 }>;
 
 
-export type GetOrderFormForVoidQuery = { __typename?: 'Query', orderForm?: { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, customer: { __typename?: 'Customer', id: string, name?: string | null, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', version: number, content?: string | null, billingItems?: any | null } } } | null };
+export type GetOrderFormForVoidQuery = { __typename?: 'Query', orderForm?: { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', version: number, content?: string | null, billingItems?: any | null } } } | null };
 
 export type VoidOrderFormMutationVariables = Exact<{
   input: VoidOrderFormInput;
@@ -14396,7 +14387,7 @@ export type UpdateCustomerCurrencyForQuoteMutationVariables = Exact<{
 
 export type UpdateCustomerCurrencyForQuoteMutation = { __typename?: 'Mutation', updateCustomer?: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null } | null };
 
-export type OrderFormListItemFragment = { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, name?: string | null, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null } } };
+export type OrderFormListItemFragment = { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null } } };
 
 export type GetOrderFormsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -14406,22 +14397,22 @@ export type GetOrderFormsQueryVariables = Exact<{
 }>;
 
 
-export type GetOrderFormsQuery = { __typename?: 'Query', orderForms: { __typename?: 'OrderFormCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, name?: string | null, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null } } }> } };
+export type GetOrderFormsQuery = { __typename?: 'Query', orderForms: { __typename?: 'OrderFormCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null } } }> } };
 
 export type QuotePreviewVersionFragment = { __typename?: 'QuoteVersion', content?: string | null, billingItems?: any | null };
 
 export type QuotePreviewCustomerFragment = { __typename?: 'Customer', currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null };
 
-export type QuoteDetailItemFragment = { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null } };
+export type QuoteDetailItemFragment = { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null } };
 
 export type GetQuoteQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetQuoteQuery = { __typename?: 'Query', quote?: { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, name?: string | null, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null } } | null };
+export type GetQuoteQuery = { __typename?: 'Query', quote?: { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null } } | null };
 
-export type QuoteListItemFragment = { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number }>, customer: { __typename?: 'Customer', id: string, name?: string | null } };
+export type QuoteListItemFragment = { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number }>, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string } };
 
 export type GetQuotesQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -14436,7 +14427,7 @@ export type GetQuotesQueryVariables = Exact<{
 }>;
 
 
-export type GetQuotesQuery = { __typename?: 'Query', quotes: { __typename?: 'QuoteCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number }>, customer: { __typename?: 'Customer', id: string, name?: string | null } }> } };
+export type GetQuotesQuery = { __typename?: 'Query', quotes: { __typename?: 'QuoteCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number }>, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string } }> } };
 
 export type UpdateQuoteVersionMutationVariables = Exact<{
   input: UpdateQuoteVersionInput;
@@ -14717,6 +14708,15 @@ export type UpdateDunningCampaignStatusMutationVariables = Exact<{
 
 
 export type UpdateDunningCampaignStatusMutation = { __typename?: 'Mutation', updateDunningCampaign?: { __typename?: 'DunningCampaign', id: string, appliedToOrganization: boolean } | null };
+
+export type DeleteCampaignFragment = { __typename?: 'DunningCampaign', id: string, appliedToOrganization: boolean };
+
+export type DeleteDunningCampaignMutationVariables = Exact<{
+  input: DestroyDunningCampaignInput;
+}>;
+
+
+export type DeleteDunningCampaignMutation = { __typename?: 'Mutation', destroyDunningCampaign?: { __typename?: 'DestroyDunningCampaignPayload', id?: string | null } | null };
 
 export type FlutterwaveIntegrationDetailsFragment = { __typename?: 'FlutterwaveProvider', id: string, name: string, code: string, secretKey?: any | null, webhookSecret?: string | null, successRedirectUrl?: string | null };
 
@@ -17772,12 +17772,6 @@ export const BillableMetricForUsageChargeSectionFragmentDoc = gql`
   }
 }
     `;
-export const DeleteCampaignFragmentDoc = gql`
-    fragment DeleteCampaign on DunningCampaign {
-  id
-  appliedToOrganization
-}
-    `;
 export const OrganizationInfoForPreviewDunningCampaignFragmentDoc = gql`
     fragment OrganizationInfoForPreviewDunningCampaign on CurrentOrganization {
   name
@@ -20371,6 +20365,7 @@ export const OrderFormListItemFragmentDoc = gql`
   customer {
     id
     name
+    displayName
     ...QuotePreviewCustomer
   }
   quote {
@@ -20400,6 +20395,7 @@ export const QuoteDetailItemFragmentDoc = gql`
   customer {
     id
     name
+    displayName
     externalId
     netPaymentTerm
     ...QuotePreviewCustomer
@@ -20451,6 +20447,7 @@ export const QuoteListItemFragmentDoc = gql`
   customer {
     id
     name
+    displayName
   }
 }
     `;
@@ -20573,6 +20570,12 @@ export const DunningCampaignItemFragmentDoc = gql`
   id
   name
   code
+  appliedToOrganization
+}
+    `;
+export const DeleteCampaignFragmentDoc = gql`
+    fragment DeleteCampaign on DunningCampaign {
+  id
   appliedToOrganization
 }
     `;
@@ -27713,39 +27716,6 @@ export type GetBillableMetricsQueryHookResult = ReturnType<typeof useGetBillable
 export type GetBillableMetricsLazyQueryHookResult = ReturnType<typeof useGetBillableMetricsLazyQuery>;
 export type GetBillableMetricsSuspenseQueryHookResult = ReturnType<typeof useGetBillableMetricsSuspenseQuery>;
 export type GetBillableMetricsQueryResult = Apollo.QueryResult<GetBillableMetricsQuery, GetBillableMetricsQueryVariables>;
-export const DeleteDunningCampaignDocument = gql`
-    mutation deleteDunningCampaign($input: DestroyDunningCampaignInput!) {
-  destroyDunningCampaign(input: $input) {
-    id
-  }
-}
-    `;
-export type DeleteDunningCampaignMutationFn = Apollo.MutationFunction<DeleteDunningCampaignMutation, DeleteDunningCampaignMutationVariables>;
-
-/**
- * __useDeleteDunningCampaignMutation__
- *
- * To run a mutation, you first call `useDeleteDunningCampaignMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useDeleteDunningCampaignMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [deleteDunningCampaignMutation, { data, loading, error }] = useDeleteDunningCampaignMutation({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useDeleteDunningCampaignMutation(baseOptions?: Apollo.MutationHookOptions<DeleteDunningCampaignMutation, DeleteDunningCampaignMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<DeleteDunningCampaignMutation, DeleteDunningCampaignMutationVariables>(DeleteDunningCampaignDocument, options);
-      }
-export type DeleteDunningCampaignMutationHookResult = ReturnType<typeof useDeleteDunningCampaignMutation>;
-export type DeleteDunningCampaignMutationResult = Apollo.MutationResult<DeleteDunningCampaignMutation>;
-export type DeleteDunningCampaignMutationOptions = Apollo.BaseMutationOptions<DeleteDunningCampaignMutation, DeleteDunningCampaignMutationVariables>;
 export const GetOrganizationInfoForPreviewDunningCampaignDocument = gql`
     query getOrganizationInfoForPreviewDunningCampaign {
   organization {
@@ -38998,6 +38968,7 @@ export const GetOrderFormForSignDocument = gql`
     customer {
       id
       name
+      displayName
     }
     quote {
       ...QuoteDetailItem
@@ -39085,6 +39056,7 @@ export const GetOrderFormForVoidDocument = gql`
     customer {
       id
       name
+      displayName
       ...QuotePreviewCustomer
     }
     quote {
@@ -40529,6 +40501,39 @@ export function useUpdateDunningCampaignStatusMutation(baseOptions?: Apollo.Muta
 export type UpdateDunningCampaignStatusMutationHookResult = ReturnType<typeof useUpdateDunningCampaignStatusMutation>;
 export type UpdateDunningCampaignStatusMutationResult = Apollo.MutationResult<UpdateDunningCampaignStatusMutation>;
 export type UpdateDunningCampaignStatusMutationOptions = Apollo.BaseMutationOptions<UpdateDunningCampaignStatusMutation, UpdateDunningCampaignStatusMutationVariables>;
+export const DeleteDunningCampaignDocument = gql`
+    mutation deleteDunningCampaign($input: DestroyDunningCampaignInput!) {
+  destroyDunningCampaign(input: $input) {
+    id
+  }
+}
+    `;
+export type DeleteDunningCampaignMutationFn = Apollo.MutationFunction<DeleteDunningCampaignMutation, DeleteDunningCampaignMutationVariables>;
+
+/**
+ * __useDeleteDunningCampaignMutation__
+ *
+ * To run a mutation, you first call `useDeleteDunningCampaignMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteDunningCampaignMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteDunningCampaignMutation, { data, loading, error }] = useDeleteDunningCampaignMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useDeleteDunningCampaignMutation(baseOptions?: Apollo.MutationHookOptions<DeleteDunningCampaignMutation, DeleteDunningCampaignMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteDunningCampaignMutation, DeleteDunningCampaignMutationVariables>(DeleteDunningCampaignDocument, options);
+      }
+export type DeleteDunningCampaignMutationHookResult = ReturnType<typeof useDeleteDunningCampaignMutation>;
+export type DeleteDunningCampaignMutationResult = Apollo.MutationResult<DeleteDunningCampaignMutation>;
+export type DeleteDunningCampaignMutationOptions = Apollo.BaseMutationOptions<DeleteDunningCampaignMutation, DeleteDunningCampaignMutationVariables>;
 export const FlutterwaveIntegrationDetailsDocument = gql`
     query flutterwaveIntegrationDetails($id: ID!, $limit: Int, $type: ProviderTypeEnum) {
   paymentProvider(id: $id) {

--- a/src/pages/quotes/ApproveQuote.tsx
+++ b/src/pages/quotes/ApproveQuote.tsx
@@ -201,7 +201,7 @@ const ApproveQuote = () => {
                     },
                     {
                       label: translate('text_65201c5a175a4b0238abf29a'),
-                      value: quote?.customer.name,
+                      value: quote?.customer.displayName,
                     },
                     {
                       label: translate('text_6560809c38fb9de88d8a52fb'),

--- a/src/pages/quotes/OrderFormsList.tsx
+++ b/src/pages/quotes/OrderFormsList.tsx
@@ -40,13 +40,13 @@ const OrderFormsList = ({ quoteNumber }: OrderFormsListProps): JSX.Element => {
       ),
     },
     {
-      key: 'customer.name',
+      key: 'customer.displayName',
       title: translate('text_65201c5a175a4b0238abf29a'),
       maxSpace: true,
       minWidth: 160,
       content: ({ customer }) => (
         <Typography color="grey600" noWrap>
-          {customer.name}
+          {customer.displayName}
         </Typography>
       ),
     },

--- a/src/pages/quotes/QuoteDetails.tsx
+++ b/src/pages/quotes/QuoteDetails.tsx
@@ -71,7 +71,7 @@ const QuoteDetails = (): JSX.Element => {
         entity={{
           viewName: quote?.number ?? '',
           viewNameLoading: loading,
-          metadata: quote ? `${quote.customer.name} - ${quote.customer.externalId}` : '',
+          metadata: quote ? `${quote.customer.displayName} - ${quote.customer.externalId}` : '',
           metadataLoading: loading,
         }}
         actions={{ items: headerActions, loading }}

--- a/src/pages/quotes/QuoteDetailsVersions.tsx
+++ b/src/pages/quotes/QuoteDetailsVersions.tsx
@@ -62,7 +62,7 @@ const QuoteDetailsVersions = ({ quote }: QuoteDetailsVersionsProps): JSX.Element
     },
     {
       label: translate('text_65201c5a175a4b0238abf29a'),
-      value: `${quote.customer.name} - ${quote.customer.externalId}`,
+      value: `${quote.customer.displayName} - ${quote.customer.externalId}`,
     },
     {
       label: translate('text_6560809c38fb9de88d8a52fb'),

--- a/src/pages/quotes/QuotesList.tsx
+++ b/src/pages/quotes/QuotesList.tsx
@@ -49,13 +49,13 @@ const QuotesList = (): JSX.Element => {
       ),
     },
     {
-      key: 'customer.name',
+      key: 'customer.displayName',
       title: translate('text_65201c5a175a4b0238abf29a'),
       maxSpace: true,
       minWidth: 160,
       content: ({ customer }) => (
         <Typography color="grey600" noWrap>
-          {customer.name}
+          {customer.displayName}
         </Typography>
       ),
     },

--- a/src/pages/quotes/SignOrderForm.tsx
+++ b/src/pages/quotes/SignOrderForm.tsx
@@ -57,6 +57,7 @@ gql`
       customer {
         id
         name
+        displayName
       }
       quote {
         ...QuoteDetailItem
@@ -245,7 +246,7 @@ const SignOrderForm = () => {
                       {translate('text_65201c5a175a4b0238abf29a')}
                     </Typography>
                     <Typography variant="body" color="grey700">
-                      {orderForm?.customer.name}
+                      {orderForm?.customer.displayName}
                     </Typography>
                   </div>
                   <div className="flex flex-col">

--- a/src/pages/quotes/VoidOrderForm.tsx
+++ b/src/pages/quotes/VoidOrderForm.tsx
@@ -38,6 +38,7 @@ gql`
       customer {
         id
         name
+        displayName
         ...QuotePreviewCustomer
       }
       quote {
@@ -225,10 +226,10 @@ const VoidOrderForm = () => {
                       content: ({ number }) => number,
                     },
                     {
-                      key: 'customer.name',
+                      key: 'customer.displayName',
                       title: translate('text_65201c5a175a4b0238abf29a'),
                       maxSpace: true,
-                      content: ({ customer }) => customer.name,
+                      content: ({ customer }) => customer.displayName,
                     },
                     {
                       key: 'quote.number',

--- a/src/pages/quotes/VoidQuote.tsx
+++ b/src/pages/quotes/VoidQuote.tsx
@@ -251,10 +251,10 @@ const VoidQuote = () => {
                         `${number} - v${versions[0]?.version ?? ''}`,
                     },
                     {
-                      key: 'customer.name',
+                      key: 'customer.displayName',
                       title: translate('text_65201c5a175a4b0238abf29a'),
                       maxSpace: true,
-                      content: ({ customer }) => customer.name,
+                      content: ({ customer }) => customer.displayName,
                     },
                     {
                       key: 'customer.currency',

--- a/src/pages/quotes/__tests__/ApproveQuote.test.tsx
+++ b/src/pages/quotes/__tests__/ApproveQuote.test.tsx
@@ -114,6 +114,7 @@ const mockQuote = {
   customer: {
     id: 'customer-001',
     name: 'Acme Corp',
+    displayName: 'Acme Corp',
     externalId: 'ext-acme-001',
     currency: null,
     netPaymentTerm: null,

--- a/src/pages/quotes/__tests__/OrderFormsList.test.tsx
+++ b/src/pages/quotes/__tests__/OrderFormsList.test.tsx
@@ -54,7 +54,7 @@ const mockOrderForms = [
     number: 'OF-2026-0001',
     status: OrderFormStatusEnum.Generated,
     createdAt: '2026-04-10T10:00:00Z',
-    customer: { id: 'customer-001', name: 'Acme Corp' },
+    customer: { id: 'customer-001', name: 'Acme Corp', displayName: 'Acme Corp' },
     quote: {
       id: 'q-1',
       number: 'QUO-001',
@@ -66,7 +66,7 @@ const mockOrderForms = [
     number: 'OF-2026-0002',
     status: OrderFormStatusEnum.Signed,
     createdAt: '2026-04-11T14:00:00Z',
-    customer: { id: 'customer-002', name: 'Globex Inc' },
+    customer: { id: 'customer-002', name: 'Globex Inc', displayName: 'Globex Inc' },
     quote: {
       id: 'q-2',
       number: 'QUO-002',
@@ -78,7 +78,7 @@ const mockOrderForms = [
     number: 'OF-2026-0003',
     status: OrderFormStatusEnum.Voided,
     createdAt: '2026-04-12T08:00:00Z',
-    customer: { id: 'customer-003', name: 'Wayne Enterprises' },
+    customer: { id: 'customer-003', name: 'Wayne Enterprises', displayName: 'Wayne Enterprises' },
     quote: {
       id: 'q-3',
       number: 'QUO-003',

--- a/src/pages/quotes/__tests__/QuoteDetails.test.tsx
+++ b/src/pages/quotes/__tests__/QuoteDetails.test.tsx
@@ -66,6 +66,7 @@ const mockQuote = {
   customer: {
     id: 'customer-001',
     name: 'Acme Corp',
+    displayName: 'Acme Corp',
     externalId: 'ext-acme-001',
     currency: null,
     netPaymentTerm: null,

--- a/src/pages/quotes/__tests__/QuoteDetailsVersions.test.tsx
+++ b/src/pages/quotes/__tests__/QuoteDetailsVersions.test.tsx
@@ -58,6 +58,7 @@ const mockQuote: QuoteDetailItemFragment = {
   customer: {
     id: 'customer-001',
     name: 'Acme Corp',
+    displayName: 'Acme Corp',
     externalId: 'ext-acme-001',
     currency: null,
     netPaymentTerm: null,

--- a/src/pages/quotes/__tests__/QuoteDetailsVersions.test.tsx
+++ b/src/pages/quotes/__tests__/QuoteDetailsVersions.test.tsx
@@ -57,7 +57,6 @@ const mockQuote: QuoteDetailItemFragment = {
   createdAt: '2026-04-09T15:00:00Z',
   customer: {
     id: 'customer-001',
-    name: 'Acme Corp',
     displayName: 'Acme Corp',
     externalId: 'ext-acme-001',
     currency: null,

--- a/src/pages/quotes/__tests__/QuotesList.test.tsx
+++ b/src/pages/quotes/__tests__/QuotesList.test.tsx
@@ -45,7 +45,7 @@ const mockQuotes = [
     versions: [{ id: 'version-1', status: StatusEnum.Draft, version: 2 }],
     orderType: OrderTypeEnum.SubscriptionAmendment,
     createdAt: '2026-04-09T15:00:00Z',
-    customer: { id: 'customer-001', name: 'Acme Corp' },
+    customer: { id: 'customer-001', name: 'Acme Corp', displayName: 'Acme Corp' },
   },
   {
     id: 'quote-2',
@@ -53,7 +53,7 @@ const mockQuotes = [
     versions: [{ id: 'version-2', status: StatusEnum.Approved, version: 2 }],
     orderType: OrderTypeEnum.SubscriptionCreation,
     createdAt: '2026-04-01T09:00:00Z',
-    customer: { id: 'customer-002', name: 'Globex Inc' },
+    customer: { id: 'customer-002', name: 'Globex Inc', displayName: 'Globex Inc' },
   },
   {
     id: 'quote-3',
@@ -61,7 +61,7 @@ const mockQuotes = [
     versions: [{ id: 'version-3', status: StatusEnum.Voided, version: 1 }],
     orderType: OrderTypeEnum.OneOff,
     createdAt: '2026-03-10T08:00:00Z',
-    customer: { id: 'customer-003', name: 'Wayne Enterprises' },
+    customer: { id: 'customer-003', name: 'Wayne Enterprises', displayName: 'Wayne Enterprises' },
   },
 ]
 

--- a/src/pages/quotes/__tests__/VoidQuote.test.tsx
+++ b/src/pages/quotes/__tests__/VoidQuote.test.tsx
@@ -104,6 +104,7 @@ const mockQuote = {
   customer: {
     id: 'customer-001',
     name: 'Acme',
+    displayName: 'Acme',
     externalId: 'ext-acme-001',
     netPaymentTerm: null,
     billingConfiguration: { documentLocale: 'en' },

--- a/src/pages/quotes/common/__tests__/orderFormTableColumns.test.tsx
+++ b/src/pages/quotes/common/__tests__/orderFormTableColumns.test.tsx
@@ -33,7 +33,7 @@ describe('orderFormStatusColumn', () => {
           number: 'OF-001',
           status: OrderFormStatusEnum.Generated,
           createdAt: '2026-04-10T10:00:00Z',
-          customer: { id: 'c-1', name: 'Test Customer', displayName: 'Test Customer' },
+          customer: { id: 'c-1', displayName: 'Test Customer' },
           quote: { id: 'q-1', number: 'QUO-001', currentVersion: { id: 'qv-1', version: 1 } },
         })
 
@@ -58,7 +58,7 @@ describe('orderFormStatusColumn', () => {
           number: 'OF-001',
           status,
           createdAt: '2026-04-10T10:00:00Z',
-          customer: { id: 'c-1', name: 'Test Customer', displayName: 'Test Customer' },
+          customer: { id: 'c-1', displayName: 'Test Customer' },
           quote: { id: 'q-1', number: 'QUO-001', currentVersion: { id: 'qv-1', version: 1 } },
         })
 
@@ -113,7 +113,7 @@ describe('orderFormCreatedAtColumn', () => {
           number: 'OF-001',
           status: OrderFormStatusEnum.Generated,
           createdAt: '2026-04-10T10:00:00Z',
-          customer: { id: 'c-1', name: 'Test Customer', displayName: 'Test Customer' },
+          customer: { id: 'c-1', displayName: 'Test Customer' },
           quote: { id: 'q-1', number: 'QUO-001', currentVersion: { id: 'qv-1', version: 1 } },
         })
 

--- a/src/pages/quotes/common/__tests__/orderFormTableColumns.test.tsx
+++ b/src/pages/quotes/common/__tests__/orderFormTableColumns.test.tsx
@@ -33,7 +33,7 @@ describe('orderFormStatusColumn', () => {
           number: 'OF-001',
           status: OrderFormStatusEnum.Generated,
           createdAt: '2026-04-10T10:00:00Z',
-          customer: { id: 'c-1', name: 'Test Customer' },
+          customer: { id: 'c-1', name: 'Test Customer', displayName: 'Test Customer' },
           quote: { id: 'q-1', number: 'QUO-001', currentVersion: { id: 'qv-1', version: 1 } },
         })
 
@@ -58,7 +58,7 @@ describe('orderFormStatusColumn', () => {
           number: 'OF-001',
           status,
           createdAt: '2026-04-10T10:00:00Z',
-          customer: { id: 'c-1', name: 'Test Customer' },
+          customer: { id: 'c-1', name: 'Test Customer', displayName: 'Test Customer' },
           quote: { id: 'q-1', number: 'QUO-001', currentVersion: { id: 'qv-1', version: 1 } },
         })
 
@@ -113,7 +113,7 @@ describe('orderFormCreatedAtColumn', () => {
           number: 'OF-001',
           status: OrderFormStatusEnum.Generated,
           createdAt: '2026-04-10T10:00:00Z',
-          customer: { id: 'c-1', name: 'Test Customer' },
+          customer: { id: 'c-1', name: 'Test Customer', displayName: 'Test Customer' },
           quote: { id: 'q-1', number: 'QUO-001', currentVersion: { id: 'qv-1', version: 1 } },
         })
 

--- a/src/pages/quotes/editQuote/EditQuoteAside.tsx
+++ b/src/pages/quotes/editQuote/EditQuoteAside.tsx
@@ -112,7 +112,7 @@ const EditQuoteAsideForm = ({
   const getDefaultValues = (): EditQuoteAsideFormValues => {
     return {
       orderTypeLabel: translate(getQuoteOrderTypeTranslationKey(quote.orderType)),
-      customerName: quote.customer.name ?? '',
+      customerName: quote.customer.displayName,
       billingEntityId: quote.customer.billingEntity?.id ?? '',
       currency:
         quote.customer.currency ??

--- a/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
+++ b/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
@@ -83,6 +83,7 @@ const mockQuote: QuoteDetailItemFragment = {
     __typename: 'Customer',
     id: 'customer-1',
     name: 'Acme Corp',
+    displayName: 'Acme Corp',
     externalId: 'ext-cust-1',
     netPaymentTerm: 30,
     billingEntity: {

--- a/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
+++ b/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
@@ -82,7 +82,6 @@ const mockQuote: QuoteDetailItemFragment = {
   customer: {
     __typename: 'Customer',
     id: 'customer-1',
-    name: 'Acme Corp',
     displayName: 'Acme Corp',
     externalId: 'ext-cust-1',
     netPaymentTerm: 30,

--- a/src/pages/quotes/hooks/__tests__/useOrderFormActions.test.ts
+++ b/src/pages/quotes/hooks/__tests__/useOrderFormActions.test.ts
@@ -46,7 +46,7 @@ const createMockOrderForm = (
   number: 'OF-2026-0001',
   status: OrderFormStatusEnum.Generated,
   createdAt: '2026-04-10T10:00:00Z',
-  customer: { id: 'customer-001', name: 'Acme Corp' },
+  customer: { id: 'customer-001', name: 'Acme Corp', displayName: 'Acme Corp' },
   quote: {
     id: 'q-1',
     number: 'QUO-001',

--- a/src/pages/quotes/hooks/__tests__/useOrderFormActions.test.ts
+++ b/src/pages/quotes/hooks/__tests__/useOrderFormActions.test.ts
@@ -46,7 +46,7 @@ const createMockOrderForm = (
   number: 'OF-2026-0001',
   status: OrderFormStatusEnum.Generated,
   createdAt: '2026-04-10T10:00:00Z',
-  customer: { id: 'customer-001', name: 'Acme Corp', displayName: 'Acme Corp' },
+  customer: { id: 'customer-001', displayName: 'Acme Corp' },
   quote: {
     id: 'q-1',
     number: 'QUO-001',

--- a/src/pages/quotes/hooks/__tests__/useQuoteVersionActions.test.ts
+++ b/src/pages/quotes/hooks/__tests__/useQuoteVersionActions.test.ts
@@ -47,7 +47,7 @@ const createMockQuote = (
     number: 'QT-001',
     orderType: 'SubscriptionCreation' as QuoteListItemFragment['orderType'],
     createdAt: '2026-04-01T10:00:00Z',
-    customer: { id: 'cust-1', name: 'Acme' },
+    customer: { id: 'cust-1', name: 'Acme', displayName: 'Acme' },
     versions: [{ id: versionId, status, version }],
     ...rest,
   }
@@ -184,7 +184,7 @@ describe('useQuoteVersionActions', () => {
           number: 'QT-001',
           orderType: 'SubscriptionCreation' as QuoteListItemFragment['orderType'],
           createdAt: '2026-04-01T10:00:00Z',
-          customer: { id: 'cust-1', name: 'Acme' },
+          customer: { id: 'cust-1', name: 'Acme', displayName: 'Acme' },
           versions: [
             { id: 'v2', status: StatusEnum.Approved, version: 2 },
             { id: 'v1', status: StatusEnum.Voided, version: 1 },
@@ -210,7 +210,7 @@ describe('useQuoteVersionActions', () => {
           number: 'QT-001',
           orderType: 'SubscriptionCreation' as QuoteListItemFragment['orderType'],
           createdAt: '2026-04-01T10:00:00Z',
-          customer: { id: 'cust-1', name: 'Acme' },
+          customer: { id: 'cust-1', name: 'Acme', displayName: 'Acme' },
           versions: [
             { id: 'v2', status: StatusEnum.Approved, version: 2 },
             { id: 'v1', status: StatusEnum.Draft, version: 1 },

--- a/src/pages/quotes/hooks/__tests__/useQuoteVersionActions.test.ts
+++ b/src/pages/quotes/hooks/__tests__/useQuoteVersionActions.test.ts
@@ -47,7 +47,7 @@ const createMockQuote = (
     number: 'QT-001',
     orderType: 'SubscriptionCreation' as QuoteListItemFragment['orderType'],
     createdAt: '2026-04-01T10:00:00Z',
-    customer: { id: 'cust-1', name: 'Acme', displayName: 'Acme' },
+    customer: { id: 'cust-1', displayName: 'Acme' },
     versions: [{ id: versionId, status, version }],
     ...rest,
   }
@@ -184,7 +184,7 @@ describe('useQuoteVersionActions', () => {
           number: 'QT-001',
           orderType: 'SubscriptionCreation' as QuoteListItemFragment['orderType'],
           createdAt: '2026-04-01T10:00:00Z',
-          customer: { id: 'cust-1', name: 'Acme', displayName: 'Acme' },
+          customer: { id: 'cust-1', displayName: 'Acme' },
           versions: [
             { id: 'v2', status: StatusEnum.Approved, version: 2 },
             { id: 'v1', status: StatusEnum.Voided, version: 1 },
@@ -210,7 +210,7 @@ describe('useQuoteVersionActions', () => {
           number: 'QT-001',
           orderType: 'SubscriptionCreation' as QuoteListItemFragment['orderType'],
           createdAt: '2026-04-01T10:00:00Z',
-          customer: { id: 'cust-1', name: 'Acme', displayName: 'Acme' },
+          customer: { id: 'cust-1', displayName: 'Acme' },
           versions: [
             { id: 'v2', status: StatusEnum.Approved, version: 2 },
             { id: 'v1', status: StatusEnum.Draft, version: 1 },

--- a/src/pages/quotes/hooks/useOrderForms.ts
+++ b/src/pages/quotes/hooks/useOrderForms.ts
@@ -16,7 +16,6 @@ gql`
     expiresAt
     customer {
       id
-      name
       displayName
       ...QuotePreviewCustomer
     }

--- a/src/pages/quotes/hooks/useOrderForms.ts
+++ b/src/pages/quotes/hooks/useOrderForms.ts
@@ -17,6 +17,7 @@ gql`
     customer {
       id
       name
+      displayName
       ...QuotePreviewCustomer
     }
     quote {

--- a/src/pages/quotes/hooks/useQuote.ts
+++ b/src/pages/quotes/hooks/useQuote.ts
@@ -28,7 +28,6 @@ gql`
     createdAt
     customer {
       id
-      name
       displayName
       externalId
       netPaymentTerm

--- a/src/pages/quotes/hooks/useQuote.ts
+++ b/src/pages/quotes/hooks/useQuote.ts
@@ -29,6 +29,7 @@ gql`
     customer {
       id
       name
+      displayName
       externalId
       netPaymentTerm
       ...QuotePreviewCustomer

--- a/src/pages/quotes/hooks/useQuotes.ts
+++ b/src/pages/quotes/hooks/useQuotes.ts
@@ -21,6 +21,7 @@ gql`
     customer {
       id
       name
+      displayName
     }
   }
 

--- a/src/pages/quotes/hooks/useQuotes.ts
+++ b/src/pages/quotes/hooks/useQuotes.ts
@@ -20,7 +20,6 @@ gql`
     createdAt
     customer {
       id
-      name
       displayName
     }
   }


### PR DESCRIPTION
## Context

The quote and order form screens displayed the customer's raw `name` field. This switches them to the customer's **`displayName`**

## Description

This PR
- adds to graphQL fragments `displayName`
- use `displayName` everywhere

Fixes LAGO-1603

🤖 Generated with [Claude Code](https://claude.com/claude-code)