### PR TITLE
feat(orders): display orders on quotes list and quote details

### DIFF
--- a/src/core/apolloClient/cache.ts
+++ b/src/core/apolloClient/cache.ts
@@ -26,6 +26,7 @@ export const queryFieldPolicies: Record<string, FieldPolicy> = {
   invoices: createPaginatedFieldPolicy(),
   memberships: createPaginatedFieldPolicy(),
   orderForms: createPaginatedFieldPolicy(),
+  orders: createPaginatedFieldPolicy(),
   payments: createPaginatedFieldPolicy(),
   plans: createPaginatedFieldPolicy(),
   pricingUnits: createPaginatedFieldPolicy(),

--- a/src/core/constants/tabsOptions.ts
+++ b/src/core/constants/tabsOptions.ts
@@ -72,10 +72,12 @@ export enum FeatureDetailsTabsOptionsEnum {
 export enum QuotesTabsOptionsEnum {
   quotes = 'quotes',
   orderForms = 'order-forms',
+  orders = 'orders',
 }
 
 export enum QuoteDetailsTabsOptionsEnum {
   overview = 'overview',
   orderForms = 'order-forms',
+  orders = 'orders',
   activityLogs = 'activity-logs',
 }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -14408,6 +14408,17 @@ export type GetOrderFormsQueryVariables = Exact<{
 
 export type GetOrderFormsQuery = { __typename?: 'Query', orderForms: { __typename?: 'OrderFormCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null } } }> } };
 
+export type OrderListItemFragment = { __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executedAt?: any | null, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string } } };
+
+export type GetOrdersQueryVariables = Exact<{
+  page?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  quoteNumber?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
+}>;
+
+
+export type GetOrdersQuery = { __typename?: 'Query', orders: { __typename?: 'OrderCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executedAt?: any | null, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string } } }> } };
+
 export type QuotePreviewVersionFragment = { __typename?: 'QuoteVersion', content?: string | null, billingItems?: any | null };
 
 export type QuotePreviewCustomerFragment = { __typename?: 'Customer', currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null };
@@ -20390,6 +20401,23 @@ export const OrderFormListItemFragmentDoc = gql`
 }
     ${QuotePreviewCustomerFragmentDoc}
 ${QuotePreviewVersionFragmentDoc}`;
+export const OrderListItemFragmentDoc = gql`
+    fragment OrderListItem on Order {
+  id
+  number
+  status
+  executionMode
+  executedAt
+  orderForm {
+    id
+    number
+    quote {
+      id
+      number
+    }
+  }
+}
+    `;
 export const QuoteDetailItemFragmentDoc = gql`
     fragment QuoteDetailItem on Quote {
   id
@@ -39392,6 +39420,58 @@ export type GetOrderFormsQueryHookResult = ReturnType<typeof useGetOrderFormsQue
 export type GetOrderFormsLazyQueryHookResult = ReturnType<typeof useGetOrderFormsLazyQuery>;
 export type GetOrderFormsSuspenseQueryHookResult = ReturnType<typeof useGetOrderFormsSuspenseQuery>;
 export type GetOrderFormsQueryResult = Apollo.QueryResult<GetOrderFormsQuery, GetOrderFormsQueryVariables>;
+export const GetOrdersDocument = gql`
+    query getOrders($page: Int, $limit: Int, $quoteNumber: [String!]) {
+  orders(page: $page, limit: $limit, quoteNumber: $quoteNumber) {
+    metadata {
+      currentPage
+      totalPages
+      totalCount
+    }
+    collection {
+      ...OrderListItem
+    }
+  }
+}
+    ${OrderListItemFragmentDoc}`;
+
+/**
+ * __useGetOrdersQuery__
+ *
+ * To run a query within a React component, call `useGetOrdersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetOrdersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetOrdersQuery({
+ *   variables: {
+ *      page: // value for 'page'
+ *      limit: // value for 'limit'
+ *      quoteNumber: // value for 'quoteNumber'
+ *   },
+ * });
+ */
+export function useGetOrdersQuery(baseOptions?: Apollo.QueryHookOptions<GetOrdersQuery, GetOrdersQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetOrdersQuery, GetOrdersQueryVariables>(GetOrdersDocument, options);
+      }
+export function useGetOrdersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetOrdersQuery, GetOrdersQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetOrdersQuery, GetOrdersQueryVariables>(GetOrdersDocument, options);
+        }
+// @ts-ignore
+export function useGetOrdersSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetOrdersQuery, GetOrdersQueryVariables>): Apollo.UseSuspenseQueryResult<GetOrdersQuery, GetOrdersQueryVariables>;
+export function useGetOrdersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetOrdersQuery, GetOrdersQueryVariables>): Apollo.UseSuspenseQueryResult<GetOrdersQuery | undefined, GetOrdersQueryVariables>;
+export function useGetOrdersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetOrdersQuery, GetOrdersQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetOrdersQuery, GetOrdersQueryVariables>(GetOrdersDocument, options);
+        }
+export type GetOrdersQueryHookResult = ReturnType<typeof useGetOrdersQuery>;
+export type GetOrdersLazyQueryHookResult = ReturnType<typeof useGetOrdersLazyQuery>;
+export type GetOrdersSuspenseQueryHookResult = ReturnType<typeof useGetOrdersSuspenseQuery>;
+export type GetOrdersQueryResult = Apollo.QueryResult<GetOrdersQuery, GetOrdersQueryVariables>;
 export const GetQuoteDocument = gql`
     query getQuote($id: ID!) {
   quote(id: $id) {

--- a/src/pages/quotes/OrdersList.tsx
+++ b/src/pages/quotes/OrdersList.tsx
@@ -1,0 +1,61 @@
+import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
+import { Table, TableColumn } from '~/components/designSystem/Table/Table'
+import { DetailsPage } from '~/components/layouts/DetailsPage'
+import { OrderListItemFragment } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
+
+import { createOrdersPaginationHandler } from './common/ordersPaginationHandler'
+import {
+  ordersExecutionDateColumn,
+  ordersExecutionModeColumn,
+  ordersNumberColumn,
+  ordersOrderFormColumn,
+  ordersSourceQuoteColumn,
+  ordersStatusColumn,
+} from './common/ordersTableColumns'
+import { useOrders } from './hooks/useOrders'
+
+interface OrdersListProps {
+  quoteNumber?: string
+}
+
+const OrdersList = ({ quoteNumber }: OrdersListProps): JSX.Element => {
+  const { translate } = useInternationalization()
+  const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
+  const { orders, loading, error, fetchMore, metadata } = useOrders(
+    quoteNumber ? { quoteNumber: [quoteNumber] } : undefined,
+  )
+
+  const columns: Array<TableColumn<OrderListItemFragment>> = [
+    ordersNumberColumn(translate),
+    ordersStatusColumn(translate),
+    ...(quoteNumber ? [] : [ordersSourceQuoteColumn(translate)]),
+    ordersOrderFormColumn(translate),
+    ordersExecutionModeColumn(translate),
+    ordersExecutionDateColumn(translate, intlFormatDateTimeOrgaTZ),
+  ]
+
+  return (
+    <DetailsPage.Container>
+      <InfiniteScroll onBottom={createOrdersPaginationHandler(metadata, loading, fetchMore)}>
+        <Table
+          name="orders-list"
+          data={orders}
+          isLoading={loading}
+          hasError={!!error}
+          containerSize={0}
+          columns={columns}
+          placeholder={{
+            emptyState: {
+              title: translate('text_1782392058759fvp6ye50x8g'),
+              subtitle: translate('text_1782392058759ee7h86svmtj'),
+            },
+          }}
+        />
+      </InfiniteScroll>
+    </DetailsPage.Container>
+  )
+}
+
+export default OrdersList

--- a/src/pages/quotes/QuoteDetails.tsx
+++ b/src/pages/quotes/QuoteDetails.tsx
@@ -16,11 +16,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useQuote } from './hooks/useQuote'
 import { useQuoteVersionActions } from './hooks/useQuoteVersionActions'
 import OrderFormsList from './OrderFormsList'
-<<<<<<< HEAD
-=======
 import OrdersList from './OrdersList'
-import QuoteDetailsActivityLogs from './QuoteDetailsActivityLogs'
->>>>>>> 9358695e3 (feat(orders): add Orders tab to quotes list and quote details)
 import QuoteDetailsVersions from './QuoteDetailsVersions'
 
 const QuoteDetails = (): JSX.Element => {

--- a/src/pages/quotes/QuoteDetails.tsx
+++ b/src/pages/quotes/QuoteDetails.tsx
@@ -16,6 +16,11 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useQuote } from './hooks/useQuote'
 import { useQuoteVersionActions } from './hooks/useQuoteVersionActions'
 import OrderFormsList from './OrderFormsList'
+<<<<<<< HEAD
+=======
+import OrdersList from './OrdersList'
+import QuoteDetailsActivityLogs from './QuoteDetailsActivityLogs'
+>>>>>>> 9358695e3 (feat(orders): add Orders tab to quotes list and quote details)
 import QuoteDetailsVersions from './QuoteDetailsVersions'
 
 const QuoteDetails = (): JSX.Element => {
@@ -90,6 +95,14 @@ const QuoteDetails = (): JSX.Element => {
               tab: QuoteDetailsTabsOptionsEnum.orderForms,
             }),
             content: <OrderFormsList quoteNumber={quote?.number} />,
+          },
+          {
+            title: translate('text_17823920587596x5e6nes7qv'),
+            link: generatePath(QUOTE_DETAILS_ROUTE, {
+              quoteId: quoteId as string,
+              tab: QuoteDetailsTabsOptionsEnum.orders,
+            }),
+            content: <OrdersList quoteNumber={quote?.number} />,
           },
         ]}
       />

--- a/src/pages/quotes/Quotes.tsx
+++ b/src/pages/quotes/Quotes.tsx
@@ -24,6 +24,7 @@ import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { usePermissions } from '~/hooks/usePermissions'
 
 import OrderFormsList from './OrderFormsList'
+import OrdersList from './OrdersList'
 import QuotesList from './QuotesList'
 
 export const CREATE_QUOTE_BUTTON_TEST_ID = 'create-quote-button'
@@ -70,6 +71,13 @@ const Quotes = (): JSX.Element => {
           tab: QuotesTabsOptionsEnum.orderForms,
         }),
         content: <OrderFormsList />,
+      },
+      {
+        title: translate('text_17823920587596x5e6nes7qv'),
+        link: generatePath(QUOTES_TAB_ROUTE, {
+          tab: QuotesTabsOptionsEnum.orders,
+        }),
+        content: <OrdersList />,
       },
     ],
     [translate],

--- a/src/pages/quotes/__tests__/OrdersList.test.tsx
+++ b/src/pages/quotes/__tests__/OrdersList.test.tsx
@@ -1,0 +1,161 @@
+import { screen } from '@testing-library/react'
+
+import { OrderExecutionModeEnum, OrderStatusEnum } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import { useOrders } from '../hooks/useOrders'
+import OrdersList from '../OrdersList'
+
+const mockIntersectionObserver = jest.fn()
+
+mockIntersectionObserver.mockReturnValue({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+})
+
+globalThis.IntersectionObserver = mockIntersectionObserver
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  useOrganizationInfos: () => ({
+    intlFormatDateTimeOrgaTZ: (date: string) => ({
+      date: new Date(date).toLocaleDateString('en-US'),
+    }),
+  }),
+}))
+
+jest.mock('../hooks/useOrders', () => ({
+  useOrders: jest.fn(),
+}))
+
+const mockUseOrders = useOrders as jest.MockedFunction<typeof useOrders>
+
+const mockOrders = [
+  {
+    id: 'order-1',
+    number: 'ORD-2026-0001',
+    status: OrderStatusEnum.Executed,
+    executionMode: OrderExecutionModeEnum.ExecuteInLago,
+    executedAt: '2026-04-10T10:00:00Z',
+    orderForm: { id: 'of-1', number: 'OF-2026-0001', quote: { id: 'q-1', number: 'QUO-001' } },
+  },
+  {
+    id: 'order-2',
+    number: 'ORD-2026-0002',
+    status: OrderStatusEnum.Created,
+    executionMode: null,
+    executedAt: null,
+    orderForm: { id: 'of-2', number: 'OF-2026-0002', quote: { id: 'q-2', number: 'QUO-002' } },
+  },
+]
+
+describe('OrdersList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseOrders.mockReturnValue({
+      orders: mockOrders,
+      loading: false,
+      error: undefined,
+      fetchMore: jest.fn(),
+      metadata: { currentPage: 1, totalPages: 1, totalCount: 2 },
+    })
+  })
+
+  describe('GIVEN the component is rendered on the list page (no quoteNumber)', () => {
+    it('THEN should render a row per order', () => {
+      render(<OrdersList />)
+
+      expect(screen.getByTestId('table-row-0')).toBeInTheDocument()
+      expect(screen.getByTestId('table-row-1')).toBeInTheDocument()
+    })
+
+    it('THEN should display order numbers', () => {
+      render(<OrdersList />)
+
+      expect(screen.getByText('ORD-2026-0001')).toBeInTheDocument()
+      expect(screen.getByText('ORD-2026-0002')).toBeInTheDocument()
+    })
+
+    it('THEN should display status badges', () => {
+      render(<OrdersList />)
+
+      expect(screen.getAllByTestId('status')).toHaveLength(2)
+    })
+
+    it('THEN should display the source quote column', () => {
+      render(<OrdersList />)
+
+      expect(screen.getByText('QUO-001')).toBeInTheDocument()
+    })
+
+    it('THEN should display the order form numbers', () => {
+      render(<OrdersList />)
+
+      expect(screen.getByText('OF-2026-0001')).toBeInTheDocument()
+    })
+
+    it('THEN should render a dash for missing execution mode and date', () => {
+      render(<OrdersList />)
+
+      expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('GIVEN the component is rendered in quote details (quoteNumber set)', () => {
+    it('THEN should request orders scoped to the quote', () => {
+      render(<OrdersList quoteNumber="QUO-001" />)
+
+      expect(mockUseOrders).toHaveBeenCalledWith({ quoteNumber: ['QUO-001'] })
+    })
+
+    it('THEN should NOT display the source quote column', () => {
+      render(<OrdersList quoteNumber="QUO-001" />)
+
+      expect(screen.queryByText('QUO-001')).not.toBeInTheDocument()
+    })
+
+    it('THEN should still display the order form column', () => {
+      render(<OrdersList quoteNumber="QUO-001" />)
+
+      expect(screen.getByText('OF-2026-0001')).toBeInTheDocument()
+    })
+  })
+
+  describe('GIVEN there are no orders', () => {
+    it('THEN should not render any rows', () => {
+      mockUseOrders.mockReturnValue({
+        orders: [],
+        loading: false,
+        error: undefined,
+        fetchMore: jest.fn(),
+        metadata: undefined,
+      })
+
+      render(<OrdersList />)
+
+      expect(screen.queryByTestId('table-row-0')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('GIVEN orders are loading', () => {
+    it('THEN should render the table in loading state', () => {
+      mockUseOrders.mockReturnValue({
+        orders: [],
+        loading: true,
+        error: undefined,
+        fetchMore: jest.fn(),
+        metadata: undefined,
+      })
+
+      render(<OrdersList />)
+
+      expect(screen.getByTestId('table-orders-list')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/pages/quotes/__tests__/QuoteDetails.test.tsx
+++ b/src/pages/quotes/__tests__/QuoteDetails.test.tsx
@@ -39,6 +39,11 @@ jest.mock('../OrderFormsList', () => ({
   default: () => null,
 }))
 
+jest.mock('../OrdersList', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
 const mockQuote = {
   id: 'quote-draft-001',
   number: 'QT-2026-0042',
@@ -137,12 +142,12 @@ describe('QuoteDetails', () => {
         expect(config.entity.metadata).toContain('ext-acme-001')
       })
 
-      it('THEN should configure MainHeader with two tabs', () => {
+      it('THEN should configure MainHeader with three tabs', () => {
         render(<QuoteDetails />)
 
         const config = mockMainHeaderConfigure.mock.calls[0][0]
 
-        expect(config.tabs).toHaveLength(2)
+        expect(config.tabs).toHaveLength(3)
       })
 
       it('THEN should have the first tab linking to overview', () => {
@@ -159,6 +164,14 @@ describe('QuoteDetails', () => {
         const config = mockMainHeaderConfigure.mock.calls[0][0]
 
         expect(config.tabs[1].link).toBe('/quote/quote-draft-001/order-forms')
+      })
+
+      it('THEN should have Orders as the third tab', () => {
+        render(<QuoteDetails />)
+
+        const config = mockMainHeaderConfigure.mock.calls[0][0]
+
+        expect(config.tabs[2].link).toBe('/quote/quote-draft-001/orders')
       })
     })
 

--- a/src/pages/quotes/__tests__/Quotes.test.tsx
+++ b/src/pages/quotes/__tests__/Quotes.test.tsx
@@ -66,12 +66,12 @@ describe('Quotes', () => {
         expect(capturedConfig?.entity?.viewName).toEqual(expect.any(String))
       })
 
-      it('THEN should configure MainHeader with two tabs', () => {
+      it('THEN should configure MainHeader with three tabs', () => {
         mockHasPermissions.mockReturnValue(true)
 
         render(<Quotes />)
 
-        expect(capturedConfig?.tabs).toHaveLength(2)
+        expect(capturedConfig?.tabs).toHaveLength(3)
       })
 
       it('THEN should have a Quotes tab as the first tab', () => {
@@ -90,6 +90,15 @@ describe('Quotes', () => {
 
         expect(capturedConfig?.tabs?.[1].title).toEqual(expect.any(String))
         expect(capturedConfig?.tabs?.[1].link).toBe('/quotes/order-forms')
+      })
+
+      it('THEN should have an Orders tab as the third tab', () => {
+        mockHasPermissions.mockReturnValue(true)
+
+        render(<Quotes />)
+
+        expect(capturedConfig?.tabs?.[2].title).toEqual(expect.any(String))
+        expect(capturedConfig?.tabs?.[2].link).toBe('/quotes/orders')
       })
 
       it('THEN should render the active tab content', () => {

--- a/src/pages/quotes/common/__tests__/getOrderExecutionModeTranslationKey.test.ts
+++ b/src/pages/quotes/common/__tests__/getOrderExecutionModeTranslationKey.test.ts
@@ -1,0 +1,27 @@
+import { OrderExecutionModeEnum } from '~/generated/graphql'
+
+import { getOrderExecutionModeTranslationKey } from '../getOrderExecutionModeTranslationKey'
+
+describe('getOrderExecutionModeTranslationKey', () => {
+  it('GIVEN execute_in_lago THEN returns a non-empty key', () => {
+    expect(getOrderExecutionModeTranslationKey(OrderExecutionModeEnum.ExecuteInLago)).not.toBe('')
+  })
+
+  it('GIVEN order_only THEN returns a non-empty key', () => {
+    expect(getOrderExecutionModeTranslationKey(OrderExecutionModeEnum.OrderOnly)).not.toBe('')
+  })
+
+  it('GIVEN execute_in_lago and order_only THEN returns distinct keys', () => {
+    expect(getOrderExecutionModeTranslationKey(OrderExecutionModeEnum.ExecuteInLago)).not.toBe(
+      getOrderExecutionModeTranslationKey(OrderExecutionModeEnum.OrderOnly),
+    )
+  })
+
+  it('GIVEN null THEN returns an empty string', () => {
+    expect(getOrderExecutionModeTranslationKey(null)).toBe('')
+  })
+
+  it('GIVEN undefined THEN returns an empty string', () => {
+    expect(getOrderExecutionModeTranslationKey(undefined)).toBe('')
+  })
+})

--- a/src/pages/quotes/common/__tests__/getOrderStatusMapping.test.ts
+++ b/src/pages/quotes/common/__tests__/getOrderStatusMapping.test.ts
@@ -1,0 +1,40 @@
+import { StatusType } from '~/components/designSystem/Status'
+import { OrderStatusEnum } from '~/generated/graphql'
+
+import { getOrderStatusMapping } from '../getOrderStatusMapping'
+
+describe('getOrderStatusMapping', () => {
+  const mockTranslate = jest.fn((key: string) => key)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN a created status', () => {
+    it('THEN should return warning type', () => {
+      const result = getOrderStatusMapping(OrderStatusEnum.Created, mockTranslate)
+
+      expect(result.type).toBe(StatusType.warning)
+    })
+
+    it('THEN should call translate for the label', () => {
+      getOrderStatusMapping(OrderStatusEnum.Created, mockTranslate)
+
+      expect(mockTranslate).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('GIVEN an executed status', () => {
+    it('THEN should return success type', () => {
+      const result = getOrderStatusMapping(OrderStatusEnum.Executed, mockTranslate)
+
+      expect(result.type).toBe(StatusType.success)
+    })
+
+    it('THEN should call translate for the label', () => {
+      getOrderStatusMapping(OrderStatusEnum.Executed, mockTranslate)
+
+      expect(mockTranslate).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/pages/quotes/common/__tests__/ordersPaginationHandler.test.ts
+++ b/src/pages/quotes/common/__tests__/ordersPaginationHandler.test.ts
@@ -1,0 +1,77 @@
+import { createOrdersPaginationHandler } from '../ordersPaginationHandler'
+
+describe('createOrdersPaginationHandler', () => {
+  const mockFetchMore = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN there are more pages to load', () => {
+    describe('WHEN the handler is called and not loading', () => {
+      it('THEN should call fetchMore with the next page', () => {
+        const handler = createOrdersPaginationHandler(
+          { currentPage: 1, totalPages: 3, totalCount: 60 },
+          false,
+          mockFetchMore,
+        )
+
+        handler()
+
+        expect(mockFetchMore).toHaveBeenCalledWith({
+          variables: { page: 2 },
+        })
+      })
+    })
+
+    describe('WHEN currently loading', () => {
+      it('THEN should not call fetchMore', () => {
+        const handler = createOrdersPaginationHandler(
+          { currentPage: 1, totalPages: 3, totalCount: 60 },
+          true,
+          mockFetchMore,
+        )
+
+        handler()
+
+        expect(mockFetchMore).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN the current page is the last page', () => {
+    it('THEN should not call fetchMore', () => {
+      const handler = createOrdersPaginationHandler(
+        { currentPage: 3, totalPages: 3, totalCount: 60 },
+        false,
+        mockFetchMore,
+      )
+
+      handler()
+
+      expect(mockFetchMore).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('GIVEN metadata is undefined', () => {
+    it('THEN should not call fetchMore', () => {
+      const handler = createOrdersPaginationHandler(undefined, false, mockFetchMore)
+
+      handler()
+
+      expect(mockFetchMore).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('GIVEN fetchMore is undefined', () => {
+    it('THEN should not throw', () => {
+      const handler = createOrdersPaginationHandler(
+        { currentPage: 1, totalPages: 3, totalCount: 60 },
+        false,
+        undefined,
+      )
+
+      expect(() => handler()).not.toThrow()
+    })
+  })
+})

--- a/src/pages/quotes/common/getOrderExecutionModeTranslationKey.ts
+++ b/src/pages/quotes/common/getOrderExecutionModeTranslationKey.ts
@@ -1,0 +1,14 @@
+import { OrderExecutionModeEnum } from '~/generated/graphql'
+
+export const getOrderExecutionModeTranslationKey = (
+  executionMode?: OrderExecutionModeEnum | null,
+): string => {
+  switch (executionMode) {
+    case OrderExecutionModeEnum.ExecuteInLago:
+      return 'text_1782392058759vsncvwa3829'
+    case OrderExecutionModeEnum.OrderOnly:
+      return 'text_1782392058759l2hdxjsbklc'
+    default:
+      return ''
+  }
+}

--- a/src/pages/quotes/common/getOrderStatusMapping.ts
+++ b/src/pages/quotes/common/getOrderStatusMapping.ts
@@ -1,0 +1,17 @@
+import { StatusProps, StatusType } from '~/components/designSystem/Status'
+import { OrderStatusEnum } from '~/generated/graphql'
+import { TranslateFunc } from '~/hooks/core/useInternationalization'
+
+export const getOrderStatusMapping = (
+  status: OrderStatusEnum,
+  translate: TranslateFunc,
+): Pick<StatusProps, 'type' | 'label'> => {
+  switch (status) {
+    case OrderStatusEnum.Created:
+      return { type: StatusType.warning, label: translate('text_1782392058759gdepj0tu2cn') }
+    case OrderStatusEnum.Executed:
+      return { type: StatusType.success, label: translate('text_17823920587590tcd0ckxjde') }
+    default:
+      return { type: StatusType.outline, label: status }
+  }
+}

--- a/src/pages/quotes/common/ordersPaginationHandler.ts
+++ b/src/pages/quotes/common/ordersPaginationHandler.ts
@@ -1,0 +1,23 @@
+import { FetchMoreQueryOptions, OperationVariables } from '@apollo/client'
+
+import { GetOrdersQuery } from '~/generated/graphql'
+
+export const createOrdersPaginationHandler = (
+  metadata: GetOrdersQuery['orders']['metadata'] | undefined,
+  loading: boolean,
+  fetchMore:
+    | ((
+        fetchMoreOptions: FetchMoreQueryOptions<OperationVariables, GetOrdersQuery>,
+      ) => Promise<unknown>)
+    | undefined,
+) => {
+  return () => {
+    const { currentPage = 0, totalPages = 0 } = metadata || {}
+
+    currentPage < totalPages &&
+      !loading &&
+      fetchMore?.({
+        variables: { page: currentPage + 1 },
+      })
+  }
+}

--- a/src/pages/quotes/common/ordersTableColumns.tsx
+++ b/src/pages/quotes/common/ordersTableColumns.tsx
@@ -1,0 +1,106 @@
+import { generatePath } from 'react-router-dom'
+
+import { Status } from '~/components/designSystem/Status'
+import { TableColumn } from '~/components/designSystem/Table/Table'
+import { Typography } from '~/components/designSystem/Typography'
+import { QuoteDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
+import { Link, QUOTE_DETAILS_ROUTE } from '~/core/router'
+import { OrderListItemFragment } from '~/generated/graphql'
+import { TranslateFunc } from '~/hooks/core/useInternationalization'
+
+import { getOrderExecutionModeTranslationKey } from './getOrderExecutionModeTranslationKey'
+import { getOrderStatusMapping } from './getOrderStatusMapping'
+
+export const ordersNumberColumn = (
+  translate: TranslateFunc,
+): TableColumn<OrderListItemFragment> => ({
+  key: 'number',
+  title: translate('text_1782392058759pmmuy0h997w'),
+  minWidth: 160,
+  maxSpace: true,
+  content: ({ number }) => (
+    <Typography variant="bodyHl" noWrap>
+      {number}
+    </Typography>
+  ),
+})
+
+export const ordersStatusColumn = (
+  translate: TranslateFunc,
+): TableColumn<OrderListItemFragment> => ({
+  key: 'status',
+  title: translate('text_63ac86d797f728a87b2f9fa7'),
+  minWidth: 100,
+  content: ({ status }) => <Status {...getOrderStatusMapping(status, translate)} />,
+})
+
+export const ordersSourceQuoteColumn = (
+  translate: TranslateFunc,
+): TableColumn<OrderListItemFragment> => ({
+  key: 'orderForm.quote.number',
+  title: translate('text_1779695273381h7tmhdzrv48'),
+  minWidth: 160,
+  content: ({ orderForm }) => (
+    <Typography color="info600" noWrap>
+      <Link
+        to={generatePath(QUOTE_DETAILS_ROUTE, {
+          quoteId: orderForm.quote.id,
+          tab: QuoteDetailsTabsOptionsEnum.overview,
+        })}
+      >
+        {orderForm.quote.number}
+      </Link>
+    </Typography>
+  ),
+})
+
+export const ordersOrderFormColumn = (
+  translate: TranslateFunc,
+): TableColumn<OrderListItemFragment> => ({
+  key: 'orderForm.number',
+  title: translate('text_1782392058759f99av1go7r6'),
+  minWidth: 160,
+  content: ({ orderForm }) => (
+    <Typography color="info600" noWrap>
+      <Link
+        to={generatePath(QUOTE_DETAILS_ROUTE, {
+          quoteId: orderForm.quote.id,
+          tab: QuoteDetailsTabsOptionsEnum.orderForms,
+        })}
+      >
+        {orderForm.number}
+      </Link>
+    </Typography>
+  ),
+})
+
+export const ordersExecutionModeColumn = (
+  translate: TranslateFunc,
+): TableColumn<OrderListItemFragment> => ({
+  key: 'executionMode',
+  title: translate('text_17823920587599ha9n3uhfuj'),
+  minWidth: 140,
+  content: ({ executionMode }) => {
+    const key = getOrderExecutionModeTranslationKey(executionMode)
+
+    return (
+      <Typography color="grey600" noWrap>
+        {key ? translate(key) : '-'}
+      </Typography>
+    )
+  },
+})
+
+export const ordersExecutionDateColumn = (
+  translate: TranslateFunc,
+  intlFormatDateTimeOrgaTZ: (date: string) => { date: string },
+): TableColumn<OrderListItemFragment> => ({
+  key: 'executedAt',
+  title: translate('text_1782392058759njezxv1yrhl'),
+  minWidth: 120,
+  content: ({ executedAt }) => (
+    <Typography color="grey600">
+      {executedAt ? intlFormatDateTimeOrgaTZ(executedAt).date : '-'}
+    </Typography>
+  ),
+})

--- a/src/pages/quotes/hooks/__tests__/useOrders.test.ts
+++ b/src/pages/quotes/hooks/__tests__/useOrders.test.ts
@@ -1,0 +1,106 @@
+import { renderHook } from '@testing-library/react'
+
+import { useGetOrdersQuery } from '~/generated/graphql'
+
+import { useOrders } from '../useOrders'
+
+jest.mock('~/generated/graphql', () => ({
+  useGetOrdersQuery: jest.fn(),
+}))
+
+const mockUseGetOrdersQuery = useGetOrdersQuery as jest.Mock
+
+describe('useOrders', () => {
+  const mockFetchMore = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseGetOrdersQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+      fetchMore: mockFetchMore,
+    })
+  })
+
+  describe('GIVEN the hook is rendered', () => {
+    it('THEN should pass limit of 20 as default', () => {
+      renderHook(() => useOrders())
+
+      expect(mockUseGetOrdersQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: expect.objectContaining({ limit: 20 }),
+        }),
+      )
+    })
+  })
+
+  describe('GIVEN a quoteNumber is provided', () => {
+    it('THEN should merge it with defaults', () => {
+      renderHook(() => useOrders({ quoteNumber: ['QUO-001'] }))
+
+      expect(mockUseGetOrdersQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            limit: 20,
+            quoteNumber: ['QUO-001'],
+          }),
+        }),
+      )
+    })
+  })
+
+  describe('GIVEN the query returns data', () => {
+    it('THEN should return the orders collection', () => {
+      const mockOrders = [
+        { id: 'order-1', number: 'ORD-001' },
+        { id: 'order-2', number: 'ORD-002' },
+      ]
+
+      mockUseGetOrdersQuery.mockReturnValue({
+        data: {
+          orders: {
+            collection: mockOrders,
+            metadata: { currentPage: 1, totalPages: 2, totalCount: 10 },
+          },
+        },
+        loading: false,
+        error: undefined,
+        fetchMore: mockFetchMore,
+      })
+
+      const { result } = renderHook(() => useOrders())
+
+      expect(result.current.orders).toEqual(mockOrders)
+      expect(result.current.metadata).toEqual({
+        currentPage: 1,
+        totalPages: 2,
+        totalCount: 10,
+      })
+    })
+  })
+
+  describe('GIVEN the query has no data yet', () => {
+    it('THEN should return an empty array for orders', () => {
+      const { result } = renderHook(() => useOrders())
+
+      expect(result.current.orders).toEqual([])
+      expect(result.current.metadata).toBeUndefined()
+    })
+  })
+
+  describe('GIVEN the query is loading', () => {
+    it('THEN should return loading true', () => {
+      mockUseGetOrdersQuery.mockReturnValue({
+        data: undefined,
+        loading: true,
+        error: undefined,
+        fetchMore: mockFetchMore,
+      })
+
+      const { result } = renderHook(() => useOrders())
+
+      expect(result.current.loading).toBe(true)
+    })
+  })
+})

--- a/src/pages/quotes/hooks/useOrders.ts
+++ b/src/pages/quotes/hooks/useOrders.ts
@@ -1,0 +1,73 @@
+import { FetchMoreQueryOptions, gql, OperationVariables } from '@apollo/client'
+
+import {
+  GetOrdersQuery,
+  GetOrdersQueryVariables,
+  OrderListItemFragment,
+  useGetOrdersQuery,
+} from '~/generated/graphql'
+
+gql`
+  fragment OrderListItem on Order {
+    id
+    number
+    status
+    executionMode
+    executedAt
+    orderForm {
+      id
+      number
+      quote {
+        id
+        number
+      }
+    }
+  }
+
+  query getOrders($page: Int, $limit: Int, $quoteNumber: [String!]) {
+    orders(page: $page, limit: $limit, quoteNumber: $quoteNumber) {
+      metadata {
+        currentPage
+        totalPages
+        totalCount
+      }
+      collection {
+        ...OrderListItem
+      }
+    }
+  }
+`
+
+interface UseOrdersReturn {
+  orders: OrderListItemFragment[]
+  metadata: GetOrdersQuery['orders']['metadata'] | undefined
+  loading: boolean
+  error: Error | undefined
+  fetchMore:
+    | ((
+        fetchMoreOptions: FetchMoreQueryOptions<OperationVariables, GetOrdersQuery>,
+      ) => Promise<unknown>)
+    | undefined
+}
+
+export const useOrders = (
+  variables?: Omit<GetOrdersQueryVariables, 'limit' | 'page'>,
+): UseOrdersReturn => {
+  const { data, loading, error, fetchMore } = useGetOrdersQuery({
+    variables: {
+      limit: 20,
+      ...variables,
+    },
+    notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'network-only',
+    nextFetchPolicy: 'network-only',
+  })
+
+  return {
+    orders: data?.orders?.collection || [],
+    metadata: data?.orders?.metadata,
+    loading,
+    error,
+    fetchMore,
+  }
+}

--- a/translations/base.json
+++ b/translations/base.json
@@ -4370,7 +4370,7 @@
   "text_1782392058759njezxv1yrhl": "Execution date",
   "text_1782392058759gdepj0tu2cn": "Created",
   "text_17823920587590tcd0ckxjde": "Executed",
-  "text_1782392058759vsncvwa3829": "In Lago",
+  "text_1782392058759vsncvwa3829": "Execute in Lago",
   "text_1782392058759l2hdxjsbklc": "Order only",
   "text_1782392058759fvp6ye50x8g": "No order yet",
   "text_1782392058759ee7h86svmtj": "Orders will appear here once their order forms are signed."

--- a/translations/base.json
+++ b/translations/base.json
@@ -4362,5 +4362,16 @@
   "text_1781874334924qwjnv1swbo2": "Valid until: {{date}}",
   "text_1782378031093sfjoizk5vap": "This customer is linked to an entity using Lago EU Tax Management. Changing the billing entity may change how taxes are calculated on future invoices.",
   "text_1782378031093gnp1nv78zfv": "The selected billing entity uses Lago EU Tax Management. Switching to it may change how taxes are calculated on future invoices.",
-  "text_1782385268545ex9rk4gx0rf": "Please select a tax or remove the empty row"
+  "text_1782385268545ex9rk4gx0rf": "Please select a tax or remove the empty row",
+  "text_17823920587596x5e6nes7qv": "Orders",
+  "text_1782392058759pmmuy0h997w": "Order number",
+  "text_1782392058759f99av1go7r6": "Order form",
+  "text_17823920587599ha9n3uhfuj": "Execution mode",
+  "text_1782392058759njezxv1yrhl": "Execution date",
+  "text_1782392058759gdepj0tu2cn": "Created",
+  "text_17823920587590tcd0ckxjde": "Executed",
+  "text_1782392058759vsncvwa3829": "In Lago",
+  "text_1782392058759l2hdxjsbklc": "Order only",
+  "text_1782392058759fvp6ye50x8g": "No order yet",
+  "text_1782392058759ee7h86svmtj": "Orders will appear here once their order forms are signed."
 }


### PR DESCRIPTION
## Context

Adds a read-only **Orders** list to the Quotes feature, completing the Quote → Order Form → **Order** hierarchy alongside the existing Quotes and Order Forms lists.

## Description

A single `OrdersList` component, reused in two places (mirroring how `OrderFormsList` is reused):


Fixes LAGO-1430

🤖 Generated with [Claude Code](https://claude.com/claude-code)