### PR TITLE
refactor(customers): migrate DeleteCustomerDocumentLocaleDialog to useCentralizedDialog

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -2,10 +2,7 @@ import { gql } from '@apollo/client'
 import { Icon } from 'lago-design-system'
 import { useMemo, useRef } from 'react'
 
-import {
-  DeleteCustomerDocumentLocaleDialog,
-  DeleteCustomerDocumentLocaleDialogRef,
-} from '~/components/customers/DeleteCustomerDocumentLocaleDialog'
+import { useDeleteCustomerDocumentLocaleDialog } from '~/components/customers/DeleteCustomerDocumentLocaleDialog'
 import {
   DeleteCustomerFinalizeZeroAmountInvoiceDialog,
   DeleteCustomerFinalizeZeroAmountInvoiceDialogRef,
@@ -220,7 +217,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
   const editCustomerDunningCampaignDialogRef = useRef<EditCustomerDunningCampaignDialogRef>(null)
   const editCustomerInvoiceCustomSectionsDialogRef =
     useRef<EditCustomerInvoiceCustomSectionsDialogRef>(null)
-  const deleteCustomerDocumentLocale = useRef<DeleteCustomerDocumentLocaleDialogRef>(null)
+  const { openDeleteCustomerDocumentLocaleDialog } = useDeleteCustomerDocumentLocaleDialog()
   const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const editNetPaymentTermDialogRef = useRef<EditNetPaymentTermDialogRef>(null)
   const deleteOrganizationNetPaymentTermDialogRef =
@@ -459,7 +456,9 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                                   variant="quaternary"
                                   align="left"
                                   onClick={() => {
-                                    deleteCustomerDocumentLocale.current?.openDialog()
+                                    if (customer) {
+                                      openDeleteCustomerDocumentLocaleDialog(customer)
+                                    }
                                     closePopper()
                                   }}
                                 >
@@ -965,10 +964,6 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
             customerId={customerId}
           />
           <DeleteCustomerGracePeriodeDialog ref={deleteGracePeriodDialogRef} customer={customer} />
-          <DeleteCustomerDocumentLocaleDialog
-            ref={deleteCustomerDocumentLocale}
-            customer={customer}
-          />
           <EditNetPaymentTermDialog
             ref={editNetPaymentTermDialogRef}
             description={translate('text_64c7a89b6c67eb6c988980eb')}

--- a/src/components/customers/DeleteCustomerDocumentLocaleDialog.tsx
+++ b/src/components/customers/DeleteCustomerDocumentLocaleDialog.tsx
@@ -1,9 +1,7 @@
 import { gql } from '@apollo/client'
-import { forwardRef } from 'react'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import {
   DeleteCustomerDocumentLocaleFragment,
@@ -30,17 +28,10 @@ gql`
   }
 `
 
-export type DeleteCustomerDocumentLocaleDialogRef = WarningDialogRef
+export const useDeleteCustomerDocumentLocaleDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
 
-interface DeleteCustomerDocumentLocaleDialogProps {
-  customer: DeleteCustomerDocumentLocaleFragment
-}
-
-export const DeleteCustomerDocumentLocaleDialog = forwardRef<
-  DialogRef,
-  DeleteCustomerDocumentLocaleDialogProps
->(({ customer }: DeleteCustomerDocumentLocaleDialogProps, ref) => {
-  const customerName = customer?.displayName
   const [deleteCustomerDocumentLocale] = useDeleteCustomerDocumentLocaleMutation({
     onCompleted(data) {
       if (data && data.updateCustomer) {
@@ -51,20 +42,22 @@ export const DeleteCustomerDocumentLocaleDialog = forwardRef<
       }
     },
   })
-  const { translate } = useInternationalization()
 
-  return (
-    <WarningDialog
-      ref={ref}
-      title={translate('text_63ea0f84f400488553caa68a')}
-      description={
+  const openDeleteCustomerDocumentLocaleDialog = (
+    customer: DeleteCustomerDocumentLocaleFragment,
+  ) => {
+    centralizedDialog.open({
+      title: translate('text_63ea0f84f400488553caa68a'),
+      description: (
         <Typography
           html={translate('text_63ea0f84f400488553caa691', {
-            customerName,
+            customerName: customer.displayName,
           })}
         />
-      }
-      onContinue={async () =>
+      ),
+      colorVariant: 'danger',
+      actionText: translate('text_63ea0f84f400488553caa697'),
+      onAction: async () => {
         await deleteCustomerDocumentLocale({
           variables: {
             input: {
@@ -77,10 +70,9 @@ export const DeleteCustomerDocumentLocaleDialog = forwardRef<
             },
           },
         })
-      }
-      continueText={translate('text_63ea0f84f400488553caa697')}
-    />
-  )
-})
+      },
+    })
+  }
 
-DeleteCustomerDocumentLocaleDialog.displayName = 'DeleteCustomerDocumentLocaleDialog'
+  return { openDeleteCustomerDocumentLocaleDialog }
+}

--- a/src/components/customers/__tests__/CustomerSettings.test.tsx
+++ b/src/components/customers/__tests__/CustomerSettings.test.tsx
@@ -62,13 +62,11 @@ jest.mock('~/components/customers/EditCustomerDocumentLocaleDialog', () => ({
   }),
 }))
 
