### PR TITLE
refactor(subscriptions): migrate SubscriptionProgressiveBillingForm close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/subscriptions/SubscriptionProgressiveBillingForm.tsx
+++ b/src/pages/subscriptions/SubscriptionProgressiveBillingForm.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { InputAdornment } from '@mui/material'
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Alert } from '~/components/designSystem/Alert'
@@ -8,7 +8,7 @@ import { Button } from '~/components/designSystem/Button'
 import { ChargeTable } from '~/components/designSystem/Table'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { addToast } from '~/core/apolloClient'
 import { CustomerSubscriptionDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
@@ -75,7 +75,7 @@ const SubscriptionProgressiveBillingForm = () => {
   const { customerId = '', planId = '', subscriptionId = '' } = useParams()
   const { translate } = useInternationalization()
   const navigate = useNavigate()
-  const warningDirtyAttributesDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
 
   const { data: subscriptionData, loading: subscriptionLoading } =
     useGetSubscriptionForProgressiveBillingFormQuery({
@@ -254,9 +254,18 @@ const SubscriptionProgressiveBillingForm = () => {
     [currency, form, translate],
   )
 
+  const openDirtyAttributesWarning = () =>
+    centralizedDialog.open({
+      title: translate('text_665deda4babaf700d603ea13'),
+      description: translate('text_665dedd557dc3c00c62eb83d'),
+      actionText: translate('text_6244277fe0975300fe3fb94c'),
+      colorVariant: 'danger',
+      onAction: () => onLeave(),
+    })
+
   const handleAbort = () => {
     if (isDirty) {
-      warningDirtyAttributesDialogRef.current?.openDialog()
+      openDirtyAttributesWarning()
     } else {
       onLeave()
     }
@@ -398,14 +407,6 @@ const SubscriptionProgressiveBillingForm = () => {
           </CenteredPage.StickyFooter>
         </form>
       </CenteredPage.Wrapper>
-
-      <WarningDialog
-        ref={warningDirtyAttributesDialogRef}
-        title={translate('text_665deda4babaf700d603ea13')}
-        description={translate('text_665dedd557dc3c00c62eb83d')}
-        continueText={translate('text_6244277fe0975300fe3fb94c')}
-        onContinue={onLeave}
-      />
     </>
   )
 }

--- a/src/pages/subscriptions/__tests__/SubscriptionProgressiveBillingForm.test.tsx
+++ b/src/pages/subscriptions/__tests__/SubscriptionProgressiveBillingForm.test.tsx
@@ -1,6 +1,9 @@
+import NiceModal from '@ebay/nice-modal-react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import CentralizedDialog from '~/components/dialogs/CentralizedDialog'
+import { CENTRALIZED_DIALOG_NAME } from '~/components/dialogs/const'
 import { CurrencyEnum, GetSubscriptionForProgressiveBillingFormDocument } from '~/generated/graphql'
 import { AllTheProviders, TestMocksType } from '~/test-utils'
 
@@ -13,6 +16,8 @@ import SubscriptionProgressiveBillingForm, {
   PROGRESSIVE_BILLING_HAS_RECURRING_SWITCH_TEST_ID,
   PROGRESSIVE_BILLING_SUBMIT_BUTTON_TEST_ID,
 } from '../SubscriptionProgressiveBillingForm'
+
+NiceModal.register(CENTRALIZED_DIALOG_NAME, CentralizedDialog)
 
 const mockNavigate = jest.fn()
 
@@ -67,11 +72,12 @@ const renderComponent = (mocks: TestMocksType = [createQueryMock()]) => {
   return render(<SubscriptionProgressiveBillingForm />, {
     wrapper: (props: { children: React.ReactNode }) => (
       <AllTheProviders
-        {...props}
         mocks={mocks}
         useParams={{ subscriptionId, customerId }}
         forceTypenames={false}
-      />
+      >
+        <NiceModal.Provider>{props.children}</NiceModal.Provider>
+      </AllTheProviders>
     ),
   })
 }


### PR DESCRIPTION
## Context

`SubscriptionProgressiveBillingForm` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `SubscriptionProgressiveBillingForm.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/subscriptions/SubscriptionProgressiveBillingForm.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render.
  - Added `useCentralizedDialog()` and extracted an `openDirtyAttributesWarning()` helper that opens the confirmation dialog — same title/description/action text, still with `colorVariant: 'danger'`, and still calling `onLeave()` on confirm.
  - The `handleAbort` helper now calls `openDirtyAttributesWarning()` instead of `warningDirtyAttributesDialogRef.current?.openDialog()`; the not-dirty branch keeps calling `onLeave()`.
  - Dropped `useRef` from the React import (no longer used in this file).

The form was already migrated to TanStack Form — no additional form migration required.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive.

## Test plan

- [ ] Open a subscription's *Progressive billing* form (via customer or plan subscription details).
- [ ] Change any threshold value so the form becomes `dirty`, then click the top-right close icon or the footer cancel button → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back to the progressive billing tab.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] When the form is pristine, clicking close/cancel immediately navigates away with no dialog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfmMjXVh11X82dnDvnWyK7)_