### PR TITLE
refactor(settings): migrate UpdateBillingEntityLogoDialog to useFormDialog

### DIFF
--- a/src/components/settings/PreviewEmailLayout.tsx
+++ b/src/components/settings/PreviewEmailLayout.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren, useRef } from 'react'
+import { FC, PropsWithChildren } from 'react'
 
 import { Avatar } from '~/components/designSystem/Avatar'
 import { Button } from '~/components/designSystem/Button'
@@ -12,10 +12,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import Logo from '~/public/images/logo/lago-logo-grey.svg'
 
-import {
-  UpdateBillingEntityLogoDialog,
-  UpdateBillingEntityLogoDialogRef,
-} from './emails/UpdateBillingEntityLogoDialog'
+import { useUpdateBillingEntityLogoDialog } from './emails/UpdateBillingEntityLogoDialog'
 
 interface PreviewEmailLayoutProps extends PropsWithChildren {
   language: LocaleEnum
@@ -41,7 +38,7 @@ export const PreviewEmailLayout: FC<PreviewEmailLayoutProps> = ({
   name,
   disableLogoEdit,
 }) => {
-  const updateLogoDialogRef = useRef<UpdateBillingEntityLogoDialogRef>(null)
+  const { openUpdateBillingEntityLogoDialog } = useUpdateBillingEntityLogoDialog()
 
   const { translate } = useInternationalization()
   const { translateWithContextualLocal } = useContextualLocale(language)
@@ -82,7 +79,7 @@ export const PreviewEmailLayout: FC<PreviewEmailLayoutProps> = ({
           className="rounded-xl p-0"
           size="small"
           variant="quaternary"
-          onClick={() => updateLogoDialogRef?.current?.openDialog()}
+          onClick={() => openUpdateBillingEntityLogoDialog({ existingLogoUrl: logoUrl })}
         >
           {logoAvatar}
         </Button>
@@ -95,95 +92,89 @@ export const PreviewEmailLayout: FC<PreviewEmailLayoutProps> = ({
           icon="plus"
           size="small"
           variant="secondary"
-          onClick={() => updateLogoDialogRef?.current?.openDialog()}
+          onClick={() => openUpdateBillingEntityLogoDialog({ existingLogoUrl: logoUrl })}
         />
       </Tooltip>
     )
   }
 
   return (
-    <>
-      <div>
-        {!!emailObject && (
-          <>
-            {isLoading ? (
-              <Skeleton color="dark" variant="text" className="mb-5 w-90" />
-            ) : (
-              <Typography className="mb-4" variant="bodyHl" color="grey700">
-                {emailObject}
-              </Typography>
-            )}
+    <div>
+      {!!emailObject && (
+        <>
+          {isLoading ? (
+            <Skeleton color="dark" variant="text" className="mb-5 w-90" />
+          ) : (
+            <Typography className="mb-4" variant="bodyHl" color="grey700">
+              {emailObject}
+            </Typography>
+          )}
 
-            <div className="mb-12 flex w-full items-center">
-              {isLoading ? (
-                <>
-                  <Skeleton color="dark" variant="circular" size="big" className="mr-4" />
-                  <div>
-                    <Skeleton color="dark" variant="text" className="mb-2 w-60" />
-                    <Skeleton color="dark" variant="text" className="w-30" />
-                  </div>
-                </>
-              ) : (
-                <>
-                  <div className="mr-4 size-10 rounded-full bg-grey-300" />
-                  <div>
-                    <div className="h-[1em]">
-                      <Typography variant="captionHl" color="grey700" component="span">
-                        {name}
-                      </Typography>
-                      <Typography variant="note" component="span" className="ml-1">
-                        {emailFrom || translate('text_64188b3d9735d5007d712260')}
-                      </Typography>
-                    </div>
-                    <Typography variant="note" component="span">
-                      {emailTo || translateWithContextualLocal('text_64188b3d9735d5007d712262')}
-                    </Typography>
-                  </div>
-                </>
-              )}
-            </div>
-          </>
-        )}
-
-        <div>
-          <div className="mb-8 flex items-center justify-center not-last-child:mr-3">
+          <div className="mb-12 flex w-full items-center">
             {isLoading ? (
               <>
-                <Skeleton color="dark" variant="connectorAvatar" size="medium" className="mr-3" />
-                <Skeleton color="dark" variant="text" className="w-30" />
+                <Skeleton color="dark" variant="circular" size="big" className="mr-4" />
+                <div>
+                  <Skeleton color="dark" variant="text" className="mb-2 w-60" />
+                  <Skeleton color="dark" variant="text" className="w-30" />
+                </div>
               </>
             ) : (
               <>
-                {renderLogo()}
-                <Typography variant="subhead1">{name}</Typography>
+                <div className="mr-4 size-10 rounded-full bg-grey-300" />
+                <div>
+                  <div className="h-[1em]">
+                    <Typography variant="captionHl" color="grey700" component="span">
+                      {name}
+                    </Typography>
+                    <Typography variant="note" component="span" className="ml-1">
+                      {emailFrom || translate('text_64188b3d9735d5007d712260')}
+                    </Typography>
+                  </div>
+                  <Typography variant="note" component="span">
+                    {emailTo || translateWithContextualLocal('text_64188b3d9735d5007d712262')}
+                  </Typography>
+                </div>
               </>
             )}
           </div>
+        </>
+      )}
 
-          <section className="mb-8 rounded-xl border border-grey-300 bg-white p-8">
-            {children}
-          </section>
-
-          {showPoweredBy && (
-            <div className="mb-20 flex items-center justify-center [&>svg]:mx-1">
-              {isLoading ? (
-                <Skeleton color="dark" variant="text" className="w-55" />
-              ) : (
-                <>
-                  <Typography variant="note" color="grey500">
-                    {translateWithContextualLocal('text_64188b3d9735d5007d712278')}
-                  </Typography>
-                  <Logo height="12px" />
-                </>
-              )}
-            </div>
+      <div>
+        <div className="mb-8 flex items-center justify-center not-last-child:mr-3">
+          {isLoading ? (
+            <>
+              <Skeleton color="dark" variant="connectorAvatar" size="medium" className="mr-3" />
+              <Skeleton color="dark" variant="text" className="w-30" />
+            </>
+          ) : (
+            <>
+              {renderLogo()}
+              <Typography variant="subhead1">{name}</Typography>
+            </>
           )}
         </div>
-      </div>
 
-      {!disableLogoEdit && (
-        <UpdateBillingEntityLogoDialog ref={updateLogoDialogRef} existingLogoUrl={logoUrl} />
-      )}
-    </>
+        <section className="mb-8 rounded-xl border border-grey-300 bg-white p-8">
+          {children}
+        </section>
+
+        {showPoweredBy && (
+          <div className="mb-20 flex items-center justify-center [&>svg]:mx-1">
+            {isLoading ? (
+              <Skeleton color="dark" variant="text" className="w-55" />
+            ) : (
+              <>
+                <Typography variant="note" color="grey500">
+                  {translateWithContextualLocal('text_64188b3d9735d5007d712278')}
+                </Typography>
+                <Logo height="12px" />
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
   )
 }

--- a/src/components/settings/__tests__/PreviewEmailLayout.test.tsx
+++ b/src/components/settings/__tests__/PreviewEmailLayout.test.tsx
@@ -14,6 +14,14 @@ jest.mock('~/hooks/useOrganizationInfos', () => ({
   useOrganizationInfos: () => mockOrganizationInfos,
 }))
 
+const mockOpenUpdateBillingEntityLogoDialog = jest.fn()
+
+jest.mock('~/components/settings/emails/UpdateBillingEntityLogoDialog', () => ({
+  useUpdateBillingEntityLogoDialog: () => ({
+    openUpdateBillingEntityLogoDialog: mockOpenUpdateBillingEntityLogoDialog,
+  }),
+}))
+
 describe('PreviewEmailLayout', () => {
   beforeEach(() => {
     mockOrganizationInfos.hasOrganizationPremiumAddon.mockReturnValue(false)
@@ -145,8 +153,9 @@ describe('PreviewEmailLayout', () => {
       await userEvent.click(logoButton)
     })
 
-    // Dialog should open (checking that no error occurred)
-    expect(logoButton).toBeInTheDocument()
+    expect(mockOpenUpdateBillingEntityLogoDialog).toHaveBeenCalledWith({
+      existingLogoUrl: 'https://example.com/logo.png',
+    })
   })
 
   it('opens logo dialog when clicking plus button', async () => {
@@ -162,8 +171,9 @@ describe('PreviewEmailLayout', () => {
       await userEvent.click(plusButton)
     })
 
-    // Dialog should open (checking that no error occurred)
-    expect(plusButton).toBeInTheDocument()
+    expect(mockOpenUpdateBillingEntityLogoDialog).toHaveBeenCalledWith({
+      existingLogoUrl: null,
+    })
   })
 
   it('renders a static logo without an edit button when disableLogoEdit is true', () => {

--- a/src/components/settings/emails/UpdateBillingEntityLogoDialog.tsx
+++ b/src/components/settings/emails/UpdateBillingEntityLogoDialog.tsx
@@ -1,12 +1,17 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useState } from 'react'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
 import { useParams } from 'react-router-dom'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
 import { LogoPicker } from '~/components/LogoPicker'
 import { useGetBillingEntityQuery, useUpdateBillingEntityLogoMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
+
+export const UPDATE_BILLING_ENTITY_LOGO_FORM_ID = 'update-billing-entity-logo-form'
 
 gql`
   mutation updateBillingEntityLogo($input: UpdateBillingEntityInput!) {
@@ -17,19 +22,22 @@ gql`
   }
 `
 
-export type UpdateBillingEntityLogoDialogRef = DialogRef
+const validationSchema = z.object({
+  // `null` means "clear the logo"; `undefined` means "unchanged"; a string is a data-uri upload.
+  logo: z.union([z.string(), z.null(), z.undefined()]),
+})
 
-type TUpdateBillingEntityLogoDialog = {
+type UpdateBillingEntityLogoDialogData = {
   existingLogoUrl: string | null | undefined
 }
 
-export const UpdateBillingEntityLogoDialog = forwardRef<
-  UpdateBillingEntityLogoDialogRef,
-  TUpdateBillingEntityLogoDialog
->(({ existingLogoUrl }, ref) => {
+export const useUpdateBillingEntityLogoDialog = () => {
+  const formDialog = useFormDialog()
   const { billingEntityCode } = useParams<string>()
   const { translate } = useInternationalization()
-  const [logo, setLogo] = useState<string | null>()
+  const dataRef = useRef<UpdateBillingEntityLogoDialogData | null>(null)
+  const successRef = useRef(false)
+
   const [updateLogo] = useUpdateBillingEntityLogoMutation()
 
   const { data: billingEntityData } = useGetBillingEntityQuery({
@@ -41,42 +49,75 @@ export const UpdateBillingEntityLogoDialog = forwardRef<
 
   const billingEntity = billingEntityData?.billingEntity
 
-  return (
-    <Dialog
-      ref={ref}
-      title={translate('text_6411e69b9bda18008db7ad51')}
-      description={translate('text_6411e6a2de0b3f00b25ae488')}
-      onClose={() => {
-        setLogo(undefined)
-      }}
-      actions={({ closeDialog }) => (
-        <>
-          <Button variant="quaternary" onClick={closeDialog}>
-            {translate('text_6411e6b530cb47007488b027')}
-          </Button>
-          <Button
-            variant="primary"
-            disabled={logo === undefined}
-            onClick={async () => {
-              await updateLogo({
-                variables: { input: { id: billingEntity?.id as string, logo } },
-              })
-              closeDialog()
-            }}
-          >
-            {translate('text_6411e6ac9a8c9700a7570a4e')}
-          </Button>
-        </>
-      )}
-    >
-      <LogoPicker
-        className="mb-8"
-        logoValue={logo}
-        onChange={(value) => setLogo(value)}
-        logoUrl={existingLogoUrl}
-      />
-    </Dialog>
-  )
-})
+  const form = useAppForm({
+    defaultValues: {
+      logo: undefined as string | null | undefined,
+    },
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: validationSchema,
+    },
+    onSubmit: async ({ value }) => {
+      const result = await updateLogo({
+        variables: { input: { id: billingEntity?.id as string, logo: value.logo } },
+      })
 
-UpdateBillingEntityLogoDialog.displayName = 'UpdateBillingEntityLogoDialog'
+      if (result.data?.updateBillingEntity) {
+        successRef.current = true
+      }
+    },
+  })
+
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
+
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openUpdateBillingEntityLogoDialog = (data: UpdateBillingEntityLogoDialogData) => {
+    dataRef.current = data
+    form.reset()
+
+    formDialog
+      .open({
+        title: translate('text_6411e69b9bda18008db7ad51'),
+        description: translate('text_6411e6a2de0b3f00b25ae488'),
+        closeOnError: false,
+        children: (
+          <div className="p-8">
+            <form.AppField name="logo">
+              {(field) => (
+                <LogoPicker
+                  logoValue={field.state.value}
+                  onChange={(value) => field.handleChange(value)}
+                  logoUrl={dataRef.current?.existingLogoUrl}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>{translate('text_6411e6ac9a8c9700a7570a4e')}</form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: UPDATE_BILLING_ENTITY_LOGO_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close') {
+          form.reset()
+          dataRef.current = null
+        }
+      })
+  }
+
+  return { openUpdateBillingEntityLogoDialog }
+}


### PR DESCRIPTION
## Context

`UpdateBillingEntityLogoDialog` was one of the legacy `forwardRef` + `Dialog` (`~/components/designSystem/Dialog`) consumers flagged by the `no-restricted-imports` ESLint rule. The dialog wraps a single `LogoPicker` control + a save button, so `useFormDialog` + TanStack Form (a one-field form) is a natural fit.

## Description

- **`src/components/settings/emails/UpdateBillingEntityLogoDialog.tsx`**
  - Replaced the `forwardRef` + `Dialog` + local `useState<string | null>()` with a `useUpdateBillingEntityLogoDialog` hook backed by `useFormDialog` and `useAppForm` + Zod.
  - The form owns a single `logo` field (`string | null | undefined`) — `LogoPicker` plugs into it via a `form.AppField` render prop; the picker's `onChange(value)` calls `field.handleChange(value)`.
  - The existing `useUpdateBillingEntityLogoMutation` + `useGetBillingEntityQuery(code=billingEntityCode)` are still wired at the hook level, so the billing-entity id is resolved from the URL slug on submit — unchanged behavior.
  - `handleSubmit` returns `Promise<DialogResult>` using `successRef` (set inside the mutation's `.data` check) to signal success — throws to keep the dialog open under `closeOnError: false`.
  - The `existingLogoUrl` is passed via the open-function payload (`openUpdateBillingEntityLogoDialog({ existingLogoUrl })`) and stored in a `useRef`, so the picker preview always reflects the current parent state.
  - Exports a stable `UPDATE_BILLING_ENTITY_LOGO_FORM_ID` constant used as the dialog's form id.
  - Dropped the `UpdateBillingEntityLogoDialogRef` and the top-level `DialogRef` import.

- **`src/components/settings/PreviewEmailLayout.tsx`**
  - Dropped the `updateLogoDialogRef` `useRef` + `<UpdateBillingEntityLogoDialog ref={…} existingLogoUrl={…} />` JSX render (the dialog is now dispatched globally via NiceModal).
  - Both edit affordances (the "click on logo" and the "plus" button) now call `openUpdateBillingEntityLogoDialog({ existingLogoUrl: logoUrl })` directly.
  - Removed the outer fragment that only wrapped `<div>` + the (now-gone) dialog — the layout root is now the single `<div>`.

- **`src/components/settings/__tests__/PreviewEmailLayout.test.tsx`**
  - Replaced the previous "click didn't crash" assertions with `mockOpenUpdateBillingEntityLogoDialog` mock + `expect(mock).toHaveBeenCalledWith({ existingLogoUrl })` for the two edit affordances.

## Scope

Strictly scoped to the `no-restricted-imports` warning for `UpdateBillingEntityLogoDialog`. Moved the tiny piece of local `useState` into the TanStack form since the dialog was fundamentally form-shaped (one input → one submit).

## Test plan

- [ ] Settings → Billing entity → Emails preview. Click the logo (with or without one already set) → dialog opens showing the existing logo (if any).
- [ ] Upload a new image via the picker → submit fires `updateBillingEntityLogo` with the new data URI, dialog closes, preview shows the new logo.
- [ ] Clear the logo via the trash button, submit → mutation receives `logo: null`.
- [ ] Cancel/close → no mutation.
- [ ] `pnpm exec tsc --noEmit`, `pnpm exec eslint`, and `pnpm test PreviewEmailLayout` (19/19) all pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Duj2yvsCPDSbwUJ2jgEM5w)_