### PR TITLE
refactor(plans): migrate DeletePlanDialog to CentralizedDialog

### DIFF
--- a/src/components/plans/DeletePlanDialog.tsx
+++ b/src/components/plans/DeletePlanDialog.tsx
@@ -1,8 +1,6 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import { DeletePlanDialogFragment, useDeletePlanMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -27,94 +25,78 @@ type DeletePlanDialogProps = {
   callback?: () => void
 }
 
-export interface DeletePlanDialogRef {
-  openDialog: ({ plan, callback }: DeletePlanDialogProps) => unknown
-  closeDialog: () => unknown
-}
-
-export const DeletePlanDialog = forwardRef<DeletePlanDialogRef>((_, ref) => {
+export const useDeletePlanDialog = () => {
   const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
-  const [localData, setLocalData] = useState<DeletePlanDialogProps | undefined>(undefined)
-  const {
-    id = '',
-    name = '',
-    draftInvoicesCount = 0,
-    activeSubscriptionsCount = 0,
-  } = localData?.plan || {}
 
   const [deletePlan] = useDeletePlanMutation({
-    onCompleted(data) {
-      if (data && data.destroyPlan) {
-        addToast({
-          message: translate('text_625fd165963a7b00c8f59879'),
-          severity: 'success',
-        })
-
-        localData?.callback && localData.callback()
-      }
-    },
     refetchQueries: ['plans'],
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  const centralizedDialog = useCentralizedDialog()
 
-  let usedObject1 = translate('text_63d18d34f90cc83a038f843b', { count: 0 }, 0)
+  const openDeletePlanDialog = ({ plan, callback }: DeletePlanDialogProps) => {
+    const { id = '', name = '', draftInvoicesCount = 0, activeSubscriptionsCount = 0 } = plan || {}
 
-  if (activeSubscriptionsCount > 0) {
-    usedObject1 = translate(
-      'text_63d18d34f90cc83a038f843b',
-      { count: activeSubscriptionsCount },
-      activeSubscriptionsCount,
+    let usedObject1 = translate('text_63d18d34f90cc83a038f843b', { count: 0 }, 0)
+
+    if (activeSubscriptionsCount > 0) {
+      usedObject1 = translate(
+        'text_63d18d34f90cc83a038f843b',
+        { count: activeSubscriptionsCount },
+        activeSubscriptionsCount,
+      )
+    } else if (draftInvoicesCount > 0) {
+      usedObject1 = translate(
+        'text_63d18d3edaed7e11710b4d25',
+        { count: draftInvoicesCount },
+        draftInvoicesCount,
+      )
+    }
+
+    const description = translate(
+      'text_63d18bdc54f8380e7a97351a',
+      draftInvoicesCount > 0 && activeSubscriptionsCount > 0
+        ? {
+            usedObject1: translate(
+              'text_63d18d34f90cc83a038f843b',
+              { count: activeSubscriptionsCount },
+              activeSubscriptionsCount,
+            ),
+            usedObject2: translate(
+              'text_63d18d3edaed7e11710b4d25',
+              { count: draftInvoicesCount },
+              draftInvoicesCount,
+            ),
+          }
+        : {
+            usedObject1,
+          },
+      draftInvoicesCount > 0 && activeSubscriptionsCount > 0 ? 2 : 0,
     )
-  } else if (draftInvoicesCount > 0) {
-    usedObject1 = translate(
-      'text_63d18d3edaed7e11710b4d25',
-      { count: draftInvoicesCount },
-      draftInvoicesCount,
-    )
-  }
 
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_625fd165963a7b00c8f59797', {
+    centralizedDialog.open({
+      title: translate('text_625fd165963a7b00c8f59797', {
         planName: name,
-      })}
-      description={translate(
-        'text_63d18bdc54f8380e7a97351a',
-        draftInvoicesCount > 0 && activeSubscriptionsCount > 0
-          ? {
-              usedObject1: translate(
-                'text_63d18d34f90cc83a038f843b',
-                { count: activeSubscriptionsCount },
-                activeSubscriptionsCount,
-              ),
-              usedObject2: translate(
-                'text_63d18d3edaed7e11710b4d25',
-                { count: draftInvoicesCount },
-                draftInvoicesCount,
-              ),
-            }
-          : {
-              usedObject1,
-            },
-        draftInvoicesCount > 0 && activeSubscriptionsCount > 0 ? 2 : 0,
-      )}
-      onContinue={async () =>
-        await deletePlan({
+      }),
+      description,
+      colorVariant: 'danger',
+      actionText: translate('text_625fd165963a7b00c8f597b5'),
+      onAction: async () => {
+        const result = await deletePlan({
           variables: { input: { id } },
         })
-      }
-      continueText={translate('text_625fd165963a7b00c8f597b5')}
-    />
-  )
-})
 
-DeletePlanDialog.displayName = 'DeletePlanDialog'
+        if (result.data?.destroyPlan) {
+          addToast({
+            message: translate('text_625fd165963a7b00c8f59879'),
+            severity: 'success',
+          })
+
+          callback?.()
+        }
+      },
+    })
+  }
+
+  return { openDeletePlanDialog }
+}

--- a/src/pages/PlanDetails.tsx
+++ b/src/pages/PlanDetails.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
@@ -7,7 +7,7 @@ import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { MainHeaderAction } from '~/components/MainHeader/types'
 import { useMainHeaderTabContent } from '~/components/MainHeader/useMainHeaderTabContent'
-import { DeletePlanDialog, DeletePlanDialogRef } from '~/components/plans/DeletePlanDialog'
+import { useDeletePlanDialog } from '~/components/plans/DeletePlanDialog'
 import { PlanDetailsV2 } from '~/components/plans/details-v2/PlanDetailsV2'
 import { PlanDetailsActivityLogs } from '~/components/plans/details/PlanDetailsActivityLogs'
 import PlanSubscriptionList from '~/components/plans/details/PlanSubscriptionList'
@@ -54,7 +54,7 @@ const PlanDetails = () => {
   const { translate } = useInternationalization()
   const { isPremium } = useCurrentUser()
 
-  const deletePlanDialogRef = useRef<DeletePlanDialogRef>(null)
+  const { openDeletePlanDialog } = useDeletePlanDialog()
   const {
     data: planResult,
     loading: isPlanLoading,
@@ -103,7 +103,7 @@ const PlanDetails = () => {
           label: translate('text_625fd165963a7b00c8f597b5'),
           hidden: !hasPermissions(['plansDelete']),
           onClick: (closePopper) => {
-            deletePlanDialogRef.current?.openDialog({
+            openDeletePlanDialog({
               plan: plan as DeletePlanDialogFragment,
               callback: () => {
                 navigate(PLANS_ROUTE)
@@ -185,8 +185,6 @@ const PlanDetails = () => {
       />
 
       <>{activeTabContent}</>
-
-      <DeletePlanDialog ref={deletePlanDialogRef} />
     </>
   )
 }

--- a/src/pages/PlansList.tsx
+++ b/src/pages/PlansList.tsx
@@ -1,6 +1,5 @@
 import { gql } from '@apollo/client'
 import { Icon, tw } from 'lago-design-system'
-import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { Avatar } from '~/components/designSystem/Avatar'
@@ -12,7 +11,7 @@ import { Typography } from '~/components/designSystem/Typography'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import { DeletePlanDialog, DeletePlanDialogRef } from '~/components/plans/DeletePlanDialog'
+import { useDeletePlanDialog } from '~/components/plans/DeletePlanDialog'
 import { SearchInput } from '~/components/SearchInput'
 import { updateDuplicatePlanVar } from '~/core/apolloClient/reactiveVars/duplicatePlanVar'
 import { PlanDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
@@ -55,7 +54,7 @@ const PlansList = () => {
   const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
   const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
-  const deleteDialogRef = useRef<DeletePlanDialogRef>(null)
+  const { openDeletePlanDialog } = useDeletePlanDialog()
   const [getPlans, { data, error, loading, fetchMore, variables }] = usePlansLazyQuery({
     variables: { limit: 20 },
     notifyOnNetworkStatusChange: true,
@@ -244,7 +243,7 @@ const PlansList = () => {
                 startIcon: 'trash',
                 title: translate('text_625fd39a15394c0117e7d794'),
                 onAction: () => {
-                  deleteDialogRef.current?.openDialog({ plan })
+                  openDeletePlanDialog({ plan })
                 },
               })
             }
@@ -269,8 +268,6 @@ const PlansList = () => {
           }}
         />
       </InfiniteScroll>
-
-      <DeletePlanDialog ref={deleteDialogRef} />
     </>
   )
 }

--- a/src/pages/__tests__/PlanDetails.test.tsx
+++ b/src/pages/__tests__/PlanDetails.test.tsx
@@ -41,7 +41,7 @@ jest.mock('~/components/plans/details/PlanSubscriptionList', () => ({
 }))
 
 jest.mock('~/components/plans/DeletePlanDialog', () => ({
-  DeletePlanDialog: () => null,
+  useDeletePlanDialog: () => ({ openDeletePlanDialog: jest.fn() }),
 }))
 
 jest.mock('~/hooks/usePermissions', () => ({

--- a/src/pages/__tests__/PlansList.test.tsx
+++ b/src/pages/__tests__/PlansList.test.tsx
@@ -31,7 +31,7 @@ jest.mock('~/components/SearchInput', () => ({
 }))
 
 jest.mock('~/components/plans/DeletePlanDialog', () => ({
-  DeletePlanDialog: () => null,
+  useDeletePlanDialog: () => ({ openDeletePlanDialog: jest.fn() }),
 }))
 
 jest.mock('react-router-dom', () => ({


### PR DESCRIPTION
## Context

`DeletePlanDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate `DeletePlanDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API.

- `src/components/plans/DeletePlanDialog.tsx`: rewrote the component as `useDeletePlanDialog` hook exposing `openDeletePlanDialog(...)`. The description-building logic (branching on `draftInvoicesCount` / `activeSubscriptionsCount`) is preserved verbatim inside the open function so the dialog opens with the final title and description synchronously. `refetchQueries: ['plans']` is kept on the mutation.
- `src/pages/PlansList.tsx`, `src/pages/PlanDetails.tsx`: replaced `useRef<DeletePlanDialogRef>` + `<DeletePlanDialog ref={...} />` with `useDeletePlanDialog()`, calling `openDeletePlanDialog(...)` from the row-action / dropdown handler. The optional navigation callback on the details page is preserved verbatim.
- Updated the two Jest test files (`PlanDetails.test.tsx`, `PlansList.test.tsx`) to mock the new `useDeletePlanDialog` hook instead of the removed `DeletePlanDialog` component.

No user-visible behavior change: the delete confirmation dialog still shows the same title / description / action label, still fires the same `destroyPlan` mutation, still runs the same navigation callback, and the plans list still refreshes after deletion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYYZwZJmtrJ74pkLHVGhnK)_