### PR TITLE
feat(quotes): display /discount preview as PreviewTable

### DIFF
--- a/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
@@ -1,74 +1,28 @@
 import { NodeViewProps, NodeViewWrapper } from '@tiptap/react'
 
-import { Typography } from '~/components/designSystem/Typography'
-import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
-import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { CouponFrequency, CouponTypeEnum } from '~/generated/graphql'
+import { Locale, LocaleEnum } from '~/core/translations'
+import { CurrencyEnum } from '~/generated/graphql'
+import { useContextualLocale } from '~/hooks/core/useContextualLocale'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
-import { type EntityData, useRichTextEditorContext } from '../common/RichTextEditorContext'
+import { DiscountPreviewTable } from './DiscountPreviewTable'
+
+import { useRichTextEditorContext } from '../common/RichTextEditorContext'
 import SlashCommandBlockWrapper from '../SlashCommandBlockWrapper/SlashCommandBlockWrapper'
 
 export const DISCOUNT_BLOCK_VIEW_EMPTY_TEST_ID = 'discount-block-view-empty'
 export const DISCOUNT_BLOCK_VIEW_UNRESOLVED_TEST_ID = 'discount-block-view-unresolved'
 
-// Preview-mode rendering: minimal read-only display (no chevron, no click handler).
-// NOTE: this layout is a best-effort default — no Figma design exists yet;
-// confirm copy/layout with design before shipping to customers.
-const DiscountBlockPreview = ({ entity }: { entity: EntityData }) => {
-  const { translate } = useInternationalization()
-
-  const getFrequencyKey = () => {
-    if (entity.frequency === CouponFrequency.Once) {
-      return 'text_632d68358f1fedc68eed3ea3'
-    }
-
-    if (entity.frequency === CouponFrequency.Recurring) {
-      return 'text_632d68358f1fedc68eed3e64'
-    }
-
-    return 'text_63c83a3476e46bc6ab9d85d6'
-  }
-
-  const frequencyLabel = translate(getFrequencyKey())
-
-  let valueLabel = ''
-
-  if (
-    entity.couponType === CouponTypeEnum.FixedAmount &&
-    entity.amountCents &&
-    entity.amountCurrency
-  ) {
-    valueLabel = intlFormatNumber(deserializeAmount(entity.amountCents, entity.amountCurrency), {
-      currency: entity.amountCurrency,
-    })
-  } else if (entity.couponType === CouponTypeEnum.Percentage && entity.percentageRate !== null) {
-    valueLabel = `${entity.percentageRate}%`
-  }
-
-  const caption = valueLabel ? `${valueLabel} • ${frequencyLabel}` : frequencyLabel
-
-  return (
-    <NodeViewWrapper className="spacer" data-type="discountBlock">
-      <div className="block-wrapper">
-        <div className="pricing-block">
-          <div className="pricing-block-content">
-            <div className="pricing-block-text">
-              <Typography variant="bodyHl" color="grey700">
-                {entity.name}
-              </Typography>
-              <Typography variant="caption">{caption}</Typography>
-            </div>
-          </div>
-        </div>
-      </div>
-    </NodeViewWrapper>
-  )
-}
-
 export const DiscountBlockView = ({ node, updateAttributes }: NodeViewProps) => {
-  const { entities, onDiscountCommand, mode } = useRichTextEditorContext()
+  const { entities, onDiscountCommand, mode, customerLocale, customerCurrency } =
+    useRichTextEditorContext()
   const { translate } = useInternationalization()
+  const { organization } = useOrganizationInfos()
+  const currency = customerCurrency ?? organization?.defaultCurrency ?? CurrencyEnum.Usd
+
+  const effectiveLocale: Locale = (customerLocale ?? 'en') as Locale
+  const { translateWithContextualLocal } = useContextualLocale(effectiveLocale)
 
   const couponId = (node.attrs.couponId ?? '') as string
   const localId = (node.attrs.localId ?? '') as string
@@ -79,7 +33,16 @@ export const DiscountBlockView = ({ node, updateAttributes }: NodeViewProps) => 
   // Preview mode: read-only, non-interactive
   if (mode === 'preview') {
     if (entity) {
-      return <DiscountBlockPreview entity={entity} />
+      return (
+        <NodeViewWrapper className="spacer" data-type="discountBlock">
+          <DiscountPreviewTable
+            entity={entity}
+            translate={translateWithContextualLocal}
+            currency={currency}
+            locale={LocaleEnum[effectiveLocale]}
+          />
+        </NodeViewWrapper>
+      )
     }
 
     // Empty or unresolved in preview — render nothing interactive

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountPreviewTable.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountPreviewTable.tsx
@@ -1,0 +1,108 @@
+import { PreviewTable, type PreviewTableColumn } from '~/components/designSystem/Table/PreviewTable'
+import { Typography } from '~/components/designSystem/Typography'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import type { LocaleEnum } from '~/core/translations'
+import { CouponFrequency, CouponTypeEnum, type CurrencyEnum } from '~/generated/graphql'
+import type { TranslateFunc } from '~/hooks/core/useInternationalization'
+
+import type { EntityData } from '../common/RichTextEditorContext'
+
+export const DISCOUNT_PREVIEW_TABLE_TEST_ID = 'discount-preview-table'
+
+const K = {
+  discountLabel: 'text_1782889379261hdcd0jhzdm6',
+  discountValue: 'text_1782891666475j9e81afl8in',
+  duration: 'text_632d68358f1fedc68eed3e80',
+  once: 'text_632d68358f1fedc68eed3ea3',
+  forever: 'text_63c83a3476e46bc6ab9d85d6',
+  billingPeriods: 'text_17830875698228lpz4i09jop',
+} as const
+
+interface DiscountPreviewTableProps {
+  entity: EntityData
+  translate: TranslateFunc
+  currency: CurrencyEnum
+  locale?: LocaleEnum
+}
+
+const formatValue = (entity: EntityData, currency: CurrencyEnum, locale?: LocaleEnum): string => {
+  if (
+    entity.couponType === CouponTypeEnum.Percentage &&
+    typeof entity.percentageRate === 'number'
+  ) {
+    return `${entity.percentageRate}%`
+  }
+
+  if (entity.couponType === CouponTypeEnum.FixedAmount && entity.amountCents) {
+    const ccy = entity.amountCurrency ?? currency
+
+    return intlFormatNumber(deserializeAmount(entity.amountCents, ccy), { currency: ccy, locale })
+  }
+
+  return ''
+}
+
+const formatDuration = (entity: EntityData, translate: TranslateFunc): string => {
+  if (entity.frequency === CouponFrequency.Once) {
+    return translate(K.once)
+  }
+
+  if (entity.frequency === CouponFrequency.Forever) {
+    return translate(K.forever)
+  }
+
+  if (entity.frequency === CouponFrequency.Recurring) {
+    const count = entity.frequencyDuration ?? 0
+
+    return translate(K.billingPeriods, { count }, count)
+  }
+
+  return ''
+}
+
+export const DiscountPreviewTable = ({
+  entity,
+  translate,
+  currency,
+  locale,
+}: DiscountPreviewTableProps) => {
+  const columns: PreviewTableColumn<EntityData>[] = [
+    {
+      key: 'name',
+      title: translate(K.discountLabel),
+      maxSpace: true,
+      content: (item) => (
+        <Typography variant="bodyHl" color="grey700">
+          {item.name}
+        </Typography>
+      ),
+    },
+    {
+      key: 'value',
+      title: translate(K.discountValue),
+      textAlign: 'right',
+      content: (item) => (
+        <Typography variant="body" color="grey700">
+          {formatValue(item, currency, locale)}
+        </Typography>
+      ),
+    },
+    {
+      key: 'duration',
+      title: translate(K.duration),
+      textAlign: 'right',
+      content: (item) => (
+        <Typography variant="body" color="grey700">
+          {formatDuration(item, translate)}
+        </Typography>
+      ),
+    },
+  ]
+
+  return (
+    <div data-test={DISCOUNT_PREVIEW_TABLE_TEST_ID}>
+      <PreviewTable name="discount-preview" data={[entity]} columns={columns} />
+    </div>
+  )
+}

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountPreviewTable.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountPreviewTable.tsx
@@ -8,7 +8,7 @@ import type { TranslateFunc } from '~/hooks/core/useInternationalization'
 
 import type { EntityData } from '../common/RichTextEditorContext'
 
-export const DISCOUNT_PREVIEW_TABLE_TEST_ID = 'discount-preview-table'
+export const DISCOUNT_PREVIEW_TABLE_TEST_ID = 'preview-table-discount-preview'
 
 const K = {
   discountLabel: 'text_1782889379261hdcd0jhzdm6',
@@ -102,9 +102,5 @@ export const DiscountPreviewTable = ({
     },
   ]
 
-  return (
-    <div data-test={DISCOUNT_PREVIEW_TABLE_TEST_ID}>
-      <PreviewTable name="discount-preview" data={[entity]} columns={columns} />
-    </div>
-  )
+  return <PreviewTable name="discount-preview" data={[entity]} columns={columns} />
 }

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountPreviewTable.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountPreviewTable.tsx
@@ -12,7 +12,7 @@ export const DISCOUNT_PREVIEW_TABLE_TEST_ID = 'discount-preview-table'
 
 const K = {
   discountLabel: 'text_1782889379261hdcd0jhzdm6',
-  discountValue: 'text_1782891666475j9e81afl8in',
+  discountValue: 'text_1783090333139dnllq2q6ege',
   duration: 'text_632d68358f1fedc68eed3e80',
   once: 'text_632d68358f1fedc68eed3ea3',
   forever: 'text_63c83a3476e46bc6ab9d85d6',

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountPreviewTable.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountPreviewTable.tsx
@@ -82,6 +82,7 @@ export const DiscountPreviewTable = ({
       key: 'value',
       title: translate(K.discountValue),
       textAlign: 'right',
+      minWidth: 180,
       content: (item) => (
         <Typography variant="body" color="grey700">
           {formatValue(item, currency, locale)}
@@ -92,6 +93,7 @@ export const DiscountPreviewTable = ({
       key: 'duration',
       title: translate(K.duration),
       textAlign: 'right',
+      minWidth: 200,
       content: (item) => (
         <Typography variant="body" color="grey700">
           {formatDuration(item, translate)}

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/__tests__/DiscountBlockView.test.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/__tests__/DiscountBlockView.test.tsx
@@ -15,6 +15,7 @@ import {
   DISCOUNT_BLOCK_VIEW_UNRESOLVED_TEST_ID,
   DiscountBlockView,
 } from '../DiscountBlockView'
+import { DISCOUNT_PREVIEW_TABLE_TEST_ID } from '../DiscountPreviewTable'
 
 jest.mock('@tiptap/react', () => ({
   ...jest.requireActual('@tiptap/react'),
@@ -278,6 +279,16 @@ describe('DiscountBlockView', () => {
 
         expect(screen.queryByTestId(SLASH_COMMAND_BLOCK_VIEW_TEST_ID)).not.toBeInTheDocument()
       })
+
+      it('THEN should render the preview table with the formatted fixed amount', () => {
+        renderPreview({
+          attrs: { couponId: 'coupon-2', localId: 'local-2' },
+          entities: { 'local-2': couponEntityFixed },
+        })
+
+        expect(screen.getByTestId(DISCOUNT_PREVIEW_TABLE_TEST_ID)).toBeInTheDocument()
+        expect(screen.getByText('$10.00')).toBeInTheDocument()
+      })
     })
 
     describe('WHEN rendered with a resolved percentage coupon', () => {
@@ -297,6 +308,16 @@ describe('DiscountBlockView', () => {
         })
 
         expect(screen.queryByTestId(SLASH_COMMAND_BLOCK_VIEW_TEST_ID)).not.toBeInTheDocument()
+      })
+
+      it('THEN should render the percentage value in the preview table', () => {
+        renderPreview({
+          attrs: { couponId: 'coupon-3', localId: 'local-3' },
+          entities: { 'local-3': couponEntityPct },
+        })
+
+        expect(screen.getByTestId(DISCOUNT_PREVIEW_TABLE_TEST_ID)).toBeInTheDocument()
+        expect(screen.getByText('15%')).toBeInTheDocument()
       })
     })
 

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/__tests__/DiscountPreviewTable.test.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/__tests__/DiscountPreviewTable.test.tsx
@@ -12,7 +12,7 @@ const BILLING_PERIODS_KEY = 'text_17830875698228lpz4i09jop'
 const translate = ((key: string, data?: Record<string, unknown>) => {
   const map: Record<string, string> = {
     text_1782889379261hdcd0jhzdm6: 'Discount',
-    text_1782891666475j9e81afl8in: 'Discount',
+    text_1783090333139dnllq2q6ege: 'Discount value',
     text_632d68358f1fedc68eed3e80: 'Duration',
     text_632d68358f1fedc68eed3ea3: 'Once',
     text_63c83a3476e46bc6ab9d85d6: 'Forever',

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/__tests__/DiscountPreviewTable.test.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/__tests__/DiscountPreviewTable.test.tsx
@@ -1,0 +1,78 @@
+import { screen } from '@testing-library/react'
+
+import { CurrencyEnum } from '~/generated/graphql'
+import type { TranslateFunc } from '~/hooks/core/useInternationalization'
+import { render } from '~/test-utils'
+
+import { EntityData } from '../../common/RichTextEditorContext'
+import { DISCOUNT_PREVIEW_TABLE_TEST_ID, DiscountPreviewTable } from '../DiscountPreviewTable'
+
+const BILLING_PERIODS_KEY = 'text_17830875698228lpz4i09jop'
+
+const translate = ((key: string, data?: Record<string, unknown>) => {
+  const map: Record<string, string> = {
+    text_1782889379261hdcd0jhzdm6: 'Discount',
+    text_1782891666475j9e81afl8in: 'Discount',
+    text_632d68358f1fedc68eed3e80: 'Duration',
+    text_632d68358f1fedc68eed3ea3: 'Once',
+    text_63c83a3476e46bc6ab9d85d6: 'Forever',
+    [BILLING_PERIODS_KEY]: `${data?.count} billing periods`,
+  }
+
+  return map[key] ?? key
+}) as unknown as TranslateFunc
+
+const base: EntityData = {
+  entityId: 'c1',
+  entityType: 'coupon',
+  name: 'Summer Deal',
+  code: 'summer',
+}
+
+const renderTable = (entity: EntityData) =>
+  render(<DiscountPreviewTable entity={entity} translate={translate} currency={CurrencyEnum.Usd} />)
+
+describe('DiscountPreviewTable', () => {
+  it('renders the coupon name', () => {
+    renderTable({ ...base })
+    expect(screen.getByTestId(DISCOUNT_PREVIEW_TABLE_TEST_ID)).toBeInTheDocument()
+    expect(screen.getByText('Summer Deal')).toBeInTheDocument()
+  })
+
+  it('renders a fixed-amount value with currency formatting', () => {
+    renderTable({
+      ...base,
+      couponType: 'fixed_amount' as EntityData['couponType'],
+      amountCents: '1000',
+      amountCurrency: 'USD' as EntityData['amountCurrency'],
+      percentageRate: null,
+      frequency: 'once' as EntityData['frequency'],
+      frequencyDuration: null,
+    })
+    expect(screen.getByText('$10.00')).toBeInTheDocument()
+    expect(screen.getByText('Once')).toBeInTheDocument()
+  })
+
+  it('renders a percentage value and forever duration', () => {
+    renderTable({
+      ...base,
+      couponType: 'percentage' as EntityData['couponType'],
+      percentageRate: 15,
+      frequency: 'forever' as EntityData['frequency'],
+      frequencyDuration: null,
+    })
+    expect(screen.getByText('15%')).toBeInTheDocument()
+    expect(screen.getByText('Forever')).toBeInTheDocument()
+  })
+
+  it('renders recurring duration as "{count} billing periods"', () => {
+    renderTable({
+      ...base,
+      couponType: 'percentage' as EntityData['couponType'],
+      percentageRate: 20,
+      frequency: 'recurring' as EntityData['frequency'],
+      frequencyDuration: 12,
+    })
+    expect(screen.getByText('12 billing periods')).toBeInTheDocument()
+  })
+})

--- a/translations/base.json
+++ b/translations/base.json
@@ -4469,5 +4469,6 @@
   "text_1782891666475u5j60v91cv2": "Discount and coupon",
   "text_1782891666475ht76172d37q": "Apply a coupon to this quote to grant a discount.",
   "text_1783342959387sv77znuw5yx": "Select a coupon",
-  "text_1783342959387cz07147m6qq": "Coupon: {{couponId}}"
+  "text_1783342959387cz07147m6qq": "Coupon: {{couponId}}",
+  "text_17830875698228lpz4i09jop": "{{count}} billing period|{{count}} billing periods"
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -4470,5 +4470,6 @@
   "text_1782891666475ht76172d37q": "Apply a coupon to this quote to grant a discount.",
   "text_1783342959387sv77znuw5yx": "Select a coupon",
   "text_1783342959387cz07147m6qq": "Coupon: {{couponId}}",
-  "text_17830875698228lpz4i09jop": "{{count}} billing period|{{count}} billing periods"
+  "text_17830875698228lpz4i09jop": "{{count}} billing period|{{count}} billing periods",
+  "text_1783090333139dnllq2q6ege": "Discount value"
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -249,5 +249,11 @@
   "text_1782223048616d9fxvmvy6xk": "Ab {{from}} Einheiten",
   "text_17822898603051pryf16s23k": "Pauschalgebühr für die ersten {{to}} Einheiten",
   "text_1782289860305xi20ikioh8l": "Pauschalgebühr für {{from}} bis {{to}} Einheiten",
-  "text_1782289860305wlllob2k8n0": "Pauschalgebühr ab {{from}} Einheiten"
+  "text_1782289860305wlllob2k8n0": "Pauschalgebühr ab {{from}} Einheiten",
+  "text_1782889379261hdcd0jhzdm6": "Rabatt",
+  "text_1782891666475j9e81afl8in": "Rabatt",
+  "text_632d68358f1fedc68eed3e80": "Laufzeit",
+  "text_632d68358f1fedc68eed3ea3": "Einmalig",
+  "text_63c83a3476e46bc6ab9d85d6": "Unbegrenzt",
+  "text_17830875698228lpz4i09jop": "{{count}} Abrechnungszeitraum|{{count}} Abrechnungszeiträume"
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -255,5 +255,6 @@
   "text_632d68358f1fedc68eed3e80": "Laufzeit",
   "text_632d68358f1fedc68eed3ea3": "Einmalig",
   "text_63c83a3476e46bc6ab9d85d6": "Unbegrenzt",
-  "text_17830875698228lpz4i09jop": "{{count}} Abrechnungszeitraum|{{count}} Abrechnungszeiträume"
+  "text_17830875698228lpz4i09jop": "{{count}} Abrechnungszeitraum|{{count}} Abrechnungszeiträume",
+  "text_1783090333139dnllq2q6ege": "Rabattwert"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -255,5 +255,6 @@
   "text_632d68358f1fedc68eed3e80": "Duración",
   "text_632d68358f1fedc68eed3ea3": "Una sola vez",
   "text_63c83a3476e46bc6ab9d85d6": "Para siempre",
-  "text_17830875698228lpz4i09jop": "{{count}} período de facturación|{{count}} períodos de facturación"
+  "text_17830875698228lpz4i09jop": "{{count}} período de facturación|{{count}} períodos de facturación",
+  "text_1783090333139dnllq2q6ege": "Valor del descuento"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -249,5 +249,11 @@
   "text_1782223048616d9fxvmvy6xk": "A partir de {{from}} unidades",
   "text_17822898603051pryf16s23k": "Tarifa fija para las primeras {{to}} unidades",
   "text_1782289860305xi20ikioh8l": "Tarifa fija para {{from}} a {{to}} unidades",
-  "text_1782289860305wlllob2k8n0": "Tarifa fija a partir de {{from}} unidades"
+  "text_1782289860305wlllob2k8n0": "Tarifa fija a partir de {{from}} unidades",
+  "text_1782889379261hdcd0jhzdm6": "Descuento",
+  "text_1782891666475j9e81afl8in": "Descuento",
+  "text_632d68358f1fedc68eed3e80": "Duración",
+  "text_632d68358f1fedc68eed3ea3": "Una sola vez",
+  "text_63c83a3476e46bc6ab9d85d6": "Para siempre",
+  "text_17830875698228lpz4i09jop": "{{count}} período de facturación|{{count}} períodos de facturación"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -255,5 +255,6 @@
   "text_632d68358f1fedc68eed3e80": "Durée",
   "text_632d68358f1fedc68eed3ea3": "Une seule fois",
   "text_63c83a3476e46bc6ab9d85d6": "Indéfiniment",
-  "text_17830875698228lpz4i09jop": "{{count}} période de facturation|{{count}} périodes de facturation"
+  "text_17830875698228lpz4i09jop": "{{count}} période de facturation|{{count}} périodes de facturation",
+  "text_1783090333139dnllq2q6ege": "Valeur de la remise"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -249,5 +249,11 @@
   "text_1782223048616d9fxvmvy6xk": "À partir de {{from}} unités",
   "text_17822898603051pryf16s23k": "Frais forfaitaires pour les {{to}} premières unités",
   "text_1782289860305xi20ikioh8l": "Frais forfaitaires pour {{from}} à {{to}} unités",
-  "text_1782289860305wlllob2k8n0": "Frais forfaitaires à partir de {{from}} unités"
+  "text_1782289860305wlllob2k8n0": "Frais forfaitaires à partir de {{from}} unités",
+  "text_1782889379261hdcd0jhzdm6": "Remise",
+  "text_1782891666475j9e81afl8in": "Remise",
+  "text_632d68358f1fedc68eed3e80": "Durée",
+  "text_632d68358f1fedc68eed3ea3": "Une seule fois",
+  "text_63c83a3476e46bc6ab9d85d6": "Indéfiniment",
+  "text_17830875698228lpz4i09jop": "{{count}} période de facturation|{{count}} périodes de facturation"
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -249,5 +249,11 @@
   "text_1782223048616d9fxvmvy6xk": "Da {{from}} unità in su",
   "text_17822898603051pryf16s23k": "Tariffa fissa per le prime {{to}} unità",
   "text_1782289860305xi20ikioh8l": "Tariffa fissa per {{from}} a {{to}} unità",
-  "text_1782289860305wlllob2k8n0": "Tariffa fissa da {{from}} unità in su"
+  "text_1782289860305wlllob2k8n0": "Tariffa fissa da {{from}} unità in su",
+  "text_1782889379261hdcd0jhzdm6": "Sconto",
+  "text_1782891666475j9e81afl8in": "Sconto",
+  "text_632d68358f1fedc68eed3e80": "Durata",
+  "text_632d68358f1fedc68eed3ea3": "Una sola volta",
+  "text_63c83a3476e46bc6ab9d85d6": "Per sempre",
+  "text_17830875698228lpz4i09jop": "{{count}} periodo di fatturazione|{{count}} periodi di fatturazione"
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -255,5 +255,6 @@
   "text_632d68358f1fedc68eed3e80": "Durata",
   "text_632d68358f1fedc68eed3ea3": "Una sola volta",
   "text_63c83a3476e46bc6ab9d85d6": "Per sempre",
-  "text_17830875698228lpz4i09jop": "{{count}} periodo di fatturazione|{{count}} periodi di fatturazione"
+  "text_17830875698228lpz4i09jop": "{{count}} periodo di fatturazione|{{count}} periodi di fatturazione",
+  "text_1783090333139dnllq2q6ege": "Valore dello sconto"
 }

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -255,5 +255,6 @@
   "text_632d68358f1fedc68eed3e80": "Varighet",
   "text_632d68358f1fedc68eed3ea3": "Én gang",
   "text_63c83a3476e46bc6ab9d85d6": "For alltid",
-  "text_17830875698228lpz4i09jop": "{{count}} faktureringsperiode|{{count}} faktureringsperioder"
+  "text_17830875698228lpz4i09jop": "{{count}} faktureringsperiode|{{count}} faktureringsperioder",
+  "text_1783090333139dnllq2q6ege": "Rabattverdi"
 }

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -249,5 +249,11 @@
   "text_1782223048616d9fxvmvy6xk": "Fra {{from}} enheter og oppover",
   "text_17822898603051pryf16s23k": "Fast avgift for de første {{to}} enhetene",
   "text_1782289860305xi20ikioh8l": "Fast avgift for {{from}} til {{to}} enheter",
-  "text_1782289860305wlllob2k8n0": "Fast avgift fra {{from}} enheter og oppover"
+  "text_1782289860305wlllob2k8n0": "Fast avgift fra {{from}} enheter og oppover",
+  "text_1782889379261hdcd0jhzdm6": "Rabatt",
+  "text_1782891666475j9e81afl8in": "Rabatt",
+  "text_632d68358f1fedc68eed3e80": "Varighet",
+  "text_632d68358f1fedc68eed3ea3": "Én gang",
+  "text_63c83a3476e46bc6ab9d85d6": "For alltid",
+  "text_17830875698228lpz4i09jop": "{{count}} faktureringsperiode|{{count}} faktureringsperioder"
 }

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -3165,5 +3165,8 @@
   "text_1782223048616d9fxvmvy6xk": "A partir de {{from}} unidades",
   "text_17822898603051pryf16s23k": "Taxa fixa para as primeiras {{to}} unidades",
   "text_1782289860305xi20ikioh8l": "Taxa fixa para {{from}} a {{to}} unidades",
-  "text_1782289860305wlllob2k8n0": "Taxa fixa a partir de {{from}} unidades"
+  "text_1782289860305wlllob2k8n0": "Taxa fixa a partir de {{from}} unidades",
+  "text_1782889379261hdcd0jhzdm6": "Desconto",
+  "text_1782891666475j9e81afl8in": "Desconto",
+  "text_17830875698228lpz4i09jop": "{{count}} período de faturamento|{{count}} períodos de faturamento"
 }

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -3168,5 +3168,6 @@
   "text_1782289860305wlllob2k8n0": "Taxa fixa a partir de {{from}} unidades",
   "text_1782889379261hdcd0jhzdm6": "Desconto",
   "text_1782891666475j9e81afl8in": "Desconto",
-  "text_17830875698228lpz4i09jop": "{{count}} período de faturamento|{{count}} períodos de faturamento"
+  "text_17830875698228lpz4i09jop": "{{count}} período de faturamento|{{count}} períodos de faturamento",
+  "text_1783090333139dnllq2q6ege": "Valor do desconto"
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -255,5 +255,6 @@
   "text_632d68358f1fedc68eed3e80": "Varaktighet",
   "text_632d68358f1fedc68eed3ea3": "En gång",
   "text_63c83a3476e46bc6ab9d85d6": "För alltid",
-  "text_17830875698228lpz4i09jop": "{{count}} faktureringsperiod|{{count}} faktureringsperioder"
+  "text_17830875698228lpz4i09jop": "{{count}} faktureringsperiod|{{count}} faktureringsperioder",
+  "text_1783090333139dnllq2q6ege": "Rabattvärde"
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -249,5 +249,11 @@
   "text_1782223048616d9fxvmvy6xk": "Från {{from}} enheter och uppåt",
   "text_17822898603051pryf16s23k": "Fast avgift för de första {{to}} enheterna",
   "text_1782289860305xi20ikioh8l": "Fast avgift för {{from}} till {{to}} enheter",
-  "text_1782289860305wlllob2k8n0": "Fast avgift från {{from}} enheter och uppåt"
+  "text_1782289860305wlllob2k8n0": "Fast avgift från {{from}} enheter och uppåt",
+  "text_1782889379261hdcd0jhzdm6": "Rabatt",
+  "text_1782891666475j9e81afl8in": "Rabatt",
+  "text_632d68358f1fedc68eed3e80": "Varaktighet",
+  "text_632d68358f1fedc68eed3ea3": "En gång",
+  "text_63c83a3476e46bc6ab9d85d6": "För alltid",
+  "text_17830875698228lpz4i09jop": "{{count}} faktureringsperiod|{{count}} faktureringsperioder"
 }

--- a/translations/zh-TW.json
+++ b/translations/zh-TW.json
@@ -249,5 +249,11 @@
   "text_1782223048616d9fxvmvy6xk": "{{from}} 個單位以上",
   "text_17822898603051pryf16s23k": "前 {{to}} 個單位的固定費用",
   "text_1782289860305xi20ikioh8l": "{{from}} 到 {{to}} 個單位的固定費用",
-  "text_1782289860305wlllob2k8n0": "{{from}} 個單位以上的固定費用"
+  "text_1782289860305wlllob2k8n0": "{{from}} 個單位以上的固定費用",
+  "text_1782889379261hdcd0jhzdm6": "折扣",
+  "text_1782891666475j9e81afl8in": "折扣",
+  "text_632d68358f1fedc68eed3e80": "期限",
+  "text_632d68358f1fedc68eed3ea3": "一次",
+  "text_63c83a3476e46bc6ab9d85d6": "永久",
+  "text_17830875698228lpz4i09jop": "{{count}} 個計費週期|{{count}} 個計費週期"
 }

--- a/translations/zh-TW.json
+++ b/translations/zh-TW.json
@@ -255,5 +255,6 @@
   "text_632d68358f1fedc68eed3e80": "期限",
   "text_632d68358f1fedc68eed3ea3": "一次",
   "text_63c83a3476e46bc6ab9d85d6": "永久",
-  "text_17830875698228lpz4i09jop": "{{count}} 個計費週期|{{count}} 個計費週期"
+  "text_17830875698228lpz4i09jop": "{{count}} 個計費週期|{{count}} 個計費週期",
+  "text_1783090333139dnllq2q6ege": "折扣值"
 }


### PR DESCRIPTION
## Context

Renders the `/discount` block's **preview** as a 3-column `PreviewTable` (coupon name · discount value · duration), matching [Figma `6581-33432`](https://www.figma.com/design/Vovlg3A77PuuAT5HRwTnjb/?node-id=6581-33432). Replaces the previous minimal inline preview.

| Discount | Discount | Duration |
|---|---:|---:|
| **{{coupon.name}}** | 20% | {{duration}} |
| **{{coupon.name}}** | $100 | 12 billing periods |

## Description

This PR
- Depends on #3797 
- Only displays the preview of `/discount`

Fixes LAGO-1609

🤖 Generated with [Claude Code](https://claude.com/claude-code)