### PR TITLE
refactor(alerts): migrate AlertForm close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/AlertForm.tsx
+++ b/src/pages/AlertForm.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { useFormik } from 'formik'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 import { array, boolean, number, object, string } from 'yup'
 
@@ -8,7 +8,7 @@ import AlertThresholds, { isThresholdValueValid } from '~/components/alerts/Thre
 import { Button } from '~/components/designSystem/Button'
 import { Chip } from '~/components/designSystem/Chip'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { ComboBox, ComboBoxField, ComboboxItem, TextInput, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
@@ -140,7 +140,7 @@ const AlertForm = () => {
   const { alertId = '', customerId = '', planId = '', subscriptionId = '' } = useParams()
   const { translate } = useInternationalization()
   const navigate = useNavigate()
-  const warningDirtyAttributesDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const isEdition = !!alertId
 
   const { data: subscriptionData, loading: subscriptionLoading } = useGetSubscriptionInfosQuery({
@@ -217,6 +217,16 @@ const AlertForm = () => {
     },
     [customerId, navigate, planId, subscriptionId],
   )
+
+  const warnLeaving = useCallback(() => {
+    centralizedDialog.open({
+      title: translate('text_6244277fe0975300fe3fb940'),
+      description: translate('text_1746623860224gh7o1exyjch'),
+      actionText: translate('text_6244277fe0975300fe3fb94c'),
+      colorVariant: 'danger',
+      onAction: onLeave,
+    })
+  }, [centralizedDialog, onLeave, translate])
 
   // Redirect to alerts list if alert is not found (e.g., deleted while on edit page)
   useEffect(() => {
@@ -446,9 +456,7 @@ const AlertForm = () => {
           <Button
             variant="quaternary"
             icon="close"
-            onClick={() =>
-              formikProps.dirty ? warningDirtyAttributesDialogRef.current?.openDialog() : onLeave()
-            }
+            onClick={() => (formikProps.dirty ? warnLeaving() : onLeave())}
           />
         </CenteredPage.Header>
 
@@ -580,9 +588,7 @@ const AlertForm = () => {
         <CenteredPage.StickyFooter>
           <Button
             variant="quaternary"
-            onClick={() =>
-              formikProps.dirty ? warningDirtyAttributesDialogRef.current?.openDialog() : onLeave()
-            }
+            onClick={() => (formikProps.dirty ? warnLeaving() : onLeave())}
           >
             {translate('text_6411e6b530cb47007488b027')}
           </Button>
@@ -602,14 +608,6 @@ const AlertForm = () => {
           </Button>
         </CenteredPage.StickyFooter>
       </CenteredPage.Wrapper>
-
-      <WarningDialog
-        ref={warningDirtyAttributesDialogRef}
-        title={translate('text_6244277fe0975300fe3fb940')}
-        description={translate('text_1746623860224gh7o1exyjch')}
-        continueText={translate('text_6244277fe0975300fe3fb94c')}
-        onContinue={onLeave}
-      />
     </>
   )
 }


### PR DESCRIPTION
## Context

`AlertForm` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation (used from both the header close button and the footer cancel button), which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `AlertForm.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/AlertForm.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render (and dropped the now-unused `useRef` import).
  - Added `useCentralizedDialog()` and inlined the "unsaved changes" confirmation at both dirty-guard call sites (header close button and footer cancel button) — same title/description/action text, still with `colorVariant: 'danger'`, and still calling `onLeave` on confirm.

The parent page still uses Formik (a separate migration tracked by other ESLint warnings) — the scope here is strictly the `WarningDialog` warning.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` / TanStack Form migration in this PR.

## Test plan

- [ ] From a subscription's alerts tab, click *Create alert*.
- [ ] Fill some fields so the form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back to the alerts tab.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] Same flow via the footer cancel button.
- [ ] When the form is pristine, clicking close/cancel immediately navigates away with no dialog.
- [ ] Edit an existing alert → same flow works in edition mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtc27iEhkFKzWMqP18FEMj)_