### PR TITLE
refactor(exports): migrate ExportDialog to FormDialog and TanStack Form

### DIFF
--- a/src/components/exports/ExportDialog.tsx
+++ b/src/components/exports/ExportDialog.tsx
@@ -1,144 +1,159 @@
-import { useFormik } from 'formik'
-import { forwardRef } from 'react'
-import { object, string } from 'yup'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { RadioGroupField } from '~/components/form'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
+import { ExportValues } from '~/components/exports/types'
 import {
   CreditNoteExportTypeEnum,
   DataExportFormatTypeEnum,
   InvoiceExportTypeEnum,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 
 type ExportTypeEnum = CreditNoteExportTypeEnum | InvoiceExportTypeEnum
 
-type ExportForm = {
-  format: DataExportFormatTypeEnum
-  resourceType: ExportTypeEnum
-}
-
-export type ExportValues<T> = {
-  clientMutationId?: string
-  format: DataExportFormatTypeEnum
-  resourceType: T
-}
-
-type ExportDialogProps = {
+export type OpenExportDialogArgs<T extends ExportTypeEnum = ExportTypeEnum> = {
   totalCountLabel: string
-  // TODO: Fix this type
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  onExport: Function
+  onExport: (values: ExportValues<T>) => void | Promise<void>
   disableExport?: boolean
   resourceTypeOptions: {
     label: string
     sublabel: string
-    value: ExportForm['resourceType']
+    value: T
   }[]
 }
 
-export interface ExportDialogRef {
-  openDialog: () => unknown
-  closeDialog: () => unknown
-}
+const FORM_ID = 'export-form'
 
-export const ExportDialog = forwardRef<ExportDialogRef, ExportDialogProps>(
-  (
-    { totalCountLabel, onExport, disableExport = false, resourceTypeOptions }: ExportDialogProps,
-    ref,
-  ) => {
-    const { translate } = useInternationalization()
-    const { currentUser } = useCurrentUser()
+const exportValidationSchema = z.object({
+  format: z.enum(DataExportFormatTypeEnum),
+  resourceType: z.union([z.enum(CreditNoteExportTypeEnum), z.enum(InvoiceExportTypeEnum)]),
+})
 
-    const formikProps = useFormik<Omit<ExportForm, 'filters'>>({
-      initialValues: {
-        format: DataExportFormatTypeEnum.Csv,
-        resourceType: resourceTypeOptions[0].value,
-      },
-      validationSchema: object().shape({
-        format: string().required(''),
-      }),
-      validateOnMount: true,
-      enableReinitialize: true,
-      onSubmit: (values) => onExport(values),
-    })
+export const useExportDialog = () => {
+  const formDialog = useFormDialog()
+  const { translate } = useInternationalization()
+  const { currentUser } = useCurrentUser()
+  const onExportRef = useRef<
+    ((values: ExportValues<ExportTypeEnum>) => void | Promise<void>) | null
+  >(null)
 
-    return (
-      <Dialog
-        ref={ref}
-        title={translate('text_66b21236c939426d07ff9930')}
-        description={translate('text_66b21236c939426d07ff9932')}
-        onClose={() => {
-          formikProps.resetForm()
-          formikProps.validateForm()
-        }}
-        actions={({ closeDialog }) => (
-          <>
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_63eba8c65a6c8043feee2a14')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!formikProps.isValid || disableExport}
-              onClick={async () => {
-                await formikProps.submitForm()
-                closeDialog()
-              }}
-            >
+  const form = useAppForm({
+    defaultValues: {
+      format: DataExportFormatTypeEnum.Csv as DataExportFormatTypeEnum,
+      resourceType: InvoiceExportTypeEnum.Invoices as ExportTypeEnum,
+    },
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: exportValidationSchema,
+    },
+    onSubmit: async ({ value }) => {
+      await onExportRef.current?.({
+        format: value.format,
+        resourceType: value.resourceType,
+      })
+    },
+  })
+
+  const handleSubmit = async (): Promise<DialogResult> => {
+    await form.handleSubmit()
+
+    if (!form.state.isSubmitSuccessful) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openExportDialog = <T extends ExportTypeEnum>({
+    totalCountLabel,
+    onExport,
+    disableExport = false,
+    resourceTypeOptions,
+  }: OpenExportDialogArgs<T>) => {
+    onExportRef.current = onExport as (values: ExportValues<ExportTypeEnum>) => void | Promise<void>
+    form.reset()
+    form.setFieldValue('format', DataExportFormatTypeEnum.Csv)
+    form.setFieldValue('resourceType', resourceTypeOptions[0].value)
+
+    formDialog
+      .open({
+        title: translate('text_66b21236c939426d07ff9930'),
+        description: translate('text_66b21236c939426d07ff9932'),
+        children: (
+          <div>
+            <div className="grid grid-cols-[140px_1fr] items-center gap-3 p-6">
+              <Typography variant="caption" color="grey600">
+                {translate('text_6419c64eace749372fc72b27')}
+              </Typography>
+              <Typography variant="body" color="grey700">
+                {currentUser?.email}
+              </Typography>
+
+              <Typography variant="caption" color="grey600">
+                {translate('text_66b21236c939426d07ff9936')}
+              </Typography>
+              <Typography variant="body" color="grey700">
+                {translate('text_66b21236c939426d07ff9935')}
+              </Typography>
+
+              <Typography variant="caption" color="grey600">
+                {translate('text_66b21236c939426d07ff9938')}
+              </Typography>
+              <Typography variant="body" color="grey700">
+                {totalCountLabel}
+              </Typography>
+            </div>
+
+            <div className="w-full border-b border-grey-300" />
+
+            <div className="p-6">
+              <div className="mb-4">
+                <Typography variant="bodyHl" color="grey700">
+                  {translate('text_66b21236c939426d07ff9939')}
+                </Typography>
+                <Typography variant="caption" color="grey600">
+                  {translate('text_66b21236c939426d07ff993a')}
+                </Typography>
+              </div>
+
+              <form.AppField name="resourceType">
+                {(field) => (
+                  <field.RadioGroupField
+                    optionsGapSpacing={4}
+                    optionLabelVariant="body"
+                    options={resourceTypeOptions}
+                  />
+                )}
+              </form.AppField>
+            </div>
+          </div>
+        ),
+        closeOnError: false,
+        onEntered: focusFirstInput,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton variant="primary" disabled={disableExport}>
               {translate('text_66b21236c939426d07ff9940')}
-            </Button>
-          </>
-        )}
-      >
-        <div className="mb-8">
-          <div className="grid grid-cols-[140px_1fr] items-center gap-3">
-            <Typography variant="caption" color="grey600">
-              {translate('text_6419c64eace749372fc72b27')}
-            </Typography>
-            <Typography variant="body" color="grey700">
-              {currentUser?.email}
-            </Typography>
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then(() => {
+        form.reset()
+        onExportRef.current = null
+      })
+  }
 
-            <Typography variant="caption" color="grey600">
-              {translate('text_66b21236c939426d07ff9936')}
-            </Typography>
-            <Typography variant="body" color="grey700">
-              {translate('text_66b21236c939426d07ff9935')}
-            </Typography>
-
-            <Typography variant="caption" color="grey600">
-              {translate('text_66b21236c939426d07ff9938')}
-            </Typography>
-            <Typography variant="body" color="grey700">
-              {totalCountLabel}
-            </Typography>
-          </div>
-
-          <div className="my-8 w-full border-b border-grey-300" />
-
-          <div className="mb-4">
-            <Typography variant="bodyHl" color="grey700">
-              {translate('text_66b21236c939426d07ff9939')}
-            </Typography>
-            <Typography variant="caption" color="grey600">
-              {translate('text_66b21236c939426d07ff993a')}
-            </Typography>
-          </div>
-
-          <RadioGroupField
-            name="resourceType"
-            optionsGapSpacing={4}
-            optionLabelVariant="body"
-            options={resourceTypeOptions}
-            formikProps={formikProps}
-          />
-        </div>
-      </Dialog>
-    )
-  },
-)
-
-ExportDialog.displayName = 'ExportDialog'
+  return { openExportDialog }
+}

--- a/src/components/exports/types.ts
+++ b/src/components/exports/types.ts
@@ -1,0 +1,7 @@
+import { DataExportFormatTypeEnum } from '~/generated/graphql'
+
+export type ExportValues<T> = {
+  clientMutationId?: string
+  format: DataExportFormatTypeEnum
+  resourceType: T
+}

--- a/src/pages/CreditNotesPage.tsx
+++ b/src/pages/CreditNotesPage.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
 import CreditNotesTable from '~/components/creditNote/CreditNotesTable'
@@ -9,7 +9,8 @@ import {
   formatFiltersForCreditNotesQuery,
 } from '~/components/designSystem/Filters'
 import { usePageSearchParam } from '~/components/designSystem/Pagination'
-import { ExportDialog, ExportDialogRef, ExportValues } from '~/components/exports/ExportDialog'
+import { useExportDialog } from '~/components/exports/ExportDialog'
+import { ExportValues } from '~/components/exports/types'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { SearchInput } from '~/components/SearchInput'
@@ -116,7 +117,7 @@ const CreditNotesPage = () => {
     PremiumIntegrationTypeEnum.RevenueShare,
   )
 
-  const exportCreditNotesDialogRef = useRef<ExportDialogRef>(null)
+  const { openExportDialog } = useExportDialog()
 
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE)
   const { page, goToPage } = usePageSearchParam()
@@ -196,7 +197,27 @@ const CreditNotesPage = () => {
               variant: 'secondary',
               disabled: !dataCreditNotes?.creditNotes?.metadata.totalCount,
               onClick: () => {
-                exportCreditNotesDialogRef.current?.openDialog()
+                openExportDialog({
+                  totalCountLabel: translate(
+                    'text_17346987416277yx1mf6nau2',
+                    { creditNotesTotalCount },
+                    creditNotesTotalCount,
+                  ),
+                  onExport: onCreditNotesExport,
+                  disableExport: creditNotesTotalCount === 0,
+                  resourceTypeOptions: [
+                    {
+                      label: translate('text_1734698741627bges5xz01la'),
+                      sublabel: translate('text_173469874162761dxr57rvw7'),
+                      value: CreditNoteExportTypeEnum.CreditNotes,
+                    },
+                    {
+                      label: translate('text_1734698741627449t5wdghef'),
+                      sublabel: translate('text_1734698875217ppgrrmd10q2'),
+                      value: CreditNoteExportTypeEnum.CreditNoteItems,
+                    },
+                  ],
+                })
               },
             },
           ],
@@ -249,29 +270,6 @@ const CreditNotesPage = () => {
           default: 16,
           md: 48,
         }}
-      />
-
-      <ExportDialog
-        ref={exportCreditNotesDialogRef}
-        totalCountLabel={translate(
-          'text_17346987416277yx1mf6nau2',
-          { creditNotesTotalCount },
-          creditNotesTotalCount,
-        )}
-        onExport={onCreditNotesExport}
-        disableExport={creditNotesTotalCount === 0}
-        resourceTypeOptions={[
-          {
-            label: translate('text_1734698741627bges5xz01la'),
-            sublabel: translate('text_173469874162761dxr57rvw7'),
-            value: CreditNoteExportTypeEnum.CreditNotes,
-          },
-          {
-            label: translate('text_1734698741627449t5wdghef'),
-            sublabel: translate('text_1734698875217ppgrrmd10q2'),
-            value: CreditNoteExportTypeEnum.CreditNoteItems,
-          },
-        ]}
       />
     </>
   )

--- a/src/pages/InvoicesPage.tsx
+++ b/src/pages/InvoicesPage.tsx
@@ -10,7 +10,8 @@ import {
   isOutstandingUrlParams,
 } from '~/components/designSystem/Filters'
 import { usePageSearchParam } from '~/components/designSystem/Pagination'
-import { ExportDialog, ExportDialogRef, ExportValues } from '~/components/exports/ExportDialog'
+import { useExportDialog } from '~/components/exports/ExportDialog'
+import { ExportValues } from '~/components/exports/types'
 import {
   FinalizeInvoiceDialog,
   FinalizeInvoiceDialogRef,
@@ -146,7 +147,7 @@ const InvoicesPage = () => {
   )
 
   const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
-  const exportInvoicesDialogRef = useRef<ExportDialogRef>(null)
+  const { openExportDialog } = useExportDialog()
 
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE)
   const { page, goToPage } = usePageSearchParam()
@@ -238,7 +239,27 @@ const InvoicesPage = () => {
               variant: 'secondary',
               disabled: !invoicesTotalCount,
               onClick: () => {
-                exportInvoicesDialogRef.current?.openDialog()
+                openExportDialog({
+                  totalCountLabel: translate(
+                    'text_66b21236c939426d07ff9937',
+                    { invoicesTotalCount },
+                    invoicesTotalCount,
+                  ),
+                  onExport: onInvoicesExport,
+                  disableExport: invoicesTotalCount === 0,
+                  resourceTypeOptions: [
+                    {
+                      label: translate('text_66b21236c939426d07ff993b'),
+                      sublabel: translate('text_66b21236c939426d07ff993c'),
+                      value: InvoiceExportTypeEnum.Invoices,
+                    },
+                    {
+                      label: translate('text_66b21236c939426d07ff993d'),
+                      sublabel: translate('text_66b21236c939426d07ff993e'),
+                      value: InvoiceExportTypeEnum.InvoiceFees,
+                    },
+                  ],
+                })
               },
             },
             {
@@ -314,28 +335,6 @@ const InvoicesPage = () => {
       />
 
       <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
-      <ExportDialog
-        ref={exportInvoicesDialogRef}
-        totalCountLabel={translate(
-          'text_66b21236c939426d07ff9937',
-          { invoicesTotalCount },
-          invoicesTotalCount,
-        )}
-        onExport={onInvoicesExport}
-        disableExport={invoicesTotalCount === 0}
-        resourceTypeOptions={[
-          {
-            label: translate('text_66b21236c939426d07ff993b'),
-            sublabel: translate('text_66b21236c939426d07ff993c'),
-            value: InvoiceExportTypeEnum.Invoices,
-          },
-          {
-            label: translate('text_66b21236c939426d07ff993d'),
-            sublabel: translate('text_66b21236c939426d07ff993e'),
-            value: InvoiceExportTypeEnum.InvoiceFees,
-          },
-        ]}
-      />
     </>
   )
 }

--- a/src/pages/__tests__/CreditNotesPage.test.tsx
+++ b/src/pages/__tests__/CreditNotesPage.test.tsx
@@ -66,7 +66,7 @@ jest.mock('~/components/creditNote/CreditNotesTable', () => ({
 }))
 
 jest.mock('~/components/exports/ExportDialog', () => ({
-  ExportDialog: () => null,
+  useExportDialog: () => ({ openExportDialog: jest.fn() }),
 }))
 
 describe('CreditNotesPage', () => {

--- a/src/pages/__tests__/InvoicesPage.test.tsx
+++ b/src/pages/__tests__/InvoicesPage.test.tsx
@@ -84,7 +84,7 @@ jest.mock('~/components/invoices/FinalizeInvoiceDialog', () => ({
 }))
 
 jest.mock('~/components/exports/ExportDialog', () => ({
-  ExportDialog: () => null,
+  useExportDialog: () => ({ openExportDialog: jest.fn() }),
 }))
 
 describe('InvoicesPage', () => {


### PR DESCRIPTION
## Context

Part of the ongoing effort to remove the legacy imperative ref-based `Dialog` system and Formik forms from the frontend. Each PR migrates one dialog flagged by the `no-restricted-imports` ESLint rule to the new hook-based NiceModal `FormDialog` + TanStack Form / Zod stack.

## Description

Convert `ExportDialog` from the legacy imperative `forwardRef` + `useImperativeHandle` pattern to the hook-based `useFormDialog` NiceModal system, and migrate its form from Formik + yup to `useAppForm` + zod. The dialog is opened via `useExportDialog().openExportDialog(args)`, and the per-caller configuration (`totalCountLabel`, `onExport`, `disableExport`, `resourceTypeOptions`) is now supplied at open time instead of as JSX props on a rendered component, so parents no longer keep a ref or render the dialog. The `openExportDialog` helper is generic over the resource enum so `CreditNotesPage` keeps a `CreditNoteExportTypeEnum` callback and `InvoicesPage` keeps an `InvoiceExportTypeEnum` callback with no type widening. The shared `ExportValues<T>` type moves into a new `~/components/exports/types.ts` so both parent pages can import it without tripping the `no-restricted-imports` rule that only allows `use*` imports from `ExportDialog.tsx`. Page tests were updated to mock the new hook shape; typecheck and the two page test suites pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdynmboayP9hcgY4hD6BLk)_