### PR TITLE
refactor(plans): migrate RemoveChargeWarningDialog to CentralizedDialog

### DIFF
--- a/src/components/plans/RemoveChargeWarningDialog.tsx
+++ b/src/components/plans/RemoveChargeWarningDialog.tsx
@@ -1,38 +1,23 @@
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
-
-import { DialogRef } from '~/components/designSystem/Dialog'
-import { WarningDialog } from '~/components/designSystem/WarningDialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
-type LocalData = { callback: () => void }
+type OpenRemoveChargeWarningDialogParams = { callback: () => void }
 
-export interface RemoveChargeWarningDialogRef {
-  openDialog: ({ callback }: LocalData) => unknown
-  closeDialog: () => unknown
-}
-
-export const RemoveChargeWarningDialog = forwardRef<RemoveChargeWarningDialogRef>((_, ref) => {
-  const dialogRef = useRef<DialogRef>(null)
-  const [localData, setLocalData] = useState<LocalData | undefined>(undefined)
+export const useRemoveChargeWarningDialog = () => {
   const { translate } = useInternationalization()
+  const centralizedDialog = useCentralizedDialog()
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  const openRemoveChargeWarningDialog = ({ callback }: OpenRemoveChargeWarningDialogParams) => {
+    centralizedDialog.open({
+      title: translate('text_63cfe20ad6c1a53c5352a46e'),
+      description: translate('text_63cfe20ad6c1a53c5352a470'),
+      actionText: translate('text_63cfe20ad6c1a53c5352a474'),
+      colorVariant: 'danger',
+      onAction: () => {
+        callback()
+      },
+    })
+  }
 
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_63cfe20ad6c1a53c5352a46e')}
-      description={translate('text_63cfe20ad6c1a53c5352a470')}
-      continueText={translate('text_63cfe20ad6c1a53c5352a474')}
-      onContinue={localData?.callback}
-    />
-  )
-})
-
-RemoveChargeWarningDialog.displayName = 'RemoveChargeWarningDialog'
+  return { openRemoveChargeWarningDialog }
+}

--- a/src/components/plans/UsageChargesSection.tsx
+++ b/src/components/plans/UsageChargesSection.tsx
@@ -23,10 +23,7 @@ import { PlanInterval } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { PlanFormType } from '~/hooks/plans/usePlanForm'
 
