### PR TITLE
refactor(invoices): migrate CreateInvoice close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -3,7 +3,7 @@ import InputAdornment from '@mui/material/InputAdornment'
 import { useFormik } from 'formik'
 import _get from 'lodash/get'
 import { DateTime } from 'luxon'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 import { array, number, object, string } from 'yup'
 
@@ -17,7 +17,7 @@ import { Popper } from '~/components/designSystem/Popper'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { AmountInput, ComboBox, ComboBoxField, ComboboxItem, TextInput } from '~/components/form'
 import { InvoiceCustomSectionInput } from '~/components/invoceCustomFooter/types'
 import { toInvoiceCustomSectionReference } from '~/components/invoceCustomFooter/utils'
@@ -227,7 +227,7 @@ const CreateInvoice = () => {
   const [taxProviderTaxesErrorMessage, setTaxProviderTaxesErrorMessage] =
     useState<LocalTaxProviderErrorsEnum | null>(null)
 
-  const warningDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const { openEditInvoiceItemDescriptionDialog } = useEditInvoiceItemDescriptionDialog()
   const { openEditInvoiceItemTaxDialog } = useEditInvoiceItemTaxDialog()
   const { openEditInvoiceDisplayNameDialog } = useEditInvoiceDisplayNameDialog()
@@ -630,7 +630,15 @@ const CreateInvoice = () => {
             variant="quaternary"
             icon="close"
             onClick={() =>
-              formikProps.dirty ? warningDialogRef.current?.openDialog() : handleClosePage()
+              formikProps.dirty
+                ? centralizedDialog.open({
+                    title: translate('text_645388d5bdbd7b00abffa030'),
+                    description: translate('text_645388d5bdbd7b00abffa031'),
+                    actionText: translate('text_645388d5bdbd7b00abffa033'),
+                    colorVariant: 'danger',
+                    onAction: handleClosePage,
+                  })
+                : handleClosePage()
             }
           />
         )}
@@ -1316,13 +1324,6 @@ const CreateInvoice = () => {
           </div>
         )}
       </div>
-      <WarningDialog
-        ref={warningDialogRef}
-        title={translate('text_645388d5bdbd7b00abffa030')}
-        description={translate('text_645388d5bdbd7b00abffa031')}
-        continueText={translate('text_645388d5bdbd7b00abffa033')}
-        onContinue={handleClosePage}
-      />
     </>
   )
 }


### PR DESCRIPTION
## Context

`CreateInvoice` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `CreateInvoice.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/CreateInvoice.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render (and dropped the now-unused `useRef` import).
  - Added `useCentralizedDialog()` and inlined the "unsaved changes" confirmation inside the header close button's `onClick` — same title/description/action text, still with `colorVariant: 'danger'`, and still calling `handleClosePage` on confirm.

The parent page still uses Formik (a separate migration tracked by other ESLint warnings) — the scope here is strictly the `WarningDialog` warning.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` / TanStack Form migration in this PR.

## Test plan

- [ ] Open a customer that supports invoice creation → *Create invoice*.
- [ ] Fill some fields so the form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page closes/navigates as before.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] When the form is pristine, clicking close immediately navigates away with no dialog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtc27iEhkFKzWMqP18FEMj)_