### PR TITLE
refactor(invoices): migrate CreateCustomSection close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/settings/Invoices/CreateCustomSection.tsx
+++ b/src/pages/settings/Invoices/CreateCustomSection.tsx
@@ -5,7 +5,7 @@ import { object, string } from 'yup'
 import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { TextInput, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import {
@@ -25,11 +25,20 @@ const CreateInvoiceCustomSection = () => {
   const { translate } = useInternationalization()
   const navigate = useNavigate()
 
-  const warningDirtyAttributesDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const previewCustomSectionDrawerRef = useRef<PreviewCustomSectionDrawerRef>(null)
 
   const { loading, isEdition, invoiceCustomSection, onSave, errorCode } =
     useCreateEditInvoiceCustomSection()
+
+  const openDirtyAttributesWarning = () =>
+    centralizedDialog.open({
+      title: translate('text_6244277fe0975300fe3fb940'),
+      description: translate('text_6244277fe0975300fe3fb946'),
+      actionText: translate('text_6244277fe0975300fe3fb94c'),
+      colorVariant: 'danger',
+      onAction: () => navigate(INVOICE_SETTINGS_ROUTE),
+    })
 
   const formikProps = useFormik<CreateInvoiceCustomSectionInput>({
     initialValues: {
@@ -81,9 +90,7 @@ const CreateInvoiceCustomSection = () => {
             variant="quaternary"
             icon="close"
             onClick={() =>
-              formikProps.dirty
-                ? warningDirtyAttributesDialogRef.current?.openDialog()
-                : navigate(INVOICE_SETTINGS_ROUTE)
+              formikProps.dirty ? openDirtyAttributesWarning() : navigate(INVOICE_SETTINGS_ROUTE)
             }
           />
         </CenteredPage.Header>
@@ -213,9 +220,7 @@ const CreateInvoiceCustomSection = () => {
           <Button
             variant="quaternary"
             onClick={() =>
-              formikProps.dirty
-                ? warningDirtyAttributesDialogRef.current?.openDialog()
-                : navigate(INVOICE_SETTINGS_ROUTE)
+              formikProps.dirty ? openDirtyAttributesWarning() : navigate(INVOICE_SETTINGS_ROUTE)
             }
           >
             {translate('text_6411e6b530cb47007488b027')}
@@ -232,13 +237,6 @@ const CreateInvoiceCustomSection = () => {
         </CenteredPage.StickyFooter>
       </CenteredPage.Wrapper>
 
-      <WarningDialog
-        ref={warningDirtyAttributesDialogRef}
-        title={translate('text_6244277fe0975300fe3fb940')}
-        description={translate('text_6244277fe0975300fe3fb946')}
-        continueText={translate('text_6244277fe0975300fe3fb94c')}
-        onContinue={() => navigate(INVOICE_SETTINGS_ROUTE)}
-      />
       <PreviewCustomSectionDrawer ref={previewCustomSectionDrawerRef} />
     </>
   )


### PR DESCRIPTION
## Context

`CreateInvoiceCustomSection` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `CreateCustomSection.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/settings/Invoices/CreateCustomSection.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render.
  - Added `useCentralizedDialog()` and extracted an `openDirtyAttributesWarning()` helper that opens the confirmation dialog — same title/description/action text, still with `colorVariant: 'danger'`, and still navigating to `INVOICE_SETTINGS_ROUTE` on confirm.
  - Both dirty-guard call sites (header close button and footer cancel button) now call `openDirtyAttributesWarning()` instead of `warningDirtyAttributesDialogRef.current?.openDialog()`; the not-dirty branches keep their existing behavior (`navigate(INVOICE_SETTINGS_ROUTE)`).

The parent page still uses Formik (a separate migration tracked by other ESLint warnings) — the scope here is strictly the `WarningDialog` warning.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` / TanStack Form migration in this PR.

## Test plan

- [ ] Open *Settings → Invoices → Create custom section*.
- [ ] Fill some fields so the form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back to the invoice settings list.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] Same flow via the footer cancel button.
- [ ] When the form is pristine, clicking close/cancel immediately navigates away with no dialog.
- [ ] Edit an existing custom section → same flow works in edition mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfmMjXVh11X82dnDvnWyK7)_