### PR TITLE
refactor(dunning): migrate RemoveAppliedDunningCampaignDialog to CentralizedDialog

### DIFF
--- a/src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx
+++ b/src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx
@@ -29,10 +29,7 @@ import {
   ApplyDunningCampaignDialog,
   ApplyDunningCampaignDialogRef,
 } from '~/pages/settings/BillingEntity/sections/dunning-campaigns/ApplyDunningCampaignDialog'
-import {
-  RemoveAppliedDunningCampaignDialog,
-  RemoveAppliedDunningCampaignDialogRef,
-} from '~/pages/settings/BillingEntity/sections/dunning-campaigns/RemoveAppliedDunningCampaignDialog'
+import { useRemoveAppliedDunningCampaignDialog } from '~/pages/settings/BillingEntity/sections/dunning-campaigns/RemoveAppliedDunningCampaignDialog'
 import ErrorImage from '~/public/images/maneki/error.svg'
 
 const BillingEntityDunningCampaigns = () => {
@@ -44,7 +41,7 @@ const BillingEntityDunningCampaigns = () => {
   const hasAccessToFeature = premiumIntegrations?.includes(PremiumIntegrationTypeEnum.AutoDunning)
 
   const applyDunningCampaignDialogRef = useRef<ApplyDunningCampaignDialogRef>(null)
-  const removeAppliedDunningCampaignDialogRef = useRef<RemoveAppliedDunningCampaignDialogRef>(null)
+  const { openRemoveAppliedDunningCampaignDialog } = useRemoveAppliedDunningCampaignDialog()
 
   const {
     data: billingEntityData,
@@ -190,9 +187,8 @@ const BillingEntityDunningCampaigns = () => {
                             variant="quaternary"
                             onClick={() => {
                               if (billingEntity && appliedDunningCampaign) {
-                                removeAppliedDunningCampaignDialogRef.current?.openDialog(
+                                openRemoveAppliedDunningCampaignDialog(
                                   billingEntity as BillingEntity,
-                                  appliedDunningCampaign.id,
                                 )
                               }
                             }}
@@ -209,7 +205,6 @@ const BillingEntityDunningCampaigns = () => {
       </SettingsPaddedContainer>
 
       <ApplyDunningCampaignDialog ref={applyDunningCampaignDialogRef} />
-      <RemoveAppliedDunningCampaignDialog ref={removeAppliedDunningCampaignDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/BillingEntity/sections/dunning-campaigns/RemoveAppliedDunningCampaignDialog.tsx
+++ b/src/pages/settings/BillingEntity/sections/dunning-campaigns/RemoveAppliedDunningCampaignDialog.tsx
@@ -1,8 +1,7 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import { BillingEntity, useRemoveBillingEntityDunningCampaignMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -17,64 +16,39 @@ gql`
   }
 `
 
-export type RemoveAppliedDunningCampaignDialogRef = {
-  openDialog: (billingEntity: BillingEntity, appliedDunningCampaignId: string) => unknown
-  closeDialog: () => unknown
-}
+export const useRemoveAppliedDunningCampaignDialog = () => {
+  const { translate } = useInternationalization()
+  const centralizedDialog = useCentralizedDialog()
 
-export const RemoveAppliedDunningCampaignDialog = forwardRef<RemoveAppliedDunningCampaignDialogRef>(
-  (_, ref) => {
-    const { translate } = useInternationalization()
-    const dialogRef = useRef<WarningDialogRef>(null)
+  const [removeBillingEntityDunningCampaign] = useRemoveBillingEntityDunningCampaignMutation({
+    refetchQueries: ['getBillingEntity'],
+  })
 
-    const [appliedDunningCampaignId, setAppliedDunningCampaignId] = useState<string | null>(null)
-    const [billingEntity, setBillingEntity] = useState<BillingEntity | null>(null)
+  const openRemoveAppliedDunningCampaignDialog = (billingEntity: BillingEntity) => {
+    centralizedDialog.open({
+      title: translate('text_1750663218391a7zbhnk61ce'),
+      description: <Typography>{translate('text_1750663218391z2s6w2of7xp')}</Typography>,
+      colorVariant: 'danger',
+      actionText: translate('text_175066321839172gm0lkz8eu'),
+      onAction: async () => {
+        const result = await removeBillingEntityDunningCampaign({
+          variables: {
+            input: {
+              appliedDunningCampaignId: null,
+              billingEntityId: billingEntity.id,
+            },
+          },
+        })
 
-    const [removeBillingEntityDunningCampaign] = useRemoveBillingEntityDunningCampaignMutation({
-      onCompleted(data) {
-        if (data) {
+        if (result.data) {
           addToast({
             message: translate('text_1750663218391vbamspkjr5g'),
             severity: 'success',
           })
         }
       },
-      refetchQueries: ['getBillingEntity'],
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (_billingEntity, _appliedDunningCampaignId) => {
-        setBillingEntity(_billingEntity)
-        setAppliedDunningCampaignId(_appliedDunningCampaignId)
-
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => {
-        dialogRef.current?.closeDialog()
-      },
-    }))
-
-    return (
-      <WarningDialog
-        ref={dialogRef}
-        title={translate('text_1750663218391a7zbhnk61ce')}
-        description={<Typography>{translate('text_1750663218391z2s6w2of7xp')}</Typography>}
-        onContinue={async () => {
-          if (billingEntity && appliedDunningCampaignId) {
-            await removeBillingEntityDunningCampaign({
-              variables: {
-                input: {
-                  appliedDunningCampaignId: null,
-                  billingEntityId: billingEntity.id,
-                },
-              },
-            })
-          }
-        }}
-        continueText={translate('text_175066321839172gm0lkz8eu')}
-      />
-    )
-  },
-)
-
-RemoveAppliedDunningCampaignDialog.displayName = 'RemoveAppliedDunningCampaignDialog'
+  return { openRemoveAppliedDunningCampaignDialog }
+}


### PR DESCRIPTION
## Context

`RemoveAppliedDunningCampaignDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate `RemoveAppliedDunningCampaignDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/settings/BillingEntity/sections/dunning-campaigns/RemoveAppliedDunningCampaignDialog.tsx`: rewrote the component as `useRemoveAppliedDunningCampaignDialog` hook exposing `openRemoveAppliedDunningCampaignDialog(...)`. `refetchQueries: ['getBillingEntity']` is kept on the mutation.
- Dropped the second `appliedDunningCampaignId` parameter from the open signature — the previous imperative `openDialog` accepted it but the `billingEntityUpdateAppliedDunningCampaign` mutation only sends `{ appliedDunningCampaignId: null, billingEntityId }`, so it was already unused. The caller signature is simplified accordingly.
- `src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx`: replaced `useRef<RemoveAppliedDunningCampaignDialogRef>` + `<RemoveAppliedDunningCampaignDialog ref={...} />` with `useRemoveAppliedDunningCampaignDialog()`, calling `openRemoveAppliedDunningCampaignDialog(billingEntity)` from the trash button.

No user-visible behavior change: the confirmation dialog still shows the same title / description / action label, still fires the same `billingEntityUpdateAppliedDunningCampaign` mutation, still shows the same success toast, and still refetches `getBillingEntity` to refresh the applied-campaign row.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYYZwZJmtrJ74pkLHVGhnK)_