### PR TITLE
fix(quotes): preserve one-off add-on edits on preview toggle

### DIFF
--- a/src/pages/quotes/hooks/__tests__/useOneOffPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useOneOffPricingDrawer.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { ReactNode } from 'react'
 import { z } from 'zod'
 
-import { fromBillingItems } from '~/core/serializers/serializeQuoteBillingItems'
+import { fromBillingItems, toBillingItems } from '~/core/serializers/serializeQuoteBillingItems'
 import { CurrencyEnum } from '~/generated/graphql'
 import { AllTheProviders } from '~/test-utils'
 
@@ -126,6 +126,7 @@ jest.mock('../useSubscriptionPricingDrawer', () => ({
 }))
 
 const mockedFromBillingItems = fromBillingItems as jest.Mock
+const mockedToBillingItems = toBillingItems as jest.Mock
 
 const wrapper = ({ children }: { children: ReactNode }) => (
   <AllTheProviders>{children}</AllTheProviders>
@@ -420,9 +421,13 @@ describe('useOneOffPricingDrawer', () => {
       })
     })
 
-    describe('WHEN all entities are referenced in blocks (with backward-compat entries)', () => {
-      it('THEN should clean up backward-compat keys and return updated billing items', () => {
-        // Hydration creates both localId-keyed and backward-compat catalog-keyed entries
+    describe('WHEN a block references an add-on by localEntityId and the catalog alias also exists in state', () => {
+      it('THEN should treat the add-on as active and return null (the alias is not a real orphan)', () => {
+        // Regression: after a save→refetch, hydration dual-keys state by both
+        // localId and the catalog addOnId. A block still references the add-on
+        // via its localEntityId, so the addOnId alias must NOT be mistaken for a
+        // deleted add-on — otherwise a no-op sync (e.g. on the editor preview
+        // toggle) rebuilds from catalog payloads and wipes the user's overrides.
         mockedFromBillingItems.mockReturnValue({
           entities: {
             'local-uuid-1': {
@@ -462,15 +467,17 @@ describe('useOneOffPricingDrawer', () => {
           syncResult = result.current.syncEntitiesWithBlocks(blocks)
         })
 
-        // Backward-compat key 'addon-1' was orphaned and cleaned up
-        expect(syncResult).not.toBeNull()
+        // No genuine deletion → no save, and both keys are retained (the alias
+        // is still needed to resolve legacy blocks that reference the catalog id)
+        expect(syncResult).toBeNull()
+        expect(mockedToBillingItems).not.toHaveBeenCalled()
         expect(result.current.entities).toHaveProperty('local-uuid-1')
-        expect(result.current.entities).not.toHaveProperty('addon-1')
+        expect(result.current.entities).toHaveProperty('addon-1')
       })
     })
 
-    describe('WHEN some entities are not referenced in blocks', () => {
-      it('THEN should remove orphaned entities and return updated billing items', () => {
+    describe('WHEN a block has been deleted so one add-on is no longer referenced', () => {
+      it('THEN should remove the orphaned add-on and rebuild survivors via toBillingItems (preserving overrides)', () => {
         const secondPayload = {
           ...mockAddOnPayload,
           position: 2,
@@ -485,6 +492,9 @@ describe('useOneOffPricingDrawer', () => {
               entityType: 'addOn',
               name: 'Setup Fee',
               code: 'setup',
+              units: '2',
+              unitAmountCents: '2000',
+              totalAmount: '4000',
             },
             'local-uuid-2': {
               entityId: 'local-uuid-2',
@@ -507,6 +517,20 @@ describe('useOneOffPricingDrawer', () => {
             },
           ],
         })
+
+        const rebuilt = {
+          addons: [
+            {
+              type: 'addon' as const,
+              id: 'addon-1',
+              localId: 'local-uuid-1',
+              payload: mockAddOnPayload,
+              overrides: { units: 2, unit_amount_cents: 2000, total_amount_cents: 4000 },
+            },
+          ],
+        }
+
+        mockedToBillingItems.mockReturnValueOnce(rebuilt)
 
         const billingItemsWithTwo = {
           addons: [
@@ -544,17 +568,27 @@ describe('useOneOffPricingDrawer', () => {
           syncResult = result.current.syncEntitiesWithBlocks(blocks)
         })
 
-        expect(syncResult).not.toBeNull()
+        // Survivors are rebuilt through toBillingItems so overrides are preserved
+        expect(syncResult).toBe(rebuilt)
+        expect(mockedToBillingItems).toHaveBeenCalledTimes(1)
 
-        const payload = syncResult as { addons: Array<{ id: string }> }
+        const [survivingItems] = mockedToBillingItems.mock.calls[0]
 
-        // Only local-uuid-1 should remain
-        expect(payload.addons).toHaveLength(1)
-        expect(payload.addons[0].id).toBe('local-uuid-1')
+        // Only the surviving add-on is passed, carrying its localId + catalog addOnId
+        // and its edited values (not catalog defaults)
+        expect(survivingItems).toHaveLength(1)
+        expect(survivingItems[0]).toMatchObject({
+          localId: 'local-uuid-1',
+          addOnId: 'addon-1',
+          units: '2',
+          unitAmountCents: '2000',
+          totalAmount: '4000',
+        })
 
-        // Entities should no longer include local-uuid-2
+        // Orphaned add-on removed from state, including its backward-compat alias
         expect(result.current.entities).toHaveProperty('local-uuid-1')
         expect(result.current.entities).not.toHaveProperty('local-uuid-2')
+        expect(result.current.entities).not.toHaveProperty('addon-2')
       })
     })
 

--- a/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
@@ -9,7 +9,10 @@ import type {
   OnPricingCommand,
 } from '~/components/designSystem/RichTextEditor/common/RichTextEditorContext'
 import type { PricingBlockAttributes } from '~/components/designSystem/RichTextEditor/extensions/PricingBlock.schema'
-import { pricingDrawerDefaultValues } from '~/components/designSystem/RichTextEditor/PricingBlock/constants'
+import {
+  type AddOnItem,
+  pricingDrawerDefaultValues,
+} from '~/components/designSystem/RichTextEditor/PricingBlock/constants'
 import PricingDrawerContent from '~/components/designSystem/RichTextEditor/PricingBlock/PricingDrawerContent'
 import { useFormDrawer } from '~/components/drawers/useDrawer'
 import {
@@ -289,38 +292,69 @@ export const useOneOffPricingDrawer = (
 
   const syncEntitiesWithBlocks = useCallback(
     (blocks: PricingBlockAttributes[]): BillingItemsPayload | null => {
-      const activeEntityIds = new Set(
+      // Blocks reference add-ons by localEntityIds (preferred) or legacy catalog entityIds.
+      const activeRefIds = new Set(
         blocks.flatMap((b) => (b.localEntityIds?.length ? b.localEntityIds : b.entityIds)),
       )
 
-      const currentKeys = Object.keys(entitiesRef.current)
-      const orphanedKeys = currentKeys.filter((id) => !activeEntityIds.has(id))
+      // Add-ons are canonically identified by their localId; the catalog addOnId
+      // kept in entities/payloads is only a backward-compat alias (so legacy
+      // blocks referencing the catalog id still resolve). An add-on survives if a
+      // block references it by either its localId or its catalog alias — treating
+      // the alias as its own orphan would wrongly prune add-ons on a no-op sync
+      // (e.g. the editor's preview toggle, which fires an update).
+      const allLocalIds = Object.keys(catalogIdMapRef.current)
+      const removedLocalIds = allLocalIds.filter(
+        (localId) =>
+          !activeRefIds.has(localId) && !activeRefIds.has(catalogIdMapRef.current[localId]),
+      )
 
-      if (orphanedKeys.length === 0) return null
+      if (removedLocalIds.length === 0) return null
 
+      // Prune the deleted add-ons (and their alias keys) from local state.
       const updatedEntities = { ...entitiesRef.current }
       const updatedPayloads = { ...payloadsRef.current }
 
-      for (const key of orphanedKeys) {
-        delete updatedEntities[key]
-        delete updatedPayloads[key]
+      for (const localId of removedLocalIds) {
+        const addOnId = catalogIdMapRef.current[localId]
+
+        delete updatedEntities[localId]
+        delete updatedEntities[addOnId]
+        delete updatedPayloads[localId]
+        delete updatedPayloads[addOnId]
+        delete catalogIdMapRef.current[localId]
       }
 
       entitiesRef.current = updatedEntities
       payloadsRef.current = updatedPayloads
       setEntities(updatedEntities)
 
-      // Rebuild billing items from remaining payloads
-      const remainingIds = Object.keys(updatedPayloads)
+      // Rebuild the surviving billing items through toBillingItems so the user's
+      // overrides (units, unit price, dates, names) are preserved — rebuilding
+      // straight from the catalog payloads would reset them to catalog defaults.
+      const survivingItems: AddOnItem[] = Object.keys(catalogIdMapRef.current)
+        .map((localId): AddOnItem | null => {
+          const entity = updatedEntities[localId]
 
-      return {
-        addons: remainingIds.map((id, i) => ({
-          type: 'addon' as const,
-          id,
-          payload: { ...updatedPayloads[id], position: i + 1 },
-          overrides: {},
-        })),
-      }
+          if (!entity) return null
+
+          return {
+            localId,
+            addOnId: catalogIdMapRef.current[localId],
+            name: entity.name,
+            invoiceDisplayName: entity.invoiceDisplayName ?? '',
+            code: entity.code,
+            description: entity.description ?? '',
+            units: entity.units ?? '',
+            unitAmountCents: entity.unitAmountCents ?? '',
+            totalAmount: entity.totalAmount ?? '',
+            fromDatetime: entity.fromDatetime ?? '',
+            toDatetime: entity.toDatetime ?? '',
+          }
+        })
+        .filter((item): item is AddOnItem => item !== null)
+
+      return toBillingItems(survivingItems, payloadsRef.current)
     },
     [],
   )


### PR DESCRIPTION
## Problem

On a one-off quote, editing an add-on and then toggling the editor **preview** reverted the add-on's units/price to catalog defaults — and persisted the reverted values.

Repro:
1. Open the edit flow on a one-off quote → `/pricing` → add an add-on, set units `2`, price `2000` (invoice = `4000`).
2. `PricingBlockView` correctly shows `4000`.
3. Click **preview** → the row switches to catalog `1 × 10000`.
4. Back in edit mode, the block now shows the catalog values (the revert was saved).

## Root cause

TipTap fires `onUpdate` on mode/preview switches (not just real edits), which runs `syncEntitiesWithBlocks` and, if it returns non-null, `savePricingBlock` persists the result.

After a save→`refetchQuote`, the hydrate effect **dual-keys** each add-on in `entitiesRef`/`payloadsRef` by both its `localId` and the catalog `addOnId` (a backward-compat alias so legacy blocks referencing the catalog id still resolve). The old orphan check compared raw `Object.keys(entitiesRef)` against the block's references, so the `addOnId` alias always looked orphaned — even when nothing was deleted. That false positive triggered a rebuild that re-emitted survivors from bare catalog payloads with `overrides: {}` (and the wrong `id`), wiping the user's edits.

## Fix

- Key orphan detection on `catalogIdMapRef` — the `localId` is the canonical identity. An add-on survives if a block references **either** its `localId` or its catalog alias, so the preview toggle no longer prunes anything.
- On a **genuine** block deletion, rebuild survivors through the existing `toBillingItems(...)` so overrides are preserved and the correct catalog `id` is emitted.

The subscription-quote drawer is unaffected (single-keyed by `planId`; returns `null` on the preview toggle).

## Tests

- `useOneOffPricingDrawer` suite updated — two tests had codified the buggy behavior (expected a save on a no-op sync; `id = localId`); corrected to assert the right contract and added override-preservation assertions. **29/29 pass.**
- `EditQuote` + serializer suites: 48/48. Wider pricing suites: 174/174.
- `tsc`, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)