### PR TITLE
refactor(subscriptions): migrate DeleteSubscriptionEntitlementDialog to useCentralizedDialog

### DIFF
--- a/src/components/subscriptions/DeleteSubscriptionEntitlementDialog.tsx
+++ b/src/components/subscriptions/DeleteSubscriptionEntitlementDialog.tsx
@@ -1,8 +1,6 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import {
   RemoveSubscriptionEntitlementInput,
@@ -18,65 +16,49 @@ gql`
   }
 `
 
-type DeleteSubscriptionEntitlementDialogProps = RemoveSubscriptionEntitlementInput & {
+type TDeleteSubscriptionEntitlementDialogProps = RemoveSubscriptionEntitlementInput & {
   featureName: string
 }
 
-export interface DeleteSubscriptionEntitlementDialogRef {
-  openDialog: (props: DeleteSubscriptionEntitlementDialogProps) => unknown
-  closeDialog: () => unknown
-}
+export const useDeleteSubscriptionEntitlementDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
 
-export const DeleteSubscriptionEntitlementDialog =
-  forwardRef<DeleteSubscriptionEntitlementDialogRef>((_, ref) => {
-    const { translate } = useInternationalization()
-    const dialogRef = useRef<DialogRef>(null)
-    const [localData, setLocalData] = useState<
-      DeleteSubscriptionEntitlementDialogProps | undefined
-    >(undefined)
-    const [removeSubscriptionEntitlement] = useRemoveSubscriptionEntitlementMutation({
-      onCompleted(data) {
-        if (!!data?.removeSubscriptionEntitlement?.featureCode) {
+  const [removeSubscriptionEntitlement] = useRemoveSubscriptionEntitlementMutation({
+    refetchQueries: ['getEntitlementsForSubscriptionDetails'],
+  })
+
+  const openDeleteSubscriptionEntitlementDialog = ({
+    subscriptionId,
+    featureCode,
+    featureName,
+  }: TDeleteSubscriptionEntitlementDialogProps) => {
+    centralizedDialog.open({
+      title: translate('text_1755857208789vexq2o6uue8'),
+      description: translate('text_17561254890563fn418c1xzd', {
+        entitlementName: featureName,
+      }),
+      colorVariant: 'danger',
+      actionText: translate('text_1756125489057n75k4pb2lbu'),
+      onAction: async () => {
+        const result = await removeSubscriptionEntitlement({
+          variables: {
+            input: {
+              subscriptionId,
+              featureCode,
+            },
+          },
+        })
+
+        if (result.data?.removeSubscriptionEntitlement?.featureCode) {
           addToast({
             message: translate('text_175585720878953maf5rsy64'),
             severity: 'success',
           })
         }
       },
-      refetchQueries: ['getEntitlementsForSubscriptionDetails'],
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setLocalData(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => {
-        dialogRef.current?.closeDialog()
-      },
-    }))
-
-    return (
-      <WarningDialog
-        ref={dialogRef}
-        title={translate('text_1755857208789vexq2o6uue8')}
-        description={translate('text_17561254890563fn418c1xzd', {
-          entitlementName: localData?.featureName,
-        })}
-        onContinue={async () =>
-          !!localData &&
-          (await removeSubscriptionEntitlement({
-            variables: {
-              input: {
-                subscriptionId: localData?.subscriptionId,
-                featureCode: localData?.featureCode,
-              },
-            },
-          }))
-        }
-        continueText={translate('text_1756125489057n75k4pb2lbu')}
-      />
-    )
-  })
-
-DeleteSubscriptionEntitlementDialog.displayName = 'DeleteSubscriptionEntitlementDialog'
+  return { openDeleteSubscriptionEntitlementDialog }
+}

--- a/src/components/subscriptions/SubscriptionEntitlementsTabContent.tsx
+++ b/src/components/subscriptions/SubscriptionEntitlementsTabContent.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Accordion } from '~/components/designSystem/Accordion'
@@ -10,10 +9,7 @@ import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { getEntitlementFormattedValue } from '~/components/plans/utils'
-import {
-  DeleteSubscriptionEntitlementDialog,
-  DeleteSubscriptionEntitlementDialogRef,
-} from '~/components/subscriptions/DeleteSubscriptionEntitlementDialog'
+import { useDeleteSubscriptionEntitlementDialog } from '~/components/subscriptions/DeleteSubscriptionEntitlementDialog'
 import { POPPER_GROUP_NAME } from '~/core/constants/popper'
 import {
   CREATE_ENTITLEMENT_CUSTOMER_SUBSCRIPTION_ROUTE,
@@ -50,8 +46,7 @@ gql`
 export const SubscriptionEntitlementsTabContent = () => {
   const { customerId = '', planId = '', subscriptionId = '' } = useParams()
   const { translate } = useInternationalization()
-  const deleteSubscriptionEntitlementDialogRef =
-    useRef<DeleteSubscriptionEntitlementDialogRef>(null)
+  const { openDeleteSubscriptionEntitlementDialog } = useDeleteSubscriptionEntitlementDialog()
   const { hasPermissions } = usePermissions()
   const navigate = useNavigate()
 
@@ -188,7 +183,7 @@ export const SubscriptionEntitlementsTabContent = () => {
                           align="left"
                           onClick={(e) => {
                             e.stopPropagation()
-                            deleteSubscriptionEntitlementDialogRef.current?.openDialog({
+                            openDeleteSubscriptionEntitlementDialog({
                               subscriptionId,
                               featureCode: entitlement.code,
                               featureName: entitlement.name,
@@ -255,8 +250,6 @@ export const SubscriptionEntitlementsTabContent = () => {
           </Accordion>
         ))}
       </div>
-
-      <DeleteSubscriptionEntitlementDialog ref={deleteSubscriptionEntitlementDialogRef} />
     </section>
   )
 }


### PR DESCRIPTION
## Context

`WarningDialog` is deprecated in favor of the new hook-based NiceModal dialog system (`useFormDialog`, `useCentralizedDialog`, `useFormDialogOpeningDialog`). This PR migrates `DeleteSubscriptionEntitlementDialog` to remove one of the remaining `WarningDialog` ESLint warnings.

## Description

- Convert `DeleteSubscriptionEntitlementDialog` from an imperative `forwardRef` component to the `useDeleteSubscriptionEntitlementDialog` hook backed by `useCentralizedDialog`.
- Drop the `DeleteSubscriptionEntitlementDialogRef` interface, `forwardRef`, `useImperativeHandle`, and local `useState` for the passed data — the data flows directly through the `open` function parameters.
- Preserve the existing mutation behavior: still trigger `refetchQueries: ['getEntitlementsForSubscriptionDetails']` and the success toast on `removeSubscriptionEntitlement.featureCode` (the mutation only returns the code, so the `evictFromCache` helper does not apply here — a refetch remains the correct approach).
- Update `SubscriptionEntitlementsTabContent` to consume the hook, drop the ref instantiation, and remove the JSX render of the dialog (NiceModal renders it centrally).