### PR TITLE
chore(renovate): auto-merge minor for trusted groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -59,6 +59,22 @@
       "commitMessagePrefix": "chore(deps):"
     },
     {
+      "matchPackageNames": ["@sentry/*"],
+      "groupName": "Sentry",
+      "commitMessagePrefix": "chore(deps):"
+    },
+    {
+      "matchPackageNames": [
+        "typescript",
+        "typescript-eslint",
+        "prettier",
+        "prettier-plugin-*",
+        "@trivago/prettier-plugin-*"
+      ],
+      "groupName": "TypeScript tooling",
+      "commitMessagePrefix": "chore(deps):"
+    },
+    {
       "matchUpdateTypes": ["major"],
       "commitMessagePrefix": "chore(deps-major)"
     },
@@ -69,6 +85,29 @@
     {
       "matchUpdateTypes": ["patch", "digest", "bump"],
       "commitMessagePrefix": "chore(deps)",
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "description": "Auto-merge minor updates for trusted dev/build/test tooling and Sentry (major still manual). Apollo excluded: runtime data layer.",
+      "matchUpdateTypes": ["minor"],
+      "matchPackageNames": [
+        "@sentry/*",
+        "eslint",
+        "eslint-plugin-*",
+        "@eslint/*",
+        "@babel/*",
+        "@types/react",
+        "@types/react-dom",
+        "@types/react-router-dom",
+        "@testing-library/*",
+        "cypress",
+        "typescript",
+        "typescript-eslint",
+        "prettier",
+        "prettier-plugin-*",
+        "@trivago/prettier-plugin-*"
+      ],
       "automerge": true,
       "automergeType": "branch"
     }


### PR DESCRIPTION
Enable auto-merge of **minor** updates for trusted dev/build/test tooling groups. Major stays manual everywhere; patch already auto-merges globally.

### Changes
- New **Sentry** group (`@sentry/*`)
- New **TypeScript tooling** group (`typescript`, `typescript-eslint`, `prettier`, prettier plugins) - were ungrouped before
- New consolidated rule auto-merging **minor** updates for: Sentry, ESLint, Babel, React types, Testing library, TypeScript tooling

### Behavior
| Update | Trusted groups | Apollo + rest |
|---|---|---|
| patch | auto-merge (unchanged) | auto-merge (unchanged) |
| minor | **auto-merge (new)** | manual |
| major | manual | manual |

Apollo excluded - runtime data layer, minors have shipped regressions. `minimumReleaseAge: 7 days` still applies before any auto-merge.