### PR TITLE
refactor(settings): migrate EditNetPaymentTermDialog to FormDialog and TanStack Form

### DIFF
--- a/.agents/skills/migrate-dialog/SKILL.md
+++ b/.agents/skills/migrate-dialog/SKILL.md
@@ -167,7 +167,11 @@ export const useMyDialog = () => {
           </div>
         ),
         closeOnError: false,
-        onEntered: focusFirstInput,
+        // onEntered: CLASSIFY THE FIRST FIELD FIRST (see section 2, decision table). Do NOT
+        // default to focusFirstInput. Pick exactly one branch:
+        //   2a plain-input-first  → onEntered: focusFirstInput
+        //   2b combobox-first/only → onEntered clicks the combobox MuiInputBase-root (opens dropdown)
+        onEntered: /* branch 2a or 2b — see section 2 */ focusFirstInput,
         mainAction: (
           <form.AppForm>
             <form.SubmitButton>{translate('...')}</form.SubmitButton>
@@ -440,6 +444,9 @@ export const useMyFormDialog = () => {
           </div>
         ),
         closeOnError: false,
+        // onEntered: CLASSIFY THE FIRST FIELD FIRST (see section 2, decision table). This example's
+        // first field is a TextInputField, so branch 2a (focusFirstInput) applies. A combobox-first
+        // dialog needs branch 2b (click the combobox MuiInputBase-root to open its dropdown).
         onEntered: focusFirstInput,
         mainAction: (
           <form.AppForm>
@@ -541,6 +548,9 @@ Add (for FormDialog):
 import { useRef } from 'react'
 import { useFormDialog } from '~/components/dialogs/FormDialog'
 import { DialogResult } from '~/components/dialogs/types'
+// Only for branch 2a (plain-input-first). Branch 2b (combobox-first/only) does NOT import
+// focusFirstInput — it imports MUI_INPUT_BASE_ROOT_CLASSNAME + a field className from
+// ~/core/constants/form and clicks the combobox MuiInputBase-root in onEntered. See section 2.
 import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 ```
 
@@ -556,6 +566,9 @@ Or (for FormDialogOpeningDialog):
 import { useRef } from 'react'
 import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
 import { DialogResult } from '~/components/dialogs/types'
+// Only for branch 2a (plain-input-first). Branch 2b (combobox-first/only) does NOT import
+// focusFirstInput — it imports MUI_INPUT_BASE_ROOT_CLASSNAME + a field className from
+// ~/core/constants/form and clicks the combobox MuiInputBase-root in onEntered. See section 2.
 import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 ```
 

--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -36,10 +36,7 @@ import {
   EditFinalizeZeroAmountInvoiceDialog,
   EditFinalizeZeroAmountInvoiceDialogRef,
 } from '~/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog'
-import {
-  EditNetPaymentTermDialog,
-  EditNetPaymentTermDialogRef,
-} from '~/components/settings/invoices/EditNetPaymentTermDialog'
+import { useEditNetPaymentTermDialog } from '~/components/settings/invoices/EditNetPaymentTermDialog'
 import {
   INVOICE_ISSUING_DATE_ADJUSTMENT_SETTING_KEYS,
   INVOICE_ISSUING_DATE_ANCHOR_SETTING_KEYS,
@@ -198,7 +195,8 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
     useEditCustomerInvoiceCustomSectionsDialog(customerId)
   const { openDeleteCustomerDocumentLocaleDialog } = useDeleteCustomerDocumentLocaleDialog()
   const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
-  const editNetPaymentTermDialogRef = useRef<EditNetPaymentTermDialogRef>(null)
+  const { openEditNetPaymentTermDialog } = useEditNetPaymentTermDialog()
+  const netPaymentTermDialogDescription = translate('text_64c7a89b6c67eb6c988980eb')
   const { openDeleteCustomerNetPaymentTermDialog } = useDeleteCustomerNetPaymentTermDialog()
   const editFinalizeZeroAmountInvoiceDialogRef =
     useRef<EditFinalizeZeroAmountInvoiceDialogRef>(null)
@@ -738,7 +736,10 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                             disabled={loading}
                             variant="inline"
                             onClick={() =>
-                              editNetPaymentTermDialogRef?.current?.openDialog(customer)
+                              openEditNetPaymentTermDialog({
+                                model: customer,
+                                description: netPaymentTermDialogDescription,
+                              })
                             }
                           >
                             {translate('text_645bb193927b375079d28ad2')}
@@ -762,7 +763,10 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                                   variant="quaternary"
                                   align="left"
                                   onClick={() => {
-                                    editNetPaymentTermDialogRef?.current?.openDialog(customer)
+                                    openEditNetPaymentTermDialog({
+                                      model: customer,
+                                      description: netPaymentTermDialogDescription,
+                                    })
                                     closePopper()
                                   }}
                                 >
@@ -939,10 +943,6 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
           <EditCustomerIssuingDatePolicyDialog
             ref={editIssuingDatePolicyDialogRef}
             customer={customer}
-          />
-          <EditNetPaymentTermDialog
-            ref={editNetPaymentTermDialogRef}
-            description={translate('text_64c7a89b6c67eb6c988980eb')}
           />
           <EditFinalizeZeroAmountInvoiceDialog
             ref={editFinalizeZeroAmountInvoiceDialogRef}

--- a/src/components/customers/__tests__/CustomerSettings.test.tsx
+++ b/src/components/customers/__tests__/CustomerSettings.test.tsx
@@ -106,13 +106,11 @@ jest.mock('~/components/customers/DeleteCustomerNetPaymentTermDialog', () => ({
   }),
 }))
 
-jest.mock('~/components/settings/invoices/EditNetPaymentTermDialog', () => {
-  const React = jest.requireActual('react')
-  const MockDialog = React.forwardRef(() => null)
-
-  MockDialog.displayName = 'EditNetPaymentTermDialog'
-  return { EditNetPaymentTermDialog: MockDialog }
-})
+jest.mock('~/components/settings/invoices/EditNetPaymentTermDialog', () => ({
+  useEditNetPaymentTermDialog: () => ({
+    openEditNetPaymentTermDialog: jest.fn(),
+  }),
+}))
 
 jest.mock('~/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog', () => {
   const React = jest.requireActual('react')

--- a/src/components/settings/invoices/EditNetPaymentTermDialog.tsx
+++ b/src/components/settings/invoices/EditNetPaymentTermDialog.tsx
@@ -1,13 +1,16 @@
 import { gql } from '@apollo/client'
 import InputAdornment from '@mui/material/InputAdornment'
-import { useFormik } from 'formik'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
-import { number, object, string } from 'yup'
+import { revalidateLogic, useStore } from '@tanstack/react-form'
+import { useRef } from 'react'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { ComboBoxField, TextInputField } from '~/components/form'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
 import { addToast } from '~/core/apolloClient'
+import {
+  MUI_INPUT_BASE_ROOT_CLASSNAME,
+  NET_PAYMENT_TERM_INPUT_CLASSNAME,
+} from '~/core/constants/form'
 import { NetPaymentTermValuesEnum } from '~/core/constants/paymentTerm'
 import {
   EditBillingEntityNetPaymentTermForDialogFragment,
@@ -16,6 +19,9 @@ import {
   useUpdateCustomerNetPaymentTermMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm, withForm } from '~/hooks/forms/useAppform'
+
+export const EDIT_NET_PAYMENT_TERM_FORM_ID = 'edit-net-payment-term-form'
 
 gql`
   fragment EditCustomerNetPaymentTermForDialog on Customer {
@@ -50,37 +56,150 @@ enum NetPaymentTermModelTypesEnum {
   BillingEntity = 'BillingEntity',
 }
 
-export interface EditNetPaymentTermDialogRef {
-  openDialog: (
-    model:
-      | EditCustomerNetPaymentTermForDialogFragment
-      | EditBillingEntityNetPaymentTermForDialogFragment
-      | null
-      | undefined,
-  ) => unknown
-  closeDialog: () => unknown
+type FormValues = {
+  netPaymentTerm: string
+  customPeriod: number | ''
 }
 
-interface EditNetPaymentTermDialogProps {
+const initialValues: FormValues = {
+  netPaymentTerm: '',
+  customPeriod: '',
+}
+
+const validationSchema = z
+  .object({
+    netPaymentTerm: z.enum(NetPaymentTermValuesEnum),
+    customPeriod: z.union([z.number(), z.literal('')]),
+  })
+  .refine(
+    (data) =>
+      data.netPaymentTerm !== NetPaymentTermValuesEnum.custom ||
+      (typeof data.customPeriod === 'number' && data.customPeriod >= 0),
+    { path: ['customPeriod'], message: '' },
+  )
+
+type ModelData =
+  EditCustomerNetPaymentTermForDialogFragment | EditBillingEntityNetPaymentTermForDialogFragment
+
+const getInitialFormValues = (model: ModelData | null): FormValues => {
+  if (!model || typeof model.netPaymentTerm !== 'number') {
+    return initialValues
+  }
+
+  const isCustomValue = !Object.values(NetPaymentTermValuesEnum).includes(
+    String(model.netPaymentTerm) as unknown as NetPaymentTermValuesEnum,
+  )
+
+  return {
+    netPaymentTerm: isCustomValue ? NetPaymentTermValuesEnum.custom : String(model.netPaymentTerm),
+    customPeriod: isCustomValue ? model.netPaymentTerm : '',
+  }
+}
+
+const DialogContent = withForm({
+  defaultValues: initialValues,
+  render: function Render({ form }) {
+    const { translate } = useInternationalization()
+    const netPaymentTerm = useStore(form.store, (state) => state.values.netPaymentTerm)
+
+    return (
+      <div className="flex flex-col gap-3 p-8">
+        <form.AppField name="netPaymentTerm">
+          {(field) => (
+            <field.ComboBoxField
+              className={NET_PAYMENT_TERM_INPUT_CLASSNAME}
+              label={translate('text_64c7a89b6c67eb6c98898109')}
+              placeholder={translate('text_64c7b3014f5c4639c4a51ab0')}
+              sortValues={false}
+              data={[
+                {
+                  value: NetPaymentTermValuesEnum.zero,
+                  label: translate('text_64c7a89b6c67eb6c98898125'),
+                },
+                {
+                  value: NetPaymentTermValuesEnum.thirty,
+                  label: translate(
+                    'text_64c7a89b6c67eb6c9889815f',
+                    {
+                      days: 30,
+                    },
+                    30,
+                  ),
+                },
+                {
+                  value: NetPaymentTermValuesEnum.sixty,
+                  label: translate(
+                    'text_64c7a89b6c67eb6c9889815f',
+                    {
+                      days: 60,
+                    },
+                    60,
+                  ),
+                },
+                {
+                  value: NetPaymentTermValuesEnum.ninety,
+                  label: translate(
+                    'text_64c7a89b6c67eb6c9889815f',
+                    {
+                      days: 90,
+                    },
+                    90,
+                  ),
+                },
+                {
+                  value: NetPaymentTermValuesEnum.custom,
+                  label: translate('text_64c7a89b6c67eb6c988981ae'),
+                },
+              ]}
+              PopperProps={{ displayInDialog: true }}
+            />
+          )}
+        </form.AppField>
+
+        {netPaymentTerm === NetPaymentTermValuesEnum.custom && (
+          <form.AppField name="customPeriod">
+            {(field) => (
+              <field.TextInputField
+                label={translate('text_64c7a89b6c67eb6c988981ae')}
+                placeholder={translate('text_62ff5d01a306e274d4ffcc3c')}
+                beforeChangeFormatter={['positiveNumber', 'int']}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      {translate('text_638dc196fb209d551f3d814d')}
+                    </InputAdornment>
+                  ),
+                }}
+              />
+            )}
+          </form.AppField>
+        )}
+      </div>
+    )
+  },
+})
+
+type EditNetPaymentTermDialogData = {
+  model: ModelData | null | undefined
   description: string
 }
 
-export const EditNetPaymentTermDialog = forwardRef<
-  EditNetPaymentTermDialogRef,
-  EditNetPaymentTermDialogProps
->(({ description }: EditNetPaymentTermDialogProps, ref) => {
+export const useEditNetPaymentTermDialog = () => {
+  const formDialog = useFormDialog()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
-  const [model, setLocalModel] = useState<
-    EditCustomerNetPaymentTermForDialogFragment | EditBillingEntityNetPaymentTermForDialogFragment
-  >()
-  const [isEdit, setIsEdit] = useState<boolean>(false)
+  const modelRef = useRef<ModelData | null>(null)
+  const isEditRef = useRef(false)
+  const successRef = useRef(false)
+
   const [updateBillingEntity] = useUpdateBillingEntityNetPaymentTermMutation({
     onCompleted(res) {
       if (res?.updateBillingEntity) {
+        successRef.current = true
         addToast({
           severity: 'success',
-          translateKey: isEdit ? 'text_64c7a89b6c67eb6c98898181' : 'text_64c7a89b6c67eb6c98898350',
+          translateKey: isEditRef.current
+            ? 'text_64c7a89b6c67eb6c98898181'
+            : 'text_64c7a89b6c67eb6c98898350',
         })
       }
     },
@@ -89,58 +208,31 @@ export const EditNetPaymentTermDialog = forwardRef<
   const [updateCustomer] = useUpdateCustomerNetPaymentTermMutation({
     onCompleted(res) {
       if (res?.updateCustomer) {
+        successRef.current = true
         addToast({
           severity: 'success',
-          translateKey: isEdit ? 'text_64c7a89b6c67eb6c98898181' : 'text_64c7a89b6c67eb6c98898350',
+          translateKey: isEditRef.current
+            ? 'text_64c7a89b6c67eb6c98898181'
+            : 'text_64c7a89b6c67eb6c98898350',
         })
       }
     },
   })
 
-  const getNetPaymentTermInitialValue = () => {
-    if (typeof model?.netPaymentTerm !== 'number') {
-      return null
-    }
-    const isCustomValue = !Object.values(NetPaymentTermValuesEnum).includes(
-      String(model?.netPaymentTerm) as unknown as NetPaymentTermValuesEnum,
-    )
+  const form = useAppForm({
+    defaultValues: initialValues,
+    validationLogic: revalidateLogic(),
+    validators: { onDynamic: validationSchema },
+    onSubmit: async ({ value }) => {
+      const model = modelRef.current
 
-    return isCustomValue ? NetPaymentTermValuesEnum.custom : String(model?.netPaymentTerm)
-  }
-
-  const formikProps = useFormik<{
-    netPaymentTerm: string | null
-    customPeriod: number | null
-  }>({
-    initialValues: {
-      netPaymentTerm: getNetPaymentTermInitialValue(),
-      customPeriod:
-        typeof model?.netPaymentTerm === 'number' &&
-        !Object.values(NetPaymentTermValuesEnum).includes(
-          String(model?.netPaymentTerm) as unknown as NetPaymentTermValuesEnum,
-        )
-          ? model?.netPaymentTerm
-          : null,
-    },
-    validationSchema: object().shape({
-      netPaymentTerm: string().required(''),
-      customPeriod: number()
-        .when('netPaymentTerm', {
-          is: (netPaymentTerm: string) => netPaymentTerm === NetPaymentTermValuesEnum.custom,
-          then: (schema) => schema.required(''),
-        })
-        .nullable(),
-    }),
-    validateOnMount: true,
-    enableReinitialize: true,
-    onSubmit: async (values) => {
       if (!model) return
 
       const localInput = {
         netPaymentTerm:
-          values.netPaymentTerm === NetPaymentTermValuesEnum.custom
-            ? Number(values.customPeriod)
-            : Number(values.netPaymentTerm),
+          value.netPaymentTerm === NetPaymentTermValuesEnum.custom
+            ? Number(value.customPeriod)
+            : Number(value.netPaymentTerm),
       }
 
       if (model.__typename === NetPaymentTermModelTypesEnum.Customer) {
@@ -167,115 +259,60 @@ export const EditNetPaymentTermDialog = forwardRef<
     },
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      !!data && setLocalModel(data)
-      setIsEdit(typeof data?.netPaymentTerm === 'number')
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => {
-      dialogRef.current?.closeDialog()
-    },
-  }))
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate(isEdit ? 'text_64c7a89b6c67eb6c988981e0' : 'text_64c7a89b6c67eb6c9889822d')}
-      description={description}
-      onClose={() => {
-        formikProps.resetForm()
-        formikProps.validateForm()
-        setIsEdit(false)
-        setLocalModel(undefined)
-      }}
-      actions={({ closeDialog }) => (
-        <>
-          <Button variant="quaternary" onClick={closeDialog}>
-            {translate('text_62bb10ad2a10bd182d002031')}
-          </Button>
-          <Button
-            variant="primary"
-            disabled={!formikProps.isValid || !formikProps.dirty}
-            onClick={async () => {
-              await formikProps.submitForm()
-              closeDialog()
-            }}
-          >
-            {translate('text_17432414198706rdwf76ek3u')}
-          </Button>
-        </>
-      )}
-    >
-      <div className="mb-8 flex flex-col gap-3">
-        <ComboBoxField
-          name="netPaymentTerm"
-          label={translate('text_64c7a89b6c67eb6c98898109')}
-          placeholder={translate('text_64c7b3014f5c4639c4a51ab0')}
-          formikProps={formikProps}
-          sortValues={false}
-          data={[
-            {
-              value: NetPaymentTermValuesEnum.zero,
-              label: translate('text_64c7a89b6c67eb6c98898125'),
-            },
-            {
-              value: NetPaymentTermValuesEnum.thirty,
-              label: translate(
-                'text_64c7a89b6c67eb6c9889815f',
-                {
-                  days: 30,
-                },
-                30,
-              ),
-            },
-            {
-              value: NetPaymentTermValuesEnum.sixty,
-              label: translate(
-                'text_64c7a89b6c67eb6c9889815f',
-                {
-                  days: 60,
-                },
-                60,
-              ),
-            },
-            {
-              value: NetPaymentTermValuesEnum.ninety,
-              label: translate(
-                'text_64c7a89b6c67eb6c9889815f',
-                {
-                  days: 90,
-                },
-                90,
-              ),
-            },
-            {
-              value: NetPaymentTermValuesEnum.custom,
-              label: translate('text_64c7a89b6c67eb6c988981ae'),
-            },
-          ]}
-          PopperProps={{ displayInDialog: true }}
-        />
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
 
-        {formikProps.values.netPaymentTerm === NetPaymentTermValuesEnum.custom && (
-          <TextInputField
-            name="customPeriod"
-            label={translate('text_64c7a89b6c67eb6c988981ae')}
-            placeholder={translate('text_62ff5d01a306e274d4ffcc3c')}
-            beforeChangeFormatter={['positiveNumber', 'int']}
-            formikProps={formikProps}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  {translate('text_638dc196fb209d551f3d814d')}
-                </InputAdornment>
-              ),
-            }}
-          />
-        )}
-      </div>
-    </Dialog>
-  )
-})
+    return { reason: 'success' }
+  }
 
-EditNetPaymentTermDialog.displayName = 'forwardRef'
+  const openEditNetPaymentTermDialog = ({ model, description }: EditNetPaymentTermDialogData) => {
+    modelRef.current = model ?? null
+    isEditRef.current = typeof model?.netPaymentTerm === 'number'
+
+    const seeded = getInitialFormValues(model ?? null)
+
+    form.reset()
+    form.setFieldValue('netPaymentTerm', seeded.netPaymentTerm)
+    form.setFieldValue('customPeriod', seeded.customPeriod)
+
+    formDialog
+      .open({
+        title: translate(
+          isEditRef.current ? 'text_64c7a89b6c67eb6c988981e0' : 'text_64c7a89b6c67eb6c9889822d',
+        ),
+        description,
+        closeOnError: false,
+        onEntered: (container) => {
+          container
+            .querySelector<HTMLElement>(
+              `.${NET_PAYMENT_TERM_INPUT_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+            )
+            ?.click()
+        },
+        children: <DialogContent form={form} />,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>{translate('text_17432414198706rdwf76ek3u')}</form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: EDIT_NET_PAYMENT_TERM_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close') {
+          form.reset()
+          modelRef.current = null
+          isEditRef.current = false
+        }
+      })
+  }
+
+  return { openEditNetPaymentTermDialog }
+}

