### PR TITLE
refactor(integrations): migrate DeleteSalesforceIntegrationDialog to CentralizedDialog

### DIFF
--- a/src/components/settings/integrations/AddSalesforceDialog.tsx
+++ b/src/components/settings/integrations/AddSalesforceDialog.tsx
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 import { useFormik } from 'formik'
 import { GraphQLFormattedError } from 'graphql'
-import { forwardRef, RefObject, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 import { object, string } from 'yup'
 
@@ -21,8 +21,6 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { tw } from '~/styles/utils'
-
-import { DeleteSalesforceIntegrationDialogRef } from './DeleteSalesforceIntegrationDialog'
 
 gql`
   fragment SalesforceForCreateDialog on SalesforceIntegration {
@@ -49,9 +47,8 @@ gql`
 `
 
 type TAddSalesforceDialogProps = Partial<{
-  deleteModalRef: RefObject<DeleteSalesforceIntegrationDialogRef>
+  onDelete: (provider: SalesforceForCreateDialogFragment) => void
   provider: SalesforceForCreateDialogFragment
-  deleteDialogCallback: () => void
 }>
 
 export interface AddSalesforceDialogRef {
@@ -194,10 +191,7 @@ export const AddSalesforceDialog = forwardRef<AddSalesforceDialogRef>((_, ref) =
               variant="quaternary"
               onClick={() => {
                 closeDialog()
-                localData?.deleteModalRef?.current?.openDialog({
-                  provider: salesforceProvider,
-                  callback: localData.deleteDialogCallback,
-                })
+                localData?.onDelete?.(salesforceProvider)
               }}
             >
               {translate('text_65845f35d7d69c3ab4793dad')}

--- a/src/components/settings/integrations/DeleteSalesforceIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteSalesforceIntegrationDialog.tsx
@@ -1,10 +1,11 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import {
   DeleteSalesforceIntegrationDialogFragment,
+  GetSalesforceIntegrationsListDocument,
   useDestroyNangoIntegrationMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -27,66 +28,53 @@ type TDeleteSalesforceIntegrationDialogProps = {
   callback?: (arg?: unknown) => void
 }
 
-export interface DeleteSalesforceIntegrationDialogRef {
-  openDialog: ({ provider, callback }: TDeleteSalesforceIntegrationDialogProps) => unknown
-  closeDialog: () => unknown
-}
+export const useDeleteSalesforceIntegrationDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+  const client = useApolloClient()
 
-export const DeleteSalesforceIntegrationDialog = forwardRef<DeleteSalesforceIntegrationDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
+  const [deleteSalesforce] = useDestroyNangoIntegrationMutation()
 
-    const dialogRef = useRef<WarningDialogRef>(null)
-    const [localData, setLocalData] = useState<TDeleteSalesforceIntegrationDialogProps | undefined>(
-      undefined,
-    )
-    const salesforceProvider = localData?.provider
+  const openDeleteSalesforceIntegrationDialog = ({
+    provider,
+    callback,
+  }: TDeleteSalesforceIntegrationDialogProps) => {
+    centralizedDialog.open({
+      title: translate('text_658461066530343fe1808cd7', {
+        name: provider?.name,
+      }),
+      description: translate('text_1731511951723v0hq5fotjrx'),
+      colorVariant: 'danger',
+      actionText: translate('text_645d071272418a14c1c76a81'),
+      onAction: async () => {
+        const result = await deleteSalesforce({
+          variables: {
+            input: {
+              id: provider?.id as string,
+            },
+          },
+        })
 
-    const [deleteSalesforce] = useDestroyNangoIntegrationMutation({
-      onCompleted(data) {
-        if (data.destroyIntegration) {
-          dialogRef.current?.closeDialog()
-          localData?.callback?.()
+        const destroyedId = result.data?.destroyIntegration?.id
+
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'SalesforceIntegration',
+            listFieldName: 'integrations',
+            listQueryDocument: GetSalesforceIntegrationsListDocument,
+          })
+
+          callback?.()
+
           addToast({
             message: translate('text_661ff6e56ef7e1b7c542b2f9'),
             severity: 'success',
           })
         }
       },
-      update(cache) {
-        cache.evict({ id: `SalesforceIntegration:${salesforceProvider?.id}` })
-      },
-      refetchQueries: ['getSalesforceIntegrationsList'],
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setLocalData(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => dialogRef.current?.closeDialog(),
-    }))
-
-    return (
-      <WarningDialog
-        ref={dialogRef}
-        title={translate('text_658461066530343fe1808cd7', {
-          name: salesforceProvider?.name,
-        })}
-        description={translate('text_1731511951723v0hq5fotjrx')}
-        onContinue={async () =>
-          await deleteSalesforce({
-            variables: {
-              input: {
-                id: salesforceProvider?.id as string,
-              },
-            },
-          })
-        }
-        continueText={translate('text_645d071272418a14c1c76a81')}
-      />
-    )
-  },
-)
-
-DeleteSalesforceIntegrationDialog.displayName = 'DeleteSalesforceIntegrationDialog'
+  return { openDeleteSalesforceIntegrationDialog }
+}

--- a/src/pages/settings/SalesforceIntegrationDetails.tsx
+++ b/src/pages/settings/SalesforceIntegrationDetails.tsx
@@ -10,10 +10,7 @@ import {
   AddSalesforceDialog,
   AddSalesforceDialogRef,
 } from '~/components/settings/integrations/AddSalesforceDialog'
-import {
-  DeleteSalesforceIntegrationDialog,
-  DeleteSalesforceIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteSalesforceIntegrationDialog'
+import { useDeleteSalesforceIntegrationDialog } from '~/components/settings/integrations/DeleteSalesforceIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { INTEGRATIONS_ROUTE, SALESFORCE_INTEGRATION_ROUTE, useNavigate } from '~/core/router'
 import {
@@ -69,7 +66,7 @@ const SalesforceIntegrationDetails = () => {
   const navigate = useNavigate()
 
   const addSalesforceDialogRef = useRef<AddSalesforceDialogRef>(null)
-  const deleteSalesforceDialogRef = useRef<DeleteSalesforceIntegrationDialogRef>(null)
+  const { openDeleteSalesforceIntegrationDialog } = useDeleteSalesforceIntegrationDialog()
 
   const { data, loading } = useGetSalesforceIntegrationsDetailsQuery({
     variables: {
@@ -136,8 +133,11 @@ const SalesforceIntegrationDetails = () => {
                   onClick: (closePopper) => {
                     addSalesforceDialogRef.current?.openDialog({
                       provider: salesforceIntegration,
-                      deleteModalRef: deleteSalesforceDialogRef,
-                      deleteDialogCallback,
+                      onDelete: (provider) =>
+                        openDeleteSalesforceIntegrationDialog({
+                          provider,
+                          callback: deleteDialogCallback,
+                        }),
                     })
                     closePopper()
                   },
@@ -147,7 +147,7 @@ const SalesforceIntegrationDetails = () => {
                   hidden: !salesforceIntegration,
                   onClick: (closePopper) => {
                     if (salesforceIntegration) {
-                      deleteSalesforceDialogRef.current?.openDialog({
+                      openDeleteSalesforceIntegrationDialog({
                         provider: salesforceIntegration,
                         callback: deleteDialogCallback,
                       })
@@ -172,8 +172,11 @@ const SalesforceIntegrationDetails = () => {
               onClick={() => {
                 addSalesforceDialogRef.current?.openDialog({
                   provider: salesforceIntegration,
-                  deleteModalRef: deleteSalesforceDialogRef,
-                  deleteDialogCallback,
+                  onDelete: (provider) =>
+                    openDeleteSalesforceIntegrationDialog({
+                      provider,
+                      callback: deleteDialogCallback,
+                    }),
                 })
               }}
             >
@@ -206,7 +209,6 @@ const SalesforceIntegrationDetails = () => {
       </IntegrationsPage.Container>
 
       <AddSalesforceDialog ref={addSalesforceDialogRef} />
-      <DeleteSalesforceIntegrationDialog ref={deleteSalesforceDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/SalesforceIntegrations.tsx
+++ b/src/pages/settings/SalesforceIntegrations.tsx
@@ -11,10 +11,7 @@ import {
   AddSalesforceDialog,
   AddSalesforceDialogRef,
 } from '~/components/settings/integrations/AddSalesforceDialog'
-import {
-  DeleteSalesforceIntegrationDialog,
-  DeleteSalesforceIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteSalesforceIntegrationDialog'
+import { useDeleteSalesforceIntegrationDialog } from '~/components/settings/integrations/DeleteSalesforceIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import {
   INTEGRATIONS_ROUTE,
@@ -62,7 +59,7 @@ const SalesforceIntegrations = () => {
   const { translate } = useInternationalization()
 
   const addSalesforceDialogRef = useRef<AddSalesforceDialogRef>(null)
-  const deleteSalesforceDialogRef = useRef<DeleteSalesforceIntegrationDialogRef>(null)
+  const { openDeleteSalesforceIntegrationDialog } = useDeleteSalesforceIntegrationDialog()
 
   const { data, loading } = useGetSalesforceIntegrationsListQuery({
     variables: { limit: 1000, types: [IntegrationTypeEnum.Salesforce] },
@@ -157,8 +154,11 @@ const SalesforceIntegrations = () => {
                           onClick={() => {
                             addSalesforceDialogRef.current?.openDialog({
                               provider: connection,
-                              deleteModalRef: deleteSalesforceDialogRef,
-                              deleteDialogCallback,
+                              onDelete: (provider) =>
+                                openDeleteSalesforceIntegrationDialog({
+                                  provider,
+                                  callback: deleteDialogCallback,
+                                }),
                             })
                             closePopper()
                           }}
@@ -170,7 +170,7 @@ const SalesforceIntegrations = () => {
                           variant="quaternary"
                           align="left"
                           onClick={() => {
-                            deleteSalesforceDialogRef.current?.openDialog({
+                            openDeleteSalesforceIntegrationDialog({
                               provider: connection,
                               callback: deleteDialogCallback,
                             })
@@ -189,7 +189,6 @@ const SalesforceIntegrations = () => {
       </IntegrationsPage.Container>
 
       <AddSalesforceDialog ref={addSalesforceDialogRef} />
-      <DeleteSalesforceIntegrationDialog ref={deleteSalesforceDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/__tests__/SalesforceIntegrationDetails.test.tsx
+++ b/src/pages/settings/__tests__/SalesforceIntegrationDetails.test.tsx
@@ -10,7 +10,9 @@ jest.mock('~/components/settings/integrations/AddSalesforceDialog', () => ({
   AddSalesforceDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteSalesforceIntegrationDialog', () => ({
-  DeleteSalesforceIntegrationDialog: () => null,
+  useDeleteSalesforceIntegrationDialog: () => ({
+    openDeleteSalesforceIntegrationDialog: jest.fn(),
+  }),
 }))
 
 const mockQueryResult = jest.fn()

--- a/src/pages/settings/__tests__/SalesforceIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/SalesforceIntegrations.test.tsx
@@ -14,7 +14,9 @@ jest.mock('~/components/settings/integrations/AddSalesforceDialog', () => ({
   AddSalesforceDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteSalesforceIntegrationDialog', () => ({
-  DeleteSalesforceIntegrationDialog: () => null,
+  useDeleteSalesforceIntegrationDialog: () => ({
+    openDeleteSalesforceIntegrationDialog: jest.fn(),
+  }),
 }))
 
 describe('SalesforceIntegrations', () => {


### PR DESCRIPTION
## Context

`DeleteSalesforceIntegrationDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs. Same pattern already applied to `DeleteAdyenIntegrationDialog` and `DeleteXeroIntegrationDialog` (used as canonical references here).

## Description

Migrate `DeleteSalesforceIntegrationDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API, and switch its cache handling to the `evictFromCache` helper.

- `src/components/settings/integrations/DeleteSalesforceIntegrationDialog.tsx`: rewrote the component as `useDeleteSalesforceIntegrationDialog` hook exposing `openDeleteSalesforceIntegrationDialog(...)`. Replaced the legacy `refetchQueries: ['getSalesforceIntegrationsList']` + bare `cache.evict({ id: 'SalesforceIntegration:...' })` combo with `evictFromCache(client, { id, __typename: 'SalesforceIntegration', listFieldName: 'integrations', listQueryDocument: GetSalesforceIntegrationsListDocument })`.
- `src/components/settings/integrations/AddSalesforceDialog.tsx`: removed the `deleteModalRef: RefObject<DeleteSalesforceIntegrationDialogRef>` + `deleteDialogCallback` props. Replaced by an `onDelete: (provider) => void` callback prop.
- `src/pages/settings/SalesforceIntegrations.tsx`, `src/pages/settings/SalesforceIntegrationDetails.tsx`: replaced `useRef<DeleteSalesforceIntegrationDialogRef>` + `<DeleteSalesforceIntegrationDialog ref={...} />` with `useDeleteSalesforceIntegrationDialog()`, and pass a local `openDeleteSalesforceIntegrationDialog` function to `AddSalesforceDialog` via the new `onDelete` prop. Navigation callbacks preserved verbatim.
- Updated the two Jest test files to mock the new `useDeleteSalesforceIntegrationDialog` hook instead of the removed component.

No user-visible behavior change: the delete confirmation dialog still shows the same title / description / action label, still fires the same `destroyIntegration` mutation, still runs the same navigation callback, and the Salesforce list still refreshes after deletion (now via `evictFromCache` instead of a full refetch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYYZwZJmtrJ74pkLHVGhnK)_