### PR TITLE
refactor(dunnings): migrate DefaultCampaignDialog to useCentralizedDialog

### DIFF
--- a/src/components/settings/dunnings/DefaultCampaignDialog.tsx
+++ b/src/components/settings/dunnings/DefaultCampaignDialog.tsx
@@ -1,75 +1,33 @@
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
-
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 type ActionType = 'setDefault' | 'removeDefault'
 
-type TDefaultCampaignDialogProps = {
+type OpenDefaultCampaignDialogProps = {
   type: ActionType
   onConfirm: () => void
 }
 
-export interface DefaultCampaignDialogRef {
-  openDialog: (props: TDefaultCampaignDialogProps) => unknown
-  closeDialog: () => unknown
+export const useDefaultCampaignDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
+
+  const openDefaultCampaignDialog = ({ type, onConfirm }: OpenDefaultCampaignDialogProps) => {
+    centralizedDialog.open({
+      title: translate(
+        type === 'setDefault' ? 'text_1728574726495xzb3xvrlprn' : 'text_1728575305796wa2yf2sn2ct',
+      ),
+      description: translate(
+        type === 'setDefault' ? 'text_17285753057960sioe6ltl0p' : 'text_1728575305796optuxlg8q3p',
+      ),
+      actionText: translate(
+        type === 'setDefault' ? 'text_1728574726495n9jdse2hnrf' : 'text_1728575305796o7kwackkbj6',
+      ),
+      onAction: async () => {
+        await onConfirm()
+      },
+    })
+  }
+
+  return { openDefaultCampaignDialog }
 }
-
-export const DefaultCampaignDialog = forwardRef<DefaultCampaignDialogRef, unknown>(
-  (_props, ref) => {
-    const { translate } = useInternationalization()
-    const dialogRef = useRef<DialogRef>(null)
-    const [localData, setLocalData] = useState<TDefaultCampaignDialogProps>()
-
-    useImperativeHandle(ref, () => ({
-      openDialog: (props) => {
-        setLocalData(props)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => {
-        setLocalData(undefined)
-        dialogRef.current?.closeDialog()
-      },
-    }))
-
-    return (
-      <Dialog
-        ref={dialogRef}
-        title={
-          localData?.type === 'setDefault'
-            ? translate('text_1728574726495xzb3xvrlprn')
-            : translate('text_1728575305796wa2yf2sn2ct')
-        }
-        description={translate(
-          localData?.type === 'setDefault'
-            ? 'text_17285753057960sioe6ltl0p'
-            : 'text_1728575305796optuxlg8q3p',
-        )}
-        actions={({ closeDialog }) => (
-          <>
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_62728ff857d47b013204c7e4')}
-            </Button>
-
-            <Button
-              variant="primary"
-              onClick={async () => {
-                await localData?.onConfirm()
-                closeDialog()
-              }}
-              data-test="set-organization-dunning-default-campaign"
-            >
-              {localData?.type === 'setDefault'
-                ? translate('text_1728574726495n9jdse2hnrf')
-                : translate('text_1728575305796o7kwackkbj6')}
-            </Button>
-          </>
-        )}
-        data-test="set-campaign-default-dialog"
-      />
-    )
-  },
-)
-
-DefaultCampaignDialog.displayName = 'DefaultCampaignDialog'

--- a/src/pages/settings/Dunnings/CreateDunning.tsx
+++ b/src/pages/settings/Dunnings/CreateDunning.tsx
@@ -10,10 +10,7 @@ import { Typography } from '~/components/designSystem/Typography'
 import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { AmountInputField, ComboBoxField, TextInput, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
-import {
-  DefaultCampaignDialog,
-  DefaultCampaignDialogRef,
-} from '~/components/settings/dunnings/DefaultCampaignDialog'
+import { useDefaultCampaignDialog } from '~/components/settings/dunnings/DefaultCampaignDialog'
 import {
   PreviewCampaignEmailDrawer,
   PreviewCampaignEmailDrawerRef,
@@ -45,7 +42,7 @@ const CreateDunning = () => {
   const { translate } = useInternationalization()
   const navigate = useNavigate()
 
-  const defaultCampaignDialogRef = useRef<DefaultCampaignDialogRef>(null)
+  const { openDefaultCampaignDialog } = useDefaultCampaignDialog()
   const centralizedDialog = useCentralizedDialog()
   const previewCampaignEmailDrawerRef = useRef<PreviewCampaignEmailDrawerRef>(null)
 
@@ -140,7 +137,7 @@ const CreateDunning = () => {
         formikProps.values.appliedToOrganization &&
       formikProps.values.appliedToOrganization === true
     ) {
-      defaultCampaignDialogRef.current?.openDialog({
+      openDefaultCampaignDialog({
         type: 'setDefault',
         onConfirm: () => formikProps.submitForm(),
       })
@@ -434,7 +431,6 @@ const CreateDunning = () => {
         </CenteredPage.StickyFooter>
       </CenteredPage.Wrapper>
 
-      <DefaultCampaignDialog ref={defaultCampaignDialogRef} />
       <PreviewCampaignEmailDrawer ref={previewCampaignEmailDrawerRef} />
     </>
   )

--- a/translations/base.json
+++ b/translations/base.json
@@ -697,7 +697,6 @@
   "text_6227a2e847fcd700e9038952": "API key successfully copied to clipboard",
   "text_62ce85fb3fb6842020331d83": "Find all <a rel=\"external\" target=\"_blank\" href=\"https://docs.getlago.com/api-reference/webhooks/messages\">the events</a> this webhook is listening",
   "text_62728ff857d47b013204c726": "Settings",
-  "text_62728ff857d47b013204c7e4": "Cancel",
   "text_64d23a81a7d807f8aa570509": "Edit this webhook endpoint",
   "text_64d23a81a7d807f8aa57050b": "Edit this webhook endpoint to receive live event from Lago.",
   "text_64d23a81a7d807f8aa570513": "Webhook signature",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -715,7 +715,6 @@
   "text_6227a2e847fcd700e9038952": "Chave de API copiada para a área de transferência com sucesso",
   "text_62ce85fb3fb6842020331d83": "Encontre todos <a rel=\"external\" target=\"_blank\" href=\"https://docs.getlago.com/api-reference/webhooks/messages\">os eventos</a> que este webhook está escutando",
   "text_62728ff857d47b013204c726": "Configurações",
-  "text_62728ff857d47b013204c7e4": "Cancelar",
   "text_627387d5053a1000c5287cab": "Cancelar",
   "text_64d23a81a7d807f8aa570509": "Editar este endpoint de webhook",
   "text_64d23a81a7d807f8aa57050b": "Edite este endpoint de webhook para receber eventos ao vivo do Lago.",


### PR DESCRIPTION
## Context

`DefaultCampaignDialog` was one of the last legacy `forwardRef` + `useImperativeHandle` + `Dialog` (`~/components/designSystem/Dialog`) consumers flagged by the `no-restricted-imports` ESLint rule. It is a pure confirmation dialog (set/remove default dunning campaign) with no form fields, so `useCentralizedDialog` is the right primitive.

## Description

- **`src/components/settings/dunnings/DefaultCampaignDialog.tsx`**
  - Replaced the `forwardRef` + `useImperativeHandle` + `useState(localData)` + `Dialog` boilerplate with a thin `useDefaultCampaignDialog` hook backed by `useCentralizedDialog`.
  - The `type` (`'setDefault' | 'removeDefault'`) and `onConfirm` callback are captured directly via the open-function parameter — no more `useState` plumbing.
  - The dialog now uses the built-in cancel / continue actions provided by `CentralizedDialog`, driving the title / description / action-text translations from `type`.

- **`src/pages/settings/Dunnings/CreateDunning.tsx`**
  - Dropped the `defaultCampaignDialogRef` `useRef` and the `<DefaultCampaignDialog ref={…} />` JSX render — the dialog is rendered globally via `NiceModal` now.
  - `openDefaultCampaignDialog({ type: 'setDefault', onConfirm: … })` is called directly from `onSubmit`.

- **`translations/base.json` / `translations/pt-BR.json`**
  - Removed the now-unused legacy "Cancel" key (`text_62728ff857d47b013204c7e4`). `CentralizedDialog` provides its own close/cancel translation, so the standalone key is orphaned after the migration and would fail `pnpm translations:inspect`.

## Scope

Scoped strictly to the single `no-restricted-imports` warning in this file. No form/Formik changes are involved (the dialog has no form fields).

## Test plan

- [ ] *Settings → Dunnings → Create/Edit a campaign*: toggle "apply as default" on save → confirmation dialog opens with the "set default" copy and the primary action submits the form.
- [ ] Cancel / close the dialog → no submit happens.
- [ ] `pnpm exec tsc --noEmit` and `pnpm exec eslint` on the touched files pass with no errors (verified locally).
- [ ] `pnpm translations:inspect` passes (verified locally).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJ5hA8QhGZTMgyKUiyi2nq)_