### PR TITLE
fix(ui): normalize Main section spacing to a single 40px rhythm

### DIFF
--- a/src/pages/quotes/ApproveQuote.tsx
+++ b/src/pages/quotes/ApproveQuote.tsx
@@ -175,7 +175,7 @@ const ApproveQuote = () => {
           {loading ? (
             <FormLoadingSkeleton id="approve-quote" />
           ) : (
-            <div className="flex flex-col gap-12">
+            <div className="flex flex-col">
               <Alert data-test={APPROVE_QUOTE_ALERT_TEST_ID} type="info">
                 <Typography className="text-grey-700">
                   {translate('text_1776848720529x0n0j0tob0w')}

--- a/src/pages/quotes/EditOrder.tsx
+++ b/src/pages/quotes/EditOrder.tsx
@@ -202,7 +202,7 @@ const EditOrderFormContent = ({ order, loading }: EditOrderFormContentProps) => 
           {loading || !order ? (
             <FormLoadingSkeleton id="edit-order" />
           ) : (
-            <div className="flex flex-col gap-12">
+            <div className="flex flex-col">
               <div className="flex flex-col gap-1">
                 <Typography variant="headline" color="grey700">
                   {translate('text_178272359198433nj9yyhjt2', { orderNumber: order.number })}

--- a/src/pages/quotes/OrderFormDetails.tsx
+++ b/src/pages/quotes/OrderFormDetails.tsx
@@ -89,7 +89,7 @@ const OrderFormDetails = () => {
           {loading ? (
             <FormLoadingSkeleton id="order-form-details" />
           ) : (
-            <div className="flex flex-col gap-12">
+            <div className="flex flex-col">
               <div className="flex flex-col gap-1">
                 <Typography variant="headline" color="grey700">
                   {translate('text_17828094623997l9tqj385k5', { orderFormNumber })}

--- a/src/pages/quotes/QuoteVersionPreview.tsx
+++ b/src/pages/quotes/QuoteVersionPreview.tsx
@@ -121,7 +121,7 @@ const QuoteVersionPreview = () => {
           {loading ? (
             <FormLoadingSkeleton id="quote-version-preview" />
           ) : (
-            <div className="flex flex-col gap-12">
+            <div className="flex flex-col">
               <div className="flex flex-col gap-1">
                 <Typography variant="headline">
                   {translate('text_17827453798351lxoetcgnjt', {

--- a/src/pages/quotes/SignOrderForm.tsx
+++ b/src/pages/quotes/SignOrderForm.tsx
@@ -215,7 +215,7 @@ const SignOrderForm = () => {
           {loading ? (
             <FormLoadingSkeleton id="sign-order-form" />
           ) : (
-            <div className="flex flex-col gap-12">
+            <div className="flex flex-col">
               <Alert data-test={SIGN_ORDER_FORM_ALERT_TEST_ID} type="info">
                 <Typography className="text-grey-700">
                   {translate('text_1781686594125tgfd5ypl1h6')}

--- a/src/pages/quotes/VoidOrderForm.tsx
+++ b/src/pages/quotes/VoidOrderForm.tsx
@@ -188,7 +188,7 @@ const VoidOrderForm = () => {
           {loading ? (
             <FormLoadingSkeleton id="void-order-form" />
           ) : (
-            <div className="flex flex-col gap-12">
+            <div className="flex flex-col">
               <Alert data-test={VOID_ORDER_FORM_ALERT_TEST_ID} type="warning">
                 <Typography className="text-grey-700">
                   {translate('text_1779715648585ih339cvcfjx')}

--- a/src/pages/quotes/VoidQuote.tsx
+++ b/src/pages/quotes/VoidQuote.tsx
@@ -208,7 +208,7 @@ const VoidQuote = () => {
           {loading ? (
             <FormLoadingSkeleton id="void-quote" />
           ) : (
-            <div className="flex flex-col gap-12">
+            <div className="flex flex-col">
               <Alert data-test={VOID_QUOTE_ALERT_TEST_ID} type="warning">
                 <Typography className="text-grey-700">
                   {translate('text_1776414006125a67i2j1xl8s')}

--- a/src/styles/mainObjectsForm.tsx
+++ b/src/styles/mainObjectsForm.tsx
@@ -12,7 +12,7 @@ export const Main = ({
 }: PropsWithChildren & { footer?: ReactNode; footerAlign?: 'between' | 'end' }) => {
   if (!footer) {
     return (
-      <div className="w-full px-4 pt-12 md:w-3/5 md:p-12 md:pb-0 [&>div>*:not(:last-child)]:mb-8 [&>div]:max-w-180">
+      <div className="w-full px-4 pt-12 md:w-3/5 md:p-12 md:pb-0 [&>div>*:not(:last-child)]:mb-10 [&>div]:max-w-180">
         {children}
       </div>
     )
@@ -20,7 +20,7 @@ export const Main = ({
 
   return (
     <div className="height-minus-nav flex w-full flex-col overflow-hidden md:w-3/5">
-      <div className="flex-1 overflow-auto px-4 py-12 md:px-12 [&>div>*:not(:last-child)]:mb-8 [&>div]:max-w-180">
+      <div className="flex-1 overflow-auto px-4 py-12 md:px-12 [&>div>*:not(:last-child)]:mb-10 [&>div]:max-w-180">
         {children}
       </div>
       <footer className="shrink-0 bg-white p-4 shadow-t md:px-12">


### PR DESCRIPTION
## Summary

`Main` (`src/styles/mainObjectsForm.tsx`) auto-spaces its section children via `margin-bottom` (`mb-8` = 32px). The quote-flow pages *also* set a `flex gap-12` (48px) on the section wrapper, so sections were **double-spaced (~80px)**. This normalizes everything to one clean 40px rhythm.

## Changes

- **`Main`**: section spacer `mb-8` → `mb-10` (32px → **40px**) — the single source of truth (both no-footer and footer variants).
- **7 quote-flow pages**: dropped the redundant `gap-12` from the section wrapper so `Main`'s `mb-10` alone spaces sections — `ApproveQuote`, `VoidQuote`, `SignOrderForm`, `VoidOrderForm`, `OrderFormDetails`, `QuoteVersionPreview`, `EditOrder`.

## Blast radius (intentional, per design decision)

Every `<Main>` page's section spacing moves to 40px. The 4 non-quote Main pages (`CreateBillableMetric`, `CreateAddOn`, `CreateTax`, `CreateCoupon`) had no own wrapper gap → they simply go 32px → 40px. Confirmed `<Main>` is rendered by exactly 11 pages and the `mb-8` spacer string lived only in `Main`.

## Verification

- `pnpm run types` clean.
- 114/114 tests across the 11 quote-flow suites pass (class-only change, no test asserts on spacing).
- Scoped prettier clean on all 8 files.

## Related

Pairs with the Execute Order feature (#3890), which already renders sections at 40px; with this merged, that page's spacing is consistent with the rest of the flow. (Its interim nesting-wrapper can be simplified in a follow-up now that `Main` provides 40px natively.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)