### PR TITLE
refactor(wallets): migrate TerminateCustomerWalletDialog to CentralizedDialog

### DIFF
--- a/src/components/wallets/TerminateCustomerWalletDialog.tsx
+++ b/src/components/wallets/TerminateCustomerWalletDialog.tsx
@@ -1,9 +1,7 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import { CustomerDetailsTabsOptions } from '~/core/constants/tabsOptions'
 import { CUSTOMER_DETAILS_TAB_ROUTE, useNavigate } from '~/core/router'
@@ -31,72 +29,60 @@ gql`
   ${WalletAccordionFragmentDoc}
 `
 
-export type TerminateCustomerWalletDialogRef = {
-  openDialog: (props?: { walletId?: string }) => unknown
-  closeDialog: () => unknown
+type TerminateCustomerWalletDialogProps = {
+  walletId?: string
 }
 
-export const TerminateCustomerWalletDialog = forwardRef<TerminateCustomerWalletDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
-    const navigate = useNavigate()
-    const [localData, setLocalData] = useState<{ walletId?: string } | null>(null)
-    const dialogRef = useRef<DialogRef>(null)
-    const { customerId } = useParams()
+export const useTerminateCustomerWalletDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+  const navigate = useNavigate()
+  const { customerId } = useParams()
 
-    const [terminateWallet] = useTerminateCustomerWalletMutation({
-      onCompleted(res) {
-        if (res?.terminateCustomerWallet) {
+  const [terminateWallet] = useTerminateCustomerWalletMutation({
+    update(cache, { data }) {
+      if (!data?.terminateCustomerWallet) return
+
+      const cacheId = `Customer:${data.terminateCustomerWallet.customer?.id}`
+
+      const previousData: CustomerDetailsFragment | null = cache.readFragment({
+        id: cacheId,
+        fragment: CustomerDetailsFragmentDoc,
+        fragmentName: 'CustomerDetails',
+      })
+
+      cache.writeFragment({
+        id: cacheId,
+        fragment: CustomerDetailsFragmentDoc,
+        fragmentName: 'CustomerDetails',
+        data: {
+          ...previousData,
+          hasActiveWallet: data.terminateCustomerWallet.customer?.hasActiveWallet,
+        },
+      })
+    },
+    refetchQueries: ['getCustomerWalletList'],
+  })
+
+  const openTerminateCustomerWalletDialog = (props?: TerminateCustomerWalletDialogProps) => {
+    if (!props) {
+      return
+    }
+
+    centralizedDialog.open({
+      title: translate('text_62d9430e8b9fe36851cddd0b'),
+      description: translate('text_62d9430e8b9fe36851cddd0f'),
+      colorVariant: 'danger',
+      actionText: translate('text_62d9430e8b9fe36851cddd17'),
+      onAction: async () => {
+        const result = await terminateWallet({
+          variables: { input: { id: props.walletId as string } },
+        })
+
+        if (result.data?.terminateCustomerWallet) {
           addToast({
             severity: 'success',
             translateKey: 'text_62e257c032ae895bbfead62e',
-          })
-        }
-      },
-      update(cache, { data }) {
-        if (!data?.terminateCustomerWallet) return
-
-        const cacheId = `Customer:${data.terminateCustomerWallet.customer?.id}`
-
-        const previousData: CustomerDetailsFragment | null = cache.readFragment({
-          id: cacheId,
-          fragment: CustomerDetailsFragmentDoc,
-          fragmentName: 'CustomerDetails',
-        })
-
-        cache.writeFragment({
-          id: cacheId,
-          fragment: CustomerDetailsFragmentDoc,
-          fragmentName: 'CustomerDetails',
-          data: {
-            ...previousData,
-            hasActiveWallet: data.terminateCustomerWallet.customer?.hasActiveWallet,
-          },
-        })
-      },
-      refetchQueries: ['getCustomerWalletList'],
-    })
-
-    useImperativeHandle(ref, () => ({
-      openDialog: (props) => {
-        if (!props) {
-          return
-        }
-
-        setLocalData(props)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => dialogRef.current?.closeDialog(),
-    }))
-
-    return (
-      <WarningDialog
-        ref={dialogRef}
-        title={translate('text_62d9430e8b9fe36851cddd0b')}
-        description={translate('text_62d9430e8b9fe36851cddd0f')}
-        onContinue={async () => {
-          await terminateWallet({
-            variables: { input: { id: localData?.walletId as string } },
           })
 
           navigate(
@@ -105,11 +91,10 @@ export const TerminateCustomerWalletDialog = forwardRef<TerminateCustomerWalletD
               tab: CustomerDetailsTabsOptions.wallet,
             }),
           )
-        }}
-        continueText={translate('text_62d9430e8b9fe36851cddd17')}
-      />
-    )
-  },
-)
+        }
+      },
+    })
+  }
 
-TerminateCustomerWalletDialog.displayName = 'TerminateCustomerWalletDialog'
+  return { openTerminateCustomerWalletDialog }
+}

--- a/src/components/wallets/WalletActions.tsx
+++ b/src/components/wallets/WalletActions.tsx
@@ -1,7 +1,6 @@
 import { Button } from '~/components/designSystem/Button'
 import { Popper } from '~/components/designSystem/Popper'
 import { Tooltip } from '~/components/designSystem/Tooltip'
-import { TerminateCustomerWalletDialog } from '~/components/wallets/TerminateCustomerWalletDialog'
 import { WALLET_ACTIONS_DATA_TEST } from '~/components/wallets/utils/dataTestConstants'
 import { VoidWalletDialog } from '~/components/wallets/VoidWalletDialog'
 import { CurrencyEnum, WalletStatusEnum } from '~/generated/graphql'
@@ -31,7 +30,7 @@ const WalletActions = ({
   currency,
 }: WalletActionsProps) => {
   const { translate } = useInternationalization()
-  const { actions, terminateDialogRef, voidDialogRef } = useWalletActions({
+  const { actions, voidDialogRef } = useWalletActions({
     walletId,
     customerId,
     status,
@@ -101,7 +100,6 @@ const WalletActions = ({
         </Popper>
       )}
 
-      <TerminateCustomerWalletDialog ref={terminateDialogRef} />
       <VoidWalletDialog ref={voidDialogRef} />
     </div>
   )

--- a/src/components/wallets/__tests__/TerminateCustomerWalletDialog.test.tsx
+++ b/src/components/wallets/__tests__/TerminateCustomerWalletDialog.test.tsx
@@ -1,14 +1,13 @@
-import { act, screen } from '@testing-library/react'
-import { createRef } from 'react'
+import { act, renderHook } from '@testing-library/react'
 
-import { render } from '~/test-utils'
-
-import {
-  TerminateCustomerWalletDialog,
-  TerminateCustomerWalletDialogRef,
-} from '../TerminateCustomerWalletDialog'
+import { useTerminateCustomerWalletDialog } from '../TerminateCustomerWalletDialog'
 
 const mockTerminateWallet = jest.fn()
+const mockOpen = jest.fn()
+
+jest.mock('~/components/dialogs/CentralizedDialog', () => ({
+  useCentralizedDialog: () => ({ open: mockOpen, close: jest.fn() }),
+}))
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({
@@ -26,7 +25,12 @@ jest.mock('~/core/apolloClient', () => ({
   addToast: jest.fn(),
 }))
 
-describe('TerminateCustomerWalletDialog', () => {
+jest.mock('~/core/router', () => ({
+  ...jest.requireActual('~/core/router'),
+  useNavigate: () => jest.fn(),
+}))
+
+describe('useTerminateCustomerWalletDialog', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     const useParamsMock = jest.requireMock('react-router-dom').useParams as jest.Mock
@@ -34,33 +38,32 @@ describe('TerminateCustomerWalletDialog', () => {
     useParamsMock.mockReturnValue({ customerId: 'customer-1' })
   })
 
-  describe('GIVEN the dialog ref', () => {
-    describe('WHEN openDialog is called with undefined', () => {
-      it('THEN should not open dialog', () => {
-        const ref = createRef<TerminateCustomerWalletDialogRef>()
+  describe('WHEN openTerminateCustomerWalletDialog is called without props', () => {
+    it('THEN should not open the dialog', () => {
+      const { result } = renderHook(() => useTerminateCustomerWalletDialog())
 
-        render(<TerminateCustomerWalletDialog ref={ref} />)
-
-        act(() => {
-          ref.current?.openDialog(undefined)
-        })
-
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      act(() => {
+        result.current.openTerminateCustomerWalletDialog(undefined)
       })
+
+      expect(mockOpen).not.toHaveBeenCalled()
     })
+  })
 
-    describe('WHEN openDialog is called with walletId', () => {
-      it('THEN should show the dialog', () => {
-        const ref = createRef<TerminateCustomerWalletDialogRef>()
+  describe('WHEN openTerminateCustomerWalletDialog is called with walletId', () => {
+    it('THEN should open the centralized dialog', () => {
+      const { result } = renderHook(() => useTerminateCustomerWalletDialog())
 
-        render(<TerminateCustomerWalletDialog ref={ref} />)
-
-        act(() => {
-          ref.current?.openDialog({ walletId: 'wallet-1' })
-        })
-
-        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      act(() => {
+        result.current.openTerminateCustomerWalletDialog({ walletId: 'wallet-1' })
       })
+
+      expect(mockOpen).toHaveBeenCalledTimes(1)
+      expect(mockOpen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          colorVariant: 'danger',
+        }),
+      )
     })
   })
 })

--- a/src/components/wallets/__tests__/WalletActions.test.tsx
+++ b/src/components/wallets/__tests__/WalletActions.test.tsx
@@ -30,7 +30,7 @@ jest.mock('~/hooks/useDeveloperTool', () => ({
 }))
 
 jest.mock('~/components/wallets/TerminateCustomerWalletDialog', () => ({
-  TerminateCustomerWalletDialog: () => null,
+  useTerminateCustomerWalletDialog: () => ({ openTerminateCustomerWalletDialog: jest.fn() }),
 }))
 
 jest.mock('~/components/wallets/VoidWalletDialog', () => ({

--- a/src/hooks/wallet/__tests__/useWalletActions.test.ts
+++ b/src/hooks/wallet/__tests__/useWalletActions.test.ts
@@ -63,6 +63,14 @@ jest.mock('~/components/activityLogs/utils', () => ({
   buildLinkToActivityLog: (id: string, filter: string) => `/activity-log?${filter}=${id}`,
 }))
 
+const mockOpenTerminateCustomerWalletDialog = jest.fn()
+
+jest.mock('~/components/wallets/TerminateCustomerWalletDialog', () => ({
+  useTerminateCustomerWalletDialog: () => ({
+    openTerminateCustomerWalletDialog: mockOpenTerminateCustomerWalletDialog,
+  }),
+}))
+
 const defaultParams = {
   walletId: 'wallet-1',
   customerId: 'customer-1',
@@ -89,10 +97,9 @@ describe('useWalletActions', () => {
         expect(result.current.actions).toHaveLength(7)
       })
 
-      it('THEN should return terminateDialogRef and voidDialogRef', () => {
+      it('THEN should return voidDialogRef', () => {
         const { result } = renderHook(() => useWalletActions(defaultParams))
 
-        expect(result.current.terminateDialogRef).toBeDefined()
         expect(result.current.voidDialogRef).toBeDefined()
       })
 
@@ -295,17 +302,11 @@ describe('useWalletActions', () => {
       it('THEN should open the terminate dialog and close popper', () => {
         const { result } = renderHook(() => useWalletActions(defaultParams))
 
-        const mockOpenDialog = jest.fn()
-
-        ;(
-          result.current.terminateDialogRef as unknown as {
-            current: { openDialog: jest.Mock }
-          }
-        ).current = { openDialog: mockOpenDialog }
-
         result.current.actions[6].onAction(closePopper)
 
-        expect(mockOpenDialog).toHaveBeenCalledWith({ walletId: 'wallet-1' })
+        expect(mockOpenTerminateCustomerWalletDialog).toHaveBeenCalledWith({
+          walletId: 'wallet-1',
+        })
         expect(closePopper).toHaveBeenCalled()
       })
     })

--- a/src/hooks/wallet/useWalletActions.ts
+++ b/src/hooks/wallet/useWalletActions.ts
@@ -4,7 +4,7 @@ import { generatePath } from 'react-router-dom'
 
 import { buildLinkToActivityLog } from '~/components/activityLogs/utils'
 import { AvailableFiltersEnum } from '~/components/designSystem/Filters'
-import { TerminateCustomerWalletDialogRef } from '~/components/wallets/TerminateCustomerWalletDialog'
+import { useTerminateCustomerWalletDialog } from '~/components/wallets/TerminateCustomerWalletDialog'
 import { VoidWalletDialogRef } from '~/components/wallets/VoidWalletDialog'
 import { addToast } from '~/core/apolloClient'
 import {
@@ -42,7 +42,6 @@ interface UseWalletActionsParams {
 
 interface UseWalletActionsReturn {
   actions: WalletActionItem[]
-  terminateDialogRef: React.RefObject<TerminateCustomerWalletDialogRef>
   voidDialogRef: React.RefObject<VoidWalletDialogRef>
 }
 
@@ -59,9 +58,7 @@ export const useWalletActions = ({
   const { hasPermissions } = usePermissions()
   const { isPremium } = useCurrentUser()
   const { setUrl, openPanel: open } = useDeveloperTool()
-  const terminateDialogRef = useRef<TerminateCustomerWalletDialogRef>(
-    null,
-  ) as React.RefObject<TerminateCustomerWalletDialogRef>
+  const { openTerminateCustomerWalletDialog } = useTerminateCustomerWalletDialog()
   const voidDialogRef = useRef<VoidWalletDialogRef>(null) as React.RefObject<VoidWalletDialogRef>
 
   const isWalletActive = status === WalletStatusEnum.Active
@@ -157,7 +154,7 @@ export const useWalletActions = ({
       hidden: !isWalletActive || !hasPermissions(['walletsTerminate']),
       danger: true,
       onAction: (closePopper) => {
-        terminateDialogRef?.current?.openDialog({
+        openTerminateCustomerWalletDialog({
           walletId: walletId as string,
         })
         closePopper()
@@ -165,5 +162,5 @@ export const useWalletActions = ({
     },
   ]
 
-  return { actions, terminateDialogRef, voidDialogRef }
+  return { actions, voidDialogRef }
 }

--- a/src/pages/wallet/WalletDetails.tsx
+++ b/src/pages/wallet/WalletDetails.tsx
@@ -9,7 +9,6 @@ import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { MainHeaderAction } from '~/components/MainHeader/types'
 import { useMainHeaderTabContent } from '~/components/MainHeader/useMainHeaderTabContent'
-import { TerminateCustomerWalletDialog } from '~/components/wallets/TerminateCustomerWalletDialog'
 import { VoidWalletDialog } from '~/components/wallets/VoidWalletDialog'
 import WalletAlerts from '~/components/wallets/WalletAlerts'
 import WalletInformations from '~/components/wallets/WalletInformations'
@@ -159,11 +158,7 @@ const WalletDetails = () => {
     fallback: wallet?.customer?.externalId,
   })
 
-  const {
-    actions: walletActionItems,
-    terminateDialogRef,
-    voidDialogRef,
-  } = useWalletActions({
+  const { actions: walletActionItems, voidDialogRef } = useWalletActions({
     walletId,
     customerId,
     status: wallet?.status,
@@ -341,7 +336,6 @@ const WalletDetails = () => {
 
       <>{activeTabContent}</>
 
-      <TerminateCustomerWalletDialog ref={terminateDialogRef} />
       <VoidWalletDialog ref={voidDialogRef} />
     </>
   )


### PR DESCRIPTION
## Context

`TerminateCustomerWalletDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate `TerminateCustomerWalletDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API.

- `src/components/wallets/TerminateCustomerWalletDialog.tsx`: rewrote the component as `useTerminateCustomerWalletDialog` hook exposing `openTerminateCustomerWalletDialog(...)`. The mutation still runs the same `update` callback (writing `hasActiveWallet` back into the `Customer` fragment) and the same `refetchQueries: ['getCustomerWalletList']`. The post-success `navigate` back to the customer wallet tab is preserved verbatim inside the `onAction`, and the "no-op if called without props" guard matches the previous ref behavior.
- `src/hooks/wallet/useWalletActions.ts`: dropped `terminateDialogRef` from the returned tuple and calls `openTerminateCustomerWalletDialog(...)` directly from the trash-action's `onAction`. `voidDialogRef` (unrelated legacy dialog) is left as-is — out of scope for this PR.
- `src/components/wallets/WalletActions.tsx`, `src/pages/wallet/WalletDetails.tsx`: removed the `<TerminateCustomerWalletDialog ref={...} />` render and the imports; the dialog is now driven entirely by the hook via NiceModal.
- `src/components/wallets/__tests__/TerminateCustomerWalletDialog.test.tsx`: rewrote from ref-based tests to hook-based tests using `renderHook` + a mocked `useCentralizedDialog` (asserts `open` is / is not called with the expected props).
- `src/hooks/wallet/__tests__/useWalletActions.test.ts`: added a mock for `useTerminateCustomerWalletDialog` and updated the terminate-action test to assert the hook's open function is invoked instead of the ref's `openDialog`.
- `src/components/wallets/__tests__/WalletActions.test.tsx`: updated the `TerminateCustomerWalletDialog` module mock to expose the new hook shape.

No user-visible behavior change: the terminate confirmation dialog still shows the same title / description / action label, still fires the same `terminateCustomerWallet` mutation with the same `update` cache write, still shows the same toast, and still navigates back to the customer wallet tab on success.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYYZwZJmtrJ74pkLHVGhnK)_