### PR TITLE
refactor(billable-metrics): migrate CreateBillableMetric close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/CreateBillableMetric.tsx
+++ b/src/pages/CreateBillableMetric.tsx
@@ -19,7 +19,7 @@ import { Chip } from '~/components/designSystem/Chip'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import {
   BasicMultipleComboBoxData,
   ButtonSelector,
@@ -91,7 +91,7 @@ const CreateBillableMetric = () => {
     isDuplicate,
   })
 
-  const warningDirtyAttributesDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const customExpressionDrawerRef = useRef<CustomExpressionDrawerRef>(null)
   const canBeEdited =
     isDuplicate || (!billableMetric?.hasSubscriptions && !billableMetric?.hasPlans)
@@ -248,7 +248,19 @@ const CreateBillableMetric = () => {
           icon="close"
           onClick={() =>
             formikProps.dirty
-              ? warningDirtyAttributesDialogRef.current?.openDialog()
+              ? centralizedDialog.open({
+                  title: translate(
+                    isEdition ? 'text_62583bbb86abcf01654f693f' : 'text_6244277fe0975300fe3fb940',
+                  ),
+                  description: translate(
+                    isEdition ? 'text_62583bbb86abcf01654f6943' : 'text_6244277fe0975300fe3fb946',
+                  ),
+                  actionText: translate(
+                    isEdition ? 'text_62583bbb86abcf01654f694b' : 'text_6244277fe0975300fe3fb94c',
+                  ),
+                  colorVariant: 'danger',
+                  onAction: () => navigate(BILLABLE_METRICS_ROUTE),
+                })
               : navigate(BILLABLE_METRICS_ROUTE)
           }
         />
@@ -865,19 +877,6 @@ const CreateBillableMetric = () => {
       <CustomExpressionDrawer
         ref={customExpressionDrawerRef}
         onSave={(expression: string) => formikProps.setFieldValue('expression', expression)}
-      />
-      <WarningDialog
-        ref={warningDirtyAttributesDialogRef}
-        title={translate(
-          isEdition ? 'text_62583bbb86abcf01654f693f' : 'text_6244277fe0975300fe3fb940',
-        )}
-        description={translate(
-          isEdition ? 'text_62583bbb86abcf01654f6943' : 'text_6244277fe0975300fe3fb946',
-        )}
-        continueText={translate(
-          isEdition ? 'text_62583bbb86abcf01654f694b' : 'text_6244277fe0975300fe3fb94c',
-        )}
-        onContinue={() => navigate(BILLABLE_METRICS_ROUTE)}
       />
     </div>
   )


### PR DESCRIPTION
## Context

`CreateBillableMetric` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `CreateBillableMetric.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/CreateBillableMetric.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render.
  - Added `useCentralizedDialog()` and inlined the "unsaved changes" confirmation inside the header close button's `onClick` — same title/description/action text (both create and edition variants preserved), still with `colorVariant: 'danger'`, and still navigating to `BILLABLE_METRICS_ROUTE` on confirm.

The parent page still uses Formik (a separate migration tracked by other ESLint warnings) — the scope here is strictly the `WarningDialog` warning.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` / TanStack Form migration in this PR.

## Test plan

- [ ] Open *Billable metrics → Create*.
- [ ] Fill some fields so the form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back to the billable-metrics list.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] When the form is pristine, clicking close immediately navigates away with no dialog.
- [ ] Same flow in edition mode (existing billable metric) shows the edition-variant title/description.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtc27iEhkFKzWMqP18FEMj)_