### PR TITLE
refactor(customers): migrate DeleteCustomerGracePeriodeDialog to CentralizedDialog

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -4,10 +4,7 @@ import { useMemo, useRef } from 'react'
 
 import { useDeleteCustomerDocumentLocaleDialog } from '~/components/customers/DeleteCustomerDocumentLocaleDialog'
 import { useDeleteCustomerFinalizeZeroAmountInvoiceDialog } from '~/components/customers/DeleteCustomerFinalizeZeroAmountInvoiceDialog'
-import {
-  DeleteCustomerGracePeriodeDialog,
-  DeleteCustomerGracePeriodeDialogRef,
-} from '~/components/customers/DeleteCustomerGracePeriodeDialog'
+import { useDeleteCustomerGracePeriodeDialog } from '~/components/customers/DeleteCustomerGracePeriodeDialog'
 import { useDeleteCustomerNetPaymentTermDialog } from '~/components/customers/DeleteCustomerNetPaymentTermDialog'
 import { useDeleteCustomerVatRateDialog } from '~/components/customers/DeleteCustomerVatRateDialog'
 import { useEditCustomerDocumentLocaleDialog } from '~/components/customers/EditCustomerDocumentLocaleDialog'
@@ -206,7 +203,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
   const editIssuingDatePolicyDialogRef = useRef<EditCustomerIssuingDatePolicyDialogRef>(null)
   const { openDeleteCustomerVatRateDialog } = useDeleteCustomerVatRateDialog()
   const editInvoiceGracePeriodDialogRef = useRef<EditCustomerInvoiceGracePeriodDialogRef>(null)
-  const deleteGracePeriodDialogRef = useRef<DeleteCustomerGracePeriodeDialogRef>(null)
+  const { openDeleteCustomerGracePeriodeDialog } = useDeleteCustomerGracePeriodeDialog()
   const { openEditCustomerDocumentLocaleDialog } = useEditCustomerDocumentLocaleDialog()
   const editCustomerDunningCampaignDialogRef = useRef<EditCustomerDunningCampaignDialogRef>(null)
   const editCustomerInvoiceCustomSectionsDialogRef =
@@ -639,7 +636,9 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                                   variant="quaternary"
                                   align="left"
                                   onClick={() => {
-                                    deleteGracePeriodDialogRef.current?.openDialog()
+                                    if (customer) {
+                                      openDeleteCustomerGracePeriodeDialog({ customer })
+                                    }
                                     closePopper()
                                   }}
                                 >
@@ -960,7 +959,6 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
             ref={editCustomerInvoiceCustomSectionsDialogRef}
             customerId={customerId}
           />
-          <DeleteCustomerGracePeriodeDialog ref={deleteGracePeriodDialogRef} customer={customer} />
           <EditNetPaymentTermDialog
             ref={editNetPaymentTermDialogRef}
             description={translate('text_64c7a89b6c67eb6c988980eb')}

--- a/src/components/customers/DeleteCustomerGracePeriodeDialog.tsx
+++ b/src/components/customers/DeleteCustomerGracePeriodeDialog.tsx
@@ -1,9 +1,7 @@
 import { gql } from '@apollo/client'
-import { forwardRef } from 'react'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import {
   DeleteCustomerGracePeriodFragment,
@@ -26,17 +24,15 @@ gql`
   }
 `
 
-export type DeleteCustomerGracePeriodeDialogRef = WarningDialogRef
-
-interface DeleteCustomerGracePeriodeDialogProps {
+type DeleteCustomerGracePeriodeDialogData = {
   customer: DeleteCustomerGracePeriodFragment
 }
 
-export const DeleteCustomerGracePeriodeDialog = forwardRef<
-  DialogRef,
-  DeleteCustomerGracePeriodeDialogProps
->(({ customer }: DeleteCustomerGracePeriodeDialogProps, ref) => {
-  const customerName = customer?.displayName
+export const useDeleteCustomerGracePeriodeDialog = (): {
+  openDeleteCustomerGracePeriodeDialog: (data: DeleteCustomerGracePeriodeDialogData) => void
+} => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
 
   const [deleteGracePeriode] = useDeleteCustomerGracePeriodMutation({
     onCompleted(data) {
@@ -48,27 +44,28 @@ export const DeleteCustomerGracePeriodeDialog = forwardRef<
       }
     },
   })
-  const { translate } = useInternationalization()
 
-  return (
-    <WarningDialog
-      ref={ref}
-      title={translate('text_63aa085d28b8510cd464417b')}
-      description={
+  const openDeleteCustomerGracePeriodeDialog = ({
+    customer,
+  }: DeleteCustomerGracePeriodeDialogData): void => {
+    centralizedDialog.open({
+      title: translate('text_63aa085d28b8510cd464417b'),
+      description: (
         <Typography
           html={translate('text_63aa085d28b8510cd464418d', {
-            name: customerName,
+            name: customer?.displayName,
           })}
         />
-      }
-      onContinue={async () =>
+      ),
+      colorVariant: 'danger',
+      actionText: translate('text_63aa085d28b8510cd46441a5'),
+      onAction: async () => {
         await deleteGracePeriode({
           variables: { input: { id: customer?.id, invoiceGracePeriod: null } },
         })
-      }
-      continueText={translate('text_63aa085d28b8510cd46441a5')}
-    />
-  )
-})
+      },
+    })
+  }
 
-DeleteCustomerGracePeriodeDialog.displayName = 'DeleteCustomerGracePeriodeDialog'
+  return { openDeleteCustomerGracePeriodeDialog }
+}

--- a/src/components/customers/__tests__/CustomerSettings.test.tsx
+++ b/src/components/customers/__tests__/CustomerSettings.test.tsx
@@ -48,13 +48,11 @@ jest.mock('~/components/customers/EditCustomerInvoiceGracePeriodDialog', () => {
   return { EditCustomerInvoiceGracePeriodDialog: MockDialog }
 })
 
-jest.mock('~/components/customers/DeleteCustomerGracePeriodeDialog', () => {
-  const React = jest.requireActual('react')
-  const MockDialog = React.forwardRef(() => null)
-
-  MockDialog.displayName = 'DeleteCustomerGracePeriodeDialog'
-  return { DeleteCustomerGracePeriodeDialog: MockDialog }
-})
+jest.mock('~/components/customers/DeleteCustomerGracePeriodeDialog', () => ({
+  useDeleteCustomerGracePeriodeDialog: () => ({
+    openDeleteCustomerGracePeriodeDialog: jest.fn(),
+  }),
+}))
 
 jest.mock('~/components/customers/EditCustomerDocumentLocaleDialog', () => ({
   useEditCustomerDocumentLocaleDialog: () => ({


### PR DESCRIPTION
## Context

`DeleteCustomerGracePeriodeDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate `DeleteCustomerGracePeriodeDialog` from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API.

- `src/components/customers/DeleteCustomerGracePeriodeDialog.tsx`: rewrote the component as `useDeleteCustomerGracePeriodeDialog` hook exposing `openDeleteCustomerGracePeriodeDialog(...)`. The dialog only needs the customer to render its description and fire the mutation, so the migration is a straightforward switch from ref-based imperative open to hook-based open with `colorVariant: 'danger'`.
- `src/components/customers/CustomerSettings.tsx`: replaced `useRef<DeleteCustomerGracePeriodeDialogRef>` + `<DeleteCustomerGracePeriodeDialog ref={...} customer={customer} />` with `useDeleteCustomerGracePeriodeDialog()`, calling `openDeleteCustomerGracePeriodeDialog({ customer })` directly from the trash action handler (guarded on `customer` being defined).
- `src/components/customers/__tests__/CustomerSettings.test.tsx`: updated the module mock to expose the new hook shape.

No user-visible behavior change: the confirmation dialog still shows the same title, description (with the customer name), and confirm action; the same `updateCustomerInvoiceGracePeriod` mutation still fires with `invoiceGracePeriod: null`; and the same success toast appears.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. No form/Formik changes are involved (the dialog is purely a confirmation), so no TanStack Form migration was required here.

## Test plan

- [ ] Open *Customer detail → Settings* on a customer with a custom invoice grace period.
- [ ] Click the row's kebab menu → *Delete* → the confirmation dialog opens with the danger styling and the correct title/description referencing the customer name.
- [ ] Confirm → the mutation runs, the success toast appears, and the setting is removed.
- [ ] Cancel / close → no mutation runs, the dialog closes cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtc27iEhkFKzWMqP18FEMj)_