### PR TITLE
refactor(subscriptions): migrate DeleteAlertDialog to CentralizedDialog

### DIFF
--- a/src/components/subscriptions/SubscriptionAlertsList.tsx
+++ b/src/components/subscriptions/SubscriptionAlertsList.tsx
@@ -1,16 +1,13 @@
 import { gql } from '@apollo/client'
 import { Icon } from 'lago-design-system'
-import { useCallback, useRef } from 'react'
+import { useCallback } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
 import { ButtonLink } from '~/components/designSystem/ButtonLink'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
-import {
-  DeleteAlertDialog,
-  DeleteAlertDialogRef,
-} from '~/components/subscriptions/alerts/DeleteAlertDialog'
+import { useDeleteAlertDialog } from '~/components/subscriptions/alerts/DeleteAlertDialog'
 import { useNavigate } from '~/core/router'
 import {
   CREATE_ALERT_CUSTOMER_SUBSCRIPTION_ROUTE,
@@ -50,7 +47,7 @@ export const SubscriptionAlertsList = ({
   const { hasPermissions } = usePermissions()
   const navigate = useNavigate()
   const { translate } = useInternationalization()
-  const deleteAlertDialogRef = useRef<DeleteAlertDialogRef>(null)
+  const { openDeleteAlertDialog } = useDeleteAlertDialog()
   const canCreateOrUpdateAlert = hasPermissions(['subscriptionsCreate', 'subscriptionsUpdate'])
 
   const getEditAlertUrl = useCallback(
@@ -88,162 +85,153 @@ export const SubscriptionAlertsList = ({
   })
 
   return (
-    <>
-      <section className="flex flex-col gap-4 pt-6">
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex flex-col gap-2">
-            <Typography variant="subhead1" color="grey700">
-              {translate('text_17465238490269pahbvl3s2m')}
-            </Typography>
-            <Typography variant="caption" color="grey600">
-              {translate('text_17465238490260r2325jwada')}
-            </Typography>
-          </div>
-
-          {isPremium && canCreateOrUpdateAlert && (
-            <Button
-              variant="inline"
-              onClick={() => {
-                if (!!customerId) {
-                  navigate(
-                    generatePath(CREATE_ALERT_CUSTOMER_SUBSCRIPTION_ROUTE, {
-                      customerId,
-                      subscriptionId,
-                    }),
-                  )
-                } else if (!!planId) {
-                  navigate(
-                    generatePath(CREATE_ALERT_PLAN_SUBSCRIPTION_ROUTE, { planId, subscriptionId }),
-                  )
-                }
-              }}
-            >
-              {translate('text_174652384902646b3ma52uws')}
-            </Button>
-          )}
+    <section className="flex flex-col gap-4 pt-6">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-col gap-2">
+          <Typography variant="subhead1" color="grey700">
+            {translate('text_17465238490269pahbvl3s2m')}
+          </Typography>
+          <Typography variant="caption" color="grey600">
+            {translate('text_17465238490260r2325jwada')}
+          </Typography>
         </div>
 
-        {!isPremium && (
-          <div className="flex items-center justify-between gap-4 rounded-lg bg-grey-100 px-6 py-4">
-            <div>
-              <Typography
-                className="flex items-center gap-2"
-                variant="bodyHl"
-                color="textSecondary"
-              >
-                {translate('text_1746523849026gmu98qidikp')} <Icon name="sparkles" />
-              </Typography>
-              <Typography variant="caption">
-                {translate('text_1746523849026ljzi79afhmc')}
-              </Typography>
-            </div>
-            <ButtonLink
-              buttonProps={{
-                variant: 'tertiary',
-                size: 'medium',
-                endIcon: 'sparkles',
-              }}
-              type="button"
-              external
-              to={`mailto:hello@getlago.com?subject=${translate('text_174652384902646b3ma52uww')}&body=${translate('text_1746523849026ljzi79afhmq')}`}
-            >
-              {translate('text_65ae73ebe3a66bec2b91d72d')}
-            </ButtonLink>
+        {isPremium && canCreateOrUpdateAlert && (
+          <Button
+            variant="inline"
+            onClick={() => {
+              if (!!customerId) {
+                navigate(
+                  generatePath(CREATE_ALERT_CUSTOMER_SUBSCRIPTION_ROUTE, {
+                    customerId,
+                    subscriptionId,
+                  }),
+                )
+              } else if (!!planId) {
+                navigate(
+                  generatePath(CREATE_ALERT_PLAN_SUBSCRIPTION_ROUTE, { planId, subscriptionId }),
+                )
+              }
+            }}
+          >
+            {translate('text_174652384902646b3ma52uws')}
+          </Button>
+        )}
+      </div>
+
+      {!isPremium && (
+        <div className="flex items-center justify-between gap-4 rounded-lg bg-grey-100 px-6 py-4">
+          <div>
+            <Typography className="flex items-center gap-2" variant="bodyHl" color="textSecondary">
+              {translate('text_1746523849026gmu98qidikp')} <Icon name="sparkles" />
+            </Typography>
+            <Typography variant="caption">{translate('text_1746523849026ljzi79afhmc')}</Typography>
           </div>
-        )}
+          <ButtonLink
+            buttonProps={{
+              variant: 'tertiary',
+              size: 'medium',
+              endIcon: 'sparkles',
+            }}
+            type="button"
+            external
+            to={`mailto:hello@getlago.com?subject=${translate('text_174652384902646b3ma52uww')}&body=${translate('text_1746523849026ljzi79afhmq')}`}
+          >
+            {translate('text_65ae73ebe3a66bec2b91d72d')}
+          </ButtonLink>
+        </div>
+      )}
 
-        {!!isPremium && (
-          <>
-            {!alertsLoading && !alertsData?.subscriptionAlerts.collection.length ? (
-              <Typography variant="body" color="grey500">
-                {translate('text_1746523849026ljzi79afhmr')}
-              </Typography>
-            ) : (
-              <Table
-                name="alerts-list"
-                containerSize={0}
-                data={alertsData?.subscriptionAlerts.collection || []}
-                hasError={!!alertsError}
-                isLoading={alertsLoading}
-                rowSize={72}
-                placeholder={{
-                  errorState: {
-                    title: translate('text_634812d6f16b31ce5cbf4111'),
-                    subtitle: translate('text_634812d6f16b31ce5cbf411f'),
-                    buttonTitle: translate('text_634812d6f16b31ce5cbf4123'),
-                    buttonAction: () => location.reload(),
+      {!!isPremium && (
+        <>
+          {!alertsLoading && !alertsData?.subscriptionAlerts.collection.length ? (
+            <Typography variant="body" color="grey500">
+              {translate('text_1746523849026ljzi79afhmr')}
+            </Typography>
+          ) : (
+            <Table
+              name="alerts-list"
+              containerSize={0}
+              data={alertsData?.subscriptionAlerts.collection || []}
+              hasError={!!alertsError}
+              isLoading={alertsLoading}
+              rowSize={72}
+              placeholder={{
+                errorState: {
+                  title: translate('text_634812d6f16b31ce5cbf4111'),
+                  subtitle: translate('text_634812d6f16b31ce5cbf411f'),
+                  buttonTitle: translate('text_634812d6f16b31ce5cbf4123'),
+                  buttonAction: () => location.reload(),
+                },
+                emptyState: {
+                  title: translate('text_174652384902646b3ma52uwq'),
+                  subtitle: translate('text_1746523849026ljzi79afhmr'),
+                },
+              }}
+              columns={[
+                {
+                  key: 'name',
+                  maxSpace: true,
+                  minWidth: 200,
+                  title: translate('text_6388b923e514213fed58331c'),
+                  content: ({ name, code }) => (
+                    <div className="flex flex-col gap-1">
+                      <Typography color="grey700" variant="bodyHl">
+                        {name || '-'}
+                      </Typography>
+                      <Typography color="grey600" variant="caption">
+                        {code || '-'}
+                      </Typography>
+                    </div>
+                  ),
+                },
+                {
+                  key: 'createdAt',
+                  minWidth: 140,
+                  title: translate('text_62442e40cea25600b0b6d858'),
+                  content: ({ createdAt }) => {
+                    return (
+                      <Typography color="grey600" variant="body">
+                        {
+                          intlFormatDateTime(createdAt, {
+                            formatDate: DateFormat.DATE_FULL,
+                          }).date
+                        }
+                      </Typography>
+                    )
                   },
-                  emptyState: {
-                    title: translate('text_174652384902646b3ma52uwq'),
-                    subtitle: translate('text_1746523849026ljzi79afhmr'),
-                  },
-                }}
-                columns={[
-                  {
-                    key: 'name',
-                    maxSpace: true,
-                    minWidth: 200,
-                    title: translate('text_6388b923e514213fed58331c'),
-                    content: ({ name, code }) => (
-                      <div className="flex flex-col gap-1">
-                        <Typography color="grey700" variant="bodyHl">
-                          {name || '-'}
-                        </Typography>
-                        <Typography color="grey600" variant="caption">
-                          {code || '-'}
-                        </Typography>
-                      </div>
-                    ),
-                  },
-                  {
-                    key: 'createdAt',
-                    minWidth: 140,
-                    title: translate('text_62442e40cea25600b0b6d858'),
-                    content: ({ createdAt }) => {
-                      return (
-                        <Typography color="grey600" variant="body">
-                          {
-                            intlFormatDateTime(createdAt, {
-                              formatDate: DateFormat.DATE_FULL,
-                            }).date
-                          }
-                        </Typography>
-                      )
-                    },
-                  },
-                ]}
-                actionColumnTooltip={() => translate('text_6256de3bba111e00b3bfa51b')}
-                onRowActionLink={({ id }) => {
-                  return getEditAlertUrl(id)
-                }}
-                actionColumn={({ id }) => {
-                  if (!canCreateOrUpdateAlert) {
-                    return []
-                  }
+                },
+              ]}
+              actionColumnTooltip={() => translate('text_6256de3bba111e00b3bfa51b')}
+              onRowActionLink={({ id }) => {
+                return getEditAlertUrl(id)
+              }}
+              actionColumn={({ id }) => {
+                if (!canCreateOrUpdateAlert) {
+                  return []
+                }
 
-                  return [
-                    {
-                      title: translate('text_1746546924392wfvshvfrjos'),
-                      startIcon: 'pen',
-                      onAction: () => {
-                        navigate(getEditAlertUrl(id))
-                      },
+                return [
+                  {
+                    title: translate('text_1746546924392wfvshvfrjos'),
+                    startIcon: 'pen',
+                    onAction: () => {
+                      navigate(getEditAlertUrl(id))
                     },
-                    {
-                      title: translate('text_17465469243924wwxl5pgoxi'),
-                      startIcon: 'trash',
-                      onAction: () => {
-                        deleteAlertDialogRef.current?.openDialog({ id })
-                      },
+                  },
+                  {
+                    title: translate('text_17465469243924wwxl5pgoxi'),
+                    startIcon: 'trash',
+                    onAction: () => {
+                      openDeleteAlertDialog({ id })
                     },
-                  ]
-                }}
-              />
-            )}
-          </>
-        )}
-      </section>
-      <DeleteAlertDialog ref={deleteAlertDialogRef} />
-    </>
+                  },
+                ]
+              }}
+            />
+          )}
+        </>
+      )}
+    </section>
   )
 }

--- a/src/components/subscriptions/alerts/DeleteAlertDialog.tsx
+++ b/src/components/subscriptions/alerts/DeleteAlertDialog.tsx
@@ -1,8 +1,6 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import { useDestroySubscriptionAlertMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -19,49 +17,34 @@ type DeleteAlertDialogProps = {
   id: string
 }
 
-export interface DeleteAlertDialogRef {
-  openDialog: ({ id }: DeleteAlertDialogProps) => unknown
-  closeDialog: () => unknown
-}
-
-export const DeleteAlertDialog = forwardRef<DeleteAlertDialogRef>((_, ref) => {
+export const useDeleteAlertDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
-  const [localData, setLocalData] = useState<DeleteAlertDialogProps | undefined>(undefined)
 
   const [destroyAlert] = useDestroySubscriptionAlertMutation({
-    onCompleted(data) {
-      if (!!data?.destroySubscriptionAlert?.id) {
-        addToast({
-          message: translate('text_1746611635508k9cmy2th6r1'),
-          severity: 'success',
-        })
-      }
-    },
     refetchQueries: ['getAlertsOfSubscription'],
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
-
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_1746611635509m6xkucwbclx')}
-      description={translate('text_1746611635509rkns7krj9zq')}
-      onContinue={async () =>
-        await destroyAlert({
-          variables: { input: { id: localData?.id || '' } },
+  const openDeleteAlertDialog = ({ id }: DeleteAlertDialogProps) => {
+    centralizedDialog.open({
+      title: translate('text_1746611635509m6xkucwbclx'),
+      description: translate('text_1746611635509rkns7krj9zq'),
+      colorVariant: 'danger',
+      actionText: translate('text_6271200984178801ba8bdf0c'),
+      onAction: async () => {
+        const result = await destroyAlert({
+          variables: { input: { id } },
         })
-      }
-      continueText={translate('text_6271200984178801ba8bdf0c')}
-    />
-  )
-})
 
-DeleteAlertDialog.displayName = 'DeleteAlertDialog'
+        if (result.data?.destroySubscriptionAlert?.id) {
+          addToast({
+            message: translate('text_1746611635508k9cmy2th6r1'),
+            severity: 'success',
+          })
+        }
+      },
+    })
+  }
+
+  return { openDeleteAlertDialog }
+}


### PR DESCRIPTION
## Context

`DeleteAlertDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate `DeleteAlertDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API.

- `src/components/subscriptions/alerts/DeleteAlertDialog.tsx`: rewrote the component as `useDeleteAlertDialog` hook exposing `openDeleteAlertDialog(...)`. The dialog only needs an alert `id` (no local state), so the migration is a straightforward switch from ref-based imperative open to hook-based open. `refetchQueries: ['getAlertsOfSubscription']` is kept on the mutation to refresh the list after deletion.
- `src/components/subscriptions/SubscriptionAlertsList.tsx`: replaced `useRef<DeleteAlertDialogRef>` + `<DeleteAlertDialog ref={...} />` with `useDeleteAlertDialog()`, calling `openDeleteAlertDialog({ id })` directly from the row-action handler. Removed the now-unused `useRef` import.

No user-visible behavior change: the delete confirmation dialog still shows the same title / description / action label, still fires the same `destroySubscriptionAlert` mutation, and the alerts list still refreshes after deletion via the same `refetchQueries`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYYZwZJmtrJ74pkLHVGhnK)_