### PR TITLE
refactor(tax-management): migrate LagoTaxManagementIntegration WarningDialog to useCentralizedDialog

### DIFF
--- a/src/pages/settings/LagoTaxManagementIntegration.tsx
+++ b/src/pages/settings/LagoTaxManagementIntegration.tsx
@@ -6,9 +6,8 @@ import { generatePath } from 'react-router-dom'
 import { Avatar } from '~/components/designSystem/Avatar'
 import { Button } from '~/components/designSystem/Button'
 import { Chip } from '~/components/designSystem/Chip'
-import { DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { IntegrationsPage } from '~/components/layouts/Integrations'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import {
@@ -76,7 +75,7 @@ const LagoTaxManagementIntegration = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
   const { hasPermissions } = usePermissions()
-  const deleteConnectionRef = useRef<DialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const addLagoTaxManagementDialog = useRef<AddLagoTaxManagementDialogRef>(null)
 
   const { data: billingEntitiesData, loading: billingEntitiesLoading } =
@@ -156,7 +155,13 @@ const LagoTaxManagementIntegration = () => {
               disabled: loading,
               dataTest: LAGO_TAX_MANAGEMENT_REMOVE_BUTTON_TEST_ID,
               onClick: () => {
-                deleteConnectionRef.current?.openDialog()
+                centralizedDialog.open({
+                  title: translate('text_657078c28394d6b1ae1b9707'),
+                  description: translate('text_657078c28394d6b1ae1b970d'),
+                  actionText: translate('text_657078c28394d6b1ae1b971b'),
+                  colorVariant: 'danger',
+                  onAction: removeEuTaxManagement,
+                })
               },
             },
           ],
@@ -245,14 +250,6 @@ const LagoTaxManagementIntegration = () => {
       </IntegrationsPage.Container>
 
       <AddLagoTaxManagementDialog isUpdate={true} ref={addLagoTaxManagementDialog} />
-
-      <WarningDialog
-        ref={deleteConnectionRef}
-        title={translate('text_657078c28394d6b1ae1b9707')}
-        description={translate('text_657078c28394d6b1ae1b970d')}
-        continueText={translate('text_657078c28394d6b1ae1b971b')}
-        onContinue={removeEuTaxManagement}
-      />
     </>
   )
 }

