### PR TITLE
refactor(moneyhash): migrate DeleteMoneyhashIntegrationDialog to useCentralizedDialog

### DIFF
--- a/src/components/settings/integrations/AddMoneyhashDialog.tsx
+++ b/src/components/settings/integrations/AddMoneyhashDialog.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { useFormik } from 'formik'
-import { forwardRef, RefObject, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 import { object, string } from 'yup'
 
@@ -21,7 +21,7 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
-import { DeleteMoneyhashIntegrationDialogRef } from './DeleteMoneyhashIntegrationDialog'
+import { useDeleteMoneyhashIntegrationDialog } from './DeleteMoneyhashIntegrationDialog'
 
 gql`
   fragment AddMoneyhashProviderDialog on MoneyhashProvider {
@@ -71,7 +71,6 @@ gql`
 `
 
 type TAddMoneyhashDialogProps = Partial<{
-  deleteModalRef: RefObject<DeleteMoneyhashIntegrationDialogRef>
   provider: AddMoneyhashProviderDialogFragment
   deleteDialogCallback: () => void
 }>
@@ -88,6 +87,7 @@ export const AddMoneyhashDialog = forwardRef<AddMoneyhashDialogRef>((_, ref) => 
   const [localData, setLocalData] = useState<TAddMoneyhashDialogProps | undefined>(undefined)
   const moneyhashProvider = localData?.provider
   const isEdition = !!moneyhashProvider
+  const { openDeleteMoneyhashIntegrationDialog } = useDeleteMoneyhashIntegrationDialog()
 
   const [addApiKey] = useAddMoneyhashApiKeyMutation({
     onCompleted({ addMoneyhashPaymentProvider }) {
@@ -208,9 +208,9 @@ export const AddMoneyhashDialog = forwardRef<AddMoneyhashDialogRef>((_, ref) => 
               variant="quaternary"
               onClick={() => {
                 closeDialog()
-                localData?.deleteModalRef?.current?.openDialog({
+                openDeleteMoneyhashIntegrationDialog({
                   provider: moneyhashProvider,
-                  callback: localData.deleteDialogCallback,
+                  callback: localData?.deleteDialogCallback,
                 })
               }}
             >

--- a/src/components/settings/integrations/DeleteMoneyhashIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteMoneyhashIntegrationDialog.tsx
@@ -1,10 +1,11 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import {
   DeleteMoneyhashIntegrationDialogFragment,
+  GetMoneyhashIntegrationsListDocument,
   useDeleteMoneyhashIntegrationMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -21,63 +22,51 @@ gql`
   }
 `
 
-type TDeleteMoneyhashIntegrationDialogProps = {
+type OpenDeleteMoneyhashIntegrationDialogData = {
   provider: DeleteMoneyhashIntegrationDialogFragment | null
   callback?: () => void
 }
 
-export interface DeleteMoneyhashIntegrationDialogRef {
-  openDialog: ({ provider, callback }: TDeleteMoneyhashIntegrationDialogProps) => unknown
-  closeDialog: () => unknown
-}
+export const useDeleteMoneyhashIntegrationDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+  const client = useApolloClient()
 
-export const DeleteMoneyhashIntegrationDialog = forwardRef<DeleteMoneyhashIntegrationDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
+  const [deleteMoneyhash] = useDeleteMoneyhashIntegrationMutation()
 
-    const dialogRef = useRef<WarningDialogRef>(null)
-    const [localData, setLocalData] = useState<TDeleteMoneyhashIntegrationDialogProps | undefined>(
-      undefined,
-    )
-    const moneyhashProvider = localData?.provider
+  const openDeleteMoneyhashIntegrationDialog = (data: OpenDeleteMoneyhashIntegrationDialogData) => {
+    const provider = data.provider
 
-    const [deleteMoneyhash] = useDeleteMoneyhashIntegrationMutation({
-      onCompleted(data) {
-        if (data && data.destroyPaymentProvider) {
-          dialogRef.current?.closeDialog()
-          localData?.callback?.()
+    centralizedDialog.open({
+      title: translate('text_658461066530343fe1808cd7', { name: provider?.name }),
+      description: translate('text_658461066530343fe1808cc2'),
+      actionText: translate('text_645d071272418a14c1c76a81'),
+      colorVariant: 'danger',
+      onAction: async () => {
+        const res = await deleteMoneyhash({
+          variables: { input: { id: provider?.id as string } },
+        })
+
+        const destroyedId = res.data?.destroyPaymentProvider?.id
+
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'MoneyhashProvider',
+            listFieldName: 'paymentProviders',
+            listQueryDocument: GetMoneyhashIntegrationsListDocument,
+          })
+
+          data.callback?.()
+
           addToast({
             message: translate('text_1737463302046fgixue5wtvu'),
             severity: 'success',
           })
         }
       },
-      update(cache) {
-        cache.evict({ id: `MoneyhashProvider:${moneyhashProvider?.id}` })
-      },
-      refetchQueries: ['getMoneyhashIntegrationsList'],
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setLocalData(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => dialogRef.current?.closeDialog(),
-    }))
-
-    return (
-      <WarningDialog
-        ref={dialogRef}
-        title={translate('text_658461066530343fe1808cd7', { name: moneyhashProvider?.name })}
-        description={translate('text_658461066530343fe1808cc2')}
-        onContinue={async () =>
-          await deleteMoneyhash({ variables: { input: { id: moneyhashProvider?.id as string } } })
-        }
-        continueText={translate('text_645d071272418a14c1c76a81')}
-      />
-    )
-  },
-)
-
-DeleteMoneyhashIntegrationDialog.displayName = 'DeleteMoneyhashIntegrationDialog'
+  return { openDeleteMoneyhashIntegrationDialog }
+}

--- a/src/pages/settings/MoneyhashIntegrationDetails.tsx
+++ b/src/pages/settings/MoneyhashIntegrationDetails.tsx
@@ -16,10 +16,7 @@ import {
   AddMoneyhashDialog,
   AddMoneyhashDialogRef,
 } from '~/components/settings/integrations/AddMoneyhashDialog'
-import {
-  DeleteMoneyhashIntegrationDialog,
-  DeleteMoneyhashIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteMoneyhashIntegrationDialog'
+import { useDeleteMoneyhashIntegrationDialog } from '~/components/settings/integrations/DeleteMoneyhashIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { INTEGRATIONS_ROUTE, MONEYHASH_INTEGRATION_ROUTE, useNavigate } from '~/core/router'
 import {
@@ -71,8 +68,8 @@ const MoneyhashIntegrationDetails = () => {
   const navigate = useNavigate()
   const { integrationId } = useParams()
   const addMoneyhashDialogRef = useRef<AddMoneyhashDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteMoneyhashIntegrationDialogRef>(null)
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
+  const { openDeleteMoneyhashIntegrationDialog } = useDeleteMoneyhashIntegrationDialog()
   const { translate } = useInternationalization()
   const { hasPermissions } = usePermissions()
   const { data, loading } = useGetMoneyhashIntegrationsDetailsQuery({
@@ -139,7 +136,6 @@ const MoneyhashIntegrationDetails = () => {
                   onClick: (closePopper) => {
                     addMoneyhashDialogRef.current?.openDialog({
                       provider: moneyhashPaymentProvider,
-                      deleteModalRef: deleteDialogRef,
                       deleteDialogCallback,
                     })
                     closePopper()
@@ -149,7 +145,7 @@ const MoneyhashIntegrationDetails = () => {
                   label: translate('text_65845f35d7d69c3ab4793dad'),
                   hidden: !canDeleteIntegration,
                   onClick: (closePopper) => {
-                    deleteDialogRef.current?.openDialog({
+                    openDeleteMoneyhashIntegrationDialog({
                       provider: moneyhashPaymentProvider,
                       callback: deleteDialogCallback,
                     })
@@ -173,7 +169,6 @@ const MoneyhashIntegrationDetails = () => {
               onClick={() => {
                 addMoneyhashDialogRef.current?.openDialog({
                   provider: moneyhashPaymentProvider,
-                  deleteModalRef: deleteDialogRef,
                   deleteDialogCallback,
                 })
               }}
@@ -255,7 +250,6 @@ const MoneyhashIntegrationDetails = () => {
         </>
       </section>
       <AddMoneyhashDialog ref={addMoneyhashDialogRef} />
-      <DeleteMoneyhashIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/MoneyhashIntegrations.tsx
+++ b/src/pages/settings/MoneyhashIntegrations.tsx
@@ -15,10 +15,7 @@ import {
   AddMoneyhashDialog,
   AddMoneyhashDialogRef,
 } from '~/components/settings/integrations/AddMoneyhashDialog'
-import {
-  DeleteMoneyhashIntegrationDialog,
-  DeleteMoneyhashIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteMoneyhashIntegrationDialog'
+import { useDeleteMoneyhashIntegrationDialog } from '~/components/settings/integrations/DeleteMoneyhashIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { INTEGRATIONS_ROUTE, MONEYHASH_INTEGRATION_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import {
@@ -61,8 +58,8 @@ const MoneyhashIntegrations = () => {
   const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
   const addMoneyhashDialogRef = useRef<AddMoneyhashDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteMoneyhashIntegrationDialogRef>(null)
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
+  const { openDeleteMoneyhashIntegrationDialog } = useDeleteMoneyhashIntegrationDialog()
   const { translate } = useInternationalization()
   const { data, loading } = useGetMoneyhashIntegrationsListQuery({
     variables: { limit: 1000, type: ProviderTypeEnum.Moneyhash },
@@ -164,7 +161,6 @@ const MoneyhashIntegrations = () => {
                               onClick={() => {
                                 addMoneyhashDialogRef.current?.openDialog({
                                   provider: connection,
-                                  deleteModalRef: deleteDialogRef,
                                   deleteDialogCallback,
                                 })
                                 closePopper()
@@ -180,7 +176,7 @@ const MoneyhashIntegrations = () => {
                               variant="quaternary"
                               align="left"
                               onClick={() => {
-                                deleteDialogRef.current?.openDialog({
+                                openDeleteMoneyhashIntegrationDialog({
                                   provider: connection,
                                   callback: deleteDialogCallback,
                                 })
@@ -200,7 +196,6 @@ const MoneyhashIntegrations = () => {
         </section>
       </IntegrationsPage.Container>
       <AddMoneyhashDialog ref={addMoneyhashDialogRef} />
-      <DeleteMoneyhashIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/__tests__/MoneyhashIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/MoneyhashIntegrations.test.tsx
@@ -14,7 +14,9 @@ jest.mock('~/components/settings/integrations/AddMoneyhashDialog', () => ({
   AddMoneyhashDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteMoneyhashIntegrationDialog', () => ({
-  DeleteMoneyhashIntegrationDialog: () => null,
+  useDeleteMoneyhashIntegrationDialog: () => ({
+    openDeleteMoneyhashIntegrationDialog: jest.fn(),
+  }),
 }))
 jest.mock('~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog', () => ({
   AddEditDeleteSuccessRedirectUrlDialog: () => null,


### PR DESCRIPTION
## Context

`DeleteMoneyhashIntegrationDialog` still relied on the deprecated ref-based `WarningDialog`, which triggered `no-restricted-imports` warnings in every consumer and left cache handling on the pre-`evictFromCache` pattern (bare `cache.evict()` + `refetchQueries`). That combination broadcasts to detail-page watchers and can drive a `cache-and-network` query into a 404 refetch after the entity is destroyed.

## Description

- Rewrite `DeleteMoneyhashIntegrationDialog` as `useDeleteMoneyhashIntegrationDialog`, backed by `useCentralizedDialog` (danger variant).
- Replace `refetchQueries` + inline `cache.evict()` with the `evictFromCache` helper, scoping cache updates to `paymentProviders` / `GetMoneyhashIntegrationsListDocument` and suppressing detail-page watchers to avoid the post-delete 404.
- Update `MoneyhashIntegrations` and `MoneyhashIntegrationDetails` to call the hook directly instead of holding a `WarningDialogRef`.
- Drop the `deleteModalRef` plumbing in `AddMoneyhashDialog`; the edit dialog now consumes the same hook internally and only needs the callback for the post-delete navigation.
- Update the Jest mock for the Moneyhash list page to mock the hook shape.

`AddMoneyhashDialog` itself still uses Formik + the legacy `Dialog` and is intentionally left out of scope to keep the change narrow — those warnings are unchanged by this PR.

<!-- Linear link -->
Fixes LAGO-XXX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hyhgik5JttSpxg4X9DheTW)_