-import {
-  RemoveChargeWarningDialog,
-  RemoveChargeWarningDialogRef,
-} from './RemoveChargeWarningDialog'
+import { useRemoveChargeWarningDialog } from './RemoveChargeWarningDialog'
 import { LocalUsageChargeInput } from './types'
 
 gql`
@@ -65,7 +62,7 @@ export const UsageChargesSection = ({
   const amountCurrency = useStore(form.store, (s) => s.values.amountCurrency)
 
   const hasAnyCharge = !!charges.length
-  const removeChargeWarningDialogRef = useRef<RemoveChargeWarningDialogRef>(null)
+  const { openRemoveChargeWarningDialog } = useRemoveChargeWarningDialog()
   const usageChargeDrawerRef = useRef<UsageChargeDrawerRef>(null)
   const [alreadyUsedBmsIds, setAlreadyUsedBmsIds] = useState<Map<string, number>>(new Map())
 
@@ -167,7 +164,7 @@ export const UsageChargesSection = ({
               showWarningOnDelete: actionType !== 'duplicate' && isUsedInSubscription,
               onDelete: () => handleChargeDelete(i),
               onEdit: openUsageChargeDrawer,
-              removeChargeWarningDialogRef,
+              openRemoveChargeWarningDialog,
               translate,
             })}
           />
@@ -220,11 +217,9 @@ export const UsageChargesSection = ({
         subscriptionFormType={subscriptionFormType}
         onSave={handleDrawerSave}
         onDelete={handleChargeDelete}
-        removeChargeWarningDialogRef={removeChargeWarningDialogRef}
+        openRemoveChargeWarningDialog={openRemoveChargeWarningDialog}
         amountCurrency={amountCurrency}
       />
-
-      <RemoveChargeWarningDialog ref={removeChargeWarningDialogRef} />
     </>
   )
 }

--- a/src/components/plans/__tests__/UsageChargesSection.test.tsx
+++ b/src/components/plans/__tests__/UsageChargesSection.test.tsx
@@ -30,22 +30,11 @@ jest.mock('~/components/plans/drawers/usageCharge/UsageChargeDrawer', () => {
   return { UsageChargeDrawer: MockedDrawer }
 })
 
-jest.mock('~/components/plans/RemoveChargeWarningDialog', () => {
-  const React = jest.requireActual('react')
-
-  const MockedDialog = React.forwardRef((_props: unknown, ref: unknown) => {
-    React.useImperativeHandle(ref, () => ({
-      openDialog: jest.fn(),
-      closeDialog: jest.fn(),
-    }))
-
-    return React.createElement('div', { 'data-test': 'remove-charge-warning-dialog-mock' })
-  })
-
-  MockedDialog.displayName = 'RemoveChargeWarningDialog'
-
-  return { RemoveChargeWarningDialog: MockedDialog, RemoveChargeWarningDialogRef: {} }
-})
+jest.mock('~/components/plans/RemoveChargeWarningDialog', () => ({
+  useRemoveChargeWarningDialog: () => ({
+    openRemoveChargeWarningDialog: jest.fn(),
+  }),
+}))
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({

--- a/src/components/plans/__tests__/utils.test.ts
+++ b/src/components/plans/__tests__/utils.test.ts
@@ -1,6 +1,3 @@
-import { RefObject } from 'react'
-
-import { RemoveChargeWarningDialogRef } from '~/components/plans/RemoveChargeWarningDialog'
 import {
   buildChargeHoverActions,
   getFormattedChargeSelectorSubtitle,
@@ -146,17 +143,6 @@ describe('utils', () => {
 
   describe('buildChargeHoverActions', () => {
     const translate = (key: string) => key
-    const buildDialogRef = (): {
-      ref: RefObject<RemoveChargeWarningDialogRef>
-      openDialog: jest.Mock
-    } => {
-      const openDialog = jest.fn()
-      const ref = {
-        current: { openDialog },
-      } as unknown as RefObject<RemoveChargeWarningDialogRef>
-
-      return { ref, openDialog }
-    }
     const buildEvent = () =>
       ({
         stopPropagation: jest.fn(),
@@ -166,14 +152,14 @@ describe('utils', () => {
     it('returns only the edit action when showDelete is false', () => {
       const onEdit = jest.fn()
       const onDelete = jest.fn()
-      const { ref } = buildDialogRef()
+      const openRemoveChargeWarningDialog = jest.fn()
 
       const actions = buildChargeHoverActions({
         showDelete: false,
         showWarningOnDelete: false,
         onDelete,
         onEdit,
-        removeChargeWarningDialogRef: ref,
+        openRemoveChargeWarningDialog,
         translate,
       })
 
@@ -185,14 +171,14 @@ describe('utils', () => {
     })
 
     it('returns trash and edit actions when showDelete is true', () => {
-      const { ref } = buildDialogRef()
+      const openRemoveChargeWarningDialog = jest.fn()
 
       const actions = buildChargeHoverActions({
         showDelete: true,
         showWarningOnDelete: false,
         onDelete: jest.fn(),
         onEdit: jest.fn(),
-        removeChargeWarningDialogRef: ref,
+        openRemoveChargeWarningDialog,
         translate,
       })
 
@@ -203,14 +189,14 @@ describe('utils', () => {
 
     it('calls onDelete directly when showWarningOnDelete is false', () => {
       const onDelete = jest.fn()
-      const { ref, openDialog } = buildDialogRef()
+      const openRemoveChargeWarningDialog = jest.fn()
 
       const actions = buildChargeHoverActions({
         showDelete: true,
         showWarningOnDelete: false,
         onDelete,
         onEdit: jest.fn(),
-        removeChargeWarningDialogRef: ref,
+        openRemoveChargeWarningDialog,
         translate,
       })
 
@@ -221,42 +207,27 @@ describe('utils', () => {
       expect(event.stopPropagation).toHaveBeenCalledTimes(1)
       expect(event.preventDefault).toHaveBeenCalledTimes(1)
       expect(onDelete).toHaveBeenCalledTimes(1)
-      expect(openDialog).not.toHaveBeenCalled()
+      expect(openRemoveChargeWarningDialog).not.toHaveBeenCalled()
     })
 
     it('opens the warning dialog when showWarningOnDelete is true', () => {
       const onDelete = jest.fn()
-      const { ref, openDialog } = buildDialogRef()
+      const openRemoveChargeWarningDialog = jest.fn()
 
       const actions = buildChargeHoverActions({
         showDelete: true,
         showWarningOnDelete: true,
         onDelete,
         onEdit: jest.fn(),
-        removeChargeWarningDialogRef: ref,
+        openRemoveChargeWarningDialog,
         translate,
       })
 
       actions[0].onClick(buildEvent())
 
-      expect(openDialog).toHaveBeenCalledTimes(1)
-      expect(openDialog).toHaveBeenCalledWith({ callback: onDelete })
+      expect(openRemoveChargeWarningDialog).toHaveBeenCalledTimes(1)
+      expect(openRemoveChargeWarningDialog).toHaveBeenCalledWith({ callback: onDelete })
       expect(onDelete).not.toHaveBeenCalled()
-    })
-
-    it('does not throw when the dialog ref is not yet attached', () => {
-      const ref = { current: null } as RefObject<RemoveChargeWarningDialogRef>
-
-      const actions = buildChargeHoverActions({
-        showDelete: true,
-        showWarningOnDelete: true,
-        onDelete: jest.fn(),
-        onEdit: jest.fn(),
-        removeChargeWarningDialogRef: ref,
-        translate,
-      })
-
-      expect(() => actions[0].onClick(buildEvent())).not.toThrow()
     })
   })
 })

--- a/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
@@ -7,10 +7,7 @@ import {
   FixedChargeDrawerRef,
 } from '~/components/plans/drawers/fixedCharge/FixedChargeDrawer'
 import { FixedChargeInfo } from '~/components/plans/FixedChargeInfo'
-import {
-  RemoveChargeWarningDialog,
-  RemoveChargeWarningDialogRef,
-} from '~/components/plans/RemoveChargeWarningDialog'
+import { useRemoveChargeWarningDialog } from '~/components/plans/RemoveChargeWarningDialog'
 import { LocalFixedChargeInput } from '~/components/plans/types'
 import { PlanFormProvider } from '~/contexts/PlanFormContext'
 import { FORM_ERRORS_ENUM } from '~/core/constants/form'
@@ -136,7 +133,7 @@ export const PlanDetailsV2FixedChargesSection = forwardRef<
   const { canCreate, canUpdate, canDelete } = useAccordionPermissions(isInSubscriptionForm)
   const { gateOnClick, premiumIcon } = useSubscriptionPremiumGate(isInSubscriptionForm)
   const drawerRef = useRef<FixedChargeDrawerRef>(null)
-  const removeChargeWarningDialogRef = useRef<RemoveChargeWarningDialogRef>(null)
+  const { openRemoveChargeWarningDialog } = useRemoveChargeWarningDialog()
 
   const { handleSaveCharge, handleDeleteCharge } = fixedChargeMutations
 
@@ -183,7 +180,7 @@ export const PlanDetailsV2FixedChargesSection = forwardRef<
   // subscriptions; delete directly otherwise.
   const handleDelete = (chargeId: string) => {
     if (isUsedInSubscription) {
-      removeChargeWarningDialogRef.current?.openDialog({
+      openRemoveChargeWarningDialog({
         callback: () => handleDeleteCharge(chargeId),
       })
     } else {
@@ -273,11 +270,9 @@ export const PlanDetailsV2FixedChargesSection = forwardRef<
 
             if (target) handleDeleteCharge(target.id)
           }}
-          removeChargeWarningDialogRef={removeChargeWarningDialogRef}
+          openRemoveChargeWarningDialog={openRemoveChargeWarningDialog}
         />
       </PlanFormProvider>
-
-      <RemoveChargeWarningDialog ref={removeChargeWarningDialogRef} />
     </section>
   )
 })

--- a/src/components/plans/details-v2/PlanDetailsV2UsageChargesSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2UsageChargesSection.tsx
@@ -11,10 +11,7 @@ import {
   UsageChargeDrawer,
   UsageChargeDrawerRef,
 } from '~/components/plans/drawers/usageCharge/UsageChargeDrawer'
-import {
-  RemoveChargeWarningDialog,
-  RemoveChargeWarningDialogRef,
-} from '~/components/plans/RemoveChargeWarningDialog'
+import { useRemoveChargeWarningDialog } from '~/components/plans/RemoveChargeWarningDialog'
 import { LocalUsageChargeInput } from '~/components/plans/types'
 import { UsageChargeInfo } from '~/components/plans/UsageChargeInfo'
 import { PlanFormProvider } from '~/contexts/PlanFormContext'
@@ -188,7 +185,7 @@ export const PlanDetailsV2UsageChargesSection = forwardRef<
   const { gateOnClick, premiumIcon } = useSubscriptionPremiumGate(isInSubscriptionForm)
   const { hasAnyPricingUnitConfigured } = useCustomPricingUnits()
   const drawerRef = useRef<UsageChargeDrawerRef>(null)
-  const removeChargeWarningDialogRef = useRef<RemoveChargeWarningDialogRef>(null)
+  const { openRemoveChargeWarningDialog } = useRemoveChargeWarningDialog()
 
   const { handleSaveCharge, handleDeleteCharge } = chargeMutations
 
@@ -293,7 +290,7 @@ export const PlanDetailsV2UsageChargesSection = forwardRef<
   // subscriptions; delete directly otherwise.
   const handleDelete = (chargeId: string) => {
     if (isUsedInSubscription) {
-      removeChargeWarningDialogRef.current?.openDialog({
+      openRemoveChargeWarningDialog({
         callback: () => handleDeleteCharge(chargeId),
       })
     } else {
@@ -407,11 +404,9 @@ export const PlanDetailsV2UsageChargesSection = forwardRef<
 
             if (target) handleDeleteCharge(target.id)
           }}
-          removeChargeWarningDialogRef={removeChargeWarningDialogRef}
+          openRemoveChargeWarningDialog={openRemoveChargeWarningDialog}
         />
       </PlanFormProvider>
-
-      <RemoveChargeWarningDialog ref={removeChargeWarningDialogRef} />
     </section>
   )
 })

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2FixedChargesSection.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2FixedChargesSection.test.tsx
@@ -4,7 +4,8 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createRef, ReactNode } from 'react'
 
-import { FORM_DIALOG_NAME } from '~/components/dialogs/const'
+import CentralizedDialog from '~/components/dialogs/CentralizedDialog'
+import { CENTRALIZED_DIALOG_NAME, FORM_DIALOG_NAME } from '~/components/dialogs/const'
 import FormDialog from '~/components/dialogs/FormDialog'
 
 import { buildFixedChargeFixture, planDetailsV2Fixture } from './fixtures'
@@ -14,6 +15,7 @@ import {
   PlanDetailsV2FixedChargesSectionRef,
 } from '../PlanDetailsV2FixedChargesSection'
 
+NiceModal.register(CENTRALIZED_DIALOG_NAME, CentralizedDialog)
 NiceModal.register(FORM_DIALOG_NAME, FormDialog)
 
 const mockOpenDrawer = jest.fn()

--- a/src/components/plans/details-v2/__tests__/PlanDetailsV2UsageChargesSection.test.tsx
+++ b/src/components/plans/details-v2/__tests__/PlanDetailsV2UsageChargesSection.test.tsx
@@ -4,7 +4,8 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createRef, ReactNode } from 'react'
 
-import { FORM_DIALOG_NAME } from '~/components/dialogs/const'
+import CentralizedDialog from '~/components/dialogs/CentralizedDialog'
+import { CENTRALIZED_DIALOG_NAME, FORM_DIALOG_NAME } from '~/components/dialogs/const'
 import FormDialog from '~/components/dialogs/FormDialog'
 
 import { buildUsageChargeFixture, planDetailsV2Fixture } from './fixtures'
@@ -14,6 +15,7 @@ import {
   PlanDetailsV2UsageChargesSectionRef,
 } from '../PlanDetailsV2UsageChargesSection'
 
+NiceModal.register(CENTRALIZED_DIALOG_NAME, CentralizedDialog)
 NiceModal.register(FORM_DIALOG_NAME, FormDialog)
 
 const mockOpenDrawer = jest.fn()

--- a/src/components/plans/drawers/fixedCharge/FixedChargeDrawer.tsx
+++ b/src/components/plans/drawers/fixedCharge/FixedChargeDrawer.tsx
@@ -9,7 +9,6 @@ import {
   applyExistingCodeError,
   buildChargeCodeSchema,
 } from '~/components/plans/drawers/common/chargeCode'
-import { RemoveChargeWarningDialogRef } from '~/components/plans/RemoveChargeWarningDialog'
 import { LocalFixedChargeInput } from '~/components/plans/types'
 import { PlanFormProvider, usePlanFormContext } from '~/contexts/PlanFormContext'
 import { useDuplicatePlanVar } from '~/core/apolloClient'
@@ -90,7 +89,7 @@ interface FixedChargeDrawerProps {
     | FORM_ERRORS_ENUM.existingCode
     | Promise<void | boolean | FORM_ERRORS_ENUM.existingCode>
   onDelete?: (index: number) => void
-  removeChargeWarningDialogRef?: React.RefObject<RemoveChargeWarningDialogRef>
+  openRemoveChargeWarningDialog?: (params: { callback: () => void }) => void
 }
 
 export const FixedChargeDrawer = forwardRef<FixedChargeDrawerRef, FixedChargeDrawerProps>(
@@ -103,7 +102,7 @@ export const FixedChargeDrawer = forwardRef<FixedChargeDrawerRef, FixedChargeDra
       existingChargeCodes,
       onSave,
       onDelete,
-      removeChargeWarningDialogRef,
+      openRemoveChargeWarningDialog,
     },
     ref,
   ) => {
@@ -167,7 +166,7 @@ export const FixedChargeDrawer = forwardRef<FixedChargeDrawerRef, FixedChargeDra
         fixedChargeDrawer.close()
 
         if (actionType !== 'duplicate' && isUsedInSubscriptionRef.current) {
-          removeChargeWarningDialogRef?.current?.openDialog({ callback: deleteCharge })
+          openRemoveChargeWarningDialog?.({ callback: deleteCharge })
         } else {
           deleteCharge()
         }

--- a/src/components/plans/drawers/usageCharge/UsageChargeDrawer.tsx
+++ b/src/components/plans/drawers/usageCharge/UsageChargeDrawer.tsx
@@ -10,7 +10,6 @@ import {
   applyExistingCodeError,
   buildChargeCodeSchema,
 } from '~/components/plans/drawers/common/chargeCode'
-import { RemoveChargeWarningDialogRef } from '~/components/plans/RemoveChargeWarningDialog'
 import {
   LocalChargeFilterInput,
   LocalPricingUnitInput,
@@ -247,7 +246,7 @@ interface UsageChargeDrawerProps {
     | FORM_ERRORS_ENUM.existingCode
     | Promise<void | boolean | FORM_ERRORS_ENUM.existingCode>
   onDelete?: (index: number) => void
-  removeChargeWarningDialogRef?: React.RefObject<RemoveChargeWarningDialogRef>
+  openRemoveChargeWarningDialog?: (params: { callback: () => void }) => void
   amountCurrency?: string
 }
 
@@ -266,7 +265,7 @@ export const UsageChargeDrawer = forwardRef<UsageChargeDrawerRef, UsageChargeDra
       subscriptionFormType,
       onSave,
       onDelete,
-      removeChargeWarningDialogRef,
+      openRemoveChargeWarningDialog,
       amountCurrency,
     },
     ref,
@@ -335,7 +334,7 @@ export const UsageChargeDrawer = forwardRef<UsageChargeDrawerRef, UsageChargeDra
         chargeDrawer.close()
 
         if (actionType !== 'duplicate' && isUsedInSubscriptionRef.current) {
-          removeChargeWarningDialogRef?.current?.openDialog({ callback: deleteCharge })
+          openRemoveChargeWarningDialog?.({ callback: deleteCharge })
         } else {
           deleteCharge()
         }

--- a/src/components/plans/form/FixedChargesSection.tsx
+++ b/src/components/plans/form/FixedChargesSection.tsx
@@ -12,10 +12,7 @@ import {
   FixedChargeDrawer,
   FixedChargeDrawerRef,
 } from '~/components/plans/drawers/fixedCharge/FixedChargeDrawer'
-import {
-  RemoveChargeWarningDialog,
-  RemoveChargeWarningDialogRef,
-} from '~/components/plans/RemoveChargeWarningDialog'
+import { useRemoveChargeWarningDialog } from '~/components/plans/RemoveChargeWarningDialog'
 import { LocalFixedChargeInput } from '~/components/plans/types'
 import {
   buildChargeHoverActions,
@@ -88,7 +85,7 @@ export const FixedChargesSection = ({
   const billFixedChargesMonthly = useStore(form.store, (s) => s.values.billFixedChargesMonthly)
 
   const hasAnyFixedCharge = !!fixedCharges.length
-  const removeChargeWarningDialogRef = useRef<RemoveChargeWarningDialogRef>(null)
+  const { openRemoveChargeWarningDialog } = useRemoveChargeWarningDialog()
   const fixedChargeDrawerRef = useRef<FixedChargeDrawerRef>(null)
   const [alreadyUsedAddOnIds, setAlreadyUsedAddOnIds] = useState<Map<string, number>>(new Map())
 
@@ -198,7 +195,7 @@ export const FixedChargesSection = ({
                             showWarningOnDelete: actionType !== 'duplicate' && isUsedInSubscription,
                             onDelete: () => handleChargeDelete(i),
                             onEdit: openFixedChargeDrawer,
-                            removeChargeWarningDialogRef,
+                            openRemoveChargeWarningDialog,
                             translate,
                           })}
                         />
@@ -234,10 +231,8 @@ export const FixedChargesSection = ({
         isInSubscriptionForm={isInSubscriptionForm}
         onSave={handleDrawerSave}
         onDelete={handleChargeDelete}
-        removeChargeWarningDialogRef={removeChargeWarningDialogRef}
+        openRemoveChargeWarningDialog={openRemoveChargeWarningDialog}
       />
-
-      <RemoveChargeWarningDialog ref={removeChargeWarningDialogRef} />
     </>
   )
 }

--- a/src/components/plans/form/__tests__/FixedChargesSection.test.tsx
+++ b/src/components/plans/form/__tests__/FixedChargesSection.test.tsx
@@ -31,22 +31,11 @@ jest.mock('~/components/plans/drawers/fixedCharge/FixedChargeDrawer', () => {
   return { FixedChargeDrawer: MockedDrawer }
 })
 
-jest.mock('~/components/plans/RemoveChargeWarningDialog', () => {
-  const React = jest.requireActual('react')
-
-  const MockedDialog = React.forwardRef((_props: unknown, ref: unknown) => {
-    React.useImperativeHandle(ref, () => ({
-      openDialog: jest.fn(),
-      closeDialog: jest.fn(),
-    }))
-
-    return React.createElement('div', { 'data-test': 'remove-charge-warning-dialog-mock' })
-  })
-
-  MockedDialog.displayName = 'RemoveChargeWarningDialog'
-
-  return { RemoveChargeWarningDialog: MockedDialog, RemoveChargeWarningDialogRef: {} }
-})
+jest.mock('~/components/plans/RemoveChargeWarningDialog', () => ({
+  useRemoveChargeWarningDialog: () => ({
+    openRemoveChargeWarningDialog: jest.fn(),
+  }),
+}))
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({

--- a/src/components/plans/utils.ts
+++ b/src/components/plans/utils.ts
@@ -1,7 +1,4 @@
-import { RefObject } from 'react'
-
 import { SelectorActionItem } from '~/components/designSystem/Selector'
-import { RemoveChargeWarningDialogRef } from '~/components/plans/RemoveChargeWarningDialog'
 import {
   ALL_FILTER_VALUES,
   AnyChargeModel,
@@ -92,14 +89,14 @@ export const buildChargeHoverActions = ({
   showWarningOnDelete,
   onDelete,
   onEdit,
-  removeChargeWarningDialogRef,
+  openRemoveChargeWarningDialog,
   translate,
 }: {
   showDelete: boolean
   showWarningOnDelete: boolean
   onDelete: () => void
   onEdit: () => void
-  removeChargeWarningDialogRef: RefObject<RemoveChargeWarningDialogRef>
+  openRemoveChargeWarningDialog: (params: { callback: () => void }) => void
   translate: TranslateFunc
 }): SelectorActionItem[] => {
   const actions: SelectorActionItem[] = []
@@ -110,7 +107,7 @@ export const buildChargeHoverActions = ({
       e.preventDefault()
 
       if (showWarningOnDelete) {
-        removeChargeWarningDialogRef.current?.openDialog({ callback: onDelete })
+        openRemoveChargeWarningDialog({ callback: onDelete })
       } else {
         onDelete()
       }


### PR DESCRIPTION
## Context

`RemoveChargeWarningDialog` was still using the deprecated legacy imperative ref-based `WarningDialog` component, which triggers the `no-restricted-imports` ESLint warning at every consumer site. It is used from four sections (`FixedChargesSection`, `UsageChargesSection`, `PlanDetailsV2FixedChargesSection`, `PlanDetailsV2UsageChargesSection`) and threaded as a ref-prop through both drawers (`FixedChargeDrawer`, `UsageChargeDrawer`).

## Description

Migrate `RemoveChargeWarningDialog` off the legacy ref-based `WarningDialog` and onto the new hook-based `useCentralizedDialog` API. The dialog is a pure confirmation (fires a `callback` on continue) — `CentralizedDialog` with `colorVariant: 'danger'` is the right primitive, no form migration required.

- **`src/components/plans/RemoveChargeWarningDialog.tsx`**: replaced the `forwardRef` + `useImperativeHandle` + `useState` + `WarningDialog` boilerplate with a thin `useRemoveChargeWarningDialog` hook exposing `openRemoveChargeWarningDialog({ callback })`. The exported name starts with `use`, matching the `allowImportNamePattern: '^use'` rule, so imports from every consumer file are now allowed.
- **`src/components/plans/utils.ts`**: `buildChargeHoverActions` now accepts an `openRemoveChargeWarningDialog: (params: { callback: () => void }) => void` function instead of a `RefObject<RemoveChargeWarningDialogRef>`. The trash-click branch calls it directly.
- **`src/components/plans/form/FixedChargesSection.tsx`** and **`src/components/plans/UsageChargesSection.tsx`**: drop the `useRef<RemoveChargeWarningDialogRef>` + `<RemoveChargeWarningDialog ref={...} />` render, replace with the hook, forward `openRemoveChargeWarningDialog` to `buildChargeHoverActions` and to the drawer. The dialog is now rendered globally via NiceModal so the JSX wrapper is gone.
- **`src/components/plans/drawers/fixedCharge/FixedChargeDrawer.tsx`** and **`src/components/plans/drawers/usageCharge/UsageChargeDrawer.tsx`**: swap the `removeChargeWarningDialogRef?: RefObject<RemoveChargeWarningDialogRef>` prop for `openRemoveChargeWarningDialog?: (params: { callback: () => void }) => void`. The internal delete branch calls the callback directly.
- **`src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx`** and **`src/components/plans/details-v2/PlanDetailsV2UsageChargesSection.tsx`**: same refactor as the form sections above (hook + prop threading, no more `<RemoveChargeWarningDialog>` JSX).
- **Tests** (`utils.test.ts`, `UsageChargesSection.test.tsx`, `FixedChargesSection.test.tsx`): dropped the ref/forwardRef-based mocks and replaced with a simple `useRemoveChargeWarningDialog` hook mock returning a `jest.fn()`. The `buildChargeHoverActions` unit tests were rewritten around the new callback signature (drops the "does not throw when the dialog ref is not yet attached" case which no longer applies).

No user-visible behavior change: the confirmation dialog still shows the same title / description / continue label, still uses the danger color variant, and still fires the same delete callback on continue.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm eslint` on the touched files — the previous `WarningDialog` / `RemoveChargeWarningDialog(Ref)` warnings are gone (only pre-existing `react-hooks/exhaustive-deps` warnings remain on the two details-v2 sections)
- `pnpm test -- --testPathPattern "plans/(utils|__tests__/UsageChargesSection|form/__tests__/FixedChargesSection)"` — 4 suites / 55 tests passing

## Test plan

- [ ] Open a plan with subscriptions: hover a usage charge, click trash → confirmation dialog opens with the danger styling and the "remove charge" copy; confirm removes the charge; cancel closes cleanly.
- [ ] Same on a plan with fixed charges.
- [ ] Duplicate a plan (`?type=duplicate`): trash on a charge deletes without confirmation (the isUsedInSubscription branch is skipped in duplicate mode).
- [ ] Plan details v2 (fixed + usage sections): trash on an existing charge on a plan with subscriptions → confirmation opens; delete flows through.
- [ ] Open a charge drawer on such a plan, click the secondary "Delete" button → confirmation opens after the drawer closes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PwNsJ4r5hFNmojbvy9PpSi)_