### PR TITLE
fix(quotes): make mention variables inherit surrounding text style

### DIFF
--- a/src/components/designSystem/RichTextEditor/richTextEditor.css
+++ b/src/components/designSystem/RichTextEditor/richTextEditor.css
@@ -215,7 +215,7 @@
   }
 
   .variable-mention {
-    @apply rounded bg-grey-300 px-1.5 py-0.5 text-base;
+    @apply rounded bg-grey-300 px-1.5 py-0.5;
   }
 
   .variable-mention--resolved {


### PR DESCRIPTION
## LAGO-1682 — Mentions inherit surrounding text style

### Problem
Quote RTE mention variables (`.variable-mention`) forced `text-base` (16px). A mention placed inside a title/heading therefore rendered at plain body size instead of inheriting the heading's font size — visible in the on-screen preview and the downloaded PDF. The `--resolved` variant (preview/PDF) already stripped the pill but inherited the forced size.

### Change
- `richTextEditor.css`: drop `text-base` from `.variable-mention` so mentions inherit font-size/weight from their context. The edit-mode pill now scales with its surroundings; preview + PDF render clean inherited text at the title's size.

### Testing
- 27/27 mention/RTE unit tests pass. CSS-only, class names unchanged.
- ⚠️ Manual visual check still owed: mention inside a title in edit / preview / **PDF download**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
