### PR TITLE
fix(slug): prepend org slug to object-form navigate targets

### DIFF
--- a/src/components/customers/overview/CustomerInvoiceBalancesBreakdown.tsx
+++ b/src/components/customers/overview/CustomerInvoiceBalancesBreakdown.tsx
@@ -214,12 +214,12 @@ export const CustomerInvoiceBalancesBreakdown = ({
                   params.set('billingEntityId', billingEntityId)
                 }
 
-                navigate({
-                  pathname: generatePath(CUSTOMER_REQUEST_OVERDUE_PAYMENT_ROUTE, {
-                    customerId: customerId ?? '',
-                  }),
-                  search: params.toString() ? `?${params.toString()}` : '',
+                const pathname = generatePath(CUSTOMER_REQUEST_OVERDUE_PAYMENT_ROUTE, {
+                  customerId: customerId ?? '',
                 })
+                const search = params.toString()
+
+                navigate(search ? `${pathname}?${search}` : pathname)
               }}
             >
               {translate('text_66b258f62100490d0eb5caa2')}

--- a/src/components/customers/overview/__tests__/CustomerInvoiceBalancesBreakdown.test.tsx
+++ b/src/components/customers/overview/__tests__/CustomerInvoiceBalancesBreakdown.test.tsx
@@ -380,15 +380,10 @@ describe('CustomerInvoiceBalancesBreakdown', () => {
 
         await user.click(buttons[0])
 
+        expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('currency=USD'))
+        expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('billingEntityId=be-1'))
         expect(mockNavigate).toHaveBeenCalledWith(
-          expect.objectContaining({
-            search: expect.stringContaining('currency=USD'),
-          }),
-        )
-        expect(mockNavigate).toHaveBeenCalledWith(
-          expect.objectContaining({
-            search: expect.stringContaining('billingEntityId=be-1'),
-          }),
+          expect.stringMatching(/^\/customers\/[^?]+\/request-overdue-payment\?/),
         )
       })
     })

--- a/src/core/router/__tests__/useNavigate.test.ts
+++ b/src/core/router/__tests__/useNavigate.test.ts
@@ -87,14 +87,49 @@ describe('useNavigate', () => {
       })
     })
 
