### PR TITLE
refactor(subscriptions): migrate SubscriptionEntitlementForm close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/subscriptions/SubscriptionEntitlementForm.tsx
+++ b/src/pages/subscriptions/SubscriptionEntitlementForm.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { useFormik } from 'formik'
-import { useCallback, useId, useMemo, useRef, useState } from 'react'
+import { useCallback, useId, useMemo, useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 import { array, object, string } from 'yup'
 
@@ -9,7 +9,7 @@ import { Chip } from '~/components/designSystem/Chip'
 import { ChargeTable } from '~/components/designSystem/Table/ChargeTable'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { ComboBox, ComboBoxField, ComboboxItem } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { PrivilegeValueInputComponent } from '~/components/plans/PrivilegeValueInputComponent'
@@ -99,7 +99,7 @@ const SubscriptionEntitlementForm = () => {
   const { translate } = useInternationalization()
   const navigate = useNavigate()
   const componentId = useId()
-  const warningDirtyAttributesDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const [displayAddPrivilegeInput, setDisplayAddPrivilegeInput] = useState(false)
 
   const isEdition = !!entitlementCode
@@ -145,6 +145,16 @@ const SubscriptionEntitlementForm = () => {
       )
     }
   }, [customerId, navigate, planId, subscriptionId])
