### PR TITLE
refactor(integrations): migrate DeleteNetsuiteIntegrationDialog to CentralizedDialog

### DIFF
--- a/src/components/settings/integrations/AddNetsuiteDialog.tsx
+++ b/src/components/settings/integrations/AddNetsuiteDialog.tsx
@@ -3,7 +3,7 @@ import Stack from '@mui/material/Stack'
 import Nango from '@nangohq/frontend'
 import { useFormik } from 'formik'
 import { GraphQLFormattedError } from 'graphql'
-import { forwardRef, RefObject, useId, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useId, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 import { boolean, object, string } from 'yup'
 
@@ -24,8 +24,6 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { NetsuiteIntegrationDetailsTabs } from '~/pages/settings/NetsuiteIntegrationDetails'
-
-import { DeleteNetsuiteIntegrationDialogRef } from './DeleteNetsuiteIntegrationDialog'
 
 gql`
   fragment NetsuiteForCreateDialogDialog on NetsuiteIntegration {
@@ -57,9 +55,8 @@ gql`
 `
 
 type TAddNetsuiteDialogProps = Partial<{
-  deleteModalRef: RefObject<DeleteNetsuiteIntegrationDialogRef>
+  onDelete: (provider: NetsuiteForCreateDialogDialogFragment) => void
   provider: NetsuiteForCreateDialogDialogFragment
-  deleteDialogCallback: () => void
 }>
 
 export interface AddNetsuiteDialogRef {
@@ -242,10 +239,7 @@ export const AddNetsuiteDialog = forwardRef<AddNetsuiteDialogRef>((_, ref) => {
               variant="quaternary"
               onClick={() => {
                 closeDialog()
-                localData?.deleteModalRef?.current?.openDialog({
-                  provider: netsuiteProvider,
-                  callback: localData.deleteDialogCallback,
-                })
+                localData?.onDelete?.(netsuiteProvider)
               }}
             >
               {translate('text_65845f35d7d69c3ab4793dad')}

--- a/src/components/settings/integrations/DeleteNetsuiteIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteNetsuiteIntegrationDialog.tsx
@@ -1,10 +1,11 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import {
   DeleteNetsuiteIntegrationDialogFragment,
+  GetNetsuiteIntegrationsListDocument,
   useDestroyNangoIntegrationMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -27,58 +28,47 @@ type TDeleteNetsuiteIntegrationDialogProps = {
   callback?: () => void
 }
 
-export interface DeleteNetsuiteIntegrationDialogRef {
-  openDialog: ({ provider, callback }: TDeleteNetsuiteIntegrationDialogProps) => unknown
-  closeDialog: () => unknown
-}
+export const useDeleteNetsuiteIntegrationDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+  const client = useApolloClient()
 
-export const DeleteNetsuiteIntegrationDialog = forwardRef<DeleteNetsuiteIntegrationDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
+  const [deleteNetsuite] = useDestroyNangoIntegrationMutation()
 
-    const dialogRef = useRef<WarningDialogRef>(null)
-    const [localData, setLocalData] = useState<TDeleteNetsuiteIntegrationDialogProps | undefined>(
-      undefined,
-    )
-    const netsuiteProvider = localData?.provider
+  const openDeleteNetsuiteIntegrationDialog = ({
+    provider,
+    callback,
+  }: TDeleteNetsuiteIntegrationDialogProps) => {
+    centralizedDialog.open({
+      title: translate('text_658461066530343fe1808cd7', { name: provider?.name }),
+      description: translate('text_661ff6e56ef7e1b7c542b1ec'),
+      colorVariant: 'danger',
+      actionText: translate('text_645d071272418a14c1c76a81'),
+      onAction: async () => {
+        const result = await deleteNetsuite({
+          variables: { input: { id: provider?.id as string } },
+        })
 
-    const [deleteNetsuite] = useDestroyNangoIntegrationMutation({
-      onCompleted(data) {
-        if (data && data.destroyIntegration) {
-          dialogRef.current?.closeDialog()
-          localData?.callback?.()
+        const destroyedId = result.data?.destroyIntegration?.id
+
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'NetsuiteIntegration',
+            listFieldName: 'integrations',
+            listQueryDocument: GetNetsuiteIntegrationsListDocument,
+          })
+
+          callback?.()
+
           addToast({
             message: translate('text_661ff6e56ef7e1b7c542b2f9'),
             severity: 'success',
           })
         }
       },
-      update(cache) {
-        cache.evict({ id: `NetsuiteIntegration:${netsuiteProvider?.id}` })
-      },
-      refetchQueries: ['getNetsuiteIntegrationsList'],
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setLocalData(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => dialogRef.current?.closeDialog(),
-    }))
-
-    return (
-      <WarningDialog
-        ref={dialogRef}
-        title={translate('text_658461066530343fe1808cd7', { name: netsuiteProvider?.name })}
-        description={translate('text_661ff6e56ef7e1b7c542b1ec')}
-        onContinue={async () =>
-          await deleteNetsuite({ variables: { input: { id: netsuiteProvider?.id as string } } })
-        }
-        continueText={translate('text_645d071272418a14c1c76a81')}
-      />
-    )
-  },
-)
-
-DeleteNetsuiteIntegrationDialog.displayName = 'DeleteNetsuiteIntegrationDialog'
+  return { openDeleteNetsuiteIntegrationDialog }
+}

--- a/src/components/settings/integrations/NetsuiteIntegrationSettings.tsx
+++ b/src/components/settings/integrations/NetsuiteIntegrationSettings.tsx
@@ -27,10 +27,7 @@ import {
   AddEditDeleteSuccessRedirectUrlDialogRef,
 } from './AddEditDeleteSuccessRedirectUrlDialog'
 import { AddNetsuiteDialog, AddNetsuiteDialogRef } from './AddNetsuiteDialog'
-import {
-  DeleteNetsuiteIntegrationDialog,
-  DeleteNetsuiteIntegrationDialogRef,
-} from './DeleteNetsuiteIntegrationDialog'
+import { useDeleteNetsuiteIntegrationDialog } from './DeleteNetsuiteIntegrationDialog'
 
 const PROVIDER_CONNECTION_LIMIT = 2
 
@@ -98,7 +95,7 @@ const NetsuiteIntegrationSettings = () => {
   const navigate = useNavigate()
   const { integrationId = '' } = useParams()
   const addNetsuiteDialogRef = useRef<AddNetsuiteDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteNetsuiteIntegrationDialogRef>(null)
+  const { openDeleteNetsuiteIntegrationDialog } = useDeleteNetsuiteIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
   const { data, loading } = useGetNetsuiteIntegrationsSettingsQuery({
@@ -155,8 +152,11 @@ const NetsuiteIntegrationSettings = () => {
               onClick={() => {
                 addNetsuiteDialogRef.current?.openDialog({
                   provider: netsuiteIntegration,
-                  deleteModalRef: deleteDialogRef,
-                  deleteDialogCallback,
+                  onDelete: (provider) =>
+                    openDeleteNetsuiteIntegrationDialog({
+                      provider,
+                      callback: deleteDialogCallback,
+                    }),
                 })
               }}
             >
@@ -218,7 +218,6 @@ const NetsuiteIntegrationSettings = () => {
       </IntegrationsPage.Container>
 
       <AddNetsuiteDialog ref={addNetsuiteDialogRef} />
-      <DeleteNetsuiteIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/NetsuiteIntegrationDetails.tsx
+++ b/src/pages/settings/NetsuiteIntegrationDetails.tsx
@@ -12,10 +12,7 @@ import {
   AddNetsuiteDialog,
   AddNetsuiteDialogRef,
 } from '~/components/settings/integrations/AddNetsuiteDialog'
-import {
-  DeleteNetsuiteIntegrationDialog,
-  DeleteNetsuiteIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteNetsuiteIntegrationDialog'
+import { useDeleteNetsuiteIntegrationDialog } from '~/components/settings/integrations/DeleteNetsuiteIntegrationDialog'
 import NetsuiteIntegrationItemsList from '~/components/settings/integrations/NetsuiteIntegrationItemsList'
 import NetsuiteIntegrationSettings from '~/components/settings/integrations/NetsuiteIntegrationSettings'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
@@ -84,7 +81,7 @@ const NetsuiteIntegrationDetails = () => {
   const navigate = useNavigate()
   const { integrationId = '' } = useParams()
   const addNetsuiteDialogRef = useRef<AddNetsuiteDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteNetsuiteIntegrationDialogRef>(null)
+  const { openDeleteNetsuiteIntegrationDialog } = useDeleteNetsuiteIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
   const { data, loading } = useGetNetsuiteIntegrationsDetailsQuery({
@@ -147,8 +144,11 @@ const NetsuiteIntegrationDetails = () => {
                   onClick: (closePopper) => {
                     addNetsuiteDialogRef.current?.openDialog({
                       provider: netsuiteIntegration,
-                      deleteModalRef: deleteDialogRef,
-                      deleteDialogCallback,
+                      onDelete: (provider) =>
+                        openDeleteNetsuiteIntegrationDialog({
+                          provider,
+                          callback: deleteDialogCallback,
+                        }),
                     })
                     closePopper()
                   },
@@ -157,7 +157,7 @@ const NetsuiteIntegrationDetails = () => {
                   label: translate('text_65845f35d7d69c3ab4793dad'),
                   onClick: (closePopper) => {
                     if (netsuiteIntegration) {
-                      deleteDialogRef.current?.openDialog({
+                      openDeleteNetsuiteIntegrationDialog({
                         provider: netsuiteIntegration,
                         callback: deleteDialogCallback,
                       })
@@ -204,7 +204,6 @@ const NetsuiteIntegrationDetails = () => {
       <>{activeTabContent}</>
 
       <AddNetsuiteDialog ref={addNetsuiteDialogRef} />
-      <DeleteNetsuiteIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/NetsuiteIntegrations.tsx
+++ b/src/pages/settings/NetsuiteIntegrations.tsx
@@ -11,10 +11,7 @@ import {
   AddNetsuiteDialog,
   AddNetsuiteDialogRef,
 } from '~/components/settings/integrations/AddNetsuiteDialog'
-import {
-  DeleteNetsuiteIntegrationDialog,
-  DeleteNetsuiteIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteNetsuiteIntegrationDialog'
+import { useDeleteNetsuiteIntegrationDialog } from '~/components/settings/integrations/DeleteNetsuiteIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { INTEGRATIONS_ROUTE, NETSUITE_INTEGRATION_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import {
@@ -59,7 +56,7 @@ const NetsuiteIntegrations = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
   const addNetsuiteDialogRef = useRef<AddNetsuiteDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteNetsuiteIntegrationDialogRef>(null)
+  const { openDeleteNetsuiteIntegrationDialog } = useDeleteNetsuiteIntegrationDialog()
   const { data, loading } = useGetNetsuiteIntegrationsListQuery({
     variables: { limit: 1000, types: [IntegrationTypeEnum.Netsuite] },
   })
@@ -157,8 +154,11 @@ const NetsuiteIntegrations = () => {
                           onClick={() => {
                             addNetsuiteDialogRef.current?.openDialog({
                               provider: connection,
-                              deleteModalRef: deleteDialogRef,
-                              deleteDialogCallback,
+                              onDelete: (provider) =>
+                                openDeleteNetsuiteIntegrationDialog({
+                                  provider,
+                                  callback: deleteDialogCallback,
+                                }),
                             })
                             closePopper()
                           }}
@@ -170,7 +170,7 @@ const NetsuiteIntegrations = () => {
                           variant="quaternary"
                           align="left"
                           onClick={() => {
-                            deleteDialogRef.current?.openDialog({
+                            openDeleteNetsuiteIntegrationDialog({
                               provider: connection,
                               callback: deleteDialogCallback,
                             })
@@ -188,7 +188,6 @@ const NetsuiteIntegrations = () => {
         </section>
       </IntegrationsPage.Container>
       <AddNetsuiteDialog ref={addNetsuiteDialogRef} />
-      <DeleteNetsuiteIntegrationDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/__tests__/NetsuiteIntegrationDetails.test.tsx
+++ b/src/pages/settings/__tests__/NetsuiteIntegrationDetails.test.tsx
@@ -10,7 +10,7 @@ jest.mock('~/components/settings/integrations/AddNetsuiteDialog', () => ({
   AddNetsuiteDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteNetsuiteIntegrationDialog', () => ({
-  DeleteNetsuiteIntegrationDialog: () => null,
+  useDeleteNetsuiteIntegrationDialog: () => ({ openDeleteNetsuiteIntegrationDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog', () => ({
   AddEditDeleteSuccessRedirectUrlDialog: () => null,

--- a/src/pages/settings/__tests__/NetsuiteIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/NetsuiteIntegrations.test.tsx
@@ -14,7 +14,7 @@ jest.mock('~/components/settings/integrations/AddNetsuiteDialog', () => ({
   AddNetsuiteDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteNetsuiteIntegrationDialog', () => ({
-  DeleteNetsuiteIntegrationDialog: () => null,
+  useDeleteNetsuiteIntegrationDialog: () => ({ openDeleteNetsuiteIntegrationDialog: jest.fn() }),
 }))
 
 describe('NetsuiteIntegrations', () => {


### PR DESCRIPTION
## Context

`DeleteNetsuiteIntegrationDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs. Same pattern already applied to `DeleteAdyenIntegrationDialog` and `DeleteXeroIntegrationDialog` (used as canonical references here).

## Description

Migrate `DeleteNetsuiteIntegrationDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API, and switch its cache handling to the `evictFromCache` helper.

- `src/components/settings/integrations/DeleteNetsuiteIntegrationDialog.tsx`: rewrote the component as `useDeleteNetsuiteIntegrationDialog` hook exposing `openDeleteNetsuiteIntegrationDialog(...)`. Replaced the legacy `refetchQueries: ['getNetsuiteIntegrationsList']` + bare `cache.evict({ id: 'NetsuiteIntegration:...' })` combo with `evictFromCache(client, { id, __typename: 'NetsuiteIntegration', listFieldName: 'integrations', listQueryDocument: GetNetsuiteIntegrationsListDocument })`. This mirrors what `DeleteAdyenIntegrationDialog`/`DeleteXeroIntegrationDialog` already do and avoids the retained-detail-query 404 toast that `cache.evict()` causes when a detail-page query is still watched.
- `src/components/settings/integrations/AddNetsuiteDialog.tsx`: removed the `deleteModalRef: RefObject<DeleteNetsuiteIntegrationDialogRef>` + `deleteDialogCallback` props. Replaced by an `onDelete: (provider) => void` callback prop, matching the `AddAdyenDialog`/`AddXeroDialog` shape. The `AddNetsuiteDialog` itself is left on its existing Formik + `Dialog` pattern — migrating that is out of scope for this PR.
- `src/pages/settings/NetsuiteIntegrations.tsx`, `src/pages/settings/NetsuiteIntegrationDetails.tsx`, `src/components/settings/integrations/NetsuiteIntegrationSettings.tsx`: replaced `useRef<DeleteNetsuiteIntegrationDialogRef>` + `<DeleteNetsuiteIntegrationDialog ref={...} />` with `useDeleteNetsuiteIntegrationDialog()`, and pass a local `openDeleteNetsuiteIntegrationDialog` function to `AddNetsuiteDialog` via the new `onDelete` prop. The `deleteDialogCallback` navigation logic is preserved verbatim.
- Updated the two Jest test files (`NetsuiteIntegrationDetails.test.tsx`, `NetsuiteIntegrations.test.tsx`) to mock the new `useDeleteNetsuiteIntegrationDialog` hook instead of the removed `DeleteNetsuiteIntegrationDialog` component.

No user-visible behavior change: the delete confirmation dialog still shows the same title / description / action label, still fires the same `destroyIntegration` mutation, still runs the same navigation callback, and the Netsuite list still refreshes after deletion (now via `evictFromCache` instead of a full refetch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYYZwZJmtrJ74pkLHVGhnK)_