### PR TITLE
refactor(integrations): migrate DeleteAnrokIntegrationDialog to CentralizedDialog

### DIFF
--- a/src/components/settings/integrations/AddAnrokDialog.tsx
+++ b/src/components/settings/integrations/AddAnrokDialog.tsx
@@ -1,7 +1,7 @@
 import { FetchResult, gql } from '@apollo/client'
 import Stack from '@mui/material/Stack'
 import { useFormik } from 'formik'
-import { forwardRef, RefObject, useId, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useId, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 import { object, string } from 'yup'
 
@@ -23,8 +23,6 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { AnrokIntegrationDetailsTabs } from '~/pages/settings/AnrokIntegrationDetails'
-
-import { DeleteAnrokIntegrationDialogRef } from './DeleteAnrokIntegrationDialog'
 
 gql`
   fragment AddAnrokIntegrationDialog on AnrokIntegration {
@@ -54,9 +52,8 @@ gql`
 `
 
 type TAddAnrokDialogProps = Partial<{
-  deleteModalRef: RefObject<DeleteAnrokIntegrationDialogRef>
+  onDelete: (provider: AddAnrokIntegrationDialogFragment) => void
   integration: AddAnrokIntegrationDialogFragment
-  deleteDialogCallback: () => void
 }>
 
 export interface AddAnrokDialogRef {
@@ -204,10 +201,7 @@ export const AddAnrokDialog = forwardRef<AddAnrokDialogRef>((_, ref) => {
               variant="quaternary"
               onClick={() => {
                 closeDialog()
-                localData?.deleteModalRef?.current?.openDialog({
-                  provider: anrokIntegration,
-                  callback: localData?.deleteDialogCallback,
-                })
+                localData?.onDelete?.(anrokIntegration)
               }}
             >
               {translate('text_65845f35d7d69c3ab4793dad')}

--- a/src/components/settings/integrations/AnrokIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AnrokIntegrationSettings.tsx
@@ -28,10 +28,7 @@ import { AnrokIntegrationDetailsTabs } from '~/pages/settings/AnrokIntegrationDe
 import { theme } from '~/styles'
 
 import { AddAnrokDialog, AddAnrokDialogRef } from './AddAnrokDialog'
-import {
-  DeleteAnrokIntegrationDialog,
-  DeleteAnrokIntegrationDialogRef,
-} from './DeleteAnrokIntegrationDialog'
+import { useDeleteAnrokIntegrationDialog } from './DeleteAnrokIntegrationDialog'
 
 const PROVIDER_CONNECTION_LIMIT = 2
 
@@ -80,7 +77,7 @@ const AnrokIntegrationSettings = () => {
   const navigate = useNavigate()
   const { integrationId = '' } = useParams()
   const addAnrokDialogRef = useRef<AddAnrokDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteAnrokIntegrationDialogRef>(null)
+  const { openDeleteAnrokIntegrationDialog } = useDeleteAnrokIntegrationDialog()
   const { translate } = useInternationalization()
   const [retryAllInvoices] = useRetryAllInvoicesMutation({
     onCompleted(result) {
@@ -146,8 +143,11 @@ const AnrokIntegrationSettings = () => {
               onClick={() => {
                 addAnrokDialogRef.current?.openDialog({
                   integration: anrokIntegration,
-                  deleteModalRef: deleteDialogRef,
-                  deleteDialogCallback,
+                  onDelete: (provider) =>
+                    openDeleteAnrokIntegrationDialog({
+                      provider,
+                      callback: deleteDialogCallback,
+                    }),
                 })
               }}
             >
@@ -224,7 +224,6 @@ const AnrokIntegrationSettings = () => {
       </IntegrationsPage.Container>
 
       <AddAnrokDialog ref={addAnrokDialogRef} />
-      <DeleteAnrokIntegrationDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/components/settings/integrations/DeleteAnrokIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteAnrokIntegrationDialog.tsx
@@ -1,10 +1,11 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import {
   DeleteAnrokIntegrationDialogFragment,
+  GetAnrokIntegrationsListDocument,
   useDestroyNangoIntegrationMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -27,58 +28,47 @@ type TDeleteAnrokIntegrationDialogProps = {
   callback?: () => void
 }
 
-export interface DeleteAnrokIntegrationDialogRef {
-  openDialog: ({ provider, callback }: TDeleteAnrokIntegrationDialogProps) => unknown
-  closeDialog: () => unknown
-}
+export const useDeleteAnrokIntegrationDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+  const client = useApolloClient()
 
-export const DeleteAnrokIntegrationDialog = forwardRef<DeleteAnrokIntegrationDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
+  const [deleteAnrok] = useDestroyNangoIntegrationMutation()
 
-    const dialogRef = useRef<WarningDialogRef>(null)
-    const [localData, setLocalData] = useState<TDeleteAnrokIntegrationDialogProps | undefined>(
-      undefined,
-    )
-    const anrokProvider = localData?.provider
+  const openDeleteAnrokIntegrationDialog = ({
+    provider,
+    callback,
+  }: TDeleteAnrokIntegrationDialogProps) => {
+    centralizedDialog.open({
+      title: translate('text_658461066530343fe1808cd7', { name: provider?.name }),
+      description: translate('text_6668870bc8bdb352948ffb5f'),
+      colorVariant: 'danger',
+      actionText: translate('text_645d071272418a14c1c76a81'),
+      onAction: async () => {
+        const result = await deleteAnrok({
+          variables: { input: { id: provider?.id as string } },
+        })
 
-    const [deleteAnrok] = useDestroyNangoIntegrationMutation({
-      onCompleted(data) {
-        if (data && data.destroyIntegration) {
-          dialogRef.current?.closeDialog()
-          localData?.callback?.()
+        const destroyedId = result.data?.destroyIntegration?.id
+
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'AnrokIntegration',
+            listFieldName: 'integrations',
+            listQueryDocument: GetAnrokIntegrationsListDocument,
+          })
+
+          callback?.()
+
           addToast({
             message: translate('text_661ff6e56ef7e1b7c542b2f9'),
             severity: 'success',
           })
         }
       },
-      update(cache) {
-        cache.evict({ id: `AnrokIntegration:${anrokProvider?.id}` })
-      },
-      refetchQueries: ['getAnrokIntegrationsList'],
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setLocalData(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => dialogRef.current?.closeDialog(),
-    }))
-
-    return (
-      <WarningDialog
-        ref={dialogRef}
-        title={translate('text_658461066530343fe1808cd7', { name: anrokProvider?.name })}
-        description={translate('text_6668870bc8bdb352948ffb5f')}
-        onContinue={async () =>
-          await deleteAnrok({ variables: { input: { id: anrokProvider?.id as string } } })
-        }
-        continueText={translate('text_645d071272418a14c1c76a81')}
-      />
-    )
-  },
-)
-
-DeleteAnrokIntegrationDialog.displayName = 'DeleteAnrokIntegrationDialog'
+  return { openDeleteAnrokIntegrationDialog }
+}

--- a/src/pages/settings/AnrokIntegrationDetails.tsx
+++ b/src/pages/settings/AnrokIntegrationDetails.tsx
@@ -14,10 +14,7 @@ import {
 } from '~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog'
 import AnrokIntegrationItemsList from '~/components/settings/integrations/AnrokIntegrationItemsList'
 import AnrokIntegrationSettings from '~/components/settings/integrations/AnrokIntegrationSettings'
-import {
-  DeleteAnrokIntegrationDialog,
-  DeleteAnrokIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteAnrokIntegrationDialog'
+import { useDeleteAnrokIntegrationDialog } from '~/components/settings/integrations/DeleteAnrokIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import {
   ANROK_INTEGRATION_DETAILS_ROUTE,
@@ -82,7 +79,7 @@ const AnrokIntegrationDetails = () => {
   const navigate = useNavigate()
   const { integrationId = '' } = useParams()
   const addAnrokDialogRef = useRef<AddAnrokDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteAnrokIntegrationDialogRef>(null)
+  const { openDeleteAnrokIntegrationDialog } = useDeleteAnrokIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
   const { data, loading } = useGetAnrokIntegrationsDetailsQuery({
@@ -145,8 +142,11 @@ const AnrokIntegrationDetails = () => {
                   onClick: (closePopper) => {
                     addAnrokDialogRef.current?.openDialog({
                       integration: anrokIntegration,
-                      deleteModalRef: deleteDialogRef,
-                      deleteDialogCallback,
+                      onDelete: (provider) =>
+                        openDeleteAnrokIntegrationDialog({
+                          provider,
+                          callback: deleteDialogCallback,
+                        }),
                     })
                     closePopper()
                   },
@@ -154,7 +154,7 @@ const AnrokIntegrationDetails = () => {
                 {
                   label: translate('text_65845f35d7d69c3ab4793dad'),
                   onClick: (closePopper) => {
-                    deleteDialogRef.current?.openDialog({
+                    openDeleteAnrokIntegrationDialog({
                       provider: anrokIntegration,
                       callback: deleteDialogCallback,
                     })
@@ -189,7 +189,6 @@ const AnrokIntegrationDetails = () => {
       />
       <>{activeTabContent}</>
       <AddAnrokDialog ref={addAnrokDialogRef} />
-      <DeleteAnrokIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/AnrokIntegrations.tsx
+++ b/src/pages/settings/AnrokIntegrations.tsx
@@ -11,10 +11,7 @@ import {
   AddAnrokDialog,
   AddAnrokDialogRef,
 } from '~/components/settings/integrations/AddAnrokDialog'
-import {
-  DeleteAnrokIntegrationDialog,
-  DeleteAnrokIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteAnrokIntegrationDialog'
+import { useDeleteAnrokIntegrationDialog } from '~/components/settings/integrations/DeleteAnrokIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { ANROK_INTEGRATION_DETAILS_ROUTE, INTEGRATIONS_ROUTE, useNavigate } from '~/core/router'
 import {
@@ -59,7 +56,7 @@ const AnrokIntegrations = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
   const addAnrokDialogRef = useRef<AddAnrokDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteAnrokIntegrationDialogRef>(null)
+  const { openDeleteAnrokIntegrationDialog } = useDeleteAnrokIntegrationDialog()
   const { data, loading } = useGetAnrokIntegrationsListQuery({
     variables: { limit: 1000, types: [IntegrationTypeEnum.Anrok] },
   })
@@ -157,8 +154,11 @@ const AnrokIntegrations = () => {
                           onClick={() => {
                             addAnrokDialogRef.current?.openDialog({
                               integration: connection,
-                              deleteModalRef: deleteDialogRef,
-                              deleteDialogCallback,
+                              onDelete: (provider) =>
+                                openDeleteAnrokIntegrationDialog({
+                                  provider,
+                                  callback: deleteDialogCallback,
+                                }),
                             })
                             closePopper()
                           }}
@@ -170,7 +170,7 @@ const AnrokIntegrations = () => {
                           variant="quaternary"
                           align="left"
                           onClick={() => {
-                            deleteDialogRef.current?.openDialog({
+                            openDeleteAnrokIntegrationDialog({
                               provider: connection,
                               callback: deleteDialogCallback,
                             })
@@ -188,7 +188,6 @@ const AnrokIntegrations = () => {
         </section>
       </IntegrationsPage.Container>
       <AddAnrokDialog ref={addAnrokDialogRef} />
-      <DeleteAnrokIntegrationDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/__tests__/AnrokIntegrationDetails.test.tsx
+++ b/src/pages/settings/__tests__/AnrokIntegrationDetails.test.tsx
@@ -10,7 +10,7 @@ jest.mock('~/components/settings/integrations/AddAnrokDialog', () => ({
   AddAnrokDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteAnrokIntegrationDialog', () => ({
-  DeleteAnrokIntegrationDialog: () => null,
+  useDeleteAnrokIntegrationDialog: () => ({ openDeleteAnrokIntegrationDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog', () => ({
   AddEditDeleteSuccessRedirectUrlDialog: () => null,

--- a/src/pages/settings/__tests__/AnrokIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/AnrokIntegrations.test.tsx
@@ -14,7 +14,7 @@ jest.mock('~/components/settings/integrations/AddAnrokDialog', () => ({
   AddAnrokDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteAnrokIntegrationDialog', () => ({
-  DeleteAnrokIntegrationDialog: () => null,
+  useDeleteAnrokIntegrationDialog: () => ({ openDeleteAnrokIntegrationDialog: jest.fn() }),
 }))
 
 describe('AnrokIntegrations', () => {


### PR DESCRIPTION
## Context

`DeleteAnrokIntegrationDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs. Same pattern already applied to `DeleteAdyenIntegrationDialog` and `DeleteXeroIntegrationDialog` (used as canonical references here).

## Description

Migrate `DeleteAnrokIntegrationDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API, and switch its cache handling to the `evictFromCache` helper.

- `src/components/settings/integrations/DeleteAnrokIntegrationDialog.tsx`: rewrote the component as `useDeleteAnrokIntegrationDialog` hook exposing `openDeleteAnrokIntegrationDialog(...)`. Replaced the legacy `refetchQueries: ['getAnrokIntegrationsList']` + bare `cache.evict({ id: 'AnrokIntegration:...' })` combo with `evictFromCache(client, { id, __typename: 'AnrokIntegration', listFieldName: 'integrations', listQueryDocument: GetAnrokIntegrationsListDocument })`. This mirrors what `DeleteAdyenIntegrationDialog`/`DeleteXeroIntegrationDialog` already do and avoids the retained-detail-query 404 toast that `cache.evict()` causes when a detail-page query is still watched.
- `src/components/settings/integrations/AddAnrokDialog.tsx`: removed the `deleteModalRef: RefObject<DeleteAnrokIntegrationDialogRef>` + `deleteDialogCallback` props (they existed only to let the edit dialog trigger the delete dialog through the old ref system). Replaced by an `onDelete: (provider) => void` callback prop, matching the `AddAdyenDialog`/`AddXeroDialog` shape. The `AddAnrokDialog` itself is left on its existing Formik + `Dialog` pattern — migrating that is out of scope for this PR.
- `src/pages/settings/AnrokIntegrations.tsx`, `src/pages/settings/AnrokIntegrationDetails.tsx`, `src/components/settings/integrations/AnrokIntegrationSettings.tsx`: replaced `useRef<DeleteAnrokIntegrationDialogRef>` + `<DeleteAnrokIntegrationDialog ref={...} />` with `useDeleteAnrokIntegrationDialog()`, and pass a local `openDeleteAnrokIntegrationDialog` function to `AddAnrokDialog` via the new `onDelete` prop. The `deleteDialogCallback` navigation logic is preserved verbatim.
- Updated the two Jest test files (`AnrokIntegrationDetails.test.tsx`, `AnrokIntegrations.test.tsx`) to mock the new `useDeleteAnrokIntegrationDialog` hook instead of the removed `DeleteAnrokIntegrationDialog` component.

No user-visible behavior change: the delete confirmation dialog still shows the same title / description / action label, still fires the same `destroyIntegration` mutation, still runs the same navigation callback, and the Anrok list still refreshes after deletion (now via `evictFromCache` instead of a full refetch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYYZwZJmtrJ74pkLHVGhnK)_