### PR TITLE
fix(rte): apply block color from the section toolbar

### DIFF
--- a/src/components/designSystem/RichTextEditor/BlockControls/BlockToolbar.tsx
+++ b/src/components/designSystem/RichTextEditor/BlockControls/BlockToolbar.tsx
@@ -162,16 +162,21 @@ const BlockToolbar = ({ editor }: BlockToolbarProps) => {
       >
         {() => (
           <MenuPopper>
-            <ColorPicker
-              activeBackgroundColor={blockSelection.backgroundColor}
-              activeTextColor={blockSelection.textColor}
-              onSelectBackground={(color) => {
-                editor.commands.setBlockBackgroundColor(color)
-              }}
-              onSelectText={(color) => {
-                editor.commands.setBlockTextColor(color)
-              }}
-            />
+            {/* Marked so the drag-handle outside-click handler does not treat a
+                click on this portaled picker as an outside click and clear the
+                block NodeSelection before the color command runs (LAGO-1671). */}
+            <div data-rte-preserve-selection>
+              <ColorPicker
+                activeBackgroundColor={blockSelection.backgroundColor}
+                activeTextColor={blockSelection.textColor}
+                onSelectBackground={(color) => {
+                  editor.commands.setBlockBackgroundColor(color)
+                }}
+                onSelectText={(color) => {
+                  editor.commands.setBlockTextColor(color)
+                }}
+              />
+            </div>
           </MenuPopper>
         )}
       </Popper>

--- a/src/components/designSystem/RichTextEditor/extensions/DragHandle.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/DragHandle.ts
@@ -202,6 +202,15 @@ export const DragHandle = Extension.create({
         view(editorView) {
           const handleOutsideClick = (event: MouseEvent) => {
             const target = event.target as HTMLElement
+
+            // Editor-owned floating UI (e.g. the block toolbar's color picker)
+            // renders in a Popper portaled to document.body — outside
+            // .rich-text-editor. Clicking it must not count as an outside click,
+            // or the active block NodeSelection would be cleared on mousedown
+            // before the toolbar command runs, so the color is never applied
+            // (LAGO-1671).
+            if (target.closest('[data-rte-preserve-selection]')) return
+
             const editorContainer = editorView.dom.closest('.rich-text-editor')
 
             if (!editorContainer || editorContainer.contains(target)) return

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
@@ -871,6 +871,44 @@ describe('DragHandle', () => {
       })
     })
 
+    describe('WHEN clicking editor UI marked to preserve selection (e.g. a portaled color picker)', () => {
+      it('THEN should keep the block NodeSelection intact', () => {
+        const editor = createEditor('<p>First</p><p>Second</p>')
+        const container = wrapEditorInContainer(editor)
+
+        // Select first block
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+
+        ;(grips[0] as HTMLElement).click()
+
+        expect(editor.state.selection instanceof NodeSelection).toBe(true)
+
+        // The block toolbar's color picker renders in a Popper portaled to
+        // document.body — OUTSIDE .rich-text-editor — but is marked so its
+        // mousedown must not be treated as an outside click that deselects.
+        const popper = document.createElement('div')
+
+        popper.setAttribute('data-rte-preserve-selection', '')
+
+        const swatch = document.createElement('button')
+
+        popper.appendChild(swatch)
+        document.body.appendChild(popper)
+
+        const mousedown = new MouseEvent('mousedown', { bubbles: true })
+
+        swatch.dispatchEvent(mousedown)
+
+        const isStillNodeSelected = editor.state.selection instanceof NodeSelection
+
+        document.body.removeChild(popper)
+        document.body.removeChild(container)
+        editor.destroy()
+
+        expect(isStillNodeSelected).toBe(true)
+      })
+    })
+
     describe('WHEN clicking outside with no block selected', () => {
       it('THEN should not change the selection', () => {
         const editor = createEditor('<p>First</p><p>Second</p>')


### PR DESCRIPTION
## Context

Applying a color to an entire section via the floating **block toolbar** did nothing (the style never appeared, even in the HTML). Selecting *part* of the text and coloring it worked fine.

## Description

This PR fixes the issue. The root cause was that clicking on the color selection block triggered click outside of RTE, closing the block before the color selection was done

Fixes LAGO-1671

🤖 Generated with [Claude Code](https://claude.com/claude-code)