### PR TITLE
refactor(integrations): migrate AddAvalaraDialog to FormDialogOpeningDialog and TanStack Form

### DIFF
--- a/src/components/settings/integrations/AddAvalaraDialog.tsx
+++ b/src/components/settings/integrations/AddAvalaraDialog.tsx
@@ -1,32 +1,30 @@
-import { FetchResult, gql } from '@apollo/client'
+import { gql, useApolloClient } from '@apollo/client'
 import { captureException } from '@sentry/react'
-import { useFormik } from 'formik'
+import { revalidateLogic } from '@tanstack/react-form'
 import { forwardRef, useId, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
-import { object, string } from 'yup'
+import { z } from 'zod'
 
 import { Alert } from '~/components/designSystem/Alert'
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { TextInputField } from '~/components/form'
+import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { addToast, envGlobalVar, hasDefinedGQLError } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { AVALARA_INTEGRATION_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import {
   AddAvalaraIntegrationDialogFragment,
   AvalaraIntegrationDetailsFragmentDoc,
-  CreateAvalaraIntegrationInput,
-  CreateAvalaraIntegrationMutation,
+  GetAvalaraIntegrationsListDocument,
   LagoApiError,
-  UpdateAvalaraIntegrationMutation,
   useCreateAvalaraIntegrationMutation,
+  useDestroyNangoIntegrationMutation,
   useUpdateAvalaraIntegrationMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 import { AvalaraIntegrationDetailsTabs } from '~/pages/settings/AvalaraIntegrationDetails'
-import { tw } from '~/styles/utils'
-
-import { useDeleteAvalaraIntegrationDialog } from './DeleteAvalaraIntegrationDialog'
 
 gql`
   fragment AddAvalaraIntegrationDialog on AvalaraIntegration {
@@ -56,31 +54,70 @@ gql`
   ${AvalaraIntegrationDetailsFragmentDoc}
 `
 
-type AddAvalaraDialogProps = {
-  integration: AddAvalaraIntegrationDialogFragment
+const ADD_AVALARA_FORM_ID = 'form-add-avalara-integration'
+
+type OpenAddAvalaraDialogData = {
+  integration?: AddAvalaraIntegrationDialogFragment
   deleteDialogCallback?: () => void
 }
 
-export interface AddAvalaraDialogRef {
-  openDialog: (props?: AddAvalaraDialogProps) => unknown
-  closeDialog: () => unknown
+type AvalaraFormValues = {
+  accountId: string
+  code: string
+  companyCode: string
+  licenseKey: string
+  name: string
 }
 
-export const AddAvalaraDialog = forwardRef<AddAvalaraDialogRef>((_, ref) => {
+const defaultFormValues: AvalaraFormValues = {
+  accountId: '',
+  code: '',
+  companyCode: '',
+  licenseKey: '',
+  name: '',
+}
+
+const validationSchema = z.object({
+  accountId: z.string().min(1),
+  code: z.string().min(1),
+  companyCode: z.string().min(1),
+  licenseKey: z.string().min(1),
+  name: z.string().min(1),
+})
+
+type NangoErrorHandle = {
+  setShow: (show: boolean) => void
+}
+
+const NangoErrorAlert = forwardRef<NangoErrorHandle>((_, ref) => {
+  const [show, setShow] = useState(false)
+  const { translate } = useInternationalization()
+
+  useImperativeHandle(ref, () => ({ setShow }), [])
+
+  if (!show) return null
+
+  return <Alert type="danger">{translate('text_1749562792335fy21gc3sxn0')}</Alert>
+})
+
+NangoErrorAlert.displayName = 'NangoErrorAlert'
+
+export const useAddAvalaraDialog = () => {
   const componentId = useId()
   const navigate = useNavigate()
+  const client = useApolloClient()
   const { nangoPublicKey } = envGlobalVar()
-  const dialogRef = useRef<DialogRef>(null)
   const { translate } = useInternationalization()
-  const [localData, setLocalData] = useState<AddAvalaraDialogProps | undefined>(undefined)
-  const [showGlobalError, setShowGlobalError] = useState(false)
-  const avalaraIntegration = localData?.integration
-  const isEdition = !!avalaraIntegration
-  const { openDeleteAvalaraIntegrationDialog } = useDeleteAvalaraIntegrationDialog()
+  const formDialogOpeningDialog = useFormDialogOpeningDialog()
+
+  const dataRef = useRef<OpenAddAvalaraDialogData | null>(null)
+  const successRef = useRef(false)
+  const nangoErrorRef = useRef<NangoErrorHandle | null>(null)
 
   const [addAvalara] = useCreateAvalaraIntegrationMutation({
     onCompleted({ createAvalaraIntegration }) {
       if (createAvalaraIntegration?.id) {
+        successRef.current = true
         navigate(
           generatePath(AVALARA_INTEGRATION_DETAILS_ROUTE, {
             integrationId: createAvalaraIntegration.id,
@@ -100,206 +137,256 @@ export const AddAvalaraDialog = forwardRef<AddAvalaraDialogRef>((_, ref) => {
   const [updateAvalara] = useUpdateAvalaraIntegrationMutation({
     onCompleted({ updateAvalaraIntegration }) {
       if (updateAvalaraIntegration?.id) {
+        successRef.current = true
         addToast({
           message: translate('text_1744293680332firnbl6qch5'),
           severity: 'success',
         })
-
-        dialogRef.current?.closeDialog()
       }
     },
   })
 
-  const formikProps = useFormik<Omit<CreateAvalaraIntegrationInput, 'connectionId'>>({
-    enableReinitialize: true,
-    validateOnMount: true,
-    initialValues: {
-      accountId: avalaraIntegration?.accountId || '',
-      code: avalaraIntegration?.code || '',
-      companyCode: avalaraIntegration?.companyCode || '',
-      licenseKey: avalaraIntegration?.licenseKey || '',
-      name: avalaraIntegration?.name || '',
+  const [deleteAvalara] = useDestroyNangoIntegrationMutation()
+
+  const form = useAppForm({
+    defaultValues: defaultFormValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: validationSchema,
     },
-    validationSchema: object().shape({
-      accountId: string().required(''),
-      code: string().required(''),
-      companyCode: string().required(''),
-      licenseKey: string().required(''),
-      name: string().required(''),
-    }),
-    onSubmit: async ({ ...values }, formikBag) => {
-      setShowGlobalError(false)
-      let res
+    onSubmit: async ({ value, formApi }) => {
+      nangoErrorRef.current?.setShow(false)
+
+      const integration = dataRef.current?.integration
+      const isEdition = !!integration
 
       if (isEdition) {
-        res = await updateAvalara({
+        const res = await updateAvalara({
           variables: {
             input: {
-              id: avalaraIntegration?.id || '',
-              ...values,
+              id: integration?.id || '',
+              ...value,
             },
           },
           context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
         })
-      } else {
-        const { default: Nango, AuthError } = await import('@nangohq/frontend')
-        const connectionId = `avalara-${componentId.replaceAll(':', '')}-${Date.now()}`
-        const nango = new Nango({ publicKey: nangoPublicKey })
 
-        try {
-          const nangoApiKeyConnection = await nango.auth('avalara-sandbox', connectionId, {
-            params: { avalaraClient: 'asd' },
-            credentials: {
-              username: values.accountId,
-              password: values.licenseKey,
-            },
-          })
-
-          res = await addAvalara({
-            variables: {
-              input: {
-                ...values,
-                connectionId: nangoApiKeyConnection?.connectionId || '',
+        if (hasDefinedGQLError('ValueAlreadyExist', res.errors)) {
+          formApi.setErrorMap({
+            onDynamic: {
+              fields: {
+                code: {
+                  message: translate('text_632a2d437e341dcc76817556'),
+                  path: ['code'],
+                },
               },
             },
           })
-        } catch (error) {
-          if (error instanceof AuthError) return setShowGlobalError(true)
+        }
 
-          captureException(error, {
-            tags: {
-              integration: 'avalara',
-              action: isEdition ? 'update' : 'create',
+        return
+      }
+
+      const { default: Nango, AuthError } = await import('@nangohq/frontend')
+      const connectionId = `avalara-${componentId.replaceAll(':', '')}-${Date.now()}`
+      const nango = new Nango({ publicKey: nangoPublicKey })
+
+      try {
+        const nangoApiKeyConnection = await nango.auth('avalara-sandbox', connectionId, {
+          params: { avalaraClient: 'asd' },
+          credentials: {
+            username: value.accountId,
+            password: value.licenseKey,
+          },
+        })
+
+        const res = await addAvalara({
+          variables: {
+            input: {
+              ...value,
+              connectionId: nangoApiKeyConnection?.connectionId || '',
             },
-            extra: {
-              accountId: values.accountId,
+          },
+        })
+
+        if (hasDefinedGQLError('ValueAlreadyExist', res.errors)) {
+          formApi.setErrorMap({
+            onDynamic: {
+              fields: {
+                code: {
+                  message: translate('text_632a2d437e341dcc76817556'),
+                  path: ['code'],
+                },
+              },
             },
           })
         }
-      }
+      } catch (error) {
+        if (error instanceof AuthError) {
+          nangoErrorRef.current?.setShow(true)
+          return
+        }
 
-      const { errors } = res as
-        | FetchResult<UpdateAvalaraIntegrationMutation>
-        | FetchResult<CreateAvalaraIntegrationMutation>
-
-      if (!errors) dialogRef.current?.closeDialog()
-
-      if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
-        formikBag.setErrors({
-          code: translate('text_632a2d437e341dcc76817556'),
+        captureException(error, {
+          tags: {
+            integration: 'avalara',
+            action: 'create',
+          },
+          extra: {
+            accountId: value.accountId,
+          },
         })
       }
     },
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setShowGlobalError(false)
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate(
-        isEdition ? 'text_658461066530343fe1808cd9' : 'text_174429360927877m0kmo6gmm',
-        {
-          name: avalaraIntegration?.name,
-        },
-      )}
-      description={translate(
-        isEdition ? 'text_17442936803327ymv9v7ecv0' : 'text_174429360927806xa8sxsreg',
-      )}
-      onClose={formikProps.resetForm}
-      actions={({ closeDialog }) => (
-        <div
-          className={tw('flex flex-row items-center justify-between gap-3', isEdition && 'w-full')}
-        >
-          {isEdition && (
-            <Button
-              danger
-              variant="quaternary"
-              onClick={() => {
-                closeDialog()
-                openDeleteAvalaraIntegrationDialog({
-                  provider: avalaraIntegration,
-                  callback: localData?.deleteDialogCallback,
-                })
-              }}
-            >
-              {translate('text_65845f35d7d69c3ab4793dad')}
-            </Button>
-          )}
-          <div className="flex items-center gap-3">
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_62b1edddbf5f461ab971276d')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!formikProps.isValid || !formikProps.dirty}
-              onClick={formikProps.submitForm}
-            >
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openAddAvalaraDialog = (data?: OpenAddAvalaraDialogData) => {
+    dataRef.current = data ?? null
+    const integration = data?.integration
+    const isEdition = !!integration
+
+    form.reset()
+    if (integration) {
+      form.setFieldValue('accountId', integration.accountId || '')
+      form.setFieldValue('code', integration.code || '')
+      form.setFieldValue('companyCode', integration.companyCode || '')
+      form.setFieldValue('licenseKey', integration.licenseKey || '')
+      form.setFieldValue('name', integration.name || '')
+    }
+
+    formDialogOpeningDialog
+      .open({
+        title: translate(
+          isEdition ? 'text_658461066530343fe1808cd9' : 'text_174429360927877m0kmo6gmm',
+          {
+            name: integration?.name,
+          },
+        ),
+        description: translate(
+          isEdition ? 'text_17442936803327ymv9v7ecv0' : 'text_174429360927806xa8sxsreg',
+        ),
+        children: (
+          <div className="flex flex-col gap-6 p-6">
+            <NangoErrorAlert ref={nangoErrorRef} />
+
+            <div className="flex flex-row items-start gap-6">
+              <form.AppField name="name">
+                {(field) => (
+                  <field.TextInputField
+                    className="flex-1"
+                    label={translate('text_6584550dc4cec7adf861504d')}
+                    placeholder={translate('text_6584550dc4cec7adf861504f')}
+                  />
+                )}
+              </form.AppField>
+              <form.AppField name="code">
+                {(field) => (
+                  <field.TextInputField
+                    className="flex-1"
+                    label={translate('text_6584550dc4cec7adf8615051')}
+                    placeholder={translate('text_6584550dc4cec7adf8615053')}
+                  />
+                )}
+              </form.AppField>
+            </div>
+
+            <form.AppField name="accountId">
+              {(field) => (
+                <field.TextInputField
+                  disabled={isEdition}
+                  label={translate('text_1744293609278tzbixvdszc6')}
+                  placeholder={translate('text_1744293635186p3wseb9b7hl')}
+                />
+              )}
+            </form.AppField>
+
+            <form.AppField name="licenseKey">
+              {(field) => (
+                <field.TextInputField
+                  disabled={isEdition}
+                  label={translate('text_1744293635187073v2g6xw0o')}
+                  placeholder={translate('text_1744293635187idjlrbzbv21')}
+                />
+              )}
+            </form.AppField>
+
+            <form.AppField name="companyCode">
+              {(field) => (
+                <field.TextInputField
+                  disabled={isEdition}
+                  label={translate('text_1744293635187hxvz11n5bq3')}
+                  placeholder={translate('text_1744293635187q00705sjtf8')}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        closeOnError: false,
+        onEntered: focusFirstInput,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>
               {translate(
                 isEdition ? 'text_664c732c264d7eed1c74fdaa' : 'text_174429360927877m0kmo6gmm',
               )}
-            </Button>
-          </div>
-        </div>
-      )}
-    >
-      <div className="mb-8 flex flex-col gap-6">
-        {!!showGlobalError && (
-          <Alert type="danger">{translate('text_1749562792335fy21gc3sxn0')}</Alert>
-        )}
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: ADD_AVALARA_FORM_ID,
+          submit: handleSubmit,
+        },
+        canOpenDialog: isEdition && !!data?.deleteDialogCallback,
+        openDialogText: translate('text_65845f35d7d69c3ab4793dad'),
+        otherDialogProps: {
+          title: translate('text_658461066530343fe1808cd7', { name: integration?.name }),
+          description: translate('text_1744293719130klvtjda8wjz'),
+          actionText: translate('text_645d071272418a14c1c76a81'),
+          colorVariant: 'danger',
+          onAction: async () => {
+            const res = await deleteAvalara({
+              variables: { input: { id: integration?.id as string } },
+            })
 
-        <div className="flex flex-row items-start gap-6">
-          <TextInputField
-            className="flex-1"
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus
-            formikProps={formikProps}
-            name="name"
-            label={translate('text_6584550dc4cec7adf861504d')}
-            placeholder={translate('text_6584550dc4cec7adf861504f')}
-          />
-          <TextInputField
-            className="flex-1"
-            formikProps={formikProps}
-            name="code"
-            label={translate('text_6584550dc4cec7adf8615051')}
-            placeholder={translate('text_6584550dc4cec7adf8615053')}
-          />
-        </div>
+            const destroyedId = res.data?.destroyIntegration?.id
 
-        <TextInputField
-          name="accountId"
-          disabled={isEdition}
-          label={translate('text_1744293609278tzbixvdszc6')}
-          placeholder={translate('text_1744293635186p3wseb9b7hl')}
-          formikProps={formikProps}
-        />
+            if (destroyedId) {
+              evictFromCache(client, {
+                id: destroyedId,
+                __typename: 'AvalaraIntegration',
+                listFieldName: 'integrations',
+                listQueryDocument: GetAvalaraIntegrationsListDocument,
+              })
 
-        <TextInputField
-          name="licenseKey"
-          disabled={isEdition}
-          label={translate('text_1744293635187073v2g6xw0o')}
-          placeholder={translate('text_1744293635187idjlrbzbv21')}
-          formikProps={formikProps}
-        />
+              data?.deleteDialogCallback?.()
 
-        <TextInputField
-          name="companyCode"
-          disabled={isEdition}
-          label={translate('text_1744293635187hxvz11n5bq3')}
-          placeholder={translate('text_1744293635187q00705sjtf8')}
-          formikProps={formikProps}
-        />
-      </div>
-    </Dialog>
-  )
-})
+              addToast({
+                message: translate('text_661ff6e56ef7e1b7c542b2f9'),
+                severity: 'success',
+              })
+            }
+          },
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close' || response.reason === 'open-other-dialog') {
+          form.reset()
+          dataRef.current = null
+          nangoErrorRef.current?.setShow(false)
+        }
+      })
+  }
 
-AddAvalaraDialog.displayName = 'AddAvalaraDialog'
+  return { openAddAvalaraDialog }
+}

--- a/src/components/settings/integrations/AvalaraIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AvalaraIntegrationSettings.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Alert } from '~/components/designSystem/Alert'
@@ -25,7 +24,7 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { AvalaraIntegrationDetailsTabs } from '~/pages/settings/AvalaraIntegrationDetails'
 
-import { AddAvalaraDialog, AddAvalaraDialogRef } from './AddAvalaraDialog'
+import { useAddAvalaraDialog } from './AddAvalaraDialog'
 
 const PROVIDER_CONNECTION_LIMIT = 2
 
@@ -75,7 +74,7 @@ gql`
 const AvalaraIntegrationSettings = () => {
   const navigate = useNavigate()
   const { integrationId = '' } = useParams()
-  const addAvalaraDialogRef = useRef<AddAvalaraDialogRef>(null)
+  const { openAddAvalaraDialog } = useAddAvalaraDialog()
   const { translate } = useInternationalization()
 
   const [retryAllAvalaraInvoices] = useRetryAllAvalaraInvoicesMutation({
@@ -114,115 +113,111 @@ const AvalaraIntegrationSettings = () => {
   }
 
   return (
-    <>
-      <IntegrationsPage.Container className="my-4 md:my-8">
-        {!!avalaraIntegration && !avalaraIntegration?.hasMappingsConfigured && (
-          <Alert
-            type="warning"
-            ButtonProps={{
-              label: translate('text_661ff6e56ef7e1b7c542b20a'),
-              onClick: () => {
-                navigate(
-                  generatePath(AVALARA_INTEGRATION_DETAILS_ROUTE, {
-                    integrationId,
-                    tab: AvalaraIntegrationDetailsTabs.Items,
-                    integrationGroup: IntegrationsTabsOptionsEnum.Lago,
-                  }),
-                )
-              },
-            }}
-          >
-            {translate('text_17454024925701tm53pi3us8')}
-          </Alert>
-        )}
+    <IntegrationsPage.Container className="my-4 md:my-8">
+      {!!avalaraIntegration && !avalaraIntegration?.hasMappingsConfigured && (
+        <Alert
+          type="warning"
+          ButtonProps={{
+            label: translate('text_661ff6e56ef7e1b7c542b20a'),
+            onClick: () => {
+              navigate(
+                generatePath(AVALARA_INTEGRATION_DETAILS_ROUTE, {
+                  integrationId,
+                  tab: AvalaraIntegrationDetailsTabs.Items,
+                  integrationGroup: IntegrationsTabsOptionsEnum.Lago,
+                }),
+              )
+            },
+          }}
+        >
+          {translate('text_17454024925701tm53pi3us8')}
+        </Alert>
+      )}
 
-        <section>
-          <IntegrationsPage.Headline label={translate('text_661ff6e56ef7e1b7c542b232')}>
-            {!!avalaraIntegration && (
-              <Button
-                variant="inline"
-                disabled={loading}
-                onClick={() => {
-                  addAvalaraDialogRef.current?.openDialog({
-                    integration: avalaraIntegration,
-                    deleteDialogCallback,
-                  })
-                }}
-              >
-                {translate('text_62b1edddbf5f461ab9712787')}
-              </Button>
-            )}
-          </IntegrationsPage.Headline>
-
-          {loading &&
-            [0, 1, 2].map((i) => <IntegrationsPage.ItemSkeleton key={`item-skeleton-item-${i}`} />)}
-          {!loading && (
-            <>
-              <IntegrationsPage.DetailsItem
-                icon="text"
-                label={translate('text_626162c62f790600f850b76a')}
-                value={avalaraIntegration?.name}
-              />
-              <IntegrationsPage.DetailsItem
-                icon="id"
-                label={translate('text_62876e85e32e0300e1803127')}
-                value={avalaraIntegration?.code}
-              />
-              <IntegrationsPage.DetailsItem
-                icon="key"
-                label={translate('text_1744293609278tzbixvdszc6')}
-                value={avalaraIntegration?.accountId || ''}
-              />
-              <IntegrationsPage.DetailsItem
-                icon="key"
-                label={translate('text_1744293635187073v2g6xw0o')}
-                value={avalaraIntegration?.licenseKey}
-              />
-              <IntegrationsPage.DetailsItem
-                icon="globe"
-                label={translate('text_1744293635187hxvz11n5bq3')}
-                value={avalaraIntegration?.companyCode}
-              />
-            </>
+      <section>
+        <IntegrationsPage.Headline label={translate('text_661ff6e56ef7e1b7c542b232')}>
+          {!!avalaraIntegration && (
+            <Button
+              variant="inline"
+              disabled={loading}
+              onClick={() => {
+                openAddAvalaraDialog({
+                  integration: avalaraIntegration,
+                  deleteDialogCallback,
+                })
+              }}
+            >
+              {translate('text_62b1edddbf5f461ab9712787')}
+            </Button>
           )}
-        </section>
+        </IntegrationsPage.Headline>
 
-        <div className="flex flex-row items-baseline justify-between gap-4 pb-6 shadow-b">
-          <div className="flex-1">
-            <Typography variant="bodyHl" color="grey700">
-              {translate('text_66ba5a76e614f000a738c97a')}
+        {loading &&
+          [0, 1, 2].map((i) => <IntegrationsPage.ItemSkeleton key={`item-skeleton-item-${i}`} />)}
+        {!loading && (
+          <>
+            <IntegrationsPage.DetailsItem
+              icon="text"
+              label={translate('text_626162c62f790600f850b76a')}
+              value={avalaraIntegration?.name}
+            />
+            <IntegrationsPage.DetailsItem
+              icon="id"
+              label={translate('text_62876e85e32e0300e1803127')}
+              value={avalaraIntegration?.code}
+            />
+            <IntegrationsPage.DetailsItem
+              icon="key"
+              label={translate('text_1744293609278tzbixvdszc6')}
+              value={avalaraIntegration?.accountId || ''}
+            />
+            <IntegrationsPage.DetailsItem
+              icon="key"
+              label={translate('text_1744293635187073v2g6xw0o')}
+              value={avalaraIntegration?.licenseKey}
+            />
+            <IntegrationsPage.DetailsItem
+              icon="globe"
+              label={translate('text_1744293635187hxvz11n5bq3')}
+              value={avalaraIntegration?.companyCode}
+            />
+          </>
+        )}
+      </section>
+
+      <div className="flex flex-row items-baseline justify-between gap-4 pb-6 shadow-b">
+        <div className="flex-1">
+          <Typography variant="bodyHl" color="grey700">
+            {translate('text_66ba5a76e614f000a738c97a')}
+          </Typography>
+          {loading && <Skeleton className="mb-1 mt-2" variant="text" />}
+          {!loading && !!avalaraIntegration?.failedInvoicesCount && (
+            <Typography variant="caption" color="grey600">
+              {translate(
+                'text_1746004262383fhhy4jl1g6o',
+                {
+                  failedInvoicesCount: avalaraIntegration?.failedInvoicesCount,
+                },
+                avalaraIntegration?.failedInvoicesCount,
+              )}
             </Typography>
-            {loading && <Skeleton className="mb-1 mt-2" variant="text" />}
-            {!loading && !!avalaraIntegration?.failedInvoicesCount && (
-              <Typography variant="caption" color="grey600">
-                {translate(
-                  'text_1746004262383fhhy4jl1g6o',
-                  {
-                    failedInvoicesCount: avalaraIntegration?.failedInvoicesCount,
-                  },
-                  avalaraIntegration?.failedInvoicesCount,
-                )}
-              </Typography>
-            )}
-            {!loading && !avalaraIntegration?.failedInvoicesCount && (
-              <Typography variant="caption" color="grey600">
-                {translate('text_66ba5ca33713b600c4e8fcf2')}
-              </Typography>
-            )}
-          </div>
-
-          <Button
-            variant="inline"
-            disabled={!avalaraIntegration?.failedInvoicesCount}
-            onClick={async () => await retryAllAvalaraInvoices({ variables: { input: {} } })}
-          >
-            {translate('text_66ba5a76e614f000a738c97e')}
-          </Button>
+          )}
+          {!loading && !avalaraIntegration?.failedInvoicesCount && (
+            <Typography variant="caption" color="grey600">
+              {translate('text_66ba5ca33713b600c4e8fcf2')}
+            </Typography>
+          )}
         </div>
-      </IntegrationsPage.Container>
 
-      <AddAvalaraDialog ref={addAvalaraDialogRef} />
-    </>
+        <Button
+          variant="inline"
+          disabled={!avalaraIntegration?.failedInvoicesCount}
+          onClick={async () => await retryAllAvalaraInvoices({ variables: { input: {} } })}
+        >
+          {translate('text_66ba5a76e614f000a738c97e')}
+        </Button>
+      </div>
+    </IntegrationsPage.Container>
   )
 }
 

--- a/src/pages/settings/AvalaraIntegrationDetails.tsx
+++ b/src/pages/settings/AvalaraIntegrationDetails.tsx
@@ -4,10 +4,7 @@ import { generatePath, useParams } from 'react-router-dom'
 
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { useMainHeaderTabContent } from '~/components/MainHeader/useMainHeaderTabContent'
-import {
-  AddAvalaraDialog,
-  AddAvalaraDialogRef,
-} from '~/components/settings/integrations/AddAvalaraDialog'
+import { useAddAvalaraDialog } from '~/components/settings/integrations/AddAvalaraDialog'
 import {
   AddEditDeleteSuccessRedirectUrlDialog,
   AddEditDeleteSuccessRedirectUrlDialogRef,
@@ -75,7 +72,7 @@ gql`
 const AvalaraIntegrationDetails = () => {
   const navigate = useNavigate()
   const { integrationId = '' } = useParams()
-  const addAvalaraDialogRef = useRef<AddAvalaraDialogRef>(null)
+  const { openAddAvalaraDialog } = useAddAvalaraDialog()
   const { openDeleteAvalaraIntegrationDialog } = useDeleteAvalaraIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
@@ -137,7 +134,7 @@ const AvalaraIntegrationDetails = () => {
                 {
                   label: translate('text_65845f35d7d69c3ab4793dac'),
                   onClick: (closePopper) => {
-                    addAvalaraDialogRef.current?.openDialog({
+                    openAddAvalaraDialog({
                       integration: avalaraIntegration,
                       deleteDialogCallback,
                     })
@@ -181,7 +178,6 @@ const AvalaraIntegrationDetails = () => {
         ]}
       />
       <>{activeTabContent}</>
-      <AddAvalaraDialog ref={addAvalaraDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/AvalaraIntegrations.tsx
+++ b/src/pages/settings/AvalaraIntegrations.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
@@ -7,10 +6,7 @@ import { Popper } from '~/components/designSystem/Popper'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { IntegrationsPage } from '~/components/layouts/Integrations'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import {
-  AddAvalaraDialog,
-  AddAvalaraDialogRef,
-} from '~/components/settings/integrations/AddAvalaraDialog'
+import { useAddAvalaraDialog } from '~/components/settings/integrations/AddAvalaraDialog'
 import { useDeleteAvalaraIntegrationDialog } from '~/components/settings/integrations/DeleteAvalaraIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { AVALARA_INTEGRATION_DETAILS_ROUTE, INTEGRATIONS_ROUTE, useNavigate } from '~/core/router'
@@ -56,7 +52,7 @@ gql`
 const AvalaraIntegrations = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
-  const addAvalaraDialogRef = useRef<AddAvalaraDialogRef>(null)
+  const { openAddAvalaraDialog } = useAddAvalaraDialog()
   const { openDeleteAvalaraIntegrationDialog } = useDeleteAvalaraIntegrationDialog()
   const { data, loading } = useGetAvalaraIntegrationsListQuery({
     variables: { limit: 1000, types: [IntegrationTypeEnum.Avalara] },
@@ -100,7 +96,7 @@ const AvalaraIntegrations = () => {
               label: translate('text_65846763e6140b469140e235'),
               variant: 'primary',
               onClick: () => {
-                addAvalaraDialogRef.current?.openDialog()
+                openAddAvalaraDialog()
               },
             },
           ],
@@ -153,7 +149,7 @@ const AvalaraIntegrations = () => {
                           variant="quaternary"
                           align="left"
                           onClick={() => {
-                            addAvalaraDialogRef.current?.openDialog({
+                            openAddAvalaraDialog({
                               integration: connection,
                               deleteDialogCallback,
                             })
@@ -184,7 +180,6 @@ const AvalaraIntegrations = () => {
             })}
         </section>
       </IntegrationsPage.Container>
-      <AddAvalaraDialog ref={addAvalaraDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -24,10 +24,7 @@ import {
   AddAnrokDialog,
   AddAnrokDialogRef,
 } from '~/components/settings/integrations/AddAnrokDialog'
-import {
-  AddAvalaraDialog,
-  AddAvalaraDialogRef,
-} from '~/components/settings/integrations/AddAvalaraDialog'
+import { useAddAvalaraDialog } from '~/components/settings/integrations/AddAvalaraDialog'
 import {
   AddCashfreeDialog,
   AddCashfreeDialogRef,
@@ -178,7 +175,7 @@ const Integrations = () => {
 
   const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const addAnrokDialogRef = useRef<AddAnrokDialogRef>(null)
-  const addAvalaraDialogRef = useRef<AddAvalaraDialogRef>(null)
+  const { openAddAvalaraDialog } = useAddAvalaraDialog()
   const addStripeDialogRef = useRef<AddStripeDialogRef>(null)
   const addAdyenDialogRef = useRef<AddAdyenDialogRef>(null)
   const addGocardlessDialogRef = useRef<AddGocardlessDialogRef>(null)
@@ -424,7 +421,7 @@ const Integrations = () => {
                               }),
                             )
                           } else {
-                            addAvalaraDialogRef.current?.openDialog()
+                            openAddAvalaraDialog()
                           }
                         }}
                       />
@@ -849,7 +846,6 @@ const Integrations = () => {
       <>{activeTabContent}</>
 
       <AddAnrokDialog ref={addAnrokDialogRef} />
-      <AddAvalaraDialog ref={addAvalaraDialogRef} />
       <AddAdyenDialog ref={addAdyenDialogRef} />
       <AddStripeDialog ref={addStripeDialogRef} />
       <AddCashfreeDialog ref={addCashfreeDialogRef} />

--- a/src/pages/settings/__tests__/AvalaraIntegrationDetails.test.tsx
+++ b/src/pages/settings/__tests__/AvalaraIntegrationDetails.test.tsx
@@ -7,7 +7,9 @@ import { renderIntegrationPage } from './integrationTestHelpers'
 import AvalaraIntegrationDetails from '../AvalaraIntegrationDetails'
 
 jest.mock('~/components/settings/integrations/AddAvalaraDialog', () => ({
-  AddAvalaraDialog: () => null,
+  useAddAvalaraDialog: () => ({
+    openAddAvalaraDialog: jest.fn(),
+  }),
 }))
 jest.mock('~/components/settings/integrations/DeleteAvalaraIntegrationDialog', () => ({
   useDeleteAvalaraIntegrationDialog: () => ({

--- a/src/pages/settings/__tests__/AvalaraIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/AvalaraIntegrations.test.tsx
@@ -11,7 +11,9 @@ import {
 import AvalaraIntegrations from '../AvalaraIntegrations'
 
 jest.mock('~/components/settings/integrations/AddAvalaraDialog', () => ({
-  AddAvalaraDialog: () => null,
+  useAddAvalaraDialog: () => ({
+    openAddAvalaraDialog: jest.fn(),
+  }),
 }))
 jest.mock('~/components/settings/integrations/DeleteAvalaraIntegrationDialog', () => ({
   useDeleteAvalaraIntegrationDialog: () => ({

--- a/src/pages/settings/__tests__/Integrations.test.tsx
+++ b/src/pages/settings/__tests__/Integrations.test.tsx
@@ -25,7 +25,9 @@ jest.mock('~/components/settings/integrations/AddAnrokDialog', () => ({
   AddAnrokDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/AddAvalaraDialog', () => ({
-  AddAvalaraDialog: () => null,
+  useAddAvalaraDialog: () => ({
+    openAddAvalaraDialog: jest.fn(),
+  }),
 }))
 jest.mock('~/components/settings/integrations/AddNetsuiteDialog', () => ({
   AddNetsuiteDialog: () => null,


### PR DESCRIPTION
## Context

Part of the ongoing effort to remove the legacy imperative ref-based `Dialog` system and Formik forms from the frontend. Each PR migrates one dialog flagged by the `no-restricted-imports` ESLint rule to the new hook-based NiceModal dialog stack + TanStack Form / Zod.

## Description

Migrates `AddAvalaraDialog` off the legacy imperative `forwardRef` + `<Dialog>` system onto the hook-based `FormDialogOpeningDialog`, and swaps Formik + yup for TanStack Form + zod. The "Delete integration" secondary button that only appears in edit mode is now wired through `canOpenDialog` + `otherDialogProps`, inlining the destroy mutation and `evictFromCache` call so the integrations list stays in sync without a refetch. The Nango sandbox `AuthError` alert is preserved via a small `forwardRef` component whose setter is captured through a ref, letting `onSubmit` toggle the alert without reopening the dialog. All four callers (`AvalaraIntegrations`, `AvalaraIntegrationDetails`, `AvalaraIntegrationSettings`, `Integrations`) now consume `useAddAvalaraDialog()` and no longer render the dialog in JSX or hold a ref. `ValueAlreadyExist` errors from create/update map to `formApi.setErrorMap` on the `code` field, and a `successRef` gates dialog closure so Nango failures keep the dialog open. Jest mocks in the three affected test files were updated to expose the new hook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdynmboayP9hcgY4hD6BLk)_