### PR TITLE
refactor(wallets): migrate CreateWallet close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/wallet/CreateWallet.tsx
+++ b/src/pages/wallet/CreateWallet.tsx
@@ -1,12 +1,12 @@
 import { gql } from '@apollo/client'
 import { useFormik } from 'formik'
 import { DateTime } from 'luxon'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { InvoiceCustomSectionInput } from '~/components/invoceCustomFooter/types'
 import { toInvoiceCustomSectionReference } from '~/components/invoceCustomFooter/utils'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
@@ -164,7 +164,8 @@ const CreateWallet = () => {
   const { translate } = useInternationalization()
   const { organization } = useOrganizationInfos()
 
-  const warningDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
+
   const formType = useMemo(() => {
     if (!!walletId) return FORM_TYPE_ENUM.edition
 
@@ -460,99 +461,97 @@ const CreateWallet = () => {
     },
   })
 
+  const openDirtyAttributesWarning = useCallback(() => {
+    centralizedDialog.open({
+      title: translate('text_665deda4babaf700d603ea13'),
+      description: translate('text_665dedd557dc3c00c62eb83d'),
+      actionText: translate('text_645388d5bdbd7b00abffa033'),
+      colorVariant: 'danger',
+      onAction: () => navigateToCustomerWalletTab(wallet?.id),
+    })
+  }, [centralizedDialog, navigateToCustomerWalletTab, translate, wallet?.id])
+
   const onAbort = useCallback(() => {
-    formikProps.dirty
-      ? warningDialogRef.current?.openDialog()
-      : navigateToCustomerWalletTab(walletId)
-  }, [formikProps.dirty, navigateToCustomerWalletTab, walletId])
+    formikProps.dirty ? openDirtyAttributesWarning() : navigateToCustomerWalletTab(walletId)
+  }, [formikProps.dirty, navigateToCustomerWalletTab, openDirtyAttributesWarning, walletId])
 
   return (
-    <>
-      <CenteredPage.Wrapper>
-        <CenteredPage.Header>
-          <Typography variant="bodyHl" color="textSecondary" noWrap>
-            {translate(
+    <CenteredPage.Wrapper>
+      <CenteredPage.Header>
+        <Typography variant="bodyHl" color="textSecondary" noWrap>
+          {translate(
+            formType === FORM_TYPE_ENUM.edition
+              ? 'text_62d9430e8b9fe36851cddd09'
+              : 'text_6560809c38fb9de88d8a505e',
+          )}
+        </Typography>
+        <Button
+          variant="quaternary"
+          icon="close"
+          onClick={onAbort}
+          data-test={CLOSE_CREATE_WALLET_BUTTON_DATA_TEST}
+        />
+      </CenteredPage.Header>
+
+      {isLoading && !wallet && (
+        <CenteredPage.Container>
+          <FormLoadingSkeleton id="create-wallet" />
+        </CenteredPage.Container>
+      )}
+
+      {!isLoading && (
+        <CenteredPage.Container>
+          <CenteredPage.PageTitle
+            title={translate(
               formType === FORM_TYPE_ENUM.edition
                 ? 'text_62d9430e8b9fe36851cddd09'
                 : 'text_6560809c38fb9de88d8a505e',
             )}
-          </Typography>
-          <Button
-            variant="quaternary"
-            icon="close"
-            onClick={onAbort}
-            data-test={CLOSE_CREATE_WALLET_BUTTON_DATA_TEST}
+            description={translate('text_1748422458559917eelhobh5')}
           />
-        </CenteredPage.Header>
 
-        {isLoading && !wallet && (
-          <CenteredPage.Container>
-            <FormLoadingSkeleton id="create-wallet" />
-          </CenteredPage.Container>
-        )}
+          <SettingsSection
+            formikProps={formikProps}
+            formType={formType}
+            customerData={customerData}
+            showExpirationDate={showExpirationDate}
+            setShowExpirationDate={setShowExpirationDate}
+            showMinTopUp={showMinTopUp}
+            setShowMinTopUp={setShowMinTopUp}
+            showMaxTopUp={showMaxTopUp}
+            setShowMaxTopUp={setShowMaxTopUp}
+          />
 
-        {!isLoading && (
-          <CenteredPage.Container>
-            <CenteredPage.PageTitle
-              title={translate(
-                formType === FORM_TYPE_ENUM.edition
-                  ? 'text_62d9430e8b9fe36851cddd09'
-                  : 'text_6560809c38fb9de88d8a505e',
-              )}
-              description={translate('text_1748422458559917eelhobh5')}
-            />
+          <ScopeSection formikProps={formikProps} />
 
-            <SettingsSection
-              formikProps={formikProps}
-              formType={formType}
-              customerData={customerData}
-              showExpirationDate={showExpirationDate}
-              setShowExpirationDate={setShowExpirationDate}
-              showMinTopUp={showMinTopUp}
-              setShowMinTopUp={setShowMinTopUp}
-              showMaxTopUp={showMaxTopUp}
-              setShowMaxTopUp={setShowMaxTopUp}
-            />
+          <TopUpSection
+            formikProps={formikProps}
+            formType={formType}
+            customerData={customerData}
+            isRecurringTopUpEnabled={isRecurringTopUpEnabled}
+            setIsRecurringTopUpEnabled={setIsRecurringTopUpEnabled}
+          />
+        </CenteredPage.Container>
+      )}
 
-            <ScopeSection formikProps={formikProps} />
-
-            <TopUpSection
-              formikProps={formikProps}
-              formType={formType}
-              customerData={customerData}
-              isRecurringTopUpEnabled={isRecurringTopUpEnabled}
-              setIsRecurringTopUpEnabled={setIsRecurringTopUpEnabled}
-            />
-          </CenteredPage.Container>
-        )}
-
-        <CenteredPage.StickyFooter>
-          <Button variant="quaternary" onClick={onAbort}>
-            {translate('text_62e79671d23ae6ff149de968')}
-          </Button>
-          <Button
-            variant="primary"
-            disabled={!formikProps.isValid}
-            onClick={formikProps.submitForm}
-            data-test={SUBMIT_WALLET_DATA_TEST}
-          >
-            {translate(
-              formType === FORM_TYPE_ENUM.edition
-                ? 'text_62e161ceb87c201025388aa2'
-                : 'text_6560809c38fb9de88d8a505e',
-            )}
-          </Button>
-        </CenteredPage.StickyFooter>
-      </CenteredPage.Wrapper>
-
-      <WarningDialog
-        ref={warningDialogRef}
-        title={translate('text_665deda4babaf700d603ea13')}
-        description={translate('text_665dedd557dc3c00c62eb83d')}
-        continueText={translate('text_645388d5bdbd7b00abffa033')}
-        onContinue={() => navigateToCustomerWalletTab(wallet?.id)}
-      />
-    </>
+      <CenteredPage.StickyFooter>
+        <Button variant="quaternary" onClick={onAbort}>
+          {translate('text_62e79671d23ae6ff149de968')}
+        </Button>
+        <Button
+          variant="primary"
+          disabled={!formikProps.isValid}
+          onClick={formikProps.submitForm}
+          data-test={SUBMIT_WALLET_DATA_TEST}
+        >
+          {translate(
+            formType === FORM_TYPE_ENUM.edition
+              ? 'text_62e161ceb87c201025388aa2'
+              : 'text_6560809c38fb9de88d8a505e',
+          )}
+        </Button>
+      </CenteredPage.StickyFooter>
+    </CenteredPage.Wrapper>
   )
 }
 


### PR DESCRIPTION
## Context

`CreateWallet` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `CreateWallet.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/wallet/CreateWallet.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render.
  - Added `useCentralizedDialog()` and extracted an `openDirtyAttributesWarning()` helper that opens the confirmation dialog — same title/description/action text, still with `colorVariant: 'danger'`, and still navigating back to the customer wallet tab on confirm.
  - Both dirty-guard call sites (header close button and footer cancel button, both wired through `onAbort`) now go through the new helper.
  - Dropped `useRef` from the React import (no longer used in this file).

The parent page still uses Formik (a separate migration tracked by other ESLint warnings) — the scope here is strictly the `WarningDialog` warning.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` / TanStack Form migration in this PR.

## Test plan

- [ ] Open *Customer → Wallet → Create wallet*.
- [ ] Fill some fields so the Formik form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back to the customer wallet tab.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] Same flow via the footer cancel button.
- [ ] When the form is pristine, clicking close/cancel immediately navigates away with no dialog.
- [ ] Edit an existing wallet → same flow works in edition mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfmMjXVh11X82dnDvnWyK7)_