### PR TITLE
refactor(customers): migrate DeleteCustomerDialog to useCentralizedDialog

### DIFF
--- a/src/components/customers/DeleteCustomerDialog.tsx
+++ b/src/components/customers/DeleteCustomerDialog.tsx
@@ -1,11 +1,14 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
-import { DeleteCustomerDialogFragment, useDeleteCustomerMutation } from '~/generated/graphql'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
+import {
+  CustomersDocument,
+  DeleteCustomerDialogFragment,
+  useDeleteCustomerMutation,
+} from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 gql`
@@ -22,76 +25,63 @@ gql`
   }
 `
 
-type TDeleteCustomerDialogProps = {
+type OpenDeleteCustomerDialogData = {
   customer?: DeleteCustomerDialogFragment
   onDeleted?: () => void
 }
 
-export interface DeleteCustomerDialogRef {
-  openDialog: (props: TDeleteCustomerDialogProps) => unknown
-  closeDialog: () => unknown
-}
-
-export const DeleteCustomerDialog = forwardRef<DeleteCustomerDialogRef, unknown>((_props, ref) => {
+export const useDeleteCustomerDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
-  const [localData, setLocalData] = useState<TDeleteCustomerDialogProps>()
+  const client = useApolloClient()
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (props) => {
-      setLocalData(props)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => {
-      setLocalData(undefined)
-      dialogRef.current?.closeDialog()
-    },
-  }))
+  const [deleteCustomer] = useDeleteCustomerMutation()
 
-  const [deleteCustomer] = useDeleteCustomerMutation({
-    onCompleted(data) {
-      if (data && data.destroyCustomer) {
-        localData?.onDeleted?.()
-        addToast({
-          message: translate('text_626162c62f790600f850b814'),
-          severity: 'success',
+  const openDeleteCustomerDialog = (data: OpenDeleteCustomerDialogData) => {
+    const customer = data.customer
+
+    centralizedDialog.open({
+      title: translate('text_626162c62f790600f850b6e8', {
+        customerFullName: customer?.displayName || translate('text_651a8ab50fd34e005d1c1dc7'),
+      }),
+      description: <Typography html={translate('text_626162c62f790600f850b6f8')} />,
+      actionText: translate('text_626162c62f790600f850b712'),
+      colorVariant: 'danger',
+      onAction: async () => {
+        const res = await deleteCustomer({
+          variables: { input: { id: customer?.id ?? '' } },
         })
-      }
-    },
-    update(cache) {
-      // Clear subscriptions cache to prevent stale customer references
-      // We use cache.modify with DELETE to avoid triggering refetches for active watchers
-      cache.modify({
-        fields: {
-          subscriptions(_, { DELETE }) {
-            return DELETE
-          },
-        },
-      })
-    },
-    refetchQueries: ['customers'],
-  })
 
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_626162c62f790600f850b6e8', {
-        customerFullName:
-          localData?.customer?.displayName || translate('text_651a8ab50fd34e005d1c1dc7'),
-      })}
-      description={<Typography html={translate('text_626162c62f790600f850b6f8')} />}
-      onContinue={async () =>
-        await deleteCustomer({
-          variables: {
-            input: {
-              id: localData?.customer?.id || '',
+        const destroyedId = res.data?.destroyCustomer?.id
+
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'Customer',
+            listFieldName: 'customers',
+            listQueryDocument: CustomersDocument,
+          })
+
+          // Clear the root subscriptions field so stale references to the
+          // just-deleted customer are dropped from cached subscription lists.
+          client.cache.modify({
+            fields: {
+              subscriptions(_, { DELETE }) {
+                return DELETE
+              },
             },
-          },
-        })
-      }
-      continueText={translate('text_626162c62f790600f850b712')}
-    />
-  )
-})
+          })
 
-DeleteCustomerDialog.displayName = 'DeleteCustomerDialog'
+          data.onDeleted?.()
+
+          addToast({
+            message: translate('text_626162c62f790600f850b814'),
+            severity: 'success',
+          })
+        }
+      },
+    })
+  }
+
+  return { openDeleteCustomerDialog }
+}

--- a/src/hooks/customer/__tests__/useCustomerDetailsHeaderActions.test.tsx
+++ b/src/hooks/customer/__tests__/useCustomerDetailsHeaderActions.test.tsx
@@ -2,7 +2,6 @@ import { renderHook } from '@testing-library/react'
 import { RefObject } from 'react'
 
 import { AddCouponToCustomerDialogRef } from '~/components/customers/AddCouponToCustomerDialog'
-import { DeleteCustomerDialogRef } from '~/components/customers/DeleteCustomerDialog'
 import { MainHeaderDropdownAction, MainHeaderInPageAction } from '~/components/MainHeader/types'
 import { CustomerAccountTypeEnum, CustomerDetailsFragment } from '~/generated/graphql'
 
@@ -13,6 +12,7 @@ const mockTranslate = jest.fn((key: string) => key)
 const mockHasPermissions = jest.fn(() => true)
 const mockHandleDownloadFile = jest.fn()
 const mockGeneratePortalUrl = jest.fn()
+const mockOpenDeleteCustomerDialog = jest.fn()
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -58,6 +58,12 @@ jest.mock('~/generated/graphql', () => ({
   useGenerateCustomerPortalUrlMutation: () => [mockGeneratePortalUrl],
 }))
 
+jest.mock('~/components/customers/DeleteCustomerDialog', () => ({
+  useDeleteCustomerDialog: () => ({
+    openDeleteCustomerDialog: mockOpenDeleteCustomerDialog,
+  }),
+}))
+
 const createMockCustomer = (
   overrides: Partial<CustomerDetailsFragment> = {},
 ): CustomerDetailsFragment =>
@@ -74,9 +80,6 @@ const createMockCustomer = (
 const defaultParams = {
   customerId: 'cust-1',
   customer: createMockCustomer(),
-  deleteDialogRef: {
-    current: { openDialog: jest.fn() },
-  } as unknown as RefObject<DeleteCustomerDialogRef>,
   addCouponDialogRef: {
     current: { openDialog: jest.fn() },
   } as unknown as RefObject<AddCouponToCustomerDialogRef>,
@@ -249,19 +252,15 @@ describe('useCustomerDetailsHeaderActions', () => {
       })
 
       it('THEN should navigate to customers list after delete', () => {
-        const onDeletedCapture = { fn: jest.fn() as (() => void) | undefined }
+        let capturedOnDeleted: (() => void) | undefined
 
-        const deleteDialogRef = {
-          current: {
-            openDialog: jest.fn(({ onDeleted }: { onDeleted: () => void }) => {
-              onDeletedCapture.fn = onDeleted
-            }),
+        mockOpenDeleteCustomerDialog.mockImplementationOnce(
+          ({ onDeleted }: { onDeleted: () => void }) => {
+            capturedOnDeleted = onDeleted
           },
-        } as unknown as RefObject<DeleteCustomerDialogRef>
-
-        const { result } = renderHook(() =>
-          useCustomerDetailsHeaderActions({ ...defaultParams, deleteDialogRef }),
         )
+
+        const { result } = renderHook(() => useCustomerDetailsHeaderActions(defaultParams))
 
         const dropdownAction = result.current[1] as MainHeaderDropdownAction
         const closePopper = jest.fn()
@@ -269,7 +268,7 @@ describe('useCustomerDetailsHeaderActions', () => {
         dropdownAction.items[6].onClick(closePopper)
 
         // Simulate the onDeleted callback
-        onDeletedCapture.fn?.()
+        capturedOnDeleted?.()
 
         expect(mockNavigate).toHaveBeenCalledWith('/customers')
       })
@@ -282,10 +281,7 @@ describe('useCustomerDetailsHeaderActions', () => {
 
         dropdownAction.items[6].onClick(closePopper)
 
-        expect(
-          (defaultParams.deleteDialogRef.current as unknown as { openDialog: jest.Mock })
-            .openDialog,
-        ).toHaveBeenCalled()
+        expect(mockOpenDeleteCustomerDialog).toHaveBeenCalled()
         expect(closePopper).toHaveBeenCalled()
       })
 

--- a/src/hooks/customer/useCustomerDetailsHeaderActions.tsx
+++ b/src/hooks/customer/useCustomerDetailsHeaderActions.tsx
@@ -2,7 +2,7 @@ import { RefObject } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { AddCouponToCustomerDialogRef } from '~/components/customers/AddCouponToCustomerDialog'
-import { DeleteCustomerDialogRef } from '~/components/customers/DeleteCustomerDialog'
+import { useDeleteCustomerDialog } from '~/components/customers/DeleteCustomerDialog'
 import { MainHeaderAction } from '~/components/MainHeader/types'
 import {
   CREATE_INVOICE_ROUTE,
@@ -25,20 +25,19 @@ const CUSTOMER_ACTIONS_BUTTON_TEST_ID = 'customer-actions'
 interface UseCustomerDetailsHeaderActionsParams {
   customerId: string
   customer: CustomerDetailsFragment | undefined | null
-  deleteDialogRef: RefObject<DeleteCustomerDialogRef>
   addCouponDialogRef: RefObject<AddCouponToCustomerDialogRef>
 }
 
 export function useCustomerDetailsHeaderActions({
   customerId,
   customer,
-  deleteDialogRef,
   addCouponDialogRef,
 }: UseCustomerDetailsHeaderActionsParams): MainHeaderAction[] {
   const { translate } = useInternationalization()
   const { hasPermissions } = usePermissions()
   const navigate = useNavigate()
   const { handleDownloadFile } = useDownloadFile()
+  const { openDeleteCustomerDialog } = useDeleteCustomerDialog()
 
   const { isCustomerReadyForOverduePayment, loading: isPaymentProcessingStatusLoading } =
     useIsCustomerReadyForOverduePayment()
@@ -125,7 +124,7 @@ export function useCustomerDetailsHeaderActions({
           label: translate('text_626162c62f790600f850b726'),
           hidden: !hasPermissions(['customersDelete']),
           onClick: (closePopper) => {
-            deleteDialogRef.current?.openDialog({
+            openDeleteCustomerDialog({
               onDeleted: () => navigate(CUSTOMERS_LIST_ROUTE),
               customer: customer ?? undefined,
             })

--- a/src/pages/CustomerDetails.tsx
+++ b/src/pages/CustomerDetails.tsx
@@ -6,10 +6,6 @@ import {
   AddCouponToCustomerDialog,
   AddCouponToCustomerDialogRef,
 } from '~/components/customers/AddCouponToCustomerDialog'
-import {
-  DeleteCustomerDialog,
-  DeleteCustomerDialogRef,
-} from '~/components/customers/DeleteCustomerDialog'
 import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { useMainHeaderTabContent } from '~/components/MainHeader/useMainHeaderTabContent'
@@ -73,7 +69,6 @@ const POLLING_INTERVAL = 1000
 const MAX_POLLING_ATTEMPTS = 3
 
 const CustomerDetails = () => {
-  const deleteDialogRef = useRef<DeleteCustomerDialogRef>(null)
   const addCouponDialogRef = useRef<AddCouponToCustomerDialogRef>(null)
   const pollingAttemptsRef = useRef(0)
   const { translate } = useInternationalization()
@@ -136,7 +131,6 @@ const CustomerDetails = () => {
   const actions = useCustomerDetailsHeaderActions({
     customerId: customerId as string,
     customer,
-    deleteDialogRef,
     addCouponDialogRef,
   })
 
@@ -179,7 +173,6 @@ const CustomerDetails = () => {
         </div>
       )}
 
-      <DeleteCustomerDialog ref={deleteDialogRef} />
       <AddCouponToCustomerDialog ref={addCouponDialogRef} customer={customer} />
     </div>
   )

--- a/src/pages/CustomersList.tsx
+++ b/src/pages/CustomersList.tsx
@@ -1,11 +1,8 @@
 import { gql } from '@apollo/client'
-import { useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import { generatePath, useSearchParams } from 'react-router-dom'
 
-import {
-  DeleteCustomerDialog,
-  DeleteCustomerDialogRef,
-} from '~/components/customers/DeleteCustomerDialog'
+import { useDeleteCustomerDialog } from '~/components/customers/DeleteCustomerDialog'
 import { computeCustomerInitials } from '~/components/customers/utils'
 import { Avatar } from '~/components/designSystem/Avatar'
 import { formatFiltersForCustomerQuery } from '~/components/designSystem/Filters'
@@ -124,7 +121,7 @@ const CustomersList = () => {
     nextFetchPolicy: 'network-only',
   })
 
-  const deleteDialogRef = useRef<DeleteCustomerDialogRef>(null)
+  const { openDeleteCustomerDialog } = useDeleteCustomerDialog()
 
   const { debouncedSearch, isLoading } = useDebouncedSearch(getCustomers, loading)
 
@@ -262,7 +259,7 @@ const CustomersList = () => {
                       startIcon: 'trash',
                       title: translate('text_6261640f28a49700f1290df5'),
                       onAction: () => {
-                        deleteDialogRef.current?.openDialog({ customer })
+                        openDeleteCustomerDialog({ customer })
                       },
                     }
                   : null,
@@ -313,7 +310,6 @@ const CustomersList = () => {
           />
         </InfiniteScroll>
       </div>
-      <DeleteCustomerDialog ref={deleteDialogRef} />
     </>
   )
 }


### PR DESCRIPTION
## Context

`DeleteCustomerDialog` still relied on the deprecated ref-based `WarningDialog`, which triggered `no-restricted-imports` warnings in every consumer and left cache handling on the pre-`evictFromCache` pattern (bare `cache.modify` + `refetchQueries: ['customers']`). That combination broadcasts to detail-page watchers and can drive a `cache-and-network` query into a 404 refetch after the customer is destroyed.

## Description

- Rewrite `DeleteCustomerDialog` as `useDeleteCustomerDialog`, backed by `useCentralizedDialog` (danger variant). Removed the `forwardRef` wrapper, the `DeleteCustomerDialogRef` interface, the `WarningDialog` import, and the internal `useImperativeHandle` / `useState` / `useRef` plumbing.
- Replace `refetchQueries: ['customers']` + inline `cache.modify` with the shared `evictFromCache` helper, scoping cache updates to `customers` / `CustomersDocument` and suppressing detail-page watchers to avoid the post-delete 404 toast. Preserve the existing `subscriptions` root-field DELETE so stale customer references are dropped from cached subscription lists.
- Update `CustomersList` and `CustomerDetails` to consume the hook directly instead of holding a `DeleteCustomerDialogRef` and rendering `<DeleteCustomerDialog />` in JSX. All existing behaviors (post-delete navigation to the customers list, permission gating) are preserved.
- Move the delete action wiring inside `useCustomerDetailsHeaderActions`: the hook now consumes `useDeleteCustomerDialog` internally and no longer needs `deleteDialogRef` in its parameters.
- Update the Jest mocks for `useCustomerDetailsHeaderActions` to mock the hook shape (`useDeleteCustomerDialog` returning `openDeleteCustomerDialog: jest.fn()`).

`AddCouponToCustomerDialog` still uses the legacy imperative `Dialog` and is intentionally left out of scope to keep the change narrow — those warnings are unchanged by this PR.
