### PR TITLE
fix(toast): stop empty toast container blocking clicks

### DIFF
--- a/src/components/designSystem/Toasts/Toast.tsx
+++ b/src/components/designSystem/Toasts/Toast.tsx
@@ -19,7 +19,7 @@ interface ToastRef {
 const AUTO_DISMISS_TIME = 6000
 
 const containerStyles = cva(
-  'mt-4 box-border flex max-h-[300px] w-fit max-w-[360px] animate-enter items-center justify-start overflow-hidden rounded-xl px-4 py-3 text-white transition-all delay-[0ms] duration-250 ease-in-out',
+  'pointer-events-auto mt-4 box-border flex max-h-[300px] w-fit max-w-[360px] animate-enter items-center justify-start overflow-hidden rounded-xl px-4 py-3 text-white transition-all delay-[0ms] duration-250 ease-in-out',
   {
     variants: {
       severity: {

--- a/src/components/designSystem/Toasts/ToastContainer.tsx
+++ b/src/components/designSystem/Toasts/ToastContainer.tsx
@@ -44,7 +44,7 @@ export const ToastContainer = () => {
   }, [])
 
   return (
-    <div className="fixed bottom-0 left-0 z-toast mb-4 ml-4 cursor-default">
+    <div className="pointer-events-none fixed bottom-0 left-0 z-toast mb-4 ml-4 cursor-default">
       {toasts.map((toast) => (
         <Toast key={toast.id} ref={elementsRefs.current[toast.id]} toast={toast} />
       ))}


### PR DESCRIPTION
Fixes LAGO-1618

The `ToastContainer` is mounted permanently as `fixed bottom-0 left-0`, overlapping the bottom-left corner of the main nav sidebar (Settings and devtools entries). Its bounding box intercepted pointer events even when no toast was displayed, so those nav entries appeared visible but could not be clicked.

The container renders its wrapping `<div>` unconditionally (no early return when there are no toasts), which is intentional: a toast mid-exit-animation lingers in the DOM until its transition ends, so a length-based guard would not fully solve it.

Fix: the wrapper now uses `pointer-events-none` so it never intercepts clicks, and each `Toast` uses `pointer-events-auto` so toasts stay interactive (close button, hover-to-pause, links).