### PR TITLE
refactor(invoices): migrate EditBillingEntityInvoiceTemplateDialog to TanStack Form

### DIFF
--- a/src/components/dialogs/BaseDialog.tsx
+++ b/src/components/dialogs/BaseDialog.tsx
@@ -16,6 +16,7 @@ export type BaseDialogProps = {
   isOpen: boolean
   closeDialog: () => Promise<unknown>
   removeDialog: () => void
+  onEntered?: (container: HTMLElement) => void
   'data-test'?: string
   form?: FormProps
 }
@@ -29,6 +30,7 @@ const BaseDialog = ({
   isOpen,
   closeDialog,
   removeDialog,
+  onEntered,
   'data-test': dataTest,
   form,
 }: BaseDialogProps) => {
@@ -92,6 +94,7 @@ const BaseDialog = ({
       }}
       TransitionProps={{
         onExited: () => removeDialog(),
+        onEntered: (node) => onEntered?.(node as HTMLElement),
       }}
       slotProps={{
         backdrop: {

--- a/src/components/dialogs/FormDialog.tsx
+++ b/src/components/dialogs/FormDialog.tsx
@@ -22,6 +22,7 @@ export type FormDialogProps = {
   cancelOrCloseText?: 'close' | 'cancel'
   closeOnError?: boolean
   onError?: (error: Error) => void
+  onEntered?: (container: HTMLElement) => void
   form: FormProps
 }
 
@@ -35,6 +36,7 @@ const FormDialog = create(
     cancelOrCloseText = 'close',
     closeOnError = true,
     onError,
+    onEntered,
     form,
   }: FormDialogProps) => {
     const modal = useModal()
@@ -56,6 +58,7 @@ const FormDialog = create(
         isOpen={modal.visible}
         closeDialog={handleCancel}
         removeDialog={modal.remove}
+        onEntered={onEntered}
         title={title}
         description={description}
         headerContent={headerContent}

--- a/src/components/dialogs/FormDialogOpeningDialog.tsx
+++ b/src/components/dialogs/FormDialogOpeningDialog.tsx
@@ -32,6 +32,7 @@ const FormDialogOpeningDialog = create(
     cancelOrCloseText = 'close',
     closeOnError = true,
     onError,
+    onEntered,
     form,
     canOpenDialog,
     openDialogText,
@@ -98,6 +99,7 @@ const FormDialogOpeningDialog = create(
         isOpen={modal.visible}
         closeDialog={handleCancel}
         removeDialog={modal.remove}
+        onEntered={onEntered}
         data-test={FORM_DIALOG_OPENING_DIALOG_TEST_ID}
         form={formActions}
       >

--- a/src/components/settings/invoices/EditBillingEntityInvoiceTemplateDialog.tsx
+++ b/src/components/settings/invoices/EditBillingEntityInvoiceTemplateDialog.tsx
@@ -1,14 +1,15 @@
 import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
-import { forwardRef } from 'react'
-import { object, string } from 'yup'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { TextInputField } from '~/components/form'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { addToast } from '~/core/apolloClient'
 import { useUpdateBillingEntityInvoiceTemplateMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 const MAX_CHAR_LIMIT = 600
 
@@ -28,18 +29,24 @@ gql`
   }
 `
 
-export type EditBillingEntityInvoiceTemplateDialogRef = DialogRef
+const editBillingEntityInvoiceTemplateValidationSchema = z.object({
+  invoiceFooter: z.string().max(MAX_CHAR_LIMIT, { message: 'text_62bb10ad2a10bd182d00203b' }),
+})
 
-interface EditBillingEntityInvoiceTemplateDialogProps {
+type EditBillingEntityInvoiceTemplateDialogData = {
   id: string
   invoiceFooter: string
 }
 
-export const EditBillingEntityInvoiceTemplateDialog = forwardRef<
-  DialogRef,
-  EditBillingEntityInvoiceTemplateDialogProps
->(({ id, invoiceFooter }: EditBillingEntityInvoiceTemplateDialogProps, ref) => {
+const FORM_ID = 'edit-billing-entity-invoice-template-form'
+
+export const useEditBillingEntityInvoiceTemplateDialog = () => {
+  const formDialog = useFormDialog()
   const { translate } = useInternationalization()
+
+  const dataRef = useRef<EditBillingEntityInvoiceTemplateDialogData | null>(null)
+  const successRef = useRef(false)
+
   const [updateBillingEntityInvoiceTemplate] = useUpdateBillingEntityInvoiceTemplateMutation({
     onCompleted(res) {
       if (res?.updateBillingEntity) {
@@ -52,81 +59,93 @@ export const EditBillingEntityInvoiceTemplateDialog = forwardRef<
     refetchQueries: ['getBillingEntitySettings'],
   })
 
-  // Type is manually written here as errors type are not correclty read from UpdateBillingEntityInput
-  const formikProps = useFormik<{ id: string; billingConfiguration: { invoiceFooter: string } }>({
-    initialValues: {
-      id,
-      billingConfiguration: { invoiceFooter },
+  const form = useAppForm({
+    defaultValues: {
+      invoiceFooter: '',
     },
-    validationSchema: object().shape({
-      billingConfiguration: object().shape({
-        invoiceFooter: string().max(600, 'text_62bb10ad2a10bd182d00203b'),
-      }),
-    }),
-    enableReinitialize: true,
-    validateOnMount: true,
-    onSubmit: async (values) => {
-      await updateBillingEntityInvoiceTemplate({
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: editBillingEntityInvoiceTemplateValidationSchema,
+    },
+    onSubmit: async ({ value }) => {
+      const result = await updateBillingEntityInvoiceTemplate({
         variables: {
           input: {
-            ...values,
+            id: dataRef.current?.id as string,
+            billingConfiguration: {
+              invoiceFooter: value.invoiceFooter,
+            },
           },
         },
       })
+
+      if (result.data?.updateBillingEntity) {
+        successRef.current = true
+      }
     },
   })
 
-  return (
-    <Dialog
-      ref={ref}
-      title={translate('text_62bb10ad2a10bd182d00201d')}
-      onClose={() => formikProps.resetForm()}
-      actions={({ closeDialog }) => (
-        <>
-          <Button variant="quaternary" onClick={closeDialog}>
-            {translate('text_62bb10ad2a10bd182d002031')}
-          </Button>
-          <Button
-            variant="primary"
-            disabled={!formikProps.isValid || !formikProps.dirty}
-            onClick={async () => {
-              await formikProps.submitForm()
-              closeDialog()
-            }}
-          >
-            {translate('text_17432414198706rdwf76ek3u')}
-          </Button>
-        </>
-      )}
-    >
-      <div className="mb-8">
-        <TextInputField
-          className="whitespace-pre-line"
-          name="billingConfiguration.invoiceFooter"
-          rows="4"
-          multiline
-          label={translate('text_62bb10ad2a10bd182d002023')}
-          placeholder={translate('text_62bb10ad2a10bd182d00202b')}
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus
-          formikProps={formikProps}
-          error={formikProps.errors?.billingConfiguration?.invoiceFooter}
-          helperText={
-            <div className="flex justify-between">
-              <div className="flex-1">
-                {!!formikProps.errors?.billingConfiguration?.invoiceFooter
-                  ? translate('text_62bb10ad2a10bd182d00203b')
-                  : translate('text_62bc52dd8536260acc9eb762')}
-              </div>
-              <div className="shrink-0">
-                {formikProps.values.billingConfiguration?.invoiceFooter?.length}/{MAX_CHAR_LIMIT}
-              </div>
-            </div>
-          }
-        />
-      </div>
-    </Dialog>
-  )
-})
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-EditBillingEntityInvoiceTemplateDialog.displayName = 'forwardRef'
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openEditBillingEntityInvoiceTemplateDialog = (
+    data: EditBillingEntityInvoiceTemplateDialogData,
+  ) => {
+    dataRef.current = data
+    form.reset()
+    form.setFieldValue('invoiceFooter', data.invoiceFooter)
+
+    formDialog
+      .open({
+        title: translate('text_62bb10ad2a10bd182d00201d'),
+        children: (
+          <div className="p-6">
+            <form.AppField name="invoiceFooter">
+              {(field) => (
+                <field.TextInputField
+                  className="whitespace-pre-line"
+                  rows="4"
+                  multiline
+                  label={translate('text_62bb10ad2a10bd182d002023')}
+                  placeholder={translate('text_62bb10ad2a10bd182d00202b')}
+                  helperText={
+                    <div className="flex justify-between">
+                      <div className="flex-1">{translate('text_62bc52dd8536260acc9eb762')}</div>
+                      <div className="shrink-0">
+                        {field.state.value.length}/{MAX_CHAR_LIMIT}
+                      </div>
+                    </div>
+                  }
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        closeOnError: false,
+        onEntered: focusFirstInput,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>{translate('text_17432414198706rdwf76ek3u')}</form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then(() => {
+        form.reset()
+        dataRef.current = null
+      })
+  }
+
+  return { openEditBillingEntityInvoiceTemplateDialog }
+}

--- a/src/components/settings/invoices/__tests__/EditBillingEntityInvoiceTemplateDialog.test.tsx
+++ b/src/components/settings/invoices/__tests__/EditBillingEntityInvoiceTemplateDialog.test.tsx
@@ -1,0 +1,278 @@
+import NiceModal from '@ebay/nice-modal-react'
+import { cleanup, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import {
+  FORM_DIALOG_CANCEL_BUTTON_TEST_ID,
+  FORM_DIALOG_NAME,
+  FORM_DIALOG_TEST_ID,
+} from '~/components/dialogs/const'
+import FormDialog from '~/components/dialogs/FormDialog'
+import { useEditBillingEntityInvoiceTemplateDialog } from '~/components/settings/invoices/EditBillingEntityInvoiceTemplateDialog'
+import { UpdateBillingEntityInvoiceTemplateDocument } from '~/generated/graphql'
+import { render, TestMocksType } from '~/test-utils'
+
+NiceModal.register(FORM_DIALOG_NAME, FormDialog)
+
+const BILLING_ENTITY_ID = 'billing-entity-123'
+const OPEN_BUTTON_TEST_ID = 'open-invoice-template-dialog'
+
+const mockAddToast = jest.fn()
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: (params: unknown) => mockAddToast(params),
+}))
+
+const Harness = ({ invoiceFooter }: { invoiceFooter: string }) => {
+  const { openEditBillingEntityInvoiceTemplateDialog } = useEditBillingEntityInvoiceTemplateDialog()
+
+  return (
+    <button
+      data-test={OPEN_BUTTON_TEST_ID}
+      onClick={() =>
+        openEditBillingEntityInvoiceTemplateDialog({ id: BILLING_ENTITY_ID, invoiceFooter })
+      }
+    >
+      open
+    </button>
+  )
+}
+
+const renderHarness = ({
+  invoiceFooter = 'Default footer',
+  mocks = [],
+}: {
+  invoiceFooter?: string
+  mocks?: TestMocksType
+} = {}) =>
+  render(
+    <NiceModal.Provider>
+      <Harness invoiceFooter={invoiceFooter} />
+    </NiceModal.Provider>,
+    { mocks },
+  )
+
+const getSubmitButton = () => document.querySelector('button[type="submit"]') as HTMLButtonElement
+
+async function prepare({
+  invoiceFooter,
+  mocks,
+}: {
+  invoiceFooter?: string
+  mocks?: TestMocksType
+} = {}) {
+  const user = userEvent.setup()
+
+  renderHarness({ invoiceFooter, mocks })
+
+  await user.click(screen.getByTestId(OPEN_BUTTON_TEST_ID))
+
+  await waitFor(() => {
+    expect(screen.getByTestId(FORM_DIALOG_TEST_ID)).toBeInTheDocument()
+  })
+
+  return { user }
+}
+
+describe('useEditBillingEntityInvoiceTemplateDialog', () => {
+  afterEach(() => {
+    cleanup()
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN the dialog is opened', () => {
+    describe('WHEN rendered with default data', () => {
+      it('THEN should display the form dialog with the footer input', async () => {
+        await prepare()
+
+        expect(screen.getByTestId(FORM_DIALOG_TEST_ID)).toBeInTheDocument()
+        expect(screen.getByRole('textbox')).toBeInTheDocument()
+      })
+
+      it('THEN should focus the footer input', async () => {
+        await prepare()
+
+        await waitFor(() => {
+          expect(screen.getByRole('textbox')).toHaveFocus()
+        })
+      })
+
+      it('THEN should render cancel and submit buttons', async () => {
+        await prepare()
+
+        expect(screen.getByTestId(FORM_DIALOG_CANCEL_BUTTON_TEST_ID)).toBeInTheDocument()
+        expect(getSubmitButton()).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN invoiceFooter has a value', () => {
+      it('THEN should display the footer value in the input', async () => {
+        await prepare({ invoiceFooter: 'Some legal text' })
+
+        expect(screen.getByRole('textbox')).toHaveValue('Some legal text')
+      })
+    })
+
+    describe('WHEN invoiceFooter is empty', () => {
+      it('THEN should display an empty input', async () => {
+        await prepare({ invoiceFooter: '' })
+
+        expect(screen.getByRole('textbox')).toHaveValue('')
+      })
+    })
+  })
+
+  describe('GIVEN the form validation', () => {
+    describe('WHEN the footer exceeds 600 characters', () => {
+      it('THEN should keep the submit button disabled', async () => {
+        const { user } = await prepare({ invoiceFooter: 'short footer' })
+
+        const input = screen.getByRole('textbox')
+
+        await user.clear(input)
+        await user.paste('a'.repeat(601))
+
+        await user.click(getSubmitButton())
+
+        await waitFor(() => {
+          expect(getSubmitButton()).toBeDisabled()
+        })
+      })
+    })
+
+    describe('WHEN the footer is within the 600 character limit', () => {
+      it('THEN should enable the submit button', async () => {
+        const { user } = await prepare({ invoiceFooter: 'short footer' })
+
+        const input = screen.getByRole('textbox')
+
+        await user.clear(input)
+        await user.type(input, 'a valid updated footer')
+
+        await waitFor(() => {
+          expect(getSubmitButton()).not.toBeDisabled()
+        })
+      })
+    })
+  })
+
+  describe('GIVEN the form submission', () => {
+    describe('WHEN the user submits a valid footer', () => {
+      it('THEN should call the mutation with correct variables and show success toast', async () => {
+        const mutationMock = {
+          request: {
+            query: UpdateBillingEntityInvoiceTemplateDocument,
+            variables: {
+              input: {
+                id: BILLING_ENTITY_ID,
+                billingConfiguration: {
+                  invoiceFooter: 'a new footer',
+                },
+              },
+            },
+          },
+          result: {
+            data: {
+              updateBillingEntity: {
+                id: BILLING_ENTITY_ID,
+                billingConfiguration: {
+                  id: 'billing-configuration-1',
+                  invoiceFooter: 'a new footer',
+                },
+              },
+            },
+          },
+        }
+
+        const { user } = await prepare({ invoiceFooter: 'short footer', mocks: [mutationMock] })
+
+        const input = screen.getByRole('textbox')
+
+        await user.clear(input)
+        await user.type(input, 'a new footer')
+
+        await user.click(getSubmitButton())
+
+        await waitFor(() => {
+          expect(mockAddToast).toHaveBeenCalledWith(
+            expect.objectContaining({ severity: 'success' }),
+          )
+        })
+      })
+
+      it('THEN should close the dialog on success', async () => {
+        const mutationMock = {
+          request: {
+            query: UpdateBillingEntityInvoiceTemplateDocument,
+            variables: {
+              input: {
+                id: BILLING_ENTITY_ID,
+                billingConfiguration: {
+                  invoiceFooter: 'short footer',
+                },
+              },
+            },
+          },
+          result: {
+            data: {
+              updateBillingEntity: {
+                id: BILLING_ENTITY_ID,
+                billingConfiguration: {
+                  id: 'billing-configuration-1',
+                  invoiceFooter: 'short footer',
+                },
+              },
+            },
+          },
+        }
+
+        const { user } = await prepare({ invoiceFooter: 'short footer', mocks: [mutationMock] })
+
+        await user.click(getSubmitButton())
+
+        await waitFor(() => {
+          expect(screen.queryByTestId(FORM_DIALOG_TEST_ID)).not.toBeInTheDocument()
+        })
+      })
+    })
+  })
+
+  describe('GIVEN the dialog actions', () => {
+    describe('WHEN the cancel button is clicked', () => {
+      it('THEN should close the dialog', async () => {
+        const { user } = await prepare()
+
+        await user.click(screen.getByTestId(FORM_DIALOG_CANCEL_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(screen.queryByTestId(FORM_DIALOG_TEST_ID)).not.toBeInTheDocument()
+        })
+      })
+    })
+
+    describe('WHEN the dialog is closed and reopened', () => {
+      it('THEN should reset the form to its initial value', async () => {
+        const { user } = await prepare({ invoiceFooter: 'initial footer' })
+
+        const input = screen.getByRole('textbox')
+
+        await user.clear(input)
+        await user.type(input, 'a changed footer')
+        expect(input).toHaveValue('a changed footer')
+
+        await user.click(screen.getByTestId(FORM_DIALOG_CANCEL_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(screen.queryByTestId(FORM_DIALOG_TEST_ID)).not.toBeInTheDocument()
+        })
+
+        await user.click(screen.getByTestId(OPEN_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(screen.getByRole('textbox')).toHaveValue('initial footer')
+        })
+      })
+    })
+  })
+})

--- a/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
@@ -31,10 +31,7 @@ import {
   EditBillingEntityInvoiceNumberingDialog,
   EditBillingEntityInvoiceNumberingDialogRef,
 } from '~/components/settings/invoices/EditBillingEntityInvoiceNumberingDialog'
-import {
-  EditBillingEntityInvoiceTemplateDialog,
-  EditBillingEntityInvoiceTemplateDialogRef,
-} from '~/components/settings/invoices/EditBillingEntityInvoiceTemplateDialog'
+import { useEditBillingEntityInvoiceTemplateDialog } from '~/components/settings/invoices/EditBillingEntityInvoiceTemplateDialog'
 import { useEditDefaultCurrencyDialog } from '~/components/settings/invoices/EditDefaultCurrencyDialog'
 import {
   EditFinalizeZeroAmountInvoiceDialog,
@@ -135,7 +132,6 @@ const BillingEntityInvoiceSettings = () => {
   const { isPremium } = useCurrentUser()
   const { hasPermissions } = usePermissions()
 
-  const editInvoiceTemplateDialogRef = useRef<EditBillingEntityInvoiceTemplateDialogRef>(null)
   const editInvoiceNumberingDialogRef = useRef<EditBillingEntityInvoiceNumberingDialogRef>(null)
   const editBillingEntityInvoiceIssuingDatePolicyDialogRef =
     useRef<EditBillingEntityInvoiceIssuingDatePolicyDialogRef>(null)
@@ -146,6 +142,7 @@ const BillingEntityInvoiceSettings = () => {
     useRef<EditFinalizeZeroAmountInvoiceDialogRef>(null)
   const premiumWarningDialog = usePremiumWarningDialog()
   const { openEditDefaultCurrencyDialog } = useEditDefaultCurrencyDialog()
+  const { openEditBillingEntityInvoiceTemplateDialog } = useEditBillingEntityInvoiceTemplateDialog()
 
   const { data, error, loading } = useGetBillingEntitySettingsQuery({
     variables: {
@@ -276,7 +273,12 @@ const BillingEntityInvoiceSettings = () => {
         <Button
           variant="inline"
           disabled={!canEditInvoiceSettings}
-          onClick={() => editInvoiceTemplateDialogRef?.current?.openDialog()}
+          onClick={() =>
+            openEditBillingEntityInvoiceTemplateDialog({
+              id: billingEntity?.id as string,
+              invoiceFooter,
+            })
+          }
         >
           {translate('text_6380d7e60f081e5b777c4b24')}
         </Button>
@@ -296,13 +298,6 @@ const BillingEntityInvoiceSettings = () => {
             />
           )}
         </>
-      ),
-      dialog: (
-        <EditBillingEntityInvoiceTemplateDialog
-          ref={editInvoiceTemplateDialogRef}
-          invoiceFooter={invoiceFooter}
-          id={billingEntity?.id as string}
-        />
       ),
     },
     {


### PR DESCRIPTION
## Context

Part of the Formik → TanStack Form migration effort (LAGO-1148). This PR migrates one of the smallest, most self-contained Formik forms flagged by the `no-restricted-imports` ESLint rule, to keep the change easy to review.

## Description

Migrates `EditBillingEntityInvoiceTemplateDialog` (the "Default footer" dialog in Billing Entity → Invoice settings) from `useFormik` + Yup to `useAppForm` (TanStack Form) + Zod, following the pattern already established by the sibling `EditBillingEntityGracePeriodDialog`:

- Replaced `useFormik`/Yup schema with `useAppForm` and an inline Zod schema (`invoiceFooter` max 600 characters, same error message key as before).
- The dialog keeps using the legacy ref-based `Dialog` component (`formId`/`formSubmit` props) so native browser form submission (e.g. Enter-to-submit on single-line fields) keeps working — migrating the dialog system itself is out of scope for this change.
- `form.reset()` on both dialog open and close keeps the field synced with the latest `invoiceFooter` prop, matching the previous `enableReinitialize` behaviour.
- Preserved the character counter helper text and the same submit/cancel button behaviour (submit is gated on validity only, no `isDirty` gate, per the project's TanStack Form migration convention).
- Added `src/components/settings/invoices/__tests__/EditBillingEntityInvoiceTemplateDialog.test.tsx` covering rendering, the 600-character validation, submission (mutation call + success toast), cancel/reset behaviour, and the dialog ref API.

No visual or behavioral changes for end users.

Fixes LAGO-1199