--- a/src/pages/settings/__tests__/LagoTaxManagementIntegration.test.tsx
+++ b/src/pages/settings/__tests__/LagoTaxManagementIntegration.test.tsx
@@ -1,8 +1,12 @@
+import NiceModal from '@ebay/nice-modal-react'
 import { act, cleanup, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { useEffect, useReducer } from 'react'
 
-import { WARNING_DIALOG_CONFIRM_BUTTON_TEST_ID } from '~/components/designSystem/WarningDialog'
+import CentralizedDialog from '~/components/dialogs/CentralizedDialog'
+import {
+  CENTRALIZED_DIALOG_CONFIRM_BUTTON_TEST_ID,
+  CENTRALIZED_DIALOG_NAME,
+} from '~/components/dialogs/const'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { CountryCode } from '~/generated/graphql'
 import { render } from '~/test-utils'
@@ -68,24 +72,14 @@ jest.mock('~/generated/graphql', () => ({
   useUpdateBillingEntityMutation: jest.fn(() => [mockUpdate]),
 }))
 
-// The remove button captures deleteConnectionRef.current at render time.
-// Refs are set after the commit phase, so a second render is needed
-// for the onClick handler to capture the populated ref.
-// This wrapper forces a re-render after mount to solve the issue.
-const PageWithRefCapture = () => {
-  const [, forceUpdate] = useReducer((x: number) => x + 1, 0)
+NiceModal.register(CENTRALIZED_DIALOG_NAME, CentralizedDialog)
 
-  useEffect(() => {
-    forceUpdate()
-  }, [])
-
-  return (
-    <>
-      <MainHeader />
-      <LagoTaxManagementIntegration />
-    </>
-  )
-}
+const Page = () => (
+  <NiceModal.Provider>
+    <MainHeader />
+    <LagoTaxManagementIntegration />
+  </NiceModal.Provider>
+)
 
 describe('LagoTaxManagementIntegration', () => {
   beforeEach(() => {
@@ -96,7 +90,7 @@ describe('LagoTaxManagementIntegration', () => {
 
   const renderPage = async () => {
     await act(async () => {
-      render(<PageWithRefCapture />)
+      render(<Page />)
     })
   }
 
@@ -128,7 +122,7 @@ describe('LagoTaxManagementIntegration', () => {
 
         await user.click(removeButton)
 
-        const confirmButton = await screen.findByTestId(WARNING_DIALOG_CONFIRM_BUTTON_TEST_ID)
+        const confirmButton = await screen.findByTestId(CENTRALIZED_DIALOG_CONFIRM_BUTTON_TEST_ID)
 
         await user.click(confirmButton)
 
@@ -152,7 +146,7 @@ describe('LagoTaxManagementIntegration', () => {
 
         await user.click(removeButton)
 
-        const confirmButton = await screen.findByTestId(WARNING_DIALOG_CONFIRM_BUTTON_TEST_ID)
+        const confirmButton = await screen.findByTestId(CENTRALIZED_DIALOG_CONFIRM_BUTTON_TEST_ID)
 
         await user.click(confirmButton)
 
@@ -178,7 +172,7 @@ describe('LagoTaxManagementIntegration', () => {
 
         await user.click(removeButton)
 
-        const confirmButton = await screen.findByTestId(WARNING_DIALOG_CONFIRM_BUTTON_TEST_ID)
+        const confirmButton = await screen.findByTestId(CENTRALIZED_DIALOG_CONFIRM_BUTTON_TEST_ID)
 
         await user.click(confirmButton)
 
@@ -200,7 +194,7 @@ describe('LagoTaxManagementIntegration', () => {
 
         await user.click(removeButton)
 
-        const confirmButton = await screen.findByTestId(WARNING_DIALOG_CONFIRM_BUTTON_TEST_ID)
+        const confirmButton = await screen.findByTestId(CENTRALIZED_DIALOG_CONFIRM_BUTTON_TEST_ID)
 
         await user.click(confirmButton)
 


### PR DESCRIPTION
## Context

The `WarningDialog` component from `~/components/designSystem/WarningDialog` is deprecated in favor of the new NiceModal-based dialog system in `~/components/dialogs`. ESLint flags remaining usages as `no-restricted-imports` warnings.

## Description

Migrated the "Remove EU tax management" confirmation dialog on the Lago Tax Management integration page from the legacy imperative ref-based `WarningDialog` to the hook-based `useCentralizedDialog` with `colorVariant: 'danger'`.

- `src/pages/settings/LagoTaxManagementIntegration.tsx`
  - Replaced the `WarningDialog` JSX + `deleteConnectionRef` with an inline `centralizedDialog.open({...})` call triggered from the "Remove connection" button's `onClick`.
  - Dropped the now-unused `WarningDialog`, `DialogRef` imports.
  - `removeEuTaxManagement` is now used as the `onAction` callback (dialog auto-closes on success/cancel).
- `src/pages/settings/__tests__/LagoTaxManagementIntegration.test.tsx`
  - Registered `CentralizedDialog` with `NiceModal` and wrapped the test tree in `NiceModal.Provider`.
  - Swapped `WARNING_DIALOG_CONFIRM_BUTTON_TEST_ID` for `CENTRALIZED_DIALOG_CONFIRM_BUTTON_TEST_ID`.
  - Removed the `PageWithRefCapture` `useReducer`+`useEffect` workaround (no longer needed — the hook-based dialog has no ref-timing issue).
  - All 5 existing test cases still pass.

Scope is limited to the `WarningDialog` warning in this file. The remaining `AddLagoTaxManagementDialog` import warning on the same page is a separate legacy dialog and left untouched.

<!-- Linear link -->
Fixes LAGO-XXX