### PR TITLE
refactor(customers): migrate DeleteCustomerFinalizeZeroAmountInvoiceDialog to CentralizedDialog

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -3,10 +3,7 @@ import { Icon } from 'lago-design-system'
 import { useMemo, useRef } from 'react'
 
 import { useDeleteCustomerDocumentLocaleDialog } from '~/components/customers/DeleteCustomerDocumentLocaleDialog'
-import {
-  DeleteCustomerFinalizeZeroAmountInvoiceDialog,
-  DeleteCustomerFinalizeZeroAmountInvoiceDialogRef,
-} from '~/components/customers/DeleteCustomerFinalizeZeroAmountInvoiceDialog'
+import { useDeleteCustomerFinalizeZeroAmountInvoiceDialog } from '~/components/customers/DeleteCustomerFinalizeZeroAmountInvoiceDialog'
 import {
   DeleteCustomerGracePeriodeDialog,
   DeleteCustomerGracePeriodeDialogRef,
@@ -224,8 +221,8 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
     useRef<DeleteOrganizationNetPaymentTermDialogRef>(null)
   const editFinalizeZeroAmountInvoiceDialogRef =
     useRef<EditFinalizeZeroAmountInvoiceDialogRef>(null)
-  const deleteCustomerFinalizeZeroAmountInvoiceDialogRef =
-    useRef<DeleteCustomerFinalizeZeroAmountInvoiceDialogRef>(null)
+  const { openDeleteCustomerFinalizeZeroAmountInvoiceDialog } =
+    useDeleteCustomerFinalizeZeroAmountInvoiceDialog()
 
   const { issuingDateAnchorSettingCopy, issuingDateAdjustmentSettingCopy } = useMemo(() => {
     const hasUserDefinedAnchor =
@@ -560,7 +557,9 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                               variant="quaternary"
                               align="left"
                               onClick={() => {
-                                deleteCustomerFinalizeZeroAmountInvoiceDialogRef?.current?.openDialog()
+                                if (customer) {
+                                  openDeleteCustomerFinalizeZeroAmountInvoiceDialog({ customer })
+                                }
                                 closePopper()
                               }}
                             >
@@ -976,10 +975,6 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
             ref={editFinalizeZeroAmountInvoiceDialogRef}
             entity={customer}
             finalizeZeroAmountInvoice={customer?.finalizeZeroAmountInvoice}
-          />
-          <DeleteCustomerFinalizeZeroAmountInvoiceDialog
-            ref={deleteCustomerFinalizeZeroAmountInvoiceDialogRef}
-            customer={customer}
           />
         </>
       )}

--- a/src/components/customers/DeleteCustomerFinalizeZeroAmountInvoiceDialog.tsx
+++ b/src/components/customers/DeleteCustomerFinalizeZeroAmountInvoiceDialog.tsx
@@ -1,9 +1,7 @@
 import { gql } from '@apollo/client'
-import { forwardRef } from 'react'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import {
   DeleteCustomerFinalizeZeroAmountInvoiceFragment,
@@ -29,19 +27,17 @@ gql`
   }
 `
 
-export type DeleteCustomerFinalizeZeroAmountInvoiceDialogRef = WarningDialogRef
-
-interface DeleteCustomerFinalizeZeroAmountInvoiceDialogProps {
+type DeleteCustomerFinalizeZeroAmountInvoiceDialogData = {
   customer: DeleteCustomerFinalizeZeroAmountInvoiceFragment
 }
 
-export const DeleteCustomerFinalizeZeroAmountInvoiceDialog = forwardRef<
-  DialogRef,
-  DeleteCustomerFinalizeZeroAmountInvoiceDialogProps
->(({ customer }: DeleteCustomerFinalizeZeroAmountInvoiceDialogProps, ref) => {
+export const useDeleteCustomerFinalizeZeroAmountInvoiceDialog = (): {
+  openDeleteCustomerFinalizeZeroAmountInvoiceDialog: (
+    data: DeleteCustomerFinalizeZeroAmountInvoiceDialogData,
+  ) => void
+} => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
-
-  const customerName = customer?.displayName
 
   const [deleteCustomerFinalizeZeroAmountInvoice] =
     useDeleteCustomerFinalizeZeroAmountInvoiceMutation({
@@ -55,18 +51,21 @@ export const DeleteCustomerFinalizeZeroAmountInvoiceDialog = forwardRef<
       },
     })
 
-  return (
-    <WarningDialog
-      ref={ref}
-      title={translate('text_1725549671288txz7z4m4qrf')}
-      description={
+  const openDeleteCustomerFinalizeZeroAmountInvoiceDialog = ({
+    customer,
+  }: DeleteCustomerFinalizeZeroAmountInvoiceDialogData): void => {
+    centralizedDialog.open({
+      title: translate('text_1725549671288txz7z4m4qrf'),
+      description: (
         <Typography
           html={translate('text_17255496712882gafqyniqpc', {
-            customerName,
+            customerName: customer?.displayName,
           })}
         />
-      }
-      onContinue={async () =>
+      ),
+      colorVariant: 'danger',
+      actionText: translate('text_63aa085d28b8510cd46441a5'),
+      onAction: async () => {
         await deleteCustomerFinalizeZeroAmountInvoice({
           variables: {
             input: {
@@ -77,11 +76,9 @@ export const DeleteCustomerFinalizeZeroAmountInvoiceDialog = forwardRef<
             },
           },
         })
-      }
-      continueText={translate('text_63aa085d28b8510cd46441a5')}
-    />
-  )
-})
+      },
+    })
+  }
 
-DeleteCustomerFinalizeZeroAmountInvoiceDialog.displayName =
-  'DeleteCustomerFinalizeZeroAmountInvoice'
+  return { openDeleteCustomerFinalizeZeroAmountInvoiceDialog }
+}

--- a/src/components/customers/__tests__/CustomerSettings.test.tsx
+++ b/src/components/customers/__tests__/CustomerSettings.test.tsx
@@ -106,13 +106,11 @@ jest.mock('~/components/customers/settings/EditCustomerIssuingDatePolicyDialog',
   return { EditCustomerIssuingDatePolicyDialog: MockDialog }
 })
 
