### PR TITLE
refactor(billing-entity): migrate RemoveInvoiceCustomSectionDialog to useCentralizedDialog

### DIFF
--- a/src/pages/settings/BillingEntity/sections/invoice-custom-sections/BillingEntityInvoiceCustomSections.tsx
+++ b/src/pages/settings/BillingEntity/sections/invoice-custom-sections/BillingEntityInvoiceCustomSections.tsx
@@ -22,10 +22,7 @@ import {
   ApplyInvoiceCustomSectionDialog,
   ApplyInvoiceCustomSectionDialogRef,
 } from '~/pages/settings/BillingEntity/sections/invoice-custom-sections/ApplyInvoiceCustomSectionDialog'
-import {
-  RemoveInvoiceCustomSectionDialog,
-  RemoveInvoiceCustomSectionDialogRef,
-} from '~/pages/settings/BillingEntity/sections/invoice-custom-sections/RemoveInvoiceCustomSectionDialog'
+import { useRemoveInvoiceCustomSectionDialog } from '~/pages/settings/BillingEntity/sections/invoice-custom-sections/RemoveInvoiceCustomSectionDialog'
 import ErrorImage from '~/public/images/maneki/error.svg'
 
 const BillingEntityInvoiceCustomSections = () => {
@@ -33,7 +30,7 @@ const BillingEntityInvoiceCustomSections = () => {
   const { translate } = useInternationalization()
 
   const applyInvoiceCustomSectionDialogRef = useRef<ApplyInvoiceCustomSectionDialogRef>(null)
-  const removeInvoiceCustomSectionDialogRef = useRef<RemoveInvoiceCustomSectionDialogRef>(null)
+  const { openRemoveInvoiceCustomSectionDialog } = useRemoveInvoiceCustomSectionDialog()
 
   const { billingEntityCode } = useParams()
 
@@ -154,10 +151,10 @@ const BillingEntityInvoiceCustomSections = () => {
                             variant="quaternary"
                             onClick={() => {
                               if (billingEntity && customSection) {
-                                removeInvoiceCustomSectionDialogRef?.current?.openDialog(
-                                  billingEntity as BillingEntity,
-                                  customSection.id,
-                                )
+                                openRemoveInvoiceCustomSectionDialog({
+                                  billingEntity: billingEntity as BillingEntity,
+                                  invoiceCustomSectionId: customSection.id,
+                                })
                               }
                             }}
                           />
@@ -173,7 +170,6 @@ const BillingEntityInvoiceCustomSections = () => {
       </SettingsPaddedContainer>
 
       <ApplyInvoiceCustomSectionDialog ref={applyInvoiceCustomSectionDialogRef} />
-      <RemoveInvoiceCustomSectionDialog ref={removeInvoiceCustomSectionDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/BillingEntity/sections/invoice-custom-sections/RemoveInvoiceCustomSectionDialog.tsx
+++ b/src/pages/settings/BillingEntity/sections/invoice-custom-sections/RemoveInvoiceCustomSectionDialog.tsx
@@ -1,8 +1,7 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import {
   BillingEntity,
@@ -18,68 +17,52 @@ gql`
   }
 `
 
-export type RemoveInvoiceCustomSectionDialogRef = {
-  openDialog: (billingEntity: BillingEntity, invoiceCustomSectionId: string) => unknown
-  closeDialog: () => unknown
+type RemoveInvoiceCustomSectionDialogArgs = {
+  billingEntity: BillingEntity
+  invoiceCustomSectionId: string
 }
 
-export const RemoveInvoiceCustomSectionDialog = forwardRef<RemoveInvoiceCustomSectionDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
-    const dialogRef = useRef<WarningDialogRef>(null)
+export const useRemoveInvoiceCustomSectionDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
 
-    const [invoiceCustomSectionId, setInvoiceCustomSectionId] = useState<string | null>(null)
-    const [billingEntity, setBillingEntity] = useState<BillingEntity | null>(null)
+  const [removeInvoiceCustomSection] = useRemoveBillingEntityInvoiceCustomSectionMutation({
+    onCompleted(data) {
+      if (data) {
+        addToast({
+          message: translate('text_1749026767605fq828vbnnwr'),
+          severity: 'success',
+        })
+      }
+    },
+    refetchQueries: ['getBillingEntity'],
+  })
 
-    const [removeInvoiceCustomSection] = useRemoveBillingEntityInvoiceCustomSectionMutation({
-      onCompleted(data) {
-        if (data) {
-          addToast({
-            message: translate('text_1749026767605fq828vbnnwr'),
-            severity: 'success',
-          })
-        }
+  const openRemoveInvoiceCustomSectionDialog = ({
+    billingEntity,
+    invoiceCustomSectionId,
+  }: RemoveInvoiceCustomSectionDialogArgs) => {
+    centralizedDialog.open({
+      title: translate('text_1749026767605ghziw4tp647'),
+      description: <Typography>{translate('text_17490267676056wp5w8xz9h5')}</Typography>,
+      colorVariant: 'danger',
+      actionText: translate('text_1749035464124mstmqfrzuvl'),
+      onAction: async () => {
+        await removeInvoiceCustomSection({
+          variables: {
+            input: {
+              id: billingEntity.id,
+              invoiceCustomSectionIds: [
+                ...(billingEntity?.selectedInvoiceCustomSections
+                  ?.filter((s) => s.id !== invoiceCustomSectionId)
+                  .map((s) => s.id) || []),
+              ],
+            },
+          },
+        })
       },
-      refetchQueries: ['getBillingEntity'],
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (_billingEntity, _invoiceCustomSectionId) => {
-        setBillingEntity(_billingEntity)
-        setInvoiceCustomSectionId(_invoiceCustomSectionId)
-
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => {
-        dialogRef.current?.closeDialog()
-      },
-    }))
-
-    return (
-      <WarningDialog
-        ref={dialogRef}
-        title={translate('text_1749026767605ghziw4tp647')}
-        description={<Typography>{translate('text_17490267676056wp5w8xz9h5')}</Typography>}
-        onContinue={async () => {
-          if (billingEntity && invoiceCustomSectionId) {
-            await removeInvoiceCustomSection({
-              variables: {
-                input: {
-                  id: billingEntity.id,
-                  invoiceCustomSectionIds: [
-                    ...(billingEntity?.selectedInvoiceCustomSections
-                      ?.filter((s) => s.id !== invoiceCustomSectionId)
-                      .map((s) => s.id) || []),
-                  ],
-                },
-              },
-            })
-          }
-        }}
-        continueText={translate('text_1749035464124mstmqfrzuvl')}
-      />
-    )
-  },
-)
-
-RemoveInvoiceCustomSectionDialog.displayName = 'RemoveInvoiceCustomSectionDialog'
+  return { openRemoveInvoiceCustomSectionDialog }
+}


### PR DESCRIPTION
## Context

`RemoveInvoiceCustomSectionDialog` was still using the deprecated
`forwardRef`-based `WarningDialog` from the legacy dialog system. The
ESLint rule `no-restricted-imports` flagged it because only hook-style
imports (matching `/^use/u`) are allowed from
`~/components/designSystem/WarningDialog` — that dialog is deprecated in
favor of the new hook-based NiceModal dialog system in
`~/components/dialogs`.

## Description

- Converted `src/pages/settings/BillingEntity/sections/invoice-custom-sections/RemoveInvoiceCustomSectionDialog.tsx`
  from a `forwardRef` component exposing an imperative
  `RemoveInvoiceCustomSectionDialogRef` to a hook-based
  `useRemoveInvoiceCustomSectionDialog` built on top of
  `useCentralizedDialog` from `~/components/dialogs/CentralizedDialog`.
- Kept the existing `removeBillingEntityInvoiceCustomSection` mutation
  as-is (it is an `updateBillingEntity` mutation, not a destroy, so no
  cache eviction is required — the existing
  `refetchQueries: ['getBillingEntity']` still handles the refresh).
- Preserved the confirm wording, translation keys, and switched to the
  `danger` color variant to match the existing warning UX.
- Updated `src/pages/settings/BillingEntity/sections/invoice-custom-sections/BillingEntityInvoiceCustomSections.tsx`
  to consume the new hook: dropped the
  `useRef<RemoveInvoiceCustomSectionDialogRef>`, removed the
  `<RemoveInvoiceCustomSectionDialog ref={...} />` JSX, and now call
  `openRemoveInvoiceCustomSectionDialog({ billingEntity, invoiceCustomSectionId })`
  directly from the row action.

<!-- Linear link -->
Fixes LAGO-XXX


---
_Generated by [Claude Code](https://claude.ai/code/session_01U9H9k6bCXG5ScBPgDxXhES)_