### PR TITLE
fix(features): redirect to detail page after feature creation

### DIFF
--- a/src/pages/features/FeatureForm.tsx
+++ b/src/pages/features/FeatureForm.tsx
@@ -217,7 +217,12 @@ const FeatureForm = () => {
           translateKey: 'text_1752692673069avy1qgb1ut9',
         })
 
-        onLeave()
+        navigate(
+          generatePath(FEATURE_DETAILS_ROUTE, {
+            featureId: createdFeature.id,
+            tab: FeatureDetailsTabsOptionsEnum.overview,
+          }),
+        )
       }
     },
   })


### PR DESCRIPTION
## Context

Creating a feature redirected back to the features **list** instead of the new resource's detail page. Now the create success handler navigates straight to the new feature's detail page

## Description

This PR get the id of a feature after creation and use it to redirect on the feature details page

Fixes [LAGO-1678](https://linear.app/getlago/issue/LAGO-1678).


🤖 Generated with [Claude Code](https://claude.com/claude-code)