+
+  const openDirtyAttributesWarning = useCallback(() => {
+    centralizedDialog.open({
+      title: translate('text_6244277fe0975300fe3fb940'),
+      description: translate('text_17561254890579cfr8pj6afl'),
+      actionText: translate('text_6244277fe0975300fe3fb94c'),
+      colorVariant: 'danger',
+      onAction: () => onLeave(),
+    })
+  }, [centralizedDialog, onLeave, translate])
 
   const [createOrUpdateEntitlement] = useCreateOrUpdateSubscriptionEntitlementMutation({
     onCompleted({ createOrUpdateSubscriptionEntitlement }) {
@@ -276,243 +286,227 @@ const SubscriptionEntitlementForm = () => {
   ])
 
   return (
-    <>
-      <CenteredPage.Wrapper>
-        <CenteredPage.Header>
-          <div className="flex gap-2">
-            <Typography variant="bodyHl" color="textSecondary" noWrap>
-              {translate(
-                isEdition ? 'text_17561254890571tcj63iu382' : 'text_1753864223060devvklm7vk0',
-              )}
-            </Typography>
-            <Chip size="small" label={translate('text_65d8d71a640c5400917f8a13')} />
-          </div>
-          <Button
-            variant="quaternary"
-            icon="close"
-            onClick={() =>
-              formikProps.dirty ? warningDirtyAttributesDialogRef.current?.openDialog() : onLeave()
-            }
-          />
-        </CenteredPage.Header>
+    <CenteredPage.Wrapper>
+      <CenteredPage.Header>
+        <div className="flex gap-2">
+          <Typography variant="bodyHl" color="textSecondary" noWrap>
+            {translate(
+              isEdition ? 'text_17561254890571tcj63iu382' : 'text_1753864223060devvklm7vk0',
+            )}
+          </Typography>
+          <Chip size="small" label={translate('text_65d8d71a640c5400917f8a13')} />
+        </div>
+        <Button
+          variant="quaternary"
+          icon="close"
+          onClick={() => (formikProps.dirty ? openDirtyAttributesWarning() : onLeave())}
+        />
+      </CenteredPage.Header>
 
-        <CenteredPage.Container>
-          {isLoading && <FormLoadingSkeleton id="create-alert" />}
-          {!isLoading && (
-            <>
-              <div className="not-last-child:mb-1">
-                <Typography variant="headline" color="grey700">
-                  {translate('text_1756125489057x892tvlnat0')}
-                </Typography>
-                <Typography variant="body" color="grey600">
-                  {translate('text_17538642230602p03937fj0f')}
-                </Typography>
-              </div>
+      <CenteredPage.Container>
+        {isLoading && <FormLoadingSkeleton id="create-alert" />}
+        {!isLoading && (
+          <>
+            <div className="not-last-child:mb-1">
+              <Typography variant="headline" color="grey700">
+                {translate('text_1756125489057x892tvlnat0')}
+              </Typography>
+              <Typography variant="body" color="grey600">
+                {translate('text_17538642230602p03937fj0f')}
+              </Typography>
+            </div>
 
-              <div className="flex flex-col gap-12">
-                <section className="not-last-child:mb-6">
-                  <div className="not-last-child:mb-2">
-                    <Typography variant="subhead1">
-                      {translate('text_17561254890572l8l58nidzn')}
-                    </Typography>
-                    <Typography variant="caption">
-                      {translate('text_1756125489057oq6le0rt7mw')}
-                    </Typography>
-                  </div>
-                  <div className="flex flex-col gap-12 *:flex-1">
-                    <ComboBoxField
-                      name="code"
-                      disableClearable={isEdition}
-                      placeholder={translate('text_1753864223060h6i2e7303eb')}
-                      disabled={isEdition}
-                      loading={subscriptionLoading}
-                      data={featuresListComboboxData}
-                      formikProps={formikProps}
-                    />
+            <div className="flex flex-col gap-12">
+              <section className="not-last-child:mb-6">
+                <div className="not-last-child:mb-2">
+                  <Typography variant="subhead1">
+                    {translate('text_17561254890572l8l58nidzn')}
+                  </Typography>
+                  <Typography variant="caption">
+                    {translate('text_1756125489057oq6le0rt7mw')}
+                  </Typography>
+                </div>
+                <div className="flex flex-col gap-12 *:flex-1">
+                  <ComboBoxField
+                    name="code"
+                    disableClearable={isEdition}
+                    placeholder={translate('text_1753864223060h6i2e7303eb')}
+                    disabled={isEdition}
+                    loading={subscriptionLoading}
+                    data={featuresListComboboxData}
+                    formikProps={formikProps}
+                  />
 
-                    {!!formikProps.values.privileges.length && (
-                      <div className="-mx-4 -my-1 w-full overflow-auto px-4 py-1">
-                        <ChargeTable
-                          className="w-full"
-                          name={`feature-entitlement-${formikProps.values.code}-privilege-table`}
-                          data={formikProps.values.privileges || []}
-                          deleteTooltipContent={translate('text_17538642230608t3xmlgja96')}
-                          onDeleteRow={(row) => {
-                            formikProps.setFieldValue(
-                              'privileges',
-                              formikProps.values.privileges?.filter(
-                                (privilegeForUpdate) => privilegeForUpdate.code !== row.code,
-                              ),
+                  {!!formikProps.values.privileges.length && (
+                    <div className="-mx-4 -my-1 w-full overflow-auto px-4 py-1">
+                      <ChargeTable
+                        className="w-full"
+                        name={`feature-entitlement-${formikProps.values.code}-privilege-table`}
+                        data={formikProps.values.privileges || []}
+                        deleteTooltipContent={translate('text_17538642230608t3xmlgja96')}
+                        onDeleteRow={(row) => {
+                          formikProps.setFieldValue(
+                            'privileges',
+                            formikProps.values.privileges?.filter(
+                              (privilegeForUpdate) => privilegeForUpdate.code !== row.code,
+                            ),
+                          )
+                        }}
+                        columns={[
+                          {
+                            size: 300,
+                            title: (
+                              <Typography variant="captionHl" className="px-4">
+                                {translate('text_175386422306019wldpp8h5q')}
+                              </Typography>
+                            ),
+                            content: (row) => (
+                              <Typography variant="body" color="grey700" className="px-4">
+                                {row.name || row.code}
+                              </Typography>
+                            ),
+                          },
+                          {
+                            size: 300,
+                            title: (
+                              <Typography variant="captionHl" className="px-4">
+                                {translate('text_63fcc3218d35b9377840f5ab')}
+                              </Typography>
+                            ),
+                            content: (row) => {
+                              return (
+                                <PrivilegeValueInputComponent
+                                  translate={translate}
+                                  valueType={row.valueType}
+                                  value={row.value || ''}
+                                  config={row.config}
+                                  onChange={(value) => {
+                                    formikProps.setFieldValue(
+                                      'privileges',
+                                      formikProps.values.privileges?.map((privilegeForUpdate) =>
+                                        privilegeForUpdate.code === row.code
+                                          ? {
+                                              ...privilegeForUpdate,
+                                              value,
+                                            }
+                                          : privilegeForUpdate,
+                                      ),
+                                    )
+                                  }}
+                                />
+                              )
+                            },
+                          },
+                        ]}
+                      />
+                    </div>
+                  )}
+
+                  {displayAddPrivilegeInput ? (
+                    <div className="flex w-full items-center gap-3">
+                      <ComboBox
+                        disableClearable
+                        containerClassName="w-full"
+                        placeholder={translate('text_1753864223060yk3svyv4dpr')}
+                        loading={subscriptionLoading}
+                        data={privilegesListComboBoxData}
+                        className={privilegeSearchClassName}
+                        onChange={(selectedPrivilege) => {
+                          if (!selectedPrivilege) return
+
+                          const selectedPrivilegeFullData =
+                            subscriptionData?.features?.collection.find(
+                              (feature) => feature.code === formikProps.values.code,
                             )
-                          }}
-                          columns={[
+
+                          if (!selectedPrivilegeFullData) {
+                            setDisplayAddPrivilegeInput(false)
+                            return
+                          }
+
+                          const selectedPrivilegeFullDataPrivilege =
+                            selectedPrivilegeFullData.privileges.find(
+                              (privilege) => privilege.code === selectedPrivilege,
+                            )
+
+                          if (!selectedPrivilegeFullDataPrivilege) {
+                            setDisplayAddPrivilegeInput(false)
+                            return
+                          }
+
+                          formikProps.setFieldValue('privileges', [
+                            ...(formikProps.values.privileges || []),
                             {
-                              size: 300,
-                              title: (
-                                <Typography variant="captionHl" className="px-4">
-                                  {translate('text_175386422306019wldpp8h5q')}
-                                </Typography>
-                              ),
-                              content: (row) => (
-                                <Typography variant="body" color="grey700" className="px-4">
-                                  {row.name || row.code}
-                                </Typography>
-                              ),
+                              code: selectedPrivilegeFullDataPrivilege.code,
+                              config: selectedPrivilegeFullDataPrivilege.config || undefined,
+                              name: selectedPrivilegeFullDataPrivilege.name,
+                              value: '',
+                              valueType: selectedPrivilegeFullDataPrivilege.valueType,
                             },
-                            {
-                              size: 300,
-                              title: (
-                                <Typography variant="captionHl" className="px-4">
-                                  {translate('text_63fcc3218d35b9377840f5ab')}
-                                </Typography>
-                              ),
-                              content: (row) => {
-                                return (
-                                  <PrivilegeValueInputComponent
-                                    translate={translate}
-                                    valueType={row.valueType}
-                                    value={row.value || ''}
-                                    config={row.config}
-                                    onChange={(value) => {
-                                      formikProps.setFieldValue(
-                                        'privileges',
-                                        formikProps.values.privileges?.map((privilegeForUpdate) =>
-                                          privilegeForUpdate.code === row.code
-                                            ? {
-                                                ...privilegeForUpdate,
-                                                value,
-                                              }
-                                            : privilegeForUpdate,
-                                        ),
-                                      )
-                                    }}
-                                  />
-                                )
-                              },
-                            },
-                          ]}
-                        />
-                      </div>
-                    )}
+                          ])
 
-                    {displayAddPrivilegeInput ? (
-                      <div className="flex w-full items-center gap-3">
-                        <ComboBox
-                          disableClearable
-                          containerClassName="w-full"
-                          placeholder={translate('text_1753864223060yk3svyv4dpr')}
-                          loading={subscriptionLoading}
-                          data={privilegesListComboBoxData}
-                          className={privilegeSearchClassName}
-                          onChange={(selectedPrivilege) => {
-                            if (!selectedPrivilege) return
-
-                            const selectedPrivilegeFullData =
-                              subscriptionData?.features?.collection.find(
-                                (feature) => feature.code === formikProps.values.code,
-                              )
-
-                            if (!selectedPrivilegeFullData) {
-                              setDisplayAddPrivilegeInput(false)
-                              return
-                            }
-
-                            const selectedPrivilegeFullDataPrivilege =
-                              selectedPrivilegeFullData.privileges.find(
-                                (privilege) => privilege.code === selectedPrivilege,
-                              )
-
-                            if (!selectedPrivilegeFullDataPrivilege) {
-                              setDisplayAddPrivilegeInput(false)
-                              return
-                            }
-
-                            formikProps.setFieldValue('privileges', [
-                              ...(formikProps.values.privileges || []),
-                              {
-                                code: selectedPrivilegeFullDataPrivilege.code,
-                                config: selectedPrivilegeFullDataPrivilege.config || undefined,
-                                name: selectedPrivilegeFullDataPrivilege.name,
-                                value: '',
-                                valueType: selectedPrivilegeFullDataPrivilege.valueType,
-                              },
-                            ])
-
+                          setDisplayAddPrivilegeInput(false)
+                        }}
+                      />
+                      <Tooltip
+                        placement="top-end"
+                        title={translate('text_63aa085d28b8510cd46443ff')}
+                      >
+                        <Button
+                          variant="quaternary"
+                          icon="trash"
+                          onClick={() => {
                             setDisplayAddPrivilegeInput(false)
                           }}
                         />
-                        <Tooltip
-                          placement="top-end"
-                          title={translate('text_63aa085d28b8510cd46443ff')}
-                        >
-                          <Button
-                            variant="quaternary"
-                            icon="trash"
-                            onClick={() => {
-                              setDisplayAddPrivilegeInput(false)
-                            }}
-                          />
-                        </Tooltip>
-                      </div>
-                    ) : (
-                      <Tooltip
-                        title={translate('text_1756125489057qfgsq8im2b2')}
-                        placement="top-start"
-                        disableHoverListener={!!formikProps.values.code}
-                      >
-                        <Button
-                          align="left"
-                          variant="inline"
-                          startIcon="plus"
-                          disabled={!formikProps.values.code}
-                          onClick={() => {
-                            setDisplayAddPrivilegeInput(true)
-
-                            scrollToAndClickElement({
-                              selector: `.${privilegeSearchClassName} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
-                            })
-                          }}
-                        >
-                          {translate('text_1753864223060n9hxs03sa15')}
-                        </Button>
                       </Tooltip>
-                    )}
-                  </div>
-                </section>
-              </div>
-            </>
-          )}
-        </CenteredPage.Container>
+                    </div>
+                  ) : (
+                    <Tooltip
+                      title={translate('text_1756125489057qfgsq8im2b2')}
+                      placement="top-start"
+                      disableHoverListener={!!formikProps.values.code}
+                    >
+                      <Button
+                        align="left"
+                        variant="inline"
+                        startIcon="plus"
+                        disabled={!formikProps.values.code}
+                        onClick={() => {
+                          setDisplayAddPrivilegeInput(true)
 
-        <CenteredPage.StickyFooter>
-          <Button
-            variant="quaternary"
-            onClick={() =>
-              formikProps.dirty ? warningDirtyAttributesDialogRef.current?.openDialog() : onLeave()
-            }
-          >
-            {translate('text_6411e6b530cb47007488b027')}
-          </Button>
-          <Button
-            variant="primary"
-            disabled={!formikProps.isValid || !formikProps.dirty || isLoading}
-            onClick={formikProps.submitForm}
-          >
-            {translate(
-              isEdition ? 'text_17432414198706rdwf76ek3u' : 'text_17561254890574dcio8alli4',
-            )}
-          </Button>
-        </CenteredPage.StickyFooter>
-      </CenteredPage.Wrapper>
+                          scrollToAndClickElement({
+                            selector: `.${privilegeSearchClassName} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+                          })
+                        }}
+                      >
+                        {translate('text_1753864223060n9hxs03sa15')}
+                      </Button>
+                    </Tooltip>
+                  )}
+                </div>
+              </section>
+            </div>
+          </>
+        )}
+      </CenteredPage.Container>
 
-      <WarningDialog
-        ref={warningDirtyAttributesDialogRef}
-        title={translate('text_6244277fe0975300fe3fb940')}
-        description={translate('text_17561254890579cfr8pj6afl')}
-        continueText={translate('text_6244277fe0975300fe3fb94c')}
-        onContinue={onLeave}
-      />
-    </>
+      <CenteredPage.StickyFooter>
+        <Button
+          variant="quaternary"
+          onClick={() => (formikProps.dirty ? openDirtyAttributesWarning() : onLeave())}
+        >
+          {translate('text_6411e6b530cb47007488b027')}
+        </Button>
+        <Button
+          variant="primary"
+          disabled={!formikProps.isValid || !formikProps.dirty || isLoading}
+          onClick={formikProps.submitForm}
+        >
+          {translate(isEdition ? 'text_17432414198706rdwf76ek3u' : 'text_17561254890574dcio8alli4')}
+        </Button>
+      </CenteredPage.StickyFooter>
+    </CenteredPage.Wrapper>
   )
 }
 


### PR DESCRIPTION
## Context

`SubscriptionEntitlementForm` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation (used from both the header close button and the footer cancel button), which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `SubscriptionEntitlementForm.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/subscriptions/SubscriptionEntitlementForm.tsx`:
  - Removed `WarningDialog` / `WarningDialogRef` import and the `<WarningDialog>` render at the bottom of the JSX.
  - Added `useCentralizedDialog()` and extracted an `openDirtyAttributesWarning()` helper that opens the confirmation dialog — same title/description/action text, still with `colorVariant: 'danger'`, and still calling `onLeave()` on confirm.
  - Both dirty-guard call sites (header close button and footer cancel button) now go through the new helper instead of `warningDirtyAttributesDialogRef.current?.openDialog()`.
  - Dropped `useRef` from the React import (no longer used in this file).

The form itself still uses Formik (a separate migration tracked by other ESLint warnings) — the scope here is strictly the `WarningDialog` warning.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` migration in this PR.

## Test plan

- [ ] Open *Customer → Subscription → Entitlements → Add entitlement* (and via the plan subscription details entry point).
- [ ] Pick a feature and add at least one privilege so the form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page navigates back to the entitlements tab.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] Same flow via the footer cancel button.
- [ ] When the form is pristine, clicking close/cancel immediately navigates away with no dialog.
- [ ] Edit an existing entitlement → same flow works in edition mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gwh2ymwJJMi3g1KkWfSAAr)_