### PR TITLE
fix(quotes): render uploaded images across all quote PDF downloads

### DIFF
--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -48,20 +48,16 @@ const EditQuote = () => {
   const { quote, loading, refetch: refetchQuote } = useQuote(quoteId)
 
   const { addQuoteImage } = useAddQuoteImage()
-  const [uploadedImages, setUploadedImages] = useState<Record<string, string>>({})
-
-  const images = useMemo(
-    () => ({ ...((quote?.images ?? {}) as Record<string, string>), ...uploadedImages }),
-    [quote?.images, uploadedImages],
-  )
+  // quote.images is the single source of truth — useAddQuoteImage writes each
+  // uploaded blob into the normalized Quote.images cache field, so it updates
+  // reactively here (on-screen editor) and everywhere quote.images is read.
+  const images = (quote?.images ?? {}) as Record<string, string>
 
   const onImageUpload = useCallback(
     async (base64: string): Promise<string> => {
       if (!quoteId) throw new Error('Missing quote id')
 
-      const { id, url } = await addQuoteImage({ id: quoteId, image: base64 })
-
-      setUploadedImages((prev) => ({ ...prev, [id]: url }))
+      const { id } = await addQuoteImage({ id: quoteId, image: base64 })
 
       return id
     },

--- a/src/pages/quotes/hooks/__tests__/useAddQuoteImage.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useAddQuoteImage.test.tsx
@@ -1,3 +1,5 @@
+import { InMemoryCache } from '@apollo/client'
+import { MockedProvider } from '@apollo/client/testing'
 import { act, renderHook } from '@testing-library/react'
 import { ReactNode } from 'react'
 
@@ -36,6 +38,52 @@ describe('useAddQuoteImage', () => {
         })
 
         expect(out).toEqual({ id: 'blob-1', url: 'https://signed/blob-1' })
+      })
+
+      it('THEN merges the uploaded blob into the cached Quote.images map', async () => {
+        const cache = new InMemoryCache()
+
+        cache.restore({
+          'Quote:quote-1': {
+            __typename: 'Quote',
+            id: 'quote-1',
+            images: { existing: 'https://signed/existing' },
+          },
+        })
+
+        const cacheMocks = [
+          {
+            request: {
+              query: AddQuoteImageDocument,
+              variables: { input: { id: 'quote-1', image: 'data:image/png;base64,AAA' } },
+            },
+            result: { data: { addQuoteImage: { id: 'blob-1', url: 'https://signed/blob-1' } } },
+          },
+        ]
+
+        const cacheWrapper = ({ children }: { children: ReactNode }) => (
+          <MockedProvider cache={cache} mocks={cacheMocks}>
+            {children}
+          </MockedProvider>
+        )
+
+        const { result } = renderHook(() => useAddQuoteImage(), { wrapper: cacheWrapper })
+
+        await act(async () => {
+          await result.current.addQuoteImage({
+            id: 'quote-1',
+            image: 'data:image/png;base64,AAA',
+          })
+        })
+
+        const extracted = cache.extract() as Record<string, { images?: Record<string, string> }>
+
+        // Previously-persisted images are preserved and the new blob is added,
+        // so every quote.images reader (editor + all PDF downloads) resolves it.
+        expect(extracted['Quote:quote-1'].images).toEqual({
+          existing: 'https://signed/existing',
+          'blob-1': 'https://signed/blob-1',
+        })
       })
     })
   })

--- a/src/pages/quotes/hooks/useAddQuoteImage.ts
+++ b/src/pages/quotes/hooks/useAddQuoteImage.ts
@@ -15,7 +15,26 @@ export const useAddQuoteImage = () => {
   const [addQuoteImageMutation, { loading: isUploadingImage }] = useAddQuoteImageMutation()
 
   const addQuoteImage = async (input: AddQuoteImageInput): Promise<{ id: string; url: string }> => {
-    const result = await addQuoteImageMutation({ variables: { input } })
+    const result = await addQuoteImageMutation({
+      variables: { input },
+      // Merge the uploaded blob into the normalized Quote.images map so every
+      // consumer of quote.images (on-screen editor + all PDF download actions)
+      // resolves the freshly-uploaded image without waiting for a refetch.
+      update: (cache, { data }) => {
+        const image = data?.addQuoteImage
+
+        if (!image) return
+
+        cache.modify({
+          id: cache.identify({ __typename: 'Quote', id: input.id }),
+          fields: {
+            images(existing = {}) {
+              return { ...existing, [image.id]: image.url }
+            },
+          },
+        })
+      },
+    })
 
     if (!result.data?.addQuoteImage) {
       throw new Error('Quote image upload failed')


### PR DESCRIPTION
## Context

An image uploaded into the Quote RTE renders on the on-screen **preview** but not on downloaded **PDFs**. 

## Fix

Write each uploaded blob into the normalized `Quote.images` cache field on upload (`cache.modify` in `useAddQuoteImage`). `quote.images` becomes the single source of truth, so **all** consumers resolve the image reactively with no refetch:

- on-screen editor
- edit-quote aside PDF download
- approve / void quote
- order-form / order / list-row PDF downloads

Removes the now-redundant local `uploadedImages` state in `EditQuote` (`quote.images` is used directly).

## Verification

Open a draft quote, upload an image, and **without reloading** download the PDF → image renders (pre-fix: blank). Order-form PDF still renders; reloaded quote still renders.

Fixes LAGO-1694

🤖 Generated with [Claude Code](https://claude.com/claude-code)