### PR TITLE
refactor(features): migrate FeatureForm close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/features/FeatureForm.tsx
+++ b/src/pages/features/FeatureForm.tsx
@@ -1,13 +1,13 @@
 import { FetchResult, gql } from '@apollo/client'
 import { useFormik } from 'formik'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 import { array, object, string } from 'yup'
 
 import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { FeaturePrivilegeAccordion } from '~/components/features/FeaturePrivilegeAccordion'
 import { TextInput, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
@@ -73,7 +73,7 @@ const FeatureForm = () => {
   const navigate = useNavigate()
   const isEdition = !!featureId
 
-  const warningDirtyAttributesDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const [shouldDisplayDescription, setShouldDisplayDescription] = useState<boolean>(false)
 
   const { data: featureData, loading: featureLoading } = useGetFeatureQuery({
@@ -181,6 +181,15 @@ const FeatureForm = () => {
     }
   }, [featureId, navigate])
 
+  const openDirtyAttributesWarning = () =>
+    centralizedDialog.open({
+      title: translate('text_6244277fe0975300fe3fb940'),
+      description: translate('text_1746623860224gh7o1exyjce'),
+      actionText: translate('text_6244277fe0975300fe3fb94c'),
+      colorVariant: 'danger',
+      onAction: () => onLeave(),
+    })
+
   const [updateFeature, { error: updateError }] = useUpdateFeatureMutation({
     context: {
       silentErrorCodes: SILENT_ERROR_CODES,
@@ -231,188 +240,170 @@ const FeatureForm = () => {
   }, [existingFeature?.description])
 
   return (
-    <>
-      <CenteredPage.Wrapper>
-        <CenteredPage.Header>
-          <Typography variant="bodyHl" color="textSecondary" noWrap>
-            {translate(
-              isEdition ? 'text_1752692673070znttbx4w0r1' : 'text_17526926730703ysbxa2g5fj',
-            )}
-          </Typography>
+    <CenteredPage.Wrapper>
+      <CenteredPage.Header>
+        <Typography variant="bodyHl" color="textSecondary" noWrap>
+          {translate(isEdition ? 'text_1752692673070znttbx4w0r1' : 'text_17526926730703ysbxa2g5fj')}
+        </Typography>
 
-          <Button
-            variant="quaternary"
-            icon="close"
-            onClick={() =>
-              formikProps.dirty ? warningDirtyAttributesDialogRef.current?.openDialog() : onLeave()
-            }
-          />
-        </CenteredPage.Header>
+        <Button
+          variant="quaternary"
+          icon="close"
+          onClick={() => (formikProps.dirty ? openDirtyAttributesWarning() : onLeave())}
+        />
+      </CenteredPage.Header>
 
-        <CenteredPage.Container>
-          {featureLoading && <FormLoadingSkeleton id="feature-form" />}
-          {!featureLoading && (
-            <>
-              <div className="not-last-child:mb-1">
-                <Typography variant="headline" color="grey700">
-                  {translate(
-                    isEdition ? 'text_1752692673070lensu4uzy0l' : 'text_17526926730703ysbxa2g5fj',
-                  )}
-                </Typography>
-                <Typography variant="body" color="grey600">
-                  {translate('text_17526926730709neo6v3ki3n')}
-                </Typography>
-              </div>
+      <CenteredPage.Container>
+        {featureLoading && <FormLoadingSkeleton id="feature-form" />}
+        {!featureLoading && (
+          <>
+            <div className="not-last-child:mb-1">
+              <Typography variant="headline" color="grey700">
+                {translate(
+                  isEdition ? 'text_1752692673070lensu4uzy0l' : 'text_17526926730703ysbxa2g5fj',
+                )}
+              </Typography>
+              <Typography variant="body" color="grey600">
+                {translate('text_17526926730709neo6v3ki3n')}
+              </Typography>
+            </div>
 
-              <div className="flex flex-col gap-12">
-                <section className="pb-12 shadow-b not-last-child:mb-6">
-                  <div className="not-last-child:mb-2">
-                    <Typography variant="subhead1">
-                      {translate('text_1752692673070lgfy2k2bri4')}
-                    </Typography>
-                    <Typography variant="caption">
-                      {translate('text_1752692673070s4ndn9doemg')}
-                    </Typography>
-                  </div>
-                  <div className="flex gap-6 *:flex-1">
-                    <TextInput
-                      // eslint-disable-next-line jsx-a11y/no-autofocus
-                      autoFocus
-                      name="name"
-                      label={translate('text_1732286530467zstzwbegfiq')}
-                      placeholder={translate('text_62876e85e32e0300e1803121')}
-                      value={formikProps.values.name || ''}
-                      onChange={(name) => {
-                        updateNameAndMaybeCode({ name, formikProps })
-                      }}
-                    />
+            <div className="flex flex-col gap-12">
+              <section className="pb-12 shadow-b not-last-child:mb-6">
+                <div className="not-last-child:mb-2">
+                  <Typography variant="subhead1">
+                    {translate('text_1752692673070lgfy2k2bri4')}
+                  </Typography>
+                  <Typography variant="caption">
+                    {translate('text_1752692673070s4ndn9doemg')}
+                  </Typography>
+                </div>
+                <div className="flex gap-6 *:flex-1">
+                  <TextInput
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                    autoFocus
+                    name="name"
+                    label={translate('text_1732286530467zstzwbegfiq')}
+                    placeholder={translate('text_62876e85e32e0300e1803121')}
+                    value={formikProps.values.name || ''}
+                    onChange={(name) => {
+                      updateNameAndMaybeCode({ name, formikProps })
+                    }}
+                  />
+                  <TextInputField
+                    name="code"
+                    beforeChangeFormatter={['code']}
+                    disabled={isEdition}
+                    label={translate('text_62876e85e32e0300e1803127')}
+                    placeholder={translate('text_623b42ff8ee4e000ba87d0c4')}
+                    formikProps={formikProps}
+                    error={formikProps.errors.code}
+                  />
+                </div>
+
+                {shouldDisplayDescription ? (
+                  <div className="flex items-center">
                     <TextInputField
-                      name="code"
-                      beforeChangeFormatter={['code']}
-                      disabled={isEdition}
-                      label={translate('text_62876e85e32e0300e1803127')}
-                      placeholder={translate('text_623b42ff8ee4e000ba87d0c4')}
+                      multiline
+                      className="mr-3 flex-1"
+                      name="description"
+                      label={translate('text_6388b923e514213fed58331c')}
+                      placeholder={translate('text_1752693359315hw1mrrfr1hm')}
+                      rows="3"
                       formikProps={formikProps}
-                      error={formikProps.errors.code}
                     />
-                  </div>
-
-                  {shouldDisplayDescription ? (
-                    <div className="flex items-center">
-                      <TextInputField
-                        multiline
-                        className="mr-3 flex-1"
-                        name="description"
-                        label={translate('text_6388b923e514213fed58331c')}
-                        placeholder={translate('text_1752693359315hw1mrrfr1hm')}
-                        rows="3"
-                        formikProps={formikProps}
-                      />
-                      <Tooltip
-                        className="mt-6"
-                        placement="top-end"
-                        title={translate('text_63aa085d28b8510cd46443ff')}
-                      >
-                        <Button
-                          icon="trash"
-                          variant="quaternary"
-                          onClick={() => {
-                            formikProps.setFieldValue('description', '')
-                            setShouldDisplayDescription(false)
-                          }}
-                        />
-                      </Tooltip>
-                    </div>
-                  ) : (
-                    <Button
-                      fitContent
-                      align="left"
-                      startIcon="plus"
-                      variant="inline"
-                      onClick={() => setShouldDisplayDescription(true)}
-                      data-test="show-description"
+                    <Tooltip
+                      className="mt-6"
+                      placement="top-end"
+                      title={translate('text_63aa085d28b8510cd46443ff')}
                     >
-                      {translate('text_642d5eb2783a2ad10d670324')}
-                    </Button>
-                  )}
-                </section>
-
-                <section className="not-last-child:mb-6">
-                  <div className="not-last-child:mb-2">
-                    <Typography variant="subhead1">
-                      {translate('text_1752693359315oilajtir2uj')}
-                    </Typography>
-                    <Typography variant="caption">
-                      {translate('text_1752693359315aaw5g0bbc1h')}
-                    </Typography>
-                  </div>
-                  <div className="flex flex-col gap-6 *:flex-1">
-                    {formikProps.values.privileges.map((privilege, privilegeIndex) => (
-                      <FeaturePrivilegeAccordion
-                        key={`privilege-accordion-${privilegeIndex}`}
-                        id={`privilege-accordion-${privilegeIndex}`}
-                        isEdition={isEdition}
-                        privilege={privilege}
-                        privilegeIndex={privilegeIndex}
-                        formikProps={formikProps}
+                      <Button
+                        icon="trash"
+                        variant="quaternary"
+                        onClick={() => {
+                          formikProps.setFieldValue('description', '')
+                          setShouldDisplayDescription(false)
+                        }}
                       />
-                    ))}
-
-                    <Button
-                      fitContent
-                      align="left"
-                      variant="inline"
-                      startIcon="plus"
-                      onClick={() => {
-                        formikProps.setFieldValue('privileges', [
-                          ...formikProps.values.privileges,
-                          {
-                            code: '',
-                            name: '',
-                            valueType: PrivilegeValueTypeEnum.Boolean,
-                          },
-                        ])
-                      }}
-                    >
-                      {translate('text_1752695518075ut8zscauuq3')}
-                    </Button>
+                    </Tooltip>
                   </div>
-                </section>
-              </div>
-            </>
-          )}
-        </CenteredPage.Container>
+                ) : (
+                  <Button
+                    fitContent
+                    align="left"
+                    startIcon="plus"
+                    variant="inline"
+                    onClick={() => setShouldDisplayDescription(true)}
+                    data-test="show-description"
+                  >
+                    {translate('text_642d5eb2783a2ad10d670324')}
+                  </Button>
+                )}
+              </section>
 
-        <CenteredPage.StickyFooter>
-          <Button
-            variant="quaternary"
-            onClick={() =>
-              formikProps.dirty ? warningDirtyAttributesDialogRef.current?.openDialog() : onLeave()
-            }
-          >
-            {translate('text_6411e6b530cb47007488b027')}
-          </Button>
-          <Button
-            data-test="submit"
-            variant="primary"
-            disabled={!formikProps.isValid || !formikProps.dirty || featureLoading}
-            onClick={formikProps.submitForm}
-          >
-            {translate(
-              isEdition ? 'text_1752693359315c6eoxf5szye' : 'text_1752693359315fi592i0bpyz',
-            )}
-          </Button>
-        </CenteredPage.StickyFooter>
-      </CenteredPage.Wrapper>
+              <section className="not-last-child:mb-6">
+                <div className="not-last-child:mb-2">
+                  <Typography variant="subhead1">
+                    {translate('text_1752693359315oilajtir2uj')}
+                  </Typography>
+                  <Typography variant="caption">
+                    {translate('text_1752693359315aaw5g0bbc1h')}
+                  </Typography>
+                </div>
+                <div className="flex flex-col gap-6 *:flex-1">
+                  {formikProps.values.privileges.map((privilege, privilegeIndex) => (
+                    <FeaturePrivilegeAccordion
+                      key={`privilege-accordion-${privilegeIndex}`}
+                      id={`privilege-accordion-${privilegeIndex}`}
+                      isEdition={isEdition}
+                      privilege={privilege}
+                      privilegeIndex={privilegeIndex}
+                      formikProps={formikProps}
+                    />
+                  ))}
 
-      <WarningDialog
-        ref={warningDirtyAttributesDialogRef}
-        title={translate('text_6244277fe0975300fe3fb940')}
-        description={translate('text_1746623860224gh7o1exyjce')}
-        continueText={translate('text_6244277fe0975300fe3fb94c')}
-        onContinue={onLeave}
-      />
-    </>
+                  <Button
+                    fitContent
+                    align="left"
+                    variant="inline"
+                    startIcon="plus"
+                    onClick={() => {
+                      formikProps.setFieldValue('privileges', [
+                        ...formikProps.values.privileges,
+                        {
+                          code: '',
+                          name: '',
+                          valueType: PrivilegeValueTypeEnum.Boolean,
+                        },
+                      ])
+                    }}
+                  >
+                    {translate('text_1752695518075ut8zscauuq3')}
+                  </Button>
+                </div>
+              </section>
+            </div>
+          </>
+        )}
+      </CenteredPage.Container>
+
+      <CenteredPage.StickyFooter>
+        <Button
+          variant="quaternary"
+          onClick={() => (formikProps.dirty ? openDirtyAttributesWarning() : onLeave())}
+        >
+          {translate('text_6411e6b530cb47007488b027')}
+        </Button>
+        <Button
+          data-test="submit"
+          variant="primary"
+          disabled={!formikProps.isValid || !formikProps.dirty || featureLoading}
+          onClick={formikProps.submitForm}
+        >
+          {translate(isEdition ? 'text_1752693359315c6eoxf5szye' : 'text_1752693359315fi592i0bpyz')}
+        </Button>
+      </CenteredPage.StickyFooter>
+    </CenteredPage.Wrapper>
   )
 }
 


### PR DESCRIPTION
## Context

`FeatureForm` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `FeatureForm.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/features/FeatureForm.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render.
  - Added `useCentralizedDialog()` and extracted an `openDirtyAttributesWarning()` helper that opens the confirmation dialog — same title/description/action text, still with `colorVariant: 'danger'`, and still calling `onLeave()` on confirm.
  - Both dirty-guard call sites (header close button and footer cancel button) now call `openDirtyAttributesWarning()` instead of `warningDirtyAttributesDialogRef.current?.openDialog()`; the not-dirty branches keep calling `onLeave()`.
  - Dropped `useRef` from the React import (no longer used in this file).

The parent page still uses Formik (a separate migration tracked by other ESLint warnings) — the scope here is strictly the `WarningDialog` warning.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` / TanStack Form migration in this PR.

## Test plan

- [ ] Open *Features → Create feature*.
- [ ] Fill fields (name, code, or privileges) so the Formik form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back to the features list.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] Same flow via the footer cancel button.
- [ ] When the form is pristine, clicking close/cancel immediately navigates away with no dialog.
- [ ] Edit an existing feature → same flow works in edition mode (navigates back to the feature details overview tab).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfmMjXVh11X82dnDvnWyK7)_