### PR TITLE
feat(quotes): add /discount command

### DIFF
--- a/src/components/customers/AddCouponToCustomerDialog.tsx
+++ b/src/components/customers/AddCouponToCustomerDialog.tsx
@@ -62,7 +62,6 @@ gql`
       collection {
         id
         name
-        code
         amountCurrency
         amountCents
         couponType

--- a/src/components/customers/AddCouponToCustomerDialog.tsx
+++ b/src/components/customers/AddCouponToCustomerDialog.tsx
@@ -62,6 +62,7 @@ gql`
       collection {
         id
         name
+        code
         amountCurrency
         amountCents
         couponType

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
@@ -1,19 +1,83 @@
 import { NodeViewProps, NodeViewWrapper } from '@tiptap/react'
 
-import { useRichTextEditorContext } from '../common/RichTextEditorContext'
+import { Typography } from '~/components/designSystem/Typography'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { CouponFrequency, CouponTypeEnum } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+import { type EntityData, useRichTextEditorContext } from '../common/RichTextEditorContext'
 import SlashCommandBlockWrapper from '../SlashCommandBlockWrapper/SlashCommandBlockWrapper'
 
 export const DISCOUNT_BLOCK_VIEW_EMPTY_TEST_ID = 'discount-block-view-empty'
 export const DISCOUNT_BLOCK_VIEW_UNRESOLVED_TEST_ID = 'discount-block-view-unresolved'
 
+// Preview-mode rendering: minimal read-only display (no chevron, no click handler).
+// NOTE: this layout is a best-effort default — no Figma design exists yet;
+// confirm copy/layout with design before shipping to customers.
+const DiscountBlockPreview = ({ entity }: { entity: EntityData }) => {
+  const { translate } = useInternationalization()
+
+  const frequencyLabel =
+    entity.frequency === CouponFrequency.Once
+      ? translate('text_632d68358f1fedc68eed3ea3')
+      : entity.frequency === CouponFrequency.Recurring
+        ? translate('text_632d68358f1fedc68eed3e64')
+        : translate('text_63c83a3476e46bc6ab9d85d6')
+
+  let valueLabel = ''
+
+  if (
+    entity.couponType === CouponTypeEnum.FixedAmount &&
+    entity.amountCents &&
+    entity.amountCurrency
+  ) {
+    valueLabel = intlFormatNumber(deserializeAmount(entity.amountCents, entity.amountCurrency), {
+      currency: entity.amountCurrency,
+    })
+  } else if (entity.couponType === CouponTypeEnum.Percentage && entity.percentageRate != null) {
+    valueLabel = `${entity.percentageRate}%`
+  }
+
+  const caption = valueLabel ? `${valueLabel} • ${frequencyLabel}` : frequencyLabel
+
+  return (
+    <NodeViewWrapper className="spacer" data-type="discountBlock">
+      <div className="block-wrapper">
+        <div className="pricing-block">
+          <div className="pricing-block-content">
+            <div className="pricing-block-text">
+              <Typography variant="bodyHl" color="grey700">
+                {entity.name}
+              </Typography>
+              <Typography variant="caption">{caption}</Typography>
+            </div>
+          </div>
+        </div>
+      </div>
+    </NodeViewWrapper>
+  )
+}
+
 export const DiscountBlockView = ({ node, updateAttributes }: NodeViewProps) => {
-  const { entities, onDiscountCommand } = useRichTextEditorContext()
+  const { entities, onDiscountCommand, mode } = useRichTextEditorContext()
+  const { translate } = useInternationalization()
 
   const couponId = (node.attrs.couponId ?? '') as string
   const localId = (node.attrs.localId ?? '') as string
   const isEmpty = couponId === ''
 
   const entity = (localId && entities[localId]) || (couponId && entities[couponId]) || undefined
+
+  // Preview mode: read-only, non-interactive
+  if (mode === 'preview') {
+    if (entity) {
+      return <DiscountBlockPreview entity={entity} />
+    }
+
+    // Empty or unresolved in preview — render nothing interactive
+    return <NodeViewWrapper className="spacer" data-type="discountBlock" />
+  }
 
   const handleClick = () => {
     onDiscountCommand?.({
@@ -45,7 +109,7 @@ export const DiscountBlockView = ({ node, updateAttributes }: NodeViewProps) => 
       <NodeViewWrapper className="spacer" data-type="discountBlock">
         <div className="block-wrapper">
           <SlashCommandBlockWrapper
-            typeText="Discount"
+            typeText={translate('text_1782889379261hdcd0jhzdm6')}
             handleClick={handleClick}
             icon="coupon"
             displayText={entity.name}

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
@@ -18,12 +18,19 @@ export const DISCOUNT_BLOCK_VIEW_UNRESOLVED_TEST_ID = 'discount-block-view-unres
 const DiscountBlockPreview = ({ entity }: { entity: EntityData }) => {
   const { translate } = useInternationalization()
 
-  const frequencyLabel =
-    entity.frequency === CouponFrequency.Once
-      ? translate('text_632d68358f1fedc68eed3ea3')
-      : entity.frequency === CouponFrequency.Recurring
-        ? translate('text_632d68358f1fedc68eed3e64')
-        : translate('text_63c83a3476e46bc6ab9d85d6')
+  const getFrequencyKey = () => {
+    if (entity.frequency === CouponFrequency.Once) {
+      return 'text_632d68358f1fedc68eed3ea3'
+    }
+
+    if (entity.frequency === CouponFrequency.Recurring) {
+      return 'text_632d68358f1fedc68eed3e64'
+    }
+
+    return 'text_63c83a3476e46bc6ab9d85d6'
+  }
+
+  const frequencyLabel = translate(getFrequencyKey())
 
   let valueLabel = ''
 

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
@@ -104,7 +104,9 @@ export const DiscountBlockView = ({ node, updateAttributes }: NodeViewProps) => 
             tabIndex={0}
             data-test={DISCOUNT_BLOCK_VIEW_EMPTY_TEST_ID}
           >
-            <span className="pricing-block__placeholder">Select a coupon</span>
+            <span className="pricing-block__placeholder">
+              {translate('text_1783342959387sv77znuw5yx')}
+            </span>
           </button>
         </div>
       </NodeViewWrapper>
@@ -131,7 +133,7 @@ export const DiscountBlockView = ({ node, updateAttributes }: NodeViewProps) => 
       <div className="block-wrapper">
         <div className="pricing-block" data-test={DISCOUNT_BLOCK_VIEW_UNRESOLVED_TEST_ID}>
           <div className="pricing-block__unresolved">
-            <span>{`Coupon: ${couponId}`}</span>
+            <span>{translate('text_1783342959387cz07147m6qq', { couponId })}</span>
           </div>
         </div>
       </div>

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
@@ -35,7 +35,7 @@ const DiscountBlockPreview = ({ entity }: { entity: EntityData }) => {
     valueLabel = intlFormatNumber(deserializeAmount(entity.amountCents, entity.amountCurrency), {
       currency: entity.amountCurrency,
     })
-  } else if (entity.couponType === CouponTypeEnum.Percentage && entity.percentageRate != null) {
+  } else if (entity.couponType === CouponTypeEnum.Percentage && entity.percentageRate !== null) {
     valueLabel = `${entity.percentageRate}%`
   }
 

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
@@ -13,7 +13,7 @@ export const DiscountBlockView = ({ node, updateAttributes }: NodeViewProps) => 
   const localId = (node.attrs.localId ?? '') as string
   const isEmpty = couponId === ''
 
-  const entity = entities[localId] ?? entities[couponId]
+  const entity = (localId && entities[localId]) || (couponId && entities[couponId]) || undefined
 
   const handleClick = () => {
     onDiscountCommand?.({

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
@@ -1,0 +1,69 @@
+import { NodeViewProps, NodeViewWrapper } from '@tiptap/react'
+
+import { useRichTextEditorContext } from '../common/RichTextEditorContext'
+import SlashCommandBlockWrapper from '../SlashCommandBlockWrapper/SlashCommandBlockWrapper'
+
+export const DISCOUNT_BLOCK_VIEW_EMPTY_TEST_ID = 'discount-block-view-empty'
+export const DISCOUNT_BLOCK_VIEW_UNRESOLVED_TEST_ID = 'discount-block-view-unresolved'
+
+export const DiscountBlockView = ({ node, updateAttributes }: NodeViewProps) => {
+  const { entities, onDiscountCommand } = useRichTextEditorContext()
+
+  const couponId = (node.attrs.couponId ?? '') as string
+  const localId = (node.attrs.localId ?? '') as string
+  const isEmpty = couponId === ''
+
+  const entity = entities[localId] ?? entities[couponId]
+
+  const handleClick = () => {
+    onDiscountCommand?.({
+      onSave: (attrs) => updateAttributes(attrs),
+      editData: isEmpty ? undefined : { couponId, localId },
+    })
+  }
+
+  if (isEmpty) {
+    return (
+      <NodeViewWrapper className="spacer" data-type="discountBlock">
+        <div className="block-wrapper">
+          <button
+            className="pricing-block pricing-block--empty"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={handleClick}
+            tabIndex={0}
+            data-test={DISCOUNT_BLOCK_VIEW_EMPTY_TEST_ID}
+          >
+            <span className="pricing-block__placeholder">Select a coupon</span>
+          </button>
+        </div>
+      </NodeViewWrapper>
+    )
+  }
+
+  if (entity) {
+    return (
+      <NodeViewWrapper className="spacer" data-type="discountBlock">
+        <div className="block-wrapper">
+          <SlashCommandBlockWrapper
+            typeText="Discount"
+            handleClick={handleClick}
+            icon="coupon"
+            displayText={entity.name}
+          />
+        </div>
+      </NodeViewWrapper>
+    )
+  }
+
+  return (
+    <NodeViewWrapper className="spacer" data-type="discountBlock">
+      <div className="block-wrapper">
+        <div className="pricing-block" data-test={DISCOUNT_BLOCK_VIEW_UNRESOLVED_TEST_ID}>
+          <div className="pricing-block__unresolved">
+            <span>{`Coupon: ${couponId}`}</span>
+          </div>
+        </div>
+      </div>
+    </NodeViewWrapper>
+  )
+}

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/__tests__/DiscountBlockView.test.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/__tests__/DiscountBlockView.test.tsx
@@ -1,0 +1,238 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NodeViewProps } from '@tiptap/react'
+
+import { render } from '~/test-utils'
+
+import {
+  EntityData,
+  OnDiscountCommand,
+  RichTextEditorProvider,
+} from '../../common/RichTextEditorContext'
+import { SLASH_COMMAND_BLOCK_VIEW_TEST_ID } from '../../SlashCommandBlockWrapper/SlashCommandBlockWrapper'
+import {
+  DISCOUNT_BLOCK_VIEW_EMPTY_TEST_ID,
+  DISCOUNT_BLOCK_VIEW_UNRESOLVED_TEST_ID,
+  DiscountBlockView,
+} from '../DiscountBlockView'
+
+jest.mock('@tiptap/react', () => ({
+  ...jest.requireActual('@tiptap/react'),
+  NodeViewWrapper: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode
+    as?: string
+    className?: string
+  }) => <div {...props}>{children}</div>,
+}))
+
+const createNodeProps = (
+  attrs: Record<string, unknown> = {},
+  overrides: Partial<NodeViewProps> = {},
+): NodeViewProps => {
+  return {
+    node: {
+      attrs: { couponId: '', localId: '', ...attrs },
+    },
+    editor: null as never,
+    extension: null as never,
+    getPos: () => 0,
+    updateAttributes: jest.fn(),
+    deleteNode: () => {},
+    selected: false,
+    decorations: [],
+    innerDecorations: null as never,
+    HTMLAttributes: {},
+    view: null as never,
+    ...overrides,
+  } as unknown as NodeViewProps
+}
+
+const renderDiscountBlockView = ({
+  attrs = {},
+  entities = {} as Record<string, EntityData>,
+  onDiscountCommand = jest.fn() as OnDiscountCommand,
+}: {
+  attrs?: Record<string, unknown>
+  entities?: Record<string, EntityData>
+  onDiscountCommand?: OnDiscountCommand
+} = {}) => {
+  const nodeProps = createNodeProps(attrs)
+
+  return {
+    ...render(
+      <RichTextEditorProvider
+        value={{
+          mode: 'edit',
+          mentionValues: {},
+          entities,
+          onDiscountCommand,
+        }}
+      >
+        <DiscountBlockView {...nodeProps} />
+      </RichTextEditorProvider>,
+    ),
+    nodeProps,
+    onDiscountCommand,
+  }
+}
+
+describe('DiscountBlockView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN couponId is empty', () => {
+    describe('WHEN rendered', () => {
+      it('THEN should display the empty state button', () => {
+        renderDiscountBlockView()
+
+        expect(screen.getByTestId(DISCOUNT_BLOCK_VIEW_EMPTY_TEST_ID)).toBeInTheDocument()
+      })
+
+      it('THEN should show the placeholder text', () => {
+        renderDiscountBlockView()
+
+        const emptyButton = screen.getByTestId(DISCOUNT_BLOCK_VIEW_EMPTY_TEST_ID)
+
+        expect(emptyButton).toHaveTextContent('Select a coupon')
+      })
+    })
+
+    describe('WHEN the empty state button is clicked', () => {
+      it('THEN should call onDiscountCommand with editData undefined', async () => {
+        const user = userEvent.setup()
+        const { onDiscountCommand } = renderDiscountBlockView()
+
+        const button = screen.getByTestId(DISCOUNT_BLOCK_VIEW_EMPTY_TEST_ID)
+
+        await user.click(button)
+
+        expect(onDiscountCommand).toHaveBeenCalledWith(
+          expect.objectContaining({
+            onSave: expect.any(Function),
+            editData: undefined,
+          }),
+        )
+      })
+    })
+
+    describe('WHEN mouseDown occurs on the empty button', () => {
+      it('THEN should stop propagation to prevent BlockToolbar overlay', () => {
+        renderDiscountBlockView()
+
+        const button = screen.getByTestId(DISCOUNT_BLOCK_VIEW_EMPTY_TEST_ID)
+        const mouseDownEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+        const stopPropagationSpy = jest.spyOn(mouseDownEvent, 'stopPropagation')
+
+        button.dispatchEvent(mouseDownEvent)
+
+        expect(stopPropagationSpy).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN couponId is set and entity is resolved', () => {
+    const couponEntity: EntityData = {
+      entityId: 'coupon-1',
+      entityType: 'coupon',
+      name: '10% Off',
+      code: 'ten-off',
+    }
+
+    describe('WHEN rendered', () => {
+      it('THEN should display the coupon name via SlashCommandBlockWrapper', () => {
+        renderDiscountBlockView({
+          attrs: { couponId: 'coupon-1', localId: 'local-1' },
+          entities: { 'local-1': couponEntity },
+        })
+
+        const button = screen.getByTestId(SLASH_COMMAND_BLOCK_VIEW_TEST_ID)
+
+        expect(button).toHaveTextContent('10% Off')
+      })
+
+      it('THEN should render the coupon icon', () => {
+        renderDiscountBlockView({
+          attrs: { couponId: 'coupon-1', localId: 'local-1' },
+          entities: { 'local-1': couponEntity },
+        })
+
+        const button = screen.getByTestId(SLASH_COMMAND_BLOCK_VIEW_TEST_ID)
+
+        expect(button.querySelector('[data-test="coupon/medium"]')).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the resolved block is clicked', () => {
+      it('THEN should call onDiscountCommand with editData containing couponId and localId', async () => {
+        const user = userEvent.setup()
+        const { onDiscountCommand } = renderDiscountBlockView({
+          attrs: { couponId: 'coupon-1', localId: 'local-1' },
+          entities: { 'local-1': couponEntity },
+        })
+
+        const button = screen.getByTestId(SLASH_COMMAND_BLOCK_VIEW_TEST_ID)
+
+        await user.click(button)
+
+        expect(onDiscountCommand).toHaveBeenCalledWith(
+          expect.objectContaining({
+            onSave: expect.any(Function),
+            editData: { couponId: 'coupon-1', localId: 'local-1' },
+          }),
+        )
+      })
+    })
+
+    describe('WHEN onSave is called from the discount command params', () => {
+      it('THEN should call updateAttributes with the new attrs', async () => {
+        const user = userEvent.setup()
+        const mockOnDiscountCommand = jest.fn()
+        const { nodeProps } = renderDiscountBlockView({
+          onDiscountCommand: mockOnDiscountCommand,
+        })
+
+        const button = screen.getByTestId(DISCOUNT_BLOCK_VIEW_EMPTY_TEST_ID)
+
+        await user.click(button)
+
+        const { onSave } = mockOnDiscountCommand.mock.calls[0][0]
+        const newAttrs = { couponId: 'coupon-new', localId: 'local-new' }
+
+        onSave(newAttrs)
+
+        expect(nodeProps.updateAttributes).toHaveBeenCalledWith(newAttrs)
+      })
+    })
+  })
+
+  describe('GIVEN couponId is set but entity is not resolved', () => {
+    describe('WHEN rendered', () => {
+      it('THEN should display the unresolved fallback with coupon id', () => {
+        renderDiscountBlockView({
+          attrs: { couponId: 'coupon-unknown', localId: '' },
+          entities: {},
+        })
+
+        expect(screen.getByTestId(DISCOUNT_BLOCK_VIEW_UNRESOLVED_TEST_ID)).toBeInTheDocument()
+        expect(screen.getByTestId(DISCOUNT_BLOCK_VIEW_UNRESOLVED_TEST_ID)).toHaveTextContent(
+          'Coupon: coupon-unknown',
+        )
+      })
+
+      it('THEN the unresolved element should not be a button', () => {
+        renderDiscountBlockView({
+          attrs: { couponId: 'coupon-unknown', localId: '' },
+          entities: {},
+        })
+
+        const unresolvedElement = screen.getByTestId(DISCOUNT_BLOCK_VIEW_UNRESOLVED_TEST_ID)
+
+        expect(unresolvedElement.tagName).not.toBe('BUTTON')
+      })
+    })
+  })
+})

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/__tests__/DiscountBlockView.test.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/__tests__/DiscountBlockView.test.tsx
@@ -67,6 +67,7 @@ const renderDiscountBlockView = ({
         value={{
           mode: 'edit',
           mentionValues: {},
+          images: {},
           entities,
           onDiscountCommand,
         }}
@@ -250,6 +251,7 @@ describe('DiscountBlockView', () => {
           value={{
             mode: 'preview',
             mentionValues: {},
+            images: {},
             entities,
           }}
         >

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/__tests__/DiscountBlockView.test.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/__tests__/DiscountBlockView.test.tsx
@@ -209,6 +209,107 @@ describe('DiscountBlockView', () => {
     })
   })
 
+  describe('GIVEN mode is preview and entity is resolved', () => {
+    const couponEntityFixed: EntityData = {
+      entityId: 'coupon-2',
+      entityType: 'coupon',
+      name: '$10 Off',
+      code: 'ten-dollars-off',
+      couponType: 'fixed_amount' as EntityData['couponType'],
+      amountCents: '1000',
+      amountCurrency: 'USD' as EntityData['amountCurrency'],
+      percentageRate: null,
+      frequency: 'once' as EntityData['frequency'],
+      frequencyDuration: null,
+    }
+
+    const couponEntityPct: EntityData = {
+      entityId: 'coupon-3',
+      entityType: 'coupon',
+      name: '15% Off',
+      code: 'fifteen-pct-off',
+      couponType: 'percentage' as EntityData['couponType'],
+      amountCents: undefined,
+      amountCurrency: undefined,
+      percentageRate: 15,
+      frequency: 'recurring' as EntityData['frequency'],
+      frequencyDuration: 3,
+    }
+
+    const renderPreview = ({
+      attrs = {},
+      entities = {} as Record<string, EntityData>,
+    }: {
+      attrs?: Record<string, unknown>
+      entities?: Record<string, EntityData>
+    } = {}) => {
+      const nodeProps = createNodeProps(attrs)
+
+      return render(
+        <RichTextEditorProvider
+          value={{
+            mode: 'preview',
+            mentionValues: {},
+            entities,
+          }}
+        >
+          <DiscountBlockView {...nodeProps} />
+        </RichTextEditorProvider>,
+      )
+    }
+
+    describe('WHEN rendered with a resolved fixed-amount coupon', () => {
+      it('THEN should display the coupon name', () => {
+        renderPreview({
+          attrs: { couponId: 'coupon-2', localId: 'local-2' },
+          entities: { 'local-2': couponEntityFixed },
+        })
+
+        expect(screen.getByText('$10 Off')).toBeInTheDocument()
+      })
+
+      it('THEN should NOT render the interactive SlashCommandBlockWrapper edit button', () => {
+        renderPreview({
+          attrs: { couponId: 'coupon-2', localId: 'local-2' },
+          entities: { 'local-2': couponEntityFixed },
+        })
+
+        expect(screen.queryByTestId(SLASH_COMMAND_BLOCK_VIEW_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN rendered with a resolved percentage coupon', () => {
+      it('THEN should display the coupon name', () => {
+        renderPreview({
+          attrs: { couponId: 'coupon-3', localId: 'local-3' },
+          entities: { 'local-3': couponEntityPct },
+        })
+
+        expect(screen.getByText('15% Off')).toBeInTheDocument()
+      })
+
+      it('THEN should NOT render the interactive edit button', () => {
+        renderPreview({
+          attrs: { couponId: 'coupon-3', localId: 'local-3' },
+          entities: { 'local-3': couponEntityPct },
+        })
+
+        expect(screen.queryByTestId(SLASH_COMMAND_BLOCK_VIEW_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN rendered with no entity resolved in preview mode', () => {
+      it('THEN should NOT render the interactive edit button', () => {
+        renderPreview({
+          attrs: { couponId: 'unknown-coupon', localId: '' },
+          entities: {},
+        })
+
+        expect(screen.queryByTestId(SLASH_COMMAND_BLOCK_VIEW_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+  })
+
   describe('GIVEN couponId is set but entity is not resolved', () => {
     describe('WHEN rendered', () => {
       it('THEN should display the unresolved fallback with coupon id', () => {

--- a/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
@@ -1,5 +1,11 @@
 import Placeholder from '@tiptap/extension-placeholder'
-import { EditorContent, ReactNodeViewRenderer, ReactRenderer, useEditor } from '@tiptap/react'
+import {
+  type Editor,
+  EditorContent,
+  ReactNodeViewRenderer,
+  ReactRenderer,
+  useEditor,
+} from '@tiptap/react'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import tippy, { type Instance as TippyInstance } from 'tippy.js'
 
@@ -142,6 +148,37 @@ const getInitialEditorContent = (content?: string, templates?: EditorTemplate[])
   return ''
 }
 
+const collectPricingBlocks = (editorInstance: Editor): PricingBlockAttributes[] => {
+  const blocks: PricingBlockAttributes[] = []
+
+  editorInstance.state.doc.descendants((node) => {
+    if (node.type.name === 'pricingBlock' && node.attrs.entityIds?.length) {
+      blocks.push({
+        pricingType: node.attrs.pricingType,
+        entityIds: node.attrs.entityIds,
+        localEntityIds: node.attrs.localEntityIds,
+      })
+    }
+  })
+
+  return blocks
+}
+
+const collectDiscountBlocks = (editorInstance: Editor): DiscountBlockAttributes[] => {
+  const discountBlocks: DiscountBlockAttributes[] = []
+
+  editorInstance.state.doc.descendants((node) => {
+    if (node.type.name === 'discountBlock' && node.attrs.couponId) {
+      discountBlocks.push({
+        couponId: node.attrs.couponId,
+        localId: node.attrs.localId,
+      })
+    }
+  })
+
+  return discountBlocks
+}
+
 const RichTextEditor = ({
   mode = 'edit',
   mentionValues = {},
@@ -231,33 +268,13 @@ const RichTextEditor = ({
     content: getInitialEditorContent(content, templates),
     onUpdate: ({ editor: editorInstance }) => {
       onChangeRef.current?.()
-      if (onPricingBlocksChangeRef.current) {
-        const blocks: PricingBlockAttributes[] = []
 
-        editorInstance.state.doc.descendants((node) => {
-          if (node.type.name === 'pricingBlock' && node.attrs.entityIds?.length) {
-            blocks.push({
-              pricingType: node.attrs.pricingType,
-              entityIds: node.attrs.entityIds,
-              localEntityIds: node.attrs.localEntityIds,
-            })
-          }
-        })
-        onPricingBlocksChangeRef.current(blocks)
+      if (onPricingBlocksChangeRef.current) {
+        onPricingBlocksChangeRef.current(collectPricingBlocks(editorInstance))
       }
 
       if (onDiscountBlocksChangeRef.current) {
-        const discountBlocks: DiscountBlockAttributes[] = []
-
-        editorInstance.state.doc.descendants((node) => {
-          if (node.type.name === 'discountBlock' && node.attrs.couponId) {
-            discountBlocks.push({
-              couponId: node.attrs.couponId,
-              localId: node.attrs.localId,
-            })
-          }
-        })
-        onDiscountBlocksChangeRef.current(discountBlocks)
+        onDiscountBlocksChangeRef.current(collectDiscountBlocks(editorInstance))
       }
     },
   })

--- a/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
@@ -6,7 +6,7 @@ import {
   ReactRenderer,
   useEditor,
 } from '@tiptap/react'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { type MutableRefObject, useCallback, useEffect, useMemo, useRef } from 'react'
 import tippy, { type Instance as TippyInstance } from 'tippy.js'
 
 import type { Locale } from '~/core/translations'
@@ -179,6 +179,53 @@ const collectDiscountBlocks = (editorInstance: Editor): DiscountBlockAttributes[
   return discountBlocks
 }
 
+const readMarkdownFromEditor = (editor: Editor | null | undefined): string | undefined => {
+  if (!editor || !editor.storage || !('markdown' in editor.storage)) return undefined
+
+  const storage: unknown = editor.storage.markdown
+
+  if (
+    !storage ||
+    typeof storage !== 'object' ||
+    !('getMarkdown' in storage) ||
+    typeof storage.getMarkdown !== 'function'
+  )
+    return undefined
+
+  const result: unknown = storage.getMarkdown()
+
+  return typeof result === 'string' ? result : undefined
+}
+
+const buildSlashCommandsOptions = ({
+  translate,
+  onPricingCommand,
+  onPricingCommandRef,
+  isPricingDisabled,
+  isPricingDisabledRef,
+  onDiscountCommand,
+  onDiscountCommandRef,
+}: {
+  translate: (key: string) => string
+  onPricingCommand?: OnPricingCommand
+  onPricingCommandRef: MutableRefObject<OnPricingCommand | undefined>
+  isPricingDisabled?: () => boolean
+  isPricingDisabledRef: MutableRefObject<(() => boolean) | undefined>
+  onDiscountCommand?: OnDiscountCommand
+  onDiscountCommandRef: MutableRefObject<OnDiscountCommand | undefined>
+}) => ({
+  translate,
+  onPricingCommand: onPricingCommand
+    ? (params: Parameters<OnPricingCommand>[0]) => onPricingCommandRef.current?.(params)
+    : undefined,
+  isPricingDisabled: isPricingDisabled
+    ? () => isPricingDisabledRef.current?.() ?? false
+    : undefined,
+  onDiscountCommand: onDiscountCommand
+    ? (params: Parameters<OnDiscountCommand>[0]) => onDiscountCommandRef.current?.(params)
+    : undefined,
+})
+
 const RichTextEditor = ({
   mode = 'edit',
   mentionValues = {},
@@ -217,6 +264,10 @@ const RichTextEditor = ({
 
   const mentionSuggestion = useMemo(() => createMentionSuggestion(variableItems), [variableItems])
 
+  const editorAttributesClass = isCompact
+    ? 'max-w-4xl mx-auto focus:outline-none min-h-[300px] mb-4 px-0'
+    : 'max-w-4xl mx-auto focus:outline-none min-h-[300px] my-4 px-10'
+
   const editor = useEditor({
     extensions: [
       ...getBaseExtensions({ tableResizable: true }),
@@ -241,18 +292,17 @@ const RichTextEditor = ({
         },
       }).configure({ images }),
       DiscountBlock.configure({ entities: entitiesFromProps }),
-      SlashCommands.configure({
-        translate,
-        onPricingCommand: onPricingCommand
-          ? (params) => onPricingCommandRef.current?.(params)
-          : undefined,
-        isPricingDisabled: isPricingDisabled
-          ? () => isPricingDisabledRef.current?.() ?? false
-          : undefined,
-        onDiscountCommand: onDiscountCommand
-          ? (params) => onDiscountCommandRef.current?.(params)
-          : undefined,
-      }),
+      SlashCommands.configure(
+        buildSlashCommandsOptions({
+          translate,
+          onPricingCommand,
+          onPricingCommandRef,
+          isPricingDisabled,
+          isPricingDisabledRef,
+          onDiscountCommand,
+          onDiscountCommandRef,
+        }),
+      ),
       LinkPasteHandler,
       TemplateSelectorExtension.configure({ templates: templates ?? [] }),
       DragHandle,
@@ -260,9 +310,7 @@ const RichTextEditor = ({
     ],
     editorProps: {
       attributes: {
-        class: isCompact
-          ? 'max-w-4xl mx-auto focus:outline-none min-h-[300px] mb-4 px-0'
-          : 'max-w-4xl mx-auto focus:outline-none min-h-[300px] my-4 px-10',
+        class: editorAttributesClass,
       },
     },
     content: getInitialEditorContent(content, templates),
@@ -304,23 +352,10 @@ const RichTextEditor = ({
     }
   }, [editor, isPreview, onPreviewReady])
 
-  const getMarkdown = useCallback((): string | undefined => {
-    if (!editor || !editor.storage || !('markdown' in editor.storage)) return undefined
-
-    const storage: unknown = editor.storage.markdown
-
-    if (
-      !storage ||
-      typeof storage !== 'object' ||
-      !('getMarkdown' in storage) ||
-      typeof storage.getMarkdown !== 'function'
-    )
-      return undefined
-
-    const result: unknown = storage.getMarkdown()
-
-    return typeof result === 'string' ? result : undefined
-  }, [editor])
+  const getMarkdown = useCallback(
+    (): string | undefined => readMarkdownFromEditor(editor),
+    [editor],
+  )
 
   const contextValue = useMemo(
     () => ({

--- a/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
@@ -10,6 +10,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import BlockToolbar from './BlockControls/BlockToolbar'
 import {
   type EntityData,
+  type OnDiscountCommand,
   type OnPricingCommand,
   RichTextEditorProvider,
 } from './common/RichTextEditorContext'
@@ -19,6 +20,8 @@ import {
   RICH_TEXT_EDITOR_TOOLBAR_TEST_ID,
 } from './constants'
 import { getBaseExtensions } from './extensions/baseExtensions'
+import { DiscountBlock } from './extensions/DiscountBlock'
+import { type DiscountBlockAttributes } from './extensions/DiscountBlock.schema'
 import { DragHandle } from './extensions/DragHandle'
 import { LinkPasteHandler } from './extensions/LinkPasteHandler'
 import {
@@ -53,6 +56,8 @@ interface RichTextEditorProps {
   onPricingCommand?: OnPricingCommand
   isPricingDisabled?: () => boolean
   onPricingBlocksChange?: (blocks: PricingBlockAttributes[]) => void
+  onDiscountCommand?: OnDiscountCommand
+  onDiscountBlocksChange?: (blocks: DiscountBlockAttributes[]) => void
   customerLocale?: Locale
   customerCurrency?: CurrencyEnum
   images?: Record<string, string>
@@ -147,6 +152,8 @@ const RichTextEditor = ({
   onPricingCommand,
   isPricingDisabled,
   onPricingBlocksChange,
+  onDiscountCommand,
+  onDiscountBlocksChange,
   onChange,
   customerLocale,
   customerCurrency,
@@ -161,11 +168,15 @@ const RichTextEditor = ({
   const onPricingBlocksChangeRef = useRef(onPricingBlocksChange)
   const onPricingCommandRef = useRef(onPricingCommand)
   const isPricingDisabledRef = useRef(isPricingDisabled)
+  const onDiscountCommandRef = useRef(onDiscountCommand)
+  const onDiscountBlocksChangeRef = useRef(onDiscountBlocksChange)
 
   onChangeRef.current = onChange
   onPricingBlocksChangeRef.current = onPricingBlocksChange
   onPricingCommandRef.current = onPricingCommand
   isPricingDisabledRef.current = isPricingDisabled
+  onDiscountCommandRef.current = onDiscountCommand
+  onDiscountBlocksChangeRef.current = onDiscountBlocksChange
 
   const mentionSuggestion = useMemo(() => createMentionSuggestion(variableItems), [variableItems])
 
@@ -192,6 +203,7 @@ const RichTextEditor = ({
           return ReactNodeViewRenderer(QuoteImageNodeView, { as: 'div' })
         },
       }).configure({ images }),
+      DiscountBlock.configure({ entities: entitiesFromProps }),
       SlashCommands.configure({
         translate,
         onPricingCommand: onPricingCommand
@@ -199,6 +211,9 @@ const RichTextEditor = ({
           : undefined,
         isPricingDisabled: isPricingDisabled
           ? () => isPricingDisabledRef.current?.() ?? false
+          : undefined,
+        onDiscountCommand: onDiscountCommand
+          ? (params) => onDiscountCommandRef.current?.(params)
           : undefined,
       }),
       LinkPasteHandler,
@@ -216,20 +231,34 @@ const RichTextEditor = ({
     content: getInitialEditorContent(content, templates),
     onUpdate: ({ editor: editorInstance }) => {
       onChangeRef.current?.()
-      if (!onPricingBlocksChangeRef.current) return
+      if (onPricingBlocksChangeRef.current) {
+        const blocks: PricingBlockAttributes[] = []
 
-      const blocks: PricingBlockAttributes[] = []
+        editorInstance.state.doc.descendants((node) => {
+          if (node.type.name === 'pricingBlock' && node.attrs.entityIds?.length) {
+            blocks.push({
+              pricingType: node.attrs.pricingType,
+              entityIds: node.attrs.entityIds,
+              localEntityIds: node.attrs.localEntityIds,
+            })
+          }
+        })
+        onPricingBlocksChangeRef.current(blocks)
+      }
 
-      editorInstance.state.doc.descendants((node) => {
-        if (node.type.name === 'pricingBlock' && node.attrs.entityIds?.length) {
-          blocks.push({
-            pricingType: node.attrs.pricingType,
-            entityIds: node.attrs.entityIds,
-            localEntityIds: node.attrs.localEntityIds,
-          })
-        }
-      })
-      onPricingBlocksChangeRef.current(blocks)
+      if (onDiscountBlocksChangeRef.current) {
+        const discountBlocks: DiscountBlockAttributes[] = []
+
+        editorInstance.state.doc.descendants((node) => {
+          if (node.type.name === 'discountBlock' && node.attrs.couponId) {
+            discountBlocks.push({
+              couponId: node.attrs.couponId,
+              localId: node.attrs.localId,
+            })
+          }
+        })
+        onDiscountBlocksChangeRef.current(discountBlocks)
+      }
     },
   })
 
@@ -284,6 +313,7 @@ const RichTextEditor = ({
       images,
       onPricingCommand,
       onImageUpload,
+      onDiscountCommand,
       customerLocale,
       customerCurrency,
     }),
@@ -292,8 +322,9 @@ const RichTextEditor = ({
       mentionValues,
       entitiesFromProps,
       images,
-      onPricingCommand,
       onImageUpload,
+      onPricingCommand,
+      onDiscountCommand,
       customerLocale,
       customerCurrency,
     ],

--- a/src/components/designSystem/RichTextEditor/__tests__/RichTextEditor.test.tsx
+++ b/src/components/designSystem/RichTextEditor/__tests__/RichTextEditor.test.tsx
@@ -23,6 +23,12 @@ jest.mock('../extensions/PricingBlock', () => ({
   },
 }))
 
+jest.mock('../extensions/DiscountBlock', () => ({
+  DiscountBlock: {
+    configure: jest.fn(() => 'discount-block-extension'),
+  },
+}))
+
 jest.mock('../extensions/SlashCommands', () => ({
   SlashCommands: {
     configure: jest.fn((config: Record<string, unknown>) => {
@@ -650,6 +656,109 @@ describe('RichTextEditor', () => {
       await act(() => render(<RichTextEditor onImageUpload={onImageUpload} />))
 
       expect(screen.getByTestId(RICH_TEXT_EDITOR_TEST_ID)).toBeInTheDocument()
+    })
+  })
+
+  describe('GIVEN onDiscountCommand prop', () => {
+    describe('WHEN onDiscountCommand is provided', () => {
+      it('THEN passes onDiscountCommand to SlashCommands.configure', async () => {
+        const onDiscountCommand = jest.fn()
+
+        await act(() => render(<RichTextEditor onDiscountCommand={onDiscountCommand} />))
+
+        expect(capturedSlashCommandsConfig.onDiscountCommand).toBeDefined()
+        expect(typeof capturedSlashCommandsConfig.onDiscountCommand).toBe('function')
+      })
+    })
+
+    describe('WHEN onDiscountCommand is not provided', () => {
+      it('THEN passes undefined onDiscountCommand to SlashCommands.configure', async () => {
+        await act(() => render(<RichTextEditor />))
+
+        expect(capturedSlashCommandsConfig.onDiscountCommand).toBeUndefined()
+      })
+    })
+  })
+
+  describe('GIVEN the DiscountBlock extension', () => {
+    it('THEN registers DiscountBlock with entities from props', async () => {
+      const { DiscountBlock } = jest.requireMock('../extensions/DiscountBlock') as {
+        DiscountBlock: { configure: jest.Mock }
+      }
+
+      DiscountBlock.configure.mockClear()
+
+      const entities = {
+        'local-1': {
+          entityId: 'cpn_1',
+          entityType: 'coupon' as const,
+          name: 'Summer Sale',
+          code: 'SUMMER',
+        },
+      }
+
+      await act(() => render(<RichTextEditor entities={entities} />))
+
+      expect(DiscountBlock.configure).toHaveBeenCalledWith({ entities })
+    })
+  })
+
+  describe('GIVEN onDiscountBlocksChange prop', () => {
+    describe('WHEN the editor updates with discount block nodes', () => {
+      it('THEN calls onDiscountBlocksChange with the collected discount blocks', async () => {
+        const onDiscountBlocksChange = jest.fn()
+
+        await act(() => render(<RichTextEditor onDiscountBlocksChange={onDiscountBlocksChange} />))
+
+        const onUpdate = (capturedEditorConfig as { onUpdate?: (arg: { editor: unknown }) => void })
+          .onUpdate
+
+        expect(onUpdate).toBeDefined()
+
+        const mockDocWithDiscount = {
+          state: {
+            doc: {
+              descendants: jest.fn((cb: (node: unknown) => void) => {
+                cb({
+                  type: { name: 'discountBlock' },
+                  attrs: { couponId: 'cpn_1', localId: 'local-1' },
+                })
+                cb({ type: { name: 'discountBlock' }, attrs: { couponId: '', localId: 'local-2' } })
+              }),
+            },
+          },
+        }
+
+        await act(() => onUpdate?.({ editor: mockDocWithDiscount }))
+
+        expect(onDiscountBlocksChange).toHaveBeenCalledWith([
+          { couponId: 'cpn_1', localId: 'local-1' },
+        ])
+      })
+    })
+
+    describe('WHEN the editor updates without discount block nodes', () => {
+      it('THEN calls onDiscountBlocksChange with an empty array', async () => {
+        const onDiscountBlocksChange = jest.fn()
+
+        await act(() => render(<RichTextEditor onDiscountBlocksChange={onDiscountBlocksChange} />))
+
+        const onUpdate = (capturedEditorConfig as { onUpdate?: (arg: { editor: unknown }) => void })
+          .onUpdate
+        const mockDocEmpty = {
+          state: {
+            doc: {
+              descendants: jest.fn((cb: (node: unknown) => void) => {
+                cb({ type: { name: 'paragraph' }, attrs: {} })
+              }),
+            },
+          },
+        }
+
+        await act(() => onUpdate?.({ editor: mockDocEmpty }))
+
+        expect(onDiscountBlocksChange).toHaveBeenCalledWith([])
+      })
     })
   })
 })

--- a/src/components/designSystem/RichTextEditor/common/RichTextEditorContext.tsx
+++ b/src/components/designSystem/RichTextEditor/common/RichTextEditorContext.tsx
@@ -5,6 +5,7 @@ import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBilli
 import type { Locale } from '~/core/translations'
 import { type CouponFrequency, type CouponTypeEnum, type CurrencyEnum } from '~/generated/graphql'
 
+import type { DiscountBlockAttributes } from '../extensions/DiscountBlock.schema'
 import type { PricingBlockAttributes, PricingType } from '../extensions/PricingBlock.schema'
 import type { RichTextEditorMode } from '../RichTextEditor'
 
@@ -41,6 +42,13 @@ interface PricingCommandParams {
 
 export type OnPricingCommand = (params: PricingCommandParams) => void
 
+export interface DiscountCommandParams {
+  onSave: (attrs: DiscountBlockAttributes) => void
+  editData?: { couponId: string; localId: string }
+}
+
+export type OnDiscountCommand = (params: DiscountCommandParams) => void
+
 interface RichTextEditorContextValue {
   mode: RichTextEditorMode
   mentionValues: Record<string, string>
@@ -48,6 +56,7 @@ interface RichTextEditorContextValue {
   images: Record<string, string>
   onPricingCommand?: OnPricingCommand
   onImageUpload?: (base64: string) => Promise<string>
+  onDiscountCommand?: OnDiscountCommand
   customerLocale?: Locale
   customerCurrency?: CurrencyEnum
 }

--- a/src/components/designSystem/RichTextEditor/common/RichTextEditorContext.tsx
+++ b/src/components/designSystem/RichTextEditor/common/RichTextEditorContext.tsx
@@ -3,14 +3,14 @@ import { createContext, useContext } from 'react'
 import type { PlanPreviewData } from '~/core/serializers/buildPlanPreviewData'
 import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBillingItems'
 import type { Locale } from '~/core/translations'
-import type { CurrencyEnum } from '~/generated/graphql'
+import { CouponFrequency, CouponTypeEnum, type CurrencyEnum } from '~/generated/graphql'
 
 import type { PricingBlockAttributes, PricingType } from '../extensions/PricingBlock.schema'
 import type { RichTextEditorMode } from '../RichTextEditor'
 
 export type EntityData = {
   entityId: string
-  entityType: 'plan' | 'addOn'
+  entityType: 'plan' | 'addOn' | 'coupon'
   name: string
   invoiceDisplayName?: string
   code: string
@@ -21,6 +21,13 @@ export type EntityData = {
   fromDatetime?: string
   toDatetime?: string
   plan?: PlanPreviewData
+  // coupon-only display fields
+  couponType?: CouponTypeEnum
+  amountCents?: string
+  amountCurrency?: CurrencyEnum
+  percentageRate?: number | null
+  frequency?: CouponFrequency
+  frequencyDuration?: number | null
 }
 
 interface PricingCommandParams {

--- a/src/components/designSystem/RichTextEditor/common/RichTextEditorContext.tsx
+++ b/src/components/designSystem/RichTextEditor/common/RichTextEditorContext.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext } from 'react'
 import type { PlanPreviewData } from '~/core/serializers/buildPlanPreviewData'
 import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBillingItems'
 import type { Locale } from '~/core/translations'
-import { CouponFrequency, CouponTypeEnum, type CurrencyEnum } from '~/generated/graphql'
+import { type CouponFrequency, type CouponTypeEnum, type CurrencyEnum } from '~/generated/graphql'
 
 import type { PricingBlockAttributes, PricingType } from '../extensions/PricingBlock.schema'
 import type { RichTextEditorMode } from '../RichTextEditor'

--- a/src/components/designSystem/RichTextEditor/extensions/DiscountBlock.schema.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/DiscountBlock.schema.ts
@@ -1,0 +1,88 @@
+import { mergeAttributes, Node } from '@tiptap/core'
+
+import type { EntityData } from '../common/RichTextEditorContext'
+import { wrapInBlockWrapper } from '../extensions/BlockWrapper'
+
+export interface DiscountBlockAttributes {
+  couponId: string
+  localId: string
+}
+
+export const DiscountBlockSchema = Node.create({
+  name: 'discountBlock',
+  group: 'block',
+  atom: true,
+
+  addOptions() {
+    return {
+      entities: {} as Record<string, EntityData>,
+    }
+  },
+
+  addAttributes() {
+    return {
+      couponId: {
+        default: '',
+        parseHTML: (element: HTMLElement) => element.dataset.couponId ?? '',
+      },
+      localId: {
+        default: '',
+        parseHTML: (element: HTMLElement) => element.dataset.localId ?? '',
+      },
+    }
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize(
+          state: { write: (text: string) => void; closeBlock: (node: unknown) => void },
+          node: { attrs: DiscountBlockAttributes },
+        ) {
+          const { couponId, localId } = node.attrs
+
+          state.write(`<!-- entity:discount:${couponId}|${localId} -->`)
+          state.closeBlock(node)
+        },
+        parse: {
+          updateDOM(element: HTMLElement) {
+            element.innerHTML = element.innerHTML.replaceAll(
+              /<!--\s*entity:discount:([\s\S]*?)-->/g,
+              (_match: string, raw: string) => {
+                const [couponId, localId] = raw.trim().split('|')
+
+                return `<div data-type="discount-block" data-coupon-id="${couponId}" data-local-id="${localId ?? ''}"></div>`
+              },
+            )
+          },
+        },
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="discount-block"]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const couponId: string = HTMLAttributes.couponId ?? ''
+    const localId: string = HTMLAttributes.localId ?? ''
+
+    const wrapperAttrs = mergeAttributes(HTMLAttributes, {
+      'data-type': 'discount-block',
+      'data-coupon-id': couponId,
+      'data-local-id': localId,
+      class: 'pricing-block',
+    })
+
+    const resolvedEntities: Record<string, EntityData> = this.options.entities ?? {}
+    const entity = resolvedEntities[localId] ?? resolvedEntities[couponId]
+    const label = entity?.name ?? (couponId ? `Coupon: ${couponId}` : 'Select a coupon')
+
+    return wrapInBlockWrapper('discountBlock', [
+      'div',
+      wrapperAttrs,
+      ['span', { class: 'pricing-block__label' }, label],
+    ])
+  },
+})

--- a/src/components/designSystem/RichTextEditor/extensions/DiscountBlock.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/DiscountBlock.ts
@@ -1,0 +1,13 @@
+import { ReactNodeViewRenderer } from '@tiptap/react'
+
+import { DiscountBlockSchema } from './DiscountBlock.schema'
+
+import { DiscountBlockView } from '../DiscountBlock/DiscountBlockView'
+
+export type { DiscountBlockAttributes } from './DiscountBlock.schema'
+
+export const DiscountBlock = DiscountBlockSchema.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(DiscountBlockView)
+  },
+})

--- a/src/components/designSystem/RichTextEditor/extensions/SlashCommands.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/SlashCommands.ts
@@ -4,7 +4,7 @@ import { Editor, Range, ReactRenderer } from '@tiptap/react'
 import Suggestion, { SuggestionKeyDownProps, SuggestionProps } from '@tiptap/suggestion'
 import tippy, { type Instance as TippyInstance } from 'tippy.js'
 
-import type { OnPricingCommand } from '../common/RichTextEditorContext'
+import type { OnDiscountCommand, OnPricingCommand } from '../common/RichTextEditorContext'
 import { SlashMenu, type SlashMenuRef } from '../SlashMenu/SlashMenu'
 
 export interface SlashCommandItem {
@@ -68,6 +68,7 @@ export const SlashCommands = Extension.create({
       translate: ((key: string) => key) as (key: string) => string,
       onPricingCommand: undefined as OnPricingCommand | undefined,
       isPricingDisabled: undefined as (() => boolean) | undefined,
+      onDiscountCommand: undefined as OnDiscountCommand | undefined,
       suggestion: {
         char: '/',
         command: ({
@@ -129,7 +130,7 @@ export const SlashCommands = Extension.create({
   },
 
   addProseMirrorPlugins() {
-    const { translate, onPricingCommand, isPricingDisabled } = this.options
+    const { translate, onPricingCommand, isPricingDisabled, onDiscountCommand } = this.options
 
     const resolvedItems: SlashCommandItem[] = slashCommandDefinitions.map((def) => ({
       title: translate(def.titleKey),
@@ -160,6 +161,30 @@ export const SlashCommands = Extension.create({
         },
       }
       resolvedItems.push(pricingItem)
+    }
+
+    if (onDiscountCommand) {
+      const discountItem: SlashCommandItem = {
+        title: translate('text_1782889379261hdcd0jhzdm6'),
+        description: translate('text_178288937926153opd9g5cwg'),
+        command: (editor) => {
+          onDiscountCommand({
+            onSave: (attrs) => {
+              editor.chain().focus().insertContent({ type: 'discountBlock', attrs }).run()
+
+              // After inserting an atom node, ProseMirror may create a NodeSelection
+              // which triggers the BlockToolbar overlay. Move to a text selection.
+              const { selection } = editor.state
+
+              if (selection instanceof NodeSelection) {
+                editor.commands.setTextSelection(selection.from + selection.node.nodeSize)
+              }
+            },
+          })
+        },
+      }
+
+      resolvedItems.push(discountItem)
     }
 
     const editorRef = this.editor

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/DiscountBlock.schema.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/DiscountBlock.schema.test.ts
@@ -1,0 +1,253 @@
+import { Editor, getSchema } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+
+import type { EntityData } from '~/components/designSystem/RichTextEditor/common/RichTextEditorContext'
+
+import { type DiscountBlockAttributes, DiscountBlockSchema } from '../DiscountBlock.schema'
+
+describe('DiscountBlockSchema', () => {
+  describe('GIVEN the DiscountBlockSchema node is created', () => {
+    it('exposes discountBlock node with couponId + localId attrs', () => {
+      const schema = getSchema([StarterKit, DiscountBlockSchema])
+
+      expect(schema.nodes.discountBlock).toBeDefined()
+      const node = schema.nodes.discountBlock.createAndFill({
+        couponId: 'cpn_1',
+        localId: 'local-1',
+      } as DiscountBlockAttributes)
+
+      expect(node?.attrs.couponId).toBe('cpn_1')
+      expect(node?.attrs.localId).toBe('local-1')
+    })
+
+    it('THEN should have the correct name', () => {
+      expect(DiscountBlockSchema.name).toBe('discountBlock')
+    })
+
+    it('THEN should be a block group', () => {
+      expect(DiscountBlockSchema.config.group).toBe('block')
+    })
+
+    it('THEN should be an atom node', () => {
+      expect(DiscountBlockSchema.config.atom).toBe(true)
+    })
+  })
+
+  describe('GIVEN the addAttributes config', () => {
+    const getAttributes = () => {
+      const addAttributes = DiscountBlockSchema.config.addAttributes as unknown as () => {
+        couponId: { default: string; parseHTML: (element: HTMLElement) => string }
+        localId: { default: string; parseHTML: (element: HTMLElement) => string }
+      }
+
+      return addAttributes()
+    }
+
+    it('THEN should have couponId attribute with empty string default', () => {
+      const attrs = getAttributes()
+
+      expect(attrs.couponId.default).toBe('')
+    })
+
+    it('THEN should have localId attribute with empty string default', () => {
+      const attrs = getAttributes()
+
+      expect(attrs.localId.default).toBe('')
+    })
+
+    describe('WHEN parseHTML is called with data-coupon-id attribute', () => {
+      it('THEN should return the couponId value', () => {
+        const attrs = getAttributes()
+        const element = document.createElement('div')
+
+        element.setAttribute('data-coupon-id', 'cpn_abc')
+
+        expect(attrs.couponId.parseHTML(element)).toBe('cpn_abc')
+      })
+    })
+
+    describe('WHEN parseHTML is called without data-coupon-id attribute', () => {
+      it('THEN should return empty string', () => {
+        const attrs = getAttributes()
+        const element = document.createElement('div')
+
+        expect(attrs.couponId.parseHTML(element)).toBe('')
+      })
+    })
+
+    describe('WHEN parseHTML is called with data-local-id attribute', () => {
+      it('THEN should return the localId value', () => {
+        const attrs = getAttributes()
+        const element = document.createElement('div')
+
+        element.setAttribute('data-local-id', 'local-xyz')
+
+        expect(attrs.localId.parseHTML(element)).toBe('local-xyz')
+      })
+    })
+
+    describe('WHEN parseHTML is called without data-local-id attribute', () => {
+      it('THEN should return empty string', () => {
+        const attrs = getAttributes()
+        const element = document.createElement('div')
+
+        expect(attrs.localId.parseHTML(element)).toBe('')
+      })
+    })
+  })
+
+  describe('GIVEN the addStorage config', () => {
+    const getStorage = () => {
+      const addStorage = DiscountBlockSchema.config.addStorage as unknown as () => {
+        markdown: {
+          serialize: (
+            state: { write: (text: string) => void; closeBlock: (node: unknown) => void },
+            node: { attrs: DiscountBlockAttributes },
+          ) => void
+          parse: {
+            updateDOM: (element: HTMLElement) => void
+          }
+        }
+      }
+
+      return addStorage()
+    }
+
+    describe('WHEN serialize is called with couponId and localId', () => {
+      it('THEN should write the entity discount comment', () => {
+        const storage = getStorage()
+        const mockWrite = jest.fn()
+        const mockCloseBlock = jest.fn()
+        const node = { attrs: { couponId: 'cpn_1', localId: 'local-1' } }
+
+        storage.markdown.serialize({ write: mockWrite, closeBlock: mockCloseBlock }, node)
+
+        expect(mockWrite).toHaveBeenCalledWith('<!-- entity:discount:cpn_1|local-1 -->')
+        expect(mockCloseBlock).toHaveBeenCalledWith(node)
+      })
+    })
+
+    describe('WHEN serialize is called with couponId and empty localId', () => {
+      it('THEN should write the entity discount comment with empty localId part', () => {
+        const storage = getStorage()
+        const mockWrite = jest.fn()
+        const mockCloseBlock = jest.fn()
+        const node = { attrs: { couponId: 'cpn_2', localId: '' } }
+
+        storage.markdown.serialize({ write: mockWrite, closeBlock: mockCloseBlock }, node)
+
+        expect(mockWrite).toHaveBeenCalledWith('<!-- entity:discount:cpn_2| -->')
+        expect(mockCloseBlock).toHaveBeenCalledWith(node)
+      })
+    })
+
+    describe('WHEN parse.updateDOM is called with entity discount comments', () => {
+      it('THEN should replace comment with discount block div', () => {
+        const storage = getStorage()
+        const element = {
+          innerHTML: 'Some text <!-- entity:discount:cpn_1|local-1 --> more text',
+        } as HTMLElement
+
+        storage.markdown.parse.updateDOM(element)
+
+        expect(element.innerHTML).toContain('data-type="discount-block"')
+        expect(element.innerHTML).toContain('data-coupon-id="cpn_1"')
+        expect(element.innerHTML).toContain('data-local-id="local-1"')
+      })
+    })
+
+    describe('WHEN parse.updateDOM is called with empty localId', () => {
+      it('THEN should replace comment with discount block div with empty data-local-id', () => {
+        const storage = getStorage()
+        const element = {
+          innerHTML: '<!-- entity:discount:cpn_2| -->',
+        } as HTMLElement
+
+        storage.markdown.parse.updateDOM(element)
+
+        expect(element.innerHTML).toContain('data-type="discount-block"')
+        expect(element.innerHTML).toContain('data-coupon-id="cpn_2"')
+        expect(element.innerHTML).toContain('data-local-id=""')
+      })
+    })
+
+    describe('WHEN parse.updateDOM is called with no discount comments', () => {
+      it('THEN should not modify the innerHTML', () => {
+        const storage = getStorage()
+        const element = { innerHTML: 'No discount blocks here.' } as HTMLElement
+
+        storage.markdown.parse.updateDOM(element)
+
+        expect(element.innerHTML).toBe('No discount blocks here.')
+      })
+    })
+
+    describe('WHEN serialize then updateDOM (round-trip)', () => {
+      it('THEN should reconstruct the original couponId and localId', () => {
+        const storage = getStorage()
+        const mockWrite = jest.fn()
+        const mockCloseBlock = jest.fn()
+        const node = { attrs: { couponId: 'cpn_roundtrip', localId: 'local-rt' } }
+
+        storage.markdown.serialize({ write: mockWrite, closeBlock: mockCloseBlock }, node)
+
+        const comment = mockWrite.mock.calls[0][0] as string
+        const element = { innerHTML: comment } as HTMLElement
+
+        storage.markdown.parse.updateDOM(element)
+
+        expect(element.innerHTML).toContain('data-coupon-id="cpn_roundtrip"')
+        expect(element.innerHTML).toContain('data-local-id="local-rt"')
+      })
+    })
+  })
+
+  describe('GIVEN the parseHTML config', () => {
+    it('THEN should match div elements with data-type="discount-block"', () => {
+      const parseHTML = DiscountBlockSchema.config.parseHTML as unknown as () => { tag: string }[]
+      const rules = parseHTML()
+
+      expect(rules).toEqual([{ tag: 'div[data-type="discount-block"]' }])
+    })
+  })
+
+  describe('GIVEN the renderHTML via getHTML()', () => {
+    const getHtmlForDiscountBlock = (
+      couponId: string,
+      localId: string,
+      entities?: Record<string, EntityData>,
+    ) => {
+      const editor = new Editor({
+        extensions: [StarterKit, DiscountBlockSchema.configure({ entities })],
+        content: {
+          type: 'doc',
+          content: [{ type: 'discountBlock', attrs: { couponId, localId } }],
+        },
+      })
+      const html = editor.getHTML()
+
+      editor.destroy()
+
+      return html
+    }
+
+    describe('WHEN called with couponId and no entities data', () => {
+      it('THEN should render a div with fallback label', () => {
+        const html = getHtmlForDiscountBlock('cpn_1', 'local-1')
+
+        expect(html).toContain('data-type="discount-block"')
+        expect(html).toContain('data-coupon-id="cpn_1"')
+        expect(html).toContain('data-local-id="local-1"')
+        expect(html).toContain('Coupon: cpn_1')
+      })
+    })
+
+    describe('WHEN called with empty couponId', () => {
+      it('THEN should render fallback "Select a coupon" label', () => {
+        const html = getHtmlForDiscountBlock('', '')
+
+        expect(html).toContain('Select a coupon')
+      })
+    })
+  })
+})

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/SlashCommands.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/SlashCommands.test.ts
@@ -51,6 +51,8 @@ const mockTranslate = (key: string): string => {
     text_1774281559657y9saycc2aev: 'Insert a 3x3 table',
     text_1774281559657l4kkx9ws4mz: 'Code Block',
     text_1774281559657qdknwsvn5ka: 'Insert a code block',
+    text_1782889379261hdcd0jhzdm6: 'Discount',
+    text_178288937926153opd9g5cwg: 'Apply a coupon discount to this quote',
   }
 
   return translations[key] ?? key
@@ -1105,6 +1107,228 @@ describe('SlashCommands', () => {
         expect(mockDestroyPopup).not.toHaveBeenCalled()
 
         document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+        editor.destroy()
+      })
+    })
+  })
+
+  describe('GIVEN onDiscountCommand is configured', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    describe('WHEN onDiscountCommand is provided', () => {
+      it('THEN the resolved items should include a discount item', () => {
+        const ReactRendererMock = jest.requireMock('@tiptap/react').ReactRenderer as jest.Mock
+        const mockOnDiscountCommand = jest.fn()
+        const editor = new Editor({
+          extensions: [
+            StarterKit,
+            SlashCommands.configure({
+              translate: mockTranslate,
+              onDiscountCommand: mockOnDiscountCommand,
+            }),
+          ],
+          content: '<p>Hello</p>',
+        })
+
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        ReactRendererMock.mockClear()
+        storage.triggerMenu(() => new DOMRect())
+
+        const rendererProps = ReactRendererMock.mock.calls[0][1].props as {
+          items: Array<{ title: string; command: (editor: Editor) => void }>
+        }
+        const discountItem = rendererProps.items.find(
+          (item) => item.title === mockTranslate('text_1782889379261hdcd0jhzdm6'),
+        )
+
+        expect(discountItem).toBeDefined()
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN onDiscountCommand is omitted', () => {
+      it('THEN the resolved items should not include a discount item', () => {
+        const ReactRendererMock = jest.requireMock('@tiptap/react').ReactRenderer as jest.Mock
+        const editor = new Editor({
+          extensions: [
+            StarterKit,
+            SlashCommands.configure({
+              translate: mockTranslate,
+            }),
+          ],
+          content: '<p>Hello</p>',
+        })
+
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        ReactRendererMock.mockClear()
+        storage.triggerMenu(() => new DOMRect())
+
+        const rendererProps = ReactRendererMock.mock.calls[0][1].props as {
+          items: Array<{ title: string; command: (editor: Editor) => void }>
+        }
+        const discountItem = rendererProps.items.find(
+          (item) => item.title === mockTranslate('text_1782889379261hdcd0jhzdm6'),
+        )
+
+        expect(discountItem).toBeUndefined()
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN the discount command is executed via triggerMenu', () => {
+      it('THEN should call onDiscountCommand with an onSave callback', () => {
+        const ReactRendererMock = jest.requireMock('@tiptap/react').ReactRenderer as jest.Mock
+        const mockOnDiscountCommand = jest.fn()
+        const editor = new Editor({
+          extensions: [
+            StarterKit,
+            SlashCommands.configure({
+              translate: mockTranslate,
+              onDiscountCommand: mockOnDiscountCommand,
+            }),
+          ],
+          content: '<p>Hello</p>',
+        })
+
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        ReactRendererMock.mockClear()
+        storage.triggerMenu(() => new DOMRect())
+
+        const rendererProps = ReactRendererMock.mock.calls[0][1].props as {
+          items: Array<{ title: string; command: (editor: Editor) => void }>
+          command: (item: { title: string; command: (editor: Editor) => void }) => void
+        }
+        const discountItem = rendererProps.items.find(
+          (item) => item.title === mockTranslate('text_1782889379261hdcd0jhzdm6'),
+        )
+
+        expect(discountItem).toBeDefined()
+
+        rendererProps.command(
+          discountItem as { title: string; disabled: boolean; command: jest.Mock },
+        )
+
+        expect(mockOnDiscountCommand).toHaveBeenCalledWith({ onSave: expect.any(Function) })
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN onSave is invoked from the discount command callback', () => {
+      it('THEN should call editor.chain().focus().insertContent() with the discountBlock node', () => {
+        const ReactRendererMock = jest.requireMock('@tiptap/react').ReactRenderer as jest.Mock
+        const mockOnDiscountCommand = jest.fn()
+        const editor = new Editor({
+          extensions: [
+            StarterKit,
+            SlashCommands.configure({
+              translate: mockTranslate,
+              onDiscountCommand: mockOnDiscountCommand,
+            }),
+          ],
+          content: '<p>Hello</p>',
+        })
+
+        const storage = (editor.storage as any).slashCommands as {
+          triggerMenu: (clientRect: () => DOMRect) => void
+        }
+
+        ReactRendererMock.mockClear()
+        storage.triggerMenu(() => new DOMRect())
+
+        const rendererProps = ReactRendererMock.mock.calls[0][1].props as {
+          items: Array<{ title: string; command: (editor: Editor) => void }>
+          command: (item: { title: string; command: (editor: Editor) => void }) => void
+        }
+        const discountItem = rendererProps.items.find(
+          (item) => item.title === mockTranslate('text_1782889379261hdcd0jhzdm6'),
+        )
+
+        // Spy on the editor's chain to track calls
+        const runMock = jest.fn()
+        const chainMethods: Record<string, jest.Mock> = {}
+        const handler: ProxyHandler<Record<string, jest.Mock>> = {
+          get: (_target, prop: string) => {
+            if (prop === 'run') return runMock
+            if (!chainMethods[prop]) {
+              chainMethods[prop] = jest.fn().mockReturnValue(new Proxy({}, handler))
+            }
+
+            return chainMethods[prop]
+          },
+        }
+
+        const mockEditorForCommand = {
+          chain: jest.fn().mockReturnValue(new Proxy({}, handler)),
+          commands: { setTextSelection: jest.fn() },
+          state: { selection: {} },
+        } as unknown as Editor
+
+        // Execute the discount item's command directly with our mock editor
+        ;(discountItem as { command: (e: Editor) => void }).command(mockEditorForCommand)
+
+        // Capture the onSave callback
+        const capturedParams = mockOnDiscountCommand.mock.calls[0][0] as {
+          onSave: (attrs: { couponId: string; localId: string }) => void
+        }
+
+        const attrs = { couponId: 'coupon-1', localId: 'local-1' }
+
+        capturedParams.onSave(attrs)
+
+        expect(mockEditorForCommand.chain).toHaveBeenCalled()
+        expect(chainMethods['insertContent']).toHaveBeenCalledWith({
+          type: 'discountBlock',
+          attrs,
+        })
+        expect(runMock).toHaveBeenCalled()
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+        editor.destroy()
+      })
+    })
+
+    describe('WHEN discount item is in the Suggestion items', () => {
+      it('THEN should never be disabled (unlimited coupons)', () => {
+        const SuggestionMock = jest.requireMock('@tiptap/suggestion').default as jest.Mock
+        const mockOnDiscountCommand = jest.fn()
+        const editor = new Editor({
+          extensions: [
+            StarterKit,
+            SlashCommands.configure({
+              translate: mockTranslate,
+              onDiscountCommand: mockOnDiscountCommand,
+            }),
+          ],
+          content: '<p>Hello</p>',
+        })
+
+        const suggestionConfig = SuggestionMock.mock.calls[SuggestionMock.mock.calls.length - 1][0]
+        const items = suggestionConfig.items({ query: '' })
+        const discountItem = items.find(
+          (item: { title: string }) =>
+            item.title === mockTranslate('text_1782889379261hdcd0jhzdm6'),
+        )
+
+        expect(discountItem).toBeDefined()
+        expect(discountItem?.disabled).toBe(false)
+
         editor.destroy()
       })
     })

--- a/src/core/serializers/__tests__/serializeQuoteBillingItems.test.ts
+++ b/src/core/serializers/__tests__/serializeQuoteBillingItems.test.ts
@@ -294,7 +294,7 @@ describe('fromBillingItems', () => {
 
     const localId = result.addOnItems[0].localId
 
-    expect(result.originalPayloads[localId]).toEqual(billingItems.addons[0].payload)
+    expect(result.originalPayloads[localId]).toEqual(billingItems.addons?.[0].payload)
   })
 
   it('sorts by position', () => {
@@ -436,7 +436,7 @@ describe('buildPreviewEntities', () => {
   })
 
   const makeBillingItems = (
-    overrides: Partial<BillingItemsPayload['addons'][number]> = {},
+    overrides: Partial<NonNullable<BillingItemsPayload['addons']>[number]> = {},
   ): BillingItemsPayload => ({
     addons: [
       {

--- a/src/core/serializers/__tests__/serializeQuoteCoupons.test.ts
+++ b/src/core/serializers/__tests__/serializeQuoteCoupons.test.ts
@@ -1,0 +1,127 @@
+import { CouponFrequency, CouponTypeEnum, CurrencyEnum } from '~/generated/graphql'
+
+import {
+  type BillingItemCoupon,
+  type DiscountFormItem,
+  fromCoupons,
+  toCoupons,
+} from '../serializeQuoteCoupons'
+
+const fixedPayload = {
+  position: 1,
+  code: 'enterprise_discount_20',
+  id: 'cpn_uuid',
+  name: 'Enterprise 20% Discount',
+  type: 'fixed_amount' as const,
+  amount_cents: 5000,
+  percentage_rate: null,
+  currency: 'EUR',
+  frequency: 'recurring' as const,
+  frequency_duration: 6,
+  expiration_at: null,
+  limited_plans: false,
+  plan_codes: [],
+  limited_billable_metrics: false,
+  billable_metric_codes: [],
+  coupon_overrides: null,
+  catalog_snapshot: null,
+  resolved_payload: null,
+}
+
+describe('serializeQuoteCoupons', () => {
+  describe('toCoupons', () => {
+    it('writes the full UI-editable set into overrides (fixed amount)', () => {
+      const items: DiscountFormItem[] = [
+        {
+          localId: 'local-1',
+          couponId: 'cpn_uuid',
+          couponType: CouponTypeEnum.FixedAmount,
+          name: 'Enterprise 20% Discount',
+          code: 'enterprise_discount_20',
+          currency: CurrencyEnum.Eur,
+          amount: '90.00',
+          percentageRate: null,
+          frequency: CouponFrequency.Recurring,
+          frequencyDuration: 6,
+        },
+      ]
+
+      const result = toCoupons(items, { 'local-1': fixedPayload })
+
+      expect(result).toHaveLength(1)
+      expect(result[0].type).toBe('coupon')
+      expect(result[0].id).toBe('cpn_uuid')
+      expect(result[0].localId).toBe('local-1')
+      expect(result[0].overrides).toEqual({
+        amount_cents: 9000,
+        percentage_rate: null,
+        frequency: 'recurring',
+        frequency_duration: 6,
+      })
+      // currency is NOT in overrides
+      expect(result[0].overrides).not.toHaveProperty('currency')
+    })
+
+    it('writes percentage_rate (amount_cents null) for percentage coupons', () => {
+      const items: DiscountFormItem[] = [
+        {
+          localId: 'local-2',
+          couponId: 'cpn_pct',
+          couponType: CouponTypeEnum.Percentage,
+          name: 'Pct',
+          code: 'pct',
+          currency: CurrencyEnum.Eur,
+          amount: '',
+          percentageRate: 12.5,
+          frequency: CouponFrequency.Forever,
+          frequencyDuration: null,
+        },
+      ]
+
+      const result = toCoupons(items, {
+        'local-2': {
+          ...fixedPayload,
+          id: 'cpn_pct',
+          type: 'percentage',
+          amount_cents: null,
+          percentage_rate: 10,
+        },
+      })
+
+      expect(result[0].overrides).toEqual({
+        amount_cents: null,
+        percentage_rate: 12.5,
+        frequency: 'forever',
+        frequency_duration: null,
+      })
+    })
+  })
+
+  describe('fromCoupons', () => {
+    it('round-trips a saved coupon into a form item keyed by localId, overrides winning', () => {
+      const saved: BillingItemCoupon[] = [
+        {
+          type: 'coupon',
+          id: 'cpn_uuid',
+          localId: 'local-1',
+          payload: fixedPayload,
+          overrides: {
+            amount_cents: 9000,
+            percentage_rate: null,
+            frequency: CouponFrequency.Recurring,
+            frequency_duration: 6,
+          },
+        },
+      ]
+
+      const { entities, discountItems, originalPayloads } = fromCoupons(saved)
+
+      expect(discountItems[0].couponId).toBe('cpn_uuid')
+      expect(discountItems[0].amount).toBe('90.00') // 9000 cents / EUR
+      expect(discountItems[0].frequency).toBe(CouponFrequency.Recurring)
+      expect(entities['local-1'].entityType).toBe('coupon')
+      expect(entities['local-1'].name).toBe('Enterprise 20% Discount')
+      expect(originalPayloads['local-1']).toEqual(fixedPayload)
+    })
+  })
+})

--- a/src/core/serializers/__tests__/serializeQuoteCoupons.test.ts
+++ b/src/core/serializers/__tests__/serializeQuoteCoupons.test.ts
@@ -117,7 +117,7 @@ describe('serializeQuoteCoupons', () => {
       const { entities, discountItems, originalPayloads } = fromCoupons(saved)
 
       expect(discountItems[0].couponId).toBe('cpn_uuid')
-      expect(discountItems[0].amount).toBe('90.00') // 9000 cents / EUR
+      expect(discountItems[0].amount).toBe('90') // 9000 cents / EUR, no trailing .00
       expect(discountItems[0].frequency).toBe(CouponFrequency.Recurring)
       expect(entities['local-1'].entityType).toBe('coupon')
       expect(entities['local-1'].name).toBe('Enterprise 20% Discount')

--- a/src/core/serializers/serializeQuoteBillingItems.ts
+++ b/src/core/serializers/serializeQuoteBillingItems.ts
@@ -1,6 +1,8 @@
 import type { EntityData } from '~/components/designSystem/RichTextEditor/common/RichTextEditorContext'
 import type { AddOnItem } from '~/components/designSystem/RichTextEditor/PricingBlock/constants'
 
+import type { BillingItemCoupon } from './serializeQuoteCoupons'
+import { fromCoupons } from './serializeQuoteCoupons'
 import { type BillingItemPlan, fromPlanBillingItems } from './serializeQuotePlanBillingItems'
 
 // --- Backend contract types (snake_case) ---
@@ -33,6 +35,7 @@ interface BillingItemAddon {
 export interface BillingItemsPayload {
   addons: BillingItemAddon[]
   plans?: BillingItemPlan[]
+  coupons?: BillingItemCoupon[]
 }
 
 // --- Serialization helpers ---
@@ -182,6 +185,16 @@ export const buildPreviewEntities = (
     const { entityData } = fromPlanBillingItems(billingItems.plans)
 
     Object.assign(previewEntities, entityData)
+  }
+
+  if (billingItems.coupons && billingItems.coupons.length > 0) {
+    const { entities: couponEntities } = fromCoupons(billingItems.coupons)
+
+    Object.assign(previewEntities, couponEntities)
+    // also key by couponId for legacy entityIds resolution
+    for (const c of billingItems.coupons) {
+      previewEntities[c.id] = couponEntities[c.localId]
+    }
   }
 
   return previewEntities

--- a/src/core/serializers/serializeQuoteBillingItems.ts
+++ b/src/core/serializers/serializeQuoteBillingItems.ts
@@ -32,7 +32,7 @@ interface BillingItemAddon {
 }
 
 export interface BillingItemsPayload {
-  addons: BillingItemAddon[]
+  addons?: BillingItemAddon[]
   plans?: BillingItemPlan[]
   coupons?: BillingItemCoupon[]
 }
@@ -50,7 +50,7 @@ const normalizeDateTime = (value: string): string | null => (value === '' ? null
 export const toBillingItems = (
   addOnItems: AddOnItem[],
   originalPayloads: Record<string, AddOnPayload>,
-): BillingItemsPayload => {
+): Required<Pick<BillingItemsPayload, 'addons'>> => {
   const addons: BillingItemAddon[] = addOnItems.map((item, index) => {
     const original = originalPayloads[item.localId] ?? originalPayloads[item.addOnId]
     const payload: AddOnPayload = { ...original, position: index + 1 }
@@ -108,7 +108,9 @@ export const fromBillingItems = (billingItems: BillingItemsPayload): FromBilling
   const addOnItems: AddOnItem[] = []
   const originalPayloads: Record<string, AddOnPayload> = {}
 
-  const sorted = [...billingItems.addons].sort((a, b) => a.payload.position - b.payload.position)
+  const sorted = [...(billingItems.addons ?? [])].sort(
+    (a, b) => a.payload.position - b.payload.position,
+  )
 
   for (const addon of sorted) {
     const { payload, overrides, id, localId: savedLocalId } = addon

--- a/src/core/serializers/serializeQuoteBillingItems.ts
+++ b/src/core/serializers/serializeQuoteBillingItems.ts
@@ -1,8 +1,7 @@
 import type { EntityData } from '~/components/designSystem/RichTextEditor/common/RichTextEditorContext'
 import type { AddOnItem } from '~/components/designSystem/RichTextEditor/PricingBlock/constants'
 
-import type { BillingItemCoupon } from './serializeQuoteCoupons'
-import { fromCoupons } from './serializeQuoteCoupons'
+import { type BillingItemCoupon, fromCoupons } from './serializeQuoteCoupons'
 import { type BillingItemPlan, fromPlanBillingItems } from './serializeQuotePlanBillingItems'
 
 // --- Backend contract types (snake_case) ---

--- a/src/core/serializers/serializeQuoteCoupons.ts
+++ b/src/core/serializers/serializeQuoteCoupons.ts
@@ -1,7 +1,7 @@
 import type { EntityData } from '~/components/designSystem/RichTextEditor/common/RichTextEditorContext'
 import { CouponFrequency, CouponTypeEnum, CurrencyEnum } from '~/generated/graphql'
 
-import { deserializeAmount, getCurrencyPrecision, serializeAmount } from './serializeAmount'
+import { deserializeAmount, serializeAmount } from './serializeAmount'
 
 // --- Backend contract (snake_case) ---
 export interface CouponPayload {
@@ -110,7 +110,6 @@ export const fromCoupons = (
       frequencyDuration: overrides.frequency_duration ?? payload.frequency_duration,
     }
 
-    const precision = getCurrencyPrecision(currency)
     const amountNumber = deserializeAmount(effectiveAmountCents, currency)
 
     discountItems.push({
@@ -120,7 +119,9 @@ export const fromCoupons = (
       name: payload.name,
       code: payload.code,
       currency,
-      amount: amountNumber.toFixed(precision),
+      // toString() (not toFixed) so whole amounts show as "90" not "90.00",
+      // matching the fresh-coupon-select prefill in useDiscountDrawer.
+      amount: amountNumber.toString(),
       percentageRate: overrides.percentage_rate ?? payload.percentage_rate,
       frequency,
       frequencyDuration: overrides.frequency_duration ?? payload.frequency_duration,

--- a/src/core/serializers/serializeQuoteCoupons.ts
+++ b/src/core/serializers/serializeQuoteCoupons.ts
@@ -1,0 +1,133 @@
+import type { EntityData } from '~/components/designSystem/RichTextEditor/common/RichTextEditorContext'
+import { CouponFrequency, CouponTypeEnum, CurrencyEnum } from '~/generated/graphql'
+
+import { deserializeAmount, getCurrencyPrecision, serializeAmount } from './serializeAmount'
+
+// --- Backend contract (snake_case) ---
+export interface CouponPayload {
+  position: number
+  code: string
+  id: string
+  name: string
+  type: 'fixed_amount' | 'percentage'
+  amount_cents: number | null
+  percentage_rate: number | null
+  currency: string
+  frequency: 'once' | 'recurring' | 'forever'
+  frequency_duration: number | null
+  expiration_at: string | null
+  limited_plans: boolean
+  plan_codes: string[]
+  limited_billable_metrics: boolean
+  billable_metric_codes: string[]
+  coupon_overrides: unknown
+  catalog_snapshot: unknown
+  resolved_payload: unknown
+}
+
+// Full UI-editable set, ALWAYS written (not Partial). Excludes currency (locked).
+export type CouponOverrides = Pick<
+  CouponPayload,
+  'amount_cents' | 'percentage_rate' | 'frequency' | 'frequency_duration'
+>
+
+export interface BillingItemCoupon {
+  type: 'coupon'
+  id: string // catalog coupon id (cpn_)
+  localId: string // FE-generated per-line key
+  payload: CouponPayload
+  overrides: CouponOverrides
+}
+
+// --- UI/form shape (camelCase) ---
+export interface DiscountFormItem {
+  localId: string
+  couponId: string
+  couponType: CouponTypeEnum
+  name: string
+  code: string
+  currency: CurrencyEnum
+  amount: string
+  percentageRate?: number | null
+  frequency: CouponFrequency
+  frequencyDuration?: number | null
+}
+
+export const toCoupons = (
+  items: DiscountFormItem[],
+  originalPayloads: Record<string, CouponPayload>,
+): BillingItemCoupon[] =>
+  items.map((item, index) => {
+    const original = originalPayloads[item.localId]
+    const payload: CouponPayload = { ...original, position: index + 1 }
+
+    const isFixed = item.couponType === CouponTypeEnum.FixedAmount
+
+    const overrides: CouponOverrides = {
+      amount_cents: isFixed ? serializeAmount(Number(item.amount), item.currency) : null,
+      percentage_rate: isFixed ? null : (item.percentageRate ?? null),
+      frequency: item.frequency as CouponPayload['frequency'],
+      frequency_duration:
+        item.frequency === CouponFrequency.Recurring ? (item.frequencyDuration ?? null) : null,
+    }
+
+    return { type: 'coupon' as const, id: item.couponId, localId: item.localId, payload, overrides }
+  })
+
+export const fromCoupons = (
+  coupons: BillingItemCoupon[],
+): {
+  entities: Record<string, EntityData>
+  discountItems: DiscountFormItem[]
+  originalPayloads: Record<string, CouponPayload>
+} => {
+  const entities: Record<string, EntityData> = {}
+  const discountItems: DiscountFormItem[] = []
+  const originalPayloads: Record<string, CouponPayload> = {}
+
+  const sorted = [...coupons].sort((a, b) => a.payload.position - b.payload.position)
+
+  for (const coupon of sorted) {
+    const { payload, overrides, id, localId: savedLocalId } = coupon
+    const localId = savedLocalId ?? crypto.randomUUID()
+    const currency = (payload.currency as CurrencyEnum) ?? CurrencyEnum.Usd
+
+    const effectiveAmountCents = overrides.amount_cents ?? payload.amount_cents ?? 0
+    const couponType =
+      payload.type === 'percentage' ? CouponTypeEnum.Percentage : CouponTypeEnum.FixedAmount
+    const frequency = (overrides.frequency ?? payload.frequency) as CouponFrequency
+
+    entities[localId] = {
+      entityId: localId,
+      entityType: 'coupon',
+      name: payload.name,
+      code: payload.code,
+      couponType,
+      amountCents: String(effectiveAmountCents),
+      amountCurrency: currency,
+      percentageRate: overrides.percentage_rate ?? payload.percentage_rate,
+      frequency,
+      frequencyDuration: overrides.frequency_duration ?? payload.frequency_duration,
+    }
+
+    const precision = getCurrencyPrecision(currency)
+    const amountNumber = deserializeAmount(effectiveAmountCents, currency)
+
+    discountItems.push({
+      localId,
+      couponId: id,
+      couponType,
+      name: payload.name,
+      code: payload.code,
+      currency,
+      amount: amountNumber.toFixed(precision),
+      percentageRate: overrides.percentage_rate ?? payload.percentage_rate,
+      frequency,
+      frequencyDuration: overrides.frequency_duration ?? payload.frequency_duration,
+    })
+
+    originalPayloads[localId] = payload
+  }
+
+  return { entities, discountItems, originalPayloads }
+}

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -10970,7 +10970,7 @@ export type GetCouponForCustomerQueryVariables = Exact<{
 }>;
 
 
-export type GetCouponForCustomerQuery = { __typename?: 'Query', coupons: { __typename?: 'CouponCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Coupon', id: string, name: string, code: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, plans?: Array<{ __typename?: 'Plan', id: string, name: string }> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, name: string }> | null }> } };
+export type GetCouponForCustomerQuery = { __typename?: 'Query', coupons: { __typename?: 'CouponCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Coupon', id: string, name: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, plans?: Array<{ __typename?: 'Plan', id: string, name: string }> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, name: string }> | null }> } };
 
 export type AddCouponMutationVariables = Exact<{
   input: CreateAppliedCouponInput;
@@ -11878,13 +11878,6 @@ export type PlanDetailsActivityLogsQueryVariables = Exact<{
 
 
 export type PlanDetailsActivityLogsQuery = { __typename?: 'Query', activityLogs?: { __typename?: 'ActivityLogCollection', collection: Array<{ __typename?: 'ActivityLog', activityId: string, activityType: ActivityTypeEnum, activityObject?: any | null, loggedAt: any, externalCustomerId?: string | null, externalSubscriptionId?: string | null }>, metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number } } | null };
-
-export type GetPlanForDetailsOverviewSectionQueryVariables = Exact<{
-  plan: Scalars['ID']['input'];
-}>;
-
-
-export type GetPlanForDetailsOverviewSectionQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, hasOverriddenPlans?: boolean | null, billFixedChargesMonthly?: boolean | null, minimumCommitment?: { __typename?: 'Commitment', amountCents: any, commitmentType: CommitmentTypeEnum, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null } | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, regroupPaidFees?: RegroupPaidFeesEnum | null, appliedPricingUnit?: { __typename?: 'AppliedPricingUnit', conversionRate: number, pricingUnit: { __typename?: 'PricingUnit', id: string, code: string, name: string, shortName: string } } | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean, filters?: Array<{ __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> }> | null }, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, pricingGroupKeys?: Array<string> | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: number, rate: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, presentationGroupKeys?: Array<{ __typename?: 'PresentationGroupKey', value: string, options?: { __typename?: 'PresentationGroupKeyOptions', displayInInvoice?: boolean | null } | null }> | null } | null, filters?: Array<{ __typename?: 'ChargeFilter', invoiceDisplayName?: string | null, values: any, properties: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, pricingGroupKeys?: Array<string> | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: number, rate: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null, usageThresholds?: Array<{ __typename?: 'UsageThreshold', id: string, amountCents: any, recurring: boolean, thresholdDisplayName?: string | null }> | null, entitlements?: Array<{ __typename?: 'PlanEntitlement', code: string, name: string, privileges: Array<{ __typename?: 'PlanEntitlementPrivilegeObject', code: string, name?: string | null, value: string, valueType: PrivilegeValueTypeEnum, config: { __typename?: 'PrivilegeConfigObject', selectOptions?: Array<string> | null } }> }> | null, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string, prorated: boolean, units: string, chargeModel: FixedChargeChargeModelEnum, invoiceDisplayName?: string | null, payInAdvance: boolean, addOn: { __typename?: 'AddOn', id: string, name: string, code: string }, properties?: { __typename?: 'FixedChargeProperties', amount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null }> | null } | null };
 
 export type GetSubscribtionsForPlanDetailsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -12878,6 +12871,8 @@ export type GetTaxesForTaxesSelectorSectionQueryVariables = Exact<{
 
 export type GetTaxesForTaxesSelectorSectionQuery = { __typename?: 'Query', taxes: { __typename?: 'TaxCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> } };
 
+export type WalletAccordionFragment = { __typename?: 'Wallet', id: string, code?: string | null, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, expirationAt?: any | null, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, name?: string | null, rateAmount: number, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, priority: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean };
+
 export type CustomerWalletFragment = { __typename?: 'Wallet', id: string, billingEntityId?: string | null, currency: CurrencyEnum, expirationAt?: any | null, name?: string | null, rateAmount: number, invoiceRequiresSuccessfulPayment: boolean, paidTopUpMinAmountCents?: any | null, paidTopUpMaxAmountCents?: any | null, priority: number, paymentMethodType?: PaymentMethodTypeEnum | null, skipInvoiceCustomSections?: boolean | null, code?: string | null, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, appliesTo?: { __typename?: 'WalletAppliesTo', feeTypes?: Array<FeeTypesEnum> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, code: string, name: string }> | null } | null, recurringTransactionRules?: Array<{ __typename?: 'RecurringTransactionRule', expirationAt?: any | null, grantedCredits: string, grantsTargetTopUp?: boolean | null, interval?: RecurringTransactionIntervalEnum | null, invoiceRequiresSuccessfulPayment: boolean, lagoId: string, method: RecurringTransactionMethodEnum, paidCredits: string, startedAt?: any | null, targetOngoingBalance?: string | null, thresholdCredits?: string | null, transactionName?: string | null, trigger: RecurringTransactionTriggerEnum, ignorePaidTopUpLimits: boolean, paymentMethodType?: PaymentMethodTypeEnum | null, skipInvoiceCustomSections?: boolean | null, paymentMethod?: { __typename?: 'PaymentMethod', id: string } | null, selectedInvoiceCustomSections?: Array<{ __typename?: 'InvoiceCustomSection', id: string, name: string }> | null, transactionMetadata?: Array<{ __typename?: 'TransactionMetadata', key: string, value: string }> | null }> | null };
 
 export type GetCustomerWalletListQueryVariables = Exact<{
@@ -12906,8 +12901,6 @@ export type TerminateCustomerWalletMutationVariables = Exact<{
 export type TerminateCustomerWalletMutation = { __typename?: 'Mutation', terminateCustomerWallet?: { __typename?: 'Wallet', id: string, status: WalletStatusEnum, code?: string | null, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, expirationAt?: any | null, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, name?: string | null, rateAmount: number, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, priority: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean, customer?: { __typename?: 'Customer', id: string, hasActiveWallet: boolean } | null } | null };
 
 export type WalletForVoidTransactionFragment = { __typename?: 'Wallet', id: string, currency: CurrencyEnum, rateAmount: number, creditsBalance: number };
-
-export type WalletAccordionFragment = { __typename?: 'Wallet', id: string, code?: string | null, balanceCents: any, consumedAmountCents: any, consumedCredits: number, createdAt: any, creditsBalance: number, currency: CurrencyEnum, expirationAt?: any | null, lastBalanceSyncAt?: any | null, lastConsumedCreditAt?: any | null, lastOngoingBalanceSyncAt?: any | null, name?: string | null, rateAmount: number, status: WalletStatusEnum, terminatedAt?: any | null, ongoingBalanceCents: any, creditsOngoingBalance: number, priority: number, ongoingUsageBalanceCents: any, creditsOngoingUsageBalance: number, traceable: boolean };
 
 export type GetWalletAlertsQueryVariables = Exact<{
   walletId: Scalars['String']['input'];
@@ -14442,6 +14435,16 @@ export type UpdateCustomerCurrencyForQuoteMutationVariables = Exact<{
 
 
 export type UpdateCustomerCurrencyForQuoteMutation = { __typename?: 'Mutation', updateCustomer?: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null } | null };
+
+export type GetCouponsForDiscountDrawerQueryVariables = Exact<{
+  page?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  status?: InputMaybe<CouponStatusEnum>;
+  searchTerm?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type GetCouponsForDiscountDrawerQuery = { __typename?: 'Query', coupons: { __typename?: 'CouponCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Coupon', id: string, name: string, code: string, couponType: CouponTypeEnum, amountCents?: any | null, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null }> } };
 
 export type GetOrderFormDetailsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -18734,7 +18737,6 @@ export const WalletAccordionFragmentDoc = gql`
   id
   code
   balanceCents
-  code
   consumedAmountCents
   consumedCredits
   createdAt
@@ -23573,7 +23575,6 @@ export const GetCouponForCustomerDocument = gql`
     collection {
       id
       name
-      code
       amountCurrency
       amountCents
       couponType
@@ -27579,49 +27580,6 @@ export type PlanDetailsActivityLogsQueryHookResult = ReturnType<typeof usePlanDe
 export type PlanDetailsActivityLogsLazyQueryHookResult = ReturnType<typeof usePlanDetailsActivityLogsLazyQuery>;
 export type PlanDetailsActivityLogsSuspenseQueryHookResult = ReturnType<typeof usePlanDetailsActivityLogsSuspenseQuery>;
 export type PlanDetailsActivityLogsQueryResult = Apollo.QueryResult<PlanDetailsActivityLogsQuery, PlanDetailsActivityLogsQueryVariables>;
-export const GetPlanForDetailsOverviewSectionDocument = gql`
-    query getPlanForDetailsOverviewSection($plan: ID!) {
-  plan(id: $plan) {
-    ...EditPlan
-  }
-}
-    ${EditPlanFragmentDoc}`;
-
-/**
- * __useGetPlanForDetailsOverviewSectionQuery__
- *
- * To run a query within a React component, call `useGetPlanForDetailsOverviewSectionQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetPlanForDetailsOverviewSectionQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetPlanForDetailsOverviewSectionQuery({
- *   variables: {
- *      plan: // value for 'plan'
- *   },
- * });
- */
-export function useGetPlanForDetailsOverviewSectionQuery(baseOptions: Apollo.QueryHookOptions<GetPlanForDetailsOverviewSectionQuery, GetPlanForDetailsOverviewSectionQueryVariables> & ({ variables: GetPlanForDetailsOverviewSectionQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetPlanForDetailsOverviewSectionQuery, GetPlanForDetailsOverviewSectionQueryVariables>(GetPlanForDetailsOverviewSectionDocument, options);
-      }
-export function useGetPlanForDetailsOverviewSectionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetPlanForDetailsOverviewSectionQuery, GetPlanForDetailsOverviewSectionQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetPlanForDetailsOverviewSectionQuery, GetPlanForDetailsOverviewSectionQueryVariables>(GetPlanForDetailsOverviewSectionDocument, options);
-        }
-// @ts-ignore
-export function useGetPlanForDetailsOverviewSectionSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetPlanForDetailsOverviewSectionQuery, GetPlanForDetailsOverviewSectionQueryVariables>): Apollo.UseSuspenseQueryResult<GetPlanForDetailsOverviewSectionQuery, GetPlanForDetailsOverviewSectionQueryVariables>;
-export function useGetPlanForDetailsOverviewSectionSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetPlanForDetailsOverviewSectionQuery, GetPlanForDetailsOverviewSectionQueryVariables>): Apollo.UseSuspenseQueryResult<GetPlanForDetailsOverviewSectionQuery | undefined, GetPlanForDetailsOverviewSectionQueryVariables>;
-export function useGetPlanForDetailsOverviewSectionSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetPlanForDetailsOverviewSectionQuery, GetPlanForDetailsOverviewSectionQueryVariables>) {
-          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<GetPlanForDetailsOverviewSectionQuery, GetPlanForDetailsOverviewSectionQueryVariables>(GetPlanForDetailsOverviewSectionDocument, options);
-        }
-export type GetPlanForDetailsOverviewSectionQueryHookResult = ReturnType<typeof useGetPlanForDetailsOverviewSectionQuery>;
-export type GetPlanForDetailsOverviewSectionLazyQueryHookResult = ReturnType<typeof useGetPlanForDetailsOverviewSectionLazyQuery>;
-export type GetPlanForDetailsOverviewSectionSuspenseQueryHookResult = ReturnType<typeof useGetPlanForDetailsOverviewSectionSuspenseQuery>;
-export type GetPlanForDetailsOverviewSectionQueryResult = Apollo.QueryResult<GetPlanForDetailsOverviewSectionQuery, GetPlanForDetailsOverviewSectionQueryVariables>;
 export const GetSubscribtionsForPlanDetailsDocument = gql`
     query getSubscribtionsForPlanDetails($page: Int, $limit: Int, $planCode: String, $status: [StatusTypeEnum!]) {
   subscriptions(page: $page, limit: $limit, planCode: $planCode, status: $status) {
@@ -39606,6 +39564,65 @@ export function useUpdateCustomerCurrencyForQuoteMutation(baseOptions?: Apollo.M
 export type UpdateCustomerCurrencyForQuoteMutationHookResult = ReturnType<typeof useUpdateCustomerCurrencyForQuoteMutation>;
 export type UpdateCustomerCurrencyForQuoteMutationResult = Apollo.MutationResult<UpdateCustomerCurrencyForQuoteMutation>;
 export type UpdateCustomerCurrencyForQuoteMutationOptions = Apollo.BaseMutationOptions<UpdateCustomerCurrencyForQuoteMutation, UpdateCustomerCurrencyForQuoteMutationVariables>;
+export const GetCouponsForDiscountDrawerDocument = gql`
+    query getCouponsForDiscountDrawer($page: Int, $limit: Int, $status: CouponStatusEnum, $searchTerm: String) {
+  coupons(page: $page, limit: $limit, status: $status, searchTerm: $searchTerm) {
+    metadata {
+      currentPage
+      totalPages
+    }
+    collection {
+      id
+      name
+      code
+      couponType
+      amountCents
+      percentageRate
+      frequency
+      frequencyDuration
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetCouponsForDiscountDrawerQuery__
+ *
+ * To run a query within a React component, call `useGetCouponsForDiscountDrawerQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCouponsForDiscountDrawerQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetCouponsForDiscountDrawerQuery({
+ *   variables: {
+ *      page: // value for 'page'
+ *      limit: // value for 'limit'
+ *      status: // value for 'status'
+ *      searchTerm: // value for 'searchTerm'
+ *   },
+ * });
+ */
+export function useGetCouponsForDiscountDrawerQuery(baseOptions?: Apollo.QueryHookOptions<GetCouponsForDiscountDrawerQuery, GetCouponsForDiscountDrawerQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetCouponsForDiscountDrawerQuery, GetCouponsForDiscountDrawerQueryVariables>(GetCouponsForDiscountDrawerDocument, options);
+      }
+export function useGetCouponsForDiscountDrawerLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetCouponsForDiscountDrawerQuery, GetCouponsForDiscountDrawerQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetCouponsForDiscountDrawerQuery, GetCouponsForDiscountDrawerQueryVariables>(GetCouponsForDiscountDrawerDocument, options);
+        }
+// @ts-ignore
+export function useGetCouponsForDiscountDrawerSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetCouponsForDiscountDrawerQuery, GetCouponsForDiscountDrawerQueryVariables>): Apollo.UseSuspenseQueryResult<GetCouponsForDiscountDrawerQuery, GetCouponsForDiscountDrawerQueryVariables>;
+export function useGetCouponsForDiscountDrawerSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetCouponsForDiscountDrawerQuery, GetCouponsForDiscountDrawerQueryVariables>): Apollo.UseSuspenseQueryResult<GetCouponsForDiscountDrawerQuery | undefined, GetCouponsForDiscountDrawerQueryVariables>;
+export function useGetCouponsForDiscountDrawerSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetCouponsForDiscountDrawerQuery, GetCouponsForDiscountDrawerQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetCouponsForDiscountDrawerQuery, GetCouponsForDiscountDrawerQueryVariables>(GetCouponsForDiscountDrawerDocument, options);
+        }
+export type GetCouponsForDiscountDrawerQueryHookResult = ReturnType<typeof useGetCouponsForDiscountDrawerQuery>;
+export type GetCouponsForDiscountDrawerLazyQueryHookResult = ReturnType<typeof useGetCouponsForDiscountDrawerLazyQuery>;
+export type GetCouponsForDiscountDrawerSuspenseQueryHookResult = ReturnType<typeof useGetCouponsForDiscountDrawerSuspenseQuery>;
+export type GetCouponsForDiscountDrawerQueryResult = Apollo.QueryResult<GetCouponsForDiscountDrawerQuery, GetCouponsForDiscountDrawerQueryVariables>;
 export const GetOrderFormDetailsDocument = gql`
     query getOrderFormDetails($id: ID!) {
   orderForm(id: $id) {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -10970,7 +10970,7 @@ export type GetCouponForCustomerQueryVariables = Exact<{
 }>;
 
 
-export type GetCouponForCustomerQuery = { __typename?: 'Query', coupons: { __typename?: 'CouponCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Coupon', id: string, name: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, plans?: Array<{ __typename?: 'Plan', id: string, name: string }> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, name: string }> | null }> } };
+export type GetCouponForCustomerQuery = { __typename?: 'Query', coupons: { __typename?: 'CouponCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Coupon', id: string, name: string, code: string, amountCurrency?: CurrencyEnum | null, amountCents?: any | null, couponType: CouponTypeEnum, percentageRate?: number | null, frequency: CouponFrequency, frequencyDuration?: number | null, plans?: Array<{ __typename?: 'Plan', id: string, name: string }> | null, billableMetrics?: Array<{ __typename?: 'BillableMetric', id: string, name: string }> | null }> } };
 
 export type AddCouponMutationVariables = Exact<{
   input: CreateAppliedCouponInput;
@@ -23573,6 +23573,7 @@ export const GetCouponForCustomerDocument = gql`
     collection {
       id
       name
+      code
       amountCurrency
       amountCents
       couponType

--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -123,8 +123,13 @@ const EditQuote = () => {
 
   const quoteCurrency = quote?.customer?.currency ?? CurrencyEnum.Usd
 
+  // Stable ref so useDiscountDrawer can call savePricingBlock without a
+  // forward-declaration error (savePricingBlock is defined below).
+  const savePricingBlockRef = useRef<(billingItems?: BillingItemsPayload) => void>(() => undefined)
+
   const discount = useDiscountDrawer(quote?.currentVersion?.billingItems, {
     currency: quoteCurrency,
+    onPersist: (billingItems) => savePricingBlockRef.current(billingItems),
   })
 
   const mergedEntities = useMemo(
@@ -228,6 +233,8 @@ const EditQuote = () => {
     }
   }, [])
 
+  // Keep the ref in sync with the latest savePricingBlock so the stable wrapper
+  // passed to useDiscountDrawer always calls the current version.
   const savePricingBlock = useCallback(
     async (billingItems?: BillingItemsPayload) => {
       if (!versionId) return
@@ -256,6 +263,8 @@ const EditQuote = () => {
     },
     [versionId, refetchQuote],
   )
+
+  savePricingBlockRef.current = savePricingBlock
 
   const handlePricingCommand = useCallback<OnPricingCommand>(
     ({ onSave, editData }) => {

--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -3,7 +3,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
-import type { OnPricingCommand } from '~/components/designSystem/RichTextEditor/common/RichTextEditorContext'
+import type {
+  OnDiscountCommand,
+  OnPricingCommand,
+} from '~/components/designSystem/RichTextEditor/common/RichTextEditorContext'
+import { DiscountBlockAttributes } from '~/components/designSystem/RichTextEditor/extensions/DiscountBlock.schema'
 import { PricingBlockAttributes } from '~/components/designSystem/RichTextEditor/extensions/PricingBlock.schema'
 import RichTextEditor, {
   type RichTextEditorMode,
@@ -16,12 +20,13 @@ import { QuoteDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { QUOTE_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBillingItems'
 import type { Locale } from '~/core/translations'
-import { OrderTypeEnum, type UpdateQuoteVersionInput } from '~/generated/graphql'
+import { CurrencyEnum, OrderTypeEnum, type UpdateQuoteVersionInput } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { QUOTE_MENTION_VARIABLES } from '~/pages/quotes/common/mentionVariables'
 
 import EditQuoteAside from './editQuote/EditQuoteAside'
 import { useAddQuoteImage } from './hooks/useAddQuoteImage'
+import { useDiscountDrawer } from './hooks/useDiscountDrawer'
 import { useOneOffPricingDrawer } from './hooks/useOneOffPricingDrawer'
 import { useQuote } from './hooks/useQuote'
 import { useSubscriptionPricingDrawer } from './hooks/useSubscriptionPricingDrawer'
@@ -115,6 +120,17 @@ const EditQuote = () => {
 
   const { onPricingCommand, isPricingDisabled, entities, syncEntitiesWithBlocks } =
     isSubscriptionOrder ? subscriptionPricing : oneOffPricing
+
+  const quoteCurrency = quote?.customer?.currency ?? CurrencyEnum.Usd
+
+  const discount = useDiscountDrawer(quote?.currentVersion?.billingItems, {
+    currency: quoteCurrency,
+  })
+
+  const mergedEntities = useMemo(
+    () => ({ ...entities, ...discount.entities }),
+    [entities, discount.entities],
+  )
 
   const customerLocale = (quote?.customer?.billingConfiguration?.documentLocale ?? 'en') as Locale
 
@@ -267,6 +283,24 @@ const EditQuote = () => {
     [syncEntitiesWithBlocks, savePricingBlock],
   )
 
+  const handleDiscountCommand = useCallback<OnDiscountCommand>(
+    ({ onSave, editData }) => {
+      discount.onDiscountCommand({ onSave, editData })
+    },
+    [discount],
+  )
+
+  const handleDiscountBlocksChange = useCallback(
+    (blocks: DiscountBlockAttributes[]) => {
+      const updated = discount.syncDiscountBlocks(blocks)
+
+      if (updated) {
+        savePricingBlock(updated)
+      }
+    },
+    [discount, savePricingBlock],
+  )
+
   const handleClose = () => {
     debouncedSave.cancel()
     onClose()
@@ -354,8 +388,10 @@ const EditQuote = () => {
             mode={editorMode}
             onPricingCommand={handlePricingCommand}
             isPricingDisabled={isPricingDisabled}
-            entities={entities}
+            entities={mergedEntities}
             onPricingBlocksChange={handlePricingBlocksChange}
+            onDiscountCommand={isSubscriptionOrder ? handleDiscountCommand : undefined}
+            onDiscountBlocksChange={handleDiscountBlocksChange}
             customerLocale={customerLocale}
             customerCurrency={quote?.customer?.currency ?? undefined}
             variableItems={mentionItems}

--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -245,7 +245,15 @@ const EditQuote = () => {
 
       setSaveStatus('saving')
 
-      const payload: UpdateQuoteVersionInput = { id: versionId, content, billingItems }
+      // Each drawer owns a single billingItems category and passes a partial
+      // ({ plans } / { addons } / { coupons }) merged over the current items.
+      // Normalize here so `addons` is always present on the wire, whichever
+      // drawer saved — keeping the backend payload shape stable.
+      const payload: UpdateQuoteVersionInput = {
+        id: versionId,
+        content,
+        billingItems: billingItems && { addons: [], ...billingItems },
+      }
 
       failedPayloadRef.current = payload
 

--- a/src/pages/quotes/__tests__/EditQuote.test.tsx
+++ b/src/pages/quotes/__tests__/EditQuote.test.tsx
@@ -694,7 +694,7 @@ describe('EditQuote', () => {
         const wrappedOnSave = mockDrawerOnPricingCommand.mock.calls[0][0].onSave
         const mockAttrs = { pricingType: 'addOns', entityIds: ['addon-1'] }
         const mockEntityData = { 'addon-1': { name: 'Test Add-on' } }
-        const mockBillingItems = [{ addOnId: 'addon-1' }]
+        const mockBillingItems = { addons: [{ addOnId: 'addon-1' }] }
 
         await act(async () => {
           wrappedOnSave(mockAttrs, mockEntityData, mockBillingItems)
@@ -746,7 +746,7 @@ describe('EditQuote', () => {
 
     describe('WHEN pricing blocks change and syncEntitiesWithBlocks returns billing items', () => {
       it('THEN should save the updated billing items', async () => {
-        const mockBillingItems = [{ addOnId: 'addon-1', units: '2' }]
+        const mockBillingItems = { addons: [{ addOnId: 'addon-1', units: '2' }] }
 
         mockSyncEntitiesWithBlocks.mockReturnValue(mockBillingItems)
         mockUpdateQuoteVersion.mockResolvedValue({
@@ -944,7 +944,9 @@ describe('EditQuote', () => {
 
     describe('WHEN discount blocks change and syncDiscountBlocks returns billing items', () => {
       it('THEN should save the updated billing items', async () => {
-        const mockBillingItems = { addons: [], coupons: [{ id: 'coupon-1', position: 1 }] }
+        // The discount drawer owns only the `coupons` key and returns a partial
+        // without `addons`; savePricingBlock normalizes `addons` back in.
+        const mockBillingItems = { coupons: [{ id: 'coupon-1', position: 1 }] }
 
         mockSyncDiscountBlocks.mockReturnValue(mockBillingItems)
         mockUpdateQuoteVersion.mockResolvedValue({
@@ -963,7 +965,9 @@ describe('EditQuote', () => {
 
         await waitFor(() => {
           expect(mockUpdateQuoteVersion).toHaveBeenCalledWith(
-            expect.objectContaining({ billingItems: mockBillingItems }),
+            expect.objectContaining({
+              billingItems: { addons: [], coupons: [{ id: 'coupon-1', position: 1 }] },
+            }),
             false,
           )
         })

--- a/src/pages/quotes/__tests__/EditQuote.test.tsx
+++ b/src/pages/quotes/__tests__/EditQuote.test.tsx
@@ -27,6 +27,8 @@ type PricingCommandParams = {
 
 let capturedOnPricingCommand: ((params: PricingCommandParams) => void) | undefined
 let capturedOnPricingBlocksChange: ((blocks: unknown[]) => void) | undefined
+let capturedOnDiscountCommand: ((params: unknown) => void) | undefined
+let capturedOnDiscountBlocksChange: ((blocks: unknown[]) => void) | undefined
 let capturedEditorCustomerLocale: string | undefined
 let capturedEditorCustomerCurrency: string | undefined
 
@@ -53,6 +55,8 @@ jest.mock('~/components/designSystem/RichTextEditor/RichTextEditor', () => {
     onChange,
     onPricingCommand,
     onPricingBlocksChange,
+    onDiscountCommand,
+    onDiscountBlocksChange,
     customerLocale,
     customerCurrency,
   }: {
@@ -60,6 +64,8 @@ jest.mock('~/components/designSystem/RichTextEditor/RichTextEditor', () => {
     onChange?: () => void
     onPricingCommand?: (params: PricingCommandParams) => void
     onPricingBlocksChange?: (blocks: unknown[]) => void
+    onDiscountCommand?: (params: unknown) => void
+    onDiscountBlocksChange?: (blocks: unknown[]) => void
     customerLocale?: string
     customerCurrency?: string
   }) => {
@@ -70,6 +76,8 @@ jest.mock('~/components/designSystem/RichTextEditor/RichTextEditor', () => {
       capturedOnChange = onChange
       capturedOnPricingCommand = onPricingCommand
       capturedOnPricingBlocksChange = onPricingBlocksChange
+      capturedOnDiscountCommand = onDiscountCommand
+      capturedOnDiscountBlocksChange = onDiscountBlocksChange
       capturedEditorCustomerLocale = customerLocale
       capturedEditorCustomerCurrency = customerCurrency
 
@@ -83,6 +91,8 @@ jest.mock('~/components/designSystem/RichTextEditor/RichTextEditor', () => {
       onChange,
       onPricingCommand,
       onPricingBlocksChange,
+      onDiscountCommand,
+      onDiscountBlocksChange,
       customerLocale,
       customerCurrency,
     ])
@@ -213,6 +223,17 @@ jest.mock('../hooks/useOneOffPricingDrawer', () => ({
   }),
 }))
 
+const mockDiscountOnDiscountCommand = jest.fn()
+const mockSyncDiscountBlocks = jest.fn().mockReturnValue(null)
+
+jest.mock('../hooks/useDiscountDrawer', () => ({
+  useDiscountDrawer: () => ({
+    onDiscountCommand: mockDiscountOnDiscountCommand,
+    entities: {},
+    syncDiscountBlocks: mockSyncDiscountBlocks,
+  }),
+}))
+
 jest.mock('../common/getQuoteStatusMapping', () => ({
   getQuoteStatusMapping: () => ({ type: 'outline', label: 'draft' }),
 }))
@@ -239,10 +260,13 @@ describe('EditQuote', () => {
     capturedAsideCallbacks = {}
     capturedOnPricingCommand = undefined
     capturedOnPricingBlocksChange = undefined
+    capturedOnDiscountCommand = undefined
+    capturedOnDiscountBlocksChange = undefined
     capturedEditorCustomerLocale = undefined
     capturedEditorCustomerCurrency = undefined
     capturedPricingDrawerArgs = []
     mockSyncEntitiesWithBlocks.mockReturnValue(null)
+    mockSyncDiscountBlocks.mockReturnValue(null)
 
     const useParamsMock = jest.requireMock('react-router-dom').useParams as jest.Mock
 
@@ -871,6 +895,95 @@ describe('EditQuote', () => {
         const options = capturedPricingDrawerArgs[1] as { customer?: { currency?: string } }
 
         expect(options.customer?.currency).toBe('EUR')
+      })
+    })
+  })
+
+  describe('GIVEN the discount command integration', () => {
+    describe('WHEN the quote is a subscription order', () => {
+      it('THEN should pass a defined onDiscountCommand to RichTextEditor', () => {
+        // mockQuote.orderType = 'subscription_creation' by default
+        render(<EditQuote />)
+
+        expect(capturedOnDiscountCommand).toBeDefined()
+      })
+    })
+
+    describe('WHEN the quote is a one-off order', () => {
+      it('THEN should pass undefined onDiscountCommand to RichTextEditor', () => {
+        mockUseQuote.mockReturnValue({
+          quote: {
+            ...mockQuote,
+            orderType: 'one_off',
+          },
+          loading: false,
+          refetch: mockRefetchQuote,
+        })
+
+        render(<EditQuote />)
+
+        expect(capturedOnDiscountCommand).toBeUndefined()
+      })
+    })
+
+    describe('WHEN handleDiscountCommand is invoked from the editor', () => {
+      it('THEN should delegate to useDiscountDrawer onDiscountCommand with editData', () => {
+        render(<EditQuote />)
+
+        const mockEditData = { couponId: 'coupon-1', localId: 'local-1' }
+
+        act(() => {
+          capturedOnDiscountCommand?.({ onSave: jest.fn(), editData: mockEditData })
+        })
+
+        expect(mockDiscountOnDiscountCommand).toHaveBeenCalledWith(
+          expect.objectContaining({ editData: mockEditData }),
+        )
+      })
+    })
+
+    describe('WHEN discount blocks change and syncDiscountBlocks returns billing items', () => {
+      it('THEN should save the updated billing items', async () => {
+        const mockBillingItems = { addons: [], coupons: [{ id: 'coupon-1', position: 1 }] }
+
+        mockSyncDiscountBlocks.mockReturnValue(mockBillingItems)
+        mockUpdateQuoteVersion.mockResolvedValue({
+          data: { updateQuoteVersion: { id: 'version-1' } },
+        })
+
+        render(<EditQuote />)
+
+        const mockBlocks = [{ couponId: 'coupon-1', localId: 'local-1' }]
+
+        await act(async () => {
+          capturedOnDiscountBlocksChange?.(mockBlocks)
+        })
+
+        expect(mockSyncDiscountBlocks).toHaveBeenCalledWith(mockBlocks)
+
+        await waitFor(() => {
+          expect(mockUpdateQuoteVersion).toHaveBeenCalledWith(
+            expect.objectContaining({ billingItems: mockBillingItems }),
+            false,
+          )
+        })
+      })
+    })
+
+    describe('WHEN discount blocks change but syncDiscountBlocks returns null', () => {
+      it('THEN should not trigger a save', async () => {
+        mockSyncDiscountBlocks.mockReturnValue(null)
+
+        render(<EditQuote />)
+
+        const mockBlocks = [{ couponId: 'coupon-1', localId: 'local-1' }]
+
+        await act(async () => {
+          capturedOnDiscountBlocksChange?.(mockBlocks)
+        })
+
+        expect(mockSyncDiscountBlocks).toHaveBeenCalledWith(mockBlocks)
+        expect(mockUpdateQuoteVersion).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
@@ -337,6 +337,92 @@ describe('useDiscountDrawer', () => {
     })
   })
 
+  it('persists a typed recurring duration (int formatter yields a number, not a string)', async () => {
+    // Regression: the `int` beforeChangeFormatter runs parseInt and stores
+    // frequencyDuration as a NUMBER. The schema previously declared z.string(),
+    // so typing a duration on a recurring discount failed validation
+    // ("Invalid input: expected string, received number") and blocked save.
+    const onPersist = jest.fn()
+    const { result } = renderHook(() =>
+      useDiscountDrawer(undefined, { currency: CurrencyEnum.Usd, onPersist }),
+    )
+
+    const onSave = jest.fn()
+
+    act(() => {
+      result.current.onDiscountCommand({ onSave })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(
+      <>
+        {openArgs.children}
+        {openArgs.actions}
+      </>,
+    )
+
+    // Only the coupon combobox is rendered until a coupon is selected.
+    const comboBoxInput = screen.getByRole('combobox') as HTMLInputElement
+
+    await userEvent.type(comboBoxInput, 'Ten')
+
+    await waitFor(() => {
+      expect(comboBoxInput.getAttribute('aria-controls')).toBeTruthy()
+    })
+
+    const listboxId = comboBoxInput.getAttribute('aria-controls') as string
+    const listbox = document.getElementById(listboxId) as HTMLElement
+
+    await userEvent.click(within(listbox).getByText('Ten Off'))
+
+    // Selecting the coupon prefills frequency = Once (its label key). Switch the
+    // frequency dropdown to Recurring so the duration field appears.
+    const freqInput = (await screen.findByDisplayValue(
+      'text_632d68358f1fedc68eed3ea3',
+    )) as HTMLInputElement
+
+    await userEvent.click(freqInput)
+
+    await waitFor(() => {
+      expect(freqInput.getAttribute('aria-controls')).toBeTruthy()
+    })
+
+    const freqListbox = document.getElementById(
+      freqInput.getAttribute('aria-controls') as string,
+    ) as HTMLElement
+
+    await userEvent.click(within(freqListbox).getByText('text_632d68358f1fedc68eed3e64'))
+
+    // Duration field now renders. Typing runs the `int` formatter → number.
+    const durationInput = await screen.findByPlaceholderText('text_632d68358f1fedc68eed3e88')
+
+    await userEvent.type(durationInput, '6')
+
+    const saveButton = screen.getByTestId(DISCOUNT_DRAWER_SAVE_TEST_ID)
+
+    // Before the fix, the numeric value failed z.string() validation, so
+    // canSubmit stayed false and the button never enabled.
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled()
+    })
+
+    await userEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(onPersist).toHaveBeenCalledTimes(1)
+    })
+
+    const persistedPayload = onPersist.mock.calls[0][0] as {
+      coupons: Array<{
+        overrides: { frequency: string; frequency_duration: number | null }
+      }>
+    }
+
+    expect(persistedPayload.coupons[0].overrides.frequency).toBe('recurring')
+    expect(persistedPayload.coupons[0].overrides.frequency_duration).toBe(6)
+  })
+
   it('calls onPersist with updated overrides when editing an existing coupon', async () => {
     const initialBillingItems: BillingItemsPayload = {
       addons: [],

--- a/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
@@ -563,8 +563,8 @@ describe('useDiscountDrawer', () => {
 
     render(<>{openArgs.children}</>)
 
-    // Prefilled amount from override (4200 cents / USD = 42.00), currency locked USD.
-    expect(screen.getByDisplayValue('42.00')).toBeInTheDocument()
+    // Prefilled amount from override (4200 cents / USD = 42), no trailing .00, currency locked USD.
+    expect(screen.getByDisplayValue('42')).toBeInTheDocument()
     expect(screen.getByDisplayValue(CurrencyEnum.Usd)).toBeInTheDocument()
   })
 })

--- a/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
@@ -567,4 +567,112 @@ describe('useDiscountDrawer', () => {
     expect(screen.getByDisplayValue('42')).toBeInTheDocument()
     expect(screen.getByDisplayValue(CurrencyEnum.Usd)).toBeInTheDocument()
   })
+
+  it('rebuilds the entity to the new coupon when editing to a different coupon', async () => {
+    // Existing block bound to a different coupon than the one offered by the
+    // combobox mock (cpn_fixed / "Ten Off"). Switching coupon must refresh the
+    // block + preview to the newly selected coupon, not keep the old identity.
+    const initialBillingItems: BillingItemsPayload = {
+      addons: [],
+      coupons: [
+        {
+          type: 'coupon',
+          id: 'cpn_edit',
+          localId: 'saved-local',
+          payload: {
+            position: 1,
+            code: 'EDIT',
+            id: 'cpn_edit',
+            name: 'Edit Coupon',
+            type: 'fixed_amount',
+            amount_cents: 5000,
+            percentage_rate: null,
+            currency: CurrencyEnum.Usd,
+            frequency: 'once',
+            frequency_duration: null,
+            expiration_at: null,
+            limited_plans: false,
+            plan_codes: [],
+            limited_billable_metrics: false,
+            billable_metric_codes: [],
+            coupon_overrides: null,
+            catalog_snapshot: null,
+            resolved_payload: null,
+          },
+          overrides: {
+            amount_cents: 5000,
+            percentage_rate: null,
+            frequency: 'once',
+            frequency_duration: null,
+          },
+        },
+      ],
+    }
+
+    const onPersist = jest.fn()
+    const { result } = renderHook(() =>
+      useDiscountDrawer(initialBillingItems, { currency: CurrencyEnum.Usd, onPersist }),
+    )
+
+    // Sanity: entity starts as the old coupon.
+    expect(result.current.entities['saved-local']).toMatchObject({
+      name: 'Edit Coupon',
+      code: 'EDIT',
+    })
+
+    const onSave = jest.fn()
+
+    act(() => {
+      result.current.onDiscountCommand({
+        onSave,
+        editData: { couponId: 'cpn_edit', localId: 'saved-local' },
+      })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(
+      <>
+        {openArgs.children}
+        {openArgs.actions}
+      </>,
+    )
+
+    // Switch to the different coupon offered by the combobox. Editing a prefilled
+    // fixed-amount coupon also renders the locked currency combobox, so target the
+    // coupon selector explicitly — it is the first combobox rendered.
+    const comboBoxInput = screen.getAllByRole('combobox')[0] as HTMLInputElement
+
+    await userEvent.type(comboBoxInput, 'Ten')
+
+    await waitFor(() => {
+      expect(comboBoxInput.getAttribute('aria-controls')).toBeTruthy()
+    })
+
+    const listboxId = comboBoxInput.getAttribute('aria-controls') as string
+    const listbox = document.getElementById(listboxId) as HTMLElement
+
+    await userEvent.click(within(listbox).getByText('Ten Off'))
+
+    const allSaveButtons = screen.getAllByTestId(DISCOUNT_DRAWER_SAVE_TEST_ID)
+    const saveButton = allSaveButtons[allSaveButtons.length - 1]
+
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled()
+    })
+
+    await userEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({ couponId: 'cpn_fixed', localId: 'saved-local' })
+    })
+
+    // The rebuilt entity (drives both the editor block and the preview) must
+    // reflect the NEW coupon's identity, not the stale one.
+    expect(result.current.entities['saved-local']).toMatchObject({
+      name: 'Ten Off',
+      code: 'COUPON_CODE',
+      couponType: CouponTypeEnum.FixedAmount,
+    })
+  })
 })

--- a/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
@@ -264,6 +264,164 @@ describe('useDiscountDrawer', () => {
     expect(payload?.coupons).toEqual([])
   })
 
+  it('calls onPersist with billingItems containing coupon overrides on add', async () => {
+    const onPersist = jest.fn()
+    const { result } = renderHook(() =>
+      useDiscountDrawer(undefined, { currency: CurrencyEnum.Usd, onPersist }),
+    )
+
+    const onSave = jest.fn()
+
+    act(() => {
+      result.current.onDiscountCommand({ onSave })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(
+      <>
+        {openArgs.children}
+        {openArgs.actions}
+      </>,
+    )
+
+    const comboBoxInput = screen.getByRole('combobox') as HTMLInputElement
+
+    await userEvent.type(comboBoxInput, 'Ten')
+
+    await waitFor(() => {
+      expect(comboBoxInput.getAttribute('aria-controls')).toBeTruthy()
+    })
+
+    const listboxId = comboBoxInput.getAttribute('aria-controls') as string
+    const listbox = document.getElementById(listboxId) as HTMLElement
+
+    await userEvent.click(within(listbox).getByText('Ten Off'))
+
+    const saveButton = screen.getByTestId(DISCOUNT_DRAWER_SAVE_TEST_ID)
+
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled()
+    })
+
+    await userEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(onPersist).toHaveBeenCalledTimes(1)
+    })
+
+    const persistedPayload = onPersist.mock.calls[0][0] as {
+      coupons: Array<{
+        id: string
+        localId: string
+        overrides: {
+          amount_cents: number | null
+          percentage_rate: number | null
+          frequency: string
+          frequency_duration: number | null
+        }
+      }>
+    }
+
+    expect(persistedPayload.coupons).toHaveLength(1)
+
+    const [coupon] = persistedPayload.coupons
+
+    expect(coupon.id).toBe('cpn_fixed')
+    expect(coupon.localId).toBe('mock-uuid-1')
+    expect(coupon.overrides).toEqual({
+      amount_cents: 1000,
+      percentage_rate: null,
+      frequency: 'once',
+      frequency_duration: null,
+    })
+  })
+
+  it('calls onPersist with updated overrides when editing an existing coupon', async () => {
+    const initialBillingItems: BillingItemsPayload = {
+      addons: [],
+      coupons: [
+        {
+          type: 'coupon',
+          id: 'cpn_fixed',
+          localId: 'saved-local',
+          payload: {
+            position: 1,
+            code: 'COUPON_CODE',
+            id: 'cpn_fixed',
+            name: 'Ten Off',
+            type: 'fixed_amount',
+            amount_cents: 1000,
+            percentage_rate: null,
+            currency: CurrencyEnum.Usd,
+            frequency: 'once',
+            frequency_duration: null,
+            expiration_at: null,
+            limited_plans: false,
+            plan_codes: [],
+            limited_billable_metrics: false,
+            billable_metric_codes: [],
+            coupon_overrides: null,
+            catalog_snapshot: null,
+            resolved_payload: null,
+          },
+          overrides: {
+            amount_cents: 1000,
+            percentage_rate: null,
+            frequency: 'once',
+            frequency_duration: null,
+          },
+        },
+      ],
+    }
+
+    const onPersist = jest.fn()
+    const { result } = renderHook(() =>
+      useDiscountDrawer(initialBillingItems, { currency: CurrencyEnum.Usd, onPersist }),
+    )
+
+    const onSave = jest.fn()
+
+    act(() => {
+      result.current.onDiscountCommand({
+        onSave,
+        editData: { couponId: 'cpn_fixed', localId: 'saved-local' },
+      })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(
+      <>
+        {openArgs.children}
+        {openArgs.actions}
+      </>,
+    )
+
+    // The form opens pre-filled with valid values from the existing coupon, so the save
+    // button is enabled immediately — no combobox interaction needed.
+    const allSaveButtons = screen.getAllByTestId(DISCOUNT_DRAWER_SAVE_TEST_ID)
+    const saveButton = allSaveButtons[allSaveButtons.length - 1]
+
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled()
+    })
+
+    await userEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(onPersist).toHaveBeenCalledTimes(1)
+    })
+
+    const persistedPayload = onPersist.mock.calls[0][0] as {
+      coupons: Array<{ id: string; localId: string }>
+    }
+
+    expect(persistedPayload.coupons).toHaveLength(1)
+    expect(persistedPayload.coupons[0].id).toBe('cpn_fixed')
+    expect(persistedPayload.coupons[0].localId).toBe('saved-local')
+  })
+
   it('prefills from saved override values when editing', () => {
     const initialBillingItems: BillingItemsPayload = {
       addons: [],

--- a/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
@@ -58,7 +58,7 @@ jest.mock('~/generated/graphql', () => {
 
   return {
     ...actual,
-    useGetCouponForCustomerLazyQuery: () => [
+    useGetCouponsForDiscountDrawerLazyQuery: () => [
       mockGetCoupons,
       {
         loading: false,

--- a/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
@@ -1,0 +1,321 @@
+import { act, renderHook, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBillingItems'
+import { CouponFrequency, CouponTypeEnum, CurrencyEnum } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import { DISCOUNT_DRAWER_SAVE_TEST_ID, useDiscountDrawer } from '../useDiscountDrawer'
+
+// --- Mocks ---
+
+const mockCryptoRandomUUID = jest.fn(() => 'mock-uuid-1')
+
+Object.defineProperty(globalThis, 'crypto', {
+  value: {
+    ...globalThis.crypto,
+    randomUUID: mockCryptoRandomUUID,
+  },
+  writable: true,
+})
+
+const mockDrawerOpen = jest.fn()
+const mockDrawerClose = jest.fn()
+
+jest.mock('~/components/drawers/useDrawer', () => ({
+  useDrawer: () => ({ open: mockDrawerOpen, close: mockDrawerClose }),
+  useFormDrawer: () => ({ open: jest.fn(), close: jest.fn() }),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+// Controllable coupon dataset returned by the lazy query. The standalone async
+// ComboBox reads `data` and calls `getCoupons` (the fetch trigger). Must be
+// prefixed with `mock` to be referenceable inside the jest.mock factory.
+const mockGetCoupons = jest.fn()
+
+jest.mock('~/generated/graphql', () => {
+  const actual = jest.requireActual('~/generated/graphql')
+
+  const fixedAmountCoupon = {
+    __typename: 'Coupon',
+    id: 'cpn_fixed',
+    name: 'Ten Off',
+    amountCurrency: actual.CurrencyEnum.Eur,
+    amountCents: 1000,
+    couponType: actual.CouponTypeEnum.FixedAmount,
+    percentageRate: null,
+    frequency: actual.CouponFrequency.Once,
+    frequencyDuration: null,
+    plans: [],
+    billableMetrics: [],
+  }
+
+  return {
+    ...actual,
+    useGetCouponForCustomerLazyQuery: () => [
+      mockGetCoupons,
+      {
+        loading: false,
+        data: { coupons: { collection: [fixedAmountCoupon] } },
+      },
+    ],
+  }
+})
+
+// Note: @tanstack/react-form is NOT mocked — real revalidateLogic is required
+// so form.setFieldValue works without "validates is not iterable" errors.
+
+// The ComboBox renders its options through a virtualizer that has no layout in
+// jsdom — mock it so the option list is actually rendered and clickable.
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 56,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, i) => ({
+        index: i,
+        key: String(i),
+        start: i * 56,
+        size: 56,
+      })),
+    scrollToIndex: jest.fn(),
+    measureElement: jest.fn(),
+  }),
+}))
+
+const options = { currency: CurrencyEnum.Usd }
+
+describe('useDiscountDrawer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCryptoRandomUUID.mockReturnValue('mock-uuid-1')
+  })
+
+  it('returns the expected interface', () => {
+    const { result } = renderHook(() => useDiscountDrawer(undefined, options))
+
+    expect(result.current).toHaveProperty('onDiscountCommand')
+    expect(result.current).toHaveProperty('entities')
+    expect(result.current).toHaveProperty('syncDiscountBlocks')
+  })
+
+  it('opens the drawer when onDiscountCommand is called', () => {
+    const { result } = renderHook(() => useDiscountDrawer(undefined, options))
+
+    act(() => {
+      result.current.onDiscountCommand({ onSave: jest.fn() })
+    })
+
+    expect(mockDrawerOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks save when no coupon is selected', async () => {
+    const { result } = renderHook(() => useDiscountDrawer(undefined, options))
+
+    const onSave = jest.fn()
+
+    act(() => {
+      result.current.onDiscountCommand({ onSave })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(
+      <>
+        {openArgs.children}
+        {openArgs.actions}
+      </>,
+    )
+
+    // Attempting to save without a coupon runs validation, which fails on the
+    // required couponId — onSave must not fire and the drawer must stay open.
+    await userEvent.click(screen.getByTestId(DISCOUNT_DRAWER_SAVE_TEST_ID))
+
+    await waitFor(() => {
+      expect(screen.getByTestId(DISCOUNT_DRAWER_SAVE_TEST_ID)).toBeDisabled()
+    })
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(mockDrawerClose).not.toHaveBeenCalled()
+  })
+
+  it('prefills amount and locks currency when a fixed-amount coupon is selected', async () => {
+    const { result } = renderHook(() => useDiscountDrawer(undefined, options))
+
+    act(() => {
+      result.current.onDiscountCommand({ onSave: jest.fn() })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(<>{openArgs.children}</>)
+
+    const comboBoxInput = screen.getByRole('combobox') as HTMLInputElement
+
+    await userEvent.type(comboBoxInput, 'Ten')
+
+    await waitFor(() => {
+      const listboxId = comboBoxInput.getAttribute('aria-controls')
+
+      expect(listboxId).toBeTruthy()
+    })
+
+    const listboxId = comboBoxInput.getAttribute('aria-controls') as string
+    const listbox = document.getElementById(listboxId) as HTMLElement
+
+    await userEvent.click(within(listbox).getByText('Ten Off'))
+
+    // Amount field appears prefilled from the coupon (1000 cents / EUR precision).
+    await waitFor(() => {
+      const amountInput = screen.getByDisplayValue('10') as HTMLInputElement
+
+      expect(amountInput).toBeInTheDocument()
+    })
+
+    // Currency is locked to the drawer's currency (USD), not the coupon's EUR.
+    expect(screen.getByDisplayValue(CurrencyEnum.Usd)).toBeInTheDocument()
+  })
+
+  it('saves a valid fixed-amount coupon and produces the coupons payload via syncDiscountBlocks', async () => {
+    const { result } = renderHook(() => useDiscountDrawer(undefined, options))
+
+    const onSave = jest.fn()
+
+    act(() => {
+      result.current.onDiscountCommand({ onSave })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(
+      <>
+        {openArgs.children}
+        {openArgs.actions}
+      </>,
+    )
+
+    const comboBoxInput = screen.getByRole('combobox') as HTMLInputElement
+
+    await userEvent.type(comboBoxInput, 'Ten')
+
+    await waitFor(() => {
+      expect(comboBoxInput.getAttribute('aria-controls')).toBeTruthy()
+    })
+
+    const listboxId = comboBoxInput.getAttribute('aria-controls') as string
+    const listbox = document.getElementById(listboxId) as HTMLElement
+
+    await userEvent.click(within(listbox).getByText('Ten Off'))
+
+    const saveButton = screen.getByTestId(DISCOUNT_DRAWER_SAVE_TEST_ID)
+
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled()
+    })
+
+    await userEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({ couponId: 'cpn_fixed', localId: 'mock-uuid-1' })
+    })
+
+    expect(mockDrawerClose).toHaveBeenCalled()
+
+    // Saving rebuilds the entities from the toCoupons -> fromCoupons round-trip,
+    // which is the same serialization that produces the payload overrides.
+    await waitFor(() => {
+      expect(result.current.entities).toHaveProperty('mock-uuid-1')
+    })
+    expect(result.current.entities['mock-uuid-1']).toMatchObject({
+      entityType: 'coupon',
+      couponType: CouponTypeEnum.FixedAmount,
+      amountCents: '1000',
+      percentageRate: null,
+      frequency: CouponFrequency.Once,
+      frequencyDuration: null,
+    })
+
+    // syncDiscountBlocks returns undefined when nothing changed, and a rebuilt
+    // payload when a block is removed.
+    let payload: BillingItemsPayload | undefined
+
+    act(() => {
+      payload = result.current.syncDiscountBlocks([
+        { couponId: 'cpn_fixed', localId: 'mock-uuid-1' },
+      ])
+    })
+
+    expect(payload).toBeUndefined()
+
+    act(() => {
+      payload = result.current.syncDiscountBlocks([])
+    })
+
+    expect(payload).toBeDefined()
+    expect(payload?.coupons).toEqual([])
+  })
+
+  it('prefills from saved override values when editing', () => {
+    const initialBillingItems: BillingItemsPayload = {
+      addons: [],
+      coupons: [
+        {
+          type: 'coupon',
+          id: 'cpn_edit',
+          localId: 'saved-local',
+          payload: {
+            position: 1,
+            code: 'EDIT',
+            id: 'cpn_edit',
+            name: 'Edit Coupon',
+            type: 'fixed_amount',
+            amount_cents: 5000,
+            percentage_rate: null,
+            currency: CurrencyEnum.Usd,
+            frequency: 'recurring',
+            frequency_duration: 3,
+            expiration_at: null,
+            limited_plans: false,
+            plan_codes: [],
+            limited_billable_metrics: false,
+            billable_metric_codes: [],
+            coupon_overrides: null,
+            catalog_snapshot: null,
+            resolved_payload: null,
+          },
+          overrides: {
+            amount_cents: 4200,
+            percentage_rate: null,
+            frequency: 'recurring',
+            frequency_duration: 6,
+          },
+        },
+      ],
+    }
+
+    const { result } = renderHook(() => useDiscountDrawer(initialBillingItems, options))
+
+    // entities hydrated from saved coupon
+    expect(result.current.entities).toHaveProperty('saved-local')
+    expect(result.current.entities['saved-local'].entityType).toBe('coupon')
+
+    act(() => {
+      result.current.onDiscountCommand({
+        onSave: jest.fn(),
+        editData: { couponId: 'cpn_edit', localId: 'saved-local' },
+      })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(<>{openArgs.children}</>)
+
+    // Prefilled amount from override (4200 cents / USD = 42.00), currency locked USD.
+    expect(screen.getByDisplayValue('42.00')).toBeInTheDocument()
+    expect(screen.getByDisplayValue(CurrencyEnum.Usd)).toBeInTheDocument()
+  })
+})

--- a/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
@@ -45,6 +45,7 @@ jest.mock('~/generated/graphql', () => {
     __typename: 'Coupon',
     id: 'cpn_fixed',
     name: 'Ten Off',
+    code: 'COUPON_CODE',
     amountCurrency: actual.CurrencyEnum.Eur,
     amountCents: 1000,
     couponType: actual.CouponTypeEnum.FixedAmount,
@@ -238,6 +239,10 @@ describe('useDiscountDrawer', () => {
       frequency: CouponFrequency.Once,
       frequencyDuration: null,
     })
+
+    // Regression guard: the saved item's code must come from coupon.code, NOT coupon.name.
+    // Previously form.setFieldValue('code', coupon.name) wrote the name into the code field.
+    expect(result.current.entities['mock-uuid-1']).toMatchObject({ code: 'COUPON_CODE' })
 
     // syncDiscountBlocks returns undefined when nothing changed, and a rebuilt
     // payload when a block is removed.

--- a/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
@@ -187,11 +187,115 @@ describe('useSubscriptionPricingDrawer', () => {
       expect.objectContaining({
         plan_123: expect.objectContaining({ entityId: 'plan_123', entityType: 'plan' }),
       }),
-      expect.objectContaining({ addons: [], plans: expect.any(Array) }),
+      // The drawer owns only the `plans` key; `addons` is normalized in by the
+      // save funnel (savePricingBlock), not by this drawer.
+      expect.objectContaining({ plans: expect.any(Array) }),
     )
     expect(onDatesChange).toHaveBeenCalledWith('2023-07-26', '2024-07-26')
     expect(result.current.entities).toHaveProperty('plan_123')
     expect(mockDrawerClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves existing coupons in the payload when saving a plan', () => {
+    // Regression: coupons live alongside plans in billingItems. Saving a plan
+    // must not overwrite billingItems and drop a previously-added coupon.
+    mockInjectedState = {
+      planId: 'plan_123',
+      planCode: 'enterprise',
+      planName: 'Enterprise Plan',
+      planDescription: '',
+      subscriptionSettings: {
+        externalId: '',
+        subscriptionName: '',
+        billingTime: 'anniversary',
+        startDate: '2023-07-26',
+        endDate: '',
+      },
+      invoicingSettings: { paymentMethodId: '', invoiceCustomFooter: '' },
+      overrides: {},
+    }
+
+    const existingCoupon = {
+      type: 'coupon',
+      id: 'cpn_1',
+      localId: 'local-cpn-1',
+      payload: {},
+      overrides: {},
+    } as unknown as NonNullable<BillingItemsPayload['coupons']>[number]
+
+    const initialBillingItems: BillingItemsPayload = {
+      addons: [],
+      coupons: [existingCoupon],
+    }
+
+    const onSave = jest.fn()
+
+    const { result } = renderHook(() => useSubscriptionPricingDrawer(initialBillingItems))
+
+    act(() => {
+      result.current.onPricingCommand({ onSave })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(openArgs.children)
+
+    act(() => {
+      openArgs.form.submit()
+    })
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ plans: expect.any(Array), coupons: [existingCoupon] }),
+    )
+  })
+
+  it('syncEntitiesWithBlocks preserves existing coupons when pruning an orphaned plan', () => {
+    const existingCoupon = {
+      type: 'coupon',
+      id: 'cpn_1',
+      localId: 'local-cpn-1',
+      payload: {},
+      overrides: {},
+    } as unknown as NonNullable<BillingItemsPayload['coupons']>[number]
+
+    const initialBillingItems: BillingItemsPayload = {
+      addons: [],
+      plans: [
+        {
+          type: 'plan',
+          id: 'plan_123',
+          payload: {
+            position: 1,
+            code: 'enterprise',
+            name: 'Enterprise Plan',
+            description: '',
+            subscription_external_id: null,
+            subscription_name: null,
+            billing_time: 'anniversary',
+            start_date: '2023-07-26',
+            end_date: null,
+            payment_method_id: null,
+            invoice_custom_footer: null,
+          },
+          overrides: {},
+        },
+      ],
+      coupons: [existingCoupon],
+    }
+
+    const { result } = renderHook(() => useSubscriptionPricingDrawer(initialBillingItems))
+
+    let billingItems: BillingItemsPayload | null = null
+
+    act(() => {
+      billingItems = result.current.syncEntitiesWithBlocks([
+        { pricingType: 'plan', entityIds: ['plan_other'] },
+      ])
+    })
+
+    expect(billingItems).toEqual(expect.objectContaining({ plans: [], coupons: [existingCoupon] }))
   })
 
   it('does not save or close the drawer when no subscription state is set', () => {

--- a/src/pages/quotes/hooks/useDiscountDrawer.tsx
+++ b/src/pages/quotes/hooks/useDiscountDrawer.tsx
@@ -142,7 +142,7 @@ const DiscountDrawerContent = withForm({
                   form.setFieldValue('couponId', coupon.id)
                   form.setFieldValue('couponType', coupon.couponType)
                   form.setFieldValue('name', coupon.name)
-                  form.setFieldValue('code', coupon.name)
+                  form.setFieldValue('code', coupon.code ?? '')
                   form.setFieldValue(
                     'amount',
                     deserializeAmount(coupon.amountCents ?? 0, lockedCurrency).toString(),

--- a/src/pages/quotes/hooks/useDiscountDrawer.tsx
+++ b/src/pages/quotes/hooks/useDiscountDrawer.tsx
@@ -1,3 +1,4 @@
+import { gql } from '@apollo/client'
 import { revalidateLogic } from '@tanstack/react-form'
 import { useCallback, useRef, useState } from 'react'
 import { z } from 'zod'
@@ -25,10 +26,36 @@ import {
   CouponStatusEnum,
   CouponTypeEnum,
   CurrencyEnum,
-  useGetCouponForCustomerLazyQuery,
+  useGetCouponsForDiscountDrawerLazyQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm, withForm } from '~/hooks/forms/useAppform'
+
+gql`
+  query getCouponsForDiscountDrawer(
+    $page: Int
+    $limit: Int
+    $status: CouponStatusEnum
+    $searchTerm: String
+  ) {
+    coupons(page: $page, limit: $limit, status: $status, searchTerm: $searchTerm) {
+      metadata {
+        currentPage
+        totalPages
+      }
+      collection {
+        id
+        name
+        code
+        couponType
+        amountCents
+        percentageRate
+        frequency
+        frequencyDuration
+      }
+    }
+  }
+`
 
 export const DISCOUNT_DRAWER_SAVE_TEST_ID = 'discount-drawer-save'
 
@@ -104,7 +131,7 @@ const DiscountDrawerContent = withForm({
   props: { lockedCurrency: CurrencyEnum.Usd as CurrencyEnum },
   render: function Render({ form, lockedCurrency }) {
     const { translate } = useInternationalization()
-    const [getCoupons, { loading, data }] = useGetCouponForCustomerLazyQuery({
+    const [getCoupons, { loading, data }] = useGetCouponsForDiscountDrawerLazyQuery({
       variables: { limit: 50, status: CouponStatusEnum.Active },
       fetchPolicy: 'network-only',
       notifyOnNetworkStatusChange: true,

--- a/src/pages/quotes/hooks/useDiscountDrawer.tsx
+++ b/src/pages/quotes/hooks/useDiscountDrawer.tsx
@@ -372,7 +372,7 @@ export const useDiscountDrawer = (
 
   const handleFormSubmit = (event?: React.FormEvent) => {
     event?.preventDefault()
-    void form.handleSubmit()
+    form.handleSubmit()
   }
 
   const onDiscountCommand = useCallback<OnDiscountCommand>(

--- a/src/pages/quotes/hooks/useDiscountDrawer.tsx
+++ b/src/pages/quotes/hooks/useDiscountDrawer.tsx
@@ -338,10 +338,16 @@ export const useDiscountDrawer = (
         frequencyDuration: value.frequencyDuration ? Number(value.frequencyDuration) : null,
       }
 
-      // Ensure a payload snapshot exists for newly added coupons.
-      if (!originalPayloadsRef.current[localId]) {
+      // Ensure a fresh payload snapshot for newly added coupons AND when the user
+      // switches an existing line to a different coupon. Without the id check, an
+      // edit that changes the coupon keeps the previous snapshot, so toCoupons
+      // rebuilds the line from the old coupon's identity (name/code/type) and both
+      // the editor block and the preview keep showing the old coupon.
+      const existingSnapshot = originalPayloadsRef.current[localId]
+
+      if (!existingSnapshot || existingSnapshot.id !== value.couponId) {
         originalPayloadsRef.current[localId] = {
-          position: Object.keys(itemsRef.current).length,
+          position: existingSnapshot?.position ?? Object.keys(itemsRef.current).length,
           code: value.code,
           id: value.couponId,
           name: value.name,

--- a/src/pages/quotes/hooks/useDiscountDrawer.tsx
+++ b/src/pages/quotes/hooks/useDiscountDrawer.tsx
@@ -39,10 +39,13 @@ interface DiscountFormValues {
   code: string
   currency: CurrencyEnum
   amount: string
-  // Kept as strings — the TanStack TextInputField stores raw string values.
+  // Kept as strings — the TanStack TextInputField stores raw string values,
+  // EXCEPT frequencyDuration: the `int` beforeChangeFormatter runs parseInt and
+  // stores a number, so its value can be a string (prefill/default) or a number
+  // (after the user types). Coerced to number|null when building the payload.
   percentageRate: string
   frequency: CouponFrequency
-  frequencyDuration: string
+  frequencyDuration: string | number
 }
 
 const makeDefaults = (currency: CurrencyEnum): DiscountFormValues => ({
@@ -67,7 +70,8 @@ const schema = z
     amount: z.string(),
     percentageRate: z.string(),
     frequency: z.nativeEnum(CouponFrequency),
-    frequencyDuration: z.string(),
+    // number when set via the `int` input formatter, string on prefill/default
+    frequencyDuration: z.union([z.string(), z.number()]),
   })
   .superRefine((data, ctx) => {
     if (data.couponType === CouponTypeEnum.FixedAmount && !data.amount) {

--- a/src/pages/quotes/hooks/useDiscountDrawer.tsx
+++ b/src/pages/quotes/hooks/useDiscountDrawer.tsx
@@ -1,0 +1,456 @@
+import { revalidateLogic } from '@tanstack/react-form'
+import { useCallback, useRef, useState } from 'react'
+import { z } from 'zod'
+
+import { Button } from '~/components/designSystem/Button'
+import type {
+  EntityData,
+  OnDiscountCommand,
+} from '~/components/designSystem/RichTextEditor/common/RichTextEditorContext'
+import type { DiscountBlockAttributes } from '~/components/designSystem/RichTextEditor/extensions/DiscountBlock.schema'
+import { Typography } from '~/components/designSystem/Typography'
+import { useDrawer } from '~/components/drawers/useDrawer'
+import { ComboBox } from '~/components/form/ComboBox/ComboBox'
+import { CenteredPage } from '~/components/layouts/CenteredPage'
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBillingItems'
+import {
+  type CouponPayload,
+  type DiscountFormItem,
+  fromCoupons,
+  toCoupons,
+} from '~/core/serializers/serializeQuoteCoupons'
+import {
+  CouponFrequency,
+  CouponStatusEnum,
+  CouponTypeEnum,
+  CurrencyEnum,
+  useGetCouponForCustomerLazyQuery,
+} from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm, withForm } from '~/hooks/forms/useAppform'
+
+export const DISCOUNT_DRAWER_SAVE_TEST_ID = 'discount-drawer-save'
+
+interface DiscountFormValues {
+  couponId: string
+  couponType: CouponTypeEnum
+  name: string
+  code: string
+  currency: CurrencyEnum
+  amount: string
+  // Kept as strings — the TanStack TextInputField stores raw string values.
+  percentageRate: string
+  frequency: CouponFrequency
+  frequencyDuration: string
+}
+
+const makeDefaults = (currency: CurrencyEnum): DiscountFormValues => ({
+  couponId: '',
+  couponType: CouponTypeEnum.FixedAmount,
+  name: '',
+  code: '',
+  currency,
+  amount: '',
+  percentageRate: '',
+  frequency: CouponFrequency.Forever,
+  frequencyDuration: '',
+})
+
+const schema = z
+  .object({
+    couponId: z.string().min(1),
+    couponType: z.nativeEnum(CouponTypeEnum),
+    name: z.string(),
+    code: z.string(),
+    currency: z.nativeEnum(CurrencyEnum),
+    amount: z.string(),
+    percentageRate: z.string(),
+    frequency: z.nativeEnum(CouponFrequency),
+    frequencyDuration: z.string(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.couponType === CouponTypeEnum.FixedAmount && !data.amount) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'text_624ea7c29103fd010732ab7d',
+        path: ['amount'],
+      })
+    }
+
+    if (data.couponType === CouponTypeEnum.Percentage && !data.percentageRate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'text_624ea7c29103fd010732ab7d',
+        path: ['percentageRate'],
+      })
+    }
+
+    if (data.frequency === CouponFrequency.Recurring && !data.frequencyDuration) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'text_63314cfeb607e57577d894c9',
+        path: ['frequencyDuration'],
+      })
+    }
+  })
+
+const DiscountDrawerContent = withForm({
+  defaultValues: makeDefaults(CurrencyEnum.Usd),
+  props: { lockedCurrency: CurrencyEnum.Usd as CurrencyEnum },
+  render: function Render({ form, lockedCurrency }) {
+    const { translate } = useInternationalization()
+    const [getCoupons, { loading, data }] = useGetCouponForCustomerLazyQuery({
+      variables: { limit: 50, status: CouponStatusEnum.Active },
+      fetchPolicy: 'network-only',
+      notifyOnNetworkStatusChange: true,
+    })
+
+    const coupons = (data?.coupons?.collection ?? []).map((c) => ({
+      value: c.id,
+      label: c.name,
+    }))
+
+    return (
+      <div className="flex flex-col gap-6">
+        <CenteredPage.PageTitle
+          title={translate('text_1782891666475u5j60v91cv2')}
+          description={translate('text_1782891666475ht76172d37q')}
+        />
+
+        <form.Subscribe
+          selector={(s) => [s.values.couponId, s.values.couponType, s.values.frequency] as const}
+        >
+          {([couponId, couponType, frequency]) => (
+            <>
+              <ComboBox
+                name="selectCoupon"
+                value={couponId ? String(couponId) : ''}
+                label={translate('text_628b8c693e464200e00e4677')}
+                placeholder={translate('text_628b8c693e464200e00e4685')}
+                data={coupons}
+                loading={loading}
+                searchQuery={getCoupons}
+                onChange={(value) => {
+                  const coupon = data?.coupons?.collection.find((c) => c.id === value)
+
+                  if (!coupon) {
+                    form.setFieldValue('couponId', '')
+                    return
+                  }
+
+                  form.setFieldValue('couponId', coupon.id)
+                  form.setFieldValue('couponType', coupon.couponType)
+                  form.setFieldValue('name', coupon.name)
+                  form.setFieldValue('code', coupon.name)
+                  form.setFieldValue(
+                    'amount',
+                    deserializeAmount(coupon.amountCents ?? 0, lockedCurrency).toString(),
+                  )
+                  form.setFieldValue('currency', lockedCurrency)
+                  form.setFieldValue(
+                    'percentageRate',
+                    coupon.percentageRate !== null && coupon.percentageRate !== undefined
+                      ? String(coupon.percentageRate)
+                      : '',
+                  )
+                  form.setFieldValue('frequency', coupon.frequency)
+                  form.setFieldValue(
+                    'frequencyDuration',
+                    coupon.frequencyDuration !== null && coupon.frequencyDuration !== undefined
+                      ? String(coupon.frequencyDuration)
+                      : '',
+                  )
+                }}
+              />
+
+              {!!couponId && couponType === CouponTypeEnum.FixedAmount && (
+                <div className="flex gap-3">
+                  <form.AppField name="amount">
+                    {(field) => (
+                      <field.AmountInputField
+                        className="flex-1"
+                        currency={lockedCurrency}
+                        beforeChangeFormatter={['positiveNumber']}
+                        label={translate('text_628b8c693e464200e00e469b')}
+                      />
+                    )}
+                  </form.AppField>
+                  <form.AppField name="currency">
+                    {(field) => (
+                      <field.ComboBoxField
+                        className="mt-7 max-w-30"
+                        data={[{ value: lockedCurrency }]}
+                        disabled
+                        disableClearable
+                      />
+                    )}
+                  </form.AppField>
+                </div>
+              )}
+
+              {!!couponId && couponType === CouponTypeEnum.Percentage && (
+                <form.AppField name="percentageRate">
+                  {(field) => (
+                    <field.TextInputField
+                      beforeChangeFormatter={['positiveNumber', 'quadDecimal']}
+                      label={translate('text_632d68358f1fedc68eed3e76')}
+                      placeholder={translate('text_632d68358f1fedc68eed3e86')}
+                      InputProps={{
+                        endAdornment: (
+                          <Typography
+                            className="mr-4 shrink-0"
+                            variant="body"
+                            color="textSecondary"
+                          >
+                            {translate('text_632d68358f1fedc68eed3e93')}
+                          </Typography>
+                        ),
+                      }}
+                    />
+                  )}
+                </form.AppField>
+              )}
+
+              {!!couponId && (
+                <form.AppField name="frequency">
+                  {(field) => (
+                    <field.ComboBoxField
+                      label={translate('text_632d68358f1fedc68eed3e9d')}
+                      helperText={translate('text_632d68358f1fedc68eed3eab')}
+                      disableClearable
+                      data={[
+                        {
+                          value: CouponFrequency.Once,
+                          label: translate('text_632d68358f1fedc68eed3ea3'),
+                        },
+                        {
+                          value: CouponFrequency.Recurring,
+                          label: translate('text_632d68358f1fedc68eed3e64'),
+                        },
+                        {
+                          value: CouponFrequency.Forever,
+                          label: translate('text_63c83a3476e46bc6ab9d85d6'),
+                        },
+                      ]}
+                    />
+                  )}
+                </form.AppField>
+              )}
+
+              {!!couponId && frequency === CouponFrequency.Recurring && (
+                <form.AppField name="frequencyDuration">
+                  {(field) => (
+                    <field.TextInputField
+                      beforeChangeFormatter={['positiveNumber', 'int']}
+                      label={translate('text_632d68358f1fedc68eed3e80')}
+                      placeholder={translate('text_632d68358f1fedc68eed3e88')}
+                      InputProps={{
+                        endAdornment: (
+                          <Typography
+                            className="mr-4 shrink-0"
+                            variant="body"
+                            color="textSecondary"
+                          >
+                            {translate('text_632d68358f1fedc68eed3e95')}
+                          </Typography>
+                        ),
+                      }}
+                    />
+                  )}
+                </form.AppField>
+              )}
+            </>
+          )}
+        </form.Subscribe>
+      </div>
+    )
+  },
+})
+
+interface PendingSave {
+  onSave: (attrs: DiscountBlockAttributes) => void
+  localId: string
+}
+
+export const useDiscountDrawer = (
+  billingItems: BillingItemsPayload | null | undefined,
+  options: { currency: CurrencyEnum },
+): {
+  onDiscountCommand: OnDiscountCommand
+  entities: Record<string, EntityData>
+  syncDiscountBlocks: (blocks: DiscountBlockAttributes[]) => BillingItemsPayload | undefined
+} => {
+  const { translate } = useInternationalization()
+  const drawer = useDrawer()
+  const currency = options.currency
+
+  const initial = fromCoupons(billingItems?.coupons ?? [])
+
+  const itemsRef = useRef<Record<string, DiscountFormItem>>(
+    Object.fromEntries(initial.discountItems.map((i) => [i.localId, i])),
+  )
+  const originalPayloadsRef = useRef<Record<string, CouponPayload>>(initial.originalPayloads)
+  const [entities, setEntities] = useState<Record<string, EntityData>>(initial.entities)
+  const entitiesRef = useRef<Record<string, EntityData>>(initial.entities)
+
+  // Ref bridge: a single stable onSubmit reads the pending save target set right
+  // before drawer.open, instead of mutating form.options.onSubmit per open.
+  const pendingSaveRef = useRef<PendingSave | null>(null)
+
+  const rebuild = useCallback((): BillingItemsPayload => {
+    const items = Object.values(itemsRef.current)
+    const coupons = toCoupons(items, originalPayloadsRef.current)
+    const { entities: nextEntities } = fromCoupons(coupons)
+
+    entitiesRef.current = nextEntities
+    setEntities(nextEntities)
+
+    return { ...(billingItems ?? { addons: [] }), coupons }
+  }, [billingItems])
+
+  const form = useAppForm({
+    defaultValues: makeDefaults(currency),
+    validationLogic: revalidateLogic(),
+    validators: { onDynamic: schema },
+    onSubmit: async ({ value }) => {
+      const pending = pendingSaveRef.current
+
+      if (!pending) return
+
+      const { onSave, localId } = pending
+
+      itemsRef.current[localId] = {
+        localId,
+        couponId: value.couponId,
+        couponType: value.couponType,
+        name: value.name,
+        code: value.code,
+        currency,
+        amount: value.amount,
+        percentageRate: value.percentageRate ? Number(value.percentageRate) : null,
+        frequency: value.frequency,
+        frequencyDuration: value.frequencyDuration ? Number(value.frequencyDuration) : null,
+      }
+
+      // Ensure a payload snapshot exists for newly added coupons.
+      if (!originalPayloadsRef.current[localId]) {
+        originalPayloadsRef.current[localId] = {
+          position: Object.keys(itemsRef.current).length,
+          code: value.code,
+          id: value.couponId,
+          name: value.name,
+          type: value.couponType === CouponTypeEnum.Percentage ? 'percentage' : 'fixed_amount',
+          amount_cents: null,
+          percentage_rate: null,
+          currency,
+          frequency: 'forever',
+          frequency_duration: null,
+          expiration_at: null,
+          limited_plans: false,
+          plan_codes: [],
+          limited_billable_metrics: false,
+          billable_metric_codes: [],
+          coupon_overrides: null,
+          catalog_snapshot: null,
+          resolved_payload: null,
+        }
+      }
+
+      rebuild()
+
+      onSave({ couponId: value.couponId, localId })
+      drawer.close()
+    },
+  })
+
+  const handleFormSubmit = (event?: React.FormEvent) => {
+    event?.preventDefault()
+    void form.handleSubmit()
+  }
+
+  const onDiscountCommand = useCallback<OnDiscountCommand>(
+    ({ onSave, editData }) => {
+      const localId = editData?.localId ?? crypto.randomUUID()
+      const existing = editData ? itemsRef.current[localId] : undefined
+
+      pendingSaveRef.current = { onSave, localId }
+
+      form.reset(
+        existing
+          ? {
+              couponId: existing.couponId,
+              couponType: existing.couponType,
+              name: existing.name,
+              code: existing.code,
+              currency,
+              amount: existing.amount,
+              percentageRate:
+                existing.percentageRate !== null && existing.percentageRate !== undefined
+                  ? String(existing.percentageRate)
+                  : '',
+              frequency: existing.frequency,
+              frequencyDuration:
+                existing.frequencyDuration !== null && existing.frequencyDuration !== undefined
+                  ? String(existing.frequencyDuration)
+                  : '',
+            }
+          : makeDefaults(currency),
+        { keepDefaultValues: true },
+      )
+
+      drawer.open({
+        title: translate('text_1782891666475j9e81afl8in'),
+        children: (
+          <form onSubmit={handleFormSubmit}>
+            <button type="submit" hidden tabIndex={-1} />
+            <DiscountDrawerContent form={form} lockedCurrency={currency} />
+          </form>
+        ),
+        actions: (
+          <div className="flex items-center justify-end gap-3">
+            <Button variant="quaternary" onClick={() => drawer.close()}>
+              {translate('text_6411e6b530cb47007488b027')}
+            </Button>
+            <form.Subscribe selector={({ canSubmit }) => canSubmit}>
+              {(canSubmit) => (
+                <Button
+                  data-test={DISCOUNT_DRAWER_SAVE_TEST_ID}
+                  onClick={() => handleFormSubmit()}
+                  disabled={!canSubmit}
+                >
+                  {translate('text_17295436903260tlyb1gp1i7')}
+                </Button>
+              )}
+            </form.Subscribe>
+          </div>
+        ),
+      })
+    },
+    // form and handleFormSubmit are stable (closure over form) — safe to omit
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [drawer, form, translate, currency],
+  )
+
+  const syncDiscountBlocks = useCallback(
+    (blocks: DiscountBlockAttributes[]): BillingItemsPayload | undefined => {
+      const present = new Set(blocks.map((b) => b.localId))
+      let changed = false
+
+      for (const key of Object.keys(itemsRef.current)) {
+        if (!present.has(key)) {
+          delete itemsRef.current[key]
+          delete originalPayloadsRef.current[key]
+          changed = true
+        }
+      }
+
+      if (!changed) return undefined
+
+      return rebuild()
+    },
+    [rebuild],
+  )
+
+  return { onDiscountCommand, entities, syncDiscountBlocks }
+}

--- a/src/pages/quotes/hooks/useDiscountDrawer.tsx
+++ b/src/pages/quotes/hooks/useDiscountDrawer.tsx
@@ -275,7 +275,7 @@ interface PendingSave {
 
 export const useDiscountDrawer = (
   billingItems: BillingItemsPayload | null | undefined,
-  options: { currency: CurrencyEnum },
+  options: { currency: CurrencyEnum; onPersist?: (billingItems: BillingItemsPayload) => void },
 ): {
   onDiscountCommand: OnDiscountCommand
   entities: Record<string, EntityData>
@@ -284,6 +284,7 @@ export const useDiscountDrawer = (
   const { translate } = useInternationalization()
   const drawer = useDrawer()
   const currency = options.currency
+  const { onPersist } = options
 
   const initial = fromCoupons(billingItems?.coupons ?? [])
 
@@ -357,9 +358,10 @@ export const useDiscountDrawer = (
         }
       }
 
-      rebuild()
+      const updated = rebuild()
 
       onSave({ couponId: value.couponId, localId })
+      onPersist?.(updated)
       drawer.close()
     },
   })

--- a/src/pages/quotes/hooks/useDiscountDrawer.tsx
+++ b/src/pages/quotes/hooks/useDiscountDrawer.tsx
@@ -311,7 +311,7 @@ export const useDiscountDrawer = (
     entitiesRef.current = nextEntities
     setEntities(nextEntities)
 
-    return { ...(billingItems ?? { addons: [] }), coupons }
+    return { ...billingItems, coupons }
   }, [billingItems])
 
   const form = useAppForm({

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -50,6 +50,16 @@ export const useSubscriptionPricingDrawer = (
   const subscriptionStateRef = useRef<SubscriptionPricingState | null>(null)
   const formValuesRef = useRef<PlanFormInput | null>(null)
 
+  // Latest saved billingItems, kept in a ref so plan saves/syncs can preserve
+  // sibling categories (coupons, addons) instead of overwriting billingItems and
+  // dropping them — each drawer only owns its own slice of billingItems.
+  const latestBillingItemsRef = useRef<BillingItemsPayload | undefined>(undefined)
+
+  useEffect(() => {
+    latestBillingItemsRef.current =
+      (initialBillingItems as BillingItemsPayload | undefined) ?? undefined
+  }, [initialBillingItems])
+
   // Determine initialization case: extract billing item plan for case 2
   const billingItemPlan = useMemo(() => {
     if (!initialBillingItems) return undefined
@@ -114,7 +124,7 @@ export const useSubscriptionPricingDrawer = (
         setEntities({ ...entitiesRef.current })
 
         onSaveRef.current?.({ pricingType: 'plan', entityIds: [state.planId] }, entityData, {
-          addons: [],
+          ...latestBillingItemsRef.current,
           ...billingItems,
         })
 
@@ -173,7 +183,9 @@ export const useSubscriptionPricingDrawer = (
       entitiesRef.current = updatedEntities
       setEntities(updatedEntities)
 
-      return { addons: [], plans: [] }
+      // Only the plan is this drawer's responsibility; sibling categories
+      // (coupons, addons) are carried through untouched.
+      return { ...latestBillingItemsRef.current, plans: [] }
     },
     [],
   )

--- a/translations/base.json
+++ b/translations/base.json
@@ -4462,5 +4462,7 @@
   "text_17828094623997l9tqj385k5": "Order form {{orderFormNumber}}",
   "text_1782821511108j6cgg7ioq23": "This is a read-only preview of this order form.",
   "text_1782918544840f0jput31j5k": "Could not upload the image. Please try again.",
-  "text_1782997762645ugjob60lzff": "PNG, JPG, WEBP, GIF less than 5MB."
+  "text_1782997762645ugjob60lzff": "PNG, JPG, WEBP, GIF less than 5MB.",
+  "text_1782889379261hdcd0jhzdm6": "Discount",
+  "text_178288937926153opd9g5cwg": "Apply a coupon discount to this quote"
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -4464,5 +4464,8 @@
   "text_1782918544840f0jput31j5k": "Could not upload the image. Please try again.",
   "text_1782997762645ugjob60lzff": "PNG, JPG, WEBP, GIF less than 5MB.",
   "text_1782889379261hdcd0jhzdm6": "Discount",
-  "text_178288937926153opd9g5cwg": "Apply a coupon discount to this quote"
+  "text_178288937926153opd9g5cwg": "Apply a coupon discount to this quote",
+  "text_1782891666475j9e81afl8in": "Discount",
+  "text_1782891666475u5j60v91cv2": "Discount and coupon",
+  "text_1782891666475ht76172d37q": "Apply a coupon to this quote to grant a discount."
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -4467,5 +4467,7 @@
   "text_178288937926153opd9g5cwg": "Apply a coupon discount to this quote",
   "text_1782891666475j9e81afl8in": "Discount",
   "text_1782891666475u5j60v91cv2": "Discount and coupon",
-  "text_1782891666475ht76172d37q": "Apply a coupon to this quote to grant a discount."
+  "text_1782891666475ht76172d37q": "Apply a coupon to this quote to grant a discount.",
+  "text_1783342959387sv77znuw5yx": "Select a coupon",
+  "text_1783342959387cz07147m6qq": "Coupon: {{couponId}}"
 }


### PR DESCRIPTION
## What

Implements the `/discount` Rich Text Editor command for Quotes 

On **Subscription creation / amendment** quotes, a new `/discount` slash command opens a drawer to apply a coupon:
- Select a coupon (mandatory, searchable).
- Amount/percentage + frequency prefill from the coupon; currency is locked to the quote currency.
- Amount, percentage, frequency (and duration when recurring) are editable and saved under an `overrides` key.
- Renders as a `DiscountBlock` node in the editor; read-only in the quote preview / PDF.
- No limit on the number of coupons (each block is keyed by a per-line `localId`).

`/discount` does **not** appear on one-off quotes (the command handler is only wired for subscription order types).

## Description

This PR creates all the necessary element to
- Use the `/discount` command
- Display it in the RichTextEditor
- Update the pricing command so that we do not overrides the coupon after creating a plan

This PR does not involve preview design at all

Fixes LAGO-1608

🤖 Generated with [Claude Code](https://claude.com/claude-code)
