### PR TITLE
fix(permissions): unstrand developers:keys:manage

### DIFF
--- a/src/core/router/ObjectsRoutes.tsx
+++ b/src/core/router/ObjectsRoutes.tsx
@@ -221,7 +221,7 @@ export const objectCreationRoutes: CustomRouteObject[] = [
     path: [CREATE_API_KEYS_ROUTE, UPDATE_API_KEYS_ROUTE],
     private: true,
     element: <ApiKeysForm />,
-    permissions: ['developersManage', 'developersKeysManage'],
+    permissions: ['developersKeysManage'],
   },
   {
     path: [CREATE_WEBHOOK_ROUTE, UPDATE_WEBHOOK_ROUTE],

--- a/src/layouts/MainNavLayout/BottomNavSection.tsx
+++ b/src/layouts/MainNavLayout/BottomNavSection.tsx
@@ -25,7 +25,7 @@ interface BottomNavSectionProps {
 
 export const BottomNavSection = ({ isLoading, onItemClick }: BottomNavSectionProps) => {
   const { translate } = useInternationalization()
-  const { hasPermissions } = usePermissions()
+  const { hasPermissions, hasPermissionsOr } = usePermissions()
   const { openPanel: openInspector } = useDeveloperTool()
 
   const { appEnv } = envGlobalVar()
@@ -49,7 +49,7 @@ export const BottomNavSection = ({ isLoading, onItemClick }: BottomNavSectionPro
       icon: 'terminal',
       onAction: openInspector,
       canBeClickedOnActive: true,
-      hidden: !hasPermissions(['developersManage']),
+      hidden: !hasPermissionsOr(['developersManage', 'developersKeysManage']),
     },
   ]
 

--- a/src/layouts/MainNavLayout/__tests__/BottomNavSection.test.tsx
+++ b/src/layouts/MainNavLayout/__tests__/BottomNavSection.test.tsx
@@ -5,11 +5,13 @@ import { render } from '~/test-utils'
 import { BOTTOM_NAV_SECTION_TEST_ID, BottomNavSection } from '../BottomNavSection'
 
 const mockHasPermissions = jest.fn()
+const mockHasPermissionsOr = jest.fn()
 const mockOpenInspector = jest.fn()
 
 jest.mock('~/hooks/usePermissions', () => ({
   usePermissions: () => ({
     hasPermissions: mockHasPermissions,
+    hasPermissionsOr: mockHasPermissionsOr,
   }),
 }))
 
@@ -47,6 +49,7 @@ describe('BottomNavSection', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockHasPermissions.mockReturnValue(true)
+    mockHasPermissionsOr.mockReturnValue(true)
     envGlobalVar.mockReturnValue({ appEnv: 'development' })
   })
 
@@ -75,6 +78,7 @@ describe('BottomNavSection', () => {
 
       // No permissions for settings or developer tools
       mockHasPermissions.mockReturnValue(false)
+      mockHasPermissionsOr.mockReturnValue(false)
 
       const { container } = render(<BottomNavSection {...defaultProps} />)
 
@@ -89,6 +93,7 @@ describe('BottomNavSection', () => {
 
       // No permissions for settings or developer tools
       mockHasPermissions.mockReturnValue(false)
+      mockHasPermissionsOr.mockReturnValue(false)
 
       const { container } = render(<BottomNavSection {...defaultProps} />)
 
@@ -103,6 +108,7 @@ describe('BottomNavSection', () => {
         // Only allow organizationView (settings)
         return permissions.includes('organizationView')
       })
+      mockHasPermissionsOr.mockReturnValue(false)
 
       render(<BottomNavSection {...defaultProps} />)
 
@@ -113,7 +119,8 @@ describe('BottomNavSection', () => {
       // Production environment (design system hidden)
       envGlobalVar.mockReturnValue({ appEnv: 'production' })
 
-      mockHasPermissions.mockImplementation((permissions: string[]) => {
+      mockHasPermissions.mockReturnValue(false)
+      mockHasPermissionsOr.mockImplementation((permissions: string[]) => {
         // Only allow developersManage (developer tools)
         return permissions.includes('developersManage')
       })
@@ -129,6 +136,7 @@ describe('BottomNavSection', () => {
 
       // No permissions for settings or developer tools
       mockHasPermissions.mockReturnValue(false)
+      mockHasPermissionsOr.mockReturnValue(false)
 
       render(<BottomNavSection {...defaultProps} />)
 
@@ -144,10 +152,13 @@ describe('BottomNavSection', () => {
       expect(mockHasPermissions).toHaveBeenCalledWith(['organizationView'])
     })
 
-    it('calls hasPermissions for developer tools visibility', () => {
+    it('calls hasPermissionsOr for developer tools visibility', () => {
       render(<BottomNavSection {...defaultProps} />)
 
-      expect(mockHasPermissions).toHaveBeenCalledWith(['developersManage'])
+      expect(mockHasPermissionsOr).toHaveBeenCalledWith([
+        'developersManage',
+        'developersKeysManage',
+      ])
     })
   })
 

--- a/src/layouts/MainNavLayout/__tests__/MainNavLayout.test.tsx
+++ b/src/layouts/MainNavLayout/__tests__/MainNavLayout.test.tsx
@@ -37,6 +37,7 @@ jest.mock('~/generated/graphql', () => ({
 jest.mock('~/hooks/usePermissions', () => ({
   usePermissions: () => ({
     hasPermissions: () => true,
+    hasPermissionsOr: () => true,
   }),
 }))
 


### PR DESCRIPTION
Fixes LAGO-1614

A role granted only `developers:keys:manage` (without `developers:manage`) could not manage API keys in the UI, even though the backend authorizes API-key operations on `developers:keys:manage` alone. The granular permission was effectively dead on its own.

Two frontend gates required `developers:manage` and stranded the keys permission between them:

- **Devtools sidebar entry** (`BottomNavSection.tsx`) was gated on `developersManage` only, so the panel where API keys live could not be opened. Now gated on `hasPermissionsOr(["developersManage", "developersKeysManage"])`.
- **API key create/edit route** (`ObjectsRoutes.tsx`) required both `developersManage` AND `developersKeysManage`, redirecting to Forbidden. Now requires `developersKeysManage` only, matching the backend.

The API Keys tab inside the panel was already correctly gated on `developersKeysManage`, so no change there.