### PR TITLE
refactor(invoices): migrate DeleteCustomSectionDialog to useCentralizedDialog

### DIFF
--- a/src/components/settings/invoices/DeleteCustomSectionDialog.tsx
+++ b/src/components/settings/invoices/DeleteCustomSectionDialog.tsx
@@ -1,11 +1,14 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
-import { DeleteCustomSectionFragment, useDeleteCustomSectionMutation } from '~/generated/graphql'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
+import {
+  DeleteCustomSectionFragment,
+  GetOrganizationSettingsInvoiceSectionsDocument,
+  useDeleteCustomSectionMutation,
+} from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 gql`
@@ -20,63 +23,46 @@ gql`
   }
 `
 
-export interface DeleteCustomSectionDialogRef {
-  openDialog: (customSection: DeleteCustomSectionFragment) => unknown
-  closeDialog: () => unknown
-}
-
-export const DeleteCustomSectionDialog = forwardRef<DeleteCustomSectionDialogRef>((_, ref) => {
+export const useDeleteCustomSectionDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
-  const [customSection, setCustomSection] = useState<DeleteCustomSectionFragment>()
+  const client = useApolloClient()
 
-  const [deleteCustomSection] = useDeleteCustomSectionMutation({
-    onCompleted(data) {
-      if (data && data.destroyInvoiceCustomSection) {
-        addToast({
-          message: translate('text_1733849149914twslm71nuy6'),
-          severity: 'success',
-        })
-      }
-    },
-    update(cache, { data }) {
-      if (!data?.destroyInvoiceCustomSection) return
-      const cacheId = cache.identify({
-        id: data?.destroyInvoiceCustomSection.id,
-        __typename: 'InvoiceCustomSection',
-      })
+  const [deleteCustomSection] = useDeleteCustomSectionMutation()
 
-      cache.evict({ id: cacheId })
-    },
-  })
-
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setCustomSection(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => {
-      dialogRef.current?.closeDialog()
-    },
-  }))
-
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_1732639579760vrvtea9dbua')}
-      description={<Typography>{translate('text_1732639579760siwe29e2rqg')}</Typography>}
-      onContinue={async () =>
-        await deleteCustomSection({
+  const openDeleteCustomSectionDialog = (customSection: DeleteCustomSectionFragment) => {
+    centralizedDialog.open({
+      title: translate('text_1732639579760vrvtea9dbua'),
+      description: <Typography>{translate('text_1732639579760siwe29e2rqg')}</Typography>,
+      colorVariant: 'danger',
+      actionText: translate('text_1732639603661uwmv1793v9b'),
+      onAction: async () => {
+        const result = await deleteCustomSection({
           variables: {
             input: {
               id: customSection?.id || '',
             },
           },
         })
-      }
-      continueText={translate('text_1732639603661uwmv1793v9b')}
-    />
-  )
-})
 
-DeleteCustomSectionDialog.displayName = 'DeleteCustomSectionDialog'
+        const destroyedId = result.data?.destroyInvoiceCustomSection?.id
+
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'InvoiceCustomSection',
+            listFieldName: 'invoiceCustomSections',
+            listQueryDocument: GetOrganizationSettingsInvoiceSectionsDocument,
+          })
+
+          addToast({
+            message: translate('text_1733849149914twslm71nuy6'),
+            severity: 'success',
+          })
+        }
+      },
+    })
+  }
+
+  return { openDeleteCustomSectionDialog }
+}

--- a/src/pages/settings/Invoices/InvoiceSections.tsx
+++ b/src/pages/settings/Invoices/InvoiceSections.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
@@ -13,10 +12,7 @@ import {
   SettingsPaddedContainer,
 } from '~/components/layouts/Settings'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import {
-  DeleteCustomSectionDialog,
-  DeleteCustomSectionDialogRef,
-} from '~/components/settings/invoices/DeleteCustomSectionDialog'
+import { useDeleteCustomSectionDialog } from '~/components/settings/invoices/DeleteCustomSectionDialog'
 import {
   CREATE_INVOICE_CUSTOM_SECTION,
   CREATE_PRICING_UNIT,
@@ -71,7 +67,7 @@ const InvoiceSections = () => {
   const { translate } = useInternationalization()
   const { hasPermissions } = usePermissions()
   const navigate = useNavigate()
-  const deleteCustomSectionDialogRef = useRef<DeleteCustomSectionDialogRef>(null)
+  const { openDeleteCustomSectionDialog } = useDeleteCustomSectionDialog()
 
   const canCreatePricingUnits = hasPermissions(['pricingUnitsCreate'])
   const canEditPricingUnits = hasPermissions(['pricingUnitsUpdate'])
@@ -261,7 +257,7 @@ const InvoiceSections = () => {
                       startIcon: 'trash',
                       title: translate('text_1732638001460kdzkctjfegi'),
                       onAction: () => {
-                        deleteCustomSectionDialogRef.current?.openDialog({
+                        openDeleteCustomSectionDialog({
                           id: section.id,
                         })
                       },
@@ -273,8 +269,6 @@ const InvoiceSections = () => {
           </SettingsListItem>
         </SettingsListWrapper>
       </SettingsPaddedContainer>
-
-      <DeleteCustomSectionDialog ref={deleteCustomSectionDialogRef} />
     </>
   )
 }


### PR DESCRIPTION
## Context

`WarningDialog` is deprecated in favor of the new hook-based NiceModal dialog system (`useFormDialog`, `useCentralizedDialog`, `useFormDialogOpeningDialog`). This PR migrates `DeleteCustomSectionDialog` to remove one of the remaining `WarningDialog` ESLint warnings.

## Description

- Convert `DeleteCustomSectionDialog` from an imperative `forwardRef` component to the `useDeleteCustomSectionDialog` hook backed by `useCentralizedDialog`.
- Drop the `DeleteCustomSectionDialogRef` interface, `forwardRef`, `useImperativeHandle`, and local `useState` for the passed data — the fragment flows directly through the `open` function parameter.
- Replace the inline `cache.evict({ id: cacheId })` call with the shared `evictFromCache` helper. It removes the entity from the paginated `invoiceCustomSections` list, nulls out root single-reference fields, and only broadcasts the update to `GetOrganizationSettingsInvoiceSectionsDocument`, preventing retained detail-page queries from refetching and hitting a 404.
- Update `InvoiceSections` to consume the hook, drop the ref instantiation, and remove the JSX render of the dialog (NiceModal renders it centrally).