### PR TITLE
refactor(credit-notes): migrate CreateCreditNote close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/createCreditNote/CreateCreditNote.tsx
+++ b/src/pages/createCreditNote/CreateCreditNote.tsx
@@ -23,7 +23,7 @@ import { Button } from '~/components/designSystem/Button'
 import { Card } from '~/components/designSystem/Card'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { ComboBoxField, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { hasDefinedGQLError } from '~/core/apolloClient'
@@ -85,8 +85,29 @@ export const CREDIT_NOTE_REASONS: { reason: CreditNoteReasonEnum; label: string 
 const CreateCreditNote = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
-  const warningDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const { customerId, invoiceId } = useParams()
+
+  const navigateBack = useCallback(
+    () =>
+      navigate(
+        generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
+          customerId: customerId as string,
+          invoiceId: invoiceId as string,
+          tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
+        }),
+      ),
+    [customerId, invoiceId, navigate],
+  )
+
+  const openDirtyAttributesWarning = () =>
+    centralizedDialog.open({
+      title: translate('text_636bdf192a28e7cf28abf00d'),
+      description: translate('text_636bed940028096908b735ed'),
+      actionText: translate('text_636beda08285f03477c7e25e'),
+      colorVariant: 'danger',
+      onAction: () => navigateBack(),
+    })
   const {
     loading,
     invoice,
@@ -281,17 +302,7 @@ const CreateCreditNote = () => {
           variant="quaternary"
           icon="close"
           data-test={CLOSE_BUTTON_TEST_ID}
-          onClick={() =>
-            formikProps.dirty
-              ? warningDialogRef.current?.openDialog()
-              : navigate(
-                  generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
-                    customerId: customerId as string,
-                    invoiceId: invoiceId as string,
-                    tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
-                  }),
-                )
-          }
+          onClick={() => (formikProps.dirty ? openDirtyAttributesWarning() : navigateBack())}
         />
       </PageHeader.Wrapper>
       <CenteredPage.Container>
@@ -547,22 +558,6 @@ const CreateCreditNote = () => {
           </Button>
         </div>
       </CenteredPage.StickyFooter>
-
-      <WarningDialog
-        ref={warningDialogRef}
-        title={translate('text_636bdf192a28e7cf28abf00d')}
-        description={translate('text_636bed940028096908b735ed')}
-        continueText={translate('text_636beda08285f03477c7e25e')}
-        onContinue={() =>
-          navigate(
-            generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
-              customerId: customerId as string,
-              invoiceId: invoiceId as string,
-              tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
-            }),
-          )
-        }
-      />
     </div>
   )
 }

--- a/src/pages/createCreditNote/__tests__/CreateCreditNote.integration.test.tsx
+++ b/src/pages/createCreditNote/__tests__/CreateCreditNote.integration.test.tsx
@@ -1,3 +1,4 @@
+import NiceModal from '@ebay/nice-modal-react'
 import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
@@ -8,6 +9,8 @@ import {
 } from '~/components/creditNote/CreditNoteFormAllocation'
 import { CREDIT_ONLY_AMOUNT_LINE_TEST_ID } from '~/components/creditNote/CreditNoteFormCalculation'
 import { getSubscriptionCheckboxTestId } from '~/components/creditNote/CreditNoteItemsForm'
+import CentralizedDialog from '~/components/dialogs/CentralizedDialog'
+import { CENTRALIZED_DIALOG_NAME } from '~/components/dialogs/const'
 import {
   CreditNoteEstimateDocument,
   CreditNoteReasonEnum,
@@ -23,6 +26,8 @@ import CreateCreditNote, {
   PREPAID_CREDITS_REFUND_ALERT_TEST_ID,
   SUBMIT_BUTTON_TEST_ID,
 } from '../CreateCreditNote'
+
+NiceModal.register(CENTRALIZED_DIALOG_NAME, CentralizedDialog)
 
 const mockOnCreate = jest.fn()
 const mockUseCreateCreditNote = jest.fn()
@@ -678,7 +683,14 @@ describe('CreateCreditNote', () => {
       const user = userEvent.setup()
       const mocks = [createCreditNoteEstimateMock()]
 
-      await act(() => render(<CreateCreditNote />, { mocks }))
+      await act(() =>
+        render(
+          <NiceModal.Provider>
+            <CreateCreditNote />
+          </NiceModal.Provider>,
+          { mocks },
+        ),
+      )
 
       // Type in description to make form dirty
       const descriptionWrapper = screen.getByTestId(DESCRIPTION_INPUT_TEST_ID)


### PR DESCRIPTION
## Context

`CreateCreditNote` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation, which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `CreateCreditNote.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/createCreditNote/CreateCreditNote.tsx`:
  - Removed `useRef<WarningDialogRef>` + the `<WarningDialog />` render.
  - Added `useCentralizedDialog()` and extracted:
    - a small `navigateBack()` helper that navigates back to the customer invoice details overview (deduplicates the previously-inlined path).
    - an `openDirtyAttributesWarning()` helper that opens the confirmation dialog — same title/description/action text, still with `colorVariant: 'danger'`, and still calling `navigateBack()` on confirm.
  - The header close button now calls `openDirtyAttributesWarning()` when the form is dirty (or `navigateBack()` when pristine) instead of driving `warningDialogRef.current?.openDialog()`.

The parent page still uses Formik (a separate migration tracked by other ESLint warnings) — the scope here is strictly the `WarningDialog` warning.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` / TanStack Form migration in this PR.

## Test plan

- [ ] Open a customer invoice → *Issue credit note*.
- [ ] Select a reason / tick some fees / edit an amount so the Formik form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back to the customer invoice details overview tab.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] When the form is pristine, clicking the close icon immediately navigates away with no dialog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfmMjXVh11X82dnDvnWyK7)_