### PR TITLE
fix(combobox): add-value uses onClick not router Link

### DIFF
--- a/src/components/customers/EditCustomerVatRateDialog.tsx
+++ b/src/components/customers/EditCustomerVatRateDialog.tsx
@@ -10,7 +10,7 @@ import {
   SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME,
 } from '~/core/constants/form'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
-import { CREATE_TAX_ROUTE } from '~/core/router'
+import { CREATE_TAX_ROUTE, useNavigate } from '~/core/router'
 import {
   CustomerAppliedTaxRatesForSettingsFragmentDoc,
   EditCustomerVatRateFragment,
@@ -66,11 +66,13 @@ export const EDIT_CUSTOMER_VAT_RATE_FORM_ID = 'edit-customer-vat-rate-form'
 interface EditCustomerVatRateContentProps {
   appliedTaxRatesTaxesIds?: string[]
   onSelect: (taxCode: string) => void
+  onCreateTaxClick: () => void
 }
 
 const EditCustomerVatRateContent = ({
   appliedTaxRatesTaxesIds,
   onSelect,
+  onCreateTaxClick,
 }: EditCustomerVatRateContentProps) => {
   const { translate } = useInternationalization()
   const { hasPermissions } = usePermissions()
@@ -115,7 +117,7 @@ const EditCustomerVatRateContent = ({
           hasPermissions(['organizationTaxesUpdate'])
             ? {
                 label: translate('text_64639c4d172d7a006ef30516'),
-                redirectionUrl: CREATE_TAX_ROUTE,
+                onClick: onCreateTaxClick,
               }
             : undefined
         }
@@ -142,6 +144,7 @@ interface OpenEditCustomerVatRateDialogParams {
 
 export const useEditCustomerVatRateDialog = () => {
   const formDialog = useFormDialog()
+  const navigate = useNavigate()
   const { translate } = useInternationalization()
   const customerRef = useRef<EditCustomerVatRateFragment | null>(null)
   const taxCodeRef = useRef<string>('')
@@ -184,6 +187,10 @@ export const useEditCustomerVatRateDialog = () => {
           onSelect={(taxCode) => {
             taxCodeRef.current = taxCode
             setDisabledRef.current(!taxCode)
+          }}
+          onCreateTaxClick={() => {
+            formDialog.close()
+            navigate(CREATE_TAX_ROUTE)
           }}
         />
       ),

--- a/src/components/customers/__tests__/EditCustomerVatRateDialog.test.tsx
+++ b/src/components/customers/__tests__/EditCustomerVatRateDialog.test.tsx
@@ -46,6 +46,13 @@ jest.mock('~/hooks/useCurrentUser', () => ({
   }),
 }))
 
+const mockNavigate = jest.fn()
+
+jest.mock('~/core/router', () => ({
+  ...jest.requireActual('~/core/router'),
+  useNavigate: () => mockNavigate,
+}))
+
 const customer = {
   id: '1234',
   name: 'Customer Name',
@@ -136,6 +143,9 @@ describe('EditCustomerVatRateDialog', () => {
     const createTaxItem = await screen.findByTestId('combobox-item-Create a tax_rate')
 
     expect(createTaxItem).toBeInTheDocument()
-    expect(createTaxItem.querySelector(`a`)).toHaveAttribute('href', CREATE_TAX_ROUTE)
+
+    await user.click(createTaxItem.querySelector('button') as HTMLElement)
+
+    expect(mockNavigate).toHaveBeenCalledWith(CREATE_TAX_ROUTE)
   })
 })

--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -165,7 +165,7 @@ export const ComboBox = ({
             option={option}
             selected={state.selected}
             virtualized={virtualized}
-            addValueRedirectionUrl={option.addValueRedirectionUrl}
+            addValueOnClick={option.addValueOnClick}
             {...props}
           />
         )
@@ -185,7 +185,7 @@ export const ComboBox = ({
           filtered.push({
             value: params.inputValue,
             label: addValueProps.label || `Add "${params.inputValue}"`,
-            addValueRedirectionUrl: addValueProps.redirectionUrl,
+            addValueOnClick: addValueProps.onClick,
             customValue: true,
           })
         }

--- a/src/components/form/ComboBox/ComboBoxItemWrapper.tsx
+++ b/src/components/form/ComboBox/ComboBoxItemWrapper.tsx
@@ -3,7 +3,6 @@ import { Icon } from 'lago-design-system'
 
 import { ConditionalWrapper } from '~/components/ConditionalWrapper'
 import { Typography } from '~/components/designSystem/Typography'
-import { Link } from '~/core/router'
 
 import { ComboboxItem } from './ComboBoxItem'
 import { ComboBoxData } from './types'
@@ -16,7 +15,7 @@ interface ComboBoxItemWrapperProps {
   selected?: boolean
   comboboxProps: React.HTMLAttributes<HTMLLIElement>
   virtualized?: boolean
-  addValueRedirectionUrl?: string
+  addValueOnClick?: () => void
 }
 
 export const ComboBoxItemWrapper = ({
@@ -25,7 +24,7 @@ export const ComboBoxItemWrapper = ({
   selected,
   virtualized,
   comboboxProps,
-  addValueRedirectionUrl,
+  addValueOnClick,
 }: ComboBoxItemWrapperProps) => {
   const { className, ...allProps } = comboboxProps
 
@@ -35,9 +34,17 @@ export const ComboBoxItemWrapper = ({
       data-test={`combobox-item-${label}`}
     >
       <ConditionalWrapper
-        condition={!!addValueRedirectionUrl}
+        condition={!!addValueOnClick}
         invalidWrapper={(children) => <>{children}</>}
-        validWrapper={(children) => <Link to={addValueRedirectionUrl as string}>{children}</Link>}
+        validWrapper={(children) => (
+          <button
+            type="button"
+            className="w-full min-w-0 cursor-pointer text-left"
+            onClick={addValueOnClick}
+          >
+            {children}
+          </button>
+        )}
       >
         <ComboboxItem
           id={id}

--- a/src/components/form/ComboBox/ComboBoxItemWrapper.tsx
+++ b/src/components/form/ComboBox/ComboBoxItemWrapper.tsx
@@ -37,11 +37,10 @@ export const ComboBoxItemWrapper = ({
         condition={!!addValueOnClick}
         invalidWrapper={(children) => <>{children}</>}
         validWrapper={(children) => (
-          <button
-            type="button"
-            className="w-full min-w-0 cursor-pointer text-left"
-            onClick={addValueOnClick}
-          >
+          // `display: contents` keeps the button out of the layout box model so the
+          // wrapped ComboboxItem sizes/insets exactly like a non-clickable option row
+          // (otherwise the full-width button makes the hover highlight overflow the popper).
+          <button type="button" className="contents cursor-pointer" onClick={addValueOnClick}>
             {children}
           </button>
         )}

--- a/src/components/form/ComboBox/types.ts
+++ b/src/components/form/ComboBox/types.ts
@@ -17,7 +17,7 @@ export interface BasicComboBoxData {
   disabled?: boolean
   customValue?: boolean
   group?: never
-  addValueRedirectionUrl?: string
+  addValueOnClick?: () => void
 }
 
 export interface ComboboxDataGrouped extends Omit<BasicComboBoxData, 'group'> {
@@ -43,7 +43,7 @@ interface BasicComboboxProps extends Omit<ComboBoxInputProps, 'params' | 'search
   }
   addValueProps?: {
     label: string
-    redirectionUrl?: string
+    onClick?: () => void
   }
   renderGroupHeader?: never
   onChange: (value: string) => unknown


### PR DESCRIPTION
Fixes BIL-327

## Problem

`EditCustomerVatRateDialog` was migrated to the NiceModal dialog system. NiceModal renders modal content at the `NiceModalProvider`, which is mounted **outside** `BrowserRouter` (`App.tsx`). The dialog's tax ComboBox rendered a router `<Link>` for its "add a tax" row, so the Link's router-context lookup returned `null` and crashed:

```
TypeError: Cannot destructure property 'basename' of 'z.useContext(...)' as it is null
```

## Fix

The ComboBox `addValueProps.redirectionUrl` (rendered a router `<Link>`) had exactly one consumer in the codebase, so it was swapped for an `onClick` callback rendered as a `<button>` — no router context needed inside the modal.

- `addValueProps.redirectionUrl` -> `addValueProps.onClick`; `<Link>` -> `<button>` in `ComboBoxItemWrapper`.
- `useEditCustomerVatRateDialog` captures `useNavigate()` (it runs inside the router) and passes `onCreateTaxClick`, which closes the dialog then navigates to the create-tax route.
- Button styled `w-full min-w-0` so it respects the popper width (the flex item's default `min-width: auto` was causing overflow).
