### PR TITLE
refactor(invoices): migrate CreatePricingUnit close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/settings/Invoices/CreatePricingUnit.tsx
+++ b/src/pages/settings/Invoices/CreatePricingUnit.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { useFormik } from 'formik'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { object, string } from 'yup'
 
@@ -8,7 +8,7 @@ import { Alert } from '~/components/designSystem/Alert'
 import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { TextInput, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
@@ -59,8 +59,17 @@ const CreatePricingUnit = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
   const { pricingUnitId = '' } = useParams()
-  const warningDirtyAttributesDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const isEdition = !!pricingUnitId
+
+  const openDirtyAttributesWarning = () =>
+    centralizedDialog.open({
+      title: translate('text_6244277fe0975300fe3fb940'),
+      description: translate('text_175025748172630micceie8p'),
+      actionText: translate('text_6244277fe0975300fe3fb94c'),
+      colorVariant: 'danger',
+      onAction: () => navigate(INVOICE_SETTINGS_ROUTE),
+    })
 
   const { data: pricingUnitData, loading: pricingUnitLoading } = useGetSinglePricingUnitQuery({
     variables: {
@@ -148,155 +157,141 @@ const CreatePricingUnit = () => {
   )
 
   return (
-    <>
-      <CenteredPage.Wrapper>
-        <CenteredPage.Header>
-          <Typography variant="bodyHl" color="textSecondary" noWrap>
-            {isEdition
-              ? translate('text_17502574817266iopiux8fb8')
-              : translate('text_1750257481726l1npjihgs20')}
-          </Typography>
-          <Button
-            variant="quaternary"
-            icon="close"
-            onClick={() =>
-              formikProps.dirty
-                ? warningDirtyAttributesDialogRef.current?.openDialog()
-                : navigate(INVOICE_SETTINGS_ROUTE)
-            }
-          />
-        </CenteredPage.Header>
+    <CenteredPage.Wrapper>
+      <CenteredPage.Header>
+        <Typography variant="bodyHl" color="textSecondary" noWrap>
+          {isEdition
+            ? translate('text_17502574817266iopiux8fb8')
+            : translate('text_1750257481726l1npjihgs20')}
+        </Typography>
+        <Button
+          variant="quaternary"
+          icon="close"
+          onClick={() =>
+            formikProps.dirty ? openDirtyAttributesWarning() : navigate(INVOICE_SETTINGS_ROUTE)
+          }
+        />
+      </CenteredPage.Header>
 
-        <CenteredPage.Container>
-          {pricingUnitLoading && <FormLoadingSkeleton id="create-pricing-unit" />}
+      <CenteredPage.Container>
+        {pricingUnitLoading && <FormLoadingSkeleton id="create-pricing-unit" />}
 
-          {!pricingUnitLoading && (
-            <>
-              <Alert type="info">{translate('text_1750424999814th7cu8hbg7u')}</Alert>
+        {!pricingUnitLoading && (
+          <>
+            <Alert type="info">{translate('text_1750424999814th7cu8hbg7u')}</Alert>
 
-              <div className="not-last-child:mb-1">
-                <Typography variant="headline" color="textSecondary">
-                  {translate('text_17502505476284yyq70yy6mx')}
+            <div className="not-last-child:mb-1">
+              <Typography variant="headline" color="textSecondary">
+                {translate('text_17502505476284yyq70yy6mx')}
+              </Typography>
+              <Typography variant="body">{translate('text_1750257831368z0azd7znlhf')}</Typography>
+            </div>
+
+            <div className="flex flex-col gap-12">
+              <div className="not-last-child:mb-2">
+                <Typography variant="subhead1">
+                  {translate('text_17502574817266uy9bvk3i8u')}
                 </Typography>
-                <Typography variant="body">{translate('text_1750257831368z0azd7znlhf')}</Typography>
+                <Typography variant="caption">
+                  {translate('text_17502578313682gsr5pls9a3')}
+                </Typography>
               </div>
-
-              <div className="flex flex-col gap-12">
-                <div className="not-last-child:mb-2">
-                  <Typography variant="subhead1">
-                    {translate('text_17502574817266uy9bvk3i8u')}
-                  </Typography>
-                  <Typography variant="caption">
-                    {translate('text_17502578313682gsr5pls9a3')}
-                  </Typography>
-                </div>
-                <div className="flex flex-col gap-6">
-                  <div className="flex items-start gap-6 *:flex-1">
-                    <TextInput
-                      // eslint-disable-next-line jsx-a11y/no-autofocus
-                      autoFocus
-                      name="name"
-                      value={formikProps.values.name}
-                      onChange={(name) => {
-                        updateNameAndMaybeCode({ name, formikProps })
-                      }}
-                      label={translate('text_6419c64eace749372fc72b0f')}
-                      placeholder={translate('text_6584550dc4cec7adf861504f')}
-                    />
-                    <TextInputField
-                      name="code"
-                      beforeChangeFormatter="code"
-                      formikProps={formikProps}
-                      disabled={isEdition}
-                      label={translate('text_62876e85e32e0300e1803127')}
-                      placeholder={translate('text_6584550dc4cec7adf8615053')}
-                    />
-                  </div>
-
-                  <TextInputField
-                    name="shortName"
-                    formikProps={formikProps}
-                    error={formikProps.errors.shortName}
-                    label={translate('text_175025054762801ioe61wdye')}
-                    placeholder={translate('text_1750250547628xh8057w5j8p')}
-                    helperText={translate('text_1750257831368e6n6ys36s6u')}
+              <div className="flex flex-col gap-6">
+                <div className="flex items-start gap-6 *:flex-1">
+                  <TextInput
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                    autoFocus
+                    name="name"
+                    value={formikProps.values.name}
+                    onChange={(name) => {
+                      updateNameAndMaybeCode({ name, formikProps })
+                    }}
+                    label={translate('text_6419c64eace749372fc72b0f')}
+                    placeholder={translate('text_6584550dc4cec7adf861504f')}
                   />
-
-                  {shouldDisplayDescription ? (
-                    <div className="flex items-center gap-2">
-                      <TextInputField
-                        className="flex-1"
-                        name="description"
-                        label={translate('text_623b42ff8ee4e000ba87d0c8')}
-                        placeholder={translate('text_1750257831368ae3rtaclhjy')}
-                        rows="3"
-                        multiline
-                        formikProps={formikProps}
-                      />
-
-                      <Tooltip
-                        className="mt-7"
-                        placement="top-end"
-                        title={translate('text_63aa085d28b8510cd46443ff')}
-                      >
-                        <Button
-                          icon="trash"
-                          variant="quaternary"
-                          onClick={() => {
-                            formikProps.setFieldValue('description', '')
-                            setShouldDisplayDescription(false)
-                          }}
-                        />
-                      </Tooltip>
-                    </div>
-                  ) : (
-                    <Button
-                      startIcon="plus"
-                      variant="inline"
-                      align="left"
-                      onClick={() => setShouldDisplayDescription(true)}
-                      data-test="show-description"
-                    >
-                      {translate('text_642d5eb2783a2ad10d670324')}
-                    </Button>
-                  )}
+                  <TextInputField
+                    name="code"
+                    beforeChangeFormatter="code"
+                    formikProps={formikProps}
+                    disabled={isEdition}
+                    label={translate('text_62876e85e32e0300e1803127')}
+                    placeholder={translate('text_6584550dc4cec7adf8615053')}
+                  />
                 </div>
+
+                <TextInputField
+                  name="shortName"
+                  formikProps={formikProps}
+                  error={formikProps.errors.shortName}
+                  label={translate('text_175025054762801ioe61wdye')}
+                  placeholder={translate('text_1750250547628xh8057w5j8p')}
+                  helperText={translate('text_1750257831368e6n6ys36s6u')}
+                />
+
+                {shouldDisplayDescription ? (
+                  <div className="flex items-center gap-2">
+                    <TextInputField
+                      className="flex-1"
+                      name="description"
+                      label={translate('text_623b42ff8ee4e000ba87d0c8')}
+                      placeholder={translate('text_1750257831368ae3rtaclhjy')}
+                      rows="3"
+                      multiline
+                      formikProps={formikProps}
+                    />
+
+                    <Tooltip
+                      className="mt-7"
+                      placement="top-end"
+                      title={translate('text_63aa085d28b8510cd46443ff')}
+                    >
+                      <Button
+                        icon="trash"
+                        variant="quaternary"
+                        onClick={() => {
+                          formikProps.setFieldValue('description', '')
+                          setShouldDisplayDescription(false)
+                        }}
+                      />
+                    </Tooltip>
+                  </div>
+                ) : (
+                  <Button
+                    startIcon="plus"
+                    variant="inline"
+                    align="left"
+                    onClick={() => setShouldDisplayDescription(true)}
+                    data-test="show-description"
+                  >
+                    {translate('text_642d5eb2783a2ad10d670324')}
+                  </Button>
+                )}
               </div>
-            </>
-          )}
-        </CenteredPage.Container>
+            </div>
+          </>
+        )}
+      </CenteredPage.Container>
 
-        <CenteredPage.StickyFooter>
-          <Button
-            variant="quaternary"
-            onClick={() =>
-              formikProps.dirty
-                ? warningDirtyAttributesDialogRef.current?.openDialog()
-                : navigate(INVOICE_SETTINGS_ROUTE)
-            }
-          >
-            {translate('text_6411e6b530cb47007488b027')}
-          </Button>
-          <Button
-            variant="primary"
-            disabled={!formikProps.isValid || !formikProps.dirty}
-            onClick={formikProps.submitForm}
-          >
-            {isEdition
-              ? translate('text_17295436903260tlyb1gp1i7')
-              : translate('text_1750319326160woun10ws3h1')}
-          </Button>
-        </CenteredPage.StickyFooter>
-      </CenteredPage.Wrapper>
-
-      <WarningDialog
-        ref={warningDirtyAttributesDialogRef}
-        title={translate('text_6244277fe0975300fe3fb940')}
-        description={translate('text_175025748172630micceie8p')}
-        continueText={translate('text_6244277fe0975300fe3fb94c')}
-        onContinue={() => navigate(INVOICE_SETTINGS_ROUTE)}
-      />
-    </>
+      <CenteredPage.StickyFooter>
+        <Button
+          variant="quaternary"
+          onClick={() =>
+            formikProps.dirty ? openDirtyAttributesWarning() : navigate(INVOICE_SETTINGS_ROUTE)
+          }
+        >
+          {translate('text_6411e6b530cb47007488b027')}
+        </Button>
+        <Button
+          variant="primary"
+          disabled={!formikProps.isValid || !formikProps.dirty}
+          onClick={formikProps.submitForm}
+        >
+          {isEdition
+            ? translate('text_17295436903260tlyb1gp1i7')
+            : translate('text_1750319326160woun10ws3h1')}
+        </Button>
+      </CenteredPage.StickyFooter>
+    </CenteredPage.Wrapper>
   )
 }
 


### PR DESCRIPTION
## Context

`CreatePricingUnit` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `CreatePricingUnit.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/settings/Invoices/CreatePricingUnit.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render.
  - Added `useCentralizedDialog()` and extracted an `openDirtyAttributesWarning()` helper that opens the confirmation dialog — same title/description/action text, still with `colorVariant: 'danger'`, and still navigating to `INVOICE_SETTINGS_ROUTE` on confirm.
  - Both dirty-guard call sites (header close button and footer cancel button) now call `openDirtyAttributesWarning()` instead of `warningDirtyAttributesDialogRef.current?.openDialog()`; the not-dirty branches keep their existing behavior.
  - Dropped `useRef` from the React import (no longer used in this file).

The parent page still uses Formik (a separate migration tracked by other ESLint warnings) — the scope here is strictly the `WarningDialog` warning.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` / TanStack Form migration in this PR.

## Test plan

- [ ] Open *Settings → Invoices → Create pricing unit*.
- [ ] Fill some fields so the Formik form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back to the invoice settings list.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] Same flow via the footer cancel button.
- [ ] When the form is pristine, clicking close/cancel immediately navigates away with no dialog.
- [ ] Edit an existing pricing unit → same flow works in edition mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfmMjXVh11X82dnDvnWyK7)_