### PR TITLE
fix(quotes): serialize pricing amounts as cents

### DIFF
--- a/src/components/designSystem/RichTextEditor/PricingBlock/OneOffAddOnsPreviewTable.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/OneOffAddOnsPreviewTable.tsx
@@ -85,10 +85,12 @@ export const OneOffAddOnsPreviewTable = ({
       textAlign: 'right',
       content: (entity) => (
         <Typography variant="body" color="grey700">
-          {intlFormatNumber(Number.parseFloat(entity.totalAmount ?? '0'), {
-            currency,
-            locale,
-          })}
+          {entity.totalAmount
+            ? intlFormatNumber(Number.parseFloat(entity.totalAmount), {
+                currency,
+                locale,
+              })
+            : '-'}
         </Typography>
       ),
     },

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/OneOffAddOnsPreviewTable.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/OneOffAddOnsPreviewTable.test.tsx
@@ -207,7 +207,7 @@ describe('OneOffAddOnsPreviewTable', () => {
     })
 
     describe('WHEN totalAmount is null', () => {
-      it('THEN should fall back to 0 and render the entity row', () => {
+      it('THEN should render a dash placeholder and still render the entity row', () => {
         const entity = createEntity({ totalAmount: undefined })
 
         render(<OneOffAddOnsPreviewTable {...defaultProps} entities={[entity]} />)
@@ -215,6 +215,20 @@ describe('OneOffAddOnsPreviewTable', () => {
         const rows = screen.getAllByTestId(/^preview-table-one-off-addons-preview-row-/)
 
         expect(rows).toHaveLength(1)
+        expect(screen.getByText('-')).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN totalAmount is empty (no currency available to deserialize)', () => {
+      it('THEN should render a dash placeholder instead of a NaN-formatted value', () => {
+        const entity = createEntity({ totalAmount: '' })
+
+        render(<OneOffAddOnsPreviewTable {...defaultProps} entities={[entity]} />)
+
+        const rows = screen.getAllByTestId(/^preview-table-one-off-addons-preview-row-/)
+
+        expect(rows).toHaveLength(1)
+        expect(screen.getByText('-')).toBeInTheDocument()
       })
     })
   })

--- a/src/core/serializers/__tests__/fixtures.test.ts
+++ b/src/core/serializers/__tests__/fixtures.test.ts
@@ -15,9 +15,9 @@ describe('billing items fixtures', () => {
       expect(item.code).toBe('setup_fee')
       expect(item.name).toBe('Setup Fee')
       expect(item.description).toBe('One-time onboarding and setup')
-      // override wins over baseline payload
-      expect(item.unitAmountCents).toBe('45000')
-      expect(item.totalAmount).toBe('45000')
+      // override wins over baseline payload; cents are deserialized to units for the form
+      expect(item.unitAmountCents).toBe('450')
+      expect(item.totalAmount).toBe('450')
 
       // original (pre-override) payload is preserved, keyed by localId
       const original = originalPayloads['a1b2c3d4-e5f6-0000-1111-222233334444']

--- a/src/core/serializers/__tests__/fixtures.test.ts
+++ b/src/core/serializers/__tests__/fixtures.test.ts
@@ -1,3 +1,5 @@
+import { CurrencyEnum } from '~/generated/graphql'
+
 import { addOnBillingItemsFixture, planBillingItemsFixture } from './fixtures'
 
 import { fromBillingItems } from '../serializeQuoteBillingItems'
@@ -6,7 +8,10 @@ import { fromPlanBillingItems } from '../serializeQuotePlanBillingItems'
 describe('billing items fixtures', () => {
   describe('addOnBillingItemsFixture', () => {
     it('deserializes the add-on payload (code/name/description) and applies overrides', () => {
-      const { addOnItems, originalPayloads } = fromBillingItems(addOnBillingItemsFixture)
+      const { addOnItems, originalPayloads } = fromBillingItems(
+        addOnBillingItemsFixture,
+        CurrencyEnum.Usd,
+      )
 
       expect(addOnItems).toHaveLength(1)
 

--- a/src/core/serializers/__tests__/serializeQuoteBillingItems.test.ts
+++ b/src/core/serializers/__tests__/serializeQuoteBillingItems.test.ts
@@ -207,7 +207,7 @@ describe('fromBillingItems', () => {
   })
 
   it('reconstructs entities keyed by localId from payload with no overrides', () => {
-    const result = fromBillingItems(makeBillingItems())
+    const result = fromBillingItems(makeBillingItems(), CurrencyEnum.Usd)
 
     const localId = result.addOnItems[0].localId
 
@@ -258,7 +258,7 @@ describe('fromBillingItems', () => {
       ],
     }
 
-    const result = fromBillingItems(billingItems)
+    const result = fromBillingItems(billingItems, CurrencyEnum.Usd)
 
     const localId = result.addOnItems[0].localId
 
@@ -271,7 +271,7 @@ describe('fromBillingItems', () => {
   })
 
   it('reconstructs addOnItems with localId and addOnId for form state', () => {
-    const result = fromBillingItems(makeBillingItems())
+    const result = fromBillingItems(makeBillingItems(), CurrencyEnum.Usd)
 
     expect(result.addOnItems).toEqual([
       {
@@ -616,6 +616,27 @@ describe('add-on amount cents conversion', () => {
     expect(result.addOnItems[0].totalAmount).toBe('500')
     expect(result.entities['local-1'].unitAmountCents).toBe('500')
     expect(result.entities['local-1'].totalAmount).toBe('500')
+  })
+
+  it('leaves amounts empty when no currency is provided (no default-USD scaling)', () => {
+    const billingItems: BillingItemsPayload = {
+      addons: [
+        {
+          type: 'addon',
+          id: 'addon-1',
+          localId: 'local-1',
+          payload: makeCentsPayload(),
+          overrides: {},
+        },
+      ],
+    }
+
+    const result = fromBillingItems(billingItems)
+
+    expect(result.addOnItems[0].unitAmountCents).toBe('')
+    expect(result.addOnItems[0].totalAmount).toBe('')
+    expect(result.entities['local-1'].unitAmountCents).toBe('')
+    expect(result.entities['local-1'].totalAmount).toBe('')
   })
 
   it('round-trips units → cents → units', () => {

--- a/src/core/serializers/__tests__/serializeQuoteBillingItems.test.ts
+++ b/src/core/serializers/__tests__/serializeQuoteBillingItems.test.ts
@@ -1,4 +1,5 @@
 import type { AddOnItem } from '~/components/designSystem/RichTextEditor/PricingBlock/constants'
+import { CurrencyEnum } from '~/generated/graphql'
 
 import {
   type AddOnPayload,
@@ -24,6 +25,7 @@ describe('toBillingItems', () => {
     ...overrides,
   })
 
+  // Form fields hold currency units ($500), the payload holds cents (50000).
   const makeAddOnItem = (overrides: Partial<AddOnItem> = {}): AddOnItem => ({
     localId: 'local-1',
     addOnId: 'addon-1',
@@ -32,8 +34,8 @@ describe('toBillingItems', () => {
     code: 'setup',
     description: 'One-time setup',
     units: '1',
-    unitAmountCents: '50000',
-    totalAmount: '50000',
+    unitAmountCents: '500',
+    totalAmount: '500',
     fromDatetime: '',
     toDatetime: '',
     ...overrides,
@@ -63,8 +65,8 @@ describe('toBillingItems', () => {
       makeAddOnItem({
         invoiceDisplayName: 'Custom Name',
         units: '3',
-        unitAmountCents: '60000',
-        totalAmount: '180000',
+        unitAmountCents: '600',
+        totalAmount: '1800',
         description: 'Custom desc',
         fromDatetime: '2026-04-01',
         toDatetime: '2026-06-30',
@@ -101,9 +103,9 @@ describe('toBillingItems', () => {
     expect(result.addons[1].payload.position).toBe(2)
   })
 
-  it('converts string form values to numbers', () => {
+  it('converts string form values (currency units) to cents numbers', () => {
     const items: AddOnItem[] = [
-      makeAddOnItem({ units: '5', unitAmountCents: '10000', totalAmount: '50001' }),
+      makeAddOnItem({ units: '5', unitAmountCents: '100', totalAmount: '500.01' }),
     ]
     const payloads: Record<string, AddOnPayload> = { 'local-1': makePayload() }
 
@@ -218,8 +220,8 @@ describe('fromBillingItems', () => {
       code: 'setup',
       description: 'One-time setup',
       units: '1',
-      unitAmountCents: '50000',
-      totalAmount: '50000',
+      unitAmountCents: '500',
+      totalAmount: '500',
       fromDatetime: '',
       toDatetime: '',
     })
@@ -262,8 +264,8 @@ describe('fromBillingItems', () => {
 
     expect(result.entities[localId].invoiceDisplayName).toBe('Custom Name')
     expect(result.entities[localId].units).toBe('3')
-    expect(result.entities[localId].unitAmountCents).toBe('60000')
-    expect(result.entities[localId].totalAmount).toBe('180000')
+    expect(result.entities[localId].unitAmountCents).toBe('600')
+    expect(result.entities[localId].totalAmount).toBe('1800')
     expect(result.entities[localId].fromDatetime).toBe('2026-04-01')
     expect(result.entities[localId].toDatetime).toBe('2026-06-30')
   })
@@ -280,8 +282,8 @@ describe('fromBillingItems', () => {
         code: 'setup',
         description: 'One-time setup',
         units: '1',
-        unitAmountCents: '50000',
-        totalAmount: '50000',
+        unitAmountCents: '500',
+        totalAmount: '500',
         fromDatetime: '',
         toDatetime: '',
       },
@@ -522,5 +524,115 @@ describe('buildPreviewEntities', () => {
     expect(entities['plan-1']).toBeDefined()
     expect(entities['plan-1'].entityType).toBe('plan')
     expect(entities['plan-1'].plan?.rows.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Amount serialization: form holds currency units, payload holds cents
+// ---------------------------------------------------------------------------
+
+describe('add-on amount cents conversion', () => {
+  // Catalog baseline stored in cents: $500 → 50000
+  const makeCentsPayload = (overrides: Partial<AddOnPayload> = {}): AddOnPayload => ({
+    position: 1,
+    code: 'setup',
+    name: 'Setup Fee',
+    description: 'One-time setup',
+    units: 1,
+    unit_amount_cents: 50000,
+    total_amount_cents: 50000,
+    invoice_display_name: 'Setup Fee',
+    from_datetime: null,
+    to_datetime: null,
+    tax_codes: [],
+    ...overrides,
+  })
+
+  // Form fields hold currency units: $500 → "500"
+  const makeUnitsItem = (overrides: Partial<AddOnItem> = {}): AddOnItem => ({
+    localId: 'local-1',
+    addOnId: 'addon-1',
+    name: 'Setup Fee',
+    invoiceDisplayName: 'Setup Fee',
+    code: 'setup',
+    description: 'One-time setup',
+    units: '1',
+    unitAmountCents: '500',
+    totalAmount: '500',
+    fromDatetime: '',
+    toDatetime: '',
+    ...overrides,
+  })
+
+  it('serializes currency-unit form amounts into cents overrides', () => {
+    const items: AddOnItem[] = [
+      makeUnitsItem({ units: '3', unitAmountCents: '600', totalAmount: '1800' }),
+    ]
+    const payloads: Record<string, AddOnPayload> = { 'local-1': makeCentsPayload() }
+
+    const result = toBillingItems(items, payloads, CurrencyEnum.Usd)
+
+    expect(result.addons[0].overrides.unit_amount_cents).toBe(60000)
+    expect(result.addons[0].overrides.total_amount_cents).toBe(180000)
+  })
+
+  it('emits no amount override when the unit-value form input equals the cents baseline', () => {
+    const items: AddOnItem[] = [makeUnitsItem()]
+    const payloads: Record<string, AddOnPayload> = { 'local-1': makeCentsPayload() }
+
+    const result = toBillingItems(items, payloads, CurrencyEnum.Usd)
+
+    expect(result.addons[0].overrides).toEqual({})
+  })
+
+  it('respects zero-decimal currency precision (no ×100)', () => {
+    // JPY has 0 decimals: form "600" → 600 cents (unchanged)
+    const items: AddOnItem[] = [makeUnitsItem({ unitAmountCents: '600', totalAmount: '600' })]
+    const payloads: Record<string, AddOnPayload> = {
+      'local-1': makeCentsPayload({ unit_amount_cents: 500, total_amount_cents: 500 }),
+    }
+
+    const result = toBillingItems(items, payloads, CurrencyEnum.Jpy)
+
+    expect(result.addons[0].overrides.unit_amount_cents).toBe(600)
+  })
+
+  it('deserializes cents payload back into currency units for form and preview', () => {
+    const billingItems: BillingItemsPayload = {
+      addons: [
+        {
+          type: 'addon',
+          id: 'addon-1',
+          localId: 'local-1',
+          payload: makeCentsPayload(),
+          overrides: {},
+        },
+      ],
+    }
+
+    const result = fromBillingItems(billingItems, CurrencyEnum.Usd)
+
+    expect(result.addOnItems[0].unitAmountCents).toBe('500')
+    expect(result.addOnItems[0].totalAmount).toBe('500')
+    expect(result.entities['local-1'].unitAmountCents).toBe('500')
+    expect(result.entities['local-1'].totalAmount).toBe('500')
+  })
+
+  it('round-trips units → cents → units', () => {
+    const items: AddOnItem[] = [
+      makeUnitsItem({
+        localId: 'local-1',
+        units: '2',
+        unitAmountCents: '600',
+        totalAmount: '1200',
+      }),
+    ]
+    const payloads: Record<string, AddOnPayload> = { 'local-1': makeCentsPayload() }
+
+    const serialized = toBillingItems(items, payloads, CurrencyEnum.Usd)
+    const deserialized = fromBillingItems(serialized, CurrencyEnum.Usd)
+
+    expect(deserialized.addOnItems[0].unitAmountCents).toBe('600')
+    expect(deserialized.addOnItems[0].totalAmount).toBe('1200')
   })
 })

--- a/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
+++ b/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
@@ -98,12 +98,13 @@ describe('toPlanBillingItems', () => {
     expect(result.plans[0].payload.invoice_custom_footer).toBeNull()
     // New plan config fields from formValues
     expect(result.plans[0].payload.interval).toBe(PlanInterval.Monthly)
-    expect(result.plans[0].payload.amount_cents).toBe('850.00')
+    // $850.00 (form units) is serialized to cents for the payload/overrides.
+    expect(result.plans[0].payload.amount_cents).toBe('85000')
     expect(result.plans[0].payload.amount_currency).toBe(CurrencyEnum.Usd)
     expect(result.plans[0].payload.charges).toEqual([])
     // Overrides are derived from the form values: the subscription fee amount is
     // always carried over (no charges/commitment/thresholds in baseFormValues).
-    expect(result.plans[0].overrides).toEqual({ amount_cents: 850 })
+    expect(result.plans[0].overrides).toEqual({ amount_cents: 85000 })
   })
 
   it('includes subscription settings in the payload', () => {
@@ -150,9 +151,10 @@ describe('toPlanBillingItems', () => {
     }
     const result = toPlanBillingItems(basePricingState, formValues)
 
+    // Form amounts ($850.00 fee, $80,000 commitment) are serialized to cents.
     expect(result.plans[0].overrides).toEqual({
-      amount_cents: 850,
-      minimum_commitment: { amount_cents: 80000, invoice_display_name: undefined },
+      amount_cents: 85000,
+      minimum_commitment: { amount_cents: 8000000, invoice_display_name: undefined },
     })
   })
 
@@ -193,7 +195,8 @@ describe('buildPlanOverrides', () => {
   it('carries over the subscription fee amount', () => {
     const result = buildPlanOverrides({ ...baseFormValues, amountCents: '850.00' })
 
-    expect(result.amount_cents).toBe(850)
+    // $850.00 → 85000 cents
+    expect(result.amount_cents).toBe(85000)
   })
 
   it('omits amount_cents when the fee is zero or empty', () => {
@@ -247,7 +250,7 @@ describe('buildPlanOverrides', () => {
     })
 
     expect(positive.minimum_commitment).toEqual({
-      amount_cents: 5000,
+      amount_cents: 500000,
       invoice_display_name: 'Annual minimum',
     })
 
@@ -277,9 +280,10 @@ describe('buildPlanOverrides', () => {
       },
     })
 
+    // Threshold form amounts ($10,000 and $50,000 units) → cents
     expect(result.usage_thresholds).toEqual([
-      { amount_cents: 10000, recurring: false, threshold_display_name: 'Tier 1' },
-      { amount_cents: 50000, recurring: true, threshold_display_name: 'Monthly cap' },
+      { amount_cents: 1000000, recurring: false, threshold_display_name: 'Tier 1' },
+      { amount_cents: 5000000, recurring: true, threshold_display_name: 'Monthly cap' },
     ])
   })
 })
@@ -426,7 +430,8 @@ describe('round-trip: toPlanBillingItems → fromPlanBillingItems', () => {
     expect(deserialized.planId).toBe('plan_123')
     expect(deserialized.formValues).not.toBeNull()
     expect(deserialized.formValues?.interval).toBe(PlanInterval.Monthly)
-    expect(deserialized.formValues?.amountCents).toBe('850.00')
+    // Round-trips through cents: '850.00' → 85000 → deserialize → '850'
+    expect(deserialized.formValues?.amountCents).toBe('850')
     expect(deserialized.formValues?.amountCurrency).toBe(CurrencyEnum.Usd)
     expect(deserialized.formValues?.charges).toHaveLength(1)
 
@@ -596,7 +601,8 @@ describe('round-trip: toPlanBillingItems → fromPlanBillingItems', () => {
     expect(result.entityData['plan-1'].plan?.rows[0]).toMatchObject({
       kind: 'main',
       rowType: 'subscriptionFee',
-      price: { type: 'displayAmount', amount: '13050' },
+      // payload cents '13050' → deserialized to currency units '130.5' for display
+      price: { type: 'displayAmount', amount: '130.5' },
     })
   })
 
@@ -625,5 +631,101 @@ describe('round-trip: toPlanBillingItems → fromPlanBillingItems', () => {
     const result = fromPlanBillingItems(plans)
 
     expect(result.entityData['plan-legacy'].plan).toEqual({ rows: [] })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Amount serialization: form holds currency units, payload holds cents
+// ---------------------------------------------------------------------------
+
+describe('plan amount cents conversion', () => {
+  it('serializes the subscription fee from currency units to cents (buildPlanOverrides)', () => {
+    const result = buildPlanOverrides({
+      ...baseFormValues,
+      amountCents: '850.00',
+      amountCurrency: CurrencyEnum.Usd,
+    })
+
+    expect(result.amount_cents).toBe(85000)
+  })
+
+  it('serializes minimum commitment and usage thresholds to cents', () => {
+    const result = buildPlanOverrides({
+      ...baseFormValues,
+      amountCents: '0',
+      amountCurrency: CurrencyEnum.Usd,
+      minimumCommitment: {
+        amountCents: '5000',
+        commitmentType: CommitmentTypeEnum.MinimumCommitment,
+      },
+      nonRecurringUsageThresholds: [
+        { amountCents: 100, thresholdDisplayName: 'Tier 1', recurring: false },
+      ],
+      recurringUsageThreshold: {
+        amountCents: 500,
+        thresholdDisplayName: 'Cap',
+        recurring: true,
+      },
+    })
+
+    expect(result.minimum_commitment?.amount_cents).toBe(500000)
+    expect(result.usage_thresholds).toEqual([
+      { amount_cents: 10000, recurring: false, threshold_display_name: 'Tier 1' },
+      { amount_cents: 50000, recurring: true, threshold_display_name: 'Cap' },
+    ])
+  })
+
+  it('serializes the subscription fee to cents in the payload', () => {
+    const result = toPlanBillingItems(basePricingState, {
+      ...baseFormValues,
+      amountCents: '850.00',
+      amountCurrency: CurrencyEnum.Usd,
+    })
+
+    expect(result.plans[0].payload.amount_cents).toBe('85000')
+  })
+
+  it('respects zero-decimal currency (JPY) precision — no ×100', () => {
+    const result = buildPlanOverrides({
+      ...baseFormValues,
+      amountCents: '850',
+      amountCurrency: CurrencyEnum.Jpy,
+    })
+
+    expect(result.amount_cents).toBe(850)
+  })
+
+  it('deserializes payload cents back into currency units on read', () => {
+    const plan: BillingItemPlan = {
+      type: 'plan',
+      id: 'plan_123',
+      overrides: {},
+      payload: {
+        ...baseBillingItemPlan.payload,
+        interval: PlanInterval.Monthly,
+        amount_cents: '85000',
+        amount_currency: 'USD',
+        pay_in_advance: false,
+        charges: [],
+        fixed_charges: [],
+        minimum_commitment: null,
+      },
+    } as unknown as BillingItemPlan
+
+    const result = fromPlanBillingItems([plan])
+
+    expect(result.formValues?.amountCents).toBe('850')
+  })
+
+  it('round-trips subscription fee units → cents → units', () => {
+    const serialized = toPlanBillingItems(basePricingState, {
+      ...baseFormValues,
+      amountCents: '850.00',
+      amountCurrency: CurrencyEnum.Usd,
+      charges: [],
+    })
+    const deserialized = fromPlanBillingItems(serialized.plans)
+
+    expect(deserialized.formValues?.amountCents).toBe('850')
   })
 })

--- a/src/core/serializers/serializeQuoteBillingItems.ts
+++ b/src/core/serializers/serializeQuoteBillingItems.ts
@@ -110,7 +110,7 @@ interface FromBillingItemsResult {
 
 export const fromBillingItems = (
   billingItems: BillingItemsPayload,
-  currency: CurrencyEnum = CurrencyEnum.Usd,
+  currency?: CurrencyEnum,
 ): FromBillingItemsResult => {
   const entities: Record<string, EntityData> = {}
   const addOnItems: AddOnItem[] = []
@@ -136,9 +136,15 @@ export const fromBillingItems = (
       to_datetime: overrides.to_datetime ?? payload.to_datetime,
     }
 
-    // Payload stores cents; the form and preview expect currency units.
-    const unitAmountCents = String(deserializeAmount(effective.unit_amount_cents, currency))
-    const totalAmount = String(deserializeAmount(effective.total_amount_cents, currency))
+    // Payload stores cents; the form and preview expect currency units. With no
+    // currency we can't know the decimal precision, so we leave the amounts empty
+    // rather than fabricate a wrong-scaled value under a default currency.
+    const unitAmountCents = currency
+      ? String(deserializeAmount(effective.unit_amount_cents, currency))
+      : ''
+    const totalAmount = currency
+      ? String(deserializeAmount(effective.total_amount_cents, currency))
+      : ''
 
     entities[localId] = {
       entityId: localId,
@@ -186,7 +192,7 @@ export const fromBillingItems = (
  */
 export const buildPreviewEntities = (
   billingItems: BillingItemsPayload,
-  currency: CurrencyEnum = CurrencyEnum.Usd,
+  currency?: CurrencyEnum,
 ): Record<string, EntityData> => {
   const { entities, addOnItems } = fromBillingItems(billingItems, currency)
   const previewEntities: Record<string, EntityData> = { ...entities }

--- a/src/core/serializers/serializeQuoteBillingItems.ts
+++ b/src/core/serializers/serializeQuoteBillingItems.ts
@@ -1,6 +1,8 @@
 import type { EntityData } from '~/components/designSystem/RichTextEditor/common/RichTextEditorContext'
 import type { AddOnItem } from '~/components/designSystem/RichTextEditor/PricingBlock/constants'
+import { CurrencyEnum } from '~/generated/graphql'
 
+import { deserializeAmount, serializeAmount } from './serializeAmount'
 import { type BillingItemCoupon, fromCoupons } from './serializeQuoteCoupons'
 import { type BillingItemPlan, fromPlanBillingItems } from './serializeQuotePlanBillingItems'
 
@@ -50,6 +52,7 @@ const normalizeDateTime = (value: string): string | null => (value === '' ? null
 export const toBillingItems = (
   addOnItems: AddOnItem[],
   originalPayloads: Record<string, AddOnPayload>,
+  currency: CurrencyEnum = CurrencyEnum.Usd,
 ): Required<Pick<BillingItemsPayload, 'addons'>> => {
   const addons: BillingItemAddon[] = addOnItems.map((item, index) => {
     const original = originalPayloads[item.localId] ?? originalPayloads[item.addOnId]
@@ -57,10 +60,12 @@ export const toBillingItems = (
 
     const overrides: Partial<OverridableFields> = {}
 
-    // Compare each overridable field
+    // Compare each overridable field. The form holds amounts in currency units
+    // (e.g. "10" for $10); the payload/overrides store cents per the backend
+    // contract, so convert with the quote currency before diffing.
     const formUnits = Number(item.units)
-    const formUnitAmountCents = Number(item.unitAmountCents)
-    const formTotalAmountCents = Number(item.totalAmount)
+    const formUnitAmountCents = serializeAmount(item.unitAmountCents, currency)
+    const formTotalAmountCents = serializeAmount(item.totalAmount, currency)
     const formFromDatetime = normalizeDateTime(item.fromDatetime)
     const formToDatetime = normalizeDateTime(item.toDatetime)
 
@@ -103,7 +108,10 @@ interface FromBillingItemsResult {
   originalPayloads: Record<string, AddOnPayload>
 }
 
-export const fromBillingItems = (billingItems: BillingItemsPayload): FromBillingItemsResult => {
+export const fromBillingItems = (
+  billingItems: BillingItemsPayload,
+  currency: CurrencyEnum = CurrencyEnum.Usd,
+): FromBillingItemsResult => {
   const entities: Record<string, EntityData> = {}
   const addOnItems: AddOnItem[] = []
   const originalPayloads: Record<string, AddOnPayload> = {}
@@ -128,6 +136,10 @@ export const fromBillingItems = (billingItems: BillingItemsPayload): FromBilling
       to_datetime: overrides.to_datetime ?? payload.to_datetime,
     }
 
+    // Payload stores cents; the form and preview expect currency units.
+    const unitAmountCents = String(deserializeAmount(effective.unit_amount_cents, currency))
+    const totalAmount = String(deserializeAmount(effective.total_amount_cents, currency))
+
     entities[localId] = {
       entityId: localId,
       entityType: 'addOn',
@@ -136,8 +148,8 @@ export const fromBillingItems = (billingItems: BillingItemsPayload): FromBilling
       code: payload.code,
       description: effective.description,
       units: String(effective.units),
-      unitAmountCents: String(effective.unit_amount_cents),
-      totalAmount: String(effective.total_amount_cents),
+      unitAmountCents,
+      totalAmount,
       fromDatetime: effective.from_datetime ?? '',
       toDatetime: effective.to_datetime ?? '',
     }
@@ -150,8 +162,8 @@ export const fromBillingItems = (billingItems: BillingItemsPayload): FromBilling
       code: payload.code,
       description: effective.description,
       units: String(effective.units),
-      unitAmountCents: String(effective.unit_amount_cents),
-      totalAmount: String(effective.total_amount_cents),
+      unitAmountCents,
+      totalAmount,
       fromDatetime: effective.from_datetime ?? '',
       toDatetime: effective.to_datetime ?? '',
     })
@@ -174,8 +186,9 @@ export const fromBillingItems = (billingItems: BillingItemsPayload): FromBilling
  */
 export const buildPreviewEntities = (
   billingItems: BillingItemsPayload,
+  currency: CurrencyEnum = CurrencyEnum.Usd,
 ): Record<string, EntityData> => {
-  const { entities, addOnItems } = fromBillingItems(billingItems)
+  const { entities, addOnItems } = fromBillingItems(billingItems, currency)
   const previewEntities: Record<string, EntityData> = { ...entities }
 
   for (const item of addOnItems) {

--- a/src/core/serializers/serializeQuotePlanBillingItems.ts
+++ b/src/core/serializers/serializeQuotePlanBillingItems.ts
@@ -4,9 +4,10 @@ import type {
   LocalUsageChargeInput,
   PlanFormInput,
 } from '~/components/plans/types'
-import { CommitmentTypeEnum } from '~/generated/graphql'
+import { CommitmentTypeEnum, CurrencyEnum } from '~/generated/graphql'
 
 import { buildPlanPreviewData } from './buildPlanPreviewData'
+import { deserializeAmount, serializeAmount } from './serializeAmount'
 
 // Re-export so consumers can import PlanFormInput from this serializer module.
 export type { PlanFormInput }
@@ -285,8 +286,14 @@ const serializeFixedCharge = (charge: LocalFixedChargeInput): SerializedFixedCha
 export const buildPlanOverrides = (formValues: PlanFormInput): PlanOverrides => {
   const overrides: PlanOverrides = {}
 
+  // Form amounts are in currency units (e.g. "10" for $10); the backend
+  // contract expects cents. Convert with the plan currency before writing.
+  const currency = (formValues.amountCurrency as CurrencyEnum) ?? CurrencyEnum.Usd
+
   // Subscription fee
-  overrides.amount_cents = Number(formValues.amountCents) || undefined
+  overrides.amount_cents = Number(formValues.amountCents)
+    ? serializeAmount(formValues.amountCents, currency)
+    : undefined
   if (formValues.invoiceDisplayName) {
     overrides.invoice_display_name = formValues.invoiceDisplayName || undefined
   }
@@ -319,7 +326,7 @@ export const buildPlanOverrides = (formValues: PlanFormInput): PlanOverrides => 
 
   if (mcAmount && !Number.isNaN(Number(mcAmount)) && Number(mcAmount) > 0) {
     overrides.minimum_commitment = {
-      amount_cents: Number(mcAmount),
+      amount_cents: serializeAmount(mcAmount, currency),
       invoice_display_name: formValues.minimumCommitment?.invoiceDisplayName || undefined,
     }
   }
@@ -327,14 +334,14 @@ export const buildPlanOverrides = (formValues: PlanFormInput): PlanOverrides => 
   // Progressive billing (usage thresholds)
   const thresholds = [
     ...(formValues.nonRecurringUsageThresholds ?? []).map((t) => ({
-      amount_cents: Number(t.amountCents),
+      amount_cents: serializeAmount(t.amountCents, currency),
       recurring: false as const,
       threshold_display_name: t.thresholdDisplayName ?? undefined,
     })),
     ...(formValues.recurringUsageThreshold
       ? [
           {
-            amount_cents: Number(formValues.recurringUsageThreshold.amountCents),
+            amount_cents: serializeAmount(formValues.recurringUsageThreshold.amountCents, currency),
             recurring: true as const,
             threshold_display_name:
               formValues.recurringUsageThreshold.thresholdDisplayName ?? undefined,
@@ -376,8 +383,15 @@ export const toPlanBillingItems = (
   }
 
   if (formValues) {
+    const currency = (formValues.amountCurrency as CurrencyEnum) ?? CurrencyEnum.Usd
+    // Form amounts are currency units; persist cents per the backend contract.
+    const toCentsString = (value: string | number | null | undefined): string =>
+      value === '' || value === null || value === undefined
+        ? ''
+        : String(serializeAmount(value, currency))
+
     payload.interval = formValues.interval
-    payload.amount_cents = String(formValues.amountCents ?? '')
+    payload.amount_cents = toCentsString(formValues.amountCents)
     payload.amount_currency = formValues.amountCurrency
     payload.pay_in_advance = formValues.payInAdvance ?? false
     payload.bill_charges_monthly = formValues.billChargesMonthly ?? null
@@ -391,7 +405,7 @@ export const toPlanBillingItems = (
     payload.minimum_commitment = formValues.minimumCommitment
       ? {
           id: formValues.minimumCommitment.id ?? undefined,
-          amount_cents: String(formValues.minimumCommitment.amountCents ?? ''),
+          amount_cents: toCentsString(formValues.minimumCommitment.amountCents),
           invoice_display_name:
             (formValues.minimumCommitment.invoiceDisplayName as string | null) ?? null,
           commitment_type: String(
@@ -404,7 +418,7 @@ export const toPlanBillingItems = (
     payload.non_recurring_usage_thresholds = (formValues.nonRecurringUsageThresholds ?? []).map(
       (t) => ({
         id: undefined,
-        amount_cents: t.amountCents as number | string,
+        amount_cents: serializeAmount(t.amountCents, currency),
         threshold_display_name: (t.thresholdDisplayName as string | null) ?? null,
         recurring: t.recurring ?? false,
       }),
@@ -412,7 +426,7 @@ export const toPlanBillingItems = (
     payload.recurring_usage_threshold = formValues.recurringUsageThreshold
       ? {
           id: undefined,
-          amount_cents: formValues.recurringUsageThreshold.amountCents as number | string,
+          amount_cents: serializeAmount(formValues.recurringUsageThreshold.amountCents, currency),
           threshold_display_name:
             (formValues.recurringUsageThreshold.thresholdDisplayName as string | null) ?? null,
           recurring: formValues.recurringUsageThreshold.recurring ?? true,
@@ -529,9 +543,14 @@ export const fromPlanBillingItems = (plans: BillingItemPlan[]): FromPlanBillingI
   let formValues: PlanFormInput | null = null
 
   if (hasFullPlanData) {
+    // Payload stores cents; the plan form expects currency units.
+    const currency = (payload.amount_currency as CurrencyEnum) ?? CurrencyEnum.Usd
+
     formValues = {
       interval: payload.interval as PlanFormInput['interval'],
-      amountCents: payload.amount_cents as PlanFormInput['amountCents'],
+      amountCents: String(
+        deserializeAmount(payload.amount_cents || 0, currency),
+      ) as PlanFormInput['amountCents'],
       amountCurrency: payload.amount_currency as PlanFormInput['amountCurrency'],
       payInAdvance: payload.pay_in_advance ?? false,
       billChargesMonthly: payload.bill_charges_monthly ?? undefined,
@@ -545,7 +564,9 @@ export const fromPlanBillingItems = (plans: BillingItemPlan[]): FromPlanBillingI
       minimumCommitment: payload.minimum_commitment
         ? {
             id: payload.minimum_commitment.id ?? undefined,
-            amountCents: payload.minimum_commitment.amount_cents,
+            amountCents: String(
+              deserializeAmount(payload.minimum_commitment.amount_cents || 0, currency),
+            ),
             invoiceDisplayName: payload.minimum_commitment.invoice_display_name ?? undefined,
             commitmentType: payload.minimum_commitment.commitment_type as CommitmentTypeEnum,
             taxCodes: payload.minimum_commitment.tax_codes ?? [],
@@ -553,13 +574,16 @@ export const fromPlanBillingItems = (plans: BillingItemPlan[]): FromPlanBillingI
           }
         : undefined,
       nonRecurringUsageThresholds: (payload.non_recurring_usage_thresholds ?? []).map((t) => ({
-        amountCents: t.amount_cents,
+        amountCents: deserializeAmount(t.amount_cents || 0, currency),
         thresholdDisplayName: t.threshold_display_name ?? undefined,
         recurring: t.recurring,
       })) as PlanFormInput['nonRecurringUsageThresholds'],
       recurringUsageThreshold: payload.recurring_usage_threshold
         ? {
-            amountCents: payload.recurring_usage_threshold.amount_cents,
+            amountCents: deserializeAmount(
+              payload.recurring_usage_threshold.amount_cents || 0,
+              currency,
+            ),
             thresholdDisplayName:
               payload.recurring_usage_threshold.threshold_display_name ?? undefined,
             recurring: payload.recurring_usage_threshold.recurring,

--- a/src/pages/quotes/common/__tests__/buildQuotePreviewProps.test.ts
+++ b/src/pages/quotes/common/__tests__/buildQuotePreviewProps.test.ts
@@ -22,7 +22,7 @@ describe('buildQuotePreviewProps', () => {
 
     const result = buildQuotePreviewProps({ version, customer })
 
-    expect(buildPreviewEntities).toHaveBeenCalledWith({ addons: [] })
+    expect(buildPreviewEntities).toHaveBeenCalledWith({ addons: [] }, CurrencyEnum.Eur)
     expect(result).toEqual({
       content: '<p>Hi</p>',
       entities: { 'addon-1': { entityId: 'addon-1' } },

--- a/src/pages/quotes/common/buildQuotePreviewProps.ts
+++ b/src/pages/quotes/common/buildQuotePreviewProps.ts
@@ -38,7 +38,10 @@ export const buildQuotePreviewProps = ({
 }): QuotePreviewProps => ({
   content: version?.content ?? '',
   entities: version?.billingItems
-    ? buildPreviewEntities(version.billingItems as BillingItemsPayload)
+    ? buildPreviewEntities(
+        version.billingItems as BillingItemsPayload,
+        customer?.currency ?? undefined,
+      )
     : {},
   customerLocale: (customer?.billingConfiguration?.documentLocale ?? 'en') as Locale,
   customerCurrency: customer?.currency ?? undefined,

--- a/src/pages/quotes/hooks/__tests__/useOneOffPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useOneOffPricingDrawer.test.tsx
@@ -232,7 +232,10 @@ describe('useOneOffPricingDrawer', () => {
           wrapper,
         })
 
-        expect(mockedFromBillingItems).toHaveBeenCalledWith(mockBillingItemsPayload)
+        expect(mockedFromBillingItems).toHaveBeenCalledWith(
+          mockBillingItemsPayload,
+          CurrencyEnum.Usd,
+        )
         // Entities should include both localId-keyed and backward-compat catalog-keyed entries
         expect(result.current.entities).toEqual({
           'local-uuid-1': expect.objectContaining({

--- a/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
@@ -44,6 +44,14 @@ export const useOneOffPricingDrawer = (
   const { translate } = useInternationalization()
   const { organization } = useOrganizationInfos()
   const formDrawer = useFormDrawer()
+
+  // The quote currency drives amount cents (de)serialization. Kept in a ref so
+  // the stable callbacks (form onSubmit, syncEntitiesWithBlocks) always read the
+  // latest value without depending on it.
+  const currency = quoteCurrency ?? organization?.defaultCurrency ?? CurrencyEnum.Usd
+  const currencyRef = useRef(currency)
+
+  currencyRef.current = currency
   const entitiesRef = useRef<Record<string, EntityData>>({})
   const [entities, setEntities] = useState<Record<string, EntityData>>({})
   const payloadsRef = useRef<Record<string, AddOnPayload>>({})
@@ -65,7 +73,11 @@ export const useOneOffPricingDrawer = (
 
     if (!parsed.addons?.length) return
 
-    const { entities: formattedEntities, originalPayloads, addOnItems } = fromBillingItems(parsed)
+    const {
+      entities: formattedEntities,
+      originalPayloads,
+      addOnItems,
+    } = fromBillingItems(parsed, currency)
 
     // Populate catalogIdMap and add backward-compat entries keyed by catalog addOnId
     // so old TipTap entityIds (catalog IDs) can still resolve
@@ -86,7 +98,7 @@ export const useOneOffPricingDrawer = (
     entitiesRef.current = updated
     setEntities(updated)
     payloadsRef.current = { ...payloadsRef.current, ...originalPayloads, ...backwardCompatPayloads }
-  }, [initialBillingItems])
+  }, [initialBillingItems, currency])
 
   const captureAddOnPayload = useCallback(
     (localId: string, addOn: AddOnForPricingSectionFragment) => {
@@ -195,7 +207,7 @@ export const useOneOffPricingDrawer = (
         }
       })
 
-      const billingItems = toBillingItems(confirmedItems, payloadsRef.current)
+      const billingItems = toBillingItems(confirmedItems, payloadsRef.current, currencyRef.current)
 
       onSaveRef.current?.(
         {
@@ -219,8 +231,6 @@ export const useOneOffPricingDrawer = (
       if (!editData && Object.keys(entitiesRef.current).length > 0) {
         return
       }
-
-      const currency = quoteCurrency ?? organization?.defaultCurrency ?? CurrencyEnum.Usd
 
       onSaveRef.current = onSave
 
@@ -287,7 +297,7 @@ export const useOneOffPricingDrawer = (
         ),
       })
     },
-    [formDrawer, translate, organization?.defaultCurrency, form, captureAddOnPayload],
+    [formDrawer, translate, currency, form, captureAddOnPayload],
   )
 
   const syncEntitiesWithBlocks = useCallback(
@@ -354,7 +364,7 @@ export const useOneOffPricingDrawer = (
         })
         .filter((item): item is AddOnItem => item !== null)
 
-      return toBillingItems(survivingItems, payloadsRef.current)
+      return toBillingItems(survivingItems, payloadsRef.current, currencyRef.current)
     },
     [],
   )


### PR DESCRIPTION
## Context

While debugging, we saw that we were not sending amounts in cents, both in plans and add-ons. Coupons are okay

## Description

This PR serializes correctly the amounts sent

Fixes LAGO-1685

🤖 Generated with [Claude Code](https://claude.com/claude-code)