### PR TITLE
refactor(customers): migrate EditCustomerVatRateDialog to new dialog system

### DIFF
--- a/.agents/skills/migrate-dialog/SKILL.md
+++ b/.agents/skills/migrate-dialog/SKILL.md
@@ -246,6 +246,31 @@ onEntered: focusFirstInput,
 
 `focusFirstInput(container)` scopes its lookup to the dialog's own container and focuses the first editable input (skipping hidden/disabled), so it works regardless of dialog-stack position. It's the same helper the plan and charge drawers use. For a dialog whose first field is not the desired target, pass a custom selector via a wrapper: `onEntered: (c) => focusFirstInput(c, '#my-field')`.
 
+**2b. When the first field is a `ComboBox`, open its dropdown instead of just focusing it.**
+
+`focusFirstInput` only focuses the underlying `<input>`, leaving the dropdown closed - the user still has to click/type to see the options. When the combobox is the dialog's primary (or only) field, the expected UX is to open the menu on enter. Match the charge-drawer pattern: give the `ComboBox` a known className, then in `onEntered` click its `MuiInputBase-root` to pop the dropdown open.
+
+```tsx
+import {
+  MUI_INPUT_BASE_ROOT_CLASSNAME,
+  SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME,
+} from '~/core/constants/form'
+
+// the ComboBox carries the search-input className:
+<ComboBox className={SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME} ... />
+
+// inside the .open({ ... }) call:
+onEntered: (container) => {
+  container
+    .querySelector<HTMLElement>(
+      `.${SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+    )
+    ?.click()
+},
+```
+
+Clicking the `MuiInputBase-root` both focuses the field and opens the menu, so it replaces `focusFirstInput` entirely (don't call both). Reference: `EditCustomerVatRateDialog.tsx`, and the plan/charge drawers (`FixedChargeDrawer.tsx`, `UsageChargeDrawer.tsx`) which gate the same click behind a `shouldFocusComboBoxRef` when the combobox should only auto-open in create mode - a dialog whose combobox is always the entry point can click unconditionally.
+
 **New Pattern (hook-based with CentralizedDialog):**
 
 ```typescript
@@ -680,7 +705,7 @@ type FormDialogOpeningDialogProps = FormDialogProps & {
 - [ ] Replace `Dialog`/`WarningDialog` with `useFormDialog()`, `useCentralizedDialog()`, or `useFormDialogOpeningDialog()`
 - [ ] Implement `handleSubmit` returning `Promise<DialogResult>` (for FormDialog/FormDialogOpeningDialog)
 - [ ] Wrap `children` JSX in a `p-8` padding container (BaseDialog does NOT pad JSX children → flush/misaligned layout otherwise)
-- [ ] Add `onEntered: focusFirstInput` so the dialog focuses its first input on open (legacy Dialog did this automatically)
+- [ ] Add `onEntered: focusFirstInput` so the dialog focuses its first input on open (legacy Dialog did this automatically) - if the first field is a `ComboBox`, `.click()` its `MuiInputBase-root` in `onEntered` to open the dropdown instead (see section 2b)
 - [ ] Handle form reset and cleanup in `.then()` callback (for FormDialog/FormDialogOpeningDialog)
 - [ ] Remove old exports (`forwardRef`, `DialogRef` interface, `displayName`)
 - [ ] (Deletion dialog) Replace `refetchQueries` / bare `cache.evict()` with the `evictFromCache` helper

--- a/cypress/e2e/10-resources/t20-create-customer.cy.ts
+++ b/cypress/e2e/10-resources/t20-create-customer.cy.ts
@@ -51,7 +51,7 @@ describe('Create customer', () => {
 
       cy.get('button[role="tab"]').contains('Settings').click()
       cy.get('[data-test="add-vat-rate-button"]').last().click()
-      cy.get('[data-test="edit-customer-vat-rate-dialog"]').should('exist')
+      cy.get('[data-test="form-dialog"]').should('exist')
     })
   })
 })

--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -20,10 +20,7 @@ import {
   EditCustomerInvoiceGracePeriodDialog,
   EditCustomerInvoiceGracePeriodDialogRef,
 } from '~/components/customers/EditCustomerInvoiceGracePeriodDialog'
-import {
-  EditCustomerVatRateDialog,
-  EditCustomerVatRateDialogRef,
-} from '~/components/customers/EditCustomerVatRateDialog'
+import { useEditCustomerVatRateDialog } from '~/components/customers/EditCustomerVatRateDialog'
 import {
   EditCustomerIssuingDatePolicyDialog,
   EditCustomerIssuingDatePolicyDialogRef,
@@ -199,8 +196,8 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
   })
   const customer = data?.customer
   const billingEntity = data?.customer?.billingEntity
