### PR TITLE
refactor(customers): migrate DeleteCustomerNetPaymentTermDialog to CentralizedDialog

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -11,10 +11,7 @@ import {
   DeleteCustomerGracePeriodeDialog,
   DeleteCustomerGracePeriodeDialogRef,
 } from '~/components/customers/DeleteCustomerGracePeriodeDialog'
-import {
-  DeleteOrganizationNetPaymentTermDialog,
-  DeleteOrganizationNetPaymentTermDialogRef,
-} from '~/components/customers/DeleteCustomerNetPaymentTermDialog'
+import { useDeleteCustomerNetPaymentTermDialog } from '~/components/customers/DeleteCustomerNetPaymentTermDialog'
 import { useDeleteCustomerVatRateDialog } from '~/components/customers/DeleteCustomerVatRateDialog'
 import { useEditCustomerDocumentLocaleDialog } from '~/components/customers/EditCustomerDocumentLocaleDialog'
 import {
@@ -220,8 +217,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
   const { openDeleteCustomerDocumentLocaleDialog } = useDeleteCustomerDocumentLocaleDialog()
   const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const editNetPaymentTermDialogRef = useRef<EditNetPaymentTermDialogRef>(null)
-  const deleteOrganizationNetPaymentTermDialogRef =
-    useRef<DeleteOrganizationNetPaymentTermDialogRef>(null)
+  const { openDeleteCustomerNetPaymentTermDialog } = useDeleteCustomerNetPaymentTermDialog()
   const editFinalizeZeroAmountInvoiceDialogRef =
     useRef<EditFinalizeZeroAmountInvoiceDialogRef>(null)
   const deleteCustomerFinalizeZeroAmountInvoiceDialogRef =
@@ -788,7 +784,9 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                                   variant="quaternary"
                                   align="left"
                                   onClick={() => {
-                                    deleteOrganizationNetPaymentTermDialogRef?.current?.openDialog()
+                                    if (customer) {
+                                      openDeleteCustomerNetPaymentTermDialog({ customer })
+                                    }
                                     closePopper()
                                   }}
                                 >
@@ -967,10 +965,6 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
           <EditNetPaymentTermDialog
             ref={editNetPaymentTermDialogRef}
             description={translate('text_64c7a89b6c67eb6c988980eb')}
-          />
-          <DeleteOrganizationNetPaymentTermDialog
-            ref={deleteOrganizationNetPaymentTermDialogRef}
-            customer={customer}
           />
           <EditFinalizeZeroAmountInvoiceDialog
             ref={editFinalizeZeroAmountInvoiceDialogRef}

--- a/src/components/customers/DeleteCustomerNetPaymentTermDialog.tsx
+++ b/src/components/customers/DeleteCustomerNetPaymentTermDialog.tsx
@@ -1,9 +1,7 @@
 import { gql } from '@apollo/client'
-import { forwardRef } from 'react'
 
-import { DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import {
   DeleteCustomerNetPaymentTermFragment,
@@ -28,17 +26,16 @@ gql`
   }
 `
 
-export type DeleteOrganizationNetPaymentTermDialogRef = WarningDialogRef
-
-interface DeleteOrganizationNetPaymentTermDialogProps {
+type DeleteCustomerNetPaymentTermDialogData = {
   customer: DeleteCustomerNetPaymentTermFragment
 }
 
-export const DeleteOrganizationNetPaymentTermDialog = forwardRef<
-  DialogRef,
-  DeleteOrganizationNetPaymentTermDialogProps
->(({ customer }: DeleteOrganizationNetPaymentTermDialogProps, ref) => {
-  const customerName = customer?.displayName
+export const useDeleteCustomerNetPaymentTermDialog = (): {
+  openDeleteCustomerNetPaymentTermDialog: (data: DeleteCustomerNetPaymentTermDialogData) => void
+} => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+
   const [deleteCustomerNetPaymentTerm] = useDeleteCustomerNetPaymentTermMutation({
     onCompleted(data) {
       if (data && data.updateCustomer) {
@@ -49,36 +46,35 @@ export const DeleteOrganizationNetPaymentTermDialog = forwardRef<
       }
     },
   })
-  const { translate } = useInternationalization()
 
-  return (
-    <WarningDialog
-      ref={ref}
-      title={translate('text_64c7a89b6c67eb6c988980db')}
-      description={
+  const openDeleteCustomerNetPaymentTermDialog = ({
+    customer,
+  }: DeleteCustomerNetPaymentTermDialogData): void => {
+    centralizedDialog.open({
+      title: translate('text_64c7a89b6c67eb6c988980db'),
+      description: (
         <Typography
           html={translate('text_64c7a89b6c67eb6c988980f9', {
-            customerName: `<span class="line-break-anywhere">${customerName}</span>`,
+            customerName: `<span class="line-break-anywhere">${customer?.displayName}</span>`,
           })}
         />
-      }
-      onContinue={async () =>
+      ),
+      colorVariant: 'danger',
+      actionText: translate('text_64c7a89b6c67eb6c98898133'),
+      onAction: async () => {
         await deleteCustomerNetPaymentTerm({
           variables: {
             input: {
               id: customer.id,
               netPaymentTerm: null,
-              // NOTE: API should not require those fields on customer update
-              // To be tackled as improvement
               externalId: customer.externalId,
               name: customer.name || '',
             },
           },
         })
-      }
-      continueText={translate('text_64c7a89b6c67eb6c98898133')}
-    />
-  )
-})
+      },
+    })
+  }
 
-DeleteOrganizationNetPaymentTermDialog.displayName = 'DeleteOrganizationNetPaymentTermDialog'
+  return { openDeleteCustomerNetPaymentTermDialog }
+}

--- a/src/components/customers/__tests__/CustomerSettings.test.tsx
+++ b/src/components/customers/__tests__/CustomerSettings.test.tsx
@@ -114,13 +114,11 @@ jest.mock('~/components/customers/DeleteCustomerFinalizeZeroAmountInvoiceDialog'
   return { DeleteCustomerFinalizeZeroAmountInvoiceDialog: MockDialog }
 })
 
-jest.mock('~/components/customers/DeleteCustomerNetPaymentTermDialog', () => {
-  const React = jest.requireActual('react')
-  const MockDialog = React.forwardRef(() => null)
-
-  MockDialog.displayName = 'DeleteOrganizationNetPaymentTermDialog'
-  return { DeleteOrganizationNetPaymentTermDialog: MockDialog }
-})
+jest.mock('~/components/customers/DeleteCustomerNetPaymentTermDialog', () => ({
+  useDeleteCustomerNetPaymentTermDialog: () => ({
+    openDeleteCustomerNetPaymentTermDialog: jest.fn(),
+  }),
+}))
 
 jest.mock('~/components/settings/invoices/EditNetPaymentTermDialog', () => {
   const React = jest.requireActual('react')


### PR DESCRIPTION
## Context

`DeleteOrganizationNetPaymentTermDialog` (in `DeleteCustomerNetPaymentTermDialog.tsx`) was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the customer net-payment-term deletion dialog from the legacy `WarningDialog` (imperative `ref` + `forwardRef` + `useImperativeHandle`) to the new hook-based `useCentralizedDialog` API.

- `src/components/customers/DeleteCustomerNetPaymentTermDialog.tsx`: rewrote the component as `useDeleteCustomerNetPaymentTermDialog` hook exposing `openDeleteCustomerNetPaymentTermDialog(...)`. The dialog only needs the customer to render its description and fire the mutation, so the migration is a straightforward switch from ref-based imperative open to hook-based open with `colorVariant: 'danger'`.
- `src/components/customers/CustomerSettings.tsx`: replaced `useRef<DeleteOrganizationNetPaymentTermDialogRef>` + `<DeleteOrganizationNetPaymentTermDialog ref={...} customer={customer} />` with `useDeleteCustomerNetPaymentTermDialog()`, calling `openDeleteCustomerNetPaymentTermDialog({ customer })` directly from the trash action handler (guarded on `customer` being defined).
- `src/components/customers/__tests__/CustomerSettings.test.tsx`: updated the module mock to expose the new hook shape.

No user-visible behavior change: the confirmation dialog still shows the same title, description (with the customer name), and confirm action; the same `updateCustomer` mutation still fires with `netPaymentTerm: null`; and the same success toast appears.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. No form/Formik changes are involved (the dialog is purely a confirmation), so no TanStack Form migration was required here.

## Test plan

- [ ] Open *Customer detail → Settings* on a customer with a custom net payment term.
- [ ] Click the row's kebab menu → *Delete* → the confirmation dialog opens with the danger styling and the correct title/description referencing the customer name.
- [ ] Confirm → the mutation runs, the success toast appears, and the setting is removed.
- [ ] Cancel / close → no mutation runs, the dialog closes cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtc27iEhkFKzWMqP18FEMj)_