### PR TITLE
refactor(integrations): migrate AddCashfreeDialog to FormDialogOpeningDialog and TanStack Form

### DIFF
--- a/src/components/settings/integrations/AddCashfreeDialog.tsx
+++ b/src/components/settings/integrations/AddCashfreeDialog.tsx
@@ -1,26 +1,28 @@
-import { gql } from '@apollo/client'
-import Stack from '@mui/material/Stack'
-import { useFormik } from 'formik'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
-import { object, string } from 'yup'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { TextInputField } from '~/components/form'
+import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
+import { DialogResult } from '~/components/dialogs/types'
 import { addToast } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { CASHFREE_INTEGRATION_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import {
-  AddCashfreePaymentProviderInput,
   AddCashfreeProviderDialogFragment,
   CashfreeIntegrationDetailsFragmentDoc,
+  DeleteCashfreeIntegrationDialogFragmentDoc,
+  GetCashfreeIntegrationsListDocument,
   LagoApiError,
   useAddCashfreeApiKeyMutation,
+  useDeleteCashfreeMutation,
   useGetProviderByCodeForCashfreeLazyQuery,
   useUpdateCashfreeApiKeyMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 gql`
   fragment AddCashfreeProviderDialog on CashfreeProvider {
@@ -72,30 +74,53 @@ gql`
   }
 
   ${CashfreeIntegrationDetailsFragmentDoc}
+  ${DeleteCashfreeIntegrationDialogFragmentDoc}
 `
 
-type TAddCashfreeDialogProps = Partial<{
-  provider: AddCashfreeProviderDialogFragment
-  onDeleteClick: () => void
-}>
+const ADD_CASHFREE_FORM_ID = 'form-add-cashfree-integration'
 
-export interface AddCashfreeDialogRef {
-  openDialog: (props?: TAddCashfreeDialogProps) => unknown
-  closeDialog: () => unknown
+type AddCashfreeFormValues = {
+  name: string
+  code: string
+  clientId: string
+  clientSecret: string
+  successRedirectUrl: string
 }
 
-export const AddCashfreeDialog = forwardRef<AddCashfreeDialogRef>((_, ref) => {
-  const navigate = useNavigate()
-  const dialogRef = useRef<DialogRef>(null)
+const defaultFormValues: AddCashfreeFormValues = {
+  name: '',
+  code: '',
+  clientId: '',
+  clientSecret: '',
+  successRedirectUrl: '',
+}
 
+const validationSchema = z.object({
+  name: z.string(),
+  code: z.string().min(1),
+  clientId: z.string().min(1),
+  clientSecret: z.string().min(1),
+  successRedirectUrl: z.string(),
+})
+
+type OpenAddCashfreeDialogData = {
+  provider?: AddCashfreeProviderDialogFragment
+  deleteCallback?: () => void
+}
+
+export const useAddCashfreeDialog = () => {
+  const navigate = useNavigate()
+  const formDialogOpeningDialog = useFormDialogOpeningDialog()
   const { translate } = useInternationalization()
-  const [localData, setLocalData] = useState<TAddCashfreeDialogProps | undefined>(undefined)
-  const cashfreeProvider = localData?.provider
-  const isEdition = !!cashfreeProvider
+  const client = useApolloClient()
+
+  const dataRef = useRef<OpenAddCashfreeDialogData | null>(null)
+  const successRef = useRef(false)
 
   const [addApiKey] = useAddCashfreeApiKeyMutation({
     onCompleted({ addCashfreePaymentProvider }) {
       if (addCashfreePaymentProvider?.id) {
+        successRef.current = true
         navigate(
           generatePath(CASHFREE_INTEGRATION_DETAILS_ROUTE, {
             integrationId: addCashfreePaymentProvider.id,
@@ -114,6 +139,7 @@ export const AddCashfreeDialog = forwardRef<AddCashfreeDialogRef>((_, ref) => {
   const [updateApiKey] = useUpdateCashfreeApiKeyMutation({
     onCompleted({ updateCashfreePaymentProvider }) {
       if (updateCashfreePaymentProvider?.id) {
+        successRef.current = true
         navigate(
           generatePath(CASHFREE_INTEGRATION_DETAILS_ROUTE, {
             integrationId: updateCashfreePaymentProvider.id,
@@ -131,26 +157,22 @@ export const AddCashfreeDialog = forwardRef<AddCashfreeDialogRef>((_, ref) => {
 
   const [getCashfreeProviderByCode] = useGetProviderByCodeForCashfreeLazyQuery()
 
-  const formikProps = useFormik<AddCashfreePaymentProviderInput>({
-    initialValues: {
-      code: cashfreeProvider?.code || '',
-      name: cashfreeProvider?.name || '',
-      clientId: cashfreeProvider?.clientId || '',
-      clientSecret: cashfreeProvider?.clientSecret || '',
-      successRedirectUrl: cashfreeProvider?.successRedirectUrl || '',
+  const [deleteCashfree] = useDeleteCashfreeMutation()
+
+  const form = useAppForm({
+    defaultValues: defaultFormValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: validationSchema,
     },
-    validationSchema: object().shape({
-      name: string(),
-      code: string().required(''),
-      clientId: string().required(''),
-      clientSecret: string().required(''),
-      successRedirectUrl: string(),
-    }),
-    onSubmit: async ({ clientId, clientSecret, successRedirectUrl, ...values }, formikBag) => {
+    onSubmit: async ({ value, formApi }) => {
+      const cashfreeProvider = dataRef.current?.provider
+      const isEdition = !!cashfreeProvider
+
       const res = await getCashfreeProviderByCode({
         context: { silentErrorCodes: [LagoApiError.NotFound] },
         variables: {
-          code: values.code,
+          code: value.code,
         },
       })
       const isNotAllowedToMutate =
@@ -160,17 +182,29 @@ export const AddCashfreeDialog = forwardRef<AddCashfreeDialogRef>((_, ref) => {
           res.data?.paymentProvider?.id !== cashfreeProvider?.id)
 
       if (isNotAllowedToMutate) {
-        formikBag.setFieldError('code', translate('text_632a2d437e341dcc76817556'))
+        formApi.setErrorMap({
+          onDynamic: {
+            fields: {
+              code: {
+                message: translate('text_632a2d437e341dcc76817556'),
+                path: ['code'],
+              },
+            },
+          },
+        })
         return
       }
+
+      const { clientId, clientSecret, successRedirectUrl, name, code } = value
 
       if (isEdition) {
         await updateApiKey({
           variables: {
             input: {
               id: cashfreeProvider?.id || '',
+              name,
+              code,
               successRedirectUrl: successRedirectUrl || undefined,
-              ...values,
             },
           },
         })
@@ -178,120 +212,157 @@ export const AddCashfreeDialog = forwardRef<AddCashfreeDialogRef>((_, ref) => {
         await addApiKey({
           variables: {
             input: {
+              name,
+              code,
               clientId,
               clientSecret,
               successRedirectUrl: successRedirectUrl || undefined,
-              ...values,
             },
           },
         })
       }
-      dialogRef.current?.closeDialog()
     },
-    validateOnMount: true,
-    enableReinitialize: true,
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate(
-        isEdition ? 'text_658461066530343fe1808cd9' : 'text_172450747075633492aqpbm2',
-        {
-          name: cashfreeProvider?.name,
-        },
-      )}
-      description={translate(
-        isEdition ? 'text_1724507963056bu20ky8z98g' : 'text_17245079170372xxmw737fhf',
-      )}
-      onClose={() => {
-        formikProps.resetForm()
-      }}
-      actions={({ closeDialog }) => (
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-          width={isEdition ? '100%' : 'inherit'}
-          spacing={3}
-        >
-          {isEdition && (
-            <Button
-              danger
-              variant="quaternary"
-              onClick={() => {
-                closeDialog()
-                localData?.onDeleteClick?.()
-              }}
-            >
-              {translate('text_65845f35d7d69c3ab4793dad')}
-            </Button>
-          )}
-          <Stack direction="row" spacing={3} alignItems="center">
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_62b1edddbf5f461ab971276d')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!formikProps.isValid || !formikProps.dirty}
-              onClick={formikProps.submitForm}
-            >
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openAddCashfreeDialog = (data?: OpenAddCashfreeDialogData) => {
+    dataRef.current = data ?? null
+    const cashfreeProvider = data?.provider
+    const isEdition = !!cashfreeProvider
+
+    form.reset()
+    if (cashfreeProvider) {
+      form.setFieldValue('name', cashfreeProvider.name || '')
+      form.setFieldValue('code', cashfreeProvider.code || '')
+      form.setFieldValue('clientId', cashfreeProvider.clientId || '')
+      form.setFieldValue('clientSecret', cashfreeProvider.clientSecret || '')
+      form.setFieldValue('successRedirectUrl', cashfreeProvider.successRedirectUrl || '')
+    }
+
+    formDialogOpeningDialog
+      .open({
+        title: translate(
+          isEdition ? 'text_658461066530343fe1808cd9' : 'text_172450747075633492aqpbm2',
+          {
+            name: cashfreeProvider?.name,
+          },
+        ),
+        description: translate(
+          isEdition ? 'text_1724507963056bu20ky8z98g' : 'text_17245079170372xxmw737fhf',
+        ),
+        children: (
+          <div className="mb-8 flex flex-col gap-6">
+            <div className="flex flex-row items-start gap-6 *:flex-1">
+              <form.AppField name="name">
+                {(field) => (
+                  <field.TextInputField
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                    autoFocus
+                    label={translate('text_6584550dc4cec7adf861504d')}
+                    placeholder={translate('text_6584550dc4cec7adf861504f')}
+                  />
+                )}
+              </form.AppField>
+              <form.AppField name="code">
+                {(field) => (
+                  <field.TextInputField
+                    label={translate('text_6584550dc4cec7adf8615051')}
+                    placeholder={translate('text_6584550dc4cec7adf8615053')}
+                  />
+                )}
+              </form.AppField>
+            </div>
+            <form.AppField name="clientId">
+              {(field) => (
+                <field.TextInputField
+                  disabled={isEdition}
+                  label={translate('text_1727620558031ftsky1vpr55')}
+                  placeholder={translate('text_1727624537843s2ublm4rsyj')}
+                />
+              )}
+            </form.AppField>
+            <form.AppField name="clientSecret">
+              {(field) => (
+                <field.TextInputField
+                  disabled={isEdition}
+                  label={translate('text_1727620574228qfyoqtsdih7')}
+                  placeholder={translate('text_17276245391922l9540z7f78')}
+                />
+              )}
+            </form.AppField>
+            <form.AppField name="successRedirectUrl">
+              {(field) => (
+                <field.TextInputField
+                  label={translate('text_65367cb78324b77fcb6af21c')}
+                  placeholder={translate('text_1733303818769298k0fvsgcz')}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        closeOnError: false,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>
               {translate(
                 isEdition ? 'text_65845f35d7d69c3ab4793dac' : 'text_172450747075633492aqpbm2',
               )}
-            </Button>
-          </Stack>
-        </Stack>
-      )}
-    >
-      <div className="mb-8 flex flex-col gap-6">
-        <div className="flex flex-row items-start gap-6 *:flex-1">
-          <TextInputField
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus
-            formikProps={formikProps}
-            name="name"
-            label={translate('text_6584550dc4cec7adf861504d')}
-            placeholder={translate('text_6584550dc4cec7adf861504f')}
-          />
-          <TextInputField
-            formikProps={formikProps}
-            name="code"
-            label={translate('text_6584550dc4cec7adf8615051')}
-            placeholder={translate('text_6584550dc4cec7adf8615053')}
-          />
-        </div>
-        <TextInputField
-          formikProps={formikProps}
-          disabled={isEdition}
-          name="clientId"
-          label={translate('text_1727620558031ftsky1vpr55')}
-          placeholder={translate('text_1727624537843s2ublm4rsyj')}
-        />
-        <TextInputField
-          formikProps={formikProps}
-          disabled={isEdition}
-          name="clientSecret"
-          label={translate('text_1727620574228qfyoqtsdih7')}
-          placeholder={translate('text_17276245391922l9540z7f78')}
-        />
-        <TextInputField
-          formikProps={formikProps}
-          name="successRedirectUrl"
-          label={translate('text_65367cb78324b77fcb6af21c')}
-          placeholder={translate('text_1733303818769298k0fvsgcz')}
-        />
-      </div>
-    </Dialog>
-  )
-})
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: ADD_CASHFREE_FORM_ID,
+          submit: handleSubmit,
+        },
+        canOpenDialog: isEdition,
+        openDialogText: translate('text_65845f35d7d69c3ab4793dad'),
+        otherDialogProps: {
+          title: translate('text_658461066530343fe1808cd7', { name: cashfreeProvider?.name }),
+          description: translate('text_1727621816788cygs13tsdyv'),
+          actionText: translate('text_659d5de7c9b7f51394f7f3fd'),
+          colorVariant: 'danger',
+          onAction: async () => {
+            const res = await deleteCashfree({
+              variables: { input: { id: cashfreeProvider?.id as string } },
+            })
 
-AddCashfreeDialog.displayName = 'AddCashfreeDialog'
+            const destroyedId = res.data?.destroyPaymentProvider?.id
+
+            if (destroyedId) {
+              evictFromCache(client, {
+                id: destroyedId,
+                __typename: 'CashfreeProvider',
+                listFieldName: 'paymentProviders',
+                listQueryDocument: GetCashfreeIntegrationsListDocument,
+              })
+
+              dataRef.current?.deleteCallback?.()
+
+              addToast({
+                message: translate('text_1727621949511zk6kkl99pzk'),
+                severity: 'success',
+              })
+            }
+          },
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close' || response.reason === 'open-other-dialog') {
+          form.reset()
+          dataRef.current = null
+        }
+      })
+  }
+
+  return { openAddCashfreeDialog }
+}

--- a/src/components/settings/integrations/AddCashfreeDialog.tsx
+++ b/src/components/settings/integrations/AddCashfreeDialog.tsx
@@ -6,10 +6,13 @@ import { z } from 'zod'
 
 import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
 import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
+import NameAndCodeGroup from '~/components/form/NameAndCodeGroup/NameAndCodeGroup'
 import { addToast } from '~/core/apolloClient'
 import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { CASHFREE_INTEGRATION_DETAILS_ROUTE, useNavigate } from '~/core/router'
+import { zodOptionalUrl } from '~/formValidation/zodCustoms'
 import {
   AddCashfreeProviderDialogFragment,
   CashfreeIntegrationDetailsFragmentDoc,
@@ -100,7 +103,7 @@ const validationSchema = z.object({
   code: z.string().min(1),
   clientId: z.string().min(1),
   clientSecret: z.string().min(1),
-  successRedirectUrl: z.string(),
+  successRedirectUrl: zodOptionalUrl,
 })
 
 type OpenAddCashfreeDialogData = {
@@ -261,27 +264,20 @@ export const useAddCashfreeDialog = () => {
           isEdition ? 'text_1724507963056bu20ky8z98g' : 'text_17245079170372xxmw737fhf',
         ),
         children: (
-          <div className="mb-8 flex flex-col gap-6">
-            <div className="flex flex-row items-start gap-6 *:flex-1">
-              <form.AppField name="name">
-                {(field) => (
-                  <field.TextInputField
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
-                    autoFocus
-                    label={translate('text_6584550dc4cec7adf861504d')}
-                    placeholder={translate('text_6584550dc4cec7adf861504f')}
-                  />
-                )}
-              </form.AppField>
-              <form.AppField name="code">
-                {(field) => (
-                  <field.TextInputField
-                    label={translate('text_6584550dc4cec7adf8615051')}
-                    placeholder={translate('text_6584550dc4cec7adf8615053')}
-                  />
-                )}
-              </form.AppField>
-            </div>
+          <div className="flex flex-col gap-6 p-6">
+            <NameAndCodeGroup
+              form={form}
+              fields={{ name: 'name', code: 'code' }}
+              disableAutoGenerateCode={isEdition}
+              nameProps={{
+                label: translate('text_6584550dc4cec7adf861504d'),
+                placeholder: translate('text_6584550dc4cec7adf861504f'),
+              }}
+              codeProps={{
+                label: translate('text_6584550dc4cec7adf8615051'),
+                placeholder: translate('text_6584550dc4cec7adf8615053'),
+              }}
+            />
             <form.AppField name="clientId">
               {(field) => (
                 <field.TextInputField
@@ -311,6 +307,7 @@ export const useAddCashfreeDialog = () => {
           </div>
         ),
         closeOnError: false,
+        onEntered: focusFirstInput,
         mainAction: (
           <form.AppForm>
             <form.SubmitButton>

--- a/src/pages/settings/CashfreeIntegrationDetails.tsx
+++ b/src/pages/settings/CashfreeIntegrationDetails.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { Icon } from 'lago-design-system'
-import { useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Alert } from '~/components/designSystem/Alert'
@@ -10,10 +10,7 @@ import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { IntegrationsPage } from '~/components/layouts/Integrations'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import {
-  AddCashfreeDialog,
-  AddCashfreeDialogRef,
-} from '~/components/settings/integrations/AddCashfreeDialog'
+import { useAddCashfreeDialog } from '~/components/settings/integrations/AddCashfreeDialog'
 import { useDeleteCashfreeIntegrationDialog } from '~/components/settings/integrations/DeleteCashfreeIntegrationDialog'
 import { addToast, envGlobalVar } from '~/core/apolloClient'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
@@ -70,7 +67,7 @@ const CashfreeIntegrationDetails = () => {
   const navigate = useNavigate()
   const { integrationId } = useParams()
   const { hasPermissions } = usePermissions()
-  const addDialogRef = useRef<AddCashfreeDialogRef>(null)
+  const { openAddCashfreeDialog } = useAddCashfreeDialog()
   const { openDeleteCashfreeIntegrationDialog } = useDeleteCashfreeIntegrationDialog()
   const { apiUrl } = envGlobalVar()
   const { currentMembership } = useCurrentUser()
@@ -145,13 +142,9 @@ const CashfreeIntegrationDetails = () => {
                   label: translate('text_65845f35d7d69c3ab4793dac'),
                   hidden: !canEditIntegration,
                   onClick: (closePopper) => {
-                    addDialogRef.current?.openDialog({
+                    openAddCashfreeDialog({
                       provider: cashfreePaymentProvider,
-                      onDeleteClick: () =>
-                        openDeleteCashfreeIntegrationDialog({
-                          provider: cashfreePaymentProvider,
-                          callback: deleteDialogCallback,
-                        }),
+                      deleteCallback: deleteDialogCallback,
                     })
                     closePopper()
                   },
@@ -188,13 +181,9 @@ const CashfreeIntegrationDetails = () => {
                 variant="inline"
                 align="left"
                 onClick={() => {
-                  addDialogRef.current?.openDialog({
+                  openAddCashfreeDialog({
                     provider: cashfreePaymentProvider,
-                    onDeleteClick: () =>
-                      openDeleteCashfreeIntegrationDialog({
-                        provider: cashfreePaymentProvider,
-                        callback: deleteDialogCallback,
-                      }),
+                    deleteCallback: deleteDialogCallback,
                   })
                 }}
               >
@@ -268,8 +257,6 @@ const CashfreeIntegrationDetails = () => {
           )}
         </section>
       </div>
-
-      <AddCashfreeDialog ref={addDialogRef} />
     </div>
   )
 }

--- a/src/pages/settings/CashfreeIntegrations.tsx
+++ b/src/pages/settings/CashfreeIntegrations.tsx
@@ -7,10 +7,7 @@ import { Popper } from '~/components/designSystem/Popper'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { IntegrationsPage } from '~/components/layouts/Integrations'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import {
-  AddCashfreeDialog,
-  AddCashfreeDialogRef,
-} from '~/components/settings/integrations/AddCashfreeDialog'
+import { useAddCashfreeDialog } from '~/components/settings/integrations/AddCashfreeDialog'
 import {
   AddEditDeleteSuccessRedirectUrlDialog,
   AddEditDeleteSuccessRedirectUrlDialogRef,
@@ -58,7 +55,7 @@ gql`
 const CashfreeIntegrations = () => {
   const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
-  const addCashfreeDialogRef = useRef<AddCashfreeDialogRef>(null)
+  const { openAddCashfreeDialog } = useAddCashfreeDialog()
   const { openDeleteCashfreeIntegrationDialog } = useDeleteCashfreeIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
@@ -107,7 +104,7 @@ const CashfreeIntegrations = () => {
               variant: 'primary',
               hidden: !canCreateIntegration,
               onClick: () => {
-                addCashfreeDialogRef.current?.openDialog()
+                openAddCashfreeDialog()
               },
             },
           ],
@@ -162,13 +159,9 @@ const CashfreeIntegrations = () => {
                               variant="quaternary"
                               align="left"
                               onClick={() => {
-                                addCashfreeDialogRef.current?.openDialog({
+                                openAddCashfreeDialog({
                                   provider: connection,
-                                  onDeleteClick: () =>
-                                    openDeleteCashfreeIntegrationDialog({
-                                      provider: connection,
-                                      callback: deleteDialogCallback,
-                                    }),
+                                  deleteCallback: deleteDialogCallback,
                                 })
                                 closePopper()
                               }}
@@ -203,7 +196,6 @@ const CashfreeIntegrations = () => {
         </section>
       </IntegrationsPage.Container>
 
-      <AddCashfreeDialog ref={addCashfreeDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -25,10 +25,7 @@ import {
   AddAnrokDialogRef,
 } from '~/components/settings/integrations/AddAnrokDialog'
 import { useAddAvalaraDialog } from '~/components/settings/integrations/AddAvalaraDialog'
-import {
-  AddCashfreeDialog,
-  AddCashfreeDialogRef,
-} from '~/components/settings/integrations/AddCashfreeDialog'
+import { useAddCashfreeDialog } from '~/components/settings/integrations/AddCashfreeDialog'
 import {
   AddFlutterwaveDialog,
   AddFlutterwaveDialogRef,
@@ -179,7 +176,7 @@ const Integrations = () => {
   const addStripeDialogRef = useRef<AddStripeDialogRef>(null)
   const addAdyenDialogRef = useRef<AddAdyenDialogRef>(null)
   const addGocardlessDialogRef = useRef<AddGocardlessDialogRef>(null)
-  const addCashfreeDialogRef = useRef<AddCashfreeDialogRef>(null)
+  const { openAddCashfreeDialog } = useAddCashfreeDialog()
   const addLagoTaxManagementDialog = useRef<AddLagoTaxManagementDialogRef>(null)
   const addNetsuiteDialogRef = useRef<AddNetsuiteDialogRef>(null)
   const addSalesforceDialogRef = useRef<AddSalesforceDialogRef>(null)
@@ -746,7 +743,7 @@ const Integrations = () => {
                               }),
                             )
                           } else {
-                            addCashfreeDialogRef.current?.openDialog()
+                            openAddCashfreeDialog()
                           }
                         }}
                       />
@@ -848,7 +845,6 @@ const Integrations = () => {
       <AddAnrokDialog ref={addAnrokDialogRef} />
       <AddAdyenDialog ref={addAdyenDialogRef} />
       <AddStripeDialog ref={addStripeDialogRef} />
-      <AddCashfreeDialog ref={addCashfreeDialogRef} />
       <AddMoneyhashDialog ref={addMoneyhashDialogRef} />
       <AddGocardlessDialog ref={addGocardlessDialogRef} />
       <AddLagoTaxManagementDialog ref={addLagoTaxManagementDialog} />

--- a/src/pages/settings/__tests__/CashfreeIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/CashfreeIntegrations.test.tsx
@@ -11,7 +11,9 @@ import {
 import CashfreeIntegrations from '../CashfreeIntegrations'
 
 jest.mock('~/components/settings/integrations/AddCashfreeDialog', () => ({
-  AddCashfreeDialog: () => null,
+  useAddCashfreeDialog: () => ({
+    openAddCashfreeDialog: jest.fn(),
+  }),
 }))
 jest.mock('~/components/settings/integrations/DeleteCashfreeIntegrationDialog', () => ({
   useDeleteCashfreeIntegrationDialog: () => ({

--- a/src/pages/settings/__tests__/Integrations.test.tsx
+++ b/src/pages/settings/__tests__/Integrations.test.tsx
@@ -51,7 +51,9 @@ jest.mock('~/components/settings/integrations/AddGocardlessDialog', () => ({
   AddGocardlessDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/AddCashfreeDialog', () => ({
-  AddCashfreeDialog: () => null,
+  useAddCashfreeDialog: () => ({
+    openAddCashfreeDialog: jest.fn(),
+  }),
 }))
 jest.mock('~/components/settings/integrations/AddMoneyhashDialog', () => ({
   AddMoneyhashDialog: () => null,


### PR DESCRIPTION
## Context

`AddCashfreeDialog` was one of the last integration dialogs still on the legacy imperative-ref `Dialog` system + Formik + Yup. Both stacks are deprecated in this codebase (see `lago/no-restricted-imports` warnings for the legacy dialog folder + the `formik` ban in `packages/configs/eslint.config.mjs`). The old design forced parents to hold a `useRef<AddCashfreeDialogRef>` and to render `<AddCashfreeDialog ref={...} />` in JSX, and the delete-from-edit affordance had to be plumbed through an `onDeleteClick` callback that reopened a second dialog held by the parent.

## Description

- Rewrote `src/components/settings/integrations/AddCashfreeDialog.tsx` as a `useAddCashfreeDialog` hook that opens a `useFormDialogOpeningDialog` — same shape as `AddOktaDialog`.
- Migrated the Formik form to TanStack Form via `useAppForm` + a Zod validation schema (`name` optional, `code`/`clientId`/`clientSecret` required, `successRedirectUrl` optional).
- Preserved the async duplicate-code check via `getProviderByCodeForCashfree` with `silentErrorCodes: [LagoApiError.NotFound]`; on collision the error is surfaced via `formApi.setErrorMap` with `{ message, path: ['code'] }` (equivalent of the old `formikBag.setFieldError`).
- Preserved the existing `onCompleted` navigation + toast behavior for both `addCashfreeApiKey` and `updateCashfreeApiKey`, and used a `successRef` bridge so the dialog stays open when the mutation reports errors.
- Inlined the delete flow into `otherDialogProps.onAction` (danger button surfaced only in edition mode). Delete uses the existing `useDeleteCashfreeMutation` + `evictFromCache(client, { __typename: 'CashfreeProvider', listFieldName: 'paymentProviders', listQueryDocument: GetCashfreeIntegrationsListDocument })` for correct cache cleanup, matching the pattern in `DeleteCashfreeIntegrationDialog.tsx`. The `deleteCallback` prop (previously `onDeleteClick`) is invoked on delete success for the post-delete navigation.
- Updated `src/pages/settings/CashfreeIntegrations.tsx`, `src/pages/settings/CashfreeIntegrationDetails.tsx`, and the Cashfree bits of `src/pages/settings/Integrations.tsx`: removed the `useRef<AddCashfreeDialogRef>` + `<AddCashfreeDialog ref />` boilerplate and the wrapping `onDeleteClick` callback; call sites now just `openAddCashfreeDialog({ provider, deleteCallback })`.
- `DeleteCashfreeIntegrationDialog` is retained because it is still used standalone from both parent pages (the trash menu item and the dropdown Delete action).
- Test mocks updated: the two Jest suites that mock the module now expose `useAddCashfreeDialog` instead of `AddCashfreeDialog`.

## How to test

- Go to `Settings → Integrations → Cashfree`.
  - Click **Add** in the header: the create dialog opens; submitting with an empty required field keeps the submit button disabled (Zod `min(1)` gate through `canSubmit`); submitting with a `code` that already exists on another provider shows the duplicate-code error on the `code` field.
  - On a successful create, the app navigates to the Cashfree detail page and shows the success toast.
  - Edit an existing connection from the row popper: the dialog opens pre-filled; `clientId` and `clientSecret` are disabled in edit mode; the danger **Delete integration** button is visible.
  - Click the danger **Delete integration** button inside the edit dialog: a confirmation `CentralizedDialog` opens; on confirm the provider is deleted, the paginated `paymentProviders` list is updated in place via `evictFromCache`, and the correct post-delete navigation happens (back to list when more than one connection remains, otherwise back to the Integrations root).
  - Use the standalone trash button in the row popper: same delete flow via `useDeleteCashfreeIntegrationDialog`.
- From `Settings → Integrations` (root) click the Cashfree tile when no Cashfree provider is configured: the create dialog opens (no danger button).
- Verified: `npx tsc --noEmit` clean; `pnpm eslint` on the four touched source files shows zero errors and zero warnings on the Cashfree imports (the remaining warnings on `Integrations.tsx` are pre-existing warnings for other unmigrated integration dialogs); `pnpm jest src/pages/settings/__tests__/CashfreeIntegrations.test.tsx` (2/2 passing) and `pnpm jest src/pages/settings/__tests__/Integrations.test.tsx` (17/17 passing) both green.

---
_Generated by [Claude Code](https://claude.ai/code/session_013RCuZTd4PpvbkQZjFix8pP)_