-jest.mock('~/components/customers/DeleteCustomerFinalizeZeroAmountInvoiceDialog', () => {
-  const React = jest.requireActual('react')
-  const MockDialog = React.forwardRef(() => null)
-
-  MockDialog.displayName = 'DeleteCustomerFinalizeZeroAmountInvoiceDialog'
-  return { DeleteCustomerFinalizeZeroAmountInvoiceDialog: MockDialog }
-})
+jest.mock('~/components/customers/DeleteCustomerFinalizeZeroAmountInvoiceDialog', () => ({
+  useDeleteCustomerFinalizeZeroAmountInvoiceDialog: () => ({
+    openDeleteCustomerFinalizeZeroAmountInvoiceDialog: jest.fn(),
+  }),
+}))
 
 jest.mock('~/components/customers/DeleteCustomerNetPaymentTermDialog', () => {
   const React = jest.requireActual('react')


### PR DESCRIPTION
## Context

`DeleteCustomerFinalizeZeroAmountInvoiceDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate `DeleteCustomerFinalizeZeroAmountInvoiceDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API.

- `src/components/customers/DeleteCustomerFinalizeZeroAmountInvoiceDialog.tsx`: rewrote the component as `useDeleteCustomerFinalizeZeroAmountInvoiceDialog` hook exposing `openDeleteCustomerFinalizeZeroAmountInvoiceDialog(...)`. The dialog only needs the customer to render its description and to fire the mutation, so the migration is a straightforward switch from ref-based imperative open to hook-based open with `colorVariant: 'danger'`.
- `src/components/customers/CustomerSettings.tsx`: replaced `useRef<DeleteCustomerFinalizeZeroAmountInvoiceDialogRef>` + `<DeleteCustomerFinalizeZeroAmountInvoiceDialog ref={...} customer={customer} />` with `useDeleteCustomerFinalizeZeroAmountInvoiceDialog()`, calling `openDeleteCustomerFinalizeZeroAmountInvoiceDialog({ customer })` directly from the trash action handler (guarded on `customer` being defined).
- `src/components/customers/__tests__/CustomerSettings.test.tsx`: updated the module mock to expose the new hook shape.

No user-visible behavior change: the confirmation dialog still shows the same title, description (with the customer name), and confirm action; the same `updateCustomer` mutation still fires with `finalizeZeroAmountInvoice: Inherit`; and the same success toast appears.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. No form/Formik changes are involved (the dialog is purely a confirmation), so no TanStack Form migration was required here.

## Test plan

- [ ] Open *Customer detail → Settings* on a customer whose `finalizeZeroAmountInvoice` is not `Inherit`.
- [ ] Click the row's kebab menu → *Delete* → the confirmation dialog opens with the danger styling and the correct title/description referencing the customer name.
- [ ] Confirm → the mutation runs, the success toast appears, and the setting reverts to `Inherit`.
- [ ] Cancel / close → no mutation runs, the dialog closes cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtc27iEhkFKzWMqP18FEMj)_