### PR TITLE
fix(superset): renew guest token on expiry

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -15872,6 +15872,13 @@ export type SupersetDashboardsQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type SupersetDashboardsQuery = { __typename?: 'Query', supersetDashboards: Array<{ __typename?: 'SupersetDashboard', id: string, embeddedId: string, dashboardTitle: string, guestToken: string }> };
 
+export type CreateSupersetGuestTokenMutationVariables = Exact<{
+  input: CreateSupersetGuestTokenInput;
+}>;
+
+
+export type CreateSupersetGuestTokenMutation = { __typename?: 'Mutation', createSupersetGuestToken?: { __typename?: 'SupersetGuestToken', guestToken: string } | null };
+
 export type GetApiKeyToEditQueryVariables = Exact<{
   apiKeyId: Scalars['ID']['input'];
 }>;
@@ -42541,6 +42548,39 @@ export type SupersetDashboardsQueryHookResult = ReturnType<typeof useSupersetDas
 export type SupersetDashboardsLazyQueryHookResult = ReturnType<typeof useSupersetDashboardsLazyQuery>;
 export type SupersetDashboardsSuspenseQueryHookResult = ReturnType<typeof useSupersetDashboardsSuspenseQuery>;
 export type SupersetDashboardsQueryResult = Apollo.QueryResult<SupersetDashboardsQuery, SupersetDashboardsQueryVariables>;
+export const CreateSupersetGuestTokenDocument = gql`
+    mutation createSupersetGuestToken($input: CreateSupersetGuestTokenInput!) {
+  createSupersetGuestToken(input: $input) {
+    guestToken
+  }
+}
+    `;
+export type CreateSupersetGuestTokenMutationFn = Apollo.MutationFunction<CreateSupersetGuestTokenMutation, CreateSupersetGuestTokenMutationVariables>;
+
+/**
+ * __useCreateSupersetGuestTokenMutation__
+ *
+ * To run a mutation, you first call `useCreateSupersetGuestTokenMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateSupersetGuestTokenMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createSupersetGuestTokenMutation, { data, loading, error }] = useCreateSupersetGuestTokenMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useCreateSupersetGuestTokenMutation(baseOptions?: Apollo.MutationHookOptions<CreateSupersetGuestTokenMutation, CreateSupersetGuestTokenMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateSupersetGuestTokenMutation, CreateSupersetGuestTokenMutationVariables>(CreateSupersetGuestTokenDocument, options);
+      }
+export type CreateSupersetGuestTokenMutationHookResult = ReturnType<typeof useCreateSupersetGuestTokenMutation>;
+export type CreateSupersetGuestTokenMutationResult = Apollo.MutationResult<CreateSupersetGuestTokenMutation>;
+export type CreateSupersetGuestTokenMutationOptions = Apollo.BaseMutationOptions<CreateSupersetGuestTokenMutation, CreateSupersetGuestTokenMutationVariables>;
 export const GetApiKeyToEditDocument = gql`
     query getApiKeyToEdit($apiKeyId: ID!) {
   apiKey(id: $apiKeyId) {

--- a/src/pages/dashboards/Dashboard.tsx
+++ b/src/pages/dashboards/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql, useApolloClient } from '@apollo/client'
 import { embedDashboard, EmbeddedDashboard } from '@superset-ui/embedded-sdk'
 import { debounce } from 'lodash'
 import { useEffect, useMemo, useRef } from 'react'
@@ -15,6 +15,7 @@ import { useSupersetDashboardsQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import '~/main.css'
+import { createFetchSupersetGuestToken } from '~/pages/dashboards/fetchSupersetGuestToken'
 import ErrorImage from '~/public/images/maneki/error.svg'
 import { PageHeader } from '~/styles'
 
@@ -42,6 +43,7 @@ export type DashboardProps = {
 const Dashboard = ({ contentTitle, dashboardTitle, dashboardTitleTestKey }: DashboardProps) => {
   const { translate } = useInternationalization()
   const { currentMembership } = useCurrentUser()
+  const client = useApolloClient()
 
   const dashboardRef = useRef<string>('')
 
@@ -107,7 +109,7 @@ const Dashboard = ({ contentTitle, dashboardTitle, dashboardTitleTestKey }: Dash
         id: dashboard.embeddedId,
         supersetDomain: lagoSupersetUrl,
         mountPoint,
-        fetchGuestToken: async () => dashboard?.guestToken,
+        fetchGuestToken: createFetchSupersetGuestToken(client, dashboard.id),
         dashboardUiConfig: {
           hideTitle: true,
           emitDataMasks: persistFilters,
@@ -133,7 +135,7 @@ const Dashboard = ({ contentTitle, dashboardTitle, dashboardTitleTestKey }: Dash
       embedded?.unmount()
       dashboardRef.current = ''
     }
-  }, [dashboard, currentMembership?.organization.id, dashboardTitle, mountId])
+  }, [dashboard, currentMembership?.organization.id, client, dashboardTitle, mountId])
 
   return (
     <>

--- a/src/pages/dashboards/Dashboard.tsx
+++ b/src/pages/dashboards/Dashboard.tsx
@@ -89,6 +89,12 @@ const Dashboard = ({ contentTitle, dashboardTitle, dashboardTitleTestKey }: Dash
         }, 500)
       : null
 
+    const fetchGuestToken = createFetchSupersetGuestToken(
+      client,
+      dashboard.id,
+      dashboard.guestToken,
+    )
+
     const mount = async () => {
       const mountPoint = document.getElementById(mountId)
 
@@ -109,7 +115,7 @@ const Dashboard = ({ contentTitle, dashboardTitle, dashboardTitleTestKey }: Dash
         id: dashboard.embeddedId,
         supersetDomain: lagoSupersetUrl,
         mountPoint,
-        fetchGuestToken: createFetchSupersetGuestToken(client, dashboard.id),
+        fetchGuestToken,
         dashboardUiConfig: {
           hideTitle: true,
           emitDataMasks: persistFilters,
@@ -131,6 +137,7 @@ const Dashboard = ({ contentTitle, dashboardTitle, dashboardTitleTestKey }: Dash
     mount()
 
     return () => {
+      fetchGuestToken.cancel()
       debouncedSaveFilters?.cancel()
       embedded?.unmount()
       dashboardRef.current = ''

--- a/src/pages/dashboards/Dashboard.tsx
+++ b/src/pages/dashboards/Dashboard.tsx
@@ -129,11 +129,8 @@ const Dashboard = ({ contentTitle, dashboardTitle, dashboardTitleTestKey }: Dash
         iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox'],
       })
 
-      // Cleanup may have run while the embed was in flight — StrictMode's double
-      // mount, a dashboard tab switch, a fast navigate. The SDK puts its iframe in
-      // the DOM before `embedDashboard` resolves, so the cleanup below had no
-      // `embedded` to unmount: do it here, otherwise the iframe stays orphaned in
-      // the DOM with its Switchboard port open.
+      // The SDK mounts its iframe before `embedDashboard` resolves, so cleanup that
+      // ran while this was in flight had no `embedded` to unmount.
       if (disposed) {
         embedded.unmount()
 
@@ -147,10 +144,8 @@ const Dashboard = ({ contentTitle, dashboardTitle, dashboardTitleTestKey }: Dash
       dashboardRef.current = dashboard.id
     }
 
-    // `embedDashboard` rejects if Superset hands back a token it can't decode
-    // (`jwtDecode` throws inside `getGuestTokenRefreshTiming`). Nothing else
-    // observes this promise, so without a catch that surfaces as an unhandled
-    // rejection and a silently blank dashboard.
+    // Nothing else observes this promise: uncaught, a bad token from Superset is an
+    // unhandled rejection and a silently blank dashboard.
     mount().catch((mountError) => {
       captureException(mountError, {
         tags: { errorType: 'SupersetDashboardMountError', component: 'Dashboard' },

--- a/src/pages/dashboards/Dashboard.tsx
+++ b/src/pages/dashboards/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { gql, useApolloClient } from '@apollo/client'
+import { captureException } from '@sentry/react'
 import { embedDashboard, EmbeddedDashboard } from '@superset-ui/embedded-sdk'
 import { debounce } from 'lodash'
 import { useEffect, useMemo, useRef } from 'react'
@@ -65,6 +66,7 @@ const Dashboard = ({ contentTitle, dashboardTitle, dashboardTitleTestKey }: Dash
     }
 
     let embedded: null | EmbeddedDashboard = null
+    let disposed = false
 
     const persistFilters = isFeatureFlagActive(FeatureFlags.SUPERSET_PERSISTENT_FILTERS)
     // Filter persistence key is scoped to the org from the URL slug (resolved
@@ -127,6 +129,17 @@ const Dashboard = ({ contentTitle, dashboardTitle, dashboardTitleTestKey }: Dash
         iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox'],
       })
 
+      // Cleanup may have run while the embed was in flight — StrictMode's double
+      // mount, a dashboard tab switch, a fast navigate. The SDK puts its iframe in
+      // the DOM before `embedDashboard` resolves, so the cleanup below had no
+      // `embedded` to unmount: do it here, otherwise the iframe stays orphaned in
+      // the DOM with its Switchboard port open.
+      if (disposed) {
+        embedded.unmount()
+
+        return
+      }
+
       if (debouncedSaveFilters) {
         embedded.observeDataMask(debouncedSaveFilters)
       }
@@ -134,9 +147,19 @@ const Dashboard = ({ contentTitle, dashboardTitle, dashboardTitleTestKey }: Dash
       dashboardRef.current = dashboard.id
     }
 
-    mount()
+    // `embedDashboard` rejects if Superset hands back a token it can't decode
+    // (`jwtDecode` throws inside `getGuestTokenRefreshTiming`). Nothing else
+    // observes this promise, so without a catch that surfaces as an unhandled
+    // rejection and a silently blank dashboard.
+    mount().catch((mountError) => {
+      captureException(mountError, {
+        tags: { errorType: 'SupersetDashboardMountError', component: 'Dashboard' },
+        extra: { dashboardId: dashboard.id },
+      })
+    })
 
     return () => {
+      disposed = true
       fetchGuestToken.cancel()
       debouncedSaveFilters?.cancel()
       embedded?.unmount()

--- a/src/pages/dashboards/Dashboards.tsx
+++ b/src/pages/dashboards/Dashboards.tsx
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql, useApolloClient } from '@apollo/client'
 import { embedDashboard, EmbeddedDashboard } from '@superset-ui/embedded-sdk'
 import { debounce } from 'lodash'
 import { useEffect, useMemo, useRef } from 'react'
@@ -15,6 +15,7 @@ import { useSupersetDashboardsQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import '~/main.css'
+import { createFetchSupersetGuestToken } from '~/pages/dashboards/fetchSupersetGuestToken'
 import ErrorImage from '~/public/images/maneki/error.svg'
 import { PageHeader } from '~/styles'
 
@@ -37,6 +38,7 @@ gql`
 const Dashboards = () => {
   const { translate } = useInternationalization()
   const { currentMembership } = useCurrentUser()
+  const client = useApolloClient()
 
   const dashboardRef = useRef<string>('')
 
@@ -97,7 +99,7 @@ const Dashboards = () => {
         id: dashboard.embeddedId,
         supersetDomain: lagoSupersetUrl,
         mountPoint,
-        fetchGuestToken: async () => dashboard?.guestToken,
+        fetchGuestToken: createFetchSupersetGuestToken(client, dashboard.id),
         dashboardUiConfig: {
           hideTitle: true,
           emitDataMasks: persistFilters,
@@ -123,7 +125,7 @@ const Dashboards = () => {
       embedded?.unmount()
       dashboardRef.current = ''
     }
-  }, [dashboard, currentMembership?.organization.id])
+  }, [dashboard, currentMembership?.organization.id, client])
 
   return (
     <>

--- a/src/pages/dashboards/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboards/__tests__/Dashboard.test.tsx
@@ -84,9 +84,7 @@ const successMock: TestMocksType = [
       query: CreateSupersetGuestTokenDocument,
       variables: { input: { dashboardId: 'dash-1' } },
     },
-    // Deliberately different from the `guestToken` seeded by the dashboards query
-    // above: if the two matched, an assertion on the fetched token would pass even
-    // when the mutation never ran or threw and fell back to the seed.
+    // Must differ from the seed above, or the assertion passes on the fallback too.
     result: { data: { createSupersetGuestToken: { guestToken: 'refreshed-token' } } },
   },
 ]
@@ -116,8 +114,6 @@ const renderRevenue = (mocks: TestMocksType = successMock) =>
   )
 
 // Whether `promise` has settled once microtasks and 0ms timers have flushed.
-// Racing against an already-resolved sentinel instead would always pick the
-// sentinel, so such an assertion could never fail.
 const hasSettled = async (promise: Promise<unknown>): Promise<boolean> => {
   let settled = false
 
@@ -168,7 +164,6 @@ describe('Dashboard', () => {
       expect(config.supersetDomain).toBe('https://localhost:8089')
       expect(config.mountPoint).toBe(document.getElementById('superset-lago-dashboard'))
       expect(config.dashboardUiConfig.hideTitle).toBe(true)
-      // Proves the token came from the mutation, not from the query's seed.
       await expect(config.fetchGuestToken()).resolves.toBe('refreshed-token')
     })
   })
@@ -262,10 +257,8 @@ describe('Dashboard', () => {
       expect(mockUnmount).toHaveBeenCalled()
     })
 
-    // The SDK's `unmount()` only clears the iframe (`index.js:159-163`); it never
-    // cancels the refresh `setTimeout` it scheduled, so cleanup has to cancel the
-    // fetcher too. Without that, the chain keeps minting tokens for the rest of the
-    // SPA session — every revisit or dashboard switch leaving another one behind.
+    // The SDK's `unmount()` clears the iframe but not its refresh `setTimeout`
+    // (`index.js:159-163`), so cleanup has to cancel the fetcher itself.
     it('THEN cancels the guest token fetcher so the refresh chain stops', async () => {
       const { unmount } = renderAnalytics()
 
@@ -275,16 +268,12 @@ describe('Dashboard', () => {
 
       unmount()
 
-      // A cancelled fetcher deliberately never settles — that is the only way to
-      // halt a chain that re-arms from our resolution. Settling here means cleanup
-      // left the loop alive: the mutation mock would have resolved it.
+      // A cancelled fetcher never settles; the mutation mock would have resolved it.
       expect(await hasSettled(fetchGuestToken())).toBe(false)
     })
 
-    // The SDK puts its iframe in the DOM before `embedDashboard` resolves, so an
-    // embed still in flight at cleanup time has to be unmounted once it lands —
-    // otherwise the iframe is orphaned with its Switchboard port open. StrictMode
-    // hits this on every dev mount.
+    // The SDK mounts its iframe before `embedDashboard` resolves, so an embed still
+    // in flight at cleanup time is orphaned unless it is unmounted once it lands.
     it('THEN tears down an embed that only resolves after cleanup ran', async () => {
       let resolveEmbed: (value: unknown) => void = () => {}
 
@@ -304,7 +293,6 @@ describe('Dashboard', () => {
       resolveEmbed({ unmount: mockUnmount, observeDataMask: mockObserveDataMask })
 
       await waitFor(() => expect(mockUnmount).toHaveBeenCalledTimes(1))
-      // The late embed must not wire up filter observation either.
       expect(mockObserveDataMask).not.toHaveBeenCalled()
     })
   })

--- a/src/pages/dashboards/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboards/__tests__/Dashboard.test.tsx
@@ -115,6 +115,28 @@ const renderRevenue = (mocks: TestMocksType = successMock) =>
     { mocks },
   )
 
+// Whether `promise` has settled once microtasks and 0ms timers have flushed.
+// Racing against an already-resolved sentinel instead would always pick the
+// sentinel, so such an assertion could never fail.
+const hasSettled = async (promise: Promise<unknown>): Promise<boolean> => {
+  let settled = false
+
+  promise.then(
+    () => {
+      settled = true
+    },
+    () => {
+      settled = true
+    },
+  )
+
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0)
+  })
+
+  return settled
+}
+
 describe('Dashboard', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -238,6 +260,25 @@ describe('Dashboard', () => {
       unmount()
 
       expect(mockUnmount).toHaveBeenCalled()
+    })
+
+    // The SDK's `unmount()` only clears the iframe (`index.js:159-163`); it never
+    // cancels the refresh `setTimeout` it scheduled, so cleanup has to cancel the
+    // fetcher too. Without that, the chain keeps minting tokens for the rest of the
+    // SPA session — every revisit or dashboard switch leaving another one behind.
+    it('THEN cancels the guest token fetcher so the refresh chain stops', async () => {
+      const { unmount } = renderAnalytics()
+
+      await waitFor(() => expect(mockEmbedDashboard).toHaveBeenCalledTimes(1))
+
+      const { fetchGuestToken } = mockEmbedDashboard.mock.calls[0][0]
+
+      unmount()
+
+      // A cancelled fetcher deliberately never settles — that is the only way to
+      // halt a chain that re-arms from our resolution. Settling here means cleanup
+      // left the loop alive: the mutation mock would have resolved it.
+      expect(await hasSettled(fetchGuestToken())).toBe(false)
     })
 
     // The SDK puts its iframe in the DOM before `embedDashboard` resolves, so an

--- a/src/pages/dashboards/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboards/__tests__/Dashboard.test.tsx
@@ -2,8 +2,10 @@ import { screen, waitFor } from '@testing-library/react'
 
 import { GENERIC_PLACEHOLDER_TEST_ID } from '~/components/designSystem/GenericPlaceholder'
 import { getItemFromLS, setItemFromLS } from '~/core/utils/localStorage'
-import { SupersetDashboardsDocument } from '~/generated/graphql'
-import { CREATE_SUPERSET_GUEST_TOKEN } from '~/pages/dashboards/fetchSupersetGuestToken'
+import {
+  CreateSupersetGuestTokenDocument,
+  SupersetDashboardsDocument,
+} from '~/generated/graphql'
 import { render, TestMocksType } from '~/test-utils'
 
 import Dashboard, { DASHBOARD_MOUNT_TEST_ID } from '../Dashboard'
@@ -82,7 +84,7 @@ const successMock: TestMocksType = [
   { request: { query: SupersetDashboardsDocument }, result: { data: dashboardsData } },
   {
     request: {
-      query: CREATE_SUPERSET_GUEST_TOKEN,
+      query: CreateSupersetGuestTokenDocument,
       variables: { input: { dashboardId: 'dash-1' } },
     },
     result: { data: { createSupersetGuestToken: { guestToken: 'token-1' } } },

--- a/src/pages/dashboards/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboards/__tests__/Dashboard.test.tsx
@@ -84,7 +84,10 @@ const successMock: TestMocksType = [
       query: CreateSupersetGuestTokenDocument,
       variables: { input: { dashboardId: 'dash-1' } },
     },
-    result: { data: { createSupersetGuestToken: { guestToken: 'token-1' } } },
+    // Deliberately different from the `guestToken` seeded by the dashboards query
+    // above: if the two matched, an assertion on the fetched token would pass even
+    // when the mutation never ran or threw and fell back to the seed.
+    result: { data: { createSupersetGuestToken: { guestToken: 'refreshed-token' } } },
   },
 ]
 
@@ -143,7 +146,8 @@ describe('Dashboard', () => {
       expect(config.supersetDomain).toBe('https://localhost:8089')
       expect(config.mountPoint).toBe(document.getElementById('superset-lago-dashboard'))
       expect(config.dashboardUiConfig.hideTitle).toBe(true)
-      await expect(config.fetchGuestToken()).resolves.toBe('token-1')
+      // Proves the token came from the mutation, not from the query's seed.
+      await expect(config.fetchGuestToken()).resolves.toBe('refreshed-token')
     })
   })
 
@@ -234,6 +238,33 @@ describe('Dashboard', () => {
       unmount()
 
       expect(mockUnmount).toHaveBeenCalled()
+    })
+
+    // The SDK puts its iframe in the DOM before `embedDashboard` resolves, so an
+    // embed still in flight at cleanup time has to be unmounted once it lands —
+    // otherwise the iframe is orphaned with its Switchboard port open. StrictMode
+    // hits this on every dev mount.
+    it('THEN tears down an embed that only resolves after cleanup ran', async () => {
+      let resolveEmbed: (value: unknown) => void = () => {}
+
+      mockEmbedDashboard.mockReturnValue(
+        new Promise((resolve) => {
+          resolveEmbed = resolve
+        }),
+      )
+
+      const { unmount } = renderAnalytics()
+
+      await waitFor(() => expect(mockEmbedDashboard).toHaveBeenCalledTimes(1))
+
+      unmount()
+      expect(mockUnmount).not.toHaveBeenCalled()
+
+      resolveEmbed({ unmount: mockUnmount, observeDataMask: mockObserveDataMask })
+
+      await waitFor(() => expect(mockUnmount).toHaveBeenCalledTimes(1))
+      // The late embed must not wire up filter observation either.
+      expect(mockObserveDataMask).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/pages/dashboards/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboards/__tests__/Dashboard.test.tsx
@@ -3,6 +3,7 @@ import { screen, waitFor } from '@testing-library/react'
 import { GENERIC_PLACEHOLDER_TEST_ID } from '~/components/designSystem/GenericPlaceholder'
 import { getItemFromLS, setItemFromLS } from '~/core/utils/localStorage'
 import { SupersetDashboardsDocument } from '~/generated/graphql'
+import { CREATE_SUPERSET_GUEST_TOKEN } from '~/pages/dashboards/fetchSupersetGuestToken'
 import { render, TestMocksType } from '~/test-utils'
 
 import Dashboard, { DASHBOARD_MOUNT_TEST_ID } from '../Dashboard'
@@ -79,6 +80,13 @@ const dashboardsData = {
 
 const successMock: TestMocksType = [
   { request: { query: SupersetDashboardsDocument }, result: { data: dashboardsData } },
+  {
+    request: {
+      query: CREATE_SUPERSET_GUEST_TOKEN,
+      variables: { input: { dashboardId: 'dash-1' } },
+    },
+    result: { data: { createSupersetGuestToken: { guestToken: 'token-1' } } },
+  },
 ]
 
 const errorMock: TestMocksType = [

--- a/src/pages/dashboards/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboards/__tests__/Dashboard.test.tsx
@@ -2,10 +2,7 @@ import { screen, waitFor } from '@testing-library/react'
 
 import { GENERIC_PLACEHOLDER_TEST_ID } from '~/components/designSystem/GenericPlaceholder'
 import { getItemFromLS, setItemFromLS } from '~/core/utils/localStorage'
-import {
-  CreateSupersetGuestTokenDocument,
-  SupersetDashboardsDocument,
-} from '~/generated/graphql'
+import { CreateSupersetGuestTokenDocument, SupersetDashboardsDocument } from '~/generated/graphql'
 import { render, TestMocksType } from '~/test-utils'
 
 import Dashboard, { DASHBOARD_MOUNT_TEST_ID } from '../Dashboard'

--- a/src/pages/dashboards/__tests__/fetchSupersetGuestToken.test.ts
+++ b/src/pages/dashboards/__tests__/fetchSupersetGuestToken.test.ts
@@ -1,0 +1,37 @@
+import { type ApolloClient } from '@apollo/client'
+
+import {
+  CREATE_SUPERSET_GUEST_TOKEN,
+  createFetchSupersetGuestToken,
+} from '~/pages/dashboards/fetchSupersetGuestToken'
+
+describe('createFetchSupersetGuestToken', () => {
+  it('mints a fresh token on every call for the given dashboard', async () => {
+    const mutate = jest
+      .fn()
+      .mockResolvedValueOnce({ data: { createSupersetGuestToken: { guestToken: 'token-1' } } })
+      .mockResolvedValueOnce({ data: { createSupersetGuestToken: { guestToken: 'token-2' } } })
+    const client = { mutate } as unknown as ApolloClient<object>
+
+    const fetchGuestToken = createFetchSupersetGuestToken(client, '42')
+
+    expect(await fetchGuestToken()).toBe('token-1')
+    expect(await fetchGuestToken()).toBe('token-2')
+
+    expect(mutate).toHaveBeenCalledTimes(2)
+    expect(mutate).toHaveBeenNthCalledWith(1, {
+      mutation: CREATE_SUPERSET_GUEST_TOKEN,
+      variables: { input: { dashboardId: '42' } },
+      fetchPolicy: 'no-cache',
+    })
+  })
+
+  it('returns an empty string when Superset returns no token', async () => {
+    const mutate = jest.fn().mockResolvedValue({ data: null })
+    const client = { mutate } as unknown as ApolloClient<object>
+
+    const fetchGuestToken = createFetchSupersetGuestToken(client, '42')
+
+    expect(await fetchGuestToken()).toBe('')
+  })
+})

--- a/src/pages/dashboards/__tests__/fetchSupersetGuestToken.test.ts
+++ b/src/pages/dashboards/__tests__/fetchSupersetGuestToken.test.ts
@@ -1,9 +1,7 @@
 import { type ApolloClient } from '@apollo/client'
 
-import {
-  CREATE_SUPERSET_GUEST_TOKEN,
-  createFetchSupersetGuestToken,
-} from '~/pages/dashboards/fetchSupersetGuestToken'
+import { CreateSupersetGuestTokenDocument } from '~/generated/graphql'
+import { createFetchSupersetGuestToken } from '~/pages/dashboards/fetchSupersetGuestToken'
 
 const makeClient = (mutate: jest.Mock) => ({ mutate }) as unknown as ApolloClient<object>
 
@@ -24,7 +22,7 @@ describe('createFetchSupersetGuestToken', () => {
 
     expect(mutate).toHaveBeenCalledTimes(2)
     expect(mutate).toHaveBeenNthCalledWith(1, {
-      mutation: CREATE_SUPERSET_GUEST_TOKEN,
+      mutation: CreateSupersetGuestTokenDocument,
       variables: { input: { dashboardId: '42' } },
       fetchPolicy: 'no-cache',
     })

--- a/src/pages/dashboards/__tests__/fetchSupersetGuestToken.test.ts
+++ b/src/pages/dashboards/__tests__/fetchSupersetGuestToken.test.ts
@@ -5,15 +5,19 @@ import {
   createFetchSupersetGuestToken,
 } from '~/pages/dashboards/fetchSupersetGuestToken'
 
+const makeClient = (mutate: jest.Mock) => ({ mutate }) as unknown as ApolloClient<object>
+
+const PENDING = Symbol('pending')
+const settledOrPending = (promise: Promise<unknown>) =>
+  Promise.race([promise, Promise.resolve(PENDING)])
+
 describe('createFetchSupersetGuestToken', () => {
   it('mints a fresh token on every call for the given dashboard', async () => {
     const mutate = jest
       .fn()
       .mockResolvedValueOnce({ data: { createSupersetGuestToken: { guestToken: 'token-1' } } })
       .mockResolvedValueOnce({ data: { createSupersetGuestToken: { guestToken: 'token-2' } } })
-    const client = { mutate } as unknown as ApolloClient<object>
-
-    const fetchGuestToken = createFetchSupersetGuestToken(client, '42')
+    const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42')
 
     expect(await fetchGuestToken()).toBe('token-1')
     expect(await fetchGuestToken()).toBe('token-2')
@@ -26,12 +30,50 @@ describe('createFetchSupersetGuestToken', () => {
     })
   })
 
-  it('returns an empty string when Superset returns no token', async () => {
-    const mutate = jest.fn().mockResolvedValue({ data: null })
-    const client = { mutate } as unknown as ApolloClient<object>
+  it('falls back to the initial token when the mutation fails, keeping the refresh loop alive', async () => {
+    const mutate = jest.fn().mockRejectedValue(new Error('network'))
+    const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
 
-    const fetchGuestToken = createFetchSupersetGuestToken(client, '42')
+    await expect(fetchGuestToken()).resolves.toBe('initial-token')
+  })
 
-    expect(await fetchGuestToken()).toBe('')
+  it('keeps the most recent successful token when a later refresh fails', async () => {
+    const mutate = jest
+      .fn()
+      .mockResolvedValueOnce({ data: { createSupersetGuestToken: { guestToken: 'token-1' } } })
+      .mockRejectedValueOnce(new Error('rate limited'))
+    const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
+
+    expect(await fetchGuestToken()).toBe('token-1')
+    await expect(fetchGuestToken()).resolves.toBe('token-1')
+  })
+
+  it('never resolves and stops hitting the mutation once cancelled', async () => {
+    const mutate = jest
+      .fn()
+      .mockResolvedValue({ data: { createSupersetGuestToken: { guestToken: 'token-1' } } })
+    const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
+
+    fetchGuestToken.cancel()
+
+    expect(await settledOrPending(fetchGuestToken())).toBe(PENDING)
+    expect(mutate).not.toHaveBeenCalled()
+  })
+
+  it('never resolves if cancelled while a mutation is in flight', async () => {
+    let resolveMutate: (value: unknown) => void = () => {}
+    const mutate = jest.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveMutate = resolve
+      }),
+    )
+    const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
+
+    const pending = fetchGuestToken()
+
+    fetchGuestToken.cancel()
+    resolveMutate({ data: { createSupersetGuestToken: { guestToken: 'token-late' } } })
+
+    expect(await settledOrPending(pending)).toBe(PENDING)
   })
 })

--- a/src/pages/dashboards/__tests__/fetchSupersetGuestToken.test.ts
+++ b/src/pages/dashboards/__tests__/fetchSupersetGuestToken.test.ts
@@ -31,8 +31,6 @@ const tokenResponse = (guestToken: string | null) => ({
 })
 
 // Whether `promise` has settled once microtasks and 0ms timers have flushed.
-// Racing against an already-resolved sentinel instead would always pick the
-// sentinel, so such an assertion could never fail.
 const hasSettled = async (promise: Promise<unknown>): Promise<boolean> => {
   let settled = false
 
@@ -99,7 +97,6 @@ describe('createFetchSupersetGuestToken', () => {
       await jest.advanceTimersByTimeAsync(0)
       expect(mutate).toHaveBeenCalledTimes(1)
 
-      // No further attempt until the first backoff has elapsed.
       await jest.advanceTimersByTimeAsync(FIRST_RETRY_BACKOFF_MS - 1)
       expect(mutate).toHaveBeenCalledTimes(1)
 
@@ -124,8 +121,6 @@ describe('createFetchSupersetGuestToken', () => {
       await drainFailedInvocation(fetchGuestToken())
       expect(mutate).toHaveBeenCalledTimes(MAX_MINT_ATTEMPTS)
 
-      // The SDK re-invokes us ~5s after we hand back an expired token. That call
-      // must not immediately hit the endpoint again.
       const second = fetchGuestToken()
 
       await jest.advanceTimersByTimeAsync(FIRST_STREAK_COOLDOWN_MS - 1)
@@ -196,13 +191,11 @@ describe('createFetchSupersetGuestToken', () => {
       .mockResolvedValue(tokenResponse('token-recovered'))
     const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
 
-    // Attempt 1 fails, attempt 2 recovers within the same invocation.
     const recovering = fetchGuestToken()
 
     await jest.advanceTimersByTimeAsync(FIRST_RETRY_BACKOFF_MS)
     await expect(recovering).resolves.toBe('token-recovered')
 
-    // Streak is reset, so the next invocation mints without waiting.
     await expect(fetchGuestToken()).resolves.toBe('token-recovered')
     expect(mutate).toHaveBeenCalledTimes(3)
   })
@@ -236,10 +229,8 @@ describe('createFetchSupersetGuestToken', () => {
       expect(mutate).not.toHaveBeenCalled()
     })
 
-    // A call already in flight MUST settle. The SDK awaits this callback inside
-    // `Promise.all([fetchGuestToken(), mountIframe()])` during the initial embed,
-    // so hanging here leaves `embedDashboard` unresolved and its already-mounted
-    // iframe orphaned, with no handle for the effect cleanup to unmount.
+    // The SDK awaits this callback inside `Promise.all` during the initial embed,
+    // so hanging here would leave `embedDashboard` unresolved forever.
     it('THEN still settles a call that was already in flight', async () => {
       let resolveMutate: (value: unknown) => void = () => {}
       const mutate = jest.fn().mockReturnValue(
@@ -261,8 +252,6 @@ describe('createFetchSupersetGuestToken', () => {
       await expect(pending).resolves.toBe('token-late')
     })
 
-    // Without waking the sleeper this would sit on the remaining backoff, so the
-    // assertion below would time out rather than resolve.
     it('THEN abandons a pending retry backoff immediately', async () => {
       const mutate = jest.fn().mockRejectedValue(new Error('network'))
       const fetchGuestToken = createFetchSupersetGuestToken(

--- a/src/pages/dashboards/__tests__/fetchSupersetGuestToken.test.ts
+++ b/src/pages/dashboards/__tests__/fetchSupersetGuestToken.test.ts
@@ -3,19 +3,39 @@ import { type ApolloClient } from '@apollo/client'
 import { CreateSupersetGuestTokenDocument } from '~/generated/graphql'
 import { createFetchSupersetGuestToken } from '~/pages/dashboards/fetchSupersetGuestToken'
 
+const mockCaptureException = jest.fn()
+const mockCaptureMessage = jest.fn()
+
+jest.mock('@sentry/react', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
+}))
+
 const makeClient = (mutate: jest.Mock) => ({ mutate }) as unknown as ApolloClient<object>
 
 const PENDING = Symbol('pending')
 const settledOrPending = (promise: Promise<unknown>) =>
   Promise.race([promise, Promise.resolve(PENDING)])
 
+// Retry backoff inside one invocation: 1s after attempt 1, 2s after attempt 2.
+const ALL_RETRY_BACKOFFS_MS = 3000
+
 describe('createFetchSupersetGuestToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   it('mints a fresh token on every call for the given dashboard', async () => {
     const mutate = jest
       .fn()
       .mockResolvedValueOnce({ data: { createSupersetGuestToken: { guestToken: 'token-1' } } })
       .mockResolvedValueOnce({ data: { createSupersetGuestToken: { guestToken: 'token-2' } } })
-    const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42')
+    const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
 
     expect(await fetchGuestToken()).toBe('token-1')
     expect(await fetchGuestToken()).toBe('token-2')
@@ -32,18 +52,27 @@ describe('createFetchSupersetGuestToken', () => {
     const mutate = jest.fn().mockRejectedValue(new Error('network'))
     const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
 
-    await expect(fetchGuestToken()).resolves.toBe('initial-token')
+    const pending = fetchGuestToken()
+
+    await jest.advanceTimersByTimeAsync(ALL_RETRY_BACKOFFS_MS)
+
+    await expect(pending).resolves.toBe('initial-token')
   })
 
   it('keeps the most recent successful token when a later refresh fails', async () => {
     const mutate = jest
       .fn()
       .mockResolvedValueOnce({ data: { createSupersetGuestToken: { guestToken: 'token-1' } } })
-      .mockRejectedValueOnce(new Error('rate limited'))
+      .mockRejectedValue(new Error('rate limited'))
     const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
 
     expect(await fetchGuestToken()).toBe('token-1')
-    await expect(fetchGuestToken()).resolves.toBe('token-1')
+
+    const pending = fetchGuestToken()
+
+    await jest.advanceTimersByTimeAsync(ALL_RETRY_BACKOFFS_MS)
+
+    await expect(pending).resolves.toBe('token-1')
   })
 
   it('never resolves and stops hitting the mutation once cancelled', async () => {
@@ -58,7 +87,11 @@ describe('createFetchSupersetGuestToken', () => {
     expect(mutate).not.toHaveBeenCalled()
   })
 
-  it('never resolves if cancelled while a mutation is in flight', async () => {
+  // Inverted deliberately: a call already in flight MUST settle. The SDK awaits
+  // this callback inside `Promise.all([fetchGuestToken(), mountIframe()])` during
+  // the initial embed, so hanging here leaves `embedDashboard` unresolved and its
+  // already-mounted iframe orphaned, with no handle for the effect to unmount.
+  it('settles a call that was already in flight when cancelled', async () => {
     let resolveMutate: (value: unknown) => void = () => {}
     const mutate = jest.fn().mockReturnValue(
       new Promise((resolve) => {
@@ -72,6 +105,6 @@ describe('createFetchSupersetGuestToken', () => {
     fetchGuestToken.cancel()
     resolveMutate({ data: { createSupersetGuestToken: { guestToken: 'token-late' } } })
 
-    expect(await settledOrPending(pending)).toBe(PENDING)
+    await expect(pending).resolves.toBe('token-late')
   })
 })

--- a/src/pages/dashboards/__tests__/fetchSupersetGuestToken.test.ts
+++ b/src/pages/dashboards/__tests__/fetchSupersetGuestToken.test.ts
@@ -1,4 +1,5 @@
-import { type ApolloClient } from '@apollo/client'
+import { type ApolloClient, ApolloError } from '@apollo/client'
+import { GraphQLError } from 'graphql'
 
 import { CreateSupersetGuestTokenDocument } from '~/generated/graphql'
 import { createFetchSupersetGuestToken } from '~/pages/dashboards/fetchSupersetGuestToken'
@@ -13,12 +14,48 @@ jest.mock('@sentry/react', () => ({
 
 const makeClient = (mutate: jest.Mock) => ({ mutate }) as unknown as ApolloClient<object>
 
-const PENDING = Symbol('pending')
-const settledOrPending = (promise: Promise<unknown>) =>
-  Promise.race([promise, Promise.resolve(PENDING)])
+// Retry backoff within a single invocation: 1s after attempt 1, 2s after attempt 2.
+const FIRST_RETRY_BACKOFF_MS = 1000
+const SECOND_RETRY_BACKOFF_MS = 2000
+const ALL_RETRY_BACKOFFS_MS = FIRST_RETRY_BACKOFF_MS + SECOND_RETRY_BACKOFF_MS
+const FIRST_STREAK_COOLDOWN_MS = 5000
+const MAX_MINT_ATTEMPTS = 3
 
-// Retry backoff inside one invocation: 1s after attempt 1, 2s after attempt 2.
-const ALL_RETRY_BACKOFFS_MS = 3000
+const SENTRY_TAGS = {
+  errorType: 'SupersetGuestTokenMintError',
+  component: 'fetchSupersetGuestToken',
+}
+
+const tokenResponse = (guestToken: string | null) => ({
+  data: { createSupersetGuestToken: { guestToken } },
+})
+
+// Whether `promise` has settled once microtasks and 0ms timers have flushed.
+// Racing against an already-resolved sentinel instead would always pick the
+// sentinel, so such an assertion could never fail.
+const hasSettled = async (promise: Promise<unknown>): Promise<boolean> => {
+  let settled = false
+
+  promise.then(
+    () => {
+      settled = true
+    },
+    () => {
+      settled = true
+    },
+  )
+
+  await jest.advanceTimersByTimeAsync(0)
+
+  return settled
+}
+
+// Drives one fully-failing invocation (all attempts + their backoffs) to settlement.
+const drainFailedInvocation = async (pending: Promise<string>): Promise<string> => {
+  await jest.advanceTimersByTimeAsync(ALL_RETRY_BACKOFFS_MS)
+
+  return pending
+}
 
 describe('createFetchSupersetGuestToken', () => {
   beforeEach(() => {
@@ -33,8 +70,8 @@ describe('createFetchSupersetGuestToken', () => {
   it('mints a fresh token on every call for the given dashboard', async () => {
     const mutate = jest
       .fn()
-      .mockResolvedValueOnce({ data: { createSupersetGuestToken: { guestToken: 'token-1' } } })
-      .mockResolvedValueOnce({ data: { createSupersetGuestToken: { guestToken: 'token-2' } } })
+      .mockResolvedValueOnce(tokenResponse('token-1'))
+      .mockResolvedValueOnce(tokenResponse('token-2'))
     const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
 
     expect(await fetchGuestToken()).toBe('token-1')
@@ -48,63 +85,201 @@ describe('createFetchSupersetGuestToken', () => {
     })
   })
 
-  it('falls back to the initial token when the mutation fails, keeping the refresh loop alive', async () => {
-    const mutate = jest.fn().mockRejectedValue(new Error('network'))
-    const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
+  describe('GIVEN the mutation keeps failing', () => {
+    it('THEN retries with a growing backoff, capped, before falling back to the last token', async () => {
+      const mutate = jest.fn().mockRejectedValue(new Error('network'))
+      const fetchGuestToken = createFetchSupersetGuestToken(
+        makeClient(mutate),
+        '42',
+        'initial-token',
+      )
 
-    const pending = fetchGuestToken()
+      const pending = fetchGuestToken()
 
-    await jest.advanceTimersByTimeAsync(ALL_RETRY_BACKOFFS_MS)
+      await jest.advanceTimersByTimeAsync(0)
+      expect(mutate).toHaveBeenCalledTimes(1)
 
-    await expect(pending).resolves.toBe('initial-token')
+      // No further attempt until the first backoff has elapsed.
+      await jest.advanceTimersByTimeAsync(FIRST_RETRY_BACKOFF_MS - 1)
+      expect(mutate).toHaveBeenCalledTimes(1)
+
+      await jest.advanceTimersByTimeAsync(1)
+      expect(mutate).toHaveBeenCalledTimes(2)
+
+      await jest.advanceTimersByTimeAsync(SECOND_RETRY_BACKOFF_MS)
+      expect(mutate).toHaveBeenCalledTimes(MAX_MINT_ATTEMPTS)
+
+      await expect(pending).resolves.toBe('initial-token')
+      expect(mutate).toHaveBeenCalledTimes(MAX_MINT_ATTEMPTS)
+    })
+
+    it('THEN cools down before the next invocation instead of re-minting every 5s', async () => {
+      const mutate = jest.fn().mockRejectedValue(new Error('network'))
+      const fetchGuestToken = createFetchSupersetGuestToken(
+        makeClient(mutate),
+        '42',
+        'initial-token',
+      )
+
+      await drainFailedInvocation(fetchGuestToken())
+      expect(mutate).toHaveBeenCalledTimes(MAX_MINT_ATTEMPTS)
+
+      // The SDK re-invokes us ~5s after we hand back an expired token. That call
+      // must not immediately hit the endpoint again.
+      const second = fetchGuestToken()
+
+      await jest.advanceTimersByTimeAsync(FIRST_STREAK_COOLDOWN_MS - 1)
+      expect(mutate).toHaveBeenCalledTimes(MAX_MINT_ATTEMPTS)
+
+      await jest.advanceTimersByTimeAsync(1)
+      expect(mutate).toHaveBeenCalledTimes(MAX_MINT_ATTEMPTS + 1)
+
+      await drainFailedInvocation(second)
+    })
+
+    it('THEN reports the first failure of the streak once, and stays quiet afterwards', async () => {
+      const mutate = jest.fn().mockRejectedValue(new TypeError('offline'))
+      const fetchGuestToken = createFetchSupersetGuestToken(
+        makeClient(mutate),
+        '42',
+        'initial-token',
+      )
+
+      await drainFailedInvocation(fetchGuestToken())
+
+      expect(mockCaptureException).toHaveBeenCalledTimes(1)
+      expect(mockCaptureException).toHaveBeenCalledWith(expect.any(TypeError), {
+        tags: SENTRY_TAGS,
+        extra: { dashboardId: '42' },
+      })
+
+      const second = fetchGuestToken()
+
+      await jest.advanceTimersByTimeAsync(FIRST_STREAK_COOLDOWN_MS)
+      await drainFailedInvocation(second)
+
+      expect(mockCaptureException).toHaveBeenCalledTimes(1)
+    })
+
+    it('THEN leaves GraphQL errors to the errorLink rather than reporting them twice', async () => {
+      const mutate = jest
+        .fn()
+        .mockRejectedValue(new ApolloError({ graphQLErrors: [new GraphQLError('forbidden')] }))
+      const fetchGuestToken = createFetchSupersetGuestToken(
+        makeClient(mutate),
+        '42',
+        'initial-token',
+      )
+
+      await drainFailedInvocation(fetchGuestToken())
+
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
   })
 
   it('keeps the most recent successful token when a later refresh fails', async () => {
     const mutate = jest
       .fn()
-      .mockResolvedValueOnce({ data: { createSupersetGuestToken: { guestToken: 'token-1' } } })
+      .mockResolvedValueOnce(tokenResponse('token-1'))
       .mockRejectedValue(new Error('rate limited'))
     const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
 
     expect(await fetchGuestToken()).toBe('token-1')
 
-    const pending = fetchGuestToken()
-
-    await jest.advanceTimersByTimeAsync(ALL_RETRY_BACKOFFS_MS)
-
-    await expect(pending).resolves.toBe('token-1')
+    await expect(drainFailedInvocation(fetchGuestToken())).resolves.toBe('token-1')
   })
 
-  it('never resolves and stops hitting the mutation once cancelled', async () => {
+  it('mints immediately again once a token comes back, dropping the cooldown', async () => {
     const mutate = jest
       .fn()
-      .mockResolvedValue({ data: { createSupersetGuestToken: { guestToken: 'token-1' } } })
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValue(tokenResponse('token-recovered'))
     const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
 
-    fetchGuestToken.cancel()
+    // Attempt 1 fails, attempt 2 recovers within the same invocation.
+    const recovering = fetchGuestToken()
 
-    expect(await settledOrPending(fetchGuestToken())).toBe(PENDING)
-    expect(mutate).not.toHaveBeenCalled()
+    await jest.advanceTimersByTimeAsync(FIRST_RETRY_BACKOFF_MS)
+    await expect(recovering).resolves.toBe('token-recovered')
+
+    // Streak is reset, so the next invocation mints without waiting.
+    await expect(fetchGuestToken()).resolves.toBe('token-recovered')
+    expect(mutate).toHaveBeenCalledTimes(3)
   })
 
-  // Inverted deliberately: a call already in flight MUST settle. The SDK awaits
-  // this callback inside `Promise.all([fetchGuestToken(), mountIframe()])` during
-  // the initial embed, so hanging here leaves `embedDashboard` unresolved and its
-  // already-mounted iframe orphaned, with no handle for the effect to unmount.
-  it('settles a call that was already in flight when cancelled', async () => {
-    let resolveMutate: (value: unknown) => void = () => {}
-    const mutate = jest.fn().mockReturnValue(
-      new Promise((resolve) => {
-        resolveMutate = resolve
-      }),
-    )
+  it('treats a token-less response as a contract violation: reports, retries, falls back', async () => {
+    const mutate = jest.fn().mockResolvedValue(tokenResponse(null))
     const fetchGuestToken = createFetchSupersetGuestToken(makeClient(mutate), '42', 'initial-token')
 
-    const pending = fetchGuestToken()
+    await expect(drainFailedInvocation(fetchGuestToken())).resolves.toBe('initial-token')
 
-    fetchGuestToken.cancel()
-    resolveMutate({ data: { createSupersetGuestToken: { guestToken: 'token-late' } } })
+    expect(mutate).toHaveBeenCalledTimes(MAX_MINT_ATTEMPTS)
+    expect(mockCaptureMessage).toHaveBeenCalledTimes(1)
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'Superset guest token mutation returned no token',
+      { level: 'error', tags: SENTRY_TAGS, extra: { dashboardId: '42' } },
+    )
+  })
 
-    await expect(pending).resolves.toBe('token-late')
+  describe('GIVEN the fetcher is cancelled', () => {
+    it('THEN never resolves and stops hitting the mutation', async () => {
+      const mutate = jest.fn().mockResolvedValue(tokenResponse('token-1'))
+      const fetchGuestToken = createFetchSupersetGuestToken(
+        makeClient(mutate),
+        '42',
+        'initial-token',
+      )
+
+      fetchGuestToken.cancel()
+
+      expect(await hasSettled(fetchGuestToken())).toBe(false)
+      expect(mutate).not.toHaveBeenCalled()
+    })
+
+    // A call already in flight MUST settle. The SDK awaits this callback inside
+    // `Promise.all([fetchGuestToken(), mountIframe()])` during the initial embed,
+    // so hanging here leaves `embedDashboard` unresolved and its already-mounted
+    // iframe orphaned, with no handle for the effect cleanup to unmount.
+    it('THEN still settles a call that was already in flight', async () => {
+      let resolveMutate: (value: unknown) => void = () => {}
+      const mutate = jest.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveMutate = resolve
+        }),
+      )
+      const fetchGuestToken = createFetchSupersetGuestToken(
+        makeClient(mutate),
+        '42',
+        'initial-token',
+      )
+
+      const pending = fetchGuestToken()
+
+      fetchGuestToken.cancel()
+      resolveMutate(tokenResponse('token-late'))
+
+      await expect(pending).resolves.toBe('token-late')
+    })
+
+    // Without waking the sleeper this would sit on the remaining backoff, so the
+    // assertion below would time out rather than resolve.
+    it('THEN abandons a pending retry backoff immediately', async () => {
+      const mutate = jest.fn().mockRejectedValue(new Error('network'))
+      const fetchGuestToken = createFetchSupersetGuestToken(
+        makeClient(mutate),
+        '42',
+        'initial-token',
+      )
+
+      const pending = fetchGuestToken()
+
+      await jest.advanceTimersByTimeAsync(0)
+      expect(mutate).toHaveBeenCalledTimes(1)
+
+      fetchGuestToken.cancel()
+
+      await expect(pending).resolves.toBe('initial-token')
+      expect(mutate).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/src/pages/dashboards/fetchSupersetGuestToken.ts
+++ b/src/pages/dashboards/fetchSupersetGuestToken.ts
@@ -1,0 +1,20 @@
+import { type ApolloClient, gql } from '@apollo/client'
+
+export const CREATE_SUPERSET_GUEST_TOKEN = gql`
+  mutation createSupersetGuestToken($input: CreateSupersetGuestTokenInput!) {
+    createSupersetGuestToken(input: $input) {
+      guestToken
+    }
+  }
+`
+
+export const createFetchSupersetGuestToken =
+  (client: ApolloClient<object>, dashboardId: string) => async (): Promise<string> => {
+    const { data } = await client.mutate({
+      mutation: CREATE_SUPERSET_GUEST_TOKEN,
+      variables: { input: { dashboardId } },
+      fetchPolicy: 'no-cache',
+    })
+
+    return data?.createSupersetGuestToken?.guestToken ?? ''
+  }

--- a/src/pages/dashboards/fetchSupersetGuestToken.ts
+++ b/src/pages/dashboards/fetchSupersetGuestToken.ts
@@ -1,4 +1,5 @@
-import { type ApolloClient, gql } from '@apollo/client'
+import { type ApolloClient, ApolloError, gql } from '@apollo/client'
+import { captureException, captureMessage } from '@sentry/react'
 
 import {
   CreateSupersetGuestTokenDocument,
@@ -14,44 +15,157 @@ gql`
   }
 `
 
+// The SDK derives the next refresh delay from whatever token we hand back
+// (`guestTokenRefresh.js`): `ttl = max(MIN_REFRESH_WAIT_MS /* 10s */, exp - now)`,
+// then `ttl - REFRESH_TIMING_BUFFER_MS /* 5s */`. Once the token we return is
+// expired, `exp - now` is negative, so the delay floors at 5s — a mint that keeps
+// failing would be re-invoked every 5s for as long as the tab stays open (~720
+// mutations/hour, each one making the backend re-authenticate against Superset,
+// which is the rate-limit pressure that broke renewal in the first place).
+//
+// The SDK awaits this callback before re-arming its timer, so waiting *inside* it
+// is the only timing lever we have: retry a few times to ride out a transient
+// blip, then let the failure streak stretch the cycle instead of hammering.
+const MAX_MINT_ATTEMPTS = 3
+const RETRY_BACKOFF_MS = 1000
+const STREAK_COOLDOWN_BASE_MS = 5000
+const MAX_STREAK_COOLDOWN_MS = 5 * 60 * 1000
+
+const SENTRY_TAGS = {
+  errorType: 'SupersetGuestTokenMintError',
+  component: 'fetchSupersetGuestToken',
+}
+
 export type FetchSupersetGuestToken = (() => Promise<string>) & { cancel: () => void }
 
+// Cancellation has to stop the SDK's refresh chain, and that chain only re-arms
+// from the *resolution* of this callback — a rejection is never observed
+// (`index.js:150-156`), it just yields an unhandled rejection while renewal dies
+// anyway. A promise that never settles is therefore the only clean way to halt
+// the loop. It is not a leak: the suspended frame and the promise reference each
+// other and nothing else, so V8 collects the cycle.
 const haltRefreshLoop = (): Promise<string> => new Promise<string>(() => {})
+
+const streakCooldown = (streak: number): number =>
+  Math.min(STREAK_COOLDOWN_BASE_MS * 2 ** (streak - 1), MAX_STREAK_COOLDOWN_MS)
 
 export const createFetchSupersetGuestToken = (
   client: ApolloClient<object>,
   dashboardId: string,
-  initialToken = '',
+  initialToken: string,
 ): FetchSupersetGuestToken => {
   let lastToken = initialToken
   let cancelled = false
+  let failureStreak = 0
+  let wakeSleeper: null | (() => void) = null
+
+  // The SDK never overlaps calls (one mint for the initial embed, then a strictly
+  // sequential refresh chain), so a single sleeper slot is enough. `cancel()`
+  // wakes it so effect cleanup never waits out a backoff.
+  const sleep = (ms: number): Promise<void> =>
+    new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        wakeSleeper = null
+        resolve()
+      }, ms)
+
+      wakeSleeper = () => {
+        clearTimeout(timer)
+        wakeSleeper = null
+        resolve()
+      }
+    })
+
+  const reportMintError = (error: unknown): void => {
+    // GraphQL errors are already captured by the errorLink in
+    // apolloClient/init.ts, so re-reporting them here would duplicate. Network
+    // errors reach no other reporter — those are ours to surface.
+    if (error instanceof ApolloError && error.graphQLErrors.length > 0) return
+
+    captureException(error, { tags: SENTRY_TAGS, extra: { dashboardId } })
+  }
+
+  const mintToken = async (): Promise<string | undefined> => {
+    const { data } = await client.mutate<
+      CreateSupersetGuestTokenMutation,
+      CreateSupersetGuestTokenMutationVariables
+    >({
+      mutation: CreateSupersetGuestTokenDocument,
+      variables: { input: { dashboardId } },
+      fetchPolicy: 'no-cache',
+    })
+
+    return data?.createSupersetGuestToken?.guestToken
+  }
 
   const fetchGuestToken = async (): Promise<string> => {
-    if (cancelled) {
-      return haltRefreshLoop()
+    // Entry guard only. Past this point the call always settles, even when
+    // `cancel()` fires mid-flight: during the initial embed the SDK awaits this
+    // callback inside `Promise.all([fetchGuestToken(), mountIframe()])`
+    // (`index.js:146`), and its iframe is in the DOM before that settles.
+    // Hanging here would leave `embedDashboard` unresolved forever, so the effect
+    // would never get the `EmbeddedDashboard` it needs to unmount that iframe and
+    // close its Switchboard port.
+    if (cancelled) return haltRefreshLoop()
+
+    if (failureStreak > 0) {
+      await sleep(streakCooldown(failureStreak))
+
+      if (cancelled) return haltRefreshLoop()
     }
 
-    try {
-      const { data } = await client.mutate<
-        CreateSupersetGuestTokenMutation,
-        CreateSupersetGuestTokenMutationVariables
-      >({
-        mutation: CreateSupersetGuestTokenDocument,
-        variables: { input: { dashboardId } },
-        fetchPolicy: 'no-cache',
-      })
+    // Only the first failure of a streak is reported: a sustained outage retries
+    // for as long as the tab stays open, and one event per attempt would bury the
+    // signal rather than surface it.
+    const isFirstFailureOfStreak = (attempt: number): boolean =>
+      failureStreak === 0 && attempt === 1
 
-      lastToken = data?.createSupersetGuestToken?.guestToken ?? lastToken
+    for (let attempt = 1; attempt <= MAX_MINT_ATTEMPTS; attempt += 1) {
+      try {
+        const token = await mintToken()
 
-      return cancelled ? haltRefreshLoop() : lastToken
-    } catch {
-      return cancelled ? haltRefreshLoop() : lastToken
+        if (token) {
+          failureStreak = 0
+          lastToken = token
+
+          return lastToken
+        }
+
+        // `guestToken` is non-null in the schema, so an empty payload is a
+        // contract violation rather than an error response. There is no exception
+        // to attach, hence captureMessage.
+        if (isFirstFailureOfStreak(attempt)) {
+          captureMessage('Superset guest token mutation returned no token', {
+            level: 'error',
+            tags: SENTRY_TAGS,
+            extra: { dashboardId },
+          })
+        }
+      } catch (error) {
+        if (isFirstFailureOfStreak(attempt)) reportMintError(error)
+      }
+
+      if (cancelled) break
+
+      if (attempt < MAX_MINT_ATTEMPTS) {
+        await sleep(RETRY_BACKOFF_MS * 2 ** (attempt - 1))
+
+        if (cancelled) break
+      }
     }
+
+    failureStreak += 1
+
+    // Falling back to the last known good token keeps the SDK's chain alive so a
+    // later refresh can still recover. That token is expired once the outage
+    // outlasts it, which is exactly what the streak cooldown above is for.
+    return lastToken
   }
 
   return Object.assign(fetchGuestToken, {
-    cancel: () => {
+    cancel: (): void => {
       cancelled = true
+      wakeSleeper?.()
     },
   })
 }

--- a/src/pages/dashboards/fetchSupersetGuestToken.ts
+++ b/src/pages/dashboards/fetchSupersetGuestToken.ts
@@ -15,17 +15,10 @@ gql`
   }
 `
 
-// The SDK derives the next refresh delay from whatever token we hand back
-// (`guestTokenRefresh.js`): `ttl = max(MIN_REFRESH_WAIT_MS /* 10s */, exp - now)`,
-// then `ttl - REFRESH_TIMING_BUFFER_MS /* 5s */`. Once the token we return is
-// expired, `exp - now` is negative, so the delay floors at 5s — a mint that keeps
-// failing would be re-invoked every 5s for as long as the tab stays open (~720
-// mutations/hour, each one making the backend re-authenticate against Superset,
-// which is the rate-limit pressure that broke renewal in the first place).
-//
-// The SDK awaits this callback before re-arming its timer, so waiting *inside* it
-// is the only timing lever we have: retry a few times to ride out a transient
-// blip, then let the failure streak stretch the cycle instead of hammering.
+// The SDK derives its next refresh delay from the token we return, flooring at 5s
+// once that token is expired (`guestTokenRefresh.js`). It awaits this callback
+// before re-arming, so waiting inside it is the only lever we have to stop a
+// failing mint from being re-invoked every 5s for as long as the tab is open.
 const MAX_MINT_ATTEMPTS = 3
 const RETRY_BACKOFF_MS = 1000
 const STREAK_COOLDOWN_BASE_MS = 5000
@@ -38,12 +31,9 @@ const SENTRY_TAGS = {
 
 export type FetchSupersetGuestToken = (() => Promise<string>) & { cancel: () => void }
 
-// Cancellation has to stop the SDK's refresh chain, and that chain only re-arms
-// from the *resolution* of this callback — a rejection is never observed
-// (`index.js:150-156`), it just yields an unhandled rejection while renewal dies
-// anyway. A promise that never settles is therefore the only clean way to halt
-// the loop. It is not a leak: the suspended frame and the promise reference each
-// other and nothing else, so V8 collects the cycle.
+// The SDK's refresh chain re-arms only from this callback's resolution and never
+// observes a rejection (`index.js:150-156`), so never settling is the only way to
+// halt it. Not a leak: the frame and the promise reference only each other.
 const haltRefreshLoop = (): Promise<string> => new Promise<string>(() => {})
 
 const streakCooldown = (streak: number): number =>
@@ -59,9 +49,6 @@ export const createFetchSupersetGuestToken = (
   let failureStreak = 0
   let wakeSleeper: null | (() => void) = null
 
-  // The SDK never overlaps calls (one mint for the initial embed, then a strictly
-  // sequential refresh chain), so a single sleeper slot is enough. `cancel()`
-  // wakes it so effect cleanup never waits out a backoff.
   const sleep = (ms: number): Promise<void> =>
     new Promise<void>((resolve) => {
       const timer = setTimeout(() => {
@@ -77,9 +64,8 @@ export const createFetchSupersetGuestToken = (
     })
 
   const reportMintError = (error: unknown): void => {
-    // GraphQL errors are already captured by the errorLink in
-    // apolloClient/init.ts, so re-reporting them here would duplicate. Network
-    // errors reach no other reporter — those are ours to surface.
+    // GraphQL errors are already captured by the errorLink; only network errors
+    // reach no other reporter.
     if (error instanceof ApolloError && error.graphQLErrors.length > 0) return
 
     captureException(error, { tags: SENTRY_TAGS, extra: { dashboardId } })
@@ -99,13 +85,9 @@ export const createFetchSupersetGuestToken = (
   }
 
   const fetchGuestToken = async (): Promise<string> => {
-    // Entry guard only. Past this point the call always settles, even when
-    // `cancel()` fires mid-flight: during the initial embed the SDK awaits this
-    // callback inside `Promise.all([fetchGuestToken(), mountIframe()])`
-    // (`index.js:146`), and its iframe is in the DOM before that settles.
-    // Hanging here would leave `embedDashboard` unresolved forever, so the effect
-    // would never get the `EmbeddedDashboard` it needs to unmount that iframe and
-    // close its Switchboard port.
+    // Entry guard only: past here the call must settle even when cancelled, or a
+    // cancel during the initial embed leaves `embedDashboard` unresolved with its
+    // iframe already in the DOM (`index.js:146`).
     if (cancelled) return haltRefreshLoop()
 
     if (failureStreak > 0) {
@@ -114,9 +96,6 @@ export const createFetchSupersetGuestToken = (
       if (cancelled) return haltRefreshLoop()
     }
 
-    // Only the first failure of a streak is reported: a sustained outage retries
-    // for as long as the tab stays open, and one event per attempt would bury the
-    // signal rather than surface it.
     const isFirstFailureOfStreak = (attempt: number): boolean =>
       failureStreak === 0 && attempt === 1
 
@@ -131,9 +110,8 @@ export const createFetchSupersetGuestToken = (
           return lastToken
         }
 
-        // `guestToken` is non-null in the schema, so an empty payload is a
-        // contract violation rather than an error response. There is no exception
-        // to attach, hence captureMessage.
+        // `guestToken` is non-null in the schema: an empty payload is a contract
+        // violation, and there is no exception to attach.
         if (isFirstFailureOfStreak(attempt)) {
           captureMessage('Superset guest token mutation returned no token', {
             level: 'error',
@@ -156,9 +134,6 @@ export const createFetchSupersetGuestToken = (
 
     failureStreak += 1
 
-    // Falling back to the last known good token keeps the SDK's chain alive so a
-    // later refresh can still recover. That token is expired once the outage
-    // outlasts it, which is exactly what the streak cooldown above is for.
     return lastToken
   }
 

--- a/src/pages/dashboards/fetchSupersetGuestToken.ts
+++ b/src/pages/dashboards/fetchSupersetGuestToken.ts
@@ -8,13 +8,41 @@ export const CREATE_SUPERSET_GUEST_TOKEN = gql`
   }
 `
 
-export const createFetchSupersetGuestToken =
-  (client: ApolloClient<object>, dashboardId: string) => async (): Promise<string> => {
-    const { data } = await client.mutate({
-      mutation: CREATE_SUPERSET_GUEST_TOKEN,
-      variables: { input: { dashboardId } },
-      fetchPolicy: 'no-cache',
-    })
+export type FetchSupersetGuestToken = (() => Promise<string>) & { cancel: () => void }
 
-    return data?.createSupersetGuestToken?.guestToken ?? ''
+const haltRefreshLoop = (): Promise<string> => new Promise<string>(() => {})
+
+export const createFetchSupersetGuestToken = (
+  client: ApolloClient<object>,
+  dashboardId: string,
+  initialToken = '',
+): FetchSupersetGuestToken => {
+  let lastToken = initialToken
+  let cancelled = false
+
+  const fetchGuestToken = async (): Promise<string> => {
+    if (cancelled) {
+      return haltRefreshLoop()
+    }
+
+    try {
+      const { data } = await client.mutate({
+        mutation: CREATE_SUPERSET_GUEST_TOKEN,
+        variables: { input: { dashboardId } },
+        fetchPolicy: 'no-cache',
+      })
+
+      lastToken = data?.createSupersetGuestToken?.guestToken ?? lastToken
+
+      return cancelled ? haltRefreshLoop() : lastToken
+    } catch {
+      return cancelled ? haltRefreshLoop() : lastToken
+    }
   }
+
+  return Object.assign(fetchGuestToken, {
+    cancel: () => {
+      cancelled = true
+    },
+  })
+}

--- a/src/pages/dashboards/fetchSupersetGuestToken.ts
+++ b/src/pages/dashboards/fetchSupersetGuestToken.ts
@@ -1,6 +1,12 @@
 import { type ApolloClient, gql } from '@apollo/client'
 
-export const CREATE_SUPERSET_GUEST_TOKEN = gql`
+import {
+  CreateSupersetGuestTokenDocument,
+  CreateSupersetGuestTokenMutation,
+  CreateSupersetGuestTokenMutationVariables,
+} from '~/generated/graphql'
+
+gql`
   mutation createSupersetGuestToken($input: CreateSupersetGuestTokenInput!) {
     createSupersetGuestToken(input: $input) {
       guestToken
@@ -26,8 +32,11 @@ export const createFetchSupersetGuestToken = (
     }
 
     try {
-      const { data } = await client.mutate({
-        mutation: CREATE_SUPERSET_GUEST_TOKEN,
+      const { data } = await client.mutate<
+        CreateSupersetGuestTokenMutation,
+        CreateSupersetGuestTokenMutationVariables
+      >({
+        mutation: CreateSupersetGuestTokenDocument,
         variables: { input: { dashboardId } },
         fetchPolicy: 'no-cache',
       })


### PR DESCRIPTION
## Context

The analytics dashboards embed Apache Superset in an iframe. Superset only authorizes an embedded viewer through a short-lived guest token (5 minutes by default). The embed SDK re-invokes the `fetchGuestToken` callback shortly before the current token expires so the session can continue without interruption.

Our callback returned the single token captured at page load, so the SDK kept handing back an already-expired token. After a few minutes every chart and filter request failed, and the only way to recover was a full page reload, which also reset the active tab and filters. This is the "leave analytics open, change a filter, get an error" behaviour customers reported.

## Description

Extract a `fetchGuestToken` helper that mints a fresh, organization-scoped token on every call through the new `createSupersetGuestToken` mutation, and wire it into the dashboard embed. Each renewal now returns a valid token, keeping long analytics sessions alive without a reload. The mutation runs with a `no-cache` fetch policy so the token is never written into the Apollo cache, which this app persists to IndexedDB — a short-lived credential has no business being stored there.

The failure and teardown paths are where the SDK's behaviour dictates ours:

- **A failed mint must not reject.** The SDK re-arms its timer only from the resolution of our callback, so a rejection kills renewal permanently until a full page reload — the exact bug this PR fixes.
- **A failed mint must not simply return the stale token either.** The SDK derives the next refresh delay from whatever we hand back, flooring at 5s once that token is expired. Returning it unconditionally turns an outage into ~720 mutations an hour per tab, each making the backend re-authenticate against Superset. So the fetcher retries up to 3 times with a 1s/2s backoff, then applies a per-streak cooldown (5s, doubling to a 5 minute cap) before minting again, and only falls back to the last known good token in the meantime.
- **Teardown must stop the loop without stranding the embed.** `unmount()` only clears the iframe, never the pending refresh timer, so the effect cleanup calls a `cancel()` that makes subsequent calls return a never-settling promise — the only way to halt a chain that ignores rejections. A call already in flight still settles: the SDK awaits our callback inside `Promise.all([fetchGuestToken(), mountIframe()])` and puts its iframe in the DOM before that resolves, so hanging there would leave `embedDashboard` unresolved and the iframe orphaned with its Switchboard port open. `Dashboard.tsx` also unmounts an embed that lands after cleanup already ran.
- **Failures are reported.** The first failure of each streak is captured with an `errorType: 'SupersetGuestTokenMintError'` tag; the rest of the streak stays quiet so a sustained outage doesn't bury the signal. GraphQL errors are left to the errorLink, which already captures them; network errors and token-less responses (a non-null schema contract violation) are captured here.

`pnpm codegen` has been run and the regenerated types committed, so the mutation is consumed through `CreateSupersetGuestTokenDocument` with generated type parameters rather than a hand-rolled document and an `any` payload.