-    describe('WHEN navigating with an object To', () => {
-      it('THEN should pass the object through without slug prepend', () => {
+    describe('WHEN navigating with an object To that has a pathname', () => {
+      it('THEN should prepend the slug to the pathname and preserve other fields', () => {
         const { result } = renderHook(() => useNavigate())
-        const to = { pathname: '/customers', search: '?page=2' }
+
+        result.current({ pathname: '/customers', search: '?page=2' })
+
+        expect(mockNavigate).toHaveBeenCalledWith({
+          pathname: '/acme/customers',
+          search: '?page=2',
+        })
+      })
+
+      it('THEN should not double-prepend an already-prefixed pathname', () => {
+        const { result } = renderHook(() => useNavigate())
+
+        result.current({ pathname: '/acme/customers', search: '?page=2' })
+
+        expect(mockNavigate).toHaveBeenCalledWith({
+          pathname: '/acme/customers',
+          search: '?page=2',
+        })
+      })
+    })
+
+    describe('WHEN navigating with an object To without a pathname', () => {
+      it('THEN should pass the object through unchanged (search-only nav stays on current page)', () => {
+        const { result } = renderHook(() => useNavigate())
+        const to = { search: '?filter=active' }
 
         result.current(to)
 
         expect(mockNavigate).toHaveBeenCalledWith(to)
+      })
+    })
+
+    describe('WHEN navigating with an object To and skipSlugPrepend', () => {
+      it('THEN should pass the object through unchanged', () => {
+        const { result } = renderHook(() => useNavigate())
+        const to = { pathname: '/other-org/customers', search: '?page=2' }
+
+        result.current(to, { skipSlugPrepend: true })
+
+        expect(mockNavigate).toHaveBeenCalledWith(to, {})
       })
     })
   })

--- a/src/core/router/useNavigate.ts
+++ b/src/core/router/useNavigate.ts
@@ -25,10 +25,11 @@ type SlugAwareNavigate = (to: To | number, options?: NavigateOptions) => void
  * Slug-aware `useNavigate` wrapper.
  *
  * Transparently prepends `/${organizationSlug}` to absolute string targets
- * so call sites keep writing `navigate('/customers')` while the URL ends up
- * `/${slug}/customers`. Pass-through for:
+ * AND to the `pathname` of object-form targets, so call sites keep writing
+ * `navigate('/customers')` or `navigate({ pathname: '/customers', search })`
+ * while the URL ends up `/${slug}/customers`. Pass-through for:
  * - `navigate(-1)` / any number (history delta)
- * - `navigate({ search, pathname })` object form
+ * - object-form targets without a `pathname` (`{ search }` only — same page)
  * - targets starting with any `NEVER_SLUG_PREFIXES` entry
  * - targets already starting with `/${organizationSlug}/` (no double-prepend)
  * - the root path `/` (HOME_ROUTE lives outside org scope)
@@ -49,8 +50,14 @@ export const useNavigate = (): SlugAwareNavigate => {
 
     const { skipSlugPrepend, ...rrOptions } = options || {}
 
-    const finalTo =
-      !skipSlugPrepend && typeof to === 'string' ? prependOrgSlug(to, organizationSlug) : to
+    const finalTo = (() => {
+      if (skipSlugPrepend) return to
+      if (typeof to === 'string') return prependOrgSlug(to, organizationSlug)
+      if (to && typeof to === 'object' && to.pathname) {
+        return { ...to, pathname: prependOrgSlug(to.pathname, organizationSlug) }
+      }
+      return to
+    })()
 
     // Only forward options when the caller actually provided any — otherwise
     // we'd change the call shape to `rrNavigate(path, {})`, which leaks into

--- a/src/layouts/OrganizationLayout.tsx
+++ b/src/layouts/OrganizationLayout.tsx
@@ -17,7 +17,6 @@ import { LEGACY_APP_PATH_SEGMENTS } from '~/core/router/legacyPaths'
 import { resolveOrgSlug } from '~/core/router/utils/orgSlug'
 import { useIsAuthenticated } from '~/hooks/auth/useIsAuthenticated'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
-import { hasIframeParams } from '~/hooks/useIframeConfig'
 
 const Error404 = lazy(() => import('~/pages/Error404'))
 
@@ -34,9 +33,6 @@ class SlugMigrationEvent extends Error {
     this.name = name
   }
 }
-
-/** Sentry `mode` tag — distinguishes which recovery branch resolved the slug. */
-type RecoveryMode = 'single-org' | 'multi-org-iframe' | 'multi-org'
 
 const OrganizationLayout = () => {
   const { organizationSlug } = useParams<{ organizationSlug: string }>()
@@ -60,8 +56,6 @@ const OrganizationLayout = () => {
     currentUser?.memberships.length === 1
       ? currentUser.memberships[0]?.organization.slug
       : undefined
-
-  const isIframeContext = hasIframeParams(location.search)
 
   // Multi-membership recovery — applies when `soleMembershipSlug` is undefined
   // (i.e., user has ≥2 memberships). Resolves via the in-memory org var
@@ -93,16 +87,11 @@ const OrganizationLayout = () => {
   // triggers a parent re-render. `replace` keeps history clean — the legacy
   // URL never gets a back-button entry.
   //
-  // Two Sentry events may fire here:
-  //
-  // 1. `legacy_url_auto_recovered` (info) — always, when recovery happens.
-  //    The `mode` tag (`single-org` / `multi-org-iframe` / `multi-org`) marks
-  //    which recovery branch resolved the slug, for analytics.
-  // 2. `slug_migration_missed_link` (error) — additionally, when the previous
-  //    in-app path was slug-prefixed. This is the developer-actionable signal
-  //    that an in-app link wasn't migrated to the slug wrapper. Auto-recovery
-  //    silences the user-facing 404, but we keep this signal so the bug
-  //    remains visible in Sentry and dev alerts can fire on it.
+  // Emits `slug_migration_missed_link` (error) when the previous in-app path
+  // was slug-prefixed. This is the developer-actionable signal that an in-app
+  // link wasn't migrated to the slug wrapper. Auto-recovery silences the
+  // user-facing 404, but we keep this signal so the bug remains visible in
+  // Sentry and dev alerts can fire on it.
   useEffect(() => {
     if (!shouldAutoRecoverLegacyPath) return
 
@@ -110,32 +99,6 @@ const OrganizationLayout = () => {
       replace: true,
       skipSlugPrepend: true,
     })
-
-    // Sentry `mode` tag — purely analytical, distinguishes which recovery
-    // branch resolved the slug.
-    const recoveryMode = (): RecoveryMode => {
-      if (soleMembershipSlug) return 'single-org'
-      if (isIframeContext) return 'multi-org-iframe'
-      return 'multi-org'
-    }
-
-    // Sentry groups by `exception.type` (= `Error.name`), so each
-    // `SlugMigrationEvent` subclass name yields its own issue with the
-    // correct level. The `feature: 'slug-migration'` tag is the unified
-    // search/alert handle across all migration events.
-    Sentry.captureException(
-      new SlugMigrationEvent('SlugMigrationAutoRecovered', 'legacy_url_auto_recovered'),
-      {
-        level: 'info',
-        tags: {
-          feature: 'slug-migration',
-          attemptedSlug: organizationSlug ?? '',
-          recoveredToSlug: recoveredSlug ?? '',
-          mode: recoveryMode(),
-        },
-        extra: { fullPath: location.pathname },
-      },
-    )
 
     // Detect missed-migration in-app links. `previousPath` is read from
     // `locationHistoryVar` which records pathnames the user navigated through;

--- a/src/layouts/__tests__/OrganizationLayout.test.tsx
+++ b/src/layouts/__tests__/OrganizationLayout.test.tsx
@@ -195,7 +195,7 @@ describe('OrganizationLayout', () => {
 
   describe('GIVEN the slug does NOT match any membership', () => {
     describe('WHEN the slug is a legacy app path segment AND previous in-app path was slug-prefixed', () => {
-      it('THEN should auto-recover AND emit slug_migration_missed_link error alongside the auto-recover info event', () => {
+      it('THEN should auto-recover AND emit slug_migration_missed_link error', () => {
         mockUseParams.mockReturnValue({ organizationSlug: 'customers' })
         mockUseLocation.mockReturnValue({
           pathname: '/customers',
@@ -220,21 +220,9 @@ describe('OrganizationLayout', () => {
           expect.objectContaining({ replace: true, skipSlugPrepend: true }),
         )
 
-        // Auto-recover (info) — the user-experience signal.
-        expect(Sentry.captureException).toHaveBeenCalledWith(
-          expect.objectContaining({
-            name: 'SlugMigrationAutoRecovered',
-            message: 'legacy_url_auto_recovered',
-          }),
-          expect.objectContaining({
-            level: 'info',
-            tags: expect.objectContaining({ mode: 'multi-org' }),
-          }),
-        )
-
-        // Missed-link (error) — the developer-actionable bug signal,
-        // emitted alongside the auto-recover so the in-app non-migrated link
-        // remains visible in Sentry even though the user no longer sees a 404.
+        // Missed-link (error) — the developer-actionable bug signal.
+        // Auto-recovery silences the user-facing 404 but the error stays
+        // visible in Sentry so non-migrated in-app links remain surfaced.
         expect(Sentry.captureException).toHaveBeenCalledWith(
           expect.objectContaining({
             name: 'SlugMigrationMissedLink',
@@ -275,7 +263,7 @@ describe('OrganizationLayout', () => {
       },
     ]
 
-    it('THEN should auto-redirect to the slug-prefixed path and emit an info Sentry event', () => {
+    it('THEN should auto-redirect to the slug-prefixed path', () => {
       mockUseParams.mockReturnValue({ organizationSlug: 'customers' })
       mockUseLocation.mockReturnValue({
         pathname: '/customers',
@@ -297,25 +285,8 @@ describe('OrganizationLayout', () => {
           skipSlugPrepend: true,
         }),
       )
-      expect(Sentry.captureException).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'SlugMigrationAutoRecovered',
-          message: 'legacy_url_auto_recovered',
-        }),
-        expect.objectContaining({
-          level: 'info',
-          tags: expect.objectContaining({
-            attemptedSlug: 'customers',
-            recoveredToSlug: TEST_ORG_SLUG,
-            mode: 'single-org',
-          }),
-        }),
-      )
-      // The 404-path events must NOT fire — auto-recover has its own event.
-      expect(Sentry.captureException).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'SlugMigrationLegacyUrl' }),
-        expect.anything(),
-      )
+      // No missed-link error when there is no previous in-app path — the user
+      // arrived directly on the legacy URL (bookmark, external link).
       expect(Sentry.captureException).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: 'SlugMigrationMissedLink' }),
         expect.anything(),
@@ -339,7 +310,7 @@ describe('OrganizationLayout', () => {
 
   describe('GIVEN a legacy path AND the user has multiple memberships', () => {
     describe('WHEN the URL has the Hubspot iframe param ?ifrm=true', () => {
-      it('THEN should auto-redirect using the LS-based slug and tag the Sentry event with mode=multi-org-iframe', () => {
+      it('THEN should auto-redirect using the LS-based slug', () => {
         mockUseParams.mockReturnValue({ organizationSlug: 'customers' })
         mockUseLocation.mockReturnValue({
           pathname: '/customers',
@@ -361,20 +332,6 @@ describe('OrganizationLayout', () => {
           expect.objectContaining({
             replace: true,
             skipSlugPrepend: true,
-          }),
-        )
-        expect(Sentry.captureException).toHaveBeenCalledWith(
-          expect.objectContaining({
-            name: 'SlugMigrationAutoRecovered',
-            message: 'legacy_url_auto_recovered',
-          }),
-          expect.objectContaining({
-            level: 'info',
-            tags: expect.objectContaining({
-              attemptedSlug: 'customers',
-              recoveredToSlug: TEST_ORG_SLUG,
-              mode: 'multi-org-iframe',
-            }),
           }),
         )
       })
@@ -408,7 +365,7 @@ describe('OrganizationLayout', () => {
     })
 
     describe('WHEN the URL has NO iframe param', () => {
-      it('THEN should auto-redirect using resolveOrgSlug and tag the Sentry event with mode=multi-org', () => {
+      it('THEN should auto-redirect using resolveOrgSlug', () => {
         mockUseParams.mockReturnValue({ organizationSlug: 'customers' })
         mockUseLocation.mockReturnValue({
           pathname: '/customers',
@@ -427,20 +384,6 @@ describe('OrganizationLayout', () => {
         expect(mockNavigate).toHaveBeenCalledWith(
           `/${TEST_ORG_SLUG}/customers`,
           expect.objectContaining({ replace: true, skipSlugPrepend: true }),
-        )
-        expect(Sentry.captureException).toHaveBeenCalledWith(
-          expect.objectContaining({
-            name: 'SlugMigrationAutoRecovered',
-            message: 'legacy_url_auto_recovered',
-          }),
-          expect.objectContaining({
-            level: 'info',
-            tags: expect.objectContaining({
-              attemptedSlug: 'customers',
-              recoveredToSlug: TEST_ORG_SLUG,
-              mode: 'multi-org',
-            }),
-          }),
         )
       })
     })
@@ -467,7 +410,7 @@ describe('OrganizationLayout', () => {
     })
 
     describe('WHEN the URL has an iframe param value other than "true"', () => {
-      it('THEN should still auto-redirect (recovery is universal) but tag mode=multi-org since the iframe param is invalid', () => {
+      it('THEN should still auto-redirect (recovery is universal)', () => {
         mockUseParams.mockReturnValue({ organizationSlug: 'customers' })
         mockUseLocation.mockReturnValue({
           pathname: '/customers',
@@ -483,18 +426,9 @@ describe('OrganizationLayout', () => {
 
         renderHook(() => OrganizationLayout())
 
-        // Multi-org auto-recovery is now universal — `?ifrm=false` is just
-        // an invalid iframe param, so `recoveryMode` falls through to
-        // `multi-org` (not iframe). The user-facing recovery still happens.
         expect(mockNavigate).toHaveBeenCalledWith(
           `/${TEST_ORG_SLUG}/customers?ifrm=false`,
           expect.objectContaining({ replace: true, skipSlugPrepend: true }),
-        )
-        expect(Sentry.captureException).toHaveBeenCalledWith(
-          expect.objectContaining({ name: 'SlugMigrationAutoRecovered' }),
-          expect.objectContaining({
-            tags: expect.objectContaining({ mode: 'multi-org' }),
-          }),
         )
       })
     })


### PR DESCRIPTION
  ## Context

  Sentry issue `SlugMigrationMissedLink` fired on
  `/customer/:customerId/request-overdue-payment`. The `useNavigate`
  wrapper in `~/core/router` only prepended `/${organizationSlug}` to
  string targets, so callers using `navigate({ pathname, search })`
  produced slug-less URLs. `SlugMigrationAutoRecovered` rewrote the URL
  after the fact but every hit still logged an error.

  ## Description

  - Extend `useNavigate` to also prepend the slug to the `pathname` of object-form targets (idempotent). `{ search }`-only navigation and `skipSlugPrepend: true` are unchanged.
  - Convert the offending call site in `CustomerInvoiceBalancesBreakdown` to the string form to match the sibling header dropdown pattern.
  - Update the affected unit tests.

  <!-- Linear link -->
  Fixes LAGO-1690