### PR TITLE
refactor(integrations): migrate DeleteStripeIntegrationDialog to CentralizedDialog

### DIFF
--- a/src/components/settings/integrations/AddStripeDialog.tsx
+++ b/src/components/settings/integrations/AddStripeDialog.tsx
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 import Stack from '@mui/material/Stack'
 import { useFormik } from 'formik'
-import { forwardRef, RefObject, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 import { object, string } from 'yup'
 
@@ -21,8 +21,6 @@ import {
   useUpdateStripeApiKeyMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-
-import { DeleteStripeIntegrationDialogRef } from './DeleteStripeIntegrationDialog'
 
 gql`
   fragment AddStripeProviderDialog on StripeProvider {
@@ -76,9 +74,8 @@ gql`
 `
 
 type TAddStripeDialogProps = Partial<{
-  deleteModalRef: RefObject<DeleteStripeIntegrationDialogRef>
+  onDelete: (provider: AddStripeProviderDialogFragment) => void
   provider: AddStripeProviderDialogFragment
-  deleteDialogCallback: () => void
 }>
 
 export interface AddStripeDialogRef {
@@ -215,10 +212,7 @@ export const AddStripeDialog = forwardRef<AddStripeDialogRef>((_, ref) => {
               variant="quaternary"
               onClick={() => {
                 closeDialog()
-                localData?.deleteModalRef?.current?.openDialog({
-                  provider: stripeProvider,
-                  callback: localData?.deleteDialogCallback,
-                })
+                localData?.onDelete?.(stripeProvider)
               }}
             >
               {translate('text_65845f35d7d69c3ab4793dad')}

--- a/src/components/settings/integrations/DeleteStripeIntegrationDialog.tsx
+++ b/src/components/settings/integrations/DeleteStripeIntegrationDialog.tsx
@@ -1,9 +1,13 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
-import { DeleteStripeIntegrationDialogFragment, useDeleteStripeMutation } from '~/generated/graphql'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
+import {
+  DeleteStripeIntegrationDialogFragment,
+  GetStripeIntegrationsListDocument,
+  useDeleteStripeMutation,
+} from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 gql`
@@ -24,59 +28,47 @@ type TDeleteStripeIntegrationDialogProps = {
   callback?: () => void
 }
 
-export interface DeleteStripeIntegrationDialogRef {
-  openDialog: ({ provider, callback }: TDeleteStripeIntegrationDialogProps) => unknown
-  closeDialog: () => unknown
-}
+export const useDeleteStripeIntegrationDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+  const client = useApolloClient()
 
-export const DeleteStripeIntegrationDialog = forwardRef<DeleteStripeIntegrationDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
+  const [deleteStripe] = useDeleteStripeMutation()
 
-    const dialogRef = useRef<WarningDialogRef>(null)
-    const [localData, setLocalData] = useState<TDeleteStripeIntegrationDialogProps | undefined>(
-      undefined,
-    )
+  const openDeleteStripeIntegrationDialog = ({
+    provider,
+    callback,
+  }: TDeleteStripeIntegrationDialogProps) => {
+    centralizedDialog.open({
+      title: translate('text_658461066530343fe1808cd7', { name: provider?.name }),
+      description: translate('text_658461066530343fe1808cdb'),
+      colorVariant: 'danger',
+      actionText: translate('text_645d071272418a14c1c76a81'),
+      onAction: async () => {
+        const result = await deleteStripe({
+          variables: { input: { id: provider?.id as string } },
+        })
 
-    const stripeProvider = localData?.provider
+        const destroyedId = result.data?.destroyPaymentProvider?.id
 
-    const [deleteStripe] = useDeleteStripeMutation({
-      onCompleted(data) {
-        if (data && data.destroyPaymentProvider) {
-          dialogRef.current?.closeDialog()
-          localData?.callback?.()
+        if (destroyedId) {
+          evictFromCache(client, {
+            id: destroyedId,
+            __typename: 'StripeProvider',
+            listFieldName: 'paymentProviders',
+            listQueryDocument: GetStripeIntegrationsListDocument,
+          })
+
+          callback?.()
+
           addToast({
             message: translate('text_62b1edddbf5f461ab9712758'),
             severity: 'success',
           })
         }
       },
-      update(cache) {
-        cache.evict({ id: `StripeProvider:${stripeProvider?.id}` })
-      },
-      refetchQueries: ['getStripeIntegrationsList'],
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setLocalData(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => dialogRef.current?.closeDialog(),
-    }))
-
-    return (
-      <WarningDialog
-        ref={dialogRef}
-        title={translate('text_658461066530343fe1808cd7', { name: stripeProvider?.name })}
-        description={translate('text_658461066530343fe1808cdb')}
-        onContinue={async () =>
-          await deleteStripe({ variables: { input: { id: stripeProvider?.id as string } } })
-        }
-        continueText={translate('text_645d071272418a14c1c76a81')}
-      />
-    )
-  },
-)
-
-DeleteStripeIntegrationDialog.displayName = 'DeleteStripeIntegrationDialog'
+  return { openDeleteStripeIntegrationDialog }
+}

--- a/src/pages/settings/StripeIntegrationDetails.tsx
+++ b/src/pages/settings/StripeIntegrationDetails.tsx
@@ -16,10 +16,7 @@ import {
   AddStripeDialog,
   AddStripeDialogRef,
 } from '~/components/settings/integrations/AddStripeDialog'
-import {
-  DeleteStripeIntegrationDialog,
-  DeleteStripeIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteStripeIntegrationDialog'
+import { useDeleteStripeIntegrationDialog } from '~/components/settings/integrations/DeleteStripeIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { INTEGRATIONS_ROUTE, STRIPE_INTEGRATION_ROUTE, useNavigate } from '~/core/router'
 import {
@@ -77,7 +74,7 @@ const StripeIntegrationDetails = () => {
   const { integrationId } = useParams()
   const { hasPermissions } = usePermissions()
   const addDialogRef = useRef<AddStripeDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteStripeIntegrationDialogRef>(null)
+  const { openDeleteStripeIntegrationDialog } = useDeleteStripeIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
   const { data, loading } = useGetStripeIntegrationsDetailsQuery({
@@ -143,8 +140,11 @@ const StripeIntegrationDetails = () => {
                   onClick: (closePopper) => {
                     addDialogRef.current?.openDialog({
                       provider: stripePaymentProvider,
-                      deleteModalRef: deleteDialogRef,
-                      deleteDialogCallback,
+                      onDelete: (provider) =>
+                        openDeleteStripeIntegrationDialog({
+                          provider,
+                          callback: deleteDialogCallback,
+                        }),
                     })
                     closePopper()
                   },
@@ -153,7 +153,7 @@ const StripeIntegrationDetails = () => {
                   label: translate('text_65845f35d7d69c3ab4793dad'),
                   hidden: !canDeleteIntegration,
                   onClick: (closePopper) => {
-                    deleteDialogRef.current?.openDialog({
+                    openDeleteStripeIntegrationDialog({
                       provider: stripePaymentProvider,
                       callback: deleteDialogCallback,
                     })
@@ -177,8 +177,11 @@ const StripeIntegrationDetails = () => {
                 onClick={() => {
                   addDialogRef.current?.openDialog({
                     provider: stripePaymentProvider,
-                    deleteModalRef: deleteDialogRef,
-                    deleteDialogCallback,
+                    onDelete: (provider) =>
+                      openDeleteStripeIntegrationDialog({
+                        provider,
+                        callback: deleteDialogCallback,
+                      }),
                   })
                 }}
               >
@@ -320,7 +323,6 @@ const StripeIntegrationDetails = () => {
       </IntegrationsPage.Container>
 
       <AddStripeDialog ref={addDialogRef} />
-      <DeleteStripeIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/StripeIntegrations.tsx
+++ b/src/pages/settings/StripeIntegrations.tsx
@@ -15,10 +15,7 @@ import {
   AddStripeDialog,
   AddStripeDialogRef,
 } from '~/components/settings/integrations/AddStripeDialog'
-import {
-  DeleteStripeIntegrationDialog,
-  DeleteStripeIntegrationDialogRef,
-} from '~/components/settings/integrations/DeleteStripeIntegrationDialog'
+import { useDeleteStripeIntegrationDialog } from '~/components/settings/integrations/DeleteStripeIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { INTEGRATIONS_ROUTE, STRIPE_INTEGRATION_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import {
@@ -63,7 +60,7 @@ const StripeIntegrations = () => {
   const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
   const addStripeDialogRef = useRef<AddStripeDialogRef>(null)
-  const deleteDialogRef = useRef<DeleteStripeIntegrationDialogRef>(null)
+  const { openDeleteStripeIntegrationDialog } = useDeleteStripeIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
   const { data, loading } = useGetStripeIntegrationsListQuery({
@@ -167,8 +164,11 @@ const StripeIntegrations = () => {
                               onClick={() => {
                                 addStripeDialogRef.current?.openDialog({
                                   provider: connection,
-                                  deleteModalRef: deleteDialogRef,
-                                  deleteDialogCallback,
+                                  onDelete: (provider) =>
+                                    openDeleteStripeIntegrationDialog({
+                                      provider,
+                                      callback: deleteDialogCallback,
+                                    }),
                                 })
                                 closePopper()
                               }}
@@ -183,7 +183,7 @@ const StripeIntegrations = () => {
                               variant="quaternary"
                               align="left"
                               onClick={() => {
-                                deleteDialogRef.current?.openDialog({
+                                openDeleteStripeIntegrationDialog({
                                   provider: connection,
                                   callback: deleteDialogCallback,
                                 })
@@ -204,7 +204,6 @@ const StripeIntegrations = () => {
       </IntegrationsPage.Container>
 
       <AddStripeDialog ref={addStripeDialogRef} />
-      <DeleteStripeIntegrationDialog ref={deleteDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/__tests__/StripeIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/StripeIntegrations.test.tsx
@@ -14,7 +14,7 @@ jest.mock('~/components/settings/integrations/AddStripeDialog', () => ({
   AddStripeDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/DeleteStripeIntegrationDialog', () => ({
-  DeleteStripeIntegrationDialog: () => null,
+  useDeleteStripeIntegrationDialog: () => ({ openDeleteStripeIntegrationDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog', () => ({
   AddEditDeleteSuccessRedirectUrlDialog: () => null,


### PR DESCRIPTION
## Context

`DeleteStripeIntegrationDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs. Same pattern already applied to `DeleteAdyenIntegrationDialog` and `DeleteXeroIntegrationDialog` (used as canonical references here).

## Description

Migrate `DeleteStripeIntegrationDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API, and switch its cache handling to the `evictFromCache` helper.

- `src/components/settings/integrations/DeleteStripeIntegrationDialog.tsx`: rewrote the component as `useDeleteStripeIntegrationDialog` hook exposing `openDeleteStripeIntegrationDialog(...)`. Replaced the legacy `refetchQueries: ['getStripeIntegrationsList']` + bare `cache.evict({ id: 'StripeProvider:...' })` combo with `evictFromCache(client, { id, __typename: 'StripeProvider', listFieldName: 'paymentProviders', listQueryDocument: GetStripeIntegrationsListDocument })`. Avoids the retained-detail-query 404 toast that `cache.evict()` causes when a detail-page query is still watched.
- `src/components/settings/integrations/AddStripeDialog.tsx`: removed the `deleteModalRef: RefObject<DeleteStripeIntegrationDialogRef>` + `deleteDialogCallback` props. Replaced by an `onDelete: (provider) => void` callback prop.
- `src/pages/settings/StripeIntegrations.tsx`, `src/pages/settings/StripeIntegrationDetails.tsx`: replaced `useRef<DeleteStripeIntegrationDialogRef>` + `<DeleteStripeIntegrationDialog ref={...} />` with `useDeleteStripeIntegrationDialog()`, and pass a local `openDeleteStripeIntegrationDialog` function to `AddStripeDialog` via the new `onDelete` prop. Navigation callbacks preserved verbatim.
- Updated the Jest test file (`StripeIntegrations.test.tsx`) to mock the new `useDeleteStripeIntegrationDialog` hook instead of the removed component.

No user-visible behavior change: the delete confirmation dialog still shows the same title / description / action label, still fires the same `destroyPaymentProvider` mutation, still runs the same navigation callback, and the Stripe list still refreshes after deletion (now via `evictFromCache` instead of a full refetch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYYZwZJmtrJ74pkLHVGhnK)_