-jest.mock('~/components/customers/DeleteCustomerDocumentLocaleDialog', () => {
-  const React = jest.requireActual('react')
-  const MockDialog = React.forwardRef(() => null)
-
-  MockDialog.displayName = 'DeleteCustomerDocumentLocaleDialog'
-  return { DeleteCustomerDocumentLocaleDialog: MockDialog }
-})
+jest.mock('~/components/customers/DeleteCustomerDocumentLocaleDialog', () => ({
+  useDeleteCustomerDocumentLocaleDialog: () => ({
+    openDeleteCustomerDocumentLocaleDialog: jest.fn(),
+  }),
+}))
 
 jest.mock('~/components/customers/EditCustomerVatRateDialog', () => {
   const React = jest.requireActual('react')


### PR DESCRIPTION
## Context

`DeleteCustomerDocumentLocaleDialog` was still built on the legacy imperative `WarningDialog` component (`forwardRef` + `useImperativeHandle` + `WarningDialogRef`), which is deprecated. The ESLint rule `no-restricted-imports` flags each usage with a warning pointing to the new hook-based dialog system in `~/components/dialogs`.

## Description

Migrated the dialog to the new hook-based centralized dialog system.

- Rewrote `src/components/customers/DeleteCustomerDocumentLocaleDialog.tsx` as a `useDeleteCustomerDocumentLocaleDialog` hook backed by `useCentralizedDialog`, keeping the same mutation, GraphQL fragment, translations, danger color variant, and success toast behavior.
- Removed the exported `DeleteCustomerDocumentLocaleDialogRef` type, the `forwardRef` wrapper, and the `WarningDialog` / `WarningDialogRef` / `DialogRef` imports.
- Updated `src/components/customers/CustomerSettings.tsx` to consume the hook instead of the ref-based component:
  - Replaced the `useRef<DeleteCustomerDocumentLocaleDialogRef>` and the JSX-rendered `<DeleteCustomerDocumentLocaleDialog />` with a call to `openDeleteCustomerDocumentLocaleDialog(customer)` from the trash-menu action.
  - Passed the current `customer` through the hook's `open` function (guarded by `if (customer)` in line with sibling call sites).
- Updated `src/components/customers/__tests__/CustomerSettings.test.tsx` to mock the new hook (`useDeleteCustomerDocumentLocaleDialog`) instead of the removed `forwardRef` component. All 33 tests in this suite pass.

The scope is intentionally limited to this single warning — the other legacy dialogs still referenced from `CustomerSettings.tsx` will be migrated separately to keep the PR small and easy to review.

## Test plan

- `pnpm types` passes.
- `pnpm eslint` no longer reports the `DeleteCustomerDocumentLocaleDialog` / `DeleteCustomerDocumentLocaleDialogRef` warnings for this file.
- `pnpm test -- src/components/customers/__tests__/CustomerSettings.test.tsx` passes (33/33).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QJr4Xj8vo9vfz4RFupj9qf)_