--- a/src/core/constants/form.ts
+++ b/src/core/constants/form.ts
@@ -47,6 +47,7 @@ export const SEARCH_TAX_INPUT_FOR_ADD_ON_CLASSNAME = 'searchTaxForAddOnInput'
 // Invoices
 export const SEARCH_TAX_INPUT_FOR_INVOICE_ADD_ON_CLASSNAME = 'searchTaxForInvoiceAddOnInput'
 export const ADD_ITEM_FOR_INVOICE_INPUT_NAME = 'addItemInput'
+export const NET_PAYMENT_TERM_INPUT_CLASSNAME = 'netPaymentTermInput'
 // Billing entity
 export const SEARCH_INVOICE_CUSTOM_SECTION_INPUT_CLASSNAME = 'searchInvoiceCustomSectionInput'
 // Customer

--- a/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
@@ -31,10 +31,7 @@ import {
   EditFinalizeZeroAmountInvoiceDialog,
   EditFinalizeZeroAmountInvoiceDialogRef,
 } from '~/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog'
-import {
-  EditNetPaymentTermDialog,
-  EditNetPaymentTermDialogRef,
-} from '~/components/settings/invoices/EditNetPaymentTermDialog'
+import { useEditNetPaymentTermDialog } from '~/components/settings/invoices/EditNetPaymentTermDialog'
 import {
   INVOICE_ISSUING_DATE_ADJUSTMENT_SETTING_KEYS,
   INVOICE_ISSUING_DATE_ANCHOR_SETTING_KEYS,
@@ -130,7 +127,8 @@ const BillingEntityInvoiceSettings = () => {
     useRef<EditBillingEntityInvoiceIssuingDatePolicyDialogRef>(null)
   const editGracePeriodDialogRef = useRef<EditBillingEntityGracePeriodDialogRef>(null)
   const { openEditBillingEntityDocumentLocaleDialog } = useEditBillingEntityDocumentLocaleDialog()
-  const editNetPaymentTermDialogRef = useRef<EditNetPaymentTermDialogRef>(null)
+  const { openEditNetPaymentTermDialog } = useEditNetPaymentTermDialog()
+  const netPaymentTermDialogDescription = translate('text_64c7a89b6c67eb6c988980eb')
   const editFinalizeZeroAmountInvoiceDialogRef =
     useRef<EditFinalizeZeroAmountInvoiceDialogRef>(null)
   const premiumWarningDialog = usePremiumWarningDialog()
@@ -384,7 +382,12 @@ const BillingEntityInvoiceSettings = () => {
         <Button
           variant="inline"
           disabled={!canEditInvoiceSettings}
-          onClick={() => editNetPaymentTermDialogRef?.current?.openDialog(billingEntity)}
+          onClick={() =>
+            openEditNetPaymentTermDialog({
+              model: billingEntity,
+              description: netPaymentTermDialogDescription,
+            })
+          }
         >
           {translate('text_637f819eff19cd55a56d55e4')}
         </Button>
@@ -395,12 +398,6 @@ const BillingEntityInvoiceSettings = () => {
           days: billingEntity?.netPaymentTerm,
         },
         billingEntity?.netPaymentTerm,
-      ),
-      dialog: (
-        <EditNetPaymentTermDialog
-          ref={editNetPaymentTermDialogRef}
-          description={translate('text_64c7a89b6c67eb6c988980eb')}
-        />
       ),
     },
   ]


