### PR TITLE
fix(sentry): report 404 redirects as warning not error

### DIFF
--- a/src/hooks/__tests__/useNotFoundRedirect.test.ts
+++ b/src/hooks/__tests__/useNotFoundRedirect.test.ts
@@ -123,6 +123,7 @@ describe('useNotFoundRedirect', () => {
 
         await waitFor(() => {
           expect(captureException).toHaveBeenCalledWith(notFoundError, {
+            level: 'warning',
             tags: {
               errorType: 'NotFoundRedirect',
               fromPath: window.location.pathname,

--- a/src/hooks/useNotFoundRedirect.ts
+++ b/src/hooks/useNotFoundRedirect.ts
@@ -25,6 +25,7 @@ export const useNotFoundRedirect = ({
     if (loading || !isNotFoundError) return
 
     captureException(error, {
+      level: 'warning',
       tags: {
         errorType: 'NotFoundRedirect',
         fromPath: window.location.pathname,


### PR DESCRIPTION
`useNotFoundRedirect` reports handled 404 redirects to Sentry via `captureException`. Default level is `error`, so expected 404s (stale bookmark, deleted resource, wrong UUID) fire error alerts.

Adds `level: 'warning'` to the capture call so these keep their signal but drop out of error-alert rules.
