### PR TITLE
refactor(customers): migrate EditCustomerInvoiceCustomSectionsDialog to FormDialog and TanStack Form

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -9,10 +9,7 @@ import { useDeleteCustomerNetPaymentTermDialog } from '~/components/customers/De
 import { useDeleteCustomerVatRateDialog } from '~/components/customers/DeleteCustomerVatRateDialog'
 import { useEditCustomerDocumentLocaleDialog } from '~/components/customers/EditCustomerDocumentLocaleDialog'
 import { useEditCustomerDunningCampaignDialog } from '~/components/customers/EditCustomerDunningCampaignDialog'
-import {
-  EditCustomerInvoiceCustomSectionsDialog,
-  EditCustomerInvoiceCustomSectionsDialogRef,
-} from '~/components/customers/EditCustomerInvoiceCustomSectionsDialog'
+import { useEditCustomerInvoiceCustomSectionsDialog } from '~/components/customers/EditCustomerInvoiceCustomSectionsDialog'
 import {
   EditCustomerInvoiceGracePeriodDialog,
   EditCustomerInvoiceGracePeriodDialogRef,
@@ -200,8 +197,8 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
   const { openDeleteCustomerGracePeriodeDialog } = useDeleteCustomerGracePeriodeDialog()
   const { openEditCustomerDocumentLocaleDialog } = useEditCustomerDocumentLocaleDialog()
   const { openEditCustomerDunningCampaignDialog } = useEditCustomerDunningCampaignDialog()
-  const editCustomerInvoiceCustomSectionsDialogRef =
-    useRef<EditCustomerInvoiceCustomSectionsDialogRef>(null)
+  const { openEditCustomerInvoiceCustomSectionsDialog } =
+    useEditCustomerInvoiceCustomSectionsDialog(customerId)
   const { openDeleteCustomerDocumentLocaleDialog } = useDeleteCustomerDocumentLocaleDialog()
   const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const editNetPaymentTermDialogRef = useRef<EditNetPaymentTermDialogRef>(null)
@@ -684,9 +681,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                         disabled={loading}
                         variant="inline"
                         endIcon={isPremium ? undefined : 'sparkles'}
-                        onClick={() =>
-                          editCustomerInvoiceCustomSectionsDialogRef?.current?.openDialog()
-                        }
+                        onClick={openEditCustomerInvoiceCustomSectionsDialog}
                       >
                         {translate('text_63e51ef4985f0ebd75c212fc')}
                       </Button>
@@ -945,10 +940,6 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
           <EditCustomerIssuingDatePolicyDialog
             ref={editIssuingDatePolicyDialogRef}
             customer={customer}
-          />
-          <EditCustomerInvoiceCustomSectionsDialog
-            ref={editCustomerInvoiceCustomSectionsDialogRef}
-            customerId={customerId}
           />
           <EditNetPaymentTermDialog
             ref={editNetPaymentTermDialogRef}

--- a/src/components/customers/EditCustomerInvoiceCustomSectionsDialog.tsx
+++ b/src/components/customers/EditCustomerInvoiceCustomSectionsDialog.tsx
@@ -1,11 +1,11 @@
 import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
-import { forwardRef, useMemo } from 'react'
-import { array, mixed, object, string } from 'yup'
+import { revalidateLogic, useStore } from '@tanstack/react-form'
+import { useEffect, useMemo, useRef } from 'react'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { MultipleComboBox, RadioField } from '~/components/form'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { addToast } from '~/core/apolloClient'
 import {
   CustomerAppliedInvoiceCustomSectionsFragmentDoc,
@@ -13,8 +13,12 @@ import {
   useEditCustomerInvoiceCustomSectionMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm, withForm } from '~/hooks/forms/useAppform'
 import { useCustomerInvoiceCustomSections } from '~/hooks/useCustomerInvoiceCustomSections'
 import { useInvoiceCustomSectionsLazy } from '~/hooks/useInvoiceCustomSections'
+
+export const EDIT_CUSTOMER_INVOICE_CUSTOM_SECTIONS_FORM_ID =
+  'edit-customer-invoice-custom-sections-form'
 
 gql`
   mutation editCustomerInvoiceCustomSection($input: UpdateCustomerInput!) {
@@ -27,41 +31,118 @@ gql`
   }
 `
 
-enum BehaviorType {
+export enum BehaviorType {
   FALLBACK = 'fallback',
   CUSTOM_SECTIONS = 'customSections',
   DEACTIVATE = 'deactivate',
 }
 
-export type EditCustomerInvoiceCustomSectionsDialogRef = DialogRef
-
-interface EditCustomerInvoiceCustomSectionsDialogProps {
-  customerId: string
+type FormValues = {
+  behavior: BehaviorType
+  configurableInvoiceCustomSectionIds: string[]
 }
 
-export const EditCustomerInvoiceCustomSectionsDialog = forwardRef<
-  DialogRef,
-  EditCustomerInvoiceCustomSectionsDialogProps
->(({ customerId }: EditCustomerInvoiceCustomSectionsDialogProps, ref) => {
+const initialValues: FormValues = {
+  behavior: BehaviorType.FALLBACK,
+  configurableInvoiceCustomSectionIds: [],
+}
+
+const validationSchema = z
+  .object({
+    behavior: z.enum(BehaviorType),
+    configurableInvoiceCustomSectionIds: z.array(z.string()),
+  })
+  .refine(
+    (data) =>
+      data.behavior !== BehaviorType.CUSTOM_SECTIONS ||
+      data.configurableInvoiceCustomSectionIds.length > 0,
+    { path: ['configurableInvoiceCustomSectionIds'], message: '' },
+  )
+
+const DialogContent = withForm({
+  defaultValues: initialValues,
+  render: function Render({ form }) {
+    const { translate } = useInternationalization()
+    const { getInvoiceCustomSections, data: orgInvoiceCustomSections } =
+      useInvoiceCustomSectionsLazy()
+
+    useEffect(() => {
+      getInvoiceCustomSections()
+    }, [getInvoiceCustomSections])
+
+    const options = useMemo(
+      () =>
+        (orgInvoiceCustomSections ?? []).map((section) => ({
+          labelNode: section.name,
+          label: section.name,
+          description: section.code,
+          value: section.id,
+        })),
+      [orgInvoiceCustomSections],
+    )
+
+    const behavior = useStore(form.store, (state) => state.values.behavior)
+
+    return (
+      <div className="p-8 not-last-child:mb-4">
+        <form.AppField name="behavior">
+          {(field) => (
+            <field.RadioField
+              value={BehaviorType.FALLBACK}
+              label={translate('text_17352239389166kugn45zj95')}
+              labelVariant="body"
+            />
+          )}
+        </form.AppField>
+        <form.AppField name="behavior">
+          {(field) => (
+            <field.RadioField
+              value={BehaviorType.CUSTOM_SECTIONS}
+              label={translate('text_1735223938916ed8ef8phwaz')}
+              labelVariant="body"
+            />
+          )}
+        </form.AppField>
+        {behavior === BehaviorType.CUSTOM_SECTIONS && (
+          <form.AppField name="configurableInvoiceCustomSectionIds">
+            {(field) => (
+              <field.MultipleComboBoxField
+                hideTags={false}
+                forcePopupIcon
+                data={options}
+                placeholder={translate('text_1735223938916qvvv12r7je0')}
+                PopperProps={{ displayInDialog: true }}
+                emptyText={translate('text_173642092241713ws50zg9v4')}
+              />
+            )}
+          </form.AppField>
+        )}
+        <form.AppField name="behavior">
+          {(field) => (
+            <field.RadioField
+              value={BehaviorType.DEACTIVATE}
+              label={translate('text_1735223938916dhd7cyzokib')}
+              labelVariant="body"
+            />
+          )}
+        </form.AppField>
+      </div>
+    )
+  },
+})
+
+export const useEditCustomerInvoiceCustomSectionsDialog = (customerId: string) => {
+  const formDialog = useFormDialog()
   const { translate } = useInternationalization()
+  const successRef = useRef(false)
 
   const { data: customerData, customer } = useCustomerInvoiceCustomSections(customerId)
 
-  const { getInvoiceCustomSections, data: orgInvoiceCustomSections } =
-    useInvoiceCustomSectionsLazy()
-
-  const options = useMemo(() => {
-    return (orgInvoiceCustomSections ?? []).map((section) => ({
-      labelNode: section.name,
-      label: section.name,
-      description: section.code,
-      value: section.id,
-    }))
-  }, [orgInvoiceCustomSections])
-
   const [editCustomerInvoiceCustomSection] = useEditCustomerInvoiceCustomSectionMutation({
     refetchQueries: ['getCustomerSettings'],
-    onCompleted: () => {
+    onCompleted: (res) => {
+      if (!res.updateCustomer) return
+      successRef.current = true
       addToast({
         severity: 'success',
         message: translate('text_17352280436833uy9uxzbqn7'),
@@ -69,42 +150,11 @@ export const EditCustomerInvoiceCustomSectionsDialog = forwardRef<
     },
   })
 
-  const initialBehavior = useMemo((): BehaviorType => {
-    if (customerData?.hasOverwrittenInvoiceCustomSectionsSelection) {
-      return BehaviorType.CUSTOM_SECTIONS
-    } else if (customerData?.skipInvoiceCustomSections) {
-      return BehaviorType.DEACTIVATE
-    }
-
-    return BehaviorType.FALLBACK
-  }, [customerData])
-
-  const initialSectionIds = useMemo(() => {
-    if (!customerData?.hasOverwrittenInvoiceCustomSectionsSelection) {
-      return undefined
-    }
-
-    return customerData.configurableInvoiceCustomSections.map((section) => section.id)
-  }, [customerData])
-
-  const formikProps = useFormik<{
-    behavior: BehaviorType | ''
-    configurableInvoiceCustomSectionIds: string[] | undefined
-  }>({
-    initialValues: {
-      behavior: initialBehavior,
-      configurableInvoiceCustomSectionIds: initialSectionIds,
-    },
-    validationSchema: object().shape({
-      behavior: mixed().oneOf(Object.values(BehaviorType)).required(''),
-      configurableInvoiceCustomSectionIds: array()
-        .of(string())
-        .when('behavior', {
-          is: (val: BehaviorType) => val === BehaviorType.CUSTOM_SECTIONS,
-          then: (schema) => schema.min(1, ''),
-        }),
-    }),
-    onSubmit: async (values) => {
+  const form = useAppForm({
+    defaultValues: initialValues,
+    validationLogic: revalidateLogic(),
+    validators: { onDynamic: validationSchema },
+    onSubmit: async ({ value }) => {
       if (!customer) return
 
       let formattedValues: UpdateCustomerInput = {
@@ -112,7 +162,7 @@ export const EditCustomerInvoiceCustomSectionsDialog = forwardRef<
         externalId: customer.externalId,
       }
 
-      switch (values.behavior) {
+      switch (value.behavior) {
         case BehaviorType.FALLBACK:
           formattedValues = {
             ...formattedValues,
@@ -124,7 +174,7 @@ export const EditCustomerInvoiceCustomSectionsDialog = forwardRef<
           formattedValues = {
             ...formattedValues,
             skipInvoiceCustomSections: false,
-            configurableInvoiceCustomSectionIds: values.configurableInvoiceCustomSectionIds,
+            configurableInvoiceCustomSectionIds: value.configurableInvoiceCustomSectionIds,
           }
           break
         case BehaviorType.DEACTIVATE:
@@ -138,88 +188,57 @@ export const EditCustomerInvoiceCustomSectionsDialog = forwardRef<
 
       await editCustomerInvoiceCustomSection({ variables: { input: formattedValues } })
     },
-    validateOnMount: true,
-    enableReinitialize: true,
   })
 
-  return (
-    <Dialog
-      ref={ref}
-      onOpen={async () => {
-        await getInvoiceCustomSections()
-      }}
-      title={translate('text_17352239389168sdqd97zo0t')}
-      description={translate('text_1735223938916hla21yfwyzw')}
-      actions={({ closeDialog }) => (
-        <>
-          <Button variant="quaternary" onClick={closeDialog}>
-            {translate('text_63ea0f84f400488553caa6a5')}
-          </Button>
-          <Button
-            variant="primary"
-            disabled={!formikProps.isValid || !formikProps.dirty}
-            onClick={async () => {
-              await formikProps.submitForm()
-              closeDialog()
-            }}
-          >
-            {translate('text_1735223938916q9pq0j0z0ju')}
-          </Button>
-        </>
-      )}
-    >
-      <div className="mb-8 not-last-child:mb-4">
-        <RadioField
-          name="behavior"
-          formikProps={formikProps}
-          value={BehaviorType.FALLBACK}
-          label={translate('text_17352239389166kugn45zj95')}
-          labelVariant="body"
-        />
-        <RadioField
-          name="behavior"
-          formikProps={formikProps}
-          value={BehaviorType.CUSTOM_SECTIONS}
-          label={translate('text_1735223938916ed8ef8phwaz')}
-          labelVariant="body"
-        />
-        {formikProps.values.behavior === BehaviorType.CUSTOM_SECTIONS && (
-          <MultipleComboBox
-            hideTags={false}
-            forcePopupIcon
-            name="configurableInvoiceCustomSectionIds"
-            data={options}
-            onChange={(section) =>
-              formikProps.setFieldValue(
-                'configurableInvoiceCustomSectionIds',
-                section.map(({ value }) => value),
-              )
-            }
-            value={
-              formikProps.values.configurableInvoiceCustomSectionIds?.map((id) => {
-                const foundSection = options.find((section) => section.value === id)
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-                return {
-                  value: id,
-                  label: foundSection?.label,
-                }
-              }) ?? []
-            }
-            placeholder={translate('text_1735223938916qvvv12r7je0')}
-            PopperProps={{ displayInDialog: true }}
-            emptyText={translate('text_173642092241713ws50zg9v4')}
-          />
-        )}
-        <RadioField
-          name="behavior"
-          formikProps={formikProps}
-          value={BehaviorType.DEACTIVATE}
-          label={translate('text_1735223938916dhd7cyzokib')}
-          labelVariant="body"
-        />
-      </div>
-    </Dialog>
-  )
-})
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
 
-EditCustomerInvoiceCustomSectionsDialog.displayName = 'EditCustomerInvoiceCustomSectionsDialog'
+    return { reason: 'success' }
+  }
+
+  const openEditCustomerInvoiceCustomSectionsDialog = () => {
+    form.reset()
+
+    if (customerData?.hasOverwrittenInvoiceCustomSectionsSelection) {
+      form.setFieldValue('behavior', BehaviorType.CUSTOM_SECTIONS)
+      form.setFieldValue(
+        'configurableInvoiceCustomSectionIds',
+        customerData.configurableInvoiceCustomSections.map((section) => section.id),
+      )
+    } else if (customerData?.skipInvoiceCustomSections) {
+      form.setFieldValue('behavior', BehaviorType.DEACTIVATE)
+    } else {
+      form.setFieldValue('behavior', BehaviorType.FALLBACK)
+    }
+
+    formDialog
+      .open({
+        title: translate('text_17352239389168sdqd97zo0t'),
+        description: translate('text_1735223938916hla21yfwyzw'),
+        closeOnError: false,
+        onEntered: focusFirstInput,
+        children: <DialogContent form={form} />,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>{translate('text_1735223938916q9pq0j0z0ju')}</form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: EDIT_CUSTOMER_INVOICE_CUSTOM_SECTIONS_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close') {
+          form.reset()
+        }
+      })
+  }
+
+  return { openEditCustomerInvoiceCustomSectionsDialog }
+}

--- a/src/components/customers/__tests__/CustomerSettings.test.tsx
+++ b/src/components/customers/__tests__/CustomerSettings.test.tsx
@@ -84,13 +84,11 @@ jest.mock('~/components/customers/EditCustomerDunningCampaignDialog', () => ({
   }),
 }))
 
-jest.mock('~/components/customers/EditCustomerInvoiceCustomSectionsDialog', () => {
-  const React = jest.requireActual('react')
-  const MockDialog = React.forwardRef(() => null)
-
-  MockDialog.displayName = 'EditCustomerInvoiceCustomSectionsDialog'
-  return { EditCustomerInvoiceCustomSectionsDialog: MockDialog }
-})
+jest.mock('~/components/customers/EditCustomerInvoiceCustomSectionsDialog', () => ({
+  useEditCustomerInvoiceCustomSectionsDialog: () => ({
+    openEditCustomerInvoiceCustomSectionsDialog: jest.fn(),
+  }),
+}))
 
 jest.mock('~/components/customers/settings/EditCustomerIssuingDatePolicyDialog', () => {
   const React = jest.requireActual('react')

--- a/src/components/customers/__tests__/EditCustomerInvoiceCustomSectionsDialog.test.tsx
+++ b/src/components/customers/__tests__/EditCustomerInvoiceCustomSectionsDialog.test.tsx
@@ -1,17 +1,19 @@
+import NiceModal from '@ebay/nice-modal-react'
 import { act, cleanup, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { createRef } from 'react'
+import { ReactNode } from 'react'
 
-import {
-  EditCustomerInvoiceCustomSectionsDialog,
-  EditCustomerInvoiceCustomSectionsDialogRef,
-} from '~/components/customers/EditCustomerInvoiceCustomSectionsDialog'
+import { useEditCustomerInvoiceCustomSectionsDialog } from '~/components/customers/EditCustomerInvoiceCustomSectionsDialog'
+import { DIALOG_TITLE_TEST_ID, FORM_DIALOG_NAME } from '~/components/dialogs/const'
+import FormDialog from '~/components/dialogs/FormDialog'
 import {
   EditCustomerInvoiceCustomSectionDocument,
   GetCustomerInvoiceCustomSectionsDocument,
   GetInvoiceCustomSectionsDocument,
 } from '~/generated/graphql'
 import { render, TestMocksType } from '~/test-utils'
+
+NiceModal.register(FORM_DIALOG_NAME, FormDialog)
 
 const CUSTOMER_ID = 'customer-123'
 const CUSTOMER_EXTERNAL_ID = 'ext-customer-123'
@@ -82,6 +84,21 @@ const mockCustomerCustomSections = {
   },
 }
 
+const NiceModalWrapper = ({ children }: { children: ReactNode }) => (
+  <NiceModal.Provider>{children}</NiceModal.Provider>
+)
+
+const TestComponent = () => {
+  const { openEditCustomerInvoiceCustomSectionsDialog } =
+    useEditCustomerInvoiceCustomSectionsDialog(CUSTOMER_ID)
+
+  return (
+    <button data-test="open-dialog" onClick={openEditCustomerInvoiceCustomSectionsDialog}>
+      Open Dialog
+    </button>
+  )
+}
+
 async function prepare({
   customerMock = mockCustomerFallback,
   mocks = [],
@@ -111,25 +128,27 @@ async function prepare({
     ...mocks,
   ]
 
-  const ref = createRef<EditCustomerInvoiceCustomSectionsDialogRef>()
-
   await act(() =>
-    render(<EditCustomerInvoiceCustomSectionsDialog ref={ref} customerId={CUSTOMER_ID} />, {
-      mocks: defaultMocks,
-    } as { mocks: TestMocksType }),
+    render(
+      <NiceModalWrapper>
+        <TestComponent />
+      </NiceModalWrapper>,
+      { mocks: defaultMocks } as { mocks: TestMocksType },
+    ),
   )
 
-  // Open the dialog
-  await act(() => {
-    ref.current?.openDialog()
+  // Wait for the customer sections query to resolve so the seed uses fresh data.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
   })
 
-  // Wait for lazy query to complete
+  await act(async () => {
+    screen.getByTestId('open-dialog').click()
+  })
+
   await waitFor(() => {
-    expect(screen.getByTestId('dialog-title')).toBeInTheDocument()
+    expect(screen.getByTestId(DIALOG_TITLE_TEST_ID)).toBeInTheDocument()
   })
-
-  return { ref }
 }
 
 describe('EditCustomerInvoiceCustomSectionsDialog', () => {
@@ -205,11 +224,12 @@ describe('EditCustomerInvoiceCustomSectionsDialog', () => {
       await prepare({ customerMock: mockCustomerCustomSections, mocks: [mutationMock] })
 
       const radioButtons = screen.getAllByRole('radio')
-      const buttons = screen.getAllByRole('button')
-      const submitButton = buttons[buttons.length - 1]
 
-      // Change from APPLY to FALLBACK
+      // Change from APPLY (seeded) to FALLBACK
       await user.click(radioButtons[0])
+
+      // The submit button is labelled "Edit behavior".
+      const submitButton = screen.getByRole('button', { name: /edit behavior/i })
 
       await waitFor(() => {
         expect(submitButton).not.toBeDisabled()


### PR DESCRIPTION
## Context

`EditCustomerInvoiceCustomSectionsDialog` was one of the legacy `forwardRef` + `Dialog` (`~/components/designSystem/Dialog`) + Formik consumers flagged by the `no-restricted-imports` ESLint rule. The dialog holds a `behavior` radio choice (fallback / custom / deactivate) with a `MultipleComboBox` that shows up only when `custom` is picked, so the migration needs both the new dialog primitive and TanStack Form.

## Description

- **`src/components/customers/EditCustomerInvoiceCustomSectionsDialog.tsx`**
  - Replaced the `forwardRef` + `Dialog` + Formik + Yup boilerplate with a `useEditCustomerInvoiceCustomSectionsDialog(customerId)` hook backed by `useFormDialog` and `useAppForm` + Zod.
  - The `behavior` and `configurableInvoiceCustomSectionIds` fields are described with a Zod schema; the "apply → at least one section" rule is expressed via `.refine()` targeting `configurableInvoiceCustomSectionIds`.
  - The dialog body is extracted with `withForm(...)` so the org invoice-custom-sections lazy query (`useInvoiceCustomSectionsLazy`) runs inside the dialog subtree and rerenders with fresh data instead of a stale snapshot captured at open time.
  - `useCustomerInvoiceCustomSections(customerId)` now runs at the hook level (top of `CustomerSettings`), so the seed used inside `openEditCustomerInvoiceCustomSectionsDialog` uses the freshest customer payload.
  - `handleSubmit` returns `Promise<DialogResult>` using `successRef` (set inside the `editCustomerInvoiceCustomSection` `.data` check) to signal success — throws to keep the dialog open under `closeOnError: false`.
  - `onEntered: focusFirstInput` restores the initial focus behavior.

- **`src/components/customers/CustomerSettings.tsx`**
  - Dropped the `editCustomerInvoiceCustomSectionsDialogRef` `useRef` + the inline `<EditCustomerInvoiceCustomSectionsDialog ref={…} customerId={…} />` JSX.
  - The "Edit" button now calls `openEditCustomerInvoiceCustomSectionsDialog` directly from the hook.

- **`src/components/customers/__tests__/EditCustomerInvoiceCustomSectionsDialog.test.tsx`**
  - Rewrote the tests to render a small `TestComponent` that calls the hook, wrapped in `NiceModal.Provider`, then click "Open Dialog" and assert on the dialog-open flow.
  - Kept the same three scenarios: radio → combobox visibility, submit with FALLBACK behavior + toast, and CUSTOM_SECTIONS radio → combobox appears.

- **`src/components/customers/__tests__/CustomerSettings.test.tsx`**
  - Replaced the `forwardRef` mock with a plain hook mock returning `openEditCustomerInvoiceCustomSectionsDialog: jest.fn()`.

## Scope

Strictly scoped to the `no-restricted-imports` warning for `EditCustomerInvoiceCustomSectionsDialog` and its Formik dependency (Dialog + form are coupled — both had to migrate together).

## Test plan

- [ ] Customer detail → Settings → Invoice custom sections. Edit dialog opens; the current selection is seeded correctly (fallback / apply-with-sections / deactivate).
- [ ] Radio interaction: switching to "apply" shows the `MultipleComboBox`; switching back hides it.
- [ ] Submitting each behavior triggers the mutation with the expected payload; success toast shows; dialog closes.
- [ ] "Apply" with no sections keeps the submit disabled.
- [ ] `pnpm exec tsc --noEmit`, `pnpm exec eslint`, and `pnpm test EditCustomerInvoiceCustomSectionsDialog|CustomerSettings` (36/36) all pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Duj2yvsCPDSbwUJ2jgEM5w)_