### PR TITLE
refactor(plans): migrate CreatePlan close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -1,11 +1,11 @@
 import { gql } from '@apollo/client'
 import { useStore } from '@tanstack/react-form'
-import { useCallback, useRef } from 'react'
+import { useCallback } from 'react'
 import { generatePath, useSearchParams } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { CommitmentsSection } from '~/components/plans/CommitmentsSection'
 import { useCascadeFormDialog } from '~/components/plans/details-v2/shared/useCascadeFormDialog'
@@ -146,7 +146,7 @@ const CreatePlan = () => {
   const { type: actionType } = useDuplicatePlanVar()
   const [searchParams] = useSearchParams()
   const { form, isEdition, loading, plan, type } = usePlanForm({})
-  const warningDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const { openCascadeDialog } = useCascadeFormDialog()
 
   const canBeEdited = !plan?.subscriptionsCount
@@ -193,13 +193,23 @@ const CreatePlan = () => {
     }
   }, [navigate, plan?.id, searchParams, actionType])
 
+  const openDirtyAttributesWarning = useCallback(() => {
+    centralizedDialog.open({
+      title: translate('text_665deda4babaf700d603ea13'),
+      description: translate('text_665dedd557dc3c00c62eb83d'),
+      actionText: translate('text_645388d5bdbd7b00abffa033'),
+      colorVariant: 'danger',
+      onAction: () => planCloseRedirection(),
+    })
+  }, [centralizedDialog, planCloseRedirection, translate])
+
   const onLeave = useCallback(() => {
     if (isDirty) {
-      return warningDialogRef.current?.openDialog()
+      return openDirtyAttributesWarning()
     }
 
     return planCloseRedirection()
-  }, [isDirty, planCloseRedirection])
+  }, [isDirty, openDirtyAttributesWarning, planCloseRedirection])
 
   const handleFormSubmit = useCallback(() => {
     if (isEdition && plan?.hasOverriddenPlans) {
@@ -341,14 +351,6 @@ const CreatePlan = () => {
           )}
         </CenteredPage.Wrapper>
       </form>
-
-      <WarningDialog
-        ref={warningDialogRef}
-        title={translate('text_665deda4babaf700d603ea13')}
-        description={translate('text_665dedd557dc3c00c62eb83d')}
-        continueText={translate('text_645388d5bdbd7b00abffa033')}
-        onContinue={() => planCloseRedirection()}
-      />
     </PlanFormProvider>
   )
 }


### PR DESCRIPTION
## Context

`CreatePlan` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `CreatePlan.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/CreatePlan.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render.
  - Added `useCentralizedDialog()` and extracted an `openDirtyAttributesWarning()` helper that opens the confirmation dialog — same title/description/action text, still with `colorVariant: 'danger'`, and still calling `planCloseRedirection()` on confirm.
  - The `onLeave` helper now calls `openDirtyAttributesWarning()` instead of `warningDialogRef.current?.openDialog()`; the not-dirty branch keeps calling `planCloseRedirection()`.
  - Dropped `useRef` from the React import (no longer used in this file).

The form already uses TanStack Form — no additional form migration required.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` migration in this PR.

## Test plan

- [ ] Open *Plans → Create plan*.
- [ ] Change any field so the form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back (plan details / plans list / subscription usage depending on origin).
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] Same flow via the footer cancel button.
- [ ] When the form is pristine, clicking close/cancel immediately navigates away with no dialog.
- [ ] Edit / duplicate an existing plan → same flow works in edition/duplicate mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfmMjXVh11X82dnDvnWyK7)_