### PR TITLE
chore(sonar): fix 3 BLOCKER/CRITICAL issues (week of 2026-07-03)

### DIFF
--- a/src/hooks/ui/useShortcuts.tsx
+++ b/src/hooks/ui/useShortcuts.tsx
@@ -34,7 +34,12 @@ export const getCleanKey = (key: string) => {
 }
 
 const getShortcutId = (keys: string[]): string => {
-  return keys.join('').split('').sort().join('').toLowerCase()
+  return keys
+    .join('')
+    .split('')
+    .sort((a, b) => a.localeCompare(b))
+    .join('')
+    .toLowerCase()
 }
 
 type UseShortcutReturn = (shortcuts: Shortcut[]) => { isMac: boolean }

--- a/src/pages/PaymentDetails.tsx
+++ b/src/pages/PaymentDetails.tsx
@@ -370,8 +370,8 @@ const PaymentDetails = () => {
                     <Button
                       variant="quaternary"
                       align="left"
-                      onClick={async () => {
-                        await downloadPaymentReceipts({
+                      onClick={() => {
+                        downloadPaymentReceipts({
                           paymentReceiptId: payment?.paymentReceipt?.id,
                         })
                         closePopper()
@@ -382,8 +382,8 @@ const PaymentDetails = () => {
                     <Button
                       variant="quaternary"
                       align="left"
-                      onClick={async () => {
-                        await downloadPaymentXmlReceipts({
+                      onClick={() => {
+                        downloadPaymentXmlReceipts({
                           paymentReceiptId: payment?.paymentReceipt?.id,
                         })
                         closePopper()


### PR DESCRIPTION
## SonarCloud weekly cleanup — week of 2026-07-03

Automated batch of the highest-severity open SonarCloud issues (BLOCKER/CRITICAL). Each change is minimal and behavior-preserving. All checks pass locally: `prettier`, `eslint`, `tsc --noEmit`, and the affected Jest suites (13 tests green).

### Fixed

| SonarCloud key | Rule | File:line | Change |
| --- | --- | --- | --- |
| AZmcONKwGssQnyKsYP0y | typescript:S2871 | `src/hooks/ui/useShortcuts.tsx:37` | Add a `localeCompare`-based compare function to `Array.prototype.sort()` so the shortcut-id string sorts deterministically. |
| — (S4123) | typescript:S4123 | `src/pages/PaymentDetails.tsx:374` | Drop the unnecessary `await` on `downloadPaymentReceipts(...)` (returns `null`/`void`, never a Promise) and the now-redundant `async`, matching the sibling menu handlers. |
| — (S4123) | typescript:S4123 | `src/pages/PaymentDetails.tsx:386` | Same fix for `downloadPaymentXmlReceipts(...)`. |

> Note: the SonarCloud API did not return issue keys for the two S4123 findings in this run; they are unambiguously identified by rule + file:line above.

### Skipped — needs human decision

Left for humans because a correct fix would change behavior, needs product knowledge, or is a structural refactor beyond a safe automated edit:

**typescript:S2819 (VULNERABILITY — `postMessage` target origin, needs product knowledge of the allowed embed origin)**
- `src/hooks/useIframeConfig.ts:42`
- `src/hooks/useIframeConfig.ts:46`

**typescript:S3776 (Cognitive Complexity — structural refactor, risk of behavior change)** — 25 issues, e.g.:
- `src/components/customers/CustomerSettings.tsx:203`
- `src/core/serializers/serializePlanInput.ts:62`
- `src/pages/CreateBillableMetric.tsx:84`
- `src/pages/settings/integrations/common/getParametersFromProvider.ts:47`
- …and 21 more

**typescript:S2004 (Functions nested >4 deep — requires extracting nested callbacks / closures)** — 18 issues, e.g.:
- `src/pages/CreateInvoice.tsx:994`, `:1015`, `:1035`
- `src/pages/settings/CashfreeIntegrations.tsx:167`
- `src/components/designSystem/Filters/FiltersPanelPopper.tsx:81`, `:85`
- …and 13 more

🤖 Generated with [Claude Code](https://claude.com/claude-code)
