### PR TITLE
refactor(dunnings): migrate CreateDunning close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/settings/Dunnings/CreateDunning.tsx
+++ b/src/pages/settings/Dunnings/CreateDunning.tsx
@@ -7,7 +7,7 @@ import { Alert } from '~/components/designSystem/Alert'
 import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { AmountInputField, ComboBoxField, TextInput, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import {
@@ -46,8 +46,17 @@ const CreateDunning = () => {
   const navigate = useNavigate()
 
   const defaultCampaignDialogRef = useRef<DefaultCampaignDialogRef>(null)
-  const warningDirtyAttributesDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const previewCampaignEmailDrawerRef = useRef<PreviewCampaignEmailDrawerRef>(null)
+
+  const openDirtyAttributesWarning = () =>
+    centralizedDialog.open({
+      title: translate('text_6244277fe0975300fe3fb940'),
+      description: translate('text_6244277fe0975300fe3fb946'),
+      actionText: translate('text_6244277fe0975300fe3fb94c'),
+      colorVariant: 'danger',
+      onAction: () => navigate(DUNNINGS_SETTINGS_ROUTE),
+    })
 
   const { organization: { defaultCurrency } = {} } = useOrganizationInfos()
 
@@ -152,9 +161,7 @@ const CreateDunning = () => {
           <Button
             variant="quaternary"
             icon="close"
-            onClick={() =>
-              formikProps.dirty ? warningDirtyAttributesDialogRef.current?.openDialog() : onClose()
-            }
+            onClick={() => (formikProps.dirty ? openDirtyAttributesWarning() : onClose())}
           />
         </CenteredPage.Header>
 
@@ -410,9 +417,7 @@ const CreateDunning = () => {
           <Button
             variant="quaternary"
             onClick={() =>
-              formikProps.dirty
-                ? warningDirtyAttributesDialogRef.current?.openDialog()
-                : navigate(DUNNINGS_SETTINGS_ROUTE)
+              formikProps.dirty ? openDirtyAttributesWarning() : navigate(DUNNINGS_SETTINGS_ROUTE)
             }
           >
             {translate('text_6411e6b530cb47007488b027')}
@@ -429,13 +434,6 @@ const CreateDunning = () => {
         </CenteredPage.StickyFooter>
       </CenteredPage.Wrapper>
 
-      <WarningDialog
-        ref={warningDirtyAttributesDialogRef}
-        title={translate('text_6244277fe0975300fe3fb940')}
-        description={translate('text_6244277fe0975300fe3fb946')}
-        continueText={translate('text_6244277fe0975300fe3fb94c')}
-        onContinue={() => navigate(DUNNINGS_SETTINGS_ROUTE)}
-      />
       <DefaultCampaignDialog ref={defaultCampaignDialogRef} />
       <PreviewCampaignEmailDrawer ref={previewCampaignEmailDrawerRef} />
     </>


### PR DESCRIPTION
## Context

`CreateDunning` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation (used from both the header close button and the footer cancel button), which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `CreateDunning.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/settings/Dunnings/CreateDunning.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render.
  - Added `useCentralizedDialog()` and extracted an `openDirtyAttributesWarning()` helper that opens the confirmation dialog — same title/description/action text, still with `colorVariant: 'danger'`, and still navigating to `DUNNINGS_SETTINGS_ROUTE` on confirm.
  - Both dirty-guard call sites (header close button and footer cancel button) now call `openDirtyAttributesWarning()` instead of `warningDirtyAttributesDialogRef.current?.openDialog()`; the not-dirty branches keep their existing behavior (`onClose()` on the header button, `navigate(DUNNINGS_SETTINGS_ROUTE)` on the footer button).

The parent page still uses Formik (a separate migration tracked by other ESLint warnings) — the scope here is strictly the `WarningDialog` warning.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` / TanStack Form migration in this PR.

## Test plan

- [ ] Open *Settings → Dunnings → Create dunning campaign*.
- [ ] Fill some fields so the form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back to the dunnings settings list.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] Same flow via the footer cancel button.
- [ ] When the form is pristine, clicking close/cancel immediately navigates away with no dialog.
- [ ] Edit an existing campaign → same flow works in edition mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtc27iEhkFKzWMqP18FEMj)_