### PR TITLE
refactor(subscriptions): migrate ResetProgressiveBillingDialog to useCentralizedDialog

### DIFF
--- a/src/components/subscriptions/ResetProgressiveBillingDialog.tsx
+++ b/src/components/subscriptions/ResetProgressiveBillingDialog.tsx
@@ -1,9 +1,7 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast } from '~/core/apolloClient'
 import { useResetSubscriptionProgressiveBillingMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -26,77 +24,46 @@ type ResetProgressiveBillingDialogProps = {
   subscriptionId: string
 }
 
-export interface ResetProgressiveBillingDialogRef {
-  openDialog: (data: ResetProgressiveBillingDialogProps) => void
-  closeDialog: () => void
-}
+export const useResetProgressiveBillingDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
+  const { translate } = useInternationalization()
 
-export const ResetProgressiveBillingDialog = forwardRef<ResetProgressiveBillingDialogRef>(
-  (_, ref) => {
-    const dialogRef = useRef<DialogRef>(null)
-    const { translate } = useInternationalization()
-    const [localData, setLocalData] = useState<ResetProgressiveBillingDialogProps | null>(null)
+  const [resetProgressiveBilling] = useResetSubscriptionProgressiveBillingMutation({
+    onCompleted({ updateSubscription: result }) {
+      if (result?.id) {
+        addToast({
+          severity: 'success',
+          translateKey: 'text_1738071730498resetsuccess',
+        })
+      }
+    },
+  })
 
-    const [resetProgressiveBilling] = useResetSubscriptionProgressiveBillingMutation({
-      onCompleted({ updateSubscription: result }) {
-        if (result?.id) {
-          addToast({
-            severity: 'success',
-            translateKey: 'text_1738071730498resetsuccess',
-          })
-        }
+  const openResetProgressiveBillingDialog = ({
+    subscriptionId,
+  }: ResetProgressiveBillingDialogProps) => {
+    centralizedDialog.open({
+      title: translate('text_17380717304987v96qpfimgc'),
+      description: (
+        <Typography variant="body" color="grey600">
+          {translate('text_1738071730498zxzs6oy5tz3')}
+        </Typography>
+      ),
+      colorVariant: 'danger',
+      actionText: translate('text_1738071730498ht52blrjax6'),
+      onAction: async () => {
+        await resetProgressiveBilling({
+          variables: {
+            input: {
+              id: subscriptionId,
+              progressiveBillingDisabled: false,
+              usageThresholds: [],
+            },
+          },
+        })
       },
     })
+  }
 
-    useImperativeHandle(ref, () => ({
-      openDialog: (data) => {
-        setLocalData(data)
-        dialogRef.current?.openDialog()
-      },
-      closeDialog: () => {
-        dialogRef.current?.closeDialog()
-      },
-    }))
-
-    return (
-      <Dialog
-        ref={dialogRef}
-        title={translate('text_17380717304987v96qpfimgc')}
-        description={
-          <Typography variant="body" color="grey600">
-            {translate('text_1738071730498zxzs6oy5tz3')}
-          </Typography>
-        }
-        actions={({ closeDialog }) => (
-          <>
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_6411e6b530cb47007488b027')}
-            </Button>
-            <Button
-              danger
-              variant="primary"
-              onClick={async () => {
-                if (localData?.subscriptionId) {
-                  await resetProgressiveBilling({
-                    variables: {
-                      input: {
-                        id: localData.subscriptionId,
-                        progressiveBillingDisabled: false,
-                        usageThresholds: [],
-                      },
-                    },
-                  })
-                }
-                closeDialog()
-              }}
-            >
-              {translate('text_1738071730498ht52blrjax6')}
-            </Button>
-          </>
-        )}
-      />
-    )
-  },
-)
-
-ResetProgressiveBillingDialog.displayName = 'ResetProgressiveBillingDialog'
+  return { openResetProgressiveBillingDialog }
+}

--- a/src/components/subscriptions/SubscriptionProgressiveBillingTab/SubscriptionProgressiveBillingTabThresholdsHeader.tsx
+++ b/src/components/subscriptions/SubscriptionProgressiveBillingTab/SubscriptionProgressiveBillingTabThresholdsHeader.tsx
@@ -6,7 +6,6 @@ import { Chip } from '~/components/designSystem/Chip'
 import { Popper } from '~/components/designSystem/Popper'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
-import { ResetProgressiveBillingDialog } from '~/components/subscriptions/ResetProgressiveBillingDialog'
 import {
   SubscriptionForProgressiveBillingTabThresholdsHeaderFragment,
   SubscriptionForUseProgressiveBillingTabThresholdsHeaderFragmentDoc,
@@ -44,7 +43,6 @@ export const SubscriptionProgressiveBillingTabThresholdsHeader: FC<
     shouldDisplayOverriddenBadge,
     tooltipTitle,
     switchingProgressiveBillingDisabledValueLoading,
-    resetDialogRef,
     navigateToEditForm,
     openResetDialog,
     toggleProgressiveBilling,
@@ -52,106 +50,102 @@ export const SubscriptionProgressiveBillingTabThresholdsHeader: FC<
   } = useSubscriptionProgressiveBillingTabThresholdsHeader({ subscription })
 
   return (
-    <>
-      <div className="flex w-full items-center justify-between p-4 shadow-b">
-        <Typography variant="bodyHl" color="grey700">
-          {translate('text_17696267549792unv7l25frt')}
-        </Typography>
+    <div className="flex w-full items-center justify-between p-4 shadow-b">
+      <Typography variant="bodyHl" color="grey700">
+        {translate('text_17696267549792unv7l25frt')}
+      </Typography>
 
-        <div className="flex items-center gap-3">
-          {shouldDisplayOverriddenBadge && (
-            <Chip
-              data-test={PROGRESSIVE_BILLING_OVERRIDDEN_CHIP_TEST_ID}
-              className="border-purple-200 bg-purple-100"
-              color="infoMain"
-              label={translate('text_65281f686a80b400c8e2f6dd')}
-            />
-          )}
-
+      <div className="flex items-center gap-3">
+        {shouldDisplayOverriddenBadge && (
           <Chip
-            data-test={PROGRESSIVE_BILLING_LIFETIME_CHIP_TEST_ID}
-            color="grey700"
-            label={translate('text_1780512470285ql6s1rc7wjr')}
+            data-test={PROGRESSIVE_BILLING_OVERRIDDEN_CHIP_TEST_ID}
+            className="border-purple-200 bg-purple-100"
+            color="infoMain"
+            label={translate('text_65281f686a80b400c8e2f6dd')}
           />
+        )}
 
-          {canEditSubscription && (
-            <Popper
-              PopperProps={{ placement: 'bottom-end' }}
-              opener={({ onClick }) => (
-                <Tooltip placement="top-start" title={tooltipTitle}>
+        <Chip
+          data-test={PROGRESSIVE_BILLING_LIFETIME_CHIP_TEST_ID}
+          color="grey700"
+          label={translate('text_1780512470285ql6s1rc7wjr')}
+        />
+
+        {canEditSubscription && (
+          <Popper
+            PopperProps={{ placement: 'bottom-end' }}
+            opener={({ onClick }) => (
+              <Tooltip placement="top-start" title={tooltipTitle}>
+                <Button
+                  data-test={PROGRESSIVE_BILLING_MENU_BUTTON_TEST_ID}
+                  variant="quaternary"
+                  icon="dots-horizontal"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onClick()
+                  }}
+                />
+              </Tooltip>
+            )}
+          >
+            {({ closePopper }) => (
+              <MenuPopper>
+                <Button
+                  data-test={PROGRESSIVE_BILLING_EDIT_BUTTON_TEST_ID}
+                  fullWidth
+                  align="left"
+                  startIcon="pen"
+                  variant="quaternary"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    navigateToEditForm()
+                    closePopper()
+                  }}
+                >
+                  {translate('text_1738071730498edit4pb8hzw')}
+                </Button>
+
+                {hasSubscriptionThresholds && (
                   <Button
-                    data-test={PROGRESSIVE_BILLING_MENU_BUTTON_TEST_ID}
-                    variant="quaternary"
-                    icon="dots-horizontal"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      onClick()
-                    }}
-                  />
-                </Tooltip>
-              )}
-            >
-              {({ closePopper }) => (
-                <MenuPopper>
-                  <Button
-                    data-test={PROGRESSIVE_BILLING_EDIT_BUTTON_TEST_ID}
+                    data-test={PROGRESSIVE_BILLING_RESET_BUTTON_TEST_ID}
                     fullWidth
                     align="left"
-                    startIcon="pen"
+                    startIcon="history"
                     variant="quaternary"
                     onClick={(e) => {
                       e.stopPropagation()
-                      navigateToEditForm()
+                      openResetDialog()
                       closePopper()
                     }}
                   >
-                    {translate('text_1738071730498edit4pb8hzw')}
+                    {translate('text_1738071730498ht52blrjax6')}
                   </Button>
+                )}
 
-                  {hasSubscriptionThresholds && (
-                    <Button
-                      data-test={PROGRESSIVE_BILLING_RESET_BUTTON_TEST_ID}
-                      fullWidth
-                      align="left"
-                      startIcon="history"
-                      variant="quaternary"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        openResetDialog()
-                        closePopper()
-                      }}
-                    >
-                      {translate('text_1738071730498ht52blrjax6')}
-                    </Button>
-                  )}
-
-                  <Button
-                    data-test={PROGRESSIVE_BILLING_TOGGLE_BUTTON_TEST_ID}
-                    fullWidth
-                    align="left"
-                    startIcon={
-                      !!subscription?.progressiveBillingDisabled ? 'validate-filled' : 'stop'
-                    }
-                    loading={switchingProgressiveBillingDisabledValueLoading}
-                    variant="quaternary"
-                    onClick={async (e) => {
-                      e.stopPropagation()
-                      await toggleProgressiveBilling()
-                      closePopper()
-                    }}
-                  >
-                    {!!subscription?.progressiveBillingDisabled
-                      ? translate('text_1769604747500dwp43wers40')
-                      : translate('text_1769604747500dwp43wers41')}
-                  </Button>
-                </MenuPopper>
-              )}
-            </Popper>
-          )}
-        </div>
+                <Button
+                  data-test={PROGRESSIVE_BILLING_TOGGLE_BUTTON_TEST_ID}
+                  fullWidth
+                  align="left"
+                  startIcon={
+                    !!subscription?.progressiveBillingDisabled ? 'validate-filled' : 'stop'
+                  }
+                  loading={switchingProgressiveBillingDisabledValueLoading}
+                  variant="quaternary"
+                  onClick={async (e) => {
+                    e.stopPropagation()
+                    await toggleProgressiveBilling()
+                    closePopper()
+                  }}
+                >
+                  {!!subscription?.progressiveBillingDisabled
+                    ? translate('text_1769604747500dwp43wers40')
+                    : translate('text_1769604747500dwp43wers41')}
+                </Button>
+              </MenuPopper>
+            )}
+          </Popper>
+        )}
       </div>
