### PR TITLE
refactor(api-keys): migrate RotateApiKeyDialog to FormDialog hook

### DIFF
--- a/.agents/skills/migrate-dialog/SKILL.md
+++ b/.agents/skills/migrate-dialog/SKILL.md
@@ -161,11 +161,12 @@ export const useMyDialog = () => {
       .open({
         title: translate('...'),
         children: (
-          <div className="...">
+          <div className="p-8">
             {/* Dialog content */}
           </div>
         ),
         closeOnError: false,
+        onEntered: focusFirstInput,
         mainAction: (
           <form.AppForm>
             <form.SubmitButton>{translate('...')}</form.SubmitButton>
@@ -211,6 +212,39 @@ const handleSubmit = async (): Promise<DialogResult> => {
 ```
 
 Do **not** drop `validationLogic` to "simplify" — without `revalidateLogic()` the `onDynamic` validator never runs and the schema is silently skipped. Keep `revalidateLogic()` (the default, submit-first); do not use `revalidateLogic({ mode: 'change' })` unless a field genuinely needs live validation feedback.
+
+#### Content padding and initial focus — REQUIRED for every migration
+
+Two things are easy to drop during migration and both produce visible regressions. Apply them to **every** `FormDialog` / `FormDialogOpeningDialog` you migrate.
+
+**1. Wrap `children` in a padding container (`p-8`).**
+
+`BaseDialog` only auto-pads content when `children` is a plain **string**. JSX children get **no** padding, so the content renders flush against the left/right edges while the header (`p-8`) and footer stay inset — a broken, misaligned layout. The legacy `Dialog` padded content for you; the new system does not.
+
+Always wrap the JSX children in a padding container so the content's left edge aligns with the header title:
+
+```tsx
+children: (
+  <div className="p-8">
+    {/* dialog content */}
+  </div>
+),
+```
+
+Use `p-8` to match the header/footer gutter. If the content is a nested form component (e.g. a `withForm` render), put the `p-8` on that component's outer wrapper instead. Never leave the children unwrapped.
+
+**2. Focus the first input on enter (`onEntered: focusFirstInput`).**
+
+The legacy `Dialog` auto-focused the first field. `FormDialog` exposes an `onEntered?: (container: HTMLElement) => void` callback (fired after the enter transition) but does nothing by default, so the migrated dialog opens with nothing focused. Wire the shared helper:
+
+```tsx
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
+
+// inside the .open({ ... }) call, as a sibling of `children` / `closeOnError`:
+onEntered: focusFirstInput,
+```
+
+`focusFirstInput(container)` scopes its lookup to the dialog's own container and focuses the first editable input (skipping hidden/disabled), so it works regardless of dialog-stack position. It's the same helper the plan and charge drawers use. For a dialog whose first field is not the desired target, pass a custom selector via a wrapper: `onEntered: (c) => focusFirstInput(c, '#my-field')`.
 
 **New Pattern (hook-based with CentralizedDialog):**
 
@@ -352,13 +386,14 @@ export const useMyFormDialog = () => {
         title: translate(isEdition ? '...' : '...'),
         description: translate('...'),
         children: (
-          <div className="...">
+          <div className="p-8">
             <form.AppField name="fieldName">
               {(field) => <field.TextInputField label={translate('...')} />}
             </form.AppField>
           </div>
         ),
         closeOnError: false,
+        onEntered: focusFirstInput,
         mainAction: (
           <form.AppForm>
             <form.SubmitButton>{translate('...')}</form.SubmitButton>
@@ -459,6 +494,7 @@ Add (for FormDialog):
 import { useRef } from 'react'
 import { useFormDialog } from '~/components/dialogs/FormDialog'
 import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 ```
 
 Or (for CentralizedDialog):
@@ -473,6 +509,7 @@ Or (for FormDialogOpeningDialog):
 import { useRef } from 'react'
 import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
 import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 ```
 
 #### Step 2.4: Remove Old Exports
@@ -642,6 +679,8 @@ type FormDialogOpeningDialogProps = FormDialogProps & {
 - [ ] Replace `useState(localData)` with `useRef` (for FormDialog/FormDialogOpeningDialog) or function parameter (for CentralizedDialog)
 - [ ] Replace `Dialog`/`WarningDialog` with `useFormDialog()`, `useCentralizedDialog()`, or `useFormDialogOpeningDialog()`
 - [ ] Implement `handleSubmit` returning `Promise<DialogResult>` (for FormDialog/FormDialogOpeningDialog)
+- [ ] Wrap `children` JSX in a `p-8` padding container (BaseDialog does NOT pad JSX children → flush/misaligned layout otherwise)
+- [ ] Add `onEntered: focusFirstInput` so the dialog focuses its first input on open (legacy Dialog did this automatically)
 - [ ] Handle form reset and cleanup in `.then()` callback (for FormDialog/FormDialogOpeningDialog)
 - [ ] Remove old exports (`forwardRef`, `DialogRef` interface, `displayName`)
 - [ ] (Deletion dialog) Replace `refetchQueries` / bare `cache.evict()` with the `evictFromCache` helper

--- a/src/components/developers/apiKeys/ApiKeys.tsx
+++ b/src/components/developers/apiKeys/ApiKeys.tsx
@@ -16,10 +16,7 @@ import {
   DeleteApiKeyDialog,
   DeleteApiKeyDialogRef,
 } from '~/components/developers/apiKeys/DeleteApiKeyDialog'
-import {
-  RotateApiKeyDialog,
-  RotateApiKeyDialogRef,
-} from '~/components/developers/apiKeys/RotateApiKeyDialog'
+import { useRotateApiKeyDialog } from '~/components/developers/apiKeys/RotateApiKeyDialog'
 import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import {
   SettingsListItem,
@@ -100,9 +97,9 @@ export const ApiKeys = () => {
   const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
   const { closePanel: close, setMainRouterUrl } = useDeveloperTool()
 
-  const rotateApiKeyDialogRef = useRef<RotateApiKeyDialogRef>(null)
   const deleteApiKeyDialogRef = useRef<DeleteApiKeyDialogRef>(null)
   const premiumWarningDialog = usePremiumWarningDialog()
+  const { openRotateApiKeyDialog } = useRotateApiKeyDialog()
   const [showOrganizationId, setShowOrganizationId] = useState(false)
   const [shownApiKeysMap, setShownApiKeysMap] = useState<Map<string, string>>(new Map())
   const [loadingKeyIds, setLoadingKeyIds] = useState<Set<string>>(new Set())
@@ -498,13 +495,14 @@ export const ApiKeys = () => {
                           disabled: apiKeysLoading,
                           title: translate('text_17315063604211fznu9haor8'),
                           onAction: () => {
-                            rotateApiKeyDialogRef.current?.openDialog({
+                            openRotateApiKeyDialog({
                               apiKey: item,
                               callBack: (itemToReveal) => {
                                 setShownApiKeysMap(
                                   (prev) => new Map(prev.set(itemToReveal.id, itemToReveal.value)),
                                 )
                               },
+                              openPremiumDialog: () => premiumWarningDialog.open(),
                             })
                           },
                         },
@@ -542,10 +540,6 @@ export const ApiKeys = () => {
         </SettingsListWrapper>
       </div>
 
-      <RotateApiKeyDialog
-        ref={rotateApiKeyDialogRef}
-        openPremiumDialog={() => premiumWarningDialog.open()}
-      />
       <DeleteApiKeyDialog ref={deleteApiKeyDialogRef} />
     </div>
   )

--- a/src/components/developers/apiKeys/RotateApiKeyDialog.tsx
+++ b/src/components/developers/apiKeys/RotateApiKeyDialog.tsx
@@ -2,12 +2,14 @@ import { gql } from '@apollo/client'
 import { revalidateLogic } from '@tanstack/react-form'
 import { Icon } from 'lago-design-system'
 import { DateTime } from 'luxon'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { useRef } from 'react'
 import { z } from 'zod'
 
 import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { addToast } from '~/core/apolloClient'
 import { intlFormatDateTime } from '~/core/timezone/utils'
 import {
@@ -62,25 +64,32 @@ gql`
   ${ApiKeyRevealedForApiKeysListFragmentDoc}
 `
 
-type RotateApiKeyDialogProps = {
+type RotateApiKeyDialogData = {
   apiKey: ApiKeyForRotateApiKeyDialogFragment
   callBack: (itemToReveal: ApiKeyRevealedForApiKeysListFragment) => void
+  openPremiumDialog: VoidFunction
 }
 
-export interface RotateApiKeyDialogRef {
-  openDialog: (data: RotateApiKeyDialogProps) => unknown
-  closeDialog: () => unknown
-}
-
-export const RotateApiKeyDialog = forwardRef<
-  RotateApiKeyDialogRef,
-  { openPremiumDialog: VoidFunction }
->(({ openPremiumDialog }, ref) => {
+export const useRotateApiKeyDialog = () => {
+  const formDialog = useFormDialog()
   const { isPremium } = useCurrentUser()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
-  const [localData, setLocalData] = useState<RotateApiKeyDialogProps | undefined>(undefined)
-  const apiKey = localData?.apiKey
+  const dataRef = useRef<RotateApiKeyDialogData | null>(null)
+  const successRef = useRef(false)
+
+  const [rotateApiKey] = useRotateApiKeyMutation({
+    onCompleted(data) {
+      if (!!data?.rotateApiKey?.id) {
+        dataRef.current?.callBack(data.rotateApiKey)
+
+        addToast({
+          message: translate('text_1731506310510htbvgegpzd8'),
+          severity: 'success',
+        })
+      }
+    },
+    refetchQueries: ['getApiKeys'],
+  })
 
   const form = useAppForm({
     defaultValues: {
@@ -102,17 +111,19 @@ export const RotateApiKeyDialog = forwardRef<
         ExpirationValuesAsTime[expiresAt as keyof typeof ExpirationValuesEnum]
 
       try {
-        await rotateApiKey({
+        const result = await rotateApiKey({
           variables: {
             input: {
-              id: apiKey?.id || '',
+              id: dataRef.current?.apiKey.id || '',
               expiresAt: transformedExpiredAt,
-              name: localData?.apiKey.name,
+              name: dataRef.current?.apiKey.name,
             },
           },
         })
 
-        dialogRef.current?.closeDialog()
+        if (result.data?.rotateApiKey?.id) {
+          successRef.current = true
+        }
       } catch {
         addToast({
           severity: 'danger',
@@ -122,142 +133,131 @@ export const RotateApiKeyDialog = forwardRef<
     },
   })
 
-  const [rotateApiKey] = useRotateApiKeyMutation({
-    onCompleted(data) {
-      if (!!data?.rotateApiKey?.id) {
-        localData?.callBack(data.rotateApiKey)
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-        addToast({
-          message: translate('text_1731506310510htbvgegpzd8'),
-          severity: 'success',
-        })
-      }
-    },
-    refetchQueries: ['getApiKeys'],
-  })
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => {
-      dialogRef.current?.closeDialog()
-    },
-  }))
-
-  const handleFormSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    form.handleSubmit()
+    return { reason: 'success' }
   }
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate('text_173151476175058ugha8fd08')}
-      description={translate('text_1731514761750dnh1s073j9o')}
-      onClose={() => form.reset()}
-      formId={ROTATE_API_KEY_FORM_ID}
-      formSubmit={handleFormSubmit}
-      actions={({ closeDialog }) => (
-        <>
-          <Button variant="quaternary" onClick={closeDialog}>
-            {translate('text_64352657267c3d916f962769')}
-          </Button>
-          <Button
-            danger
-            type="submit"
-            variant="primary"
-            data-test={ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID}
-          >
-            {translate('text_173151476175058ugha8fd08')}
-          </Button>
-        </>
-      )}
-    >
-      <div className="mb-8 flex flex-col gap-8">
-        <div className="flex w-full items-center">
-          <Typography className="w-35" variant="caption" color="grey600">
-            {translate('text_1731515447290xbe4iqm5n6r')}
-          </Typography>
-          <Typography className="flex-1" variant="body" color="grey700">
-            {!!apiKey?.lastUsedAt
-              ? intlFormatDateTime(apiKey?.lastUsedAt, {
-                  timezone: TimezoneEnum.TzUtc,
-                }).date
-              : '-'}
-          </Typography>
-        </div>
-        <div className="flex flex-col">
-          <div className="mb-4">
-            <Typography variant="bodyHl" color="grey700">
-              {translate('text_1732286530467qf204t1o5ol')}
-            </Typography>
-            <Typography variant="caption" color="grey600">
-              {translate('text_17322865304677r38axxm3cc')}
-            </Typography>
-          </div>
+  const openRotateApiKeyDialog = (data: RotateApiKeyDialogData) => {
+    dataRef.current = data
+    form.reset()
 
-          <div className="flex flex-col gap-4">
-            <form.AppField name="expiresAt">
-              {(field) => (
-                <>
-                  <field.RadioField
-                    labelVariant="body"
-                    value={ExpirationValuesEnum.Now}
-                    label={translate(ExpirationValuesTranslationLookup.Now)}
-                  />
-                  {!isPremium && (
-                    <div className="flex w-full flex-row items-center justify-between gap-2 rounded-xl bg-grey-100 px-6 py-4">
-                      <div className="flex flex-col">
-                        <div className="flex flex-row items-center gap-2">
-                          <Typography variant="bodyHl" color="grey700">
-                            {translate('text_1732286530467ezav2z7ypj1')}
-                          </Typography>
-                          <Icon name="sparkles" />
+    formDialog
+      .open({
+        title: translate('text_173151476175058ugha8fd08'),
+        description: translate('text_1731514761750dnh1s073j9o'),
+        closeOnError: false,
+        onEntered: focusFirstInput,
+        children: (
+          <div className="flex flex-col gap-8 p-8">
+            <div className="flex w-full items-center">
+              <Typography className="w-35" variant="caption" color="grey600">
+                {translate('text_1731515447290xbe4iqm5n6r')}
+              </Typography>
+              <Typography className="flex-1" variant="body" color="grey700">
+                {!!data.apiKey.lastUsedAt
+                  ? intlFormatDateTime(data.apiKey.lastUsedAt, {
+                      timezone: TimezoneEnum.TzUtc,
+                    }).date
+                  : '-'}
+              </Typography>
+            </div>
+            <div className="flex flex-col">
+              <div className="mb-4">
+                <Typography variant="bodyHl" color="grey700">
+                  {translate('text_1732286530467qf204t1o5ol')}
+                </Typography>
+                <Typography variant="caption" color="grey600">
+                  {translate('text_17322865304677r38axxm3cc')}
+                </Typography>
+              </div>
+
+              <div className="flex flex-col gap-4">
+                <form.AppField name="expiresAt">
+                  {(field) => (
+                    <>
+                      <field.RadioField
+                        labelVariant="body"
+                        value={ExpirationValuesEnum.Now}
+                        label={translate(ExpirationValuesTranslationLookup.Now)}
+                      />
+                      {!isPremium && (
+                        <div className="flex w-full flex-row items-center justify-between gap-2 rounded-xl bg-grey-100 px-6 py-4">
+                          <div className="flex flex-col">
+                            <div className="flex flex-row items-center gap-2">
+                              <Typography variant="bodyHl" color="grey700">
+                                {translate('text_1732286530467ezav2z7ypj1')}
+                              </Typography>
+                              <Icon name="sparkles" />
+                            </div>
+
+                            <Typography variant="caption" color="grey600">
+                              {translate('text_1732286530467gnhwm6q5ftl')}
+                            </Typography>
+                          </div>
+                          <Button
+                            endIcon="sparkles"
+                            variant="tertiary"
+                            onClick={data.openPremiumDialog}
+                          >
+                            {translate('text_65ae73ebe3a66bec2b91d72d')}
+                          </Button>
                         </div>
-
-                        <Typography variant="caption" color="grey600">
-                          {translate('text_1732286530467gnhwm6q5ftl')}
-                        </Typography>
-                      </div>
-                      <Button endIcon="sparkles" variant="tertiary" onClick={openPremiumDialog}>
-                        {translate('text_65ae73ebe3a66bec2b91d72d')}
-                      </Button>
-                    </div>
+                      )}
+                      <field.RadioField
+                        labelVariant="body"
+                        disabled={!isPremium}
+                        value={ExpirationValuesEnum.OneHour}
+                        label={translate(ExpirationValuesTranslationLookup.OneHour)}
+                      />
+                      <field.RadioField
+                        labelVariant="body"
+                        disabled={!isPremium}
+                        value={ExpirationValuesEnum.OneDay}
+                        label={translate(ExpirationValuesTranslationLookup.OneDay)}
+                      />
+                      <field.RadioField
+                        labelVariant="body"
+                        disabled={!isPremium}
+                        value={ExpirationValuesEnum.TwoDays}
+                        label={translate(ExpirationValuesTranslationLookup.TwoDays)}
+                      />
+                      <field.RadioField
+                        labelVariant="body"
+                        disabled={!isPremium}
+                        value={ExpirationValuesEnum.OneWeek}
+                        label={translate(ExpirationValuesTranslationLookup.OneWeek)}
+                      />
+                    </>
                   )}
-                  <field.RadioField
-                    labelVariant="body"
-                    disabled={!isPremium}
-                    value={ExpirationValuesEnum.OneHour}
-                    label={translate(ExpirationValuesTranslationLookup.OneHour)}
-                  />
-                  <field.RadioField
-                    labelVariant="body"
-                    disabled={!isPremium}
-                    value={ExpirationValuesEnum.OneDay}
-                    label={translate(ExpirationValuesTranslationLookup.OneDay)}
-                  />
-                  <field.RadioField
-                    labelVariant="body"
-                    disabled={!isPremium}
-                    value={ExpirationValuesEnum.TwoDays}
-                    label={translate(ExpirationValuesTranslationLookup.TwoDays)}
-                  />
-                  <field.RadioField
-                    labelVariant="body"
-                    disabled={!isPremium}
-                    value={ExpirationValuesEnum.OneWeek}
-                    label={translate(ExpirationValuesTranslationLookup.OneWeek)}
-                  />
-                </>
-              )}
-            </form.AppField>
+                </form.AppField>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
-    </Dialog>
-  )
-})
+        ),
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton danger dataTest={ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID}>
+              {translate('text_173151476175058ugha8fd08')}
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: ROTATE_API_KEY_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then(() => {
+        form.reset()
+        dataRef.current = null
+      })
+  }
 
-RotateApiKeyDialog.displayName = 'RotateApiKeyDialog'
+  return { openRotateApiKeyDialog }
+}

--- a/src/components/developers/apiKeys/__tests__/RotateApiKeyDialog.test.tsx
+++ b/src/components/developers/apiKeys/__tests__/RotateApiKeyDialog.test.tsx
@@ -1,14 +1,18 @@
+import NiceModal from '@ebay/nice-modal-react'
 import { act, cleanup, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { createRef } from 'react'
+import { ReactNode } from 'react'
 
 import {
   ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID,
-  RotateApiKeyDialog,
-  RotateApiKeyDialogRef,
+  useRotateApiKeyDialog,
 } from '~/components/developers/apiKeys/RotateApiKeyDialog'
+import { DIALOG_TITLE_TEST_ID, FORM_DIALOG_NAME } from '~/components/dialogs/const'
+import FormDialog from '~/components/dialogs/FormDialog'
 import { ApiKeyForRotateApiKeyDialogFragment } from '~/generated/graphql'
 import { render } from '~/test-utils'
+
+NiceModal.register(FORM_DIALOG_NAME, FormDialog)
 
 const mockRotate = jest.fn()
 
@@ -34,20 +38,47 @@ const apiKey: ApiKeyForRotateApiKeyDialogFragment = {
   lastUsedAt: null,
 }
 
+const OPEN_BUTTON_TEST_ID = 'open-rotate-api-key-dialog'
+
+const NiceModalWrapper = ({ children }: { children: ReactNode }) => (
+  <NiceModal.Provider>{children}</NiceModal.Provider>
+)
+
+const Harness = () => {
+  const { openRotateApiKeyDialog } = useRotateApiKeyDialog()
+
+  return (
+    <button
+      data-test={OPEN_BUTTON_TEST_ID}
+      onClick={() =>
+        openRotateApiKeyDialog({
+          apiKey,
+          callBack: jest.fn(),
+          openPremiumDialog: jest.fn(),
+        })
+      }
+    >
+      open
+    </button>
+  )
+}
+
 async function prepare() {
-  const ref = createRef<RotateApiKeyDialogRef>()
+  await act(() =>
+    render(
+      <NiceModalWrapper>
+        <Harness />
+      </NiceModalWrapper>,
+    ),
+  )
 
-  await act(() => render(<RotateApiKeyDialog ref={ref} openPremiumDialog={jest.fn()} />))
-
-  await act(() => {
-    ref.current?.openDialog({ apiKey, callBack: jest.fn() })
+  await act(async () => {
+    screen.getByTestId(OPEN_BUTTON_TEST_ID).click()
   })
 
   await waitFor(() => {
-    expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
+    expect(screen.getByTestId(DIALOG_TITLE_TEST_ID)).toBeInTheDocument()
   })
-
-  return { ref }
 }
 
 describe('RotateApiKeyDialog', () => {
@@ -60,6 +91,15 @@ describe('RotateApiKeyDialog', () => {
     describe('WHEN the user submits the form', () => {
       it('THEN it rotates the key with a null expiresAt', async () => {
         const user = userEvent.setup()
+
+        mockRotate.mockResolvedValue({
+          data: {
+            rotateApiKey: {
+              id: 'api-key-1',
+              value: 'new-value',
+            },
+          },
+        })
 
         await prepare()
 
@@ -87,6 +127,15 @@ describe('RotateApiKeyDialog', () => {
     describe('WHEN the user submits the form', () => {
       it('THEN it rotates the key with a non-null ISO expiresAt', async () => {
         const user = userEvent.setup()
+
+        mockRotate.mockResolvedValue({
+          data: {
+            rotateApiKey: {
+              id: 'api-key-1',
+              value: 'new-value',
+            },
+          },
+        })
 
         await prepare()
 


### PR DESCRIPTION
## Context

Part of the ongoing effort to remove the legacy imperative ref-based `Dialog` system from the frontend. Each PR migrates one dialog flagged by the `no-restricted-imports` ESLint rule to the new hook-based NiceModal `FormDialog` stack.

## Description

Migrates `RotateApiKeyDialog` from the legacy imperative ref-based `Dialog` to the hook-based `FormDialog` system (`useRotateApiKeyDialog`), removing the `forwardRef`/`useImperativeHandle`/`useState(localData)` scaffolding. The `openPremiumDialog` callback that was previously a component prop now lives on the open-function payload for consistency with recent migrations. Submission success is tracked with a ref so `handleSubmit` throws on failure and keeps the dialog open under `closeOnError: false`. The danger-styled submit button is preserved via `form.SubmitButton`'s `danger` prop, and `ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID` is wired through its `dataTest` prop. Parent `ApiKeys.tsx` calls the hook directly and no longer renders the dialog in JSX; the test now drives the hook through a NiceModal-wrapped harness, keeping both existing scenarios (`Now` and `OneWeek`) green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdynmboayP9hcgY4hD6BLk)_