### PR TITLE
refactor(design-system): migrate PreventClosingDrawerDialog to useCentralizedDialog

### DIFF
--- a/src/components/designSystem/Drawer.tsx
+++ b/src/components/designSystem/Drawer.tsx
@@ -5,7 +5,6 @@ import {
   ReactElement,
   ReactNode,
   useImperativeHandle,
-  useRef,
   useState,
 } from 'react'
 
@@ -13,10 +12,7 @@ import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
 import { tw } from '~/styles/utils'
 
-import {
-  PreventClosingDrawerDialog,
-  PreventClosingDrawerDialogRef,
-} from './PreventClosingDrawerDialog'
+import { usePreventClosingDrawerDialog } from './PreventClosingDrawerDialog'
 
 const DRAWER_TRANSITION_DURATION = 250
 
@@ -60,7 +56,7 @@ export const Drawer = forwardRef<DrawerRef, DrawerProps>(
     }: DrawerProps,
     ref,
   ) => {
-    const preventClosingDrawerDialogRef = useRef<PreventClosingDrawerDialogRef>(null)
+    const { openPreventClosingDrawerDialog } = usePreventClosingDrawerDialog()
     const [isOpen, setIsOpen] = useState(forceOpen)
 
     const closeAction = () => {
@@ -70,10 +66,8 @@ export const Drawer = forwardRef<DrawerRef, DrawerProps>(
       }
 
       if (showCloseWarningDialog) {
-        preventClosingDrawerDialogRef.current?.openDialog({
-          onContinue: () => {
-            _closeAndHideDrawer()
-          },
+        openPreventClosingDrawerDialog({
+          onContinue: _closeAndHideDrawer,
         })
       } else {
         _closeAndHideDrawer()
@@ -144,8 +138,6 @@ export const Drawer = forwardRef<DrawerRef, DrawerProps>(
             </div>
           )}
         </MuiDrawer>
-
-        <PreventClosingDrawerDialog ref={preventClosingDrawerDialogRef} />
       </>
     )
   },

--- a/src/components/designSystem/PreventClosingDrawerDialog.tsx
+++ b/src/components/designSystem/PreventClosingDrawerDialog.tsx
@@ -1,48 +1,25 @@
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
-
-import { DialogRef } from '~/components/designSystem/Dialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
-import { WarningDialog } from './WarningDialog'
-
-type PreventClosingDrawerDialogProps = {
+type PreventClosingDrawerDialogParams = {
   onContinue: () => void
 }
 
-export interface PreventClosingDrawerDialogRef {
-  openDialog: (props: PreventClosingDrawerDialogProps) => unknown
-  closeDialog: () => unknown
-}
-
-export const PreventClosingDrawerDialog = forwardRef<PreventClosingDrawerDialogRef>((_, ref) => {
+export const usePreventClosingDrawerDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
-  const [localData, setLocalData] = useState<PreventClosingDrawerDialogProps | null>(null)
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (taxRateData) => {
-      setLocalData(taxRateData)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => {
-      dialogRef.current?.closeDialog()
-    },
-  }))
+  const openPreventClosingDrawerDialog = ({ onContinue }: PreventClosingDrawerDialogParams) => {
+    centralizedDialog.open({
+      title: translate('text_665deda4babaf700d603ea13'),
+      description: translate('text_665dedd557dc3c00c62eb83d'),
+      actionText: translate('text_645388d5bdbd7b00abffa033'),
+      colorVariant: 'danger',
+      onAction: () => {
+        onContinue()
+      },
+    })
+  }
 
-  return (
-    <WarningDialog
-      ref={dialogRef}
-      title={translate('text_665deda4babaf700d603ea13')}
-      description={translate('text_665dedd557dc3c00c62eb83d')}
-      onCancel={async () => {
-        dialogRef.current?.closeDialog()
-      }}
-      onContinue={async () => {
-        localData?.onContinue()
-      }}
-      continueText={translate('text_645388d5bdbd7b00abffa033')}
-    />
-  )
-})
-
-PreventClosingDrawerDialog.displayName = 'forwardRef'
+  return { openPreventClosingDrawerDialog }
+}

--- a/src/components/designSystem/__tests__/Drawer.test.tsx
+++ b/src/components/designSystem/__tests__/Drawer.test.tsx
@@ -1,10 +1,19 @@
+import NiceModal from '@ebay/nice-modal-react'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { createRef } from 'react'
+import { createRef, ReactNode } from 'react'
 
+import CentralizedDialog from '~/components/dialogs/CentralizedDialog'
+import { CENTRALIZED_DIALOG_NAME } from '~/components/dialogs/const'
 import { render } from '~/test-utils'
 
 import { Drawer, DrawerRef } from '../Drawer'
+
+NiceModal.register(CENTRALIZED_DIALOG_NAME, CentralizedDialog)
+
+const NiceModalWrapper = ({ children }: { children: ReactNode }) => (
+  <NiceModal.Provider>{children}</NiceModal.Provider>
+)
 
 // Test IDs
 export const DRAWER_OPENER_TEST_ID = 'drawer-opener'
@@ -472,9 +481,11 @@ describe('Drawer', () => {
       const onClose = jest.fn()
 
       render(
-        <Drawer title="Test Drawer" forceOpen showCloseWarningDialog onClose={onClose}>
-          <div data-test={DRAWER_CONTENT_TEST_ID}>Content</div>
-        </Drawer>,
+        <NiceModalWrapper>
+          <Drawer title="Test Drawer" forceOpen showCloseWarningDialog onClose={onClose}>
+            <div data-test={DRAWER_CONTENT_TEST_ID}>Content</div>
+          </Drawer>
+        </NiceModalWrapper>,
       )
 
       const closeButton = screen.getByTestId('button')
@@ -495,9 +506,11 @@ describe('Drawer', () => {
       const onClose = jest.fn()
 
       render(
-        <Drawer title="Test Drawer" forceOpen showCloseWarningDialog onClose={onClose}>
-          <div data-test={DRAWER_CONTENT_TEST_ID}>Content</div>
-        </Drawer>,
+        <NiceModalWrapper>
+          <Drawer title="Test Drawer" forceOpen showCloseWarningDialog onClose={onClose}>
+            <div data-test={DRAWER_CONTENT_TEST_ID}>Content</div>
+          </Drawer>
+        </NiceModalWrapper>,
       )
 
       const closeButton = screen.getByTestId('button')
@@ -536,9 +549,11 @@ describe('Drawer', () => {
       const onClose = jest.fn()
 
       render(
-        <Drawer title="Test Drawer" forceOpen showCloseWarningDialog onClose={onClose}>
-          <div data-test={DRAWER_CONTENT_TEST_ID}>Content</div>
-        </Drawer>,
+        <NiceModalWrapper>
+          <Drawer title="Test Drawer" forceOpen showCloseWarningDialog onClose={onClose}>
+            <div data-test={DRAWER_CONTENT_TEST_ID}>Content</div>
+          </Drawer>
+        </NiceModalWrapper>,
       )
 
       const closeButton = screen.getByTestId('button')


### PR DESCRIPTION
## Context

`PreventClosingDrawerDialog` was the last remaining consumer of the deprecated legacy imperative ref-based `WarningDialog` component. Because it imports `WarningDialog` via a relative path (`./WarningDialog`) rather than the `~/components/...` alias, the `no-restricted-imports` ESLint rule doesn't catch it — so removing `WarningDialog` was silently blocked. `PreventClosingDrawerDialog` is rendered internally by the design-system `Drawer` whenever `showCloseWarningDialog` is passed, so the migration has to update `Drawer.tsx` too.

## Description

Migrate `PreventClosingDrawerDialog` off the ref-based `WarningDialog` and onto the new hook-based `useCentralizedDialog` API. The dialog is a pure confirmation (fires an `onContinue` callback on continue) — `CentralizedDialog` with `colorVariant: 'danger'` matches the previous default behavior (`WarningDialog` defaulted to danger mode).

- **`src/components/designSystem/PreventClosingDrawerDialog.tsx`**: replaced the `forwardRef` + `useImperativeHandle` + `useState` + `WarningDialog` boilerplate with a thin `usePreventClosingDrawerDialog` hook exposing `openPreventClosingDrawerDialog({ onContinue })`. The `PreventClosingDrawerDialogRef` / `PreventClosingDrawerDialogProps` exports are gone.
- **`src/components/designSystem/Drawer.tsx`**: dropped the `useRef<PreventClosingDrawerDialogRef>()` + `<PreventClosingDrawerDialog ref={...} />` JSX render, replaced by `const { openPreventClosingDrawerDialog } = usePreventClosingDrawerDialog()`. The `closeAction` branch that used to call `preventClosingDrawerDialogRef.current?.openDialog(...)` now calls `openPreventClosingDrawerDialog(...)` directly. The dialog is rendered globally via `NiceModal` (already registered in `src/core/overlays/registeredDialogs.ts`).
- **`src/components/designSystem/__tests__/Drawer.test.tsx`**: three `Close Warning Dialog` tests now wrap the rendered `<Drawer>` in a local `NiceModal.Provider` so the hook can dispatch. The `Provider` is only needed by the three tests that actually pass `showCloseWarningDialog`, since `useModal` doesn't fail on init — only when `show()` is called.

No user-visible behavior change: title / description / continue label / danger styling stay identical.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint` on the touched files — clean
- `pnpm test -- --testPathPattern "designSystem/__tests__/Drawer"` — 37/37 tests passing

## Test plan

- [ ] Open any drawer that opts into the close-warning flow (e.g. a form drawer that passes `showCloseWarningDialog`). Click the drawer's close (X) button or the backdrop → confirmation dialog opens with the danger styling.
- [ ] Confirm the dialog → the drawer closes and `onClose` fires exactly once.
- [ ] Cancel the dialog → the drawer stays open, `onClose` does not fire.
- [ ] Open a drawer that does NOT pass `showCloseWarningDialog` → clicking close still closes the drawer immediately, no dialog.

---
_Generated by [Claude Code](https://claude.ai/code/session_013ia3H5XPVEWczp1QPY1iF8)_