-
-      <ResetProgressiveBillingDialog ref={resetDialogRef} />
-    </>
+    </div>
   )
 }

--- a/src/components/subscriptions/SubscriptionProgressiveBillingTab/__tests__/SubscriptionProgressiveBillingTab.test.tsx
+++ b/src/components/subscriptions/SubscriptionProgressiveBillingTab/__tests__/SubscriptionProgressiveBillingTab.test.tsx
@@ -51,6 +51,14 @@ jest.mock('~/hooks/useOrganizationInfos', () => ({
   }),
 }))
 
+const mockOpenResetProgressiveBillingDialog = jest.fn()
+
+jest.mock('~/components/subscriptions/ResetProgressiveBillingDialog', () => ({
+  useResetProgressiveBillingDialog: () => ({
+    openResetProgressiveBillingDialog: mockOpenResetProgressiveBillingDialog,
+  }),
+}))
+
 const createMockSubscription = (
   overrides?: Partial<SubscriptionForProgressiveBillingTabFragment>,
 ): SubscriptionForProgressiveBillingTabFragment => ({
@@ -700,9 +708,8 @@ describe('SubscriptionProgressiveBillingTab', () => {
         await user.click(screen.getByTestId(PROGRESSIVE_BILLING_RESET_BUTTON_TEST_ID))
       })
 
-      // Dialog should be opened (check for dialog content)
-      await waitFor(() => {
-        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      expect(mockOpenResetProgressiveBillingDialog).toHaveBeenCalledWith({
+        subscriptionId: 'subscription-123',
       })
     })
   })

