### PR TITLE
chore: migrate DeleteFlutterwaveIntegrationDialog to CentralizedDialog

### DIFF
--- a/src/components/settings/integrations/AddFlutterwaveDialog.tsx
+++ b/src/components/settings/integrations/AddFlutterwaveDialog.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { useFormik } from 'formik'
-import { forwardRef, RefObject, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 import { object, string } from 'yup'
 
@@ -19,8 +19,6 @@ import {
   useUpdateFlutterwavePaymentProviderMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-
-import { DeleteFlutterwaveIntegrationDialogRef } from './DeleteFlutterwaveIntegrationDialog'
 
 gql`
   fragment AddFlutterwaveProviderDialog on FlutterwaveProvider {
@@ -71,9 +69,8 @@ gql`
 `
 
 type TAddFlutterwaveDialogProps = Partial<{
-  deleteModalRef: RefObject<DeleteFlutterwaveIntegrationDialogRef>
+  onDelete: (provider: FlutterwaveIntegrationDetailsFragment) => void
   provider: FlutterwaveIntegrationDetailsFragment
-  deleteDialogCallback: () => void
 }>
 
 export interface AddFlutterwaveDialogRef {
@@ -211,10 +208,9 @@ export const AddFlutterwaveDialog = forwardRef<AddFlutterwaveDialogRef>((_, ref)
               variant="quaternary"
               onClick={() => {
                 closeDialog()
-                localData?.deleteModalRef?.current?.openDialog({
-                  provider: flutterwaveProvider,
-                  callback: localData?.deleteDialogCallback,
-                })
+                if (flutterwaveProvider) {
+                  localData?.onDelete?.(flutterwaveProvider)
+                }
               }}
             >
               {translate('text_65845f35d7d69c3ab4793dad')}

--- a/src/components/settings/integrations/DeleteFlutterwaveIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteFlutterwaveIntegrationDialog.tsx
@@ -1,10 +1,11 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import {
   DeleteFlutterwaveIntegrationDialogFragment,
+  GetFlutterwaveIntegrationsListDocument,
   useDeleteFlutterwaveIntegrationMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -26,63 +27,47 @@ type TDeleteFlutterwaveIntegrationDialogProps = {
   callback?: () => void
 }
 
-export interface DeleteFlutterwaveIntegrationDialogRef {
-  openDialog: ({ provider, callback }: TDeleteFlutterwaveIntegrationDialogProps) => unknown
-  closeDialog: () => unknown
-}
+export const useDeleteFlutterwaveIntegrationDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+  const client = useApolloClient()
 
-export const DeleteFlutterwaveIntegrationDialog = forwardRef<DeleteFlutterwaveIntegrationDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
+  const [deleteFlutterwave] = useDeleteFlutterwaveIntegrationMutation()
 
-    const dialogRef = useRef<WarningDialogRef>(null)
-    const [localData, setLocalData] = useState<
-      TDeleteFlutterwaveIntegrationDialogProps | undefined
-    >(undefined)
-    const flutterwaveProvider = localData?.provider
+  const openDeleteFlutterwaveIntegrationDialog = ({
+    provider,
+    callback,
+  }: TDeleteFlutterwaveIntegrationDialogProps) => {
+    centralizedDialog.open({
+      title: translate('text_1749799070145vfvz9sq757a', { name: provider?.name }),
+      description: translate('text_1749799070145zdncdpo3g37'),
+      colorVariant: 'danger',
+      actionText: translate('text_1749799070145czycjo9guoq'),
+      onAction: async () => {
+        const result = await deleteFlutterwave({
+          variables: { input: { id: provider?.id as string } },
+        })
 
-    const [deleteFlutterwave] = useDeleteFlutterwaveIntegrationMutation({
-      onCompleted(data) {
-        if (data && data.destroyPaymentProvider) {
-          dialogRef.current?.closeDialog()
-          localData?.callback?.()
+        const destroyedId = result.data?.destroyPaymentProvider?.id
+
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'FlutterwaveProvider',
+            listFieldName: 'paymentProviders',
+            listQueryDocument: GetFlutterwaveIntegrationsListDocument,
+          })
+
+          callback?.()
+
           addToast({
             message: translate('text_1749799070145axw96s27789'),
             severity: 'success',
           })
         }
       },
-      update(cache) {
-        cache.evict({ id: `FlutterwaveProvider:${flutterwaveProvider?.id}` })
-      },
-      refetchQueries: ['getFlutterwaveIntegrationsList'],
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setLocalData(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => dialogRef.current?.closeDialog(),
-    }))
-
-    return (
-      <WarningDialog
-        mode="danger"
-        ref={dialogRef}
-        title={translate('text_1749799070145vfvz9sq757a', {
-          name: flutterwaveProvider?.name,
-        })}
-        description={translate('text_1749799070145zdncdpo3g37')}
-        onContinue={async () =>
-          await deleteFlutterwave({
-            variables: { input: { id: flutterwaveProvider?.id as string } },
-          })
-        }
-        continueText={translate('text_1749799070145czycjo9guoq')}
-      />
-    )
-  },
-)
-
-DeleteFlutterwaveIntegrationDialog.displayName = 'DeleteFlutterwaveIntegrationDialog'
+  return { openDeleteFlutterwaveIntegrationDialog }
+}

--- a/src/pages/settings/FlutterwaveIntegrationDetails.tsx
+++ b/src/pages/settings/FlutterwaveIntegrationDetails.tsx
@@ -19,10 +19,7 @@ import {
   AddFlutterwaveDialog,
   AddFlutterwaveDialogRef,
 } from '~/components/settings/integrations/AddFlutterwaveDialog'
-import {
-  DeleteFlutterwaveIntegrationDialog,
-  DeleteFlutterwaveIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteFlutterwaveIntegrationDialog'
+import { useDeleteFlutterwaveIntegrationDialog } from '~/components/settings/integrations/DeleteFlutterwaveIntegrationDialog'
 import { addToast, envGlobalVar } from '~/core/apolloClient'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { FLUTTERWAVE_INTEGRATION_ROUTE, INTEGRATIONS_ROUTE, useNavigate } from '~/core/router'
@@ -73,7 +70,7 @@ const FlutterwaveIntegrationDetails = () => {
   const { integrationId } = useParams()
   const { hasPermissions } = usePermissions()
   const addDialogRef = useRef<AddFlutterwaveDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteFlutterwaveIntegrationDialogRef>(null)
+  const { openDeleteFlutterwaveIntegrationDialog } = useDeleteFlutterwaveIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { apiUrl } = envGlobalVar()
   // CRITICAL: this organizationId is baked into a webhook URL the user copies
@@ -161,8 +158,11 @@ const FlutterwaveIntegrationDetails = () => {
                   onClick: (closePopper) => {
                     addDialogRef.current?.openDialog({
                       provider: flutterwavePaymentProvider,
-                      deleteModalRef: deleteDialogRef,
-                      deleteDialogCallback,
+                      onDelete: (provider) =>
+                        openDeleteFlutterwaveIntegrationDialog({
+                          provider,
+                          callback: deleteDialogCallback,
+                        }),
                     })
                     closePopper()
                   },
@@ -171,7 +171,7 @@ const FlutterwaveIntegrationDetails = () => {
                   label: translate('text_65845f35d7d69c3ab4793dad'),
                   hidden: !canDeleteIntegration,
                   onClick: (closePopper) => {
-                    deleteDialogRef.current?.openDialog({
+                    openDeleteFlutterwaveIntegrationDialog({
                       provider: flutterwavePaymentProvider,
                       callback: deleteDialogCallback,
                     })
@@ -201,8 +201,11 @@ const FlutterwaveIntegrationDetails = () => {
                 onClick={() => {
                   addDialogRef.current?.openDialog({
                     provider: flutterwavePaymentProvider,
-                    deleteModalRef: deleteDialogRef,
-                    deleteDialogCallback,
+                    onDelete: (provider) =>
+                      openDeleteFlutterwaveIntegrationDialog({
+                        provider,
+                        callback: deleteDialogCallback,
+                      }),
                   })
                 }}
               >
@@ -386,7 +389,6 @@ const FlutterwaveIntegrationDetails = () => {
       </div>
 
       <AddFlutterwaveDialog ref={addDialogRef} />
-      <DeleteFlutterwaveIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </div>
   )

--- a/src/pages/settings/FlutterwaveIntegrations.tsx
+++ b/src/pages/settings/FlutterwaveIntegrations.tsx
@@ -11,10 +11,7 @@ import {
   AddFlutterwaveDialog,
   AddFlutterwaveDialogRef,
 } from '~/components/settings/integrations/AddFlutterwaveDialog'
-import {
-  DeleteFlutterwaveIntegrationDialog,
-  DeleteFlutterwaveIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteFlutterwaveIntegrationDialog'
+import { useDeleteFlutterwaveIntegrationDialog } from '~/components/settings/integrations/DeleteFlutterwaveIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import {
   FLUTTERWAVE_INTEGRATION_DETAILS_ROUTE,
@@ -58,7 +55,7 @@ const FlutterwaveIntegrations = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
   const addDialogRef = useRef<AddFlutterwaveDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteFlutterwaveIntegrationDialogRef>(null)
+  const { openDeleteFlutterwaveIntegrationDialog } = useDeleteFlutterwaveIntegrationDialog()
   const { hasPermissions } = usePermissions()
 
   const { data, loading } = useGetFlutterwaveIntegrationsListQuery({
@@ -164,8 +161,11 @@ const FlutterwaveIntegrations = () => {
                               onClick={() => {
                                 addDialogRef.current?.openDialog({
                                   provider: connection,
-                                  deleteModalRef: deleteDialogRef,
-                                  deleteDialogCallback,
+                                  onDelete: (provider) =>
+                                    openDeleteFlutterwaveIntegrationDialog({
+                                      provider,
+                                      callback: deleteDialogCallback,
+                                    }),
                                 })
                                 closePopper()
                               }}
@@ -180,7 +180,7 @@ const FlutterwaveIntegrations = () => {
                               variant="quaternary"
                               align="left"
                               onClick={() => {
-                                deleteDialogRef.current?.openDialog({
+                                openDeleteFlutterwaveIntegrationDialog({
                                   provider: connection,
                                   callback: deleteDialogCallback,
                                 })
@@ -201,7 +201,6 @@ const FlutterwaveIntegrations = () => {
       </IntegrationsPage.Container>
 
       <AddFlutterwaveDialog ref={addDialogRef} />
-      <DeleteFlutterwaveIntegrationDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/__tests__/FlutterwaveIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/FlutterwaveIntegrations.test.tsx
@@ -14,7 +14,9 @@ jest.mock('~/components/settings/integrations/AddFlutterwaveDialog', () => ({
   AddFlutterwaveDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteFlutterwaveIntegrationDialog', () => ({
-  DeleteFlutterwaveIntegrationDialog: () => null,
+  useDeleteFlutterwaveIntegrationDialog: () => ({
+    openDeleteFlutterwaveIntegrationDialog: () => null,
+  }),
 }))
 
 describe('FlutterwaveIntegrations', () => {


### PR DESCRIPTION
## Context

`DeleteFlutterwaveIntegrationDialog` was flagged by the `no-restricted-imports` ESLint rule because it imports the deprecated `WarningDialog` component (and exposes a ref-based imperative API). The new dialog system in `~/components/dialogs` is hook-based and is the established replacement across the codebase (see `DeleteAdyenIntegrationDialog` for the canonical equivalent).

This migration also fixes the long-standing post-delete cache handling: bare `cache.evict()` + `refetchQueries` is replaced by the `evictFromCache` helper, which suppresses watchers on still-mounted detail queries to avoid the 404 toast that fires after deletion.

## Description

- Replace the `forwardRef`/`useImperativeHandle` `DeleteFlutterwaveIntegrationDialog` component with a `useDeleteFlutterwaveIntegrationDialog` hook returning `openDeleteFlutterwaveIntegrationDialog`.
- Use `useCentralizedDialog` with `colorVariant: 'danger'` for the confirmation UI.
- Replace `refetchQueries: ['getFlutterwaveIntegrationsList']` + inline `cache.evict` with the `evictFromCache` helper (typename `FlutterwaveProvider`, list field `paymentProviders`, list document `GetFlutterwaveIntegrationsListDocument`).
- `AddFlutterwaveDialog` no longer accepts a `deleteModalRef` + `deleteDialogCallback`; it now takes a single `onDelete: (provider) => void` callback, matching the pattern used by `AddAdyenDialog`. Parents wire `onDelete` to `openDeleteFlutterwaveIntegrationDialog`.
- `FlutterwaveIntegrations` and `FlutterwaveIntegrationDetails` consume the new hook directly and no longer render the delete dialog component.
- Test mock in `FlutterwaveIntegrations.test.tsx` updated to mock the new hook export.

<!-- Linear link -->
Fixes LAGO-XXX

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7DUNeWivuDr12KK9By17a)_