### PR DESCRIPTION
## Context

`EditNetPaymentTermDialog` was one of the legacy `forwardRef` + `Dialog` (`~/components/designSystem/Dialog`) + Formik consumers flagged by the `no-restricted-imports` ESLint rule. The dialog is polymorphic — same UI targets either `Customer` (via `updateCustomer`) or `BillingEntity` (via `updateBillingEntity`) — with a preset dropdown + a conditional "custom period" number input, so `useFormDialog` + TanStack Form is a natural fit.

## Description

- **`src/components/settings/invoices/EditNetPaymentTermDialog.tsx`**
  - Replaced the `forwardRef` + `Dialog` + Formik + Yup boilerplate with a `useEditNetPaymentTermDialog` hook backed by `useFormDialog` and `useAppForm` + Zod.
  - The two fields (`netPaymentTerm` preset + optional `customPeriod`) live in the form; the "custom period is required when preset is custom" rule is expressed via a `.refine()` targeting `customPeriod`.
  - The dialog body is extracted with `withForm(...)` and uses `useStore(form.store, s => s.values.netPaymentTerm)` to toggle the custom-period field's visibility.
  - The polymorphic submit path (Customer vs BillingEntity) is preserved via `__typename` on `modelRef.current`; both mutations were kept as-is with a shared `successRef` and the add/edit toast branching driven by `isEditRef`.
  - `handleSubmit` returns `Promise<DialogResult>` using `successRef` (set inside the mutations' `onCompleted` handlers) to signal success — throws to keep the dialog open under `closeOnError: false`.
  - Exports a stable `EDIT_NET_PAYMENT_TERM_FORM_ID` constant used as the dialog's form id.
  - Dropped `EditNetPaymentTermDialogRef` and the top-level `DialogRef` import.

- **`src/components/customers/CustomerSettings.tsx`**
  - Dropped the `editNetPaymentTermDialogRef` `useRef` + the inline `<EditNetPaymentTermDialog ref={…} description={…} />` JSX.
  - Both call sites (add + edit) now call `openEditNetPaymentTermDialog({ model: customer, description })` directly.

- **`src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx`**
  - Same drop for the billing-entity side: the ref/JSX pair is gone and the "edit" action calls `openEditNetPaymentTermDialog({ model: billingEntity, description })` directly. The item's `dialog` field is dropped so the map below no longer renders anything for this row.

- **`src/components/customers/__tests__/CustomerSettings.test.tsx`**
  - Replaced the `forwardRef` mock with a plain hook mock returning `openEditNetPaymentTermDialog: jest.fn()`.

## Scope

Strictly scoped to the `no-restricted-imports` warning for `EditNetPaymentTermDialog` and its Formik dependency (Dialog + form are coupled — both had to migrate together). No unrelated cleanup.

## Test plan

- [ ] Customer detail → Settings → Net payment term. "Add net payment term" opens the dialog when unset; the "Edit" menu action opens it with the current preset value seeded.
- [ ] Billing entity settings → Invoice settings → Net payment term "Edit" opens the dialog with the entity's current preset seeded.
- [ ] Switching the preset to "Custom" reveals the number input; picking a non-custom preset hides it. Submit disabled until custom period is provided.
- [ ] Submitting a customer's net payment term fires `updateCustomer` with the correct `id`, `externalId`, `name`, `netPaymentTerm`; billing-entity submits fire `updateBillingEntity` with `id` + `netPaymentTerm`. Success toast branches add vs edit.
- [ ] Cancel/close → no mutation.
- [ ] `pnpm exec tsc --noEmit`, `pnpm exec eslint`, and `pnpm test CustomerSettings|EditNetPaymentTerm|BillingEntityInvoiceSettings` (33/33) all pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Duj2yvsCPDSbwUJ2jgEM5w)_