### PR TITLE
fix(order-forms): redirect to Orders tab after signing

### DIFF
--- a/src/pages/quotes/SignOrderForm.tsx
+++ b/src/pages/quotes/SignOrderForm.tsx
@@ -132,7 +132,7 @@ const SignOrderForm = () => {
         navigate(
           generatePath(QUOTE_DETAILS_ROUTE, {
             quoteId,
-            tab: QuoteDetailsTabsOptionsEnum.orderForms,
+            tab: QuoteDetailsTabsOptionsEnum.orders,
           }),
         )
       }

--- a/src/pages/quotes/__tests__/SignOrderForm.test.tsx
+++ b/src/pages/quotes/__tests__/SignOrderForm.test.tsx
@@ -178,7 +178,7 @@ describe('SignOrderForm', () => {
     await waitFor(() => {
       expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
     })
-    expect(testMockNavigateFn).toHaveBeenCalledWith('/quote/quote-456/order-forms')
+    expect(testMockNavigateFn).toHaveBeenCalledWith('/quote/quote-456/orders')
   })
 
   it('signs without an execution date (executeAt is optional)', async () => {
@@ -216,7 +216,7 @@ describe('SignOrderForm', () => {
     })
 
     await waitFor(() => {
-      expect(testMockNavigateFn).toHaveBeenCalledWith('/quote/quote-456/order-forms')
+      expect(testMockNavigateFn).toHaveBeenCalledWith('/quote/quote-456/orders')
     })
   })
 


### PR DESCRIPTION
## LAGO-1684 — Redirect to Orders tab after signing

### Problem
After signing an order form, the user landed on the Quote details **Order Forms** tab. The resulting order appears in the **Orders** tab.

### Change
- `SignOrderForm.tsx`: switch the post-sign navigation target from `QuoteDetailsTabsOptionsEnum.orderForms` to `.orders`. Success toast unchanged.
- (FE-only: the sign mutation returns no order id and there's no order-details page, so we land on the Orders list where the signed order shows.)

### Testing
- TDD: updated the two navigation assertions first (RED), then flipped the source (GREEN). `SignOrderForm` 16/16 pass; `tsc` + scoped lint clean.
- ⚠️ Manual visual check still owed: signing lands on the Orders tab with the order present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
