### PR TITLE
refactor(invoices): migrate EditBillingEntityInvoiceNumberingDialog to FormDialog and TanStack Form

### DIFF
--- a/src/components/settings/invoices/EditBillingEntityInvoiceNumberingDialog.tsx
+++ b/src/components/settings/invoices/EditBillingEntityInvoiceNumberingDialog.tsx
@@ -1,13 +1,14 @@
 import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
-import { forwardRef } from 'react'
-import { object, string } from 'yup'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
 import { Chip } from '~/components/designSystem/Chip'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { RadioGroupField, TextInput, TextInputField } from '~/components/form'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
+import { TextInput } from '~/components/form'
 import { addToast } from '~/core/apolloClient'
 import { getBillingEntityNumberPreview } from '~/core/utils/billingEntityNumberPreview'
 import {
@@ -15,8 +16,9 @@ import {
   useUpdateBillingEntityInvoiceNumberingMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
-const DynamicPrefixTranslationLookup = {
+const DynamicPrefixTranslationLookup: Record<BillingEntityDocumentNumberingEnum, string> = {
   [BillingEntityDocumentNumberingEnum.PerCustomer]: 'text_6566f920a1d6c35693d6cce0',
   [BillingEntityDocumentNumberingEnum.PerBillingEntity]: 'YYYYMM',
 }
@@ -36,142 +38,171 @@ gql`
   }
 `
 
-export type EditBillingEntityInvoiceNumberingDialogRef = DialogRef
+const editBillingEntityInvoiceNumberingValidationSchema = z.object({
+  documentNumbering: z.enum(BillingEntityDocumentNumberingEnum),
+  documentNumberPrefix: z.string().min(1).max(10, { message: 'text_6566f920a1d6c35693d6cd77' }),
+})
 
-interface EditBillingEntityInvoiceNumberingDialogProps {
+type EditBillingEntityInvoiceNumberingDialogData = {
   id: string
-  documentNumbering?: BillingEntityDocumentNumberingEnum
-  documentNumberPrefix?: string
+  documentNumbering?: BillingEntityDocumentNumberingEnum | null
+  documentNumberPrefix?: string | null
 }
 
-export const EditBillingEntityInvoiceNumberingDialog = forwardRef<
-  DialogRef,
-  EditBillingEntityInvoiceNumberingDialogProps
->(
-  (
-    { id, documentNumbering, documentNumberPrefix }: EditBillingEntityInvoiceNumberingDialogProps,
-    ref,
-  ) => {
-    const { translate } = useInternationalization()
-    const [updateBillingEntityInvoiceNumbering] = useUpdateBillingEntityInvoiceNumberingMutation({
-      onCompleted(res) {
-        if (res?.updateBillingEntity) {
-          addToast({
-            severity: 'success',
-            translateKey: 'text_6566f920a1d6c35693d6ce0f',
-          })
-        }
-      },
-      refetchQueries: ['getBillingEntitySettings'],
-    })
+const FORM_ID = 'edit-billing-entity-invoice-numbering-form'
 
-    // Type is manually written here as errors type are not correctly read from UpdateBillingEntityInput
-    const formikProps = useFormik<EditBillingEntityInvoiceNumberingDialogProps>({
-      initialValues: {
-        id,
-        documentNumbering,
-        documentNumberPrefix,
-      },
-      validationSchema: object().shape({
-        documentNumbering: string().required(''),
-        documentNumberPrefix: string().required('').max(10, 'text_6566f920a1d6c35693d6cd77'),
-      }),
-      enableReinitialize: true,
-      validateOnMount: true,
-      onSubmit: async (values) => {
-        await updateBillingEntityInvoiceNumbering({
-          variables: {
-            input: {
-              ...values,
-            },
-          },
+export const useEditBillingEntityInvoiceNumberingDialog = () => {
+  const formDialog = useFormDialog()
+  const { translate } = useInternationalization()
+
+  const dataRef = useRef<EditBillingEntityInvoiceNumberingDialogData | null>(null)
+  const successRef = useRef(false)
+
+  const [updateBillingEntityInvoiceNumbering] = useUpdateBillingEntityInvoiceNumberingMutation({
+    onCompleted(res) {
+      if (res?.updateBillingEntity) {
+        addToast({
+          severity: 'success',
+          translateKey: 'text_6566f920a1d6c35693d6ce0f',
         })
-      },
-    })
+      }
+    },
+    refetchQueries: ['getBillingEntitySettings'],
+  })
 
-    return (
-      <Dialog
-        ref={ref}
-        title={translate('text_6566f920a1d6c35693d6cc8c')}
-        description={translate('text_6566f920a1d6c35693d6cc94')}
-        onClose={() => formikProps.resetForm()}
-        actions={({ closeDialog }) => (
-          <>
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_62bb10ad2a10bd182d002031')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!formikProps.isValid || !formikProps.dirty}
-              onClick={async () => {
-                await formikProps.submitForm()
-                closeDialog()
-              }}
-            >
-              {translate('text_17432414198706rdwf76ek3u')}
-            </Button>
-          </>
-        )}
-      >
-        <div className="mb-8 flex flex-col gap-8">
-          <div className="flex items-center gap-3 rounded-xl border border-grey-300 p-3">
-            <Chip label={translate('text_6566f920a1d6c35693d6cc9e')} />
-            <Typography variant="body" color="grey700">
-              {getBillingEntityNumberPreview(
-                formikProps.values.documentNumbering as BillingEntityDocumentNumberingEnum,
-                formikProps.values.documentNumberPrefix || '',
+  const form = useAppForm({
+    defaultValues: {
+      documentNumbering: BillingEntityDocumentNumberingEnum.PerCustomer,
+      documentNumberPrefix: '',
+    },
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: editBillingEntityInvoiceNumberingValidationSchema,
+    },
+    onSubmit: async ({ value }) => {
+      const result = await updateBillingEntityInvoiceNumbering({
+        variables: {
+          input: {
+            id: dataRef.current?.id as string,
+            documentNumbering: value.documentNumbering,
+            documentNumberPrefix: value.documentNumberPrefix,
+          },
+        },
+      })
+
+      if (result.data?.updateBillingEntity) {
+        successRef.current = true
+      }
+    },
+  })
+
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
+
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openEditBillingEntityInvoiceNumberingDialog = (
+    data: EditBillingEntityInvoiceNumberingDialogData,
+  ) => {
+    dataRef.current = data
+    form.reset()
+    if (data.documentNumbering) {
+      form.setFieldValue('documentNumbering', data.documentNumbering)
+    }
+    form.setFieldValue('documentNumberPrefix', data.documentNumberPrefix ?? '')
+
+    formDialog
+      .open({
+        title: translate('text_6566f920a1d6c35693d6cc8c'),
+        description: translate('text_6566f920a1d6c35693d6cc94'),
+        children: (
+          <div className="mb-8 flex flex-col gap-8 p-6">
+            <div className="flex items-center gap-3 rounded-xl border border-grey-300 p-3">
+              <Chip label={translate('text_6566f920a1d6c35693d6cc9e')} />
+              <form.Subscribe
+                selector={(state) => ({
+                  documentNumbering: state.values.documentNumbering,
+                  documentNumberPrefix: state.values.documentNumberPrefix,
+                })}
+              >
+                {({ documentNumbering, documentNumberPrefix }) => (
+                  <Typography variant="body" color="grey700">
+                    {getBillingEntityNumberPreview(documentNumbering, documentNumberPrefix || '')}
+                  </Typography>
+                )}
+              </form.Subscribe>
+            </div>
+
+            <form.AppField name="documentNumbering">
+              {(field) => (
+                <field.RadioGroupField
+                  label={translate('text_6566f920a1d6c35693d6ccae')}
+                  options={[
+                    {
+                      label: translate('text_6566f920a1d6c35693d6ccb8'),
+                      value: BillingEntityDocumentNumberingEnum.PerCustomer,
+                    },
+                    {
+                      label: translate('text_6566f920a1d6c35693d6ccc0'),
+                      value: BillingEntityDocumentNumberingEnum.PerBillingEntity,
+                    },
+                  ]}
+                />
               )}
-            </Typography>
+            </form.AppField>
+
+            <div className="grid grid-cols-[1fr_8px_1fr_8px_80px] gap-3">
+              <form.AppField name="documentNumberPrefix">
+                {(field) => (
+                  <field.TextInputField label={translate('text_6566f920a1d6c35693d6ccc8')} />
+                )}
+              </form.AppField>
+              <Typography className="mt-[38px] h-fit" variant="body">
+                -
+              </Typography>
+              <form.Subscribe selector={(state) => state.values.documentNumbering}>
+                {(documentNumbering) => (
+                  <TextInput
+                    disabled
+                    label={translate('text_6566f920a1d6c35693d6ccd8')}
+                    value={translate(DynamicPrefixTranslationLookup[documentNumbering])}
+                  />
+                )}
+              </form.Subscribe>
+              <Typography className="mt-[38px] h-fit" variant="body">
+                -
+              </Typography>
+              <TextInput
+                disabled
+                label={translate('text_6566f920a1d6c35693d6cce8')}
+                value={'001'}
+              />
+            </div>
           </div>
+        ),
+        closeOnError: false,
+        onEntered: focusFirstInput,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>{translate('text_17432414198706rdwf76ek3u')}</form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then(() => {
+        form.reset()
+        dataRef.current = null
+      })
+  }
 
-          <RadioGroupField
-            formikProps={formikProps}
-            name="documentNumbering"
-            label={translate('text_6566f920a1d6c35693d6ccae')}
-            options={[
-              {
-                label: translate('text_6566f920a1d6c35693d6ccb8'),
-                value: BillingEntityDocumentNumberingEnum.PerCustomer,
-              },
-              {
-                label: translate('text_6566f920a1d6c35693d6ccc0'),
-                value: BillingEntityDocumentNumberingEnum.PerBillingEntity,
-              },
-            ]}
-          />
-
-          <div className="grid grid-cols-[1fr_8px_1fr_8px_80px] gap-3">
-            <TextInputField
-              name="documentNumberPrefix"
-              formikProps={formikProps}
-              label={translate('text_6566f920a1d6c35693d6ccc8')}
-              error={
-                formikProps.errors.documentNumberPrefix
-                  ? translate(formikProps.errors.documentNumberPrefix)
-                  : undefined
-              }
-            />
-            <Typography className="mt-[38px] h-fit" variant="body">
-              -
-            </Typography>
-            <TextInput
-              disabled
-              label={translate('text_6566f920a1d6c35693d6ccd8')}
-              value={translate(
-                DynamicPrefixTranslationLookup[
-                  formikProps.values.documentNumbering as BillingEntityDocumentNumberingEnum
-                ],
-              )}
-            />
-            <Typography className="mt-[38px] h-fit" variant="body">
-              -
-            </Typography>
-            <TextInput disabled label={translate('text_6566f920a1d6c35693d6cce8')} value={'001'} />
-          </div>
-        </div>
-      </Dialog>
-    )
-  },
-)
-
-EditBillingEntityInvoiceNumberingDialog.displayName = 'forwardRef'
+  return { openEditBillingEntityInvoiceNumberingDialog }
+}

--- a/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
@@ -27,10 +27,7 @@ import {
   EditBillingEntityInvoiceIssuingDatePolicyDialog,
   EditBillingEntityInvoiceIssuingDatePolicyDialogRef,
 } from '~/components/settings/invoices/EditBillingEntityInvoiceIssuingDatePolicyDialog'
-import {
-  EditBillingEntityInvoiceNumberingDialog,
-  EditBillingEntityInvoiceNumberingDialogRef,
-} from '~/components/settings/invoices/EditBillingEntityInvoiceNumberingDialog'
+import { useEditBillingEntityInvoiceNumberingDialog } from '~/components/settings/invoices/EditBillingEntityInvoiceNumberingDialog'
 import { useEditBillingEntityInvoiceTemplateDialog } from '~/components/settings/invoices/EditBillingEntityInvoiceTemplateDialog'
 import { useEditDefaultCurrencyDialog } from '~/components/settings/invoices/EditDefaultCurrencyDialog'
 import {
@@ -132,7 +129,6 @@ const BillingEntityInvoiceSettings = () => {
   const { isPremium } = useCurrentUser()
   const { hasPermissions } = usePermissions()
 
-  const editInvoiceNumberingDialogRef = useRef<EditBillingEntityInvoiceNumberingDialogRef>(null)
   const editBillingEntityInvoiceIssuingDatePolicyDialogRef =
     useRef<EditBillingEntityInvoiceIssuingDatePolicyDialogRef>(null)
   const editGracePeriodDialogRef = useRef<EditBillingEntityGracePeriodDialogRef>(null)
@@ -143,6 +139,8 @@ const BillingEntityInvoiceSettings = () => {
   const premiumWarningDialog = usePremiumWarningDialog()
   const { openEditDefaultCurrencyDialog } = useEditDefaultCurrencyDialog()
   const { openEditBillingEntityInvoiceTemplateDialog } = useEditBillingEntityInvoiceTemplateDialog()
+  const { openEditBillingEntityInvoiceNumberingDialog } =
+    useEditBillingEntityInvoiceNumberingDialog()
 
   const { data, error, loading } = useGetBillingEntitySettingsQuery({
     variables: {
@@ -308,7 +306,13 @@ const BillingEntityInvoiceSettings = () => {
         <Button
           variant="inline"
           disabled={!canEditInvoiceSettings}
-          onClick={() => editInvoiceNumberingDialogRef?.current?.openDialog()}
+          onClick={() =>
+            openEditBillingEntityInvoiceNumberingDialog({
+              id: billingEntity?.id as string,
+              documentNumbering: billingEntity?.documentNumbering,
+              documentNumberPrefix: billingEntity?.documentNumberPrefix,
+            })
+          }
         >
           {translate('text_6380d7e60f081e5b777c4b24')}
         </Button>
@@ -329,14 +333,6 @@ const BillingEntityInvoiceSettings = () => {
             )}
           </Typography>
         </div>
-      ),
-      dialog: (
-        <EditBillingEntityInvoiceNumberingDialog
-          ref={editInvoiceNumberingDialogRef}
-          documentNumbering={billingEntity?.documentNumbering}
-          documentNumberPrefix={billingEntity?.documentNumberPrefix}
-          id={billingEntity?.id as string}
-        />
       ),
     },
     {


### PR DESCRIPTION
## Context

Part of the ongoing effort to remove the legacy imperative ref-based `Dialog` system and Formik forms from the frontend. Each PR migrates one dialog flagged by the `no-restricted-imports` ESLint rule to the new hook-based NiceModal `FormDialog` + TanStack Form / Zod stack.

## Description

Migrates `EditBillingEntityInvoiceNumberingDialog` from the legacy imperative ref-based `Dialog` + Formik/Yup stack to the hook-based `useFormDialog` + TanStack Form + Zod stack, aligning it with the recently-migrated sibling dialogs in the same folder. The dialog is now exposed as a `useEditBillingEntityInvoiceNumberingDialog` hook that stores the passed billing entity data in a ref and drives the mutation through TanStack Form, with a `successRef` bridging the mutation result into the FormDialog close/keep-open contract. Validation is rewritten in Zod (`z.enum(BillingEntityDocumentNumberingEnum)` and a min/max string constraint that preserves the existing max-length translation key), and the submit button now relies on `canSubmit` via `form.SubmitButton` instead of the legacy `!isValid || !dirty` gate. The live number preview chip and the dynamic middle "prefix" placeholder read the form values via `form.Subscribe` so they stay reactive to radio/input changes. The parent `BillingEntityInvoiceSettings` was updated to consume the hook and drop the ref plumbing and inline dialog JSX for this dialog, matching the pattern used for the neighbouring invoice-template and default-currency dialogs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdynmboayP9hcgY4hD6BLk)_