### PR TITLE
fix: scope email preview logo edit to billing entity

### DIFF
--- a/src/components/emails/EmailPreview.tsx
+++ b/src/components/emails/EmailPreview.tsx
@@ -82,6 +82,7 @@ const EmailPreview = ({
           isLoading={loading}
           language={invoiceLanguage}
           logoUrl={billingEntity?.logoUrl}
+          name={billingEntityName}
           emailObject={
             showEmailHeader
               ? translateWithContextualLocal(translationsKey.subject, {

--- a/src/components/settings/PreviewEmailLayout.tsx
+++ b/src/components/settings/PreviewEmailLayout.tsx
@@ -25,6 +25,9 @@ interface PreviewEmailLayoutProps extends PropsWithChildren {
   isLoading?: boolean
   logoUrl: string | null | undefined
   name?: string | null
+  // When the preview isn't scoped to a billing entity (e.g. org-level dunning preview),
+  // the logo has no valid update target, so editing must be disabled.
+  disableLogoEdit?: boolean
 }
 
 export const PreviewEmailLayout: FC<PreviewEmailLayoutProps> = ({
@@ -36,6 +39,7 @@ export const PreviewEmailLayout: FC<PreviewEmailLayoutProps> = ({
   children,
   logoUrl,
   name,
+  disableLogoEdit,
 }) => {
   const updateLogoDialogRef = useRef<UpdateBillingEntityLogoDialogRef>(null)
 
@@ -47,6 +51,55 @@ export const PreviewEmailLayout: FC<PreviewEmailLayoutProps> = ({
   const showPoweredBy = !hasOrganizationPremiumAddon(
     PremiumIntegrationTypeEnum.RemoveBrandingWatermark,
   )
+
+  const renderLogo = (): JSX.Element => {
+    const logoAvatar = (
+      <Avatar size="medium" variant="connector">
+        <img src={logoUrl as string} alt="company-logo" />
+      </Avatar>
+    )
+
+    if (disableLogoEdit) {
+      if (!!logoUrl) {
+        return logoAvatar
+      }
+
+      return (
+        <Tooltip title={translate('text_1783371078378djljy5s2hez')} placement="top">
+          <Avatar
+            size="medium"
+            variant="company"
+            identifier={name || ''}
+            initials={(name || '').split(' ').reduce((acc, word) => acc + (word[0] || ''), '')}
+          />
+        </Tooltip>
+      )
+    }
+
+    if (!!logoUrl) {
+      return (
+        <Button
+          className="rounded-xl p-0"
+          size="small"
+          variant="quaternary"
+          onClick={() => updateLogoDialogRef?.current?.openDialog()}
+        >
+          {logoAvatar}
+        </Button>
+      )
+    }
+
+    return (
+      <Tooltip title={translate('text_6411e0aa915fd500a4d92cfb')} placement="top">
+        <Button
+          icon="plus"
+          size="small"
+          variant="secondary"
+          onClick={() => updateLogoDialogRef?.current?.openDialog()}
+        />
+      </Tooltip>
+    )
+  }
 
   return (
     <>
@@ -101,31 +154,7 @@ export const PreviewEmailLayout: FC<PreviewEmailLayoutProps> = ({
               </>
             ) : (
               <>
-                {!!logoUrl ? (
-                  <Button
-                    className="rounded-xl p-0"
-                    size="small"
-                    variant="quaternary"
-                    onClick={() => {
-                      updateLogoDialogRef?.current?.openDialog()
-                    }}
-                  >
-                    <Avatar size="medium" variant="connector">
-                      <img src={logoUrl} alt="company-logo" />
-                    </Avatar>
-                  </Button>
-                ) : (
-                  <Tooltip title={translate('text_6411e0aa915fd500a4d92cfb')} placement="top">
-                    <Button
-                      icon="plus"
-                      size="small"
-                      variant="secondary"
-                      onClick={() => {
-                        updateLogoDialogRef?.current?.openDialog()
-                      }}
-                    />
-                  </Tooltip>
-                )}
+                {renderLogo()}
                 <Typography variant="subhead1">{name}</Typography>
               </>
             )}
@@ -152,7 +181,9 @@ export const PreviewEmailLayout: FC<PreviewEmailLayoutProps> = ({
         </div>
       </div>
 
-      <UpdateBillingEntityLogoDialog ref={updateLogoDialogRef} existingLogoUrl={logoUrl} />
+      {!disableLogoEdit && (
+        <UpdateBillingEntityLogoDialog ref={updateLogoDialogRef} existingLogoUrl={logoUrl} />
+      )}
     </>
   )
 }

--- a/src/components/settings/__tests__/PreviewEmailLayout.test.tsx
+++ b/src/components/settings/__tests__/PreviewEmailLayout.test.tsx
@@ -166,6 +166,39 @@ describe('PreviewEmailLayout', () => {
     expect(plusButton).toBeInTheDocument()
   })
 
+  it('renders a static logo without an edit button when disableLogoEdit is true', () => {
+    render(
+      <PreviewEmailLayout
+        language={LocaleEnum.en}
+        logoUrl="https://example.com/logo.png"
+        name="Test Company"
+        disableLogoEdit
+      >
+        <div>Content</div>
+      </PreviewEmailLayout>,
+    )
+
+    expect(screen.getByAltText('company-logo')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('renders a static placeholder box (no edit button) when disableLogoEdit is true and no logo is provided', () => {
+    const { container } = render(
+      <PreviewEmailLayout
+        language={LocaleEnum.en}
+        logoUrl={null}
+        name="Test Company"
+        disableLogoEdit
+      >
+        <div>Content</div>
+      </PreviewEmailLayout>,
+    )
+
+    // A company placeholder avatar is rendered instead of an editable plus button
+    expect(container.querySelector('[data-test="company/medium"]')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
   it('shows "Powered by" section when organization does not have premium addon', () => {
     mockOrganizationInfos.hasOrganizationPremiumAddon.mockReturnValue(false)
 

--- a/src/components/settings/dunnings/PreviewCampaignEmailDrawer.tsx
+++ b/src/components/settings/dunnings/PreviewCampaignEmailDrawer.tsx
@@ -92,6 +92,7 @@ export const PreviewCampaignEmailDrawer = forwardRef<PreviewCampaignEmailDrawerR
             <PreviewEmailLayout
               name={data?.organization?.name}
               logoUrl={data?.organization?.logoUrl}
+              disableLogoEdit
               isLoading={loading}
               language={locale}
               emailObject={translateWithContextualLocal('text_1729256593854oiy13slixjr', {

--- a/translations/base.json
+++ b/translations/base.json
@@ -4478,5 +4478,6 @@
   "text_17822197712864tnvgq76xou": "Add number",
   "text_17822197712869ou05y6kwt7": "Type a purchase order number",
   "text_1782219771286e8qwitkefxr": "The PO number defined here will display on the invoice.",
-  "text_1782219771287u79diql28g4": "Purchase order number must be 255 characters or fewer."
+  "text_1782219771287u79diql28g4": "Purchase order number must be 255 characters or fewer.",
+  "text_1783371078378djljy5s2hez": "To update the logo, go to the billing entity email settings"
 }


### PR DESCRIPTION
Fixes LAGO-1681

`PreviewEmailLayout` always rendered a clickable logo button + `UpdateBillingEntityLogoDialog`. That dialog sources the billing entity id from the `billingEntityCode` URL param. On the dunning campaign email preview drawer (route `/settings/dunnings/:id/edit`, no `billingEntityCode`), the query is skipped, `billingEntity` is undefined, and the mutation fires `updateBillingEntity` with a null id → `Variable $input of type UpdateBillingEntityInput! was provided invalid value for id`.

### Changes
- `PreviewEmailLayout`: new `disableLogoEdit` prop. When set, the logo is read-only: existing logo renders as a static avatar, no logo renders a company-initials placeholder box with a tooltip pointing to the billing entity email settings. The update dialog is not mounted.
- `PreviewCampaignEmailDrawer` (dunning): passes `disableLogoEdit` (org-level logo, no valid billing entity target).
- `EmailPreview`: passes the missing `name` prop so the company name shows in the billing entity email preview.
- Logo editing stays fully functional on the billing entity email scenarios page.