### PR TITLE
refactor(payments): migrate CreatePayment close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/CreatePayment.tsx
+++ b/src/pages/CreatePayment.tsx
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client'
 import InputAdornment from '@mui/material/InputAdornment'
 import { useFormik } from 'formik'
 import { DateTime } from 'luxon'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { generatePath, useParams, useSearchParams } from 'react-router-dom'
 import { date, object, string } from 'yup'
 
@@ -11,7 +11,7 @@ import { Button } from '~/components/designSystem/Button'
 import { Status } from '~/components/designSystem/Status'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { AmountInputField, ComboBox, DatePickerField, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { addToast } from '~/core/apolloClient'
@@ -76,8 +76,21 @@ const CreatePayment = () => {
   const params = useParams<{ invoiceId?: string }>()
   const [searchParams] = useSearchParams()
 
-  const warningDirtyAttributesDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const { timezone } = useOrganizationInfos()
+
+  const openDirtyAttributesWarning = useCallback(
+    (onLeave: () => void) => {
+      centralizedDialog.open({
+        title: translate('text_6244277fe0975300fe3fb940'),
+        description: translate('text_6244277fe0975300fe3fb946'),
+        actionText: translate('text_6244277fe0975300fe3fb94c'),
+        colorVariant: 'danger',
+        onAction: onLeave,
+      })
+    },
+    [centralizedDialog, translate],
+  )
 
   const formikProps = useFormik<CreatePaymentInput>({
     initialValues: {
@@ -202,9 +215,7 @@ const CreatePayment = () => {
           <Button
             variant="quaternary"
             icon="close"
-            onClick={() =>
-              formikProps.dirty ? warningDirtyAttributesDialogRef.current?.openDialog() : onLeave()
-            }
+            onClick={() => (formikProps.dirty ? openDirtyAttributesWarning(onLeave) : onLeave())}
           />
         </CenteredPage.Header>
 
@@ -380,9 +391,7 @@ const CreatePayment = () => {
         <CenteredPage.StickyFooter>
           <Button
             variant="quaternary"
-            onClick={() =>
-              formikProps.dirty ? warningDirtyAttributesDialogRef.current?.openDialog() : onLeave()
-            }
+            onClick={() => (formikProps.dirty ? openDirtyAttributesWarning(onLeave) : onLeave())}
           >
             {translate('text_6411e6b530cb47007488b027')}
           </Button>
@@ -395,14 +404,6 @@ const CreatePayment = () => {
           </Button>
         </CenteredPage.StickyFooter>
       </CenteredPage.Wrapper>
-
-      <WarningDialog
-        ref={warningDirtyAttributesDialogRef}
-        title={translate('text_6244277fe0975300fe3fb940')}
-        description={translate('text_6244277fe0975300fe3fb946')}
-        continueText={translate('text_6244277fe0975300fe3fb94c')}
-        onContinue={onLeave}
-      />
     </>
   )
 }


### PR DESCRIPTION
## Context

`CreatePayment` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation (used from both the header close button and the footer cancel button), which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `CreatePayment.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/CreatePayment.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render (and dropped the now-unused `useRef` import).
  - Added `useCentralizedDialog()` and extracted an `openDirtyAttributesWarning(onLeave)` helper that opens the confirmation dialog — same title/description/action text, still with `colorVariant: 'danger'`, and still navigating away on confirm.
  - Both dirty-guard call sites (header close button and footer cancel button) now call `openDirtyAttributesWarning(onLeave)` instead of `warningDirtyAttributesDialogRef.current?.openDialog()`.

The parent page still uses Formik (a separate migration tracked by other ESLint warnings) — the scope here is strictly the `WarningDialog` warning.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` / TanStack Form migration in this PR.

## Test plan

- [ ] Open *Payments → Create payment*.
- [ ] Fill some fields so the form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back to the payments list.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] Same flow via the footer cancel button.
- [ ] When the form is pristine, clicking close/cancel immediately navigates away with no dialog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtc27iEhkFKzWMqP18FEMj)_