### PR TITLE
refactor(integrations): migrate AddMoneyhashDialog to FormDialogOpeningDialog and TanStack Form

### DIFF
--- a/src/components/settings/integrations/AddMoneyhashDialog.tsx
+++ b/src/components/settings/integrations/AddMoneyhashDialog.tsx
@@ -1,27 +1,28 @@
-import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
-import { object, string } from 'yup'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { TextInputField } from '~/components/form'
+import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
+import { DialogResult } from '~/components/dialogs/types'
 import { addToast } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { MONEYHASH_INTEGRATION_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import {
   AddMoneyhashPaymentProviderInput,
   AddMoneyhashProviderDialogFragment,
+  GetMoneyhashIntegrationsListDocument,
   LagoApiError,
   MoneyhashIntegrationDetailsFragmentDoc,
   useAddMoneyhashApiKeyMutation,
+  useDeleteMoneyhashIntegrationMutation,
   useGetProviderByCodeForMoneyhashLazyQuery,
   useUpdateMoneyhashApiKeyMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-
-import { useDeleteMoneyhashIntegrationDialog } from './DeleteMoneyhashIntegrationDialog'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 gql`
   fragment AddMoneyhashProviderDialog on MoneyhashProvider {
@@ -70,28 +71,40 @@ gql`
   ${MoneyhashIntegrationDetailsFragmentDoc}
 `
 
-type TAddMoneyhashDialogProps = Partial<{
-  provider: AddMoneyhashProviderDialogFragment
-  deleteDialogCallback: () => void
-}>
+const ADD_MONEYHASH_FORM_ID = 'form-add-moneyhash-integration'
 
-export interface AddMoneyhashDialogRef {
-  openDialog: (props?: TAddMoneyhashDialogProps) => unknown
-  closeDialog: () => unknown
+type OpenAddMoneyhashDialogData = {
+  provider?: AddMoneyhashProviderDialogFragment
+  deleteDialogCallback?: () => void
 }
 
-export const AddMoneyhashDialog = forwardRef<AddMoneyhashDialogRef>((_, ref) => {
+const defaultFormValues: AddMoneyhashPaymentProviderInput = {
+  name: '',
+  code: '',
+  apiKey: '',
+  flowId: '',
+}
+
+const validationSchema = z.object({
+  name: z.string().min(1),
+  code: z.string().min(1),
+  apiKey: z.string().min(1),
+  flowId: z.string().min(1),
+})
+
+export const useAddMoneyhashDialog = () => {
+  const formDialogOpeningDialog = useFormDialogOpeningDialog()
   const { translate } = useInternationalization()
   const navigate = useNavigate()
-  const dialogRef = useRef<DialogRef>(null)
-  const [localData, setLocalData] = useState<TAddMoneyhashDialogProps | undefined>(undefined)
-  const moneyhashProvider = localData?.provider
-  const isEdition = !!moneyhashProvider
-  const { openDeleteMoneyhashIntegrationDialog } = useDeleteMoneyhashIntegrationDialog()
+  const client = useApolloClient()
+
+  const dataRef = useRef<OpenAddMoneyhashDialogData | null>(null)
+  const successRef = useRef(false)
 
   const [addApiKey] = useAddMoneyhashApiKeyMutation({
     onCompleted({ addMoneyhashPaymentProvider }) {
       if (addMoneyhashPaymentProvider?.id) {
+        successRef.current = true
         navigate(
           generatePath(MONEYHASH_INTEGRATION_DETAILS_ROUTE, {
             integrationId: addMoneyhashPaymentProvider.id,
@@ -109,6 +122,7 @@ export const AddMoneyhashDialog = forwardRef<AddMoneyhashDialogRef>((_, ref) => 
   const [updateApiKey] = useUpdateMoneyhashApiKeyMutation({
     onCompleted({ updateMoneyhashPaymentProvider }) {
       if (updateMoneyhashPaymentProvider?.id) {
+        successRef.current = true
         addToast({
           message: translate('text_17337300102103wt4s6yz2gh'),
           severity: 'success',
@@ -117,26 +131,24 @@ export const AddMoneyhashDialog = forwardRef<AddMoneyhashDialogRef>((_, ref) => 
     },
   })
 
+  const [deleteMoneyhash] = useDeleteMoneyhashIntegrationMutation()
+
   const [getMoneyhashProviderByCode] = useGetProviderByCodeForMoneyhashLazyQuery()
 
-  const formikProps = useFormik<AddMoneyhashPaymentProviderInput>({
-    initialValues: {
-      name: moneyhashProvider?.name || '',
-      code: moneyhashProvider?.code || '',
-      apiKey: moneyhashProvider?.apiKey || '',
-      flowId: moneyhashProvider?.flowId || '',
+  const form = useAppForm({
+    defaultValues: defaultFormValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: validationSchema,
     },
-    validationSchema: object().shape({
-      name: string().required(''),
-      code: string().required(''),
-      apiKey: string().required(''),
-      flowId: string().required(''),
-    }),
-    onSubmit: async ({ apiKey, flowId, ...values }, formikBag) => {
+    onSubmit: async ({ value, formApi }) => {
+      const provider = dataRef.current?.provider
+      const isEdition = !!provider
+
       const res = await getMoneyhashProviderByCode({
         context: { silentErrorCodes: [LagoApiError.NotFound] },
         variables: {
-          code: values.code,
+          code: value.code,
         },
       })
 
@@ -144,19 +156,31 @@ export const AddMoneyhashDialog = forwardRef<AddMoneyhashDialogRef>((_, ref) => 
         (!!res.data?.paymentProvider?.id && !isEdition) ||
         (isEdition &&
           !!res.data?.paymentProvider?.id &&
-          res.data?.paymentProvider?.id !== moneyhashProvider?.id)
+          res.data?.paymentProvider?.id !== provider?.id)
 
       if (isNotAllowedToMutate) {
-        formikBag.setFieldError('code', translate('text_632a2d437e341dcc76817556'))
+        formApi.setErrorMap({
+          onDynamic: {
+            fields: {
+              code: {
+                message: translate('text_632a2d437e341dcc76817556'),
+                path: ['code'],
+              },
+            },
+          },
+        })
         return
       }
+
+      const { apiKey, flowId, name, code } = value
 
       if (isEdition) {
         await updateApiKey({
           variables: {
             input: {
-              ...values,
-              id: moneyhashProvider?.id,
+              id: provider.id,
+              name,
+              code,
               flowId,
             },
           },
@@ -165,110 +189,148 @@ export const AddMoneyhashDialog = forwardRef<AddMoneyhashDialogRef>((_, ref) => 
         await addApiKey({
           variables: {
             input: {
-              ...values,
+              name,
+              code,
               apiKey,
               flowId,
             },
           },
         })
       }
-
-      dialogRef.current?.closeDialog()
     },
-    validateOnMount: true,
-    enableReinitialize: true,
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate(
-        isEdition ? 'text_658461066530343fe1808cd9' : 'text_1733489819311q0nzqi3u7wz',
-        {
-          name: moneyhashProvider?.name,
-        },
-      )}
-      description={translate(
-        isEdition ? 'text_17337299668343fncntgiyhf' : 'text_1733491430992msh3b2v8nlx',
-      )}
-      onClose={formikProps.resetForm}
-      actions={({ closeDialog }) => (
-        <div className="flex w-full items-center gap-3">
-          {isEdition && (
-            <Button
-              danger
-              variant="quaternary"
-              onClick={() => {
-                closeDialog()
-                openDeleteMoneyhashIntegrationDialog({
-                  provider: moneyhashProvider,
-                  callback: localData?.deleteDialogCallback,
-                })
-              }}
-            >
-              {translate('text_65845f35d7d69c3ab4793dad')}
-            </Button>
-          )}
-          <div className="ml-auto flex items-center gap-3">
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_63eba8c65a6c8043feee2a14')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!formikProps.isValid || !formikProps.dirty}
-              onClick={formikProps.submitForm}
-            >
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openAddMoneyhashDialog = (data?: OpenAddMoneyhashDialogData) => {
+    dataRef.current = data ?? null
+    const provider = data?.provider
+    const isEdition = !!provider
+
+    form.reset()
+    if (provider) {
+      form.setFieldValue('name', provider.name || '')
+      form.setFieldValue('code', provider.code || '')
+      form.setFieldValue('apiKey', provider.apiKey || '')
+      form.setFieldValue('flowId', provider.flowId || '')
+    }
+
+    formDialogOpeningDialog
+      .open({
+        title: translate(
+          isEdition ? 'text_658461066530343fe1808cd9' : 'text_1733489819311q0nzqi3u7wz',
+          {
+            name: provider?.name,
+          },
+        ),
+        description: translate(
+          isEdition ? 'text_17337299668343fncntgiyhf' : 'text_1733491430992msh3b2v8nlx',
+        ),
+        children: (
+          <div className="flex flex-col gap-6 p-8">
+            <div className="flex items-start gap-6">
+              <form.AppField name="name">
+                {(field) => (
+                  <field.TextInputField
+                    className="flex-1"
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                    autoFocus
+                    label={translate('text_6584550dc4cec7adf861504d')}
+                    placeholder={translate('text_6584550dc4cec7adf861504f')}
+                  />
+                )}
+              </form.AppField>
+              <form.AppField name="code">
+                {(field) => (
+                  <field.TextInputField
+                    className="flex-1"
+                    label={translate('text_6584550dc4cec7adf8615051')}
+                    placeholder={translate('text_6584550dc4cec7adf8615053')}
+                  />
+                )}
+              </form.AppField>
+            </div>
+            <form.AppField name="apiKey">
+              {(field) => (
+                <field.TextInputField
+                  disabled={isEdition}
+                  label={translate('text_645d071272418a14c1c76a77')}
+                  placeholder={translate('text_645d071272418a14c1c76a83')}
+                />
+              )}
+            </form.AppField>
+            <form.AppField name="flowId">
+              {(field) => (
+                <field.TextInputField
+                  label={translate('text_1737453888927uw38sepj7xy')}
+                  placeholder={translate('text_1737453902655bnm8uycr7o7')}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        closeOnError: false,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>
               {translate(
                 isEdition ? 'text_1733729938415dtehv31k9in' : 'text_1733489819311q0nzqi3u7wz',
               )}
-            </Button>
-          </div>
-        </div>
-      )}
-    >
-      <div className="mb-8 flex flex-col gap-6">
-        <div className="flex items-start gap-6">
-          <TextInputField
-            className="flex-1"
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus
-            formikProps={formikProps}
-            name="name"
-            label={translate('text_6584550dc4cec7adf861504d')}
-            placeholder={translate('text_6584550dc4cec7adf861504f')}
-          />
-          <TextInputField
-            className="flex-1"
-            formikProps={formikProps}
-            name="code"
-            label={translate('text_6584550dc4cec7adf8615051')}
-            placeholder={translate('text_6584550dc4cec7adf8615053')}
-          />
-        </div>
-        <TextInputField
-          name="apiKey"
-          disabled={isEdition}
-          label={translate('text_645d071272418a14c1c76a77')}
-          placeholder={translate('text_645d071272418a14c1c76a83')}
-          formikProps={formikProps}
-        />
-        <TextInputField
-          name="flowId"
-          label={translate('text_1737453888927uw38sepj7xy')}
-          placeholder={translate('text_1737453902655bnm8uycr7o7')}
-          formikProps={formikProps}
-        />
-      </div>
-    </Dialog>
-  )
-})
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: ADD_MONEYHASH_FORM_ID,
+          submit: handleSubmit,
+        },
+        canOpenDialog: isEdition,
+        openDialogText: translate('text_65845f35d7d69c3ab4793dad'),
+        otherDialogProps: {
+          title: translate('text_658461066530343fe1808cd7', { name: provider?.name }),
+          description: translate('text_658461066530343fe1808cc2'),
+          colorVariant: 'danger',
+          actionText: translate('text_645d071272418a14c1c76a81'),
+          onAction: async () => {
+            const res = await deleteMoneyhash({
+              variables: { input: { id: provider?.id as string } },
+            })
 
-AddMoneyhashDialog.displayName = 'AddMoneyhashDialog'
+            const destroyedId = res.data?.destroyPaymentProvider?.id
+
+            if (destroyedId) {
+              evictFromCache(client, {
+                id: destroyedId,
+                __typename: 'MoneyhashProvider',
+                listFieldName: 'paymentProviders',
+                listQueryDocument: GetMoneyhashIntegrationsListDocument,
+              })
+
+              data?.deleteDialogCallback?.()
+
+              addToast({
+                message: translate('text_1737463302046fgixue5wtvu'),
+                severity: 'success',
+              })
+            }
+          },
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close' || response.reason === 'open-other-dialog') {
+          form.reset()
+          dataRef.current = null
+        }
+      })
+  }
+
+  return { openAddMoneyhashDialog }
+}

--- a/src/components/settings/integrations/AddMoneyhashDialog.tsx
+++ b/src/components/settings/integrations/AddMoneyhashDialog.tsx
@@ -6,6 +6,7 @@ import { z } from 'zod'
 
 import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
 import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { addToast } from '~/core/apolloClient'
 import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
@@ -236,14 +237,12 @@ export const useAddMoneyhashDialog = () => {
           isEdition ? 'text_17337299668343fncntgiyhf' : 'text_1733491430992msh3b2v8nlx',
         ),
         children: (
-          <div className="flex flex-col gap-6 p-8">
+          <div className="flex flex-col gap-6 p-6">
             <div className="flex items-start gap-6">
               <form.AppField name="name">
                 {(field) => (
                   <field.TextInputField
                     className="flex-1"
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
-                    autoFocus
                     label={translate('text_6584550dc4cec7adf861504d')}
                     placeholder={translate('text_6584550dc4cec7adf861504f')}
                   />
@@ -279,6 +278,7 @@ export const useAddMoneyhashDialog = () => {
           </div>
         ),
         closeOnError: false,
+        onEntered: focusFirstInput,
         mainAction: (
           <form.AppForm>
             <form.SubmitButton>

--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -42,10 +42,7 @@ import {
   AddLagoTaxManagementDialog,
   AddLagoTaxManagementDialogRef,
 } from '~/components/settings/integrations/AddLagoTaxManagementDialog'
-import {
-  AddMoneyhashDialog,
-  AddMoneyhashDialogRef,
-} from '~/components/settings/integrations/AddMoneyhashDialog'
+import { useAddMoneyhashDialog } from '~/components/settings/integrations/AddMoneyhashDialog'
 import {
   AddNetsuiteDialog,
   AddNetsuiteDialogRef,
@@ -182,8 +179,9 @@ const Integrations = () => {
   const addSalesforceDialogRef = useRef<AddSalesforceDialogRef>(null)
   const addXeroDialogRef = useRef<AddXeroDialogRef>(null)
   const addHubspotDialogRef = useRef<AddHubspotDialogRef>(null)
-  const addMoneyhashDialogRef = useRef<AddMoneyhashDialogRef>(null)
   const addFlutterwaveDialogRef = useRef<AddFlutterwaveDialogRef>(null)
+
+  const { openAddMoneyhashDialog } = useAddMoneyhashDialog()
 
   const { data, loading } = useIntegrationsSettingQuery({
     variables: { limit: 1000 },
@@ -826,7 +824,7 @@ const Integrations = () => {
                             const element = document.activeElement as HTMLElement
 
                             element.blur && element.blur()
-                            addMoneyhashDialogRef.current?.openDialog()
+                            openAddMoneyhashDialog()
                           }
                         }}
                         fullWidth
@@ -845,7 +843,6 @@ const Integrations = () => {
       <AddAnrokDialog ref={addAnrokDialogRef} />
       <AddAdyenDialog ref={addAdyenDialogRef} />
       <AddStripeDialog ref={addStripeDialogRef} />
-      <AddMoneyhashDialog ref={addMoneyhashDialogRef} />
       <AddGocardlessDialog ref={addGocardlessDialogRef} />
       <AddLagoTaxManagementDialog ref={addLagoTaxManagementDialog} />
       <AddNetsuiteDialog ref={addNetsuiteDialogRef} />

--- a/src/pages/settings/MoneyhashIntegrationDetails.tsx
+++ b/src/pages/settings/MoneyhashIntegrationDetails.tsx
@@ -12,10 +12,7 @@ import {
   AddEditDeleteSuccessRedirectUrlDialog,
   AddEditDeleteSuccessRedirectUrlDialogRef,
 } from '~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog'
-import {
-  AddMoneyhashDialog,
-  AddMoneyhashDialogRef,
-} from '~/components/settings/integrations/AddMoneyhashDialog'
+import { useAddMoneyhashDialog } from '~/components/settings/integrations/AddMoneyhashDialog'
 import { useDeleteMoneyhashIntegrationDialog } from '~/components/settings/integrations/DeleteMoneyhashIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { INTEGRATIONS_ROUTE, MONEYHASH_INTEGRATION_ROUTE, useNavigate } from '~/core/router'
@@ -67,8 +64,8 @@ gql`
 const MoneyhashIntegrationDetails = () => {
   const navigate = useNavigate()
   const { integrationId } = useParams()
-  const addMoneyhashDialogRef = useRef<AddMoneyhashDialogRef>(null)
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
+  const { openAddMoneyhashDialog } = useAddMoneyhashDialog()
   const { openDeleteMoneyhashIntegrationDialog } = useDeleteMoneyhashIntegrationDialog()
   const { translate } = useInternationalization()
   const { hasPermissions } = usePermissions()
@@ -134,7 +131,7 @@ const MoneyhashIntegrationDetails = () => {
                   label: translate('text_65845f35d7d69c3ab4793dac'),
                   hidden: !canEditIntegration,
                   onClick: (closePopper) => {
-                    addMoneyhashDialogRef.current?.openDialog({
+                    openAddMoneyhashDialog({
                       provider: moneyhashPaymentProvider,
                       deleteDialogCallback,
                     })
@@ -167,7 +164,7 @@ const MoneyhashIntegrationDetails = () => {
               variant="inline"
               disabled={loading}
               onClick={() => {
-                addMoneyhashDialogRef.current?.openDialog({
+                openAddMoneyhashDialog({
                   provider: moneyhashPaymentProvider,
                   deleteDialogCallback,
                 })
@@ -249,7 +246,6 @@ const MoneyhashIntegrationDetails = () => {
           )}
         </>
       </section>
-      <AddMoneyhashDialog ref={addMoneyhashDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/MoneyhashIntegrations.tsx
+++ b/src/pages/settings/MoneyhashIntegrations.tsx
@@ -11,10 +11,7 @@ import {
   AddEditDeleteSuccessRedirectUrlDialog,
   AddEditDeleteSuccessRedirectUrlDialogRef,
 } from '~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog'
-import {
-  AddMoneyhashDialog,
-  AddMoneyhashDialogRef,
-} from '~/components/settings/integrations/AddMoneyhashDialog'
+import { useAddMoneyhashDialog } from '~/components/settings/integrations/AddMoneyhashDialog'
 import { useDeleteMoneyhashIntegrationDialog } from '~/components/settings/integrations/DeleteMoneyhashIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { INTEGRATIONS_ROUTE, MONEYHASH_INTEGRATION_DETAILS_ROUTE, useNavigate } from '~/core/router'
@@ -57,8 +54,8 @@ gql`
 const MoneyhashIntegrations = () => {
   const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
-  const addMoneyhashDialogRef = useRef<AddMoneyhashDialogRef>(null)
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
+  const { openAddMoneyhashDialog } = useAddMoneyhashDialog()
   const { openDeleteMoneyhashIntegrationDialog } = useDeleteMoneyhashIntegrationDialog()
   const { translate } = useInternationalization()
   const { data, loading } = useGetMoneyhashIntegrationsListQuery({
@@ -105,7 +102,7 @@ const MoneyhashIntegrations = () => {
               variant: 'primary',
               hidden: !canCreateIntegration,
               onClick: () => {
-                addMoneyhashDialogRef.current?.openDialog()
+                openAddMoneyhashDialog()
               },
             },
           ],
@@ -159,7 +156,7 @@ const MoneyhashIntegrations = () => {
                               variant="quaternary"
                               align="left"
                               onClick={() => {
-                                addMoneyhashDialogRef.current?.openDialog({
+                                openAddMoneyhashDialog({
                                   provider: connection,
                                   deleteDialogCallback,
                                 })
@@ -195,7 +192,6 @@ const MoneyhashIntegrations = () => {
             })}
         </section>
       </IntegrationsPage.Container>
-      <AddMoneyhashDialog ref={addMoneyhashDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/__tests__/Integrations.test.tsx
+++ b/src/pages/settings/__tests__/Integrations.test.tsx
@@ -56,7 +56,9 @@ jest.mock('~/components/settings/integrations/AddCashfreeDialog', () => ({
   }),
 }))
 jest.mock('~/components/settings/integrations/AddMoneyhashDialog', () => ({
-  AddMoneyhashDialog: () => null,
+  useAddMoneyhashDialog: () => ({
+    openAddMoneyhashDialog: jest.fn(),
+  }),
 }))
 jest.mock('~/components/settings/integrations/AddLagoTaxManagementDialog', () => ({
   AddLagoTaxManagementDialog: () => null,

--- a/src/pages/settings/__tests__/MoneyhashIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/MoneyhashIntegrations.test.tsx
@@ -11,7 +11,9 @@ import {
 import MoneyhashIntegrations from '../MoneyhashIntegrations'
 
 jest.mock('~/components/settings/integrations/AddMoneyhashDialog', () => ({
-  AddMoneyhashDialog: () => null,
+  useAddMoneyhashDialog: () => ({
+    openAddMoneyhashDialog: jest.fn(),
+  }),
 }))
 jest.mock('~/components/settings/integrations/DeleteMoneyhashIntegrationDialog', () => ({
   useDeleteMoneyhashIntegrationDialog: () => ({


### PR DESCRIPTION
## Context

`AddMoneyhashDialog` was still on the legacy `forwardRef` + imperative `openDialog()` pattern with a Formik form. This blocked the migration to the new hook-based NiceModal dialog system and left the delete-from-within-edit flow going through a separate `openDeleteMoneyhashIntegrationDialog` call chained via `closeDialog()`.

Model: `AddOktaDialog` (FormDialogOpeningDialog + TanStack Form + inlined delete inside edit) and `DeleteAdyenIntegrationDialog` (`evictFromCache` cache handling).

## Description

- Rewrote `src/components/settings/integrations/AddMoneyhashDialog.tsx` as a `useAddMoneyhashDialog` hook backed by `useFormDialogOpeningDialog`.
- Form migrated from Formik + Yup to `useAppForm` with a Zod schema and `revalidateLogic()`.
- Preserved the `getProviderByCodeForMoneyhash` duplicate-code check with `silentErrorCodes: [LagoApiError.NotFound]`; the `setFieldError('code', …)` is now `formApi.setErrorMap({ onDynamic: { fields: { code: { message, path: ['code'] } } } })`.
- Delete-inside-edit is now the FormDialogOpeningDialog `otherDialogProps.onAction`: inlined `useDeleteMoneyhashIntegrationMutation` + `evictFromCache(client, { __typename: 'MoneyhashProvider', listFieldName: 'paymentProviders', listQueryDocument: GetMoneyhashIntegrationsListDocument })` + `deleteDialogCallback` + success toast — no more `refetchQueries`/bare `cache.evict`.
- `DeleteMoneyhashIntegrationDialog` remains (still used for the standalone delete menu items in `MoneyhashIntegrations` and `MoneyhashIntegrationDetails`, and its fragment feeds the list/details queries).
- Updated callers `MoneyhashIntegrations.tsx`, `MoneyhashIntegrationDetails.tsx`, and the Moneyhash bits of `Integrations.tsx` to drop `useRef<AddMoneyhashDialogRef>` + JSX `<AddMoneyhashDialog ref={…} />` in favor of `const { openAddMoneyhashDialog } = useAddMoneyhashDialog()`.
- Updated the jest mocks in `MoneyhashIntegrations.test.tsx` and `Integrations.test.tsx` to mock the new `useAddMoneyhashDialog` hook.

## How to test

- Settings → Integrations → Community → MoneyHash card: without a connection, the primary action opens the create dialog; with one, the card navigates to the detail page.
- `MoneyhashIntegrations` list: use the row menu to Edit — the FormDialogOpeningDialog opens with prefilled fields, submit updates the provider (toast + close). The Delete button inside the edit dialog opens the confirmation and deletes, evicting from cache — the list page updates without a stale-cache toast.
- Row menu Delete (standalone) still goes through the existing `useDeleteMoneyhashIntegrationDialog`.
- `MoneyhashIntegrationDetails`: header dropdown Edit → same flow as above; header dropdown Delete → standalone confirmation.
- Create flow (Settings → Integrations → MoneyHash → New): submit navigates to the details page and toasts.
- Duplicate code check: try to save with an existing code — the `code` field shows the duplicate error and the dialog stays open.

### Verification

- `pnpm eslint --cache --cache-location .eslintcache src/components/settings/integrations/AddMoneyhashDialog.tsx src/pages/settings/MoneyhashIntegrations.tsx src/pages/settings/MoneyhashIntegrationDetails.tsx src/pages/settings/Integrations.tsx` — 0 errors, no `no-restricted-imports` warnings from any Moneyhash-related import (only pre-existing warnings for other legacy dialogs in `Integrations.tsx`).
- `pnpm tsc --noEmit` — passes.
- `pnpm jest src/pages/settings/__tests__/MoneyhashIntegrations.test.tsx` — 2/2 tests pass.
- `pnpm jest src/pages/settings/__tests__/Integrations.test.tsx` — 17/17 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_013RCuZTd4PpvbkQZjFix8pP)_