### PR TITLE
fix(orders): display execution date in the Order list

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -14461,7 +14461,7 @@ export type GetOrderFormsQueryVariables = Exact<{
 
 export type GetOrderFormsQuery = { __typename?: 'Query', orderForms: { __typename?: 'OrderFormCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } }> } };
 
-export type OrderListItemFragment = { __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executedAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } } };
+export type OrderListItemFragment = { __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executeAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } } };
 
 export type GetOrdersQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -14477,7 +14477,7 @@ export type GetOrdersQueryVariables = Exact<{
 }>;
 
 
-export type GetOrdersQuery = { __typename?: 'Query', orders: { __typename?: 'OrderCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executedAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } } }> } };
+export type GetOrdersQuery = { __typename?: 'Query', orders: { __typename?: 'OrderCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executeAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } } }> } };
 
 export type QuotePreviewVersionFragment = { __typename?: 'QuoteVersion', content?: string | null, billingItems?: any | null, mentionVariables: any };
 
@@ -20497,7 +20497,7 @@ export const OrderListItemFragmentDoc = gql`
   number
   status
   executionMode
-  executedAt
+  executeAt
   customer {
     id
     displayName

--- a/src/pages/quotes/__tests__/OrdersList.test.tsx
+++ b/src/pages/quotes/__tests__/OrdersList.test.tsx
@@ -46,7 +46,7 @@ const mockOrders = [
     number: 'ORD-2026-0001',
     status: OrderStatusEnum.Executed,
     executionMode: OrderExecutionModeEnum.ExecuteInLago,
-    executedAt: '2026-04-10T10:00:00Z',
+    executeAt: '2026-04-10T10:00:00Z',
     customer: { id: 'customer-001', displayName: 'Acme Corp' },
     orderForm: {
       id: 'of-1',
@@ -64,7 +64,7 @@ const mockOrders = [
     number: 'ORD-2026-0002',
     status: OrderStatusEnum.Created,
     executionMode: null,
-    executedAt: null,
+    executeAt: null,
     customer: { id: 'customer-002', displayName: 'Globex Corp' },
     orderForm: {
       id: 'of-2',

--- a/src/pages/quotes/common/__tests__/useOrdersColumns.test.tsx
+++ b/src/pages/quotes/common/__tests__/useOrdersColumns.test.tsx
@@ -24,7 +24,7 @@ describe('useOrdersColumns', () => {
       'orderForm.quote.number',
       'orderForm.number',
       'executionMode',
-      'executedAt',
+      'executeAt',
     ])
     expect(result.current[0].title).toBe('text_1782392058759pmmuy0h997w')
   })
@@ -37,7 +37,7 @@ describe('useOrdersColumns', () => {
       'status',
       'orderForm.number',
       'executionMode',
-      'executedAt',
+      'executeAt',
     ])
   })
 })

--- a/src/pages/quotes/common/useOrdersColumns.tsx
+++ b/src/pages/quotes/common/useOrdersColumns.tsx
@@ -89,12 +89,12 @@ export const useOrdersColumns = ({
       },
     },
     {
-      key: 'executedAt',
+      key: 'executeAt',
       title: translate('text_1782392058759njezxv1yrhl'),
       minWidth: 120,
-      content: ({ executedAt }) => (
+      content: ({ executeAt }) => (
         <Typography color="grey600">
-          {executedAt ? intlFormatDateTimeOrgaTZ(executedAt).date : '-'}
+          {executeAt ? intlFormatDateTimeOrgaTZ(executeAt).date : '-'}
         </Typography>
       ),
     },

--- a/src/pages/quotes/hooks/__tests__/useOrderActions.test.ts
+++ b/src/pages/quotes/hooks/__tests__/useOrderActions.test.ts
@@ -40,7 +40,7 @@ const createMockOrder = (
   number: 'OR-2026-0001',
   status: OrderStatusEnum.Created,
   executionMode: null,
-  executedAt: null,
+  executeAt: null,
   customer: { id: 'customer-001', displayName: 'Acme Corp' },
   orderForm: {
     id: 'of-1',

--- a/src/pages/quotes/hooks/useOrders.ts
+++ b/src/pages/quotes/hooks/useOrders.ts
@@ -14,7 +14,7 @@ gql`
     number
     status
     executionMode
-    executedAt
+    executeAt
     customer {
       id
       displayName


### PR DESCRIPTION
## Context
The Orders table has an "Execution date" column, but it was always blank (`-`), even though the same date shows correctly on the Order details page.

## Fix

- `useOrders.ts` — `OrderListItem` fragment now selects `executeAt` instead of `executedAt`.
- `useOrdersColumns.tsx` — column reads/renders `executeAt` (title unchanged).
- Regenerated GraphQL types.
- Updated the 3 affected test suites.

Fixes LAGO-1695

🤖 Generated with [Claude Code](https://claude.com/claude-code)