### PR TITLE
refactor(taxes): migrate DeleteTaxDialog to useCentralizedDialog

### DIFF
--- a/src/components/taxes/DeleteTaxDialog.tsx
+++ b/src/components/taxes/DeleteTaxDialog.tsx
@@ -1,11 +1,15 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
+import { ReactNode } from 'react'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
-import { DeleteTaxFragment, useDeleteTaxMutation } from '~/generated/graphql'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
+import {
+  DeleteTaxFragment,
+  GetTaxesSettingsInformationsDocument,
+  useDeleteTaxMutation,
+} from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 gql`
@@ -22,70 +26,54 @@ gql`
   }
 `
 
-export interface DeleteTaxDialogRef {
-  openDialog: (tax: DeleteTaxFragment) => unknown
-  closeDialog: () => unknown
-}
-
-export const DeleteTaxDialog = forwardRef<DeleteTaxDialogRef>((_, ref) => {
+export const useDeleteTaxDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
-  const [tax, setTax] = useState<DeleteTaxFragment | undefined>(undefined)
-  const [deleteTax] = useDeleteTaxMutation({
-    onCompleted(data) {
-      if (data && data.destroyTax) {
-        addToast({
-          message: translate('text_645bb193927b375079d28b5a'),
-          severity: 'success',
+  const client = useApolloClient()
+
+  const [deleteTax] = useDeleteTaxMutation()
+
+  const getDescription = (customersCount: number): ReactNode => {
+    let copy = translate('text_645cb766cca2dd00e2956271')
+
+    if (customersCount) {
+      copy = translate('text_645bb193927b375079d28b0c', { count: customersCount }, customersCount)
+    }
+
+    return <Typography>{copy}</Typography>
+  }
+
+  const openDeleteTaxDialog = (tax: DeleteTaxFragment) => {
+    centralizedDialog.open({
+      title: translate('text_645bb193927b375079d28af7', {
+        name: tax.name,
+      }),
+      description: getDescription(tax.customersCount),
+      colorVariant: 'danger',
+      actionText: translate('text_645bb193927b375079d28b34'),
+      onAction: async () => {
+        const result = await deleteTax({
+          variables: { input: { id: tax.id } },
         })
-      }
-    },
-    update(cache, { data }) {
-      if (!data?.destroyTax) return
-      const cacheId = cache.identify({
-        id: data?.destroyTax.id,
-        __typename: 'Tax',
-      })
 
-      cache.evict({ id: cacheId })
-    },
-  })
+        const destroyedId = result.data?.destroyTax?.id
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setTax(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => {
-      dialogRef.current?.closeDialog()
-    },
-  }))
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'Tax',
+            listFieldName: 'taxes',
+            listQueryDocument: GetTaxesSettingsInformationsDocument,
+          })
 
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_645bb193927b375079d28af7', {
-        name: tax?.name,
-      })}
-      description={
-        <Typography>
-          {!!tax?.customersCount
-            ? translate(
-                'text_645bb193927b375079d28b0c',
-                { count: tax?.customersCount },
-                tax?.customersCount,
-              )
-            : translate('text_645cb766cca2dd00e2956271')}
-        </Typography>
-      }
-      onContinue={async () =>
-        await deleteTax({
-          variables: { input: { id: tax?.id || '' } },
-        })
-      }
-      continueText={translate('text_645bb193927b375079d28b34')}
-    />
-  )
-})
+          addToast({
+            message: translate('text_645bb193927b375079d28b5a'),
+            severity: 'success',
+          })
+        }
+      },
+    })
+  }
 
-DeleteTaxDialog.displayName = 'DeleteTaxDialog'
+  return { openDeleteTaxDialog }
+}

--- a/src/pages/settings/TaxesSettings.tsx
+++ b/src/pages/settings/TaxesSettings.tsx
@@ -1,6 +1,5 @@
 import { gql } from '@apollo/client'
 import { Icon } from 'lago-design-system'
-import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { Alert } from '~/components/designSystem/Alert'
@@ -18,7 +17,7 @@ import {
   SettingsPaddedContainer,
 } from '~/components/layouts/Settings'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import { DeleteTaxDialog, DeleteTaxDialogRef } from '~/components/taxes/DeleteTaxDialog'
+import { useDeleteTaxDialog } from '~/components/taxes/DeleteTaxDialog'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CREATE_TAX_ROUTE, UPDATE_TAX_ROUTE, useNavigate } from '~/core/router'
 import {
@@ -63,7 +62,7 @@ const TaxesSettings = () => {
   const { hasPermissions } = usePermissions()
   const { hasTaxProvider } = useIntegrations()
   const { translate } = useInternationalization()
-  const deleteDialogRef = useRef<DeleteTaxDialogRef>(null)
+  const { openDeleteTaxDialog } = useDeleteTaxDialog()
   const { data, error, loading, fetchMore } = useGetTaxesSettingsInformationsQuery({
     variables: {
       limit: 20,
@@ -204,7 +203,7 @@ const TaxesSettings = () => {
                             title: translate('text_645bb193927b375079d28b82'),
                             startIcon: 'trash',
                             onAction: () => {
-                              deleteDialogRef.current?.openDialog(tax)
+                              openDeleteTaxDialog(tax)
                             },
                           })
                         }
@@ -217,7 +216,6 @@ const TaxesSettings = () => {
           </SettingsListItem>
         </SettingsListWrapper>
       </SettingsPaddedContainer>
-      <DeleteTaxDialog ref={deleteDialogRef} />
     </>
   )
 }


### PR DESCRIPTION
## Context

`DeleteTaxDialog` was still using the deprecated forwardRef-based `WarningDialog` from the legacy dialog system. The ESLint rule `no-restricted-imports` flagged it because only hook-style imports (matching `/^use/u`) are allowed from `~/components/designSystem/WarningDialog`.

## Description

- Converted `src/components/taxes/DeleteTaxDialog.tsx` from a `forwardRef` component exposing an imperative `DeleteTaxDialogRef` to a hook-based `useDeleteTaxDialog` built on top of `useCentralizedDialog` from `~/components/dialogs/CentralizedDialog`.
- Replaced the inline `update(cache)` + `cache.evict()` cleanup with the canonical `evictFromCache` helper (`src/core/apolloClient/evictFromCache.ts`), passing the `taxes` paginated field and `GetTaxesSettingsInformationsDocument`. This removes the deleted tax from the paginated list, nulls single-reference root fields, and suppresses other watchers to prevent retained detail queries from hitting a 404.
- Updated `src/pages/settings/TaxesSettings.tsx` to consume the new hook: dropped the `useRef<DeleteTaxDialogRef>`, removed the now-unused `<DeleteTaxDialog ref={...} />` JSX, and call `openDeleteTaxDialog(tax)` directly from the row action.
- Kept the existing translation keys, the `DeleteTax` GraphQL fragment, and the `danger` color variant + confirm wording to preserve UX parity.

<!-- Linear link -->
Fixes LAGO-XXX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmVYZX26ABoiM23z2jZ2oQ)_