### PR TITLE
refactor(billableMetrics): migrate DeleteBillableMetricDialog to CentralizedDialog

### DIFF
--- a/src/components/billableMetrics/DeleteBillableMetricDialog.tsx
+++ b/src/components/billableMetrics/DeleteBillableMetricDialog.tsx
@@ -1,15 +1,14 @@
-import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
-import { Skeleton } from '~/components/designSystem/Skeleton'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import {
+  DeleteBillableMetricDialogFragment,
+  GetBillableMetricToDeleteDocument,
+  GetBillableMetricToDeleteQuery,
   useDeleteBillableMetricMutation,
-  useGetBillableMetricToDeleteLazyQuery,
 } from '~/generated/graphql'
-import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { TranslateFunc, useInternationalization } from '~/hooks/core/useInternationalization'
 
 gql`
   fragment DeleteBillableMetricDialog on BillableMetric {
@@ -37,104 +36,79 @@ type DeleteBillableMetricDialogProps = {
   callback?: () => void
 }
 
-export interface DeleteBillableMetricDialogRef {
-  openDialog: (props: DeleteBillableMetricDialogProps) => unknown
-  closeDialog: () => unknown
-}
+const buildDescription = (
+  translate: TranslateFunc,
+  billableMetric: DeleteBillableMetricDialogFragment | null | undefined,
+) => {
+  const { hasDraftInvoices, hasActiveSubscriptions } = billableMetric || {}
 
-export const DeleteBillableMetricDialog = forwardRef<DeleteBillableMetricDialogRef>((_, ref) => {
-  const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
-  const [localData, setLocalData] = useState<DeleteBillableMetricDialogProps | undefined>(undefined)
-  const [getBillableMetricToDelete, { data, loading }] = useGetBillableMetricToDeleteLazyQuery()
-
-  const billableMetric = data?.billableMetric
-
-  const { id = '', name = '', hasDraftInvoices, hasActiveSubscriptions } = billableMetric || {}
-
-  const [deleteBillableMetric] = useDeleteBillableMetricMutation({
-    onCompleted({ destroyBillableMetric }) {
-      if (destroyBillableMetric) {
-        addToast({
-          message: translate('text_6256f9f1184d3301290c7299'),
-          severity: 'success',
-        })
-
-        if (localData?.callback) {
-          localData.callback()
-          setLocalData(undefined)
-        }
-      }
-    },
-    refetchQueries: ['billableMetrics'],
-  })
-
-  useImperativeHandle(ref, () => ({
-    openDialog: (args) => {
-      setLocalData(args)
-      getBillableMetricToDelete({
-        variables: {
-          id: args.billableMetricId,
-        },
-      })
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
-
-  const getDescription = () => {
-    if (loading) {
-      return (
-        <>
-          <Skeleton className="mb-4 w-full" variant="text" />
-          <Skeleton className="mb-4 w-full" variant="text" />
-          <Skeleton className="w-full" variant="text" />
-        </>
-      )
-    }
-
-    if (!!hasDraftInvoices || !!hasActiveSubscriptions) {
-      return translate(
-        'text_63c842d84a91637c3acf0395',
-        !!hasDraftInvoices && !!hasActiveSubscriptions
-          ? {
-              usedObject1: translate('text_63c842ee2cd5dfeb173c2726'),
-              usedObject2: translate('text_63c8431193e8aca80f14cced'),
-            }
-          : {
-              usedObject1: !!hasActiveSubscriptions
-                ? translate('text_63c842ee2cd5dfeb173c2726')
-                : translate('text_63c8431193e8aca80f14cced'),
-            },
-        !!hasDraftInvoices && !!hasActiveSubscriptions ? 2 : 0,
-      )
-    }
-
+  if (!hasDraftInvoices && !hasActiveSubscriptions) {
     return translate('text_6256f824b6368e01153caa49')
   }
 
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      disableOnContinue={loading}
-      title={
-        loading ? (
-          <Skeleton className="mb-5 h-4 w-full" variant="text" />
-        ) : (
-          translate('text_6256f824b6368e01153caa47', {
-            billableMetricName: name,
-          })
-        )
-      }
-      description={getDescription()}
-      onContinue={async () =>
-        await deleteBillableMetric({
+  const usedObjects =
+    !!hasDraftInvoices && !!hasActiveSubscriptions
+      ? {
+          usedObject1: translate('text_63c842ee2cd5dfeb173c2726'),
+          usedObject2: translate('text_63c8431193e8aca80f14cced'),
+        }
+      : {
+          usedObject1: !!hasActiveSubscriptions
+            ? translate('text_63c842ee2cd5dfeb173c2726')
+            : translate('text_63c8431193e8aca80f14cced'),
+        }
+
+  return translate(
+    'text_63c842d84a91637c3acf0395',
+    usedObjects,
+    !!hasDraftInvoices && !!hasActiveSubscriptions ? 2 : 0,
+  )
+}
+
+export const useDeleteBillableMetricDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+  const client = useApolloClient()
+
+  const [deleteBillableMetric] = useDeleteBillableMetricMutation({
+    refetchQueries: ['billableMetrics'],
+  })
+
+  const openDeleteBillableMetricDialog = async ({
+    billableMetricId,
+    callback,
+  }: DeleteBillableMetricDialogProps) => {
+    const { data } = await client.query<GetBillableMetricToDeleteQuery>({
+      query: GetBillableMetricToDeleteDocument,
+      variables: { id: billableMetricId },
+    })
+
+    const billableMetric = data?.billableMetric
+    const { id = '', name = '' } = billableMetric || {}
+
+    centralizedDialog.open({
+      title: translate('text_6256f824b6368e01153caa47', {
+        billableMetricName: name,
+      }),
+      description: buildDescription(translate, billableMetric),
+      colorVariant: 'danger',
+      actionText: translate('text_6256f824b6368e01153caa4d'),
+      onAction: async () => {
+        const result = await deleteBillableMetric({
           variables: { input: { id } },
         })
-      }
-      continueText={translate('text_6256f824b6368e01153caa4d')}
-    />
-  )
-})
 
-DeleteBillableMetricDialog.displayName = 'DeleteBillableMetricDialog'
+        if (result.data?.destroyBillableMetric) {
+          addToast({
+            message: translate('text_6256f9f1184d3301290c7299'),
+            severity: 'success',
+          })
+
+          callback?.()
+        }
+      },
+    })
+  }
+
+  return { openDeleteBillableMetricDialog }
+}

--- a/src/pages/BillableMetricDetails.tsx
+++ b/src/pages/BillableMetricDetails.tsx
@@ -1,13 +1,9 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { BillableMetricDetailsActivityLogs } from '~/components/billableMetrics/BillableMetricDetailsActivityLogs'
 import { BillableMetricDetailsOverview } from '~/components/billableMetrics/BillableMetricDetailsOverview'
-import {
-  DeleteBillableMetricDialog,
-  DeleteBillableMetricDialogRef,
-} from '~/components/billableMetrics/DeleteBillableMetricDialog'
+import { useDeleteBillableMetricDialog } from '~/components/billableMetrics/DeleteBillableMetricDialog'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { MainHeaderAction } from '~/components/MainHeader/types'
@@ -45,7 +41,7 @@ const BillableMetricDetails = () => {
   const { billableMetricId } = useParams()
   const { isPremium } = useCurrentUser()
 
-  const deleteBillableMetricDialogRef = useRef<DeleteBillableMetricDialogRef>(null)
+  const { openDeleteBillableMetricDialog } = useDeleteBillableMetricDialog()
 
   const { data, loading, error } = useGetBillableMetricForHeaderDetailsQuery({
     variables: {
@@ -106,7 +102,7 @@ const BillableMetricDetails = () => {
           label: translate('text_1748440972215btigjp0mowx'),
           hidden: !hasPermissions(['billableMetricsDelete']),
           onClick: (closePopper) => {
-            deleteBillableMetricDialogRef.current?.openDialog({
+            openDeleteBillableMetricDialog({
               billableMetricId: billableMetricId as string,
               callback: () => {
                 navigate(generatePath(BILLABLE_METRICS_ROUTE))
@@ -164,8 +160,6 @@ const BillableMetricDetails = () => {
       />
 
       <>{activeTabContent}</>
-
-      <DeleteBillableMetricDialog ref={deleteBillableMetricDialogRef} />
     </>
   )
 }

--- a/src/pages/BillableMetricsList.tsx
+++ b/src/pages/BillableMetricsList.tsx
@@ -1,12 +1,8 @@
 import { gql } from '@apollo/client'
 import { Icon, tw } from 'lago-design-system'
-import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
 
-import {
-  DeleteBillableMetricDialog,
-  DeleteBillableMetricDialogRef,
-} from '~/components/billableMetrics/DeleteBillableMetricDialog'
+import { useDeleteBillableMetricDialog } from '~/components/billableMetrics/DeleteBillableMetricDialog'
 import { Avatar } from '~/components/designSystem/Avatar'
 import { InfiniteScroll } from '~/components/designSystem/InfiniteScroll'
 import { Table, TableColumn, TablePlaceholder } from '~/components/designSystem/Table/Table'
@@ -57,7 +53,7 @@ const BillableMetricsList = () => {
   const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
   const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
-  const deleteDialogRef = useRef<DeleteBillableMetricDialogRef>(null)
+  const { openDeleteBillableMetricDialog } = useDeleteBillableMetricDialog()
   const [getBillableMetrics, { data, error, loading, fetchMore, variables }] =
     useBillableMetricsLazyQuery({
       variables: { limit: 20 },
@@ -106,7 +102,7 @@ const BillableMetricsList = () => {
         startIcon: 'trash',
         title: translate('text_6256de3bba111e00b3bfa533'),
         onAction: () => {
-          deleteDialogRef.current?.openDialog({ billableMetricId: id })
+          openDeleteBillableMetricDialog({ billableMetricId: id })
         },
       })
     }
@@ -254,8 +250,6 @@ const BillableMetricsList = () => {
           placeholder={placeholder}
         />
       </InfiniteScroll>
-
-      <DeleteBillableMetricDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/pages/__tests__/BillableMetricDetails.test.tsx
+++ b/src/pages/__tests__/BillableMetricDetails.test.tsx
@@ -35,7 +35,7 @@ jest.mock('~/components/billableMetrics/BillableMetricDetailsActivityLogs', () =
 }))
 
 jest.mock('~/components/billableMetrics/DeleteBillableMetricDialog', () => ({
-  DeleteBillableMetricDialog: () => null,
+  useDeleteBillableMetricDialog: () => ({ openDeleteBillableMetricDialog: jest.fn() }),
 }))
 
 jest.mock('~/hooks/usePermissions', () => ({

--- a/src/pages/__tests__/BillableMetricsList.test.tsx
+++ b/src/pages/__tests__/BillableMetricsList.test.tsx
@@ -31,7 +31,7 @@ jest.mock('~/components/SearchInput', () => ({
 }))
 
 jest.mock('~/components/billableMetrics/DeleteBillableMetricDialog', () => ({
-  DeleteBillableMetricDialog: () => null,
+  useDeleteBillableMetricDialog: () => ({ openDeleteBillableMetricDialog: jest.fn() }),
 }))
 
 jest.mock('react-router-dom', () => ({


### PR DESCRIPTION
## Context

`DeleteBillableMetricDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate `DeleteBillableMetricDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API.

- `src/components/billableMetrics/DeleteBillableMetricDialog.tsx`: rewrote the component as `useDeleteBillableMetricDialog` hook exposing `openDeleteBillableMetricDialog(...)`. The lazy `getBillableMetricToDelete` query is now issued via `client.query()` before the dialog opens, so the dialog can render its final title (with the billable metric name) and its final description (accounting for `hasDraftInvoices` / `hasActiveSubscriptions`) synchronously. The previous in-dialog loading skeleton is dropped in favor of the button-triggering context handling the async wait (queries are typically cached after the details/list page).
- Extracted the description-building logic into a `buildDescription` helper that maps the loaded billable metric to the right translated string, preserving the original 4 branches (no active/draft, only active, only draft, both).
- `src/pages/BillableMetricsList.tsx`, `src/pages/BillableMetricDetails.tsx`: replaced `useRef<DeleteBillableMetricDialogRef>` + `<DeleteBillableMetricDialog ref={...} />` with `useDeleteBillableMetricDialog()`, calling `openDeleteBillableMetricDialog(...)` directly from the row-action / dropdown handler. The optional `callback` (navigate-away after delete on the details page) is preserved verbatim.
- Updated the two Jest test files (`BillableMetricDetails.test.tsx`, `BillableMetricsList.test.tsx`) to mock the new `useDeleteBillableMetricDialog` hook instead of the removed `DeleteBillableMetricDialog` component.

No user-visible behavior change beyond the timing of the network fetch: the delete confirmation dialog still shows the same title / description / action label, still fires the same `destroyBillableMetric` mutation, still runs the same navigation callback, and the billable metrics list still refreshes after deletion via the same `refetchQueries: ['billableMetrics']`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYYZwZJmtrJ74pkLHVGhnK)_