### PR TITLE
refactor(customers): migrate EditCustomerDunningCampaignDialog to FormDialog and TanStack Form

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -8,10 +8,7 @@ import { useDeleteCustomerGracePeriodeDialog } from '~/components/customers/Dele
 import { useDeleteCustomerNetPaymentTermDialog } from '~/components/customers/DeleteCustomerNetPaymentTermDialog'
 import { useDeleteCustomerVatRateDialog } from '~/components/customers/DeleteCustomerVatRateDialog'
 import { useEditCustomerDocumentLocaleDialog } from '~/components/customers/EditCustomerDocumentLocaleDialog'
-import {
-  EditCustomerDunningCampaignDialog,
-  EditCustomerDunningCampaignDialogRef,
-} from '~/components/customers/EditCustomerDunningCampaignDialog'
+import { useEditCustomerDunningCampaignDialog } from '~/components/customers/EditCustomerDunningCampaignDialog'
 import {
   EditCustomerInvoiceCustomSectionsDialog,
   EditCustomerInvoiceCustomSectionsDialogRef,
@@ -205,7 +202,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
   const editInvoiceGracePeriodDialogRef = useRef<EditCustomerInvoiceGracePeriodDialogRef>(null)
   const { openDeleteCustomerGracePeriodeDialog } = useDeleteCustomerGracePeriodeDialog()
   const { openEditCustomerDocumentLocaleDialog } = useEditCustomerDocumentLocaleDialog()
-  const editCustomerDunningCampaignDialogRef = useRef<EditCustomerDunningCampaignDialogRef>(null)
+  const { openEditCustomerDunningCampaignDialog } = useEditCustomerDunningCampaignDialog()
   const editCustomerInvoiceCustomSectionsDialogRef =
     useRef<EditCustomerInvoiceCustomSectionsDialogRef>(null)
   const { openDeleteCustomerDocumentLocaleDialog } = useDeleteCustomerDocumentLocaleDialog()
@@ -495,7 +492,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                       <Button
                         disabled={loading}
                         variant="inline"
-                        onClick={() => editCustomerDunningCampaignDialogRef?.current?.openDialog()}
+                        onClick={() => customer && openEditCustomerDunningCampaignDialog(customer)}
                       >
                         {translate('text_63e51ef4985f0ebd75c212fc')}
                       </Button>
@@ -946,11 +943,6 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
             ref={editInvoiceGracePeriodDialogRef}
             invoiceGracePeriod={customer?.invoiceGracePeriod}
           />
-          <EditCustomerDunningCampaignDialog
-            ref={editCustomerDunningCampaignDialogRef}
-            customer={customer}
-          />
-
           <EditCustomerIssuingDatePolicyDialog
             ref={editIssuingDatePolicyDialogRef}
             customer={customer}

--- a/src/components/customers/EditCustomerDunningCampaignDialog.tsx
+++ b/src/components/customers/EditCustomerDunningCampaignDialog.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod'
 
 import { useFormDialog } from '~/components/dialogs/FormDialog'
 import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { addToast } from '~/core/apolloClient'
 import {
   EditCustomerDunningCampaignFragment,
@@ -108,7 +109,7 @@ const DialogContent = withForm({
     const behavior = useStore(form.store, (state) => state.values.behavior)
 
     return (
-      <div className="mb-8 not-last-child:mb-4">
+      <div className="p-6 not-last-child:mb-4">
         <form.AppField name="behavior">
           {(field) => (
             <field.RadioField
@@ -243,6 +244,7 @@ export const useEditCustomerDunningCampaignDialog = () => {
         description: translate('text_1729543665907gw6pj8jsj3z'),
         children: <DialogContent customer={customer} form={form} />,
         closeOnError: false,
+        onEntered: focusFirstInput,
         mainAction: (
           <form.AppForm>
             <form.SubmitButton>{translate('text_17295436903260tlyb1gp1i7')}</form.SubmitButton>

--- a/src/components/customers/EditCustomerDunningCampaignDialog.tsx
+++ b/src/components/customers/EditCustomerDunningCampaignDialog.tsx
@@ -1,11 +1,10 @@
 import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
-import { forwardRef } from 'react'
-import { mixed, object, string } from 'yup'
+import { revalidateLogic, useStore } from '@tanstack/react-form'
+import { useEffect, useRef } from 'react'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { ComboBoxField, RadioField } from '~/components/form'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
 import { addToast } from '~/core/apolloClient'
 import {
   EditCustomerDunningCampaignFragment,
@@ -14,6 +13,7 @@ import {
   useGetApplicableDunningCampaignsLazyQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm, withForm } from '~/hooks/forms/useAppform'
 
 gql`
   fragment EditCustomerDunningCampaign on Customer {
@@ -59,26 +59,119 @@ export const getInitialBehavior = (customer: EditCustomerDunningCampaignFragment
   return BehaviorType.FALLBACK
 }
 
-export type EditCustomerDunningCampaignDialogRef = DialogRef
+const EDIT_CUSTOMER_DUNNING_CAMPAIGN_FORM_ID = 'edit-customer-dunning-campaign-form'
 
-interface EditCustomerDunningCampaignDialogProps {
-  customer: EditCustomerDunningCampaignFragment
+const validationSchema = z
+  .object({
+    behavior: z.enum(BehaviorType),
+    appliedDunningCampaignId: z.string(),
+  })
+  .refine(
+    (data) =>
+      data.behavior !== BehaviorType.NEW_CAMPAIGN || data.appliedDunningCampaignId.length > 0,
+    { path: ['appliedDunningCampaignId'], message: '' },
+  )
+
+type FormValues = {
+  behavior: BehaviorType
+  appliedDunningCampaignId: string
 }
 
-export const EditCustomerDunningCampaignDialog = forwardRef<
-  DialogRef,
-  EditCustomerDunningCampaignDialogProps
->(({ customer }: EditCustomerDunningCampaignDialogProps, ref) => {
+const initialValues: FormValues = {
+  behavior: BehaviorType.FALLBACK,
+  appliedDunningCampaignId: '',
+}
+
+type DialogContentProps = {
+  customer: EditCustomerDunningCampaignFragment | null
+}
+
+const defaultDialogContentProps: DialogContentProps = {
+  customer: null,
+}
+
+const DialogContent = withForm({
+  defaultValues: initialValues,
+  props: defaultDialogContentProps,
+  render: function Render({ form, customer }) {
+    const { translate } = useInternationalization()
+    const [getDunningCampaigns, { data, loading }] = useGetApplicableDunningCampaignsLazyQuery({
+      variables: {
+        currency: customer?.currency,
+      },
+    })
+
+    useEffect(() => {
+      getDunningCampaigns()
+    }, [getDunningCampaigns])
+
+    const behavior = useStore(form.store, (state) => state.values.behavior)
+
+    return (
+      <div className="mb-8 not-last-child:mb-4">
+        <form.AppField name="behavior">
+          {(field) => (
+            <field.RadioField
+              value={BehaviorType.FALLBACK}
+              label={translate('text_1729543665907g5bbnbl8yvr')}
+              labelVariant="body"
+            />
+          )}
+        </form.AppField>
+        <form.AppField name="behavior">
+          {(field) => (
+            <field.RadioField
+              value={BehaviorType.NEW_CAMPAIGN}
+              label={translate('text_17295436659071kau9ol0axk')}
+              labelVariant="body"
+            />
+          )}
+        </form.AppField>
+        {behavior === BehaviorType.NEW_CAMPAIGN && (
+          <form.AppField name="appliedDunningCampaignId">
+            {(field) => (
+              <field.ComboBoxField
+                loading={loading}
+                data={
+                  data?.dunningCampaigns.collection.map((campaign) => ({
+                    label: campaign.name,
+                    description: campaign.code,
+                    value: campaign.id,
+                  })) ?? []
+                }
+                placeholder={translate('text_1729543690326d4dmmcw7n89')}
+                PopperProps={{ displayInDialog: true }}
+                emptyText={translate('text_1731078338811aok1u8oopxl')}
+              />
+            )}
+          </form.AppField>
+        )}
+        <form.AppField name="behavior">
+          {(field) => (
+            <field.RadioField
+              value={BehaviorType.DEACTIVATE}
+              label={translate('text_1729543690326ndlmz7bdmy1')}
+              sublabel={translate('text_17295436903267b0kiid8h8r')}
+              labelVariant="body"
+            />
+          )}
+        </form.AppField>
+      </div>
+    )
+  },
+})
+
+export const useEditCustomerDunningCampaignDialog = () => {
+  const formDialog = useFormDialog()
   const { translate } = useInternationalization()
-  const [getDunningCampaigns, { data, loading }] = useGetApplicableDunningCampaignsLazyQuery({
-    variables: {
-      currency: customer.currency,
-    },
-  })
+  const customerRef = useRef<EditCustomerDunningCampaignFragment | null>(null)
+  const successRef = useRef(false)
 
   const [editCustomerDunningCampaignBehavior] = useEditCustomerDunningCampaignMutation({
     refetchQueries: ['getCustomerSettings'],
-    onCompleted: () => {
+    onCompleted: (res) => {
+      if (!res.updateCustomer) return
+      successRef.current = true
       addToast({
         severity: 'success',
         message: translate('text_17295437652543pf2j5lqe67'),
@@ -86,28 +179,21 @@ export const EditCustomerDunningCampaignDialog = forwardRef<
     },
   })
 
-  const formikProps = useFormik<{
-    behavior: BehaviorType | ''
-    appliedDunningCampaignId: string
-  }>({
-    initialValues: {
-      behavior: getInitialBehavior(customer),
-      appliedDunningCampaignId: customer.appliedDunningCampaign?.id ?? '',
-    },
-    validationSchema: object().shape({
-      behavior: mixed().oneOf(Object.values(BehaviorType)).required(''),
-      appliedDunningCampaignId: string().when('behavior', {
-        is: (val: BehaviorType) => val === BehaviorType.NEW_CAMPAIGN,
-        then: (schema) => schema.required(''),
-      }),
-    }),
-    onSubmit: async (values) => {
+  const form = useAppForm({
+    defaultValues: initialValues,
+    validationLogic: revalidateLogic(),
+    validators: { onDynamic: validationSchema },
+    onSubmit: async ({ value }) => {
+      const customer = customerRef.current
+
+      if (!customer) return
+
       let formattedValues: UpdateCustomerInput = {
         id: customer.id,
         externalId: customer.externalId,
       }
 
-      switch (values.behavior) {
+      switch (value.behavior) {
         case BehaviorType.FALLBACK:
           formattedValues = {
             ...formattedValues,
@@ -118,7 +204,7 @@ export const EditCustomerDunningCampaignDialog = forwardRef<
         case BehaviorType.NEW_CAMPAIGN:
           formattedValues = {
             ...formattedValues,
-            appliedDunningCampaignId: values.appliedDunningCampaignId,
+            appliedDunningCampaignId: value.appliedDunningCampaignId,
           }
           break
         case BehaviorType.DEACTIVATE:
@@ -131,80 +217,49 @@ export const EditCustomerDunningCampaignDialog = forwardRef<
 
       await editCustomerDunningCampaignBehavior({ variables: { input: formattedValues } })
     },
-    validateOnMount: true,
-    enableReinitialize: true,
   })
 
-  return (
-    <Dialog
-      ref={ref}
-      onOpen={async () => {
-        await getDunningCampaigns()
-      }}
-      title={translate('text_1729543665906svxp253ug1g')}
-      description={translate('text_1729543665907gw6pj8jsj3z')}
-      actions={({ closeDialog }) => (
-        <>
-          <Button variant="quaternary" onClick={closeDialog}>
-            {translate('text_63ea0f84f400488553caa6a5')}
-          </Button>
-          <Button
-            variant="primary"
-            disabled={!formikProps.isValid || !formikProps.dirty}
-            onClick={async () => {
-              await formikProps.submitForm()
-              closeDialog()
-            }}
-          >
-            {translate('text_17295436903260tlyb1gp1i7')}
-          </Button>
-        </>
-      )}
-    >
-      <div className="mb-8 not-last-child:mb-4">
-        <RadioField
-          name="behavior"
-          formikProps={formikProps}
-          value={BehaviorType.FALLBACK}
-          label={translate('text_1729543665907g5bbnbl8yvr')}
-          labelVariant="body"
-        />
-        <RadioField
-          name="behavior"
-          formikProps={formikProps}
-          value={BehaviorType.NEW_CAMPAIGN}
-          label={translate('text_17295436659071kau9ol0axk')}
-          labelVariant="body"
-        />
-        {formikProps.values.behavior === 'newCampaign' && (
-          <ComboBoxField
-            name="appliedDunningCampaignId"
-            formikProps={formikProps}
-            loading={loading}
-            data={
-              data?.dunningCampaigns.collection.map((campaign) => ({
-                label: campaign.name,
-                description: campaign.code,
-                value: campaign.id,
-              })) ?? []
-            }
-            isEmptyNull={false}
-            placeholder={translate('text_1729543690326d4dmmcw7n89')}
-            PopperProps={{ displayInDialog: true }}
-            emptyText={translate('text_1731078338811aok1u8oopxl')}
-          />
-        )}
-        <RadioField
-          name="behavior"
-          formikProps={formikProps}
-          value={BehaviorType.DEACTIVATE}
-          label={translate('text_1729543690326ndlmz7bdmy1')}
-          sublabel={translate('text_17295436903267b0kiid8h8r')}
-          labelVariant="body"
-        />
-      </div>
-    </Dialog>
-  )
-})
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-EditCustomerDunningCampaignDialog.displayName = 'EditCustomerDunningCampaignDialog'
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openEditCustomerDunningCampaignDialog = (customer: EditCustomerDunningCampaignFragment) => {
+    customerRef.current = customer
+
+    form.reset()
+    form.setFieldValue('behavior', getInitialBehavior(customer))
+    form.setFieldValue('appliedDunningCampaignId', customer.appliedDunningCampaign?.id ?? '')
+
+    formDialog
+      .open({
+        title: translate('text_1729543665906svxp253ug1g'),
+        description: translate('text_1729543665907gw6pj8jsj3z'),
+        children: <DialogContent customer={customer} form={form} />,
+        closeOnError: false,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>{translate('text_17295436903260tlyb1gp1i7')}</form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: EDIT_CUSTOMER_DUNNING_CAMPAIGN_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close') {
+          form.reset()
+          customerRef.current = null
+        }
+      })
+  }
+
+  return { openEditCustomerDunningCampaignDialog }
+}

--- a/src/components/customers/__tests__/CustomerSettings.test.tsx
+++ b/src/components/customers/__tests__/CustomerSettings.test.tsx
@@ -80,13 +80,11 @@ jest.mock('~/components/customers/DeleteCustomerVatRateDialog', () => ({
   }),
 }))
 
-jest.mock('~/components/customers/EditCustomerDunningCampaignDialog', () => {
-  const React = jest.requireActual('react')
-  const MockDialog = React.forwardRef(() => null)
-
-  MockDialog.displayName = 'EditCustomerDunningCampaignDialog'
-  return { EditCustomerDunningCampaignDialog: MockDialog }
-})
+jest.mock('~/components/customers/EditCustomerDunningCampaignDialog', () => ({
+  useEditCustomerDunningCampaignDialog: () => ({
+    openEditCustomerDunningCampaignDialog: jest.fn(),
+  }),
+}))
 
 jest.mock('~/components/customers/EditCustomerInvoiceCustomSectionsDialog', () => {
   const React = jest.requireActual('react')


### PR DESCRIPTION
## Context

The legacy imperative ref-based dialog system (`forwardRef` + `useImperativeHandle` + `Dialog` from the design system) is being retired in favor of the hook-based NiceModal system. In parallel, forms are being migrated from Formik + Yup to TanStack Form + Zod (via `useAppForm`).

`EditCustomerDunningCampaignDialog` was still using both legacy patterns: Formik/Yup for the form and a `forwardRef` ref API for open/close control.

## Description

- Rewrote `EditCustomerDunningCampaignDialog.tsx` as a `useEditCustomerDunningCampaignDialog()` hook backed by `useFormDialog()`.
- Migrated the Formik + Yup form to TanStack Form (`useAppForm`) + Zod (`z.enum(BehaviorType)` and a `.refine()` covering the conditional `appliedDunningCampaignId` requirement for `NEW_CAMPAIGN`).
- The form body was extracted into a `withForm(...)` sub-component so it can read the reactive `behavior` value via `useStore` and lazily fetch `dunningCampaigns` for the selected currency.
- The customer is passed through the hook's `open` function and stored via `useRef` for the submit closure; the form is reset + prefilled before opening, and cleaned up in the close handler.
- Preserved the existing `refetchQueries: ['getCustomerSettings']` behavior and success toast (`onCompleted` -> `successRef` -> `handleSubmit` throws on failure so the dialog stays open with `closeOnError: false`).
- Kept `getInitialBehavior` and `BehaviorType` exported unchanged so `EditCustomerDunningCampaignDialog.test.ts` continues to pass without changes.
- Updated `CustomerSettings.tsx` to use the new hook (removed the ref import and the JSX render of the dialog).
- Updated `CustomerSettings.test.tsx` mock to expose `useEditCustomerDunningCampaignDialog` returning a stub `openEditCustomerDunningCampaignDialog`.

## How to test

- Open a customer's Settings tab.
- With Auto Dunning premium integration enabled, click the dunning-campaign action button.
- Verify the dialog opens with the correct initial behavior radio selected based on the customer's current setting (fallback / new campaign / deactivated).
- Select `New campaign` and pick a campaign in the ComboBox; confirm the submit button becomes enabled and posts the mutation with `appliedDunningCampaignId` set.
- Select `Fallback`; confirm submit clears both `appliedDunningCampaignId` and `excludeFromDunningCampaign`.
- Select `Deactivate`; confirm submit sets `excludeFromDunningCampaign: true`.
- Confirm the customer-settings list refetches and the success toast appears.
- Close/reopen the dialog and verify the form is reset to the current customer state.
- `pnpm tsc --noEmit` passes.
- `pnpm test src/components/customers/__tests__/EditCustomerDunningCampaignDialog.test.ts src/components/customers/__tests__/CustomerSettings.test.tsx` — both suites green (5/5 and 33/33).

---
_Generated by [Claude Code](https://claude.ai/code/session_013RCuZTd4PpvbkQZjFix8pP)_