### PR TITLE
refactor(hubspot): migrate DeleteHubspotIntegrationDialog to useCentralizedDialog

### DIFF
--- a/src/components/settings/integrations/AddHubspotDialog.tsx
+++ b/src/components/settings/integrations/AddHubspotDialog.tsx
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client'
 import Nango from '@nangohq/frontend'
 import { useFormik } from 'formik'
 import { GraphQLFormattedError } from 'graphql'
-import { forwardRef, RefObject, useId, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useId, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 import { boolean, object, string } from 'yup'
 
@@ -12,7 +12,7 @@ import { Chip } from '~/components/designSystem/Chip'
 import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
 import { Checkbox, CheckboxField, ComboBoxField, TextInputField } from '~/components/form'
-import { DeleteHubspotIntegrationDialogRef } from '~/components/settings/integrations/DeleteHubspotIntegrationDialog'
+import { useDeleteHubspotIntegrationDialog } from '~/components/settings/integrations/DeleteHubspotIntegrationDialog'
 import { addToast, envGlobalVar, hasDefinedGQLError } from '~/core/apolloClient'
 import { getHubspotTargetedObjectTranslationKey } from '~/core/constants/form'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
@@ -55,7 +55,6 @@ gql`
 `
 
 type TAddHubspotDialogProps = Partial<{
-  deleteModalRef: RefObject<DeleteHubspotIntegrationDialogRef>
   provider: HubspotForCreateDialogFragment
   deleteDialogCallback: () => void
 }>
@@ -76,6 +75,7 @@ export const AddHubspotDialog = forwardRef<AddHubspotDialogRef>((_, ref) => {
   const [showGlobalError, setShowGlobalError] = useState(false)
   const hubspotProvider = localData?.provider
   const isEdition = !!hubspotProvider
+  const { openDeleteHubspotIntegrationDialog } = useDeleteHubspotIntegrationDialog()
 
   const [createIntegration] = useCreateHubspotIntegrationMutation({
     onCompleted({ createHubspotIntegration }) {
@@ -216,9 +216,9 @@ export const AddHubspotDialog = forwardRef<AddHubspotDialogRef>((_, ref) => {
               variant="quaternary"
               onClick={() => {
                 closeDialog()
-                localData?.deleteModalRef?.current?.openDialog({
+                openDeleteHubspotIntegrationDialog({
                   provider: hubspotProvider,
-                  callback: localData.deleteDialogCallback,
+                  callback: localData?.deleteDialogCallback,
                 })
               }}
             >

--- a/src/components/settings/integrations/DeleteHubspotIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteHubspotIntegrationDialog.tsx
@@ -1,10 +1,11 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import {
   DeleteHubspotIntegrationDialogFragment,
+  GetHubspotIntegrationsListDocument,
   useDestroyNangoIntegrationMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -22,71 +23,51 @@ gql`
   }
 `
 
-type TDeleteHubspotIntegrationDialogProps = {
+type OpenDeleteHubspotIntegrationDialogData = {
   provider: DeleteHubspotIntegrationDialogFragment | null
   callback?: () => void
 }
 
-export interface DeleteHubspotIntegrationDialogRef {
-  openDialog: ({ provider, callback }: TDeleteHubspotIntegrationDialogProps) => unknown
-  closeDialog: () => unknown
-}
+export const useDeleteHubspotIntegrationDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+  const client = useApolloClient()
 
-export const DeleteHubspotIntegrationDialog = forwardRef<DeleteHubspotIntegrationDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
+  const [deleteHubspot] = useDestroyNangoIntegrationMutation()
 
-    const dialogRef = useRef<WarningDialogRef>(null)
-    const [localData, setLocalData] = useState<TDeleteHubspotIntegrationDialogProps | undefined>(
-      undefined,
-    )
-    const hubspotProvider = localData?.provider
+  const openDeleteHubspotIntegrationDialog = (data: OpenDeleteHubspotIntegrationDialogData) => {
+    const provider = data.provider
 
-    const [deleteHubspot] = useDestroyNangoIntegrationMutation({
-      onCompleted(data) {
-        if (data.destroyIntegration) {
-          dialogRef.current?.closeDialog()
-          localData?.callback?.()
+    centralizedDialog.open({
+      title: translate('text_658461066530343fe1808cd7', { name: provider?.name }),
+      description: translate('text_1727453876790u9azb7rvhox'),
+      actionText: translate('text_645d071272418a14c1c76a81'),
+      colorVariant: 'danger',
+      onAction: async () => {
+        const res = await deleteHubspot({
+          variables: { input: { id: provider?.id as string } },
+        })
+
+        const destroyedId = res.data?.destroyIntegration?.id
+
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'HubspotIntegration',
+            listFieldName: 'integrations',
+            listQueryDocument: GetHubspotIntegrationsListDocument,
+          })
+
+          data.callback?.()
+
           addToast({
             message: translate('text_661ff6e56ef7e1b7c542b2f9'),
             severity: 'success',
           })
         }
       },
-      update(cache) {
-        cache.evict({ id: `HubspotIntegration:${hubspotProvider?.id}` })
-      },
-      refetchQueries: ['getHubspotIntegrationsList'],
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setLocalData(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => dialogRef.current?.closeDialog(),
-    }))
-
-    return (
-      <WarningDialog
-        ref={dialogRef}
-        title={translate('text_658461066530343fe1808cd7', {
-          name: hubspotProvider?.name,
-        })}
-        description={translate('text_1727453876790u9azb7rvhox')}
-        onContinue={async () =>
-          await deleteHubspot({
-            variables: {
-              input: {
-                id: hubspotProvider?.id as string,
-              },
-            },
-          })
-        }
-        continueText={translate('text_645d071272418a14c1c76a81')}
-      />
-    )
-  },
-)
-
-DeleteHubspotIntegrationDialog.displayName = 'DeleteHubspotIntegrationDialog'
+  return { openDeleteHubspotIntegrationDialog }
+}

--- a/src/pages/settings/HubspotIntegrationDetails.tsx
+++ b/src/pages/settings/HubspotIntegrationDetails.tsx
@@ -9,10 +9,7 @@ import {
   AddHubspotDialog,
   AddHubspotDialogRef,
 } from '~/components/settings/integrations/AddHubspotDialog'
-import {
-  DeleteHubspotIntegrationDialog,
-  DeleteHubspotIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteHubspotIntegrationDialog'
+import { useDeleteHubspotIntegrationDialog } from '~/components/settings/integrations/DeleteHubspotIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { HUBSPOT_INTEGRATION_ROUTE, INTEGRATIONS_ROUTE, useNavigate } from '~/core/router'
 import {
@@ -70,7 +67,7 @@ const HubspotIntegrationDetails = () => {
   const navigate = useNavigate()
 
   const addHubspotDialogRef = useRef<AddHubspotDialogRef>(null)
-  const deleteHubspotDialogRef = useRef<DeleteHubspotIntegrationDialogRef>(null)
+  const { openDeleteHubspotIntegrationDialog } = useDeleteHubspotIntegrationDialog()
 
   const { data, loading } = useGetHubspotIntegrationsDetailsQuery({
     variables: {
@@ -135,7 +132,6 @@ const HubspotIntegrationDetails = () => {
                   onClick: (closePopper) => {
                     addHubspotDialogRef.current?.openDialog({
                       provider: hubspotIntegration,
-                      deleteModalRef: deleteHubspotDialogRef,
                       deleteDialogCallback,
                     })
                     closePopper()
@@ -146,7 +142,7 @@ const HubspotIntegrationDetails = () => {
                   hidden: !hubspotIntegration,
                   onClick: (closePopper) => {
                     if (hubspotIntegration) {
-                      deleteHubspotDialogRef.current?.openDialog({
+                      openDeleteHubspotIntegrationDialog({
                         provider: hubspotIntegration,
                         callback: deleteDialogCallback,
                       })
@@ -170,7 +166,6 @@ const HubspotIntegrationDetails = () => {
               onClick={() => {
                 addHubspotDialogRef.current?.openDialog({
                   provider: hubspotIntegration,
-                  deleteModalRef: deleteHubspotDialogRef,
                   deleteDialogCallback,
                 })
               }}
@@ -218,7 +213,6 @@ const HubspotIntegrationDetails = () => {
       </IntegrationsPage.Container>
 
       <AddHubspotDialog ref={addHubspotDialogRef} />
-      <DeleteHubspotIntegrationDialog ref={deleteHubspotDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/HubspotIntegrations.tsx
+++ b/src/pages/settings/HubspotIntegrations.tsx
@@ -11,10 +11,7 @@ import {
   AddHubspotDialog,
   AddHubspotDialogRef,
 } from '~/components/settings/integrations/AddHubspotDialog'
-import {
-  DeleteHubspotIntegrationDialog,
-  DeleteHubspotIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteHubspotIntegrationDialog'
+import { useDeleteHubspotIntegrationDialog } from '~/components/settings/integrations/DeleteHubspotIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { HUBSPOT_INTEGRATION_DETAILS_ROUTE, INTEGRATIONS_ROUTE, useNavigate } from '~/core/router'
 import {
@@ -55,7 +52,7 @@ const HubspotIntegrations = () => {
   const { translate } = useInternationalization()
 
   const addHubspotDialogRef = useRef<AddHubspotDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteHubspotIntegrationDialogRef>(null)
+  const { openDeleteHubspotIntegrationDialog } = useDeleteHubspotIntegrationDialog()
 
   const { data, loading } = useGetHubspotIntegrationsListQuery({
     variables: { limit: 1000, types: [IntegrationTypeEnum.Hubspot] },
@@ -154,7 +151,6 @@ const HubspotIntegrations = () => {
                           onClick={() => {
                             addHubspotDialogRef.current?.openDialog({
                               provider: connection,
-                              deleteModalRef: deleteDialogRef,
                               deleteDialogCallback,
                             })
                             closePopper()
@@ -167,7 +163,7 @@ const HubspotIntegrations = () => {
                           variant="quaternary"
                           align="left"
                           onClick={() => {
-                            deleteDialogRef.current?.openDialog({
+                            openDeleteHubspotIntegrationDialog({
                               provider: connection,
                               callback: deleteDialogCallback,
                             })
@@ -185,7 +181,6 @@ const HubspotIntegrations = () => {
         </section>
       </IntegrationsPage.Container>
       <AddHubspotDialog ref={addHubspotDialogRef} />
-      <DeleteHubspotIntegrationDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/__tests__/HubspotIntegrationDetails.test.tsx
+++ b/src/pages/settings/__tests__/HubspotIntegrationDetails.test.tsx
@@ -10,7 +10,9 @@ jest.mock('~/components/settings/integrations/AddHubspotDialog', () => ({
   AddHubspotDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteHubspotIntegrationDialog', () => ({
-  DeleteHubspotIntegrationDialog: () => null,
+  useDeleteHubspotIntegrationDialog: () => ({
+    openDeleteHubspotIntegrationDialog: jest.fn(),
+  }),
 }))
 
 const mockQueryResult = jest.fn()

--- a/src/pages/settings/__tests__/HubspotIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/HubspotIntegrations.test.tsx
@@ -14,7 +14,9 @@ jest.mock('~/components/settings/integrations/AddHubspotDialog', () => ({
   AddHubspotDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteHubspotIntegrationDialog', () => ({
-  DeleteHubspotIntegrationDialog: () => null,
+  useDeleteHubspotIntegrationDialog: () => ({
+    openDeleteHubspotIntegrationDialog: jest.fn(),
+  }),
 }))
 
 describe('HubspotIntegrations', () => {


### PR DESCRIPTION
## Context

`DeleteHubspotIntegrationDialog` still relied on the deprecated ref-based `WarningDialog`, which triggered `no-restricted-imports` warnings in every consumer and left cache handling on the pre-`evictFromCache` pattern (bare `cache.evict()` + `refetchQueries`). That combination broadcasts to detail-page watchers and can drive a `cache-and-network` query into a 404 refetch after the entity is destroyed.

## Description

- Rewrite `DeleteHubspotIntegrationDialog` as `useDeleteHubspotIntegrationDialog`, backed by `useCentralizedDialog` (danger variant).
- Replace `refetchQueries` + inline `cache.evict()` with the `evictFromCache` helper, scoping cache updates to `integrations` / `GetHubspotIntegrationsListDocument` and suppressing detail-page watchers to avoid the post-delete 404.
- Update `HubspotIntegrations` and `HubspotIntegrationDetails` to call the hook directly instead of holding a `WarningDialogRef`.
- Drop the `deleteModalRef` plumbing in `AddHubspotDialog`; the edit dialog now consumes the same hook internally and only needs the callback for the post-delete navigation.
- Update the Jest mocks for both Hubspot pages to mock the hook shape.

`AddHubspotDialog` itself still uses Formik + the legacy `Dialog` and is intentionally left out of scope to keep the change narrow — those warnings are unchanged by this PR.

<!-- Linear link -->
Fixes LAGO-XXX