### PR TITLE
fix(rte): render empty quote variables as nothing in preview

### DIFF
--- a/src/components/designSystem/RichTextEditor/Mentions/MentionNodeView.tsx
+++ b/src/components/designSystem/RichTextEditor/Mentions/MentionNodeView.tsx
@@ -10,12 +10,17 @@ export const MentionNodeView = ({ node }: NodeViewProps) => {
   const label = String(node.attrs.label ?? id)
   const resolvedValue = mentionValues[id]
 
-  // In preview/PDF (read-only), substitute the resolved value. While authoring
-  // (edit mode) keep the @label token so the variable stays visible/editable.
-  // A null/missing value falls through to the @label fallback. This mirrors the
-  // schema renderHTML, and is the rendering path that actually reaches preview
-  // and the PDF (serialized from the live NodeView DOM, not getHTML()).
-  if (mode === 'preview' && resolvedValue) {
+  // In preview/PDF (read-only), substitute the resolved value — including an
+  // empty or null value, which renders nothing so empty variables disappear
+  // instead of showing their @label. Resolution is keyed on the variable being
+  // present in mentionValues: an absent id (unknown variable) still falls back
+  // to @label. While authoring (edit mode) we always keep the @label token so
+  // the variable stays visible/editable. This mirrors the schema renderHTML,
+  // and is the rendering path that actually reaches preview and the PDF
+  // (serialized from the live NodeView DOM, not getHTML()).
+  const isResolved = mode === 'preview' && Object.prototype.hasOwnProperty.call(mentionValues, id)
+
+  if (isResolved) {
     return (
       <NodeViewWrapper
         as="span"

--- a/src/components/designSystem/RichTextEditor/Mentions/MentionNodeView.tsx
+++ b/src/components/designSystem/RichTextEditor/Mentions/MentionNodeView.tsx
@@ -18,7 +18,7 @@ export const MentionNodeView = ({ node }: NodeViewProps) => {
   // the variable stays visible/editable. This mirrors the schema renderHTML,
   // and is the rendering path that actually reaches preview and the PDF
   // (serialized from the live NodeView DOM, not getHTML()).
-  const isResolved = mode === 'preview' && Object.prototype.hasOwnProperty.call(mentionValues, id)
+  const isResolved = mode === 'preview' && Object.hasOwn(mentionValues, id)
 
   if (isResolved) {
     return (

--- a/src/components/designSystem/RichTextEditor/Mentions/__tests__/MentionNodeView.test.tsx
+++ b/src/components/designSystem/RichTextEditor/Mentions/__tests__/MentionNodeView.test.tsx
@@ -146,5 +146,33 @@ describe('MentionNodeView', () => {
         expect(element).toHaveTextContent('@Customer Name')
       })
     })
+
+    describe('WHEN the resolved value is an empty string', () => {
+      it('THEN should render nothing instead of the @label', () => {
+        renderMentionNodeView({
+          mode: 'preview',
+          mentionValues: { customerName: '' },
+        })
+
+        const element = screen.getByTestId(MENTION_NODE_VIEW_TEST_ID)
+
+        expect(element).not.toHaveTextContent('@Customer Name')
+        expect(element).toBeEmptyDOMElement()
+      })
+    })
+
+    describe('WHEN the resolved value is null', () => {
+      it('THEN should render nothing instead of the @label', () => {
+        renderMentionNodeView({
+          mode: 'preview',
+          mentionValues: { customerName: null as unknown as string },
+        })
+
+        const element = screen.getByTestId(MENTION_NODE_VIEW_TEST_ID)
+
+        expect(element).not.toHaveTextContent('@Customer Name')
+        expect(element).toBeEmptyDOMElement()
+      })
+    })
   })
 })

--- a/src/components/designSystem/RichTextEditor/extensions/Mention.schema.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/Mention.schema.ts
@@ -40,10 +40,14 @@ export const MentionSchema = Mention.extend({
   renderHTML({ node }) {
     const id = node.attrs.id as string
     const label = (node.attrs.label as string | undefined) ?? id
-    const resolvedValue = (this.options as { mentionValues?: Record<string, string> })
-      .mentionValues?.[id]
+    const mentionValues = (this.options as { mentionValues?: Record<string, string> }).mentionValues
+    // Resolution is keyed on the variable being present in mentionValues: a
+    // present-but-empty/null value resolves to nothing (empty variables
+    // disappear), while an absent id (unknown variable, or edit mode with no
+    // configured values) keeps the @label token.
+    const isResolved = !!mentionValues && Object.prototype.hasOwnProperty.call(mentionValues, id)
 
-    if (resolvedValue) {
+    if (isResolved) {
       return [
         'span',
         {
@@ -51,7 +55,7 @@ export const MentionSchema = Mention.extend({
           'data-id': id,
           class: 'variable-mention variable-mention--resolved',
         },
-        resolvedValue,
+        mentionValues[id] ?? '',
       ]
     }
 

--- a/src/components/designSystem/RichTextEditor/extensions/Mention.schema.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/Mention.schema.ts
@@ -45,7 +45,7 @@ export const MentionSchema = Mention.extend({
     // present-but-empty/null value resolves to nothing (empty variables
     // disappear), while an absent id (unknown variable, or edit mode with no
     // configured values) keeps the @label token.
-    const isResolved = !!mentionValues && Object.prototype.hasOwnProperty.call(mentionValues, id)
+    const isResolved = !!mentionValues && Object.hasOwn(mentionValues, id)
 
     if (isResolved) {
       return [

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/MentionSchema.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/MentionSchema.test.ts
@@ -133,6 +133,24 @@ describe('MentionSchema', () => {
         expect(html).not.toContain('variable-mention--resolved')
         expect(html).toContain('@Customer Name')
       })
+
+      it('THEN should render nothing (not @label) when the value is an empty string', () => {
+        const html = getHtmlForMention(
+          { id: 'customerName', label: 'Customer Name' },
+          { customerName: '' },
+        )
+
+        expect(html).not.toContain('@Customer Name')
+      })
+
+      it('THEN should render nothing (not @label) when the value is null', () => {
+        const html = getHtmlForMention(
+          { id: 'customerName', label: 'Customer Name' },
+          { customerName: null as unknown as string },
+        )
+
+        expect(html).not.toContain('@Customer Name')
+      })
     })
   })
 })


### PR DESCRIPTION
## Context
When a mention/variable in a quote has an empty value, the **preview** showed the variable's `@name` placeholder instead of rendering nothing.

## Description
This PR changes the way we handle variable resolution
Resolution is now keyed on the variable being **present** in `mentionValues` rather than on truthiness

Fixes LAGO-1670

🤖 Generated with [Claude Code](https://claude.com/claude-code)