--- a/src/components/subscriptions/SubscriptionProgressiveBillingTab/hooks/__tests__/useSubscriptionProgressiveBillingTabThresholdsHeader.test.ts
+++ b/src/components/subscriptions/SubscriptionProgressiveBillingTab/hooks/__tests__/useSubscriptionProgressiveBillingTabThresholdsHeader.test.ts
@@ -43,6 +43,14 @@ jest.mock('~/generated/graphql', () => ({
   useSwitchProgressiveBillingDisabledValueMutation: () => [mockSwitchMutation, { loading: false }],
 }))
 
+const mockOpenResetProgressiveBillingDialog = jest.fn()
+
+jest.mock('~/components/subscriptions/ResetProgressiveBillingDialog', () => ({
+  useResetProgressiveBillingDialog: () => ({
+    openResetProgressiveBillingDialog: mockOpenResetProgressiveBillingDialog,
+  }),
+}))
+
 const createMockSubscription = (overrides?: {
   id?: string
   progressiveBillingDisabled?: boolean
@@ -269,15 +277,33 @@ describe('useSubscriptionProgressiveBillingTabThresholdsHeader', () => {
     })
   })
 
-  describe('resetDialogRef', () => {
-    it('returns a ref object', () => {
+  describe('openResetDialog', () => {
+    it('opens the reset progressive billing dialog with the subscription id', () => {
       const { result } = renderHook(() =>
         useSubscriptionProgressiveBillingTabThresholdsHeader({
           subscription: createMockSubscription(),
         }),
       )
 
-      expect(result.current.resetDialogRef).toHaveProperty('current')
+      act(() => {
+        result.current.openResetDialog()
+      })
+
+      expect(mockOpenResetProgressiveBillingDialog).toHaveBeenCalledWith({
+        subscriptionId: 'subscription-123',
+      })
+    })
+
+    it('does not open the dialog when subscription is null', () => {
+      const { result } = renderHook(() =>
+        useSubscriptionProgressiveBillingTabThresholdsHeader({ subscription: null }),
+      )
+
+      act(() => {
+        result.current.openResetDialog()
+      })
+
+      expect(mockOpenResetProgressiveBillingDialog).not.toHaveBeenCalled()
     })
   })
 

--- a/src/components/subscriptions/SubscriptionProgressiveBillingTab/hooks/useSubscriptionProgressiveBillingTabThresholdsHeader.ts
+++ b/src/components/subscriptions/SubscriptionProgressiveBillingTab/hooks/useSubscriptionProgressiveBillingTabThresholdsHeader.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
-import { useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
-import { ResetProgressiveBillingDialogRef } from '~/components/subscriptions/ResetProgressiveBillingDialog'
+import { useResetProgressiveBillingDialog } from '~/components/subscriptions/ResetProgressiveBillingDialog'
 import {
   EDIT_PROGRESSIVE_BILLING_CUSTOMER_SUBSCRIPTION_ROUTE,
   EDIT_PROGRESSIVE_BILLING_PLAN_SUBSCRIPTION_ROUTE,
@@ -50,7 +50,7 @@ export const useSubscriptionProgressiveBillingTabThresholdsHeader = ({
   const { hasPermissions } = usePermissions()
   const { customerId = '', planId = '' } = useParams()
 
-  const resetDialogRef = useRef<ResetProgressiveBillingDialogRef>(null)
+  const { openResetProgressiveBillingDialog } = useResetProgressiveBillingDialog()
   const canEditSubscription = hasPermissions(['subscriptionsUpdate'])
 
   const hasSubscriptionThresholds = (subscription?.usageThresholds?.length || 0) > 0
@@ -108,7 +108,7 @@ export const useSubscriptionProgressiveBillingTabThresholdsHeader = ({
 
   const openResetDialog = () => {
     if (subscription?.id) {
-      resetDialogRef.current?.openDialog({
+      openResetProgressiveBillingDialog({
         subscriptionId: subscription.id,
       })
     }
@@ -125,9 +125,6 @@ export const useSubscriptionProgressiveBillingTabThresholdsHeader = ({
     shouldDisplayOverriddenBadge,
     tooltipTitle,
     switchingProgressiveBillingDisabledValueLoading,
-
-    // Refs
-    resetDialogRef,
 
     // Actions
     navigateToEditForm,


### PR DESCRIPTION
## Context

`ResetProgressiveBillingDialog` was one of the legacy `forwardRef` + `useImperativeHandle` + `Dialog` (`~/components/designSystem/Dialog`) consumers flagged by the `no-restricted-imports` ESLint rule. It is a simple danger-confirmation dialog (fires an `updateSubscription` mutation on confirm) — no form fields, no chained dialog — so `useCentralizedDialog` is the right primitive.

## Description

- **`src/components/subscriptions/ResetProgressiveBillingDialog.tsx`**
  - Replaced the `forwardRef` + `useImperativeHandle` + `useState` + `Dialog` boilerplate with a `useResetProgressiveBillingDialog` hook backed by `useCentralizedDialog`.
  - `colorVariant: 'danger'` mirrors the previous danger primary button.
  - The `subscriptionId` is passed via the open-function parameter (no more `localData` state) and closed over the `onAction` callback so the mutation still receives the right id.
  - The `ResetProgressiveBillingDialogRef` type export is dropped — the hook API takes its place.

- **`src/components/subscriptions/SubscriptionProgressiveBillingTab/hooks/useSubscriptionProgressiveBillingTabThresholdsHeader.ts`**
  - Dropped the `useRef<ResetProgressiveBillingDialogRef>` and now calls `openResetProgressiveBillingDialog({ subscriptionId })` from the hook.
  - Removed the `resetDialogRef` from the returned bag.

- **`src/components/subscriptions/SubscriptionProgressiveBillingTab/SubscriptionProgressiveBillingTabThresholdsHeader.tsx`**
  - Dropped the `<ResetProgressiveBillingDialog ref={...} />` JSX render and the surrounding fragment (the dialog is now dispatched globally via `NiceModal`).
  - Removed the `resetDialogRef` destructure from the hook.

- **Tests**
  - `useSubscriptionProgressiveBillingTabThresholdsHeader.test.ts`: mocked `useResetProgressiveBillingDialog` and replaced the `resetDialogRef` assertion with two `openResetDialog` behavior tests (opens with the correct id, no-op when subscription is null).
  - `SubscriptionProgressiveBillingTab.test.tsx`: mocked `useResetProgressiveBillingDialog` and asserted on the mock call instead of `screen.getByRole('dialog')` (the dialog is now rendered by the global provider, not inline).

## Scope

Strictly scoped to the `no-restricted-imports` warning for `ResetProgressiveBillingDialog`. No form migration was needed (no form elements). No unrelated cleanup.

## Test plan

- [ ] Subscription detail → Progressive billing tab → menu → "Reset thresholds" → danger dialog opens with the same title/description/action label.
- [ ] Confirm → mutation fires with `progressiveBillingDisabled: false` and `usageThresholds: []`, success toast shows, dialog closes.
- [ ] Cancel/close → no mutation, dialog closes.
- [ ] `pnpm exec tsc --noEmit`, `pnpm exec eslint`, and `pnpm test SubscriptionProgressiveBillingTab` (95/95) all pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Duj2yvsCPDSbwUJ2jgEM5w)_