### PR TITLE
refactor(subscriptions): migrate CreateSubscription close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/subscriptions/CreateSubscription.tsx
+++ b/src/pages/subscriptions/CreateSubscription.tsx
@@ -10,7 +10,7 @@ import { Avatar } from '~/components/designSystem/Avatar'
 import { Button } from '~/components/designSystem/Button'
 import { Selector } from '~/components/designSystem/Selector'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { BasicComboBoxData, ComboboxItem } from '~/components/form'
 import { toInvoiceCustomSectionReference } from '~/components/invoceCustomFooter/utils'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
@@ -115,7 +115,7 @@ const CreateSubscription = () => {
   const { hasFeatureFlag, intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
   const { isRunningInSalesForceIframe, isRunningInIframeContext } = useIframeConfig()
 
-  const warningDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const [showCurrencyError, setShowCurrencyError] = useState<boolean>(false)
 
   const hasMultiEntityBilling = hasFeatureFlag(FeatureFlagEnum.MultiEntityBilling)
@@ -430,13 +430,23 @@ const CreateSubscription = () => {
     }
   }, [searchParams, navigate, plan?.id, customerId])
 
+  const openDirtyAttributesWarning = useCallback(() => {
+    centralizedDialog.open({
+      title: translate('text_65118a52df984447c18694ee'),
+      description: translate('text_65118a52df984447c18694fe'),
+      actionText: translate('text_645388d5bdbd7b00abffa033'),
+      colorVariant: 'danger',
+      onAction: () => navigateBack(),
+    })
+  }, [centralizedDialog, navigateBack, translate])
+
   const handleClose = useCallback(() => {
     if (subscriptionIsDirty || planFormIsDirty) {
-      warningDialogRef.current?.openDialog()
+      openDirtyAttributesWarning()
     } else {
       navigateBack()
     }
-  }, [subscriptionIsDirty, planFormIsDirty, navigateBack])
+  }, [subscriptionIsDirty, planFormIsDirty, navigateBack, openDirtyAttributesWarning])
 
   const pageHeaderTitle = useMemo(() => {
     if (formType === FORM_TYPE_ENUM.edition) {
@@ -707,14 +717,6 @@ const CreateSubscription = () => {
           </CenteredPage.StickyFooter>
         </CenteredPage.Wrapper>
       </form>
-
-      <WarningDialog
-        ref={warningDialogRef}
-        title={translate('text_65118a52df984447c18694ee')}
-        description={translate('text_65118a52df984447c18694fe')}
-        continueText={translate('text_645388d5bdbd7b00abffa033')}
-        onContinue={() => navigateBack()}
-      />
     </>
   )
 }

--- a/src/pages/subscriptions/__tests__/CreateSubscription.test.tsx
+++ b/src/pages/subscriptions/__tests__/CreateSubscription.test.tsx
@@ -1,9 +1,14 @@
+import NiceModal from '@ebay/nice-modal-react'
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import CentralizedDialog from '~/components/dialogs/CentralizedDialog'
+import { CENTRALIZED_DIALOG_NAME } from '~/components/dialogs/const'
 import { render, testMockNavigateFn } from '~/test-utils'
 
 import CreateSubscription from '../CreateSubscription'
+
+NiceModal.register(CENTRALIZED_DIALOG_NAME, CentralizedDialog)
 
 // --- Mock state ---
 
@@ -311,9 +316,14 @@ jest.mock('~/components/customers/subscriptions/SubscriptionDatesOffsetHelperCom
 // --- Helpers ---
 
 const renderCreateSubscription = () =>
-  render(<CreateSubscription />, {
-    mocks: [],
-  })
+  render(
+    <NiceModal.Provider>
+      <CreateSubscription />
+    </NiceModal.Provider>,
+    {
+      mocks: [],
+    },
+  )
 
 // --- Tests ---
 


### PR DESCRIPTION
## Context

`CreateSubscription` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `CreateSubscription.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/subscriptions/CreateSubscription.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render.
  - Added `useCentralizedDialog()` and extracted an `openDirtyAttributesWarning()` helper that opens the confirmation dialog — same title/description/action text, still with `colorVariant: 'danger'`, and still calling `navigateBack()` on confirm.
  - The `handleClose` helper now calls `openDirtyAttributesWarning()` instead of `warningDialogRef.current?.openDialog()`; the not-dirty branch keeps its existing behavior (`navigateBack()`).

The form already uses TanStack Form — no additional form migration required.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` migration in this PR.

## Test plan

- [ ] Open *Customer → Create subscription*.
- [ ] Fill some fields (or change the plan / adjust an override) so the form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back (customer details / plan subscription details / usage tab depending on origin).
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] Same flow via the footer cancel button.
- [ ] When the form is pristine, clicking close/cancel immediately navigates away with no dialog.
- [ ] Edit an existing subscription → same flow works in edition mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfmMjXVh11X82dnDvnWyK7)_