### PR TITLE
refactor(avalara): migrate DeleteAvalaraIntegrationDialog to useCentralizedDialog

### DIFF
--- a/src/components/settings/integrations/AddAvalaraDialog.tsx
+++ b/src/components/settings/integrations/AddAvalaraDialog.tsx
@@ -1,7 +1,7 @@
 import { FetchResult, gql } from '@apollo/client'
 import { captureException } from '@sentry/react'
 import { useFormik } from 'formik'
-import { forwardRef, RefObject, useId, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useId, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 import { object, string } from 'yup'
 
@@ -26,7 +26,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { AvalaraIntegrationDetailsTabs } from '~/pages/settings/AvalaraIntegrationDetails'
 import { tw } from '~/styles/utils'
 
-import { DeleteAvalaraIntegrationDialogRef } from './DeleteAvalaraIntegrationDialog'
+import { useDeleteAvalaraIntegrationDialog } from './DeleteAvalaraIntegrationDialog'
 
 gql`
   fragment AddAvalaraIntegrationDialog on AvalaraIntegration {
@@ -59,7 +59,6 @@ gql`
 type AddAvalaraDialogProps = {
   integration: AddAvalaraIntegrationDialogFragment
   deleteDialogCallback?: () => void
-  deleteModalRef: RefObject<DeleteAvalaraIntegrationDialogRef>
 }
 
 export interface AddAvalaraDialogRef {
@@ -77,6 +76,7 @@ export const AddAvalaraDialog = forwardRef<AddAvalaraDialogRef>((_, ref) => {
   const [showGlobalError, setShowGlobalError] = useState(false)
   const avalaraIntegration = localData?.integration
   const isEdition = !!avalaraIntegration
+  const { openDeleteAvalaraIntegrationDialog } = useDeleteAvalaraIntegrationDialog()
 
   const [addAvalara] = useCreateAvalaraIntegrationMutation({
     onCompleted({ createAvalaraIntegration }) {
@@ -224,7 +224,7 @@ export const AddAvalaraDialog = forwardRef<AddAvalaraDialogRef>((_, ref) => {
               variant="quaternary"
               onClick={() => {
                 closeDialog()
-                localData?.deleteModalRef?.current?.openDialog({
+                openDeleteAvalaraIntegrationDialog({
                   provider: avalaraIntegration,
                   callback: localData?.deleteDialogCallback,
                 })

--- a/src/components/settings/integrations/AvalaraIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AvalaraIntegrationSettings.tsx
@@ -7,10 +7,6 @@ import { Button } from '~/components/designSystem/Button'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Typography } from '~/components/designSystem/Typography'
 import { IntegrationsPage } from '~/components/layouts/Integrations'
-import {
-  DeleteAvalaraIntegrationDialog,
-  DeleteAvalaraIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteAvalaraIntegrationDialog'
 import { addToast } from '~/core/apolloClient'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { useNavigate } from '~/core/router'
@@ -80,7 +76,6 @@ const AvalaraIntegrationSettings = () => {
   const navigate = useNavigate()
   const { integrationId = '' } = useParams()
   const addAvalaraDialogRef = useRef<AddAvalaraDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteAvalaraIntegrationDialogRef>(null)
   const { translate } = useInternationalization()
 
   const [retryAllAvalaraInvoices] = useRetryAllAvalaraInvoicesMutation({
@@ -150,7 +145,6 @@ const AvalaraIntegrationSettings = () => {
                 onClick={() => {
                   addAvalaraDialogRef.current?.openDialog({
                     integration: avalaraIntegration,
-                    deleteModalRef: deleteDialogRef,
                     deleteDialogCallback,
                   })
                 }}
@@ -228,7 +222,6 @@ const AvalaraIntegrationSettings = () => {
       </IntegrationsPage.Container>
 
       <AddAvalaraDialog ref={addAvalaraDialogRef} />
-      <DeleteAvalaraIntegrationDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/components/settings/integrations/DeleteAvalaraIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteAvalaraIntegrationDialog.tsx
@@ -1,11 +1,11 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import {
   DeleteAvalaraIntegrationDialogFragment,
+  GetAvalaraIntegrationsListDocument,
   useDestroyNangoIntegrationMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -23,61 +23,51 @@ gql`
   }
 `
 
-interface DeleteProviderDialogProps {
+type OpenDeleteAvalaraIntegrationDialogData = {
   provider: DeleteAvalaraIntegrationDialogFragment
   callback?: () => void
 }
 
-export interface DeleteAvalaraIntegrationDialogRef {
-  openDialog: (value: DeleteProviderDialogProps) => unknown
-  closeDialog: () => unknown
-}
+export const useDeleteAvalaraIntegrationDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+  const client = useApolloClient()
 
-export const DeleteAvalaraIntegrationDialog = forwardRef<DeleteAvalaraIntegrationDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
-    const dialogRef = useRef<DialogRef>(null)
+  const [deleteAvalara] = useDestroyNangoIntegrationMutation()
 
-    const [localData, setLocalData] = useState<DeleteProviderDialogProps | undefined>(undefined)
-    const avalaraProvider = localData?.provider
+  const openDeleteAvalaraIntegrationDialog = (data: OpenDeleteAvalaraIntegrationDialogData) => {
+    const provider = data.provider
 
-    const [deleteAvalara] = useDestroyNangoIntegrationMutation({
-      onCompleted(data) {
-        if (data && data.destroyIntegration) {
-          dialogRef.current?.closeDialog()
-          localData?.callback?.()
+    centralizedDialog.open({
+      title: translate('text_658461066530343fe1808cd7', { name: provider?.name }),
+      description: translate('text_1744293719130klvtjda8wjz'),
+      actionText: translate('text_645d071272418a14c1c76a81'),
+      colorVariant: 'danger',
+      onAction: async () => {
+        const res = await deleteAvalara({
+          variables: { input: { id: provider?.id as string } },
+        })
+
+        const destroyedId = res.data?.destroyIntegration?.id
+
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'AvalaraIntegration',
+            listFieldName: 'integrations',
+            listQueryDocument: GetAvalaraIntegrationsListDocument,
+          })
+
+          data.callback?.()
+
           addToast({
             message: translate('text_661ff6e56ef7e1b7c542b2f9'),
             severity: 'success',
           })
         }
       },
-      update(cache) {
-        cache.evict({ id: `AvalaraIntegration:${avalaraProvider?.id}` })
-      },
-      refetchQueries: ['getAvalaraIntegrationsList'],
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setLocalData(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => dialogRef.current?.closeDialog(),
-    }))
-
-    return (
-      <WarningDialog
-        ref={dialogRef}
-        title={translate('text_658461066530343fe1808cd7', { name: avalaraProvider?.name })}
-        description={translate('text_1744293719130klvtjda8wjz')}
-        onContinue={async () =>
-          await deleteAvalara({ variables: { input: { id: avalaraProvider?.id as string } } })
-        }
-        continueText={translate('text_645d071272418a14c1c76a81')}
-      />
-    )
-  },
-)
-
-DeleteAvalaraIntegrationDialog.displayName = 'DeleteAvalaraIntegrationDialog'
+  return { openDeleteAvalaraIntegrationDialog }
+}

--- a/src/pages/settings/AvalaraIntegrationDetails.tsx
+++ b/src/pages/settings/AvalaraIntegrationDetails.tsx
@@ -14,10 +14,7 @@ import {
 } from '~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog'
 import AvalaraIntegrationItemsList from '~/components/settings/integrations/AvalaraIntegrationItemsList'
 import AvalaraIntegrationSettings from '~/components/settings/integrations/AvalaraIntegrationSettings'
-import {
-  DeleteAvalaraIntegrationDialog,
-  DeleteAvalaraIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteAvalaraIntegrationDialog'
+import { useDeleteAvalaraIntegrationDialog } from '~/components/settings/integrations/DeleteAvalaraIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import {
   AVALARA_INTEGRATION_DETAILS_ROUTE,
@@ -79,7 +76,7 @@ const AvalaraIntegrationDetails = () => {
   const navigate = useNavigate()
   const { integrationId = '' } = useParams()
   const addAvalaraDialogRef = useRef<AddAvalaraDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteAvalaraIntegrationDialogRef>(null)
+  const { openDeleteAvalaraIntegrationDialog } = useDeleteAvalaraIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
   const { data, loading } = useGetAvalaraIntegrationsDetailsQuery({
@@ -142,7 +139,6 @@ const AvalaraIntegrationDetails = () => {
                   onClick: (closePopper) => {
                     addAvalaraDialogRef.current?.openDialog({
                       integration: avalaraIntegration,
-                      deleteModalRef: deleteDialogRef,
                       deleteDialogCallback,
                     })
                     closePopper()
@@ -151,7 +147,7 @@ const AvalaraIntegrationDetails = () => {
                 {
                   label: translate('text_65845f35d7d69c3ab4793dad'),
                   onClick: (closePopper) => {
-                    deleteDialogRef.current?.openDialog({
+                    openDeleteAvalaraIntegrationDialog({
                       provider: avalaraIntegration,
                       callback: deleteDialogCallback,
                     })
@@ -186,7 +182,6 @@ const AvalaraIntegrationDetails = () => {
       />
       <>{activeTabContent}</>
       <AddAvalaraDialog ref={addAvalaraDialogRef} />
-      <DeleteAvalaraIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/AvalaraIntegrations.tsx
+++ b/src/pages/settings/AvalaraIntegrations.tsx
@@ -11,10 +11,7 @@ import {
   AddAvalaraDialog,
   AddAvalaraDialogRef,
 } from '~/components/settings/integrations/AddAvalaraDialog'
-import {
-  DeleteAvalaraIntegrationDialog,
-  DeleteAvalaraIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteAvalaraIntegrationDialog'
+import { useDeleteAvalaraIntegrationDialog } from '~/components/settings/integrations/DeleteAvalaraIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { AVALARA_INTEGRATION_DETAILS_ROUTE, INTEGRATIONS_ROUTE, useNavigate } from '~/core/router'
 import {
@@ -60,7 +57,7 @@ const AvalaraIntegrations = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
   const addAvalaraDialogRef = useRef<AddAvalaraDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteAvalaraIntegrationDialogRef>(null)
+  const { openDeleteAvalaraIntegrationDialog } = useDeleteAvalaraIntegrationDialog()
   const { data, loading } = useGetAvalaraIntegrationsListQuery({
     variables: { limit: 1000, types: [IntegrationTypeEnum.Avalara] },
   })
@@ -158,7 +155,6 @@ const AvalaraIntegrations = () => {
                           onClick={() => {
                             addAvalaraDialogRef.current?.openDialog({
                               integration: connection,
-                              deleteModalRef: deleteDialogRef,
                               deleteDialogCallback,
                             })
                             closePopper()
@@ -171,7 +167,7 @@ const AvalaraIntegrations = () => {
                           variant="quaternary"
                           align="left"
                           onClick={() => {
-                            deleteDialogRef.current?.openDialog({
+                            openDeleteAvalaraIntegrationDialog({
                               provider: connection,
                               callback: deleteDialogCallback,
                             })
@@ -189,7 +185,6 @@ const AvalaraIntegrations = () => {
         </section>
       </IntegrationsPage.Container>
       <AddAvalaraDialog ref={addAvalaraDialogRef} />
-      <DeleteAvalaraIntegrationDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/__tests__/AvalaraIntegrationDetails.test.tsx
+++ b/src/pages/settings/__tests__/AvalaraIntegrationDetails.test.tsx
@@ -10,7 +10,9 @@ jest.mock('~/components/settings/integrations/AddAvalaraDialog', () => ({
   AddAvalaraDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteAvalaraIntegrationDialog', () => ({
-  DeleteAvalaraIntegrationDialog: () => null,
+  useDeleteAvalaraIntegrationDialog: () => ({
+    openDeleteAvalaraIntegrationDialog: jest.fn(),
+  }),
 }))
 jest.mock('~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog', () => ({
   AddEditDeleteSuccessRedirectUrlDialog: () => null,

--- a/src/pages/settings/__tests__/AvalaraIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/AvalaraIntegrations.test.tsx
@@ -14,7 +14,9 @@ jest.mock('~/components/settings/integrations/AddAvalaraDialog', () => ({
   AddAvalaraDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteAvalaraIntegrationDialog', () => ({
-  DeleteAvalaraIntegrationDialog: () => null,
+  useDeleteAvalaraIntegrationDialog: () => ({
+    openDeleteAvalaraIntegrationDialog: jest.fn(),
+  }),
 }))
 
 describe('AvalaraIntegrations', () => {


### PR DESCRIPTION
## Context

`DeleteAvalaraIntegrationDialog` still relied on the deprecated ref-based `WarningDialog`, which triggered `no-restricted-imports` warnings in every consumer and left cache handling on the pre-`evictFromCache` pattern (bare `cache.evict()` + `refetchQueries`). That combination broadcasts to detail-page watchers and can drive a `cache-and-network` query into a 404 refetch after the entity is destroyed.

## Description

- Rewrite `DeleteAvalaraIntegrationDialog` as `useDeleteAvalaraIntegrationDialog`, backed by `useCentralizedDialog` (danger variant). Removed the `forwardRef` wrapper, the `DeleteAvalaraIntegrationDialogRef` interface, the `WarningDialog` import, and the internal `useImperativeHandle` / `useState` / `useRef` plumbing.
- Replace `refetchQueries: ['getAvalaraIntegrationsList']` + inline `cache.evict()` with the shared `evictFromCache` helper, scoping cache updates to `integrations` / `GetAvalaraIntegrationsListDocument` and suppressing detail-page watchers to avoid the post-delete 404 toast.
- Update `AvalaraIntegrations`, `AvalaraIntegrationDetails`, and `AvalaraIntegrationSettings` to consume the hook directly instead of holding a ref and rendering `<DeleteAvalaraIntegrationDialog />` in JSX. All existing behaviors (post-delete navigation callback, list vs detail redirects) are preserved.
- Drop the `deleteModalRef` plumbing in `AddAvalaraDialog`; the edit dialog now consumes the same hook internally and only needs the `deleteDialogCallback` for the post-delete navigation.
- Update the Jest mocks for the Avalara list and details pages to mock the hook shape (`useDeleteAvalaraIntegrationDialog` returning `openDeleteAvalaraIntegrationDialog: jest.fn()`).

`AddAvalaraDialog` itself still uses Formik + the legacy `Dialog` and is intentionally left out of scope to keep the change narrow — those warnings are unchanged by this PR. Same applies to `AddEditDeleteSuccessRedirectUrlDialog` referenced from the two pages.
