### PR TITLE
refactor(invoices): migrate DisputeInvoiceDialog to CentralizedDialog

### DIFF
--- a/src/components/invoices/DisputeInvoiceDialog.tsx
+++ b/src/components/invoices/DisputeInvoiceDialog.tsx
@@ -1,8 +1,6 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import {
   AllInvoiceDetailsForCustomerInvoiceDetailsFragmentDoc,
@@ -27,49 +25,34 @@ type DisputeInvoiceDialogProps = {
   id: string
 }
 
-export interface DisputeInvoiceDialogRef {
-  openDialog: (dialogData: DisputeInvoiceDialogProps) => unknown
-  closeDialog: () => unknown
-}
-
-export const DisputeInvoiceDialog = forwardRef<DisputeInvoiceDialogRef>((_, ref) => {
-  const dialogRef = useRef<DialogRef>(null)
+export const useDisputeInvoiceDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
-  const [dialogData, setDialogData] = useState<DisputeInvoiceDialogProps | undefined>(undefined)
 
   const [disputeInvoice] = useDisputeInvoiceMutation({
-    onCompleted(data) {
-      if (data && data.loseInvoiceDispute) {
-        addToast({
-          message: translate('text_66141e9feef09978ae251222'),
-          severity: 'success',
-        })
-      }
-    },
     refetchQueries: ['getInvoiceDetails'],
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setDialogData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
-
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_66141e30699a0631f0b2ec59')}
-      description={translate('text_66141e30699a0631f0b2ec61')}
-      onContinue={async () =>
-        await disputeInvoice({
-          variables: { input: { id: dialogData?.id as string } },
+  const openDisputeInvoiceDialog = ({ id }: DisputeInvoiceDialogProps) => {
+    centralizedDialog.open({
+      title: translate('text_66141e30699a0631f0b2ec59'),
+      description: translate('text_66141e30699a0631f0b2ec61'),
+      colorVariant: 'danger',
+      actionText: translate('text_66141e30699a0631f0b2ec71'),
+      onAction: async () => {
+        const result = await disputeInvoice({
+          variables: { input: { id } },
         })
-      }
-      continueText={translate('text_66141e30699a0631f0b2ec71')}
-    />
-  )
-})
 
-DisputeInvoiceDialog.displayName = 'DisputeInvoiceDialog'
+        if (result.data?.loseInvoiceDispute) {
+          addToast({
+            message: translate('text_66141e9feef09978ae251222'),
+            severity: 'success',
+          })
+        }
+      },
+    })
+  }
+
+  return { openDisputeInvoiceDialog }
+}

--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -10,10 +10,7 @@ import { Typography } from '~/components/designSystem/Typography'
 import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { buildInvoiceDocumentData } from '~/components/emails/buildDocumentData'
 import { AddMetadataDrawer, AddMetadataDrawerRef } from '~/components/invoices/AddMetadataDrawer'
-import {
-  DisputeInvoiceDialog,
-  DisputeInvoiceDialogRef,
-} from '~/components/invoices/DisputeInvoiceDialog'
+import { useDisputeInvoiceDialog } from '~/components/invoices/DisputeInvoiceDialog'
 import { useUpdateInvoicePaymentStatusDialog } from '~/components/invoices/EditInvoicePaymentStatusDialog'
 import {
   FinalizeInvoiceDialog,
@@ -320,7 +317,7 @@ const CustomerInvoiceDetails = () => {
   const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const { openUpdateInvoicePaymentStatusDialog } = useUpdateInvoicePaymentStatusDialog()
   const addMetadataDrawerDialogRef = useRef<AddMetadataDrawerRef>(null)
-  const disputeInvoiceDialogRef = useRef<DisputeInvoiceDialogRef>(null)
+  const { openDisputeInvoiceDialog } = useDisputeInvoiceDialog()
   const activeTabContent = useMainHeaderTabContent()
 
   const { data, loading, error, refetch } = useGetInvoiceDetailsQuery({
@@ -938,7 +935,7 @@ const CustomerInvoiceDetails = () => {
           label: translate('text_66141e30699a0631f0b2ec71'),
           hidden: !authorizations.canDispute,
           onClick: (closePopper: () => void) => {
-            disputeInvoiceDialogRef.current?.openDialog({
+            openDisputeInvoiceDialog({
               id: data?.invoice?.id || '',
             })
             closePopper()
@@ -1035,7 +1032,6 @@ const CustomerInvoiceDetails = () => {
       )}
 
       <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
-      <DisputeInvoiceDialog ref={disputeInvoiceDialogRef} />
       {!!invoice && <AddMetadataDrawer ref={addMetadataDrawerDialogRef} invoiceId={invoice.id} />}
     </>
   )

--- a/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
+++ b/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
@@ -241,7 +241,7 @@ jest.mock('~/components/invoices/EditInvoicePaymentStatusDialog', () => ({
 }))
 
 jest.mock('~/components/invoices/DisputeInvoiceDialog', () => ({
-  DisputeInvoiceDialog: () => null,
+  useDisputeInvoiceDialog: () => ({ openDisputeInvoiceDialog: jest.fn() }),
 }))
 
 jest.mock('~/components/invoices/AddMetadataDrawer', () => ({


### PR DESCRIPTION
## Context

`DisputeInvoiceDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate `DisputeInvoiceDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API.

- `src/components/invoices/DisputeInvoiceDialog.tsx`: rewrote the component as `useDisputeInvoiceDialog` hook exposing `openDisputeInvoiceDialog(...)`. The dialog only needs an invoice `id` (no local state beyond that), so the migration is a straightforward switch from ref-based imperative open to hook-based open. `refetchQueries: ['getInvoiceDetails']` is kept on the mutation so the invoice detail page still refreshes after dispute.
- `src/pages/CustomerInvoiceDetails.tsx`: replaced `useRef<DisputeInvoiceDialogRef>` + `<DisputeInvoiceDialog ref={...} />` with `useDisputeInvoiceDialog()`, calling `openDisputeInvoiceDialog({ id })` directly from the dropdown action handler.
- `src/pages/__tests__/CustomerInvoiceDetails.test.tsx`: updated the module mock to expose the new hook shape.

No user-visible behavior change: the dispute confirmation dialog still shows the same title / description / action label, still fires the same `loseInvoiceDispute` mutation, and the invoice detail page still refreshes after the dispute.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYYZwZJmtrJ74pkLHVGhnK)_