### PR TITLE
refactor(add-ons): migrate CreateAddOn close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -1,5 +1,5 @@
 import { useFormik } from 'formik'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 import { number, object, string } from 'yup'
 
@@ -10,7 +10,7 @@ import { Card } from '~/components/designSystem/Card'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { AmountInputField, ComboBoxField, TextInput, TextInputField } from '~/components/form'
 import { TaxesSelectorSection } from '~/components/taxes/TaxesSelectorSection'
 import { FORM_ERRORS_ENUM, SEARCH_TAX_INPUT_FOR_ADD_ON_CLASSNAME } from '~/core/constants/form'
@@ -31,7 +31,7 @@ const CreateAddOn = () => {
   const { organization } = useOrganizationInfos()
   const { addOnId } = useParams()
   const { isEdition, loading, addOn, errorCode, onSave } = useCreateEditAddOn()
-  const warningDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
 
   const onCloseRedirection = () => {
     if (isEdition && !!addOnId) {
@@ -94,7 +94,15 @@ const CreateAddOn = () => {
           variant="quaternary"
           icon="close"
           onClick={() => {
-            if (formikProps.dirty) return warningDialogRef.current?.openDialog()
+            if (formikProps.dirty) {
+              return centralizedDialog.open({
+                title: translate('text_665deda4babaf700d603ea13'),
+                description: translate('text_665dedd557dc3c00c62eb83d'),
+                actionText: translate('text_645388d5bdbd7b00abffa033'),
+                colorVariant: 'danger',
+                onAction: onCloseRedirection,
+              })
+            }
 
             onCloseRedirection()
           }}
@@ -347,13 +355,6 @@ const CreateAddOn = () => {
           <AddOnCodeSnippet loading={loading} addOn={formikProps.values} />
         </Side>
       </div>
-      <WarningDialog
-        ref={warningDialogRef}
-        title={translate('text_665deda4babaf700d603ea13')}
-        description={translate('text_665dedd557dc3c00c62eb83d')}
-        continueText={translate('text_645388d5bdbd7b00abffa033')}
-        onContinue={onCloseRedirection}
-      />
     </div>
   )
 }


### PR DESCRIPTION
## Context

`CreateAddOn` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `CreateAddOn.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/CreateAddOn.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render.
  - Added `useCentralizedDialog()` and inlined the "unsaved changes" confirmation inside the header close button's `onClick` — same title/description/action text, still with `colorVariant: 'danger'`, and still calling `onCloseRedirection` on confirm.
  - Removed the now-unused `useRef` import.

The parent page still uses Formik (a separate migration tracked by other ESLint warnings) — the scope here is strictly the `WarningDialog` warning.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` / TanStack Form migration in this PR.

## Test plan

- [ ] Open *Add-ons → Create*.
- [ ] Fill some fields so the form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back to the add-ons list (or add-on detail in edition mode).
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] When the form is pristine, clicking close immediately navigates away with no dialog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtc27iEhkFKzWMqP18FEMj)_