### PR TITLE
refactor(gocardless): migrate DeleteGocardlessIntegrationDialog to useCentralizedDialog

### DIFF
--- a/src/components/settings/integrations/AddGocardlessDialog.tsx
+++ b/src/components/settings/integrations/AddGocardlessDialog.tsx
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 import Stack from '@mui/material/Stack'
 import { useFormik } from 'formik'
-import { forwardRef, RefObject, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 import { object, string } from 'yup'
 
@@ -22,7 +22,7 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
-import { DeleteGocardlessIntegrationDialogRef } from './DeleteGocardlessIntegrationDialog'
+import { useDeleteGocardlessIntegrationDialog } from './DeleteGocardlessIntegrationDialog'
 
 gql`
   fragment AddGocardlessProviderDialog on GocardlessProvider {
@@ -66,7 +66,6 @@ gql`
 `
 
 type TAddGocardlessDialogProps = Partial<{
-  deleteModalRef: RefObject<DeleteGocardlessIntegrationDialogRef>
   provider: AddGocardlessProviderDialogFragment
   deleteDialogCallback: () => void
 }>
@@ -85,6 +84,7 @@ export const AddGocardlessDialog = forwardRef<AddGocardlessDialogRef>((_, ref) =
   const [localData, setLocalData] = useState<TAddGocardlessDialogProps | undefined>(undefined)
   const gocardlessProvider = localData?.provider
   const isEdition = !!gocardlessProvider
+  const { openDeleteGocardlessIntegrationDialog } = useDeleteGocardlessIntegrationDialog()
 
   const [updateApiKey] = useUpdateGocardlessApiKeyMutation({
     onCompleted({ updateGocardlessPaymentProvider }) {
@@ -206,7 +206,7 @@ export const AddGocardlessDialog = forwardRef<AddGocardlessDialogRef>((_, ref) =
               variant="quaternary"
               onClick={() => {
                 closeDialog()
-                localData?.deleteModalRef?.current?.openDialog({
+                openDeleteGocardlessIntegrationDialog({
                   provider: gocardlessProvider,
                   callback: localData?.deleteDialogCallback,
                 })

--- a/src/components/settings/integrations/DeleteGocardlessIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteGocardlessIntegrationDialog.tsx
@@ -1,10 +1,11 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import {
   DeleteGocardlessIntegrationDialogFragment,
+  GetGocardlessIntegrationsListDocument,
   useDeleteGocardlessMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -22,65 +23,53 @@ gql`
   }
 `
 
-type TDeleteGocardlessIntegrationDialogProps = {
+type OpenDeleteGocardlessIntegrationDialogData = {
   provider: DeleteGocardlessIntegrationDialogFragment | null
   callback?: () => void
 }
 
-export interface DeleteGocardlessIntegrationDialogRef {
-  openDialog: ({ provider, callback }: TDeleteGocardlessIntegrationDialogProps) => unknown
-  closeDialog: () => unknown
-}
+export const useDeleteGocardlessIntegrationDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+  const client = useApolloClient()
 
-export const DeleteGocardlessIntegrationDialog = forwardRef<DeleteGocardlessIntegrationDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
+  const [deleteGocardless] = useDeleteGocardlessMutation()
 
-    const dialogRef = useRef<WarningDialogRef>(null)
-    const [localData, setLocalData] = useState<TDeleteGocardlessIntegrationDialogProps | undefined>(
-      undefined,
-    )
+  const openDeleteGocardlessIntegrationDialog = (
+    data: OpenDeleteGocardlessIntegrationDialogData,
+  ) => {
+    const provider = data.provider
 
-    const gocardlessProvider = localData?.provider
+    centralizedDialog.open({
+      title: translate('text_658461066530343fe1808cd7', { name: provider?.name }),
+      description: translate('text_65846181a741a1401ecdddb7'),
+      actionText: translate('text_659d5de7c9b7f51394f7f3fd'),
+      colorVariant: 'danger',
+      onAction: async () => {
+        const res = await deleteGocardless({
+          variables: { input: { id: provider?.id as string } },
+        })
 
-    const [deleteGocardless] = useDeleteGocardlessMutation({
-      onCompleted(data) {
-        if (data && data.destroyPaymentProvider) {
-          dialogRef.current?.closeDialog()
-          localData?.callback?.()
+        const destroyedId = res.data?.destroyPaymentProvider?.id
+
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'GocardlessProvider',
+            listFieldName: 'paymentProviders',
+            listQueryDocument: GetGocardlessIntegrationsListDocument,
+          })
+
+          data.callback?.()
+
           addToast({
             message: translate('text_62b1edddbf5f461ab9712758'),
             severity: 'success',
           })
         }
       },
-      update(cache) {
-        cache.evict({ id: `GocardlessProvider:${gocardlessProvider?.id}` })
-      },
-      refetchQueries: ['getGocardlessIntegrationsList'],
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setLocalData(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => dialogRef.current?.closeDialog(),
-    }))
-
-    return (
-      <WarningDialog
-        mode="danger"
-        ref={dialogRef}
-        title={translate('text_658461066530343fe1808cd7', { name: gocardlessProvider?.name })}
-        description={translate('text_65846181a741a1401ecdddb7')}
-        onContinue={async () =>
-          await deleteGocardless({ variables: { input: { id: gocardlessProvider?.id as string } } })
-        }
-        continueText={translate('text_659d5de7c9b7f51394f7f3fd')}
-      />
-    )
-  },
-)
-
-DeleteGocardlessIntegrationDialog.displayName = 'DeleteGocardlessIntegrationDialog'
+  return { openDeleteGocardlessIntegrationDialog }
+}

--- a/src/pages/settings/GocardlessIntegrationDetails.tsx
+++ b/src/pages/settings/GocardlessIntegrationDetails.tsx
@@ -18,10 +18,7 @@ import {
   AddGocardlessDialog,
   AddGocardlessDialogRef,
 } from '~/components/settings/integrations/AddGocardlessDialog'
-import {
-  DeleteGocardlessIntegrationDialog,
-  DeleteGocardlessIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteGocardlessIntegrationDialog'
+import { useDeleteGocardlessIntegrationDialog } from '~/components/settings/integrations/DeleteGocardlessIntegrationDialog'
 import { addToast, envGlobalVar } from '~/core/apolloClient'
 import { buildGocardlessAuthUrl } from '~/core/constants/externalUrls'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
@@ -79,7 +76,7 @@ const GocardlessIntegrationDetails = () => {
   const { lagoOauthProxyUrl } = envGlobalVar()
   const { hasPermissions } = usePermissions()
   const addDialogRef = useRef<AddGocardlessDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteGocardlessIntegrationDialogRef>(null)
+  const { openDeleteGocardlessIntegrationDialog } = useDeleteGocardlessIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
   const { data, loading } = useGetGocardlessIntegrationsDetailsQuery({
@@ -150,7 +147,6 @@ const GocardlessIntegrationDetails = () => {
                   onClick: (closePopper) => {
                     addDialogRef.current?.openDialog({
                       provider: gocardlessPaymentProvider,
-                      deleteModalRef: deleteDialogRef,
                       deleteDialogCallback,
                     })
                     closePopper()
@@ -185,7 +181,7 @@ const GocardlessIntegrationDetails = () => {
                   label: translate('text_65845f35d7d69c3ab4793dad'),
                   hidden: !canDeleteIntegration,
                   onClick: (closePopper) => {
-                    deleteDialogRef.current?.openDialog({
+                    openDeleteGocardlessIntegrationDialog({
                       provider: gocardlessPaymentProvider,
                       callback: deleteDialogCallback,
                     })
@@ -209,7 +205,6 @@ const GocardlessIntegrationDetails = () => {
                 onClick={() => {
                   addDialogRef.current?.openDialog({
                     provider: gocardlessPaymentProvider,
-                    deleteModalRef: deleteDialogRef,
                     deleteDialogCallback,
                   })
                 }}
@@ -370,7 +365,6 @@ const GocardlessIntegrationDetails = () => {
         </section>
       </IntegrationsPage.Container>
       <AddGocardlessDialog ref={addDialogRef} />
-      <DeleteGocardlessIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </div>
   )

--- a/src/pages/settings/GocardlessIntegrations.tsx
+++ b/src/pages/settings/GocardlessIntegrations.tsx
@@ -15,10 +15,7 @@ import {
   AddGocardlessDialog,
   AddGocardlessDialogRef,
 } from '~/components/settings/integrations/AddGocardlessDialog'
-import {
-  DeleteGocardlessIntegrationDialog,
-  DeleteGocardlessIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteGocardlessIntegrationDialog'
+import { useDeleteGocardlessIntegrationDialog } from '~/components/settings/integrations/DeleteGocardlessIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import {
   GOCARDLESS_INTEGRATION_DETAILS_ROUTE,
@@ -67,7 +64,7 @@ const GocardlessIntegrations = () => {
   const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
   const addGocardlessDialogRef = useRef<AddGocardlessDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteGocardlessIntegrationDialogRef>(null)
+  const { openDeleteGocardlessIntegrationDialog } = useDeleteGocardlessIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
   const { data, loading } = useGetGocardlessIntegrationsListQuery({
@@ -171,7 +168,6 @@ const GocardlessIntegrations = () => {
                               onClick={() => {
                                 addGocardlessDialogRef.current?.openDialog({
                                   provider: connection,
-                                  deleteModalRef: deleteDialogRef,
                                   deleteDialogCallback,
                                 })
                                 closePopper()
@@ -187,7 +183,7 @@ const GocardlessIntegrations = () => {
                               variant="quaternary"
                               align="left"
                               onClick={() => {
-                                deleteDialogRef.current?.openDialog({
+                                openDeleteGocardlessIntegrationDialog({
                                   provider: connection,
                                   callback: deleteDialogCallback,
                                 })
@@ -208,7 +204,6 @@ const GocardlessIntegrations = () => {
       </IntegrationsPage.Container>
 
       <AddGocardlessDialog ref={addGocardlessDialogRef} />
-      <DeleteGocardlessIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/__tests__/GocardlessIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/GocardlessIntegrations.test.tsx
@@ -14,7 +14,9 @@ jest.mock('~/components/settings/integrations/AddGocardlessDialog', () => ({
   AddGocardlessDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteGocardlessIntegrationDialog', () => ({
-  DeleteGocardlessIntegrationDialog: () => null,
+  useDeleteGocardlessIntegrationDialog: () => ({
+    openDeleteGocardlessIntegrationDialog: jest.fn(),
+  }),
 }))
 jest.mock('~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog', () => ({
   AddEditDeleteSuccessRedirectUrlDialog: () => null,


### PR DESCRIPTION
## Context

`DeleteGocardlessIntegrationDialog` still relied on the deprecated ref-based `WarningDialog`, which triggered `no-restricted-imports` warnings in every consumer and left cache handling on the pre-`evictFromCache` pattern (bare `cache.evict()` + `refetchQueries`). That combination broadcasts to detail-page watchers and can drive a `cache-and-network` query into a 404 refetch after the entity is destroyed.

## Description

- Rewrite `DeleteGocardlessIntegrationDialog` as `useDeleteGocardlessIntegrationDialog`, backed by `useCentralizedDialog` (danger variant). Removed the `forwardRef` wrapper, the `DeleteGocardlessIntegrationDialogRef` interface, the `WarningDialog` / `WarningDialogRef` imports, and the internal `useImperativeHandle` / `useState` / `useRef` plumbing.
- Replace `refetchQueries: ['getGocardlessIntegrationsList']` + inline `cache.evict()` with the shared `evictFromCache` helper, scoping cache updates to `paymentProviders` / `GetGocardlessIntegrationsListDocument` and suppressing detail-page watchers to avoid the post-delete 404 toast.
- Update `GocardlessIntegrations` and `GocardlessIntegrationDetails` to consume the hook directly instead of holding a `WarningDialogRef` and rendering `<DeleteGocardlessIntegrationDialog />` in JSX. All existing behaviors (post-delete navigation callback, permission gating, list vs detail redirects) are preserved.
- Drop the `deleteModalRef` plumbing in `AddGocardlessDialog`; the edit dialog now consumes the same hook internally and only needs the `deleteDialogCallback` for the post-delete navigation.
- Update the Jest mock for the Gocardless list page to mock the hook shape (`useDeleteGocardlessIntegrationDialog` returning `openDeleteGocardlessIntegrationDialog: jest.fn()`).

`AddGocardlessDialog` itself still uses Formik + the legacy `Dialog` and is intentionally left out of scope to keep the change narrow — those warnings are unchanged by this PR. Same applies to `AddEditDeleteSuccessRedirectUrlDialog` referenced from the two pages.

## Test plan

- `pnpm types` passes.
- `pnpm eslint` no longer reports `DeleteGocardlessIntegrationDialog` / `DeleteGocardlessIntegrationDialogRef` / `WarningDialog` warnings for any of the touched files.
- `pnpm test -- src/pages/settings/__tests__/GocardlessIntegrations.test.tsx` passes (2/2).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QJr4Xj8vo9vfz4RFupj9qf)_