### PR TITLE
feat(orders): add Download order action

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -14458,7 +14458,7 @@ export type GetOrderFormsQueryVariables = Exact<{
 
 export type GetOrderFormsQuery = { __typename?: 'Query', orderForms: { __typename?: 'OrderFormCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } }> } };
 
-export type OrderListItemFragment = { __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executedAt?: any | null, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string } } };
+export type OrderListItemFragment = { __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executedAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } } };
 
 export type GetOrdersQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -14474,7 +14474,7 @@ export type GetOrdersQueryVariables = Exact<{
 }>;
 
 
-export type GetOrdersQuery = { __typename?: 'Query', orders: { __typename?: 'OrderCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executedAt?: any | null, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string } } }> } };
+export type GetOrdersQuery = { __typename?: 'Query', orders: { __typename?: 'OrderCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executedAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } } }> } };
 
 export type QuotePreviewVersionFragment = { __typename?: 'QuoteVersion', content?: string | null, billingItems?: any | null, mentionVariables: any };
 
@@ -20490,16 +20490,27 @@ export const OrderListItemFragmentDoc = gql`
   status
   executionMode
   executedAt
+  customer {
+    id
+    displayName
+    ...QuotePreviewCustomer
+  }
   orderForm {
     id
     number
     quote {
       id
       number
+      currentVersion {
+        id
+        version
+        ...QuotePreviewVersion
+      }
     }
   }
 }
-    `;
+    ${QuotePreviewCustomerFragmentDoc}
+${QuotePreviewVersionFragmentDoc}`;
 export const QuoteDetailItemFragmentDoc = gql`
     fragment QuoteDetailItem on Quote {
   id

--- a/src/pages/quotes/__tests__/OrdersList.test.tsx
+++ b/src/pages/quotes/__tests__/OrdersList.test.tsx
@@ -34,6 +34,10 @@ jest.mock('../hooks/useOrders', () => ({
   useOrders: jest.fn(),
 }))
 
+jest.mock('~/pages/quotes/common/QuotePdfProvider', () => ({
+  useDownloadQuotePdf: () => ({ download: jest.fn() }),
+}))
+
 const mockUseOrders = useOrders as jest.MockedFunction<typeof useOrders>
 
 const mockOrders = [

--- a/src/pages/quotes/__tests__/OrdersList.test.tsx
+++ b/src/pages/quotes/__tests__/OrdersList.test.tsx
@@ -43,7 +43,16 @@ const mockOrders = [
     status: OrderStatusEnum.Executed,
     executionMode: OrderExecutionModeEnum.ExecuteInLago,
     executedAt: '2026-04-10T10:00:00Z',
-    orderForm: { id: 'of-1', number: 'OF-2026-0001', quote: { id: 'q-1', number: 'QUO-001' } },
+    customer: { id: 'customer-001', displayName: 'Acme Corp' },
+    orderForm: {
+      id: 'of-1',
+      number: 'OF-2026-0001',
+      quote: {
+        id: 'q-1',
+        number: 'QUO-001',
+        currentVersion: { id: 'qv-1', version: 1, content: '# Hello World', mentionVariables: {} },
+      },
+    },
   },
   {
     id: 'order-2',
@@ -51,7 +60,16 @@ const mockOrders = [
     status: OrderStatusEnum.Created,
     executionMode: null,
     executedAt: null,
-    orderForm: { id: 'of-2', number: 'OF-2026-0002', quote: { id: 'q-2', number: 'QUO-002' } },
+    customer: { id: 'customer-002', displayName: 'Globex Corp' },
+    orderForm: {
+      id: 'of-2',
+      number: 'OF-2026-0002',
+      quote: {
+        id: 'q-2',
+        number: 'QUO-002',
+        currentVersion: { id: 'qv-2', version: 1, content: '# Hello World', mentionVariables: {} },
+      },
+    },
   },
 ]
 

--- a/src/pages/quotes/hooks/__tests__/useOrderActions.test.ts
+++ b/src/pages/quotes/hooks/__tests__/useOrderActions.test.ts
@@ -1,11 +1,13 @@
 import { renderHook } from '@testing-library/react'
 
 import { OrderListItemFragment, OrderStatusEnum } from '~/generated/graphql'
+import { buildQuotePreviewProps } from '~/pages/quotes/common/buildQuotePreviewProps'
 import { testMockNavigateFn } from '~/test-utils'
 
 import { useOrderActions } from '../useOrderActions'
 
 const mockHasPermissions = jest.fn()
+const mockDownload = jest.fn()
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({
@@ -18,6 +20,18 @@ jest.mock('~/hooks/usePermissions', () => ({
     hasPermissions: mockHasPermissions,
   }),
 }))
+
+jest.mock('~/pages/quotes/common/QuotePdfProvider', () => ({
+  useDownloadQuotePdf: () => ({ download: mockDownload }),
+}))
+
+jest.mock('~/pages/quotes/common/buildQuotePreviewProps', () => ({
+  buildQuotePreviewProps: jest.fn(() => ({ content: '# Hello World' })),
+}))
+
+const mockedBuildQuotePreviewProps = buildQuotePreviewProps as jest.MockedFunction<
+  typeof buildQuotePreviewProps
+>
 
 const createMockOrder = (
   overrides: Partial<OrderListItemFragment> = {},
@@ -44,36 +58,40 @@ describe('useOrderActions', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockHasPermissions.mockReturnValue(true)
+    mockDownload.mockResolvedValue(undefined)
   })
 
   describe('GIVEN a created order with ordersUpdate permission', () => {
-    it('THEN returns a single edit action', () => {
+    it('THEN returns edit and download actions', () => {
       const { result } = renderHook(() => useOrderActions())
       const actions = result.current.getActions(createMockOrder())
 
-      expect(actions).toHaveLength(1)
+      expect(actions).toHaveLength(2)
       expect(actions[0].icon).toBe('pen')
+      expect(actions[1].icon).toBe('download')
     })
   })
 
   describe('GIVEN an executed order', () => {
-    it('THEN returns no actions', () => {
+    it('THEN returns only the download action', () => {
       const { result } = renderHook(() => useOrderActions())
       const actions = result.current.getActions(
         createMockOrder({ status: OrderStatusEnum.Executed }),
       )
 
-      expect(actions).toHaveLength(0)
+      expect(actions).toHaveLength(1)
+      expect(actions[0].icon).toBe('download')
     })
   })
 
   describe('GIVEN a created order without ordersUpdate permission', () => {
-    it('THEN returns no actions', () => {
+    it('THEN returns only the download action', () => {
       mockHasPermissions.mockReturnValue(false)
       const { result } = renderHook(() => useOrderActions())
       const actions = result.current.getActions(createMockOrder())
 
-      expect(actions).toHaveLength(0)
+      expect(actions).toHaveLength(1)
+      expect(actions[0].icon).toBe('download')
     })
   })
 
@@ -85,6 +103,48 @@ describe('useOrderActions', () => {
       actions[0].onAction()
 
       expect(testMockNavigateFn).toHaveBeenCalledWith('/order/order-42/edit')
+    })
+  })
+
+  describe('GIVEN an order with no quote version content', () => {
+    it('THEN omits the download action', () => {
+      const { result } = renderHook(() => useOrderActions())
+      const actions = result.current.getActions(
+        createMockOrder({
+          orderForm: {
+            id: 'of-1',
+            number: 'OF-2026-0001',
+            quote: {
+              id: 'q-1',
+              number: 'QT-001',
+              currentVersion: { id: 'qv-1', version: 1, content: null, mentionVariables: {} },
+            },
+          },
+        }),
+      )
+
+      expect(actions.find((a) => a.icon === 'download')).toBeUndefined()
+    })
+  })
+
+  describe('GIVEN the download action', () => {
+    it('THEN downloads with preview props and the Order header', () => {
+      const { result } = renderHook(() => useOrderActions())
+      const order = createMockOrder()
+      const actions = result.current.getActions(order)
+      const downloadAction = actions.find((a) => a.icon === 'download')
+
+      downloadAction?.onAction()
+
+      expect(mockedBuildQuotePreviewProps).toHaveBeenCalledWith(
+        order.orderForm.quote.currentVersion,
+        order.customer,
+        {
+          documentNumber: 'OR-2026-0001',
+          rows: ['text_1782723591984l12xpznkwqd'],
+        },
+      )
+      expect(mockDownload).toHaveBeenCalledWith({ content: '# Hello World' })
     })
   })
 })

--- a/src/pages/quotes/hooks/__tests__/useOrderActions.test.ts
+++ b/src/pages/quotes/hooks/__tests__/useOrderActions.test.ts
@@ -27,10 +27,15 @@ const createMockOrder = (
   status: OrderStatusEnum.Created,
   executionMode: null,
   executedAt: null,
+  customer: { id: 'customer-001', displayName: 'Acme Corp' },
   orderForm: {
     id: 'of-1',
     number: 'OF-2026-0001',
-    quote: { id: 'q-1', number: 'QT-001' },
+    quote: {
+      id: 'q-1',
+      number: 'QT-001',
+      currentVersion: { id: 'qv-1', version: 1, content: '# Hello World', mentionVariables: {} },
+    },
   },
   ...overrides,
 })

--- a/src/pages/quotes/hooks/useOrderActions.ts
+++ b/src/pages/quotes/hooks/useOrderActions.ts
@@ -5,6 +5,9 @@ import { EDIT_ORDER_ROUTE, useNavigate } from '~/core/router'
 import { OrderListItemFragment, OrderStatusEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { usePermissions } from '~/hooks/usePermissions'
+import { buildOrderHeader } from '~/pages/quotes/common/buildOrderHeader'
+import { buildQuotePreviewProps } from '~/pages/quotes/common/buildQuotePreviewProps'
+import { useDownloadQuotePdf } from '~/pages/quotes/common/QuotePdfProvider'
 
 export interface OrderAction {
   icon: IconName
@@ -16,6 +19,7 @@ export const useOrderActions = () => {
   const { translate } = useInternationalization()
   const { hasPermissions } = usePermissions()
   const navigate = useNavigate()
+  const { download } = useDownloadQuotePdf()
 
   const getActions = (order: OrderListItemFragment): OrderAction[] => {
     const actions: OrderAction[] = []
@@ -26,6 +30,24 @@ export const useOrderActions = () => {
         icon: 'pen',
         label: translate('text_17827235919844cwbnt9ltfe'),
         onAction: () => navigate(generatePath(EDIT_ORDER_ROUTE, { orderId: order.id })),
+      })
+    }
+
+    // Download PDF — only when the quote version has content
+    const version = order.orderForm.quote.currentVersion
+    const content = version?.content
+
+    if (content) {
+      const header = buildOrderHeader(order, translate)
+
+      actions.push({
+        icon: 'download',
+        label: translate('text_17797156485850t8yms6hf7z'),
+        onAction: () => {
+          void download(buildQuotePreviewProps(version, order.customer, header)).catch(
+            () => undefined,
+          )
+        },
       })
     }
 

--- a/src/pages/quotes/hooks/useOrders.ts
+++ b/src/pages/quotes/hooks/useOrders.ts
@@ -14,12 +14,22 @@ gql`
     status
     executionMode
     executedAt
+    customer {
+      id
+      displayName
+      ...QuotePreviewCustomer
+    }
     orderForm {
       id
       number
       quote {
         id
         number
+        currentVersion {
+          id
+          version
+          ...QuotePreviewVersion
+        }
       }
     }
   }


### PR DESCRIPTION
## Context
We want our users to be able to download an order before or after execution

## Description
This PR adds a **Download order** action to the order row action menu on the Orders list. 

Fixes LAGO-1612

🤖 Generated with [Claude Code](https://claude.com/claude-code)
