### PR TITLE
refactor(customers): migrate CreateCustomer close-confirmation WarningDialog to CentralizedDialog

### DIFF
--- a/src/pages/createCustomers/CreateCustomer.tsx
+++ b/src/pages/createCustomers/CreateCustomer.tsx
@@ -1,11 +1,11 @@
 import { revalidateLogic } from '@tanstack/react-form'
 import { Icon } from 'lago-design-system'
-import { useRef } from 'react'
+import { useCallback } from 'react'
 
 import { SUBMIT_CUSTOMER_DATA_TEST } from '~/components/customers/utils/dataTestConstants'
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
-import { WarningDialog, WarningDialogRef } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { extractThirdPartyErrorMessage, hasDefinedGQLError } from '~/core/apolloClient'
@@ -34,7 +34,7 @@ const STRIPE_CUSTOMER_ERROR_MESSAGE_DETAILS = 'Stripe: resource_missing'
 
 const CreateCustomer = () => {
   const { translate } = useInternationalization()
-  const warningDialogRef = useRef<WarningDialogRef>(null)
+  const centralizedDialog = useCentralizedDialog()
   const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const { organization: { premiumIntegrations } = {} } = useOrganizationInfos()
   const { getPaymentProvider } = usePaymentProviders()
@@ -118,10 +118,20 @@ const CreateCustomer = () => {
     },
   })
 
+  const openDirtyAttributesWarning = useCallback(() => {
+    centralizedDialog.open({
+      title: translate('text_665deda4babaf700d603ea13'),
+      description: translate('text_665dedd557dc3c00c62eb83d'),
+      actionText: translate('text_645388d5bdbd7b00abffa033'),
+      colorVariant: 'danger',
+      onAction: () => onClose(),
+    })
+  }, [centralizedDialog, onClose, translate])
+
   const handleAbort = () => {
     const isDirty = form.store.state.isDirty
 
-    isDirty ? warningDialogRef.current?.openDialog() : onClose()
+    isDirty ? openDirtyAttributesWarning() : onClose()
   }
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -229,14 +239,6 @@ const CreateCustomer = () => {
           </form.AppForm>
         </CenteredPage.StickyFooter>
       </form>
-
-      <WarningDialog
-        ref={warningDialogRef}
-        title={translate('text_665deda4babaf700d603ea13')}
-        description={translate('text_665dedd557dc3c00c62eb83d')}
-        continueText={translate('text_645388d5bdbd7b00abffa033')}
-        onContinue={onClose}
-      />
     </CenteredPage.Wrapper>
   )
 }


### PR DESCRIPTION
## Context

`CreateCustomer` was still using the deprecated legacy imperative ref-based `WarningDialog` for its "unsaved changes" close-confirmation (used from both the header close button and the footer cancel button), which triggers the `no-restricted-imports` ESLint warning. The new hook-based `NiceModal` dialog system (`useCentralizedDialog`) is the target pattern for confirmation-style dialogs.

## Description

Migrate the close-confirmation dialog on `CreateCustomer.tsx` from the legacy `WarningDialog` (imperative `ref`) to the new hook-based `useCentralizedDialog` API.

- `src/pages/createCustomers/CreateCustomer.tsx`:
  - Removed `WarningDialog` / `WarningDialogRef` import and the `<WarningDialog>` render at the bottom of the JSX.
  - Added `useCentralizedDialog()` and extracted an `openDirtyAttributesWarning()` helper that opens the confirmation dialog — same title/description/action text, still with `colorVariant: 'danger'`, and still calling `onClose()` on confirm.
  - `handleAbort` now calls `openDirtyAttributesWarning()` instead of `warningDialogRef.current?.openDialog()`; the not-dirty branch keeps its existing behavior (`onClose()`).
  - Dropped `useRef` from the React import (no longer used in this file); added `useCallback` for the memoized helper.

The form already uses TanStack Form — no additional form migration required.

## Scope

Scoped strictly to the single `WarningDialog` warning in this file. The dialog is a pure confirmation with no form fields, so `CentralizedDialog` is the right primitive — no need for `FormDialog` migration in this PR.

## Test plan

- [ ] Open *Customers → Create customer*.
- [ ] Fill some fields so the form becomes `dirty`, then click the top-right close icon → the confirmation dialog opens with the danger styling and the correct title/description.
- [ ] Confirm → the page closes back to the customers list.
- [ ] Cancel / close → the dialog closes cleanly and the form stays as-is.
- [ ] Same flow via the footer cancel button.
- [ ] When the form is pristine, clicking close/cancel immediately closes with no dialog.
- [ ] Edit an existing customer → same flow works in edition mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gwh2ymwJJMi3g1KkWfSAAr)_