### PR TITLE
refactor(features): migrate DeleteFeatureDialog to CentralizedDialog

### DIFF
--- a/src/components/features/DeleteFeatureDialog.tsx
+++ b/src/components/features/DeleteFeatureDialog.tsx
@@ -1,7 +1,6 @@
 import { gql, useApolloClient } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import {
@@ -23,69 +22,53 @@ gql`
   }
 `
 
-interface DeleteFeatureDialogProps {
+type TDeleteFeatureDialogProps = {
   feature: FeatureForDeleteFeatureDialogFragment | undefined
   callback?: () => void
 }
 
-export interface DeleteFeatureDialogRef {
-  openDialog: (dialogData: DeleteFeatureDialogProps) => unknown
-  closeDialog: () => unknown
-}
-
-export const DeleteFeatureDialog = forwardRef<DeleteFeatureDialogRef>((_, ref) => {
+export const useDeleteFeatureDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<WarningDialogRef>(null)
-  const [dialogData, setDialogData] = useState<DeleteFeatureDialogProps | undefined>(undefined)
   const client = useApolloClient()
 
-  const [destroyFeature] = useDestroyFeatureMutation({
-    onCompleted({ destroyFeature: destroyedFeature }) {
-      if (destroyedFeature?.id) {
-        dialogRef.current?.closeDialog()
+  const [destroyFeature] = useDestroyFeatureMutation()
 
-        addToast({
-          message: translate('text_1752692673070wmlmc9i3rjz'),
-          severity: 'success',
-        })
-
-        evictFromCache(client, {
-          id: destroyedFeature.id,
-          __typename: 'FeatureObject',
-          listFieldName: 'features',
-          listQueryDocument: GetFeaturesListDocument,
-        })
-
-        dialogData?.callback?.()
-      }
-    },
-  })
-
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setDialogData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
-
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_1752692673070h6yiax84d7x')}
-      description={translate('text_1752693359315c6eoxf5szyk')}
-      onContinue={async () => {
-        await destroyFeature({
+  const openDeleteFeatureDialog = ({ feature, callback }: TDeleteFeatureDialogProps) => {
+    centralizedDialog.open({
+      title: translate('text_1752692673070h6yiax84d7x'),
+      description: translate('text_1752693359315c6eoxf5szyk'),
+      colorVariant: 'danger',
+      actionText: translate('text_1752693359315sd2ms0qxvi3'),
+      onAction: async () => {
+        const result = await destroyFeature({
           variables: {
             input: {
-              id: dialogData?.feature?.id || '',
+              id: feature?.id || '',
             },
           },
         })
-      }}
-      continueText={translate('text_1752693359315sd2ms0qxvi3')}
-    />
-  )
-})
 
-DeleteFeatureDialog.displayName = 'DeleteFeatureDialog'
+        const destroyedId = result.data?.destroyFeature?.id
+
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'FeatureObject',
+            listFieldName: 'features',
+            listQueryDocument: GetFeaturesListDocument,
+          })
+
+          callback?.()
+
+          addToast({
+            message: translate('text_1752692673070wmlmc9i3rjz'),
+            severity: 'success',
+          })
+        }
+      },
+    })
+  }
+
+  return { openDeleteFeatureDialog }
+}

--- a/src/pages/features/FeatureDetails.tsx
+++ b/src/pages/features/FeatureDetails.tsx
@@ -1,11 +1,7 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
-import {
-  DeleteFeatureDialog,
-  DeleteFeatureDialogRef,
-} from '~/components/features/DeleteFeatureDialog'
+import { useDeleteFeatureDialog } from '~/components/features/DeleteFeatureDialog'
 import { FeatureDetailsActivityLogs } from '~/components/features/FeatureDetailsActivityLogs'
 import { FeatureDetailsOverview } from '~/components/features/FeatureDetailsOverview'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
@@ -49,7 +45,7 @@ const FeatureDetails = () => {
   const { isPremium } = useCurrentUser()
   const { featureId } = useParams()
 
-  const deleteDialogRef = useRef<DeleteFeatureDialogRef>(null)
+  const { openDeleteFeatureDialog } = useDeleteFeatureDialog()
 
   const {
     data: featureResult,
@@ -92,7 +88,7 @@ const FeatureDetails = () => {
               label: translate('text_1752693359315sd2ms0qxvi3'),
               hidden: !hasPermissions(['featuresDelete']),
               onClick: (closePopper) => {
-                deleteDialogRef.current?.openDialog({
+                openDeleteFeatureDialog({
                   feature,
                   callback: () => {
                     navigate(FEATURES_ROUTE)
@@ -145,8 +141,6 @@ const FeatureDetails = () => {
       />
 
       <>{activeTabContent}</>
-
-      <DeleteFeatureDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/pages/features/FeaturesList.tsx
+++ b/src/pages/features/FeaturesList.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { Icon, tw } from 'lago-design-system'
-import { useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { Avatar } from '~/components/designSystem/Avatar'
@@ -9,10 +9,7 @@ import { Table } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
 import { Typography } from '~/components/designSystem/Typography'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
-import {
-  DeleteFeatureDialog,
-  DeleteFeatureDialogRef,
-} from '~/components/features/DeleteFeatureDialog'
+import { useDeleteFeatureDialog } from '~/components/features/DeleteFeatureDialog'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { SearchInput } from '~/components/SearchInput'
@@ -54,7 +51,7 @@ gql`
 
 const FeaturesList = () => {
   const navigate = useNavigate()
-  const deleteDialogRef = useRef<DeleteFeatureDialogRef>(null)
+  const { openDeleteFeatureDialog } = useDeleteFeatureDialog()
   const { hasPermissions } = usePermissions()
   const { translate } = useInternationalization()
 
@@ -244,7 +241,7 @@ const FeaturesList = () => {
                 title: translate('text_63ea0f84f400488553caa786'),
                 startIcon: 'trash',
                 onAction: async () => {
-                  deleteDialogRef.current?.openDialog({
+                  openDeleteFeatureDialog({
                     feature: { id: feature.id },
                   })
                 },
@@ -255,8 +252,6 @@ const FeaturesList = () => {
           }}
         />
       </InfiniteScroll>
-
-      <DeleteFeatureDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/pages/features/__tests__/FeatureDetails.test.tsx
+++ b/src/pages/features/__tests__/FeatureDetails.test.tsx
@@ -35,7 +35,7 @@ jest.mock('~/components/features/FeatureDetailsActivityLogs', () => ({
 }))
 
 jest.mock('~/components/features/DeleteFeatureDialog', () => ({
-  DeleteFeatureDialog: () => null,
+  useDeleteFeatureDialog: () => ({ openDeleteFeatureDialog: jest.fn() }),
 }))
 
 jest.mock('~/hooks/usePermissions', () => ({

--- a/src/pages/features/__tests__/FeaturesList.test.tsx
+++ b/src/pages/features/__tests__/FeaturesList.test.tsx
@@ -31,7 +31,7 @@ jest.mock('~/components/SearchInput', () => ({
 }))
 
 jest.mock('~/components/features/DeleteFeatureDialog', () => ({
-  DeleteFeatureDialog: () => null,
+  useDeleteFeatureDialog: () => ({ openDeleteFeatureDialog: jest.fn() }),
 }))
 
 jest.mock('react-router-dom', () => ({


### PR DESCRIPTION
## Context

`DeleteFeatureDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate `DeleteFeatureDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API.

- `src/components/features/DeleteFeatureDialog.tsx`: rewrote the component as `useDeleteFeatureDialog` hook that exposes `openDeleteFeatureDialog(...)` and calls `centralizedDialog.open(...)` with `colorVariant: 'danger'`. The `evictFromCache` call (already correctly used previously) is preserved. The mutation is no longer driven through an `onCompleted` closure; success is detected from the mutation result inside `onAction`, keeping the dialog's automatic close behavior in sync with the CentralizedDialog contract.
- `src/pages/features/FeaturesList.tsx`: removed the `useRef<DeleteFeatureDialogRef>` + `<DeleteFeatureDialog ref={...} />` pattern and replaced it with the `useDeleteFeatureDialog()` hook.
- `src/pages/features/FeatureDetails.tsx`: same migration — removed the ref/JSX pattern in favor of the hook.
- Updated the two Jest test files (`FeaturesList.test.tsx`, `FeatureDetails.test.tsx`) to mock the new `useDeleteFeatureDialog` hook instead of the removed `DeleteFeatureDialog` component.

No behavior change: the delete confirmation dialog still shows the same title / description / action label, uses the same mutation and the same `evictFromCache` cache handling.