### PR TITLE
fix(quotes): display quote currency when updating pricing

### DIFF
--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
@@ -42,6 +42,7 @@ interface SubscriptionPricingContentProps {
   initialState?: SubscriptionPricingState | null
   quoteDates?: { startDate?: string; endDate?: string }
   customer?: QuoteCustomer | null
+  currency?: CurrencyEnum | null
   billingItemPlan?: BillingItemPlan
   subscriptionId?: string
 }
@@ -52,6 +53,7 @@ export function SubscriptionPricingContent({
   initialState,
   quoteDates,
   customer,
+  currency,
   billingItemPlan,
   subscriptionId,
 }: Readonly<SubscriptionPricingContentProps>) {
@@ -145,13 +147,12 @@ export function SubscriptionPricingContent({
   const formName = useStore(planForm.store, (s) => s.values.name)
   const formDescription = useStore(planForm.store, (s) => s.values.description)
   const formCode = useStore(planForm.store, (s) => s.values.code)
-  const formCurrency = useStore(planForm.store, (s) => s.values.amountCurrency)
   const formInterval = useStore(planForm.store, (s) => s.values.interval)
   // Full form values — snapshot into formValuesRef so the serializer can derive
   // both the plan payload and the overrides from a single source of truth.
   const formValues = useStore(planForm.store, (s) => s.values)
 
-  const displayCurrency = (formCurrency as CurrencyEnum) || CurrencyEnum.Usd
+  const displayCurrency = currency ?? CurrencyEnum.Usd
   const displayInterval = formInterval || PlanInterval.Monthly
 
   // Sync to stateRef + formValuesRef. Overrides are no longer computed here:

--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -115,8 +115,12 @@ const EditQuote = () => {
     onDatesChange: handleSubscriptionDatesChange,
     customer: quote?.customer,
     subscriptionId: quote?.subscription?.id,
+    currency: quote?.currentVersion?.currency as CurrencyEnum | undefined,
   })
-  const oneOffPricing = useOneOffPricingDrawer(quote?.currentVersion?.billingItems)
+  const oneOffPricing = useOneOffPricingDrawer(
+    quote?.currentVersion?.billingItems,
+    quote?.currentVersion?.currency as CurrencyEnum | undefined,
+  )
 
   const { onPricingCommand, isPricingDisabled, entities, syncEntitiesWithBlocks } =
     isSubscriptionOrder ? subscriptionPricing : oneOffPricing

--- a/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
@@ -39,7 +39,7 @@ export interface UseOneOffPricingDrawerReturn {
 
 export const useOneOffPricingDrawer = (
   initialBillingItems?: unknown,
-  customerCurrency?: CurrencyEnum | null,
+  quoteCurrency?: CurrencyEnum | null,
 ): UseOneOffPricingDrawerReturn => {
   const { translate } = useInternationalization()
   const { organization } = useOrganizationInfos()
@@ -220,7 +220,7 @@ export const useOneOffPricingDrawer = (
         return
       }
 
-      const currency = customerCurrency ?? organization?.defaultCurrency ?? CurrencyEnum.Usd
+      const currency = quoteCurrency ?? organization?.defaultCurrency ?? CurrencyEnum.Usd
 
       onSaveRef.current = onSave
 

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -15,6 +15,7 @@ import {
   type SubscriptionPricingState,
   toPlanBillingItems,
 } from '~/core/serializers/serializeQuotePlanBillingItems'
+import { CurrencyEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 interface UseSubscriptionPricingDrawerReturn {
@@ -35,6 +36,7 @@ export interface SubscriptionPricingDrawerOptions {
   onDatesChange?: (startDate?: string, endDate?: string) => void
   customer?: QuoteCustomer | null
   subscriptionId?: string
+  currency?: CurrencyEnum | null
 }
 
 export const useSubscriptionPricingDrawer = (
@@ -155,6 +157,7 @@ export const useSubscriptionPricingDrawer = (
             initialState={initialStateRef.current}
             quoteDates={options?.quoteDates}
             customer={options?.customer}
+            currency={options?.currency}
             billingItemPlan={billingItemPlan}
             subscriptionId={billingItemPlan ? undefined : options?.subscriptionId}
           />


### PR DESCRIPTION
## LAGO-1683 — Display quote currency when updating pricing

### Problem
The Quotes RTE pricing forms showed the wrong currency for amount inputs/formatting: the subscription form used the plan's `amountCurrency`, and the one-off add-on form fell back to the org default — instead of the quote's own currency.

### Change (display-only)
Thread `quote.currentVersion.currency` into both flows:
- **Subscription:** new `currency` option on `useSubscriptionPricingDrawer`, forwarded as a prop to `SubscriptionPricingContent`, which now derives `displayCurrency = currency ?? USD` (removed the old plan-`amountCurrency` source).
- **One-off:** `EditQuote` passes the quote currency to `useOneOffPricingDrawer` (param renamed `customerCurrency` → `quoteCurrency`).
- `QuoteVersion.currency` is generated as `Maybe<String>`, so it's cast `as CurrencyEnum` at the `EditQuote` call sites, matching the existing idiom in `EditQuoteAside.tsx`.

No values or currency selection/locking change.

### Testing
- `tsc` clean; `SubscriptionPricingContent` 12/12; `AddOnSelectionContent`/`PricingDrawerContent`/`EditQuote` 115/115.
- ⚠️ Manual visual check still owed: cross-currency quote shows the quote currency in subscription + one-off amount inputs.

### Note (out of scope)
The discount drawer in `EditQuote` still uses the *customer's* currency (`:128`) while pricing now uses the *quote's* — possible follow-up if consistency is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
