### PR TITLE
refactor(taxes): migrate CreateTax WarningDialogs to CentralizedDialog

### DIFF
--- a/src/pages/CreateTax.tsx
+++ b/src/pages/CreateTax.tsx
@@ -7,7 +7,7 @@ import { Card } from '~/components/designSystem/Card'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import NameAndCodeGroup from '~/components/form/NameAndCodeGroup/NameAndCodeGroup'
 import { TaxCodeSnippet } from '~/components/taxes/TaxCodeSnippet'
 import { TaxFormInput } from '~/components/taxes/types'
@@ -27,8 +27,7 @@ export const CREATE_TAX_DESCRIPTION_DELETE_TEST_ID = 'create-tax-description-del
 
 const CreateTaxRate = () => {
   const { isEdition, errorCode, loading, onClose, onSave, tax } = useCreateEditTax()
-  const leavingNotSavedChargesWarningDialogRef = useRef<WarningDialogRef>(null)
-  const savingAppliedTaxRateWarningDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const saveAfterConfirmRef = useRef<() => Promise<void>>(async () => {})
   const { translate } = useInternationalization()
 
@@ -48,7 +47,21 @@ const CreateTaxRate = () => {
         saveAfterConfirmRef.current = async () => {
           await onSave(value as unknown as TaxFormInput)
         }
-        savingAppliedTaxRateWarningDialogRef.current?.openDialog()
+        centralizedDialog.open({
+          title: translate('text_6464a12047f2dd00affa924f', {
+            name: tax?.name,
+          }),
+          description: translate(
+            'text_6464a12047f2dd00affa9250',
+            {
+              customersCount: tax?.customersCount,
+            },
+            tax?.customersCount,
+          ),
+          colorVariant: 'info',
+          actionText: translate('text_6464a12047f2dd00affa9252'),
+          onAction: () => saveAfterConfirmRef.current(),
+        })
       } else {
         await onSave(value as unknown as TaxFormInput)
       }
@@ -120,7 +133,15 @@ const CreateTaxRate = () => {
           icon="close"
           data-test={CREATE_TAX_CLOSE_BUTTON_TEST_ID}
           onClick={() =>
-            isDirty ? leavingNotSavedChargesWarningDialogRef.current?.openDialog() : onClose()
+            isDirty
+              ? centralizedDialog.open({
+                  title: translate('text_645bb193927b375079d289cb'),
+                  description: translate('text_645bb193927b375079d289d9'),
+                  actionText: translate('text_645bb193927b375079d289f9'),
+                  colorVariant: 'danger',
+                  onAction: onClose,
+                })
+              : onClose()
           }
         />
       </PageHeader.Wrapper>
@@ -276,29 +297,6 @@ const CreateTaxRate = () => {
           />
         </Side>
       </form>
-      <WarningDialog
-        ref={leavingNotSavedChargesWarningDialogRef}
-        title={translate('text_645bb193927b375079d289cb')}
-        description={translate('text_645bb193927b375079d289d9')}
-        continueText={translate('text_645bb193927b375079d289f9')}
-        onContinue={onClose}
-      />
-      <WarningDialog
-        mode="info"
-        ref={savingAppliedTaxRateWarningDialogRef}
-        title={translate('text_6464a12047f2dd00affa924f', {
-          name: tax?.name,
-        })}
-        description={translate(
-          'text_6464a12047f2dd00affa9250',
-          {
-            customersCount: tax?.customersCount,
-          },
-          tax?.customersCount,
-        )}
-        continueText={translate('text_6464a12047f2dd00affa9252')}
-        onContinue={() => saveAfterConfirmRef.current()}
-      />
     </div>
   )
 }


### PR DESCRIPTION
## Context

`CreateTax` was still using the deprecated legacy imperative ref-based `WarningDialog` for both its "unsaved changes" close-confirmation and its "applied tax rate is used by customers" save-confirmation, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate both `WarningDialog` usages on `CreateTax.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API. Both are pure confirmations (no form fields inside the dialog), so `CentralizedDialog` is the right primitive — the parent page's form is already TanStack-based and stays as-is.

- `src/pages/CreateTax.tsx`:
  - Removed the two `useRef<WarningDialogRef>` and the two `<WarningDialog />` renders.
  - Added `useCentralizedDialog()` and inlined the "unsaved changes" confirmation inside the header close button's `onClick` — same title/description/action text, still with `colorVariant: 'danger'`, and still calling `onClose` on confirm.
  - Inlined the "confirm save with N applied customers" dialog inside the form's `onSubmit` — same title/description/action text with the same `name` / `customersCount` interpolation, `colorVariant: 'info'` (mirrors the original `mode="info"`), and still calling `saveAfterConfirmRef.current()` on confirm.

## Scope

Scoped strictly to the two `WarningDialog` warnings in this file. Both dialogs are pure confirmations with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` migration. The page's form itself is already on TanStack Form.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm test -- --testPathPattern CreateTax` — 2 suites / 31 tests passing

## Test plan

- [ ] Open *Settings → Taxes → Create*.
- [ ] Fill some fields so the form becomes dirty, then click the top-right close icon → the confirmation dialog opens with the danger styling. Confirm navigates back to the taxes list; cancel keeps the form.
- [ ] With a tax already applied to N customers, open *Edit* on that tax, change the rate, submit → the "confirm save" dialog opens with the info styling and the customer-count copy. Confirm fires the mutation; cancel closes the dialog.
- [ ] When the form is pristine, clicking close immediately navigates away with no dialog.
- [ ] When the tax has no applied customers, submitting goes straight through with no confirm dialog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtc27iEhkFKzWMqP18FEMj)_