### PR TITLE
refactor(integrations): migrate DeleteXeroIntegrationDialog to CentralizedDialog

### DIFF
--- a/src/components/settings/integrations/AddXeroDialog.tsx
+++ b/src/components/settings/integrations/AddXeroDialog.tsx
@@ -3,7 +3,7 @@ import Stack from '@mui/material/Stack'
 import Nango from '@nangohq/frontend'
 import { useFormik } from 'formik'
 import { GraphQLFormattedError } from 'graphql'
-import { forwardRef, RefObject, useId, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useId, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 import { boolean, object, string } from 'yup'
 
@@ -24,8 +24,6 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { XeroIntegrationDetailsTabs } from '~/pages/settings/XeroIntegrationDetails'
-
-import { DeleteXeroIntegrationDialogRef } from './DeleteXeroIntegrationDialog'
 
 gql`
   fragment XeroForCreateDialogDialog on XeroIntegration {
@@ -53,9 +51,8 @@ gql`
 `
 
 type TAddXeroDialogProps = Partial<{
-  deleteModalRef: RefObject<DeleteXeroIntegrationDialogRef>
+  onDelete: (provider: XeroForCreateDialogDialogFragment) => void
   provider: XeroForCreateDialogDialogFragment
-  deleteDialogCallback: () => void
 }>
 
 export interface AddXeroDialogRef {
@@ -217,10 +214,7 @@ export const AddXeroDialog = forwardRef<AddXeroDialogRef>((_, ref) => {
               variant="quaternary"
               onClick={() => {
                 closeDialog()
-                localData?.deleteModalRef?.current?.openDialog({
-                  provider: xeroProvider,
-                  callback: localData.deleteDialogCallback,
-                })
+                localData?.onDelete?.(xeroProvider)
               }}
             >
               {translate('text_65845f35d7d69c3ab4793dad')}

--- a/src/components/settings/integrations/DeleteXeroIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteXeroIntegrationDialog.tsx
@@ -1,10 +1,11 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import {
   DeleteXeroIntegrationDialogFragment,
+  GetXeroIntegrationsListDocument,
   useDestroyNangoIntegrationMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -27,56 +28,47 @@ type TDeleteXeroIntegrationDialogProps = {
   callback?: () => void
 }
 
-export interface DeleteXeroIntegrationDialogRef {
-  openDialog: ({ provider, callback }: TDeleteXeroIntegrationDialogProps) => unknown
-  closeDialog: () => unknown
-}
-
-export const DeleteXeroIntegrationDialog = forwardRef<DeleteXeroIntegrationDialogRef>((_, ref) => {
+export const useDeleteXeroIntegrationDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
+  const client = useApolloClient()
 
-  const dialogRef = useRef<WarningDialogRef>(null)
-  const [localData, setLocalData] = useState<TDeleteXeroIntegrationDialogProps | undefined>(
-    undefined,
-  )
-  const xeroProvider = localData?.provider
+  const [deleteXero] = useDestroyNangoIntegrationMutation()
 
-  const [deleteXero] = useDestroyNangoIntegrationMutation({
-    onCompleted(data) {
-      if (data && data.destroyIntegration) {
-        dialogRef.current?.closeDialog()
-        localData?.callback?.()
-        addToast({
-          message: translate('text_661ff6e56ef7e1b7c542b2f9'),
-          severity: 'success',
+  const openDeleteXeroIntegrationDialog = ({
+    provider,
+    callback,
+  }: TDeleteXeroIntegrationDialogProps) => {
+    centralizedDialog.open({
+      title: translate('text_658461066530343fe1808cd7', { name: provider?.name }),
+      description: translate('text_6672ebb8b1b50be550eccada'),
+      colorVariant: 'danger',
+      actionText: translate('text_645d071272418a14c1c76a81'),
+      onAction: async () => {
+        const result = await deleteXero({
+          variables: { input: { id: provider?.id as string } },
         })
-      }
-    },
-    update(cache) {
-      cache.evict({ id: `XeroIntegration:${xeroProvider?.id}` })
-    },
-    refetchQueries: ['getXeroIntegrationsList'],
-  })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+        const destroyedId = result.data?.destroyIntegration?.id
 
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_658461066530343fe1808cd7', { name: xeroProvider?.name })}
-      description={translate('text_6672ebb8b1b50be550eccada')}
-      onContinue={async () =>
-        await deleteXero({ variables: { input: { id: xeroProvider?.id as string } } })
-      }
-      continueText={translate('text_645d071272418a14c1c76a81')}
-    />
-  )
-})
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'XeroIntegration',
+            listFieldName: 'integrations',
+            listQueryDocument: GetXeroIntegrationsListDocument,
+          })
 
-DeleteXeroIntegrationDialog.displayName = 'DeleteXeroIntegrationDialog'
+          callback?.()
+
+          addToast({
+            message: translate('text_661ff6e56ef7e1b7c542b2f9'),
+            severity: 'success',
+          })
+        }
+      },
+    })
+  }
+
+  return { openDeleteXeroIntegrationDialog }
+}

--- a/src/components/settings/integrations/XeroIntegrationSettings.tsx
+++ b/src/components/settings/integrations/XeroIntegrationSettings.tsx
@@ -27,10 +27,7 @@ import {
   AddEditDeleteSuccessRedirectUrlDialogRef,
 } from './AddEditDeleteSuccessRedirectUrlDialog'
 import { AddXeroDialog, AddXeroDialogRef } from './AddXeroDialog'
-import {
-  DeleteXeroIntegrationDialog,
-  DeleteXeroIntegrationDialogRef,
-} from './DeleteXeroIntegrationDialog'
+import { useDeleteXeroIntegrationDialog } from './DeleteXeroIntegrationDialog'
 
 const PROVIDER_CONNECTION_LIMIT = 2
 
@@ -99,7 +96,7 @@ const XeroIntegrationSettings = () => {
   const navigate = useNavigate()
   const { integrationId = '' } = useParams()
   const addXeroDialogRef = useRef<AddXeroDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteXeroIntegrationDialogRef>(null)
+  const { openDeleteXeroIntegrationDialog } = useDeleteXeroIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
   const { data, loading } = useGetXeroIntegrationsSettingsQuery({
@@ -123,6 +120,13 @@ const XeroIntegrationSettings = () => {
         generatePath(INTEGRATIONS_ROUTE, { integrationGroup: IntegrationsTabsOptionsEnum.Lago }),
       )
     }
+  }
+  const openDeleteDialog = () => {
+    if (!xeroIntegration) return
+    openDeleteXeroIntegrationDialog({
+      provider: xeroIntegration,
+      callback: deleteDialogCallback,
+    })
   }
 
   return (
@@ -156,8 +160,7 @@ const XeroIntegrationSettings = () => {
               onClick={() => {
                 addXeroDialogRef.current?.openDialog({
                   provider: xeroIntegration,
-                  deleteModalRef: deleteDialogRef,
-                  deleteDialogCallback,
+                  onDelete: openDeleteDialog,
                 })
               }}
             >
@@ -196,7 +199,6 @@ const XeroIntegrationSettings = () => {
         </section>
       </IntegrationsPage.Container>
       <AddXeroDialog ref={addXeroDialogRef} />
-      <DeleteXeroIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/XeroIntegrationDetails.tsx
+++ b/src/pages/settings/XeroIntegrationDetails.tsx
@@ -10,10 +10,7 @@ import {
   AddEditDeleteSuccessRedirectUrlDialogRef,
 } from '~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog'
 import { AddXeroDialog, AddXeroDialogRef } from '~/components/settings/integrations/AddXeroDialog'
-import {
-  DeleteXeroIntegrationDialog,
-  DeleteXeroIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteXeroIntegrationDialog'
+import { useDeleteXeroIntegrationDialog } from '~/components/settings/integrations/DeleteXeroIntegrationDialog'
 import XeroIntegrationItemsList from '~/components/settings/integrations/XeroIntegrationItemsList'
 import XeroIntegrationSettings from '~/components/settings/integrations/XeroIntegrationSettings'
 import { addToast, envGlobalVar } from '~/core/apolloClient'
@@ -83,7 +80,7 @@ const XeroIntegrationDetails = () => {
   const { nangoPublicKey } = envGlobalVar()
   const { integrationId = '' } = useParams()
   const addXeroDialogRef = useRef<AddXeroDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteXeroIntegrationDialogRef>(null)
+  const { openDeleteXeroIntegrationDialog } = useDeleteXeroIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
   const { data, loading } = useGetXeroIntegrationsDetailsQuery({
@@ -108,6 +105,12 @@ const XeroIntegrationDetails = () => {
         generatePath(INTEGRATIONS_ROUTE, { integrationGroup: IntegrationsTabsOptionsEnum.Lago }),
       )
     }
+  }
+  const openDeleteDialog = () => {
+    openDeleteXeroIntegrationDialog({
+      provider: xeroIntegration,
+      callback: deleteDialogCallback,
+    })
   }
 
   return (
@@ -146,8 +149,7 @@ const XeroIntegrationDetails = () => {
                   onClick: (closePopper) => {
                     addXeroDialogRef.current?.openDialog({
                       provider: xeroIntegration,
-                      deleteModalRef: deleteDialogRef,
-                      deleteDialogCallback,
+                      onDelete: openDeleteDialog,
                     })
                     closePopper()
                   },
@@ -177,10 +179,7 @@ const XeroIntegrationDetails = () => {
                 {
                   label: translate('text_65845f35d7d69c3ab4793dad'),
                   onClick: (closePopper) => {
-                    deleteDialogRef.current?.openDialog({
-                      provider: xeroIntegration,
-                      callback: deleteDialogCallback,
-                    })
+                    openDeleteDialog()
                     closePopper()
                   },
                 },
@@ -214,7 +213,6 @@ const XeroIntegrationDetails = () => {
       <>{activeTabContent}</>
 
       <AddXeroDialog ref={addXeroDialogRef} />
-      <DeleteXeroIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/XeroIntegrations.tsx
+++ b/src/pages/settings/XeroIntegrations.tsx
@@ -8,10 +8,7 @@ import { Tooltip } from '~/components/designSystem/Tooltip'
 import { IntegrationsPage } from '~/components/layouts/Integrations'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { AddXeroDialog, AddXeroDialogRef } from '~/components/settings/integrations/AddXeroDialog'
-import {
-  DeleteXeroIntegrationDialog,
-  DeleteXeroIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteXeroIntegrationDialog'
+import { useDeleteXeroIntegrationDialog } from '~/components/settings/integrations/DeleteXeroIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { INTEGRATIONS_ROUTE, useNavigate, XERO_INTEGRATION_DETAILS_ROUTE } from '~/core/router'
 import {
@@ -56,7 +53,7 @@ const XeroIntegrations = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
   const addXeroDialogRef = useRef<AddXeroDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteXeroIntegrationDialogRef>(null)
+  const { openDeleteXeroIntegrationDialog } = useDeleteXeroIntegrationDialog()
   const { data, loading } = useGetXeroIntegrationsListQuery({
     variables: { limit: 1000, types: [IntegrationTypeEnum.Xero] },
   })
@@ -72,6 +69,13 @@ const XeroIntegrations = () => {
             }),
           )
       : undefined
+
+  const openDeleteDialog = (provider: XeroIntegrationsFragment) => {
+    openDeleteXeroIntegrationDialog({
+      provider,
+      callback: deleteDialogCallback,
+    })
+  }
 
   return (
     <>
@@ -154,8 +158,7 @@ const XeroIntegrations = () => {
                           onClick={() => {
                             addXeroDialogRef.current?.openDialog({
                               provider: connection,
-                              deleteModalRef: deleteDialogRef,
-                              deleteDialogCallback,
+                              onDelete: openDeleteDialog,
                             })
                             closePopper()
                           }}
@@ -167,10 +170,7 @@ const XeroIntegrations = () => {
                           variant="quaternary"
                           align="left"
                           onClick={() => {
-                            deleteDialogRef.current?.openDialog({
-                              provider: connection,
-                              callback: deleteDialogCallback,
-                            })
+                            openDeleteDialog(connection)
                             closePopper()
                           }}
                         >
@@ -186,7 +186,6 @@ const XeroIntegrations = () => {
       </IntegrationsPage.Container>
 
       <AddXeroDialog ref={addXeroDialogRef} />
-      <DeleteXeroIntegrationDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/__tests__/XeroIntegrationDetails.test.tsx
+++ b/src/pages/settings/__tests__/XeroIntegrationDetails.test.tsx
@@ -14,7 +14,7 @@ jest.mock('~/components/settings/integrations/AddXeroDialog', () => ({
   AddXeroDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteXeroIntegrationDialog', () => ({
-  DeleteXeroIntegrationDialog: () => null,
+  useDeleteXeroIntegrationDialog: () => ({ openDeleteXeroIntegrationDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog', () => ({
   AddEditDeleteSuccessRedirectUrlDialog: () => null,

--- a/src/pages/settings/__tests__/XeroIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/XeroIntegrations.test.tsx
@@ -18,7 +18,7 @@ jest.mock('~/components/settings/integrations/AddXeroDialog', () => ({
   AddXeroDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteXeroIntegrationDialog', () => ({
-  DeleteXeroIntegrationDialog: () => null,
+  useDeleteXeroIntegrationDialog: () => ({ openDeleteXeroIntegrationDialog: jest.fn() }),
 }))
 
 describe('XeroIntegrations', () => {


### PR DESCRIPTION
## Context

`DeleteXeroIntegrationDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs. Same pattern already applied to `DeleteAdyenIntegrationDialog` (used as canonical reference here).

## Description

Migrate `DeleteXeroIntegrationDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API, and switch its cache handling to the `evictFromCache` helper.

- `src/components/settings/integrations/DeleteXeroIntegrationDialog.tsx`: rewrote the component as `useDeleteXeroIntegrationDialog` hook exposing `openDeleteXeroIntegrationDialog(...)`. Replaced the legacy `refetchQueries: ['getXeroIntegrationsList']` + bare `cache.evict({ id: 'XeroIntegration:...' })` combo with `evictFromCache(client, { id, __typename: 'XeroIntegration', listFieldName: 'integrations', listQueryDocument: GetXeroIntegrationsListDocument })`. This mirrors what `DeleteAdyenIntegrationDialog` already does and avoids the retained-detail-query 404 toast that `cache.evict()` causes when a detail-page query is still watched.
- `src/components/settings/integrations/AddXeroDialog.tsx`: removed the `deleteModalRef: RefObject<DeleteXeroIntegrationDialogRef>` + `deleteDialogCallback` props (they existed only to let the edit dialog trigger the delete dialog through the old ref system). Replaced by an `onDelete: (provider) => void` callback prop, matching the `AddAdyenDialog` shape. The `AddXeroDialog` itself is left on its existing Formik + `Dialog` pattern — migrating that is out of scope for this PR.
- `src/pages/settings/XeroIntegrations.tsx`, `src/pages/settings/XeroIntegrationDetails.tsx`, `src/components/settings/integrations/XeroIntegrationSettings.tsx`: replaced `useRef<DeleteXeroIntegrationDialogRef>` + `<DeleteXeroIntegrationDialog ref={...} />` with `useDeleteXeroIntegrationDialog()`, and pass a local `openDeleteDialog` function to `AddXeroDialog` via the new `onDelete` prop. The `deleteDialogCallback` navigation logic is preserved verbatim.
- Updated the two Jest test files (`XeroIntegrationDetails.test.tsx`, `XeroIntegrations.test.tsx`) to mock the new `useDeleteXeroIntegrationDialog` hook instead of the removed `DeleteXeroIntegrationDialog` component.

No user-visible behavior change: the delete confirmation dialog still shows the same title / description / action label, still fires the same `destroyIntegration` mutation, still runs the same navigation callback, and the Xero list still refreshes after deletion (now via `evictFromCache` instead of a full refetch).