-  const editVATDialogRef = useRef<EditCustomerVatRateDialogRef>(null)
   const editIssuingDatePolicyDialogRef = useRef<EditCustomerIssuingDatePolicyDialogRef>(null)
+  const { openEditCustomerVatRateDialog } = useEditCustomerVatRateDialog()
   const { openDeleteCustomerVatRateDialog } = useDeleteCustomerVatRateDialog()
   const editInvoiceGracePeriodDialogRef = useRef<EditCustomerInvoiceGracePeriodDialogRef>(null)
   const { openDeleteCustomerGracePeriodeDialog } = useDeleteCustomerGracePeriodeDialog()
@@ -844,7 +841,14 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                       <Button
                         variant="inline"
                         disabled={loading}
-                        onClick={() => editVATDialogRef?.current?.openDialog()}
+                        onClick={() => {
+                          if (customer) {
+                            openEditCustomerVatRateDialog({
+                              customer,
+                              appliedTaxRatesTaxesIds: customer.taxes?.map((t) => t.id),
+                            })
+                          }
+                        }}
                         data-test="add-vat-rate-button"
                       >
                         {translate('text_645bb193927b375079d28ad2')}
@@ -937,11 +941,6 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
 
       {!!customer && (
         <>
-          <EditCustomerVatRateDialog
-            ref={editVATDialogRef}
-            customer={customer}
-            appliedTaxRatesTaxesIds={customer.taxes?.map((t) => t.id)}
-          />
           <EditCustomerInvoiceGracePeriodDialog
             ref={editInvoiceGracePeriodDialogRef}
             invoiceGracePeriod={customer?.invoiceGracePeriod}

--- a/src/components/customers/EditCustomerVatRateDialog.tsx
+++ b/src/components/customers/EditCustomerVatRateDialog.tsx
@@ -1,12 +1,14 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
 import { ComboBox, ComboboxItem } from '~/components/form'
 import { addToast } from '~/core/apolloClient'
-import { SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME } from '~/core/constants/form'
+import {
+  MUI_INPUT_BASE_ROOT_CLASSNAME,
+  SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME,
+} from '~/core/constants/form'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { CREATE_TAX_ROUTE } from '~/core/router'
 import {
@@ -17,6 +19,10 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { usePermissions } from '~/hooks/usePermissions'
+import {
+  DialogActionButton,
+  useSetDisabledRef,
+} from '~/pages/createCoupon/dialogs/DialogActionButton'
 
 gql`
   fragment EditCustomerVatRate on Customer {
@@ -55,130 +61,170 @@ gql`
   ${CustomerAppliedTaxRatesForSettingsFragmentDoc}
 `
 
-export type EditCustomerVatRateDialogRef = DialogRef
+export const EDIT_CUSTOMER_VAT_RATE_FORM_ID = 'edit-customer-vat-rate-form'
 
-interface EditCustomerVatRateDialogProps {
-  customer: EditCustomerVatRateFragment
+interface EditCustomerVatRateContentProps {
   appliedTaxRatesTaxesIds?: string[]
-  forceOpen?: boolean
+  onSelect: (taxCode: string) => void
 }
 
-export const EditCustomerVatRateDialog = forwardRef<DialogRef, EditCustomerVatRateDialogProps>(
-  (
-    { appliedTaxRatesTaxesIds, customer, forceOpen = false }: EditCustomerVatRateDialogProps,
-    ref,
-  ) => {
-    const { translate } = useInternationalization()
-    const { hasPermissions } = usePermissions()
-    const [localTax, setLocalTax] = useState<string>('')
-    const [getTaxRates, { loading, data }] = useGetTaxRatesForEditCustomerLazyQuery({
-      variables: { limit: 500 },
+const EditCustomerVatRateContent = ({
+  appliedTaxRatesTaxesIds,
+  onSelect,
+}: EditCustomerVatRateContentProps) => {
+  const { translate } = useInternationalization()
+  const { hasPermissions } = usePermissions()
+  const [localTax, setLocalTax] = useState<string>('')
+  const [getTaxRates, { loading, data }] = useGetTaxRatesForEditCustomerLazyQuery({
+    variables: { limit: 500 },
+  })
+
+  const comboboxTaxRatesData = useMemo(() => {
+    if (!data || !data?.taxes || !data?.taxes?.collection) return []
+
+    return data?.taxes?.collection.map((taxRate) => {
+      const { id, name, rate, code } = taxRate
+      const formatedRate = intlFormatNumber(Number(rate) / 100 || 0, {
+        style: 'percent',
+      })
+
+      return {
+        label: `${name} (${formatedRate})`,
+        labelNode: (
+          <ComboboxItem>
+            <Typography variant="body" color="grey700" noWrap>
+              {name}
+            </Typography>
+            <Typography variant="caption" color="grey600" noWrap>
+              {formatedRate}
+            </Typography>
+          </ComboboxItem>
+        ),
+        value: code,
+        disabled: appliedTaxRatesTaxesIds?.includes(id),
+      }
     })
-    const customerName = customer?.displayName
-    const [createCustomerAppliedTax] = useCreateCustomerAppliedTaxMutation({
-      onCompleted({ updateCustomer: mutationRes }) {
-        if (mutationRes?.id) {
-          addToast({
-            message: translate('text_64639f5e63a5cc0076779de0'),
-            severity: 'success',
-          })
+  }, [appliedTaxRatesTaxesIds, data])
+
+  return (
+    <div className="p-6">
+      <ComboBox
+        allowAddValue
+        className={SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME}
+        addValueProps={
+          hasPermissions(['organizationTaxesUpdate'])
+            ? {
+                label: translate('text_64639c4d172d7a006ef30516'),
+                redirectionUrl: CREATE_TAX_ROUTE,
+              }
+            : undefined
         }
+        data={comboboxTaxRatesData}
+        label={translate('text_64639c4d172d7a006ef30514')}
+        loading={loading}
+        onChange={(value) => {
+          setLocalTax(value)
+          onSelect(value)
+        }}
+        placeholder={translate('text_64639c4d172d7a006ef30515')}
+        PopperProps={{ displayInDialog: true }}
+        searchQuery={getTaxRates}
+        value={localTax}
+      />
+    </div>
+  )
+}
+
+interface OpenEditCustomerVatRateDialogParams {
+  customer: EditCustomerVatRateFragment
+  appliedTaxRatesTaxesIds?: string[]
+}
+
+export const useEditCustomerVatRateDialog = () => {
+  const formDialog = useFormDialog()
+  const { translate } = useInternationalization()
+  const customerRef = useRef<EditCustomerVatRateFragment | null>(null)
+  const taxCodeRef = useRef<string>('')
+  const setDisabledRef = useSetDisabledRef()
+
+  const [createCustomerAppliedTax] = useCreateCustomerAppliedTaxMutation({
+    onCompleted({ updateCustomer: mutationRes }) {
+      if (mutationRes?.id) {
+        addToast({
+          message: translate('text_64639f5e63a5cc0076779de0'),
+          severity: 'success',
+        })
+      }
+    },
+  })
+
+  const openEditCustomerVatRateDialog = ({
+    customer,
+    appliedTaxRatesTaxesIds,
+  }: OpenEditCustomerVatRateDialogParams) => {
+    customerRef.current = customer
+    taxCodeRef.current = ''
+
+    formDialog.open({
+      title: translate('text_64639f5e63a5cc0076779d42', {
+        name: customer.displayName,
+      }),
+      description: translate('text_64639f5e63a5cc0076779d46'),
+      closeOnError: false,
+      onEntered: (container) => {
+        container
+          .querySelector<HTMLElement>(
+            `.${SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+          )
+          ?.click()
+      },
+      children: (
+        <EditCustomerVatRateContent
+          appliedTaxRatesTaxesIds={appliedTaxRatesTaxesIds}
+          onSelect={(taxCode) => {
+            taxCodeRef.current = taxCode
+            setDisabledRef.current(!taxCode)
+          }}
+        />
+      ),
+      mainAction: (
+        <DialogActionButton
+          label={translate('text_64639f5e63a5cc0076779d57')}
+          setDisabledRef={setDisabledRef}
+        />
+      ),
+      form: {
+        id: EDIT_CUSTOMER_VAT_RATE_FORM_ID,
+        submit: async () => {
+          const activeCustomer = customerRef.current
+
+          if (!activeCustomer || !taxCodeRef.current) {
+            throw new Error('No tax rate selected')
+          }
+
+          const res = await createCustomerAppliedTax({
+            variables: {
+              input: {
+                id: activeCustomer.id,
+                taxCodes: [
+                  ...(activeCustomer?.taxes?.map((t) => t.code) || []),
+                  taxCodeRef.current,
+                ],
+                // NOTE: API should not require those fields on customer update
+                // To be tackled as improvement
+                externalId: activeCustomer.externalId,
+                name: activeCustomer.name || '',
+              },
+            },
+          })
+
+          if (res.errors) {
+            throw new Error('Failed to update customer applied tax')
+          }
+        },
       },
     })
+  }
 
-    const comboboxTaxRatesData = useMemo(() => {
-      if (!data || !data?.taxes || !data?.taxes?.collection) return []
-
-      return data?.taxes?.collection.map((taxRate) => {
-        const { id, name, rate, code } = taxRate
-        const formatedRate = intlFormatNumber(Number(rate) / 100 || 0, {
-          style: 'percent',
-        })
-
-        return {
-          label: `${name} (${formatedRate})`,
-          labelNode: (
-            <ComboboxItem>
-              <Typography variant="body" color="grey700" noWrap>
-                {name}
-              </Typography>
-              <Typography variant="caption" color="grey600" noWrap>
-                {formatedRate}
-              </Typography>
-            </ComboboxItem>
-          ),
-          value: code,
-          disabled: appliedTaxRatesTaxesIds?.includes(id),
-        }
-      })
-    }, [appliedTaxRatesTaxesIds, data])
-
-    return (
-      <Dialog
-        open={!!forceOpen}
-        ref={ref}
-        title={translate('text_64639f5e63a5cc0076779d42', { name: customerName })}
-        description={translate('text_64639f5e63a5cc0076779d46')}
-        onClose={() => {
-          setLocalTax('')
-        }}
-        actions={({ closeDialog }) => (
-          <>
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_627387d5053a1000c5287cab')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!localTax}
-              onClick={async () => {
-                const res = await createCustomerAppliedTax({
-                  variables: {
-                    input: {
-                      id: customer.id,
-                      taxCodes: [...(customer?.taxes?.map((t) => t.code) || []), localTax],
-                      // NOTE: API should not require those fields on customer update
-                      // To be tackled as improvement
-                      externalId: customer.externalId,
-                      name: customer.name || '',
-                    },
-                  },
-                })
-
-                if (res.errors) return
-                closeDialog()
-              }}
-            >
-              {translate('text_64639f5e63a5cc0076779d57')}
-            </Button>
-          </>
-        )}
-        data-test="edit-customer-vat-rate-dialog"
-      >
-        <div className="mb-8">
-          <ComboBox
-            allowAddValue
-            className={SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME}
-            addValueProps={
-              hasPermissions(['organizationTaxesUpdate'])
-                ? {
-                    label: translate('text_64639c4d172d7a006ef30516'),
-                    redirectionUrl: CREATE_TAX_ROUTE,
-                  }
-                : undefined
-            }
-            data={comboboxTaxRatesData}
-            label={translate('text_64639c4d172d7a006ef30514')}
-            loading={loading}
-            onChange={setLocalTax}
-            placeholder={translate('text_64639c4d172d7a006ef30515')}
-            PopperProps={{ displayInDialog: true }}
-            searchQuery={getTaxRates}
-            value={localTax}
-          />
-        </div>
-      </Dialog>
-    )
-  },
-)
-
-EditCustomerVatRateDialog.displayName = 'forwardRef'
+  return { openEditCustomerVatRateDialog }
+}

--- a/src/components/customers/__tests__/CustomerSettings.test.tsx
+++ b/src/components/customers/__tests__/CustomerSettings.test.tsx
@@ -66,13 +66,11 @@ jest.mock('~/components/customers/DeleteCustomerDocumentLocaleDialog', () => ({
   }),
 }))
 
-jest.mock('~/components/customers/EditCustomerVatRateDialog', () => {
-  const React = jest.requireActual('react')
-  const MockDialog = React.forwardRef(() => null)
-
-  MockDialog.displayName = 'EditCustomerVatRateDialog'
-  return { EditCustomerVatRateDialog: MockDialog }
-})
+jest.mock('~/components/customers/EditCustomerVatRateDialog', () => ({
+  useEditCustomerVatRateDialog: () => ({
+    openEditCustomerVatRateDialog: jest.fn(),
+  }),
+}))
 
 jest.mock('~/components/customers/DeleteCustomerVatRateDialog', () => ({
   useDeleteCustomerVatRateDialog: () => ({

--- a/src/components/customers/__tests__/EditCustomerVatRateDialog.test.tsx
+++ b/src/components/customers/__tests__/EditCustomerVatRateDialog.test.tsx
@@ -1,7 +1,10 @@
-import { act, cleanup, screen } from '@testing-library/react'
+import NiceModal from '@ebay/nice-modal-react'
+import { act, cleanup, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { ReactNode } from 'react'
 
-import { EditCustomerVatRateDialog } from '~/components/customers/EditCustomerVatRateDialog'
+import { FORM_DIALOG_NAME, FORM_DIALOG_TEST_ID } from '~/components/dialogs/const'
+import FormDialog from '~/components/dialogs/FormDialog'
 import {
   MUI_INPUT_BASE_ROOT_CLASSNAME,
   SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME,
@@ -9,6 +12,25 @@ import {
 import { CREATE_TAX_ROUTE } from '~/core/router'
 import { GetTaxRatesForEditCustomerDocument } from '~/generated/graphql'
 import { render, TestMocksType } from '~/test-utils'
+
+import { useEditCustomerVatRateDialog } from '../EditCustomerVatRateDialog'
+
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 56,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, i) => ({
+        index: i,
+        key: String(i),
+        start: i * 56,
+        size: 56,
+      })),
+    scrollToIndex: jest.fn(),
+    measureElement: jest.fn(),
+  }),
+}))
+
+NiceModal.register(FORM_DIALOG_NAME, FormDialog)
 
 const membershipWithPermissions = {
   id: '2',
@@ -28,12 +50,33 @@ jest.mock('~/hooks/useCurrentUser', () => ({
   }),
 }))
 
+const customer = {
+  id: '1234',
+  name: 'Customer Name',
+  displayName: 'Customer name',
+  externalId: '4567',
+}
+
+const NiceModalWrapper = ({ children }: { children: ReactNode }) => {
+  return <NiceModal.Provider>{children}</NiceModal.Provider>
+}
+
+const TestComponent = () => {
+  const { openEditCustomerVatRateDialog } = useEditCustomerVatRateDialog()
+
+  return (
+    <button data-test="open-dialog" onClick={() => openEditCustomerVatRateDialog({ customer })}>
+      Open Dialog
+    </button>
+  )
+}
+
 async function prepare({
   mocks = [
     {
       request: {
         query: GetTaxRatesForEditCustomerDocument,
-        variables: { limit: 20 },
+        variables: { limit: 500 },
       },
       result: {
         data: {
@@ -49,45 +92,51 @@ async function prepare({
     },
   ],
 }: { mocks?: TestMocksType } = {}) {
-  const customer = {
-    id: '1234',
-    name: 'Customer Name',
-    displayName: 'Customer name',
-    externalId: '4567',
-  }
-
   await act(() =>
-    render(<EditCustomerVatRateDialog forceOpen customer={customer} />, {
-      mocks,
-    }),
+    render(
+      <NiceModalWrapper>
+        <TestComponent />
+      </NiceModalWrapper>,
+      { mocks },
+    ),
   )
+
+  await act(async () => {
+    screen.getByTestId('open-dialog').click()
+  })
+
+  await waitFor(() => {
+    expect(screen.getByTestId(FORM_DIALOG_TEST_ID)).toBeInTheDocument()
+  })
 }
 
 describe('EditCustomerVatRateDialog', () => {
-  afterEach(cleanup)
+  afterEach(() => {
+    cleanup()
+    jest.clearAllMocks()
+    NiceModal.remove(FORM_DIALOG_NAME)
+  })
 
   it('renders', async () => {
     await prepare()
 
-    expect(screen.queryByTestId('edit-customer-vat-rate-dialog')).toBeInTheDocument()
+    expect(screen.queryByTestId(FORM_DIALOG_TEST_ID)).toBeInTheDocument()
   })
 
   it('should propose to create a new tax if none exists and have permissions', async () => {
     await prepare()
 
-    userEvent
-      .click(
-        screen
-          .queryByTestId('edit-customer-vat-rate-dialog')
-          ?.querySelector(
-            `.${SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
-          ) as HTMLElement,
-      )
-      .then(() => {
-        expect(screen.queryByTestId('combobox-item-Create a tax_rate')).toBeInTheDocument()
-        expect(
-          screen.queryByTestId('combobox-item-Create a tax_rate')?.querySelector(`a`),
-        ).toHaveAttribute('href', CREATE_TAX_ROUTE)
-      })
+    await userEvent.click(
+      screen
+        .queryByTestId(FORM_DIALOG_TEST_ID)
+        ?.querySelector(
+          `.${SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+        ) as HTMLElement,
+    )
+
+    const createTaxItem = await screen.findByTestId('combobox-item-Create a tax_rate')
+
+    expect(createTaxItem).toBeInTheDocument()
+    expect(createTaxItem.querySelector(`a`)).toHaveAttribute('href', CREATE_TAX_ROUTE)
   })
 })

--- a/src/components/customers/__tests__/EditCustomerVatRateDialog.test.tsx
+++ b/src/components/customers/__tests__/EditCustomerVatRateDialog.test.tsx
@@ -5,10 +5,6 @@ import { ReactNode } from 'react'
 
 import { FORM_DIALOG_NAME, FORM_DIALOG_TEST_ID } from '~/components/dialogs/const'
 import FormDialog from '~/components/dialogs/FormDialog'
-import {
-  MUI_INPUT_BASE_ROOT_CLASSNAME,
-  SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME,
-} from '~/core/constants/form'
 import { CREATE_TAX_ROUTE } from '~/core/router'
 import { GetTaxRatesForEditCustomerDocument } from '~/generated/graphql'
 import { render, TestMocksType } from '~/test-utils'
@@ -124,15 +120,18 @@ describe('EditCustomerVatRateDialog', () => {
   })
 
   it('should propose to create a new tax if none exists and have permissions', async () => {
+    const user = userEvent.setup()
+
     await prepare()
 
-    await userEvent.click(
-      screen
-        .queryByTestId(FORM_DIALOG_TEST_ID)
-        ?.querySelector(
-          `.${SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
-        ) as HTMLElement,
-    )
+    const input = screen
+      .getByTestId(FORM_DIALOG_TEST_ID)
+      .querySelector('[role="combobox"]') as HTMLElement
+
+    // The tax rate ComboBox is freeSolo (allowAddValue): typing opens the popper and,
+    // when no tax matches, surfaces the "create a tax" option.
+    await user.click(input)
+    await user.keyboard('a')
 
     const createTaxItem = await screen.findByTestId('combobox-item-Create a tax_rate')
 

--- a/translations/base.json
+++ b/translations/base.json
@@ -699,7 +699,6 @@
   "text_62ce85fb3fb6842020331d83": "Find all <a rel=\"external\" target=\"_blank\" href=\"https://docs.getlago.com/api-reference/webhooks/messages\">the events</a> this webhook is listening",
   "text_62728ff857d47b013204c726": "Settings",
   "text_62728ff857d47b013204c7e4": "Cancel",
-  "text_627387d5053a1000c5287cab": "Cancel",
   "text_64d23a81a7d807f8aa570509": "Edit this webhook endpoint",
   "text_64d23a81a7d807f8aa57050b": "Edit this webhook endpoint to receive live event from Lago.",
   "text_64d23a81a7d807f8aa570513": "Webhook signature",


### PR DESCRIPTION
## Context

Part of the ongoing effort to remove the legacy imperative ref-based `Dialog` system from the frontend. Each PR migrates one dialog flagged by the `no-restricted-imports` ESLint rule to the new hook-based NiceModal `FormDialog` stack.

## Description

Migrates `EditCustomerVatRateDialog` from the legacy `forwardRef` + `useImperativeHandle` + `Dialog` pattern to the hook-based NiceModal `FormDialog` system. The new `useEditCustomerVatRateDialog` hook owns the customer + selected-tax refs, opens the dialog via `useFormDialog`, and preserves the "confirm is disabled until a tax is selected" UX by wiring the ComboBox's `onChange` to a `DialogActionButton` / `useSetDisabledRef` pair — matching the `AddBillableMetricToCouponDialog` reference. `CustomerSettings.tsx` drops the ref and the JSX rendering and simply calls `openEditCustomerVatRateDialog({ customer, appliedTaxRatesTaxesIds })` from the Add button; the `forceOpen` prop is gone (its only caller was the test file). The Jest suite for the dialog is rewritten around the hook + NiceModal, and a `@tanstack/react-virtual` mock is added so the ComboBox popper items render under jsdom — this also fixes a latent bug where the previous assertion sat in an un-awaited `.then()` chain and never actually ran. `CustomerSettings.test.tsx` swaps its `forwardRef` mock for a hook mock, the Cypress `create-customer` spec asserts on the new `form-dialog` test id, and an orphaned Cancel-button translation key is removed to keep `pnpm translations:inspect` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdynmboayP9hcgY4hD6BLk)_