### PR TITLE
refactor(multiple-connections): extract reusable connection primitives for the multi-connection feature

### DIFF
--- a/src/components/customerConnections/AddConnectionMenu.tsx
+++ b/src/components/customerConnections/AddConnectionMenu.tsx
@@ -1,0 +1,69 @@
+import { Button } from '~/components/designSystem/Button'
+import { Popper } from '~/components/designSystem/Popper'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { MenuPopper } from '~/styles'
+
+import { ConnectionCategory } from './types'
+
+const CATEGORY_LABEL_KEYS: Record<ConnectionCategory, string> = {
+  [ConnectionCategory.Payment]: 'text_634ea0ecc6147de10ddb6631',
+  [ConnectionCategory.Accounting]: 'text_66423cad72bbad009f2f568f',
+  [ConnectionCategory.Tax]: 'text_6668821d94e4da4dfd8b3840',
+  [ConnectionCategory.Crm]: 'text_1728658962985xpfdvl5ru8a',
+}
+
+const MENU_ORDER: ConnectionCategory[] = [
+  ConnectionCategory.Payment,
+  ConnectionCategory.Accounting,
+  ConnectionCategory.Tax,
+  ConnectionCategory.Crm,
+]
+
+type AddConnectionMenuProps = {
+  /** Disables the whole opener button */
+  disabled?: boolean
+  /** Disables individual category entries (e.g. one-per-type limit) */
+  disabledCategories?: ConnectionCategory[]
+  onSelect: (category: ConnectionCategory, utils: { closePopper: () => void }) => void
+}
+
+/**
+ * The shared "Add a connection" menu: a Popper listing the four connection
+ * categories. Used on customer create/edit and on the customer information
+ * view; the mount site decides what selecting a category does (show a
+ * section, open the connection drawer, ...).
+ */
+export const AddConnectionMenu = ({
+  disabled,
+  disabledCategories,
+  onSelect,
+}: AddConnectionMenuProps) => {
+  const { translate } = useInternationalization()
+
+  return (
+    <Popper
+      PopperProps={{ placement: 'bottom-start' }}
+      opener={
+        <Button startIcon="plus" variant="inline" disabled={disabled}>
+          {translate('text_65846763e6140b469140e235')}
+        </Button>
+      }
+    >
+      {({ closePopper }) => (
+        <MenuPopper>
+          {MENU_ORDER.map((category) => (
+            <Button
+              key={category}
+              variant="quaternary"
+              align="left"
+              disabled={disabledCategories?.includes(category)}
+              onClick={() => onSelect(category, { closePopper })}
+            >
+              {translate(CATEGORY_LABEL_KEYS[category])}
+            </Button>
+          ))}
+        </MenuPopper>
+      )}
+    </Popper>
+  )
+}

--- a/src/components/customerConnections/ConnectionComboBox.tsx
+++ b/src/components/customerConnections/ConnectionComboBox.tsx
@@ -1,0 +1,53 @@
+import { ComboboxDataGrouped, ComboboxItem } from '~/components/form'
+
+import { Typography } from '../designSystem/Typography'
+
+/**
+ * Shared presentation primitives for the provider-grouped connection combobox.
+ *
+ * Form-agnostic on purpose: the customer create/edit accordions feed it the
+ * org-level integrations, while the per-object surfaces (subscription, one-off
+ * invoice, wallet) feed it the customer's connections — same presentation,
+ * different data source.
+ */
+
+export type ConnectionComboBoxDataItem = {
+  /** Option value (the routing key: provider/connection code) */
+  value: string
+  /** Main label (name) */
+  label: string
+  /** Secondary label rendered under the main one (usually the code) */
+  subLabel?: string
+  /** Group header (provider type, e.g. "Stripe", "NetSuite") */
+  group?: string
+}
+
+export const ConnectionComboBoxLabel = ({
+  label,
+  subLabel,
+}: {
+  label: string
+  subLabel?: string
+}) => {
+  return (
+    <ComboboxItem>
+      <Typography variant="body" color="grey700" noWrap>
+        {label}
+      </Typography>
+      <Typography variant="caption" color="grey600" noWrap>
+        {subLabel}
+      </Typography>
+    </ComboboxItem>
+  )
+}
+
+export const buildConnectionComboBoxData = (
+  items: ConnectionComboBoxDataItem[],
+): ComboboxDataGrouped[] => {
+  return items.map(({ value, label, subLabel, group }) => ({
+    value,
+    label,
+    group: group ?? '',
+    labelNode: <ConnectionComboBoxLabel label={label} subLabel={subLabel} />,
+  }))
+}

--- a/src/components/customerConnections/__tests__/AddConnectionMenu.test.tsx
+++ b/src/components/customerConnections/__tests__/AddConnectionMenu.test.tsx
@@ -1,0 +1,169 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { AddConnectionMenu } from '~/components/customerConnections/AddConnectionMenu'
+import { ConnectionCategory } from '~/components/customerConnections/types'
+import { render } from '~/test-utils'
+
+const OPENER_LABEL = /add a connection/i
+
+const CATEGORY_LABELS: Array<[ConnectionCategory, RegExp]> = [
+  [ConnectionCategory.Payment, /payment provider/i],
+  [ConnectionCategory.Accounting, /accounting provider/i],
+  [ConnectionCategory.Tax, /tax provider/i],
+  [ConnectionCategory.Crm, /crm connection/i],
+]
+
+const openMenu = async () => {
+  await userEvent.click(screen.getByRole('button', { name: OPENER_LABEL }))
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /payment provider/i })).toBeVisible()
+  })
+}
+
+describe('AddConnectionMenu', () => {
+  describe('GIVEN the menu is rendered with default props', () => {
+    describe('WHEN in initial state', () => {
+      it('THEN should display the opener button', async () => {
+        await act(() => render(<AddConnectionMenu onSelect={jest.fn()} />))
+
+        expect(screen.getByRole('button', { name: OPENER_LABEL })).toBeInTheDocument()
+      })
+
+      it('THEN should not render category entries before the opener is clicked', async () => {
+        await act(() => render(<AddConnectionMenu onSelect={jest.fn()} />))
+
+        expect(screen.queryByRole('button', { name: /payment provider/i })).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the opener is clicked', () => {
+      it.each(CATEGORY_LABELS)('THEN should show the %s category button', async (_, label) => {
+        await act(() => render(<AddConnectionMenu onSelect={jest.fn()} />))
+
+        await openMenu()
+
+        expect(screen.getByRole('button', { name: label })).toBeVisible()
+      })
+
+      it('THEN should list the four categories in MENU_ORDER (payment → accounting → tax → CRM)', async () => {
+        await act(() => render(<AddConnectionMenu onSelect={jest.fn()} />))
+
+        await openMenu()
+
+        const categoryButtons = screen
+          .getAllByRole('button')
+          .filter((btn) => btn.textContent && !OPENER_LABEL.test(btn.textContent))
+          .map((btn) => btn.textContent)
+
+        expect(categoryButtons).toEqual([
+          'Payment provider',
+          'Accounting provider',
+          'Tax provider',
+          'CRM connection',
+        ])
+      })
+    })
+  })
+
+  describe('GIVEN a user selects a category', () => {
+    it.each(CATEGORY_LABELS)(
+      'WHEN clicking the %s entry THEN onSelect is called with the matching enum value and a closePopper util',
+      async (category, label) => {
+        const onSelect = jest.fn()
+
+        await act(() => render(<AddConnectionMenu onSelect={onSelect} />))
+        await openMenu()
+
+        await userEvent.click(screen.getByRole('button', { name: label }))
+
+        expect(onSelect).toHaveBeenCalledTimes(1)
+        expect(onSelect).toHaveBeenCalledWith(
+          category,
+          expect.objectContaining({ closePopper: expect.any(Function) }),
+        )
+      },
+    )
+
+    describe('WHEN the consumer invokes the provided closePopper util', () => {
+      it('THEN should close the popper', async () => {
+        const onSelect = jest.fn<void, [ConnectionCategory, { closePopper: () => void }]>(
+          (_, { closePopper }) => closePopper(),
+        )
+
+        await act(() => render(<AddConnectionMenu onSelect={onSelect} />))
+        await openMenu()
+
+        await userEvent.click(screen.getByRole('button', { name: /payment provider/i }))
+
+        await waitFor(() => {
+          expect(
+            screen.queryByRole('button', { name: /payment provider/i }),
+          ).not.toBeInTheDocument()
+        })
+      })
+    })
+  })
+
+  describe('GIVEN the whole menu is disabled', () => {
+    describe('WHEN the disabled prop is true', () => {
+      it('THEN should disable the opener button', async () => {
+        await act(() => render(<AddConnectionMenu disabled onSelect={jest.fn()} />))
+
+        expect(screen.getByRole('button', { name: OPENER_LABEL })).toBeDisabled()
+      })
+    })
+  })
+
+  describe('GIVEN some categories are already used', () => {
+    describe('WHEN disabledCategories lists a subset of the categories', () => {
+      it('THEN should disable only the listed entries and keep the rest enabled', async () => {
+        await act(() =>
+          render(
+            <AddConnectionMenu
+              disabledCategories={[ConnectionCategory.Payment, ConnectionCategory.Tax]}
+              onSelect={jest.fn()}
+            />,
+          ),
+        )
+        await openMenu()
+
+        expect(screen.getByRole('button', { name: /payment provider/i })).toBeDisabled()
+        expect(screen.getByRole('button', { name: /tax provider/i })).toBeDisabled()
+        expect(screen.getByRole('button', { name: /accounting provider/i })).toBeEnabled()
+        expect(screen.getByRole('button', { name: /crm connection/i })).toBeEnabled()
+      })
+
+      it('THEN should not invoke onSelect when a disabled entry is clicked', async () => {
+        const onSelect = jest.fn()
+
+        await act(() =>
+          render(
+            <AddConnectionMenu
+              disabledCategories={[ConnectionCategory.Payment]}
+              onSelect={onSelect}
+            />,
+          ),
+        )
+        await openMenu()
+
+        // fireEvent bypasses user-event's pointer-events check; the point of
+        // the assertion is that the disabled attribute itself blocks onSelect.
+        fireEvent.click(screen.getByRole('button', { name: /payment provider/i }))
+
+        expect(onSelect).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN disabledCategories is undefined', () => {
+      it('THEN should render all category entries as enabled', async () => {
+        await act(() => render(<AddConnectionMenu onSelect={jest.fn()} />))
+        await openMenu()
+
+        CATEGORY_LABELS.forEach(([, label]) => {
+          expect(screen.getByRole('button', { name: label })).toBeEnabled()
+        })
+      })
+    })
+  })
+})

--- a/src/components/customerConnections/__tests__/ConnectionComboBox.test.tsx
+++ b/src/components/customerConnections/__tests__/ConnectionComboBox.test.tsx
@@ -1,0 +1,124 @@
+import { screen } from '@testing-library/react'
+import { isValidElement } from 'react'
+
+import {
+  buildConnectionComboBoxData,
+  ConnectionComboBoxDataItem,
+  ConnectionComboBoxLabel,
+} from '~/components/customerConnections/ConnectionComboBox'
+import { render } from '~/test-utils'
+
+describe('ConnectionComboBoxLabel', () => {
+  describe('GIVEN a label and a subLabel are provided', () => {
+    describe('WHEN the component is rendered', () => {
+      it('THEN should display both the label and the subLabel', () => {
+        render(<ConnectionComboBoxLabel label="Stripe main" subLabel="stripe-1" />)
+
+        expect(screen.getByText('Stripe main')).toBeInTheDocument()
+        expect(screen.getByText('stripe-1')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN only a label is provided', () => {
+    describe('WHEN the component is rendered without subLabel', () => {
+      it('THEN should render the label and leave the caption slot empty', () => {
+        const { container } = render(<ConnectionComboBoxLabel label="Stripe main" />)
+
+        expect(screen.getByText('Stripe main')).toBeInTheDocument()
+        // Two Typography nodes are always rendered; the caption is present but
+        // has no text content when subLabel is undefined.
+        const caption = container.querySelector('.MuiTypography-caption')
+
+        expect(caption?.textContent).toBe('')
+      })
+    })
+  })
+})
+
+describe('buildConnectionComboBoxData', () => {
+  describe('GIVEN an empty items array', () => {
+    describe('WHEN buildConnectionComboBoxData is called', () => {
+      it('THEN should return an empty array', () => {
+        expect(buildConnectionComboBoxData([])).toEqual([])
+      })
+    })
+  })
+
+  describe('GIVEN a list of items with full fields', () => {
+    const items: ConnectionComboBoxDataItem[] = [
+      {
+        value: 'stripe-1',
+        label: 'Stripe main',
+        subLabel: 'stripe-1',
+        group: 'stripe',
+      },
+      {
+        value: 'netsuite-1',
+        label: 'NetSuite prod',
+        subLabel: 'netsuite-1',
+        group: 'netsuite',
+      },
+    ]
+
+    describe('WHEN buildConnectionComboBoxData is called', () => {
+      const result = buildConnectionComboBoxData(items)
+
+      it('THEN should preserve one output entry per input item', () => {
+        expect(result).toHaveLength(items.length)
+      })
+
+      it.each([
+        ['stripe-1', 'Stripe main', 'stripe'],
+        ['netsuite-1', 'NetSuite prod', 'netsuite'],
+      ])(
+        'THEN should carry value=%s, label=%s and group=%s straight through',
+        (value, label, group) => {
+          const entry = result.find((r) => r.value === value)
+
+          expect(entry).toMatchObject({ value, label, group })
+        },
+      )
+
+      it('THEN should attach a ConnectionComboBoxLabel React node in labelNode', () => {
+        result.forEach((entry, index) => {
+          expect(isValidElement(entry.labelNode)).toBe(true)
+          expect(entry.labelNode).toMatchObject({
+            props: { label: items[index].label, subLabel: items[index].subLabel },
+          })
+        })
+      })
+
+      it('THEN the labelNode renders both the label and the subLabel', () => {
+        const [first] = result
+
+        render(<>{first.labelNode}</>)
+
+        expect(screen.getByText('Stripe main')).toBeInTheDocument()
+        expect(screen.getByText('stripe-1')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN an item without a group', () => {
+    describe('WHEN buildConnectionComboBoxData is called', () => {
+      it('THEN should default the group to an empty string', () => {
+        const [entry] = buildConnectionComboBoxData([{ value: 'v1', label: 'Provider A' }])
+
+        expect(entry.group).toBe('')
+      })
+    })
+  })
+
+  describe('GIVEN an item without a subLabel', () => {
+    describe('WHEN buildConnectionComboBoxData is called', () => {
+      it('THEN should still build a labelNode that renders only the main label', () => {
+        const [entry] = buildConnectionComboBoxData([{ value: 'v1', label: 'Provider A' }])
+
+        render(<>{entry.labelNode}</>)
+
+        expect(screen.getByText('Provider A')).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/components/customerConnections/types.ts
+++ b/src/components/customerConnections/types.ts
@@ -1,0 +1,10 @@
+/**
+ * The four customer-connection categories billing objects route to.
+ * Mirrors the backend connection categories (payment / tax / accounting / CRM).
+ */
+export enum ConnectionCategory {
+  Payment = 'payment',
+  Accounting = 'accounting',
+  Tax = 'tax',
+  Crm = 'crm',
+}

--- a/src/pages/createCustomers/externalAppsAccordion/ExternalAppsAccordion.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/ExternalAppsAccordion.tsx
@@ -1,10 +1,10 @@
 import { useStore } from '@tanstack/react-form'
 import { useEffect, useState } from 'react'
 
+import { AddConnectionMenu } from '~/components/customerConnections/AddConnectionMenu'
+import { ConnectionCategory } from '~/components/customerConnections/types'
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Alert } from '~/components/designSystem/Alert'
-import { Button } from '~/components/designSystem/Button'
-import { Popper } from '~/components/designSystem/Popper'
 import { Typography } from '~/components/designSystem/Typography'
 import {
   ADD_CUSTOMER_ACCOUNTING_PROVIDER_ACCORDION,
@@ -18,7 +18,6 @@ import { AddCustomerDrawerFragment, ProviderTypeEnum } from '~/generated/graphql
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { withForm } from '~/hooks/forms/useAppform'
 import { emptyCreateCustomerDefaultValues } from '~/pages/createCustomers/formInitialization/validationSchema'
-import { MenuPopper } from '~/styles'
 
 import AccountingProvidersAccordion from './accountingProvidersAccordion/AccountingProvidersAccordion'
 import CrmProvidersAccordion from './crmProvidersAccordion/CrmProvidersAccordion'
@@ -119,87 +118,49 @@ const ExternalAppsAccordion = withForm({
             />
           )}
 
-          <Popper
-            PopperProps={{ placement: 'bottom-start' }}
-            opener={
-              <Button
-                startIcon="plus"
-                variant="inline"
-                disabled={
-                  showAccountingSection && showPaymentSection && showTaxSection && showCrmSection
-                }
-              >
-                {translate('text_65846763e6140b469140e235')}
-              </Button>
+          <AddConnectionMenu
+            disabled={
+              showAccountingSection && showPaymentSection && showTaxSection && showCrmSection
             }
-          >
-            {({ closePopper }) => (
-              <MenuPopper>
-                <Button
-                  variant="quaternary"
-                  align="left"
-                  disabled={showPaymentSection}
-                  onClick={() => {
-                    setShowPaymentSection(true)
+            disabledCategories={[
+              ...(showPaymentSection ? [ConnectionCategory.Payment] : []),
+              ...(showAccountingSection ? [ConnectionCategory.Accounting] : []),
+              ...(showTaxSection ? [ConnectionCategory.Tax] : []),
+              ...(showCrmSection ? [ConnectionCategory.Crm] : []),
+            ]}
+            onSelect={(category, { closePopper }) => {
+              const sectionByCategory: Record<
+                ConnectionCategory,
+                { show: () => void; accordionClassName: string }
+              > = {
+                [ConnectionCategory.Payment]: {
+                  show: () => setShowPaymentSection(true),
+                  accordionClassName: ADD_CUSTOMER_PAYMENT_PROVIDER_ACCORDION,
+                },
+                [ConnectionCategory.Accounting]: {
+                  show: () => setShowAccountingSection(true),
+                  accordionClassName: ADD_CUSTOMER_ACCOUNTING_PROVIDER_ACCORDION,
+                },
+                [ConnectionCategory.Tax]: {
+                  show: () => setShowTaxSection(true),
+                  accordionClassName: ADD_CUSTOMER_TAX_PROVIDER_ACCORDION,
+                },
+                [ConnectionCategory.Crm]: {
+                  show: () => setShowCrmSection(true),
+                  accordionClassName: ADD_CUSTOMER_CRM_PROVIDER_ACCORDION,
+                },
+              }
 
-                    scrollToAndClickElement({
-                      selector: `.${ADD_CUSTOMER_PAYMENT_PROVIDER_ACCORDION} .${MUI_BUTTON_BASE_ROOT_CLASSNAME}`,
-                      callback: closePopper,
-                    })
-                  }}
-                >
-                  {translate('text_634ea0ecc6147de10ddb6631')}
-                </Button>
-                <Button
-                  variant="quaternary"
-                  align="left"
-                  disabled={showAccountingSection}
-                  onClick={() => {
-                    setShowAccountingSection(true)
+              const section = sectionByCategory[category]
 
-                    scrollToAndClickElement({
-                      selector: `.${ADD_CUSTOMER_ACCOUNTING_PROVIDER_ACCORDION} .${MUI_BUTTON_BASE_ROOT_CLASSNAME}`,
-                      callback: closePopper,
-                    })
-                  }}
-                >
-                  {translate('text_66423cad72bbad009f2f568f')}
-                </Button>
+              section.show()
 
-                <Button
-                  variant="quaternary"
-                  align="left"
-                  disabled={showTaxSection}
-                  onClick={() => {
-                    setShowTaxSection(true)
-
-                    scrollToAndClickElement({
-                      selector: `.${ADD_CUSTOMER_TAX_PROVIDER_ACCORDION} .${MUI_BUTTON_BASE_ROOT_CLASSNAME}`,
-                      callback: closePopper,
-                    })
-                  }}
-                >
-                  {translate('text_6668821d94e4da4dfd8b3840')}
-                </Button>
-
-                <Button
-                  variant="quaternary"
-                  align="left"
-                  disabled={showCrmSection}
-                  onClick={() => {
-                    setShowCrmSection(true)
-
-                    scrollToAndClickElement({
-                      selector: `.${ADD_CUSTOMER_CRM_PROVIDER_ACCORDION} .${MUI_BUTTON_BASE_ROOT_CLASSNAME}`,
-                      callback: closePopper,
-                    })
-                  }}
-                >
-                  {translate('text_1728658962985xpfdvl5ru8a')}
-                </Button>
-              </MenuPopper>
-            )}
-          </Popper>
+              scrollToAndClickElement({
+                selector: `.${section.accordionClassName} .${MUI_BUTTON_BASE_ROOT_CLASSNAME}`,
+                callback: closePopper,
+              })
+            }}
+          />
 
           {!!paymentProviderCustomer &&
             !!paymentProviderCustomer.syncWithProvider &&

--- a/src/pages/createCustomers/externalAppsAccordion/accountingProvidersAccordion/AccountingProvidersAccordion.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/accountingProvidersAccordion/AccountingProvidersAccordion.tsx
@@ -1,6 +1,7 @@
 import { useStore } from '@tanstack/react-form'
 import { Dispatch, SetStateAction, useMemo } from 'react'
 
+import { buildConnectionComboBoxData } from '~/components/customerConnections/ConnectionComboBox'
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Alert } from '~/components/designSystem/Alert'
 import { Avatar } from '~/components/designSystem/Avatar'
@@ -120,17 +121,14 @@ const AccountingProvidersAccordion = withForm({
     const connectedAccountingIntegrationsData: ComboboxDataGrouped[] | [] = useMemo(() => {
       if (!allAccountingIntegrationsData?.length) return []
 
-      return allAccountingIntegrationsData?.map((integration) => ({
-        value: integration.code,
-        label: integration.name,
-        group: integration?.__typename?.replace('Integration', '') || '',
-        labelNode: (
-          <ExternalAppsAccordionLayout.ComboboxItem
-            label={integration.name}
-            subLabel={integration.code}
-          />
-        ),
-      }))
+      return buildConnectionComboBoxData(
+        allAccountingIntegrationsData.map((integration) => ({
+          value: integration.code,
+          label: integration.name,
+          subLabel: integration.code,
+          group: integration?.__typename?.replace('Integration', '') || '',
+        })),
+      )
     }, [allAccountingIntegrationsData])
 
     const getAccordionSummaryAvatar = () => {
@@ -210,6 +208,11 @@ const AccountingProvidersAccordion = withForm({
             {!!selectedNetsuiteIntegration && (
               <NetsuiteAccountingProviderContent
                 form={form}
+                fields={{
+                  externalCustomerId: 'accountingCustomer.accountingCustomerId',
+                  syncWithProvider: 'accountingCustomer.syncWithProvider',
+                  subsidiaryId: 'accountingCustomer.subsidiaryId',
+                }}
                 hadInitialNetsuiteIntegrationCustomer={hadInitialNetsuiteIntegrationCustomer}
                 selectedNetsuiteIntegration={selectedNetsuiteIntegration}
                 isEdition={isEdition}
@@ -219,6 +222,10 @@ const AccountingProvidersAccordion = withForm({
             {!!selectedXeroIntegration && (
               <XeroAccountingProviderContent
                 form={form}
+                fields={{
+                  externalCustomerId: 'accountingCustomer.accountingCustomerId',
+                  syncWithProvider: 'accountingCustomer.syncWithProvider',
+                }}
                 hadInitialXeroIntegrationCustomer={hadInitialXeroIntegrationCustomer}
                 selectedXeroIntegration={selectedXeroIntegration}
                 isEdition={isEdition}

--- a/src/pages/createCustomers/externalAppsAccordion/accountingProvidersAccordion/NetsuiteAccountingProviderContent.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/accountingProvidersAccordion/NetsuiteAccountingProviderContent.tsx
@@ -5,9 +5,12 @@ import { Alert } from '~/components/designSystem/Alert'
 import { BasicComboBoxData } from '~/components/form'
 import { NetsuiteIntegration } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { withForm } from '~/hooks/forms/useAppform'
+import { withFieldGroup } from '~/hooks/forms/useAppform'
+import {
+  connectionFieldGroupDefaultValues,
+  ConnectionFieldGroupValues,
+} from '~/pages/createCustomers/externalAppsAccordion/common/connectionFieldGroup'
 import { ExternalAppsAccordionLayout } from '~/pages/createCustomers/externalAppsAccordion/common/ExternalAppsAccordionLayout'
-import { emptyCreateCustomerDefaultValues } from '~/pages/createCustomers/formInitialization/validationSchema'
 
 import { useAccountingProvidersSubsidaries } from './useAccountingProvidersSubsidaries'
 
@@ -23,11 +26,20 @@ const defaultProps: NetsuiteAccountingProviderContentProps = {
   isEdition: false,
 }
 
-const NetsuiteAccountingProviderContent = withForm({
-  defaultValues: emptyCreateCustomerDefaultValues,
+type NetsuiteConnectionValues = ConnectionFieldGroupValues & {
+  subsidiaryId: string | undefined
+}
+
+const defaultValues: NetsuiteConnectionValues = {
+  ...connectionFieldGroupDefaultValues,
+  subsidiaryId: '',
+}
+
+const NetsuiteAccountingProviderContent = withFieldGroup({
+  defaultValues,
   props: defaultProps,
   render: function Render({
-    form,
+    group,
     hadInitialNetsuiteIntegrationCustomer,
     selectedNetsuiteIntegration,
     isEdition,
@@ -36,10 +48,7 @@ const NetsuiteAccountingProviderContent = withForm({
 
     const { subsidiariesData } = useAccountingProvidersSubsidaries(selectedNetsuiteIntegration?.id)
 
-    const syncWithProvider = useStore(
-      form.store,
-      (state) => state.values.accountingCustomer?.syncWithProvider,
-    )
+    const syncWithProvider = useStore(group.store, (state) => state.values.syncWithProvider)
 
     const connectedIntegrationSubsidiaries: BasicComboBoxData[] | [] = useMemo(() => {
       if (!subsidiariesData?.integrationSubsidiaries?.collection.length) return []
@@ -59,12 +68,12 @@ const NetsuiteAccountingProviderContent = withForm({
     const handleSyncWithProviderChange = (value: boolean | undefined) => {
       if (!value || isEdition) return
 
-      form.setFieldValue('accountingCustomer.accountingCustomerId', '')
+      group.setFieldValue('externalCustomerId', '')
     }
 
     return (
       <>
-        <form.AppField name="accountingCustomer.accountingCustomerId">
+        <group.AppField name="externalCustomerId">
           {(field) => (
             <field.TextInputField
               disabled={!!syncWithProvider || hadInitialNetsuiteIntegrationCustomer}
@@ -72,9 +81,9 @@ const NetsuiteAccountingProviderContent = withForm({
               placeholder={translate('text_66423cad72bbad009f2f569c')}
             />
           )}
-        </form.AppField>
-        <form.AppField
-          name="accountingCustomer.syncWithProvider"
+        </group.AppField>
+        <group.AppField
+          name="syncWithProvider"
           listeners={{
             onChange: ({ value }) => handleSyncWithProviderChange(value),
           }}
@@ -87,10 +96,10 @@ const NetsuiteAccountingProviderContent = withForm({
               })}
             />
           )}
-        </form.AppField>
+        </group.AppField>
 
         {!!syncWithProvider && (
-          <form.AppField name="accountingCustomer.subsidiaryId">
+          <group.AppField name="subsidiaryId">
             {(field) => (
               <field.ComboBoxField
                 data={connectedIntegrationSubsidiaries}
@@ -100,7 +109,7 @@ const NetsuiteAccountingProviderContent = withForm({
                 PopperProps={{ displayInDialog: true }}
               />
             )}
-          </form.AppField>
+          </group.AppField>
         )}
         {syncWithProvider && isEdition && !hadInitialNetsuiteIntegrationCustomer && (
           <Alert type="info">{translate('text_66423cad72bbad009f2f56a4')}</Alert>

--- a/src/pages/createCustomers/externalAppsAccordion/accountingProvidersAccordion/XeroAccountingProviderContent.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/accountingProvidersAccordion/XeroAccountingProviderContent.tsx
@@ -2,8 +2,8 @@ import { useStore } from '@tanstack/react-form'
 
 import { XeroIntegration } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { withForm } from '~/hooks/forms/useAppform'
-import { emptyCreateCustomerDefaultValues } from '~/pages/createCustomers/formInitialization/validationSchema'
+import { withFieldGroup } from '~/hooks/forms/useAppform'
+import { connectionFieldGroupDefaultValues } from '~/pages/createCustomers/externalAppsAccordion/common/connectionFieldGroup'
 
 type XeroAccountingProviderContentProps = {
   hadInitialXeroIntegrationCustomer: boolean
@@ -17,31 +17,28 @@ const defaultProps: XeroAccountingProviderContentProps = {
   isEdition: false,
 }
 
-const XeroAccountingProviderContent = withForm({
-  defaultValues: emptyCreateCustomerDefaultValues,
+const XeroAccountingProviderContent = withFieldGroup({
+  defaultValues: connectionFieldGroupDefaultValues,
   props: defaultProps,
   render: function Render({
-    form,
+    group,
     hadInitialXeroIntegrationCustomer,
     selectedXeroIntegration,
     isEdition,
   }) {
     const { translate } = useInternationalization()
 
-    const syncWithProvider = useStore(
-      form.store,
-      (state) => state.values.accountingCustomer?.syncWithProvider,
-    )
+    const syncWithProvider = useStore(group.store, (state) => state.values.syncWithProvider)
 
     const handleSyncWithProviderChange = (value: boolean | undefined) => {
       if (!value || isEdition) return
 
-      form.setFieldValue('accountingCustomer.accountingCustomerId', '')
+      group.setFieldValue('externalCustomerId', '')
     }
 
     return (
       <>
-        <form.AppField name="accountingCustomer.accountingCustomerId">
+        <group.AppField name="externalCustomerId">
           {(field) => (
             <field.TextInputField
               disabled={!!syncWithProvider || hadInitialXeroIntegrationCustomer}
@@ -49,9 +46,9 @@ const XeroAccountingProviderContent = withForm({
               placeholder={translate('text_667d39dc1a765800d28d0605')}
             />
           )}
-        </form.AppField>
-        <form.AppField
-          name="accountingCustomer.syncWithProvider"
+        </group.AppField>
+        <group.AppField
+          name="syncWithProvider"
           listeners={{
             onChange: ({ value }) => handleSyncWithProviderChange(value),
           }}
@@ -64,7 +61,7 @@ const XeroAccountingProviderContent = withForm({
               })}
             />
           )}
-        </form.AppField>
+        </group.AppField>
       </>
     )
   },

--- a/src/pages/createCustomers/externalAppsAccordion/accountingProvidersAccordion/__tests__/NetsuiteAccountingProviderContent.test.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/accountingProvidersAccordion/__tests__/NetsuiteAccountingProviderContent.test.tsx
@@ -58,6 +58,11 @@ const TestNetsuiteAccountingProviderContentWrapper = ({
   return (
     <NetsuiteAccountingProviderContent
       form={form}
+      fields={{
+        externalCustomerId: 'accountingCustomer.accountingCustomerId',
+        syncWithProvider: 'accountingCustomer.syncWithProvider',
+        subsidiaryId: 'accountingCustomer.subsidiaryId',
+      }}
       hadInitialNetsuiteIntegrationCustomer={hadInitialNetsuiteIntegrationCustomer}
       selectedNetsuiteIntegration={selectedNetsuiteIntegration}
       isEdition={isEdition}

--- a/src/pages/createCustomers/externalAppsAccordion/accountingProvidersAccordion/__tests__/XeroAccountingProviderContent.test.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/accountingProvidersAccordion/__tests__/XeroAccountingProviderContent.test.tsx
@@ -34,6 +34,10 @@ const TestXeroAccountingProviderContentWrapper = ({
   return (
     <XeroAccountingProviderContent
       form={form}
+      fields={{
+        externalCustomerId: 'accountingCustomer.accountingCustomerId',
+        syncWithProvider: 'accountingCustomer.syncWithProvider',
+      }}
       hadInitialXeroIntegrationCustomer={hadInitialXeroIntegrationCustomer}
       selectedXeroIntegration={selectedXeroIntegration}
       isEdition={isEdition}

--- a/src/pages/createCustomers/externalAppsAccordion/common/ExternalAppsAccordionLayout.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/common/ExternalAppsAccordionLayout.tsx
@@ -1,27 +1,18 @@
 import { Icon } from 'lago-design-system'
 import { FC, ReactNode } from 'react'
 
+import { ConnectionComboBoxLabel } from '~/components/customerConnections/ConnectionComboBox'
 import { Avatar } from '~/components/designSystem/Avatar'
 import { Button } from '~/components/designSystem/Button'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Typography } from '~/components/designSystem/Typography'
-import { ComboboxItem } from '~/components/form'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 const ExternalAppsAccordionComboboxItem: FC<{
   label: string
   subLabel: string
 }> = ({ label, subLabel }) => {
-  return (
-    <ComboboxItem>
-      <Typography variant="body" color="grey700" noWrap>
-        {label}
-      </Typography>
-      <Typography variant="caption" color="grey600" noWrap>
-        {subLabel}
-      </Typography>
-    </ComboboxItem>
-  )
+  return <ConnectionComboBoxLabel label={label} subLabel={subLabel} />
 }
 
 const ExternalAppsAccordionSummary: FC<{

--- a/src/pages/createCustomers/externalAppsAccordion/common/connectionFieldGroup.ts
+++ b/src/pages/createCustomers/externalAppsAccordion/common/connectionFieldGroup.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared value shape for the per-provider connection field groups.
+ *
+ * Each provider content component is a `withFieldGroup` bound to this
+ * single-connection subtree with RELATIVE paths. The mount site decides where
+ * the subtree lives in the host form via the `fields` mapping, e.g. on the
+ * customer form today (`taxCustomer.taxCustomerId`) or on a standalone
+ * single-connection drawer form later — the group itself is form-agnostic.
+ */
+export type ConnectionFieldGroupValues = {
+  externalCustomerId: string | undefined
+  syncWithProvider: boolean | undefined
+}
+
+export const connectionFieldGroupDefaultValues: ConnectionFieldGroupValues = {
+  externalCustomerId: '',
+  syncWithProvider: false,
+}

--- a/src/pages/createCustomers/externalAppsAccordion/crmProvidersAccordion/CrmProvidersAccordion.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/crmProvidersAccordion/CrmProvidersAccordion.tsx
@@ -1,6 +1,7 @@
 import { useStore } from '@tanstack/react-form'
 import { Dispatch, SetStateAction, useMemo } from 'react'
 
+import { buildConnectionComboBoxData } from '~/components/customerConnections/ConnectionComboBox'
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Alert } from '~/components/designSystem/Alert'
 import { Avatar } from '~/components/designSystem/Avatar'
@@ -118,17 +119,14 @@ const CrmProvidersAccordion = withForm({
     const connectedCrmIntegrationsData: ComboboxDataGrouped[] | [] = useMemo(() => {
       if (!allAccountingIntegrationsData?.length) return []
 
-      return allAccountingIntegrationsData?.map((integration) => ({
-        value: integration.code,
-        label: integration.name,
-        group: integration?.__typename?.replace('Integration', '') || '',
-        labelNode: (
-          <ExternalAppsAccordionLayout.ComboboxItem
-            label={integration.name}
-            subLabel={integration.code}
-          />
-        ),
-      }))
+      return buildConnectionComboBoxData(
+        allAccountingIntegrationsData.map((integration) => ({
+          value: integration.code,
+          label: integration.name,
+          subLabel: integration.code,
+          group: integration?.__typename?.replace('Integration', '') || '',
+        })),
+      )
     }, [allAccountingIntegrationsData])
 
     const getAccordionSummaryAvatar = () => {
@@ -206,6 +204,11 @@ const CrmProvidersAccordion = withForm({
             {!!selectedHubspotIntegration && (
               <HubspotCrmProviderContent
                 form={form}
+                fields={{
+                  externalCustomerId: 'crmCustomer.crmCustomerId',
+                  syncWithProvider: 'crmCustomer.syncWithProvider',
+                  targetedObject: 'crmCustomer.targetedObject',
+                }}
                 hadInitialHubspotIntegrationCustomer={hadInitialHubspotIntegrationCustomer}
                 selectedHubspotIntegration={selectedHubspotIntegration}
                 isEdition={isEdition}
@@ -215,6 +218,10 @@ const CrmProvidersAccordion = withForm({
             {!!selectedSalesforceIntegration && (
               <SalesforceCrmProviderContent
                 form={form}
+                fields={{
+                  externalCustomerId: 'crmCustomer.crmCustomerId',
+                  syncWithProvider: 'crmCustomer.syncWithProvider',
+                }}
                 hadInitialSalesforceIntegrationCustomer={hadInitialSalesforceIntegrationCustomer}
                 selectedSalesforceIntegration={selectedSalesforceIntegration}
                 isEdition={isEdition}

--- a/src/pages/createCustomers/externalAppsAccordion/crmProvidersAccordion/HubspotCrmProviderContent.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/crmProvidersAccordion/HubspotCrmProviderContent.tsx
@@ -3,8 +3,11 @@ import { useStore } from '@tanstack/react-form'
 import { getHubspotTargetedObjectTranslationKey } from '~/core/constants/form'
 import { HubspotIntegration, HubspotTargetedObjectsEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { withForm } from '~/hooks/forms/useAppform'
-import { emptyCreateCustomerDefaultValues } from '~/pages/createCustomers/formInitialization/validationSchema'
+import { withFieldGroup } from '~/hooks/forms/useAppform'
+import {
+  connectionFieldGroupDefaultValues,
+  ConnectionFieldGroupValues,
+} from '~/pages/createCustomers/externalAppsAccordion/common/connectionFieldGroup'
 
 type HubspotCrmProviderContentProps = {
   hadInitialHubspotIntegrationCustomer: boolean
@@ -16,6 +19,15 @@ const defaultProps: HubspotCrmProviderContentProps = {
   hadInitialHubspotIntegrationCustomer: false,
   selectedHubspotIntegration: undefined,
   isEdition: false,
+}
+
+type HubspotConnectionValues = ConnectionFieldGroupValues & {
+  targetedObject: HubspotTargetedObjectsEnum | undefined
+}
+
+const defaultValues: HubspotConnectionValues = {
+  ...connectionFieldGroupDefaultValues,
+  targetedObject: undefined,
 }
 
 const hubspotExternalIdTypeCopyMap: Record<
@@ -32,23 +44,20 @@ const hubspotExternalIdTypeCopyMap: Record<
   },
 }
 
-const HubspotCrmProviderContent = withForm({
-  defaultValues: emptyCreateCustomerDefaultValues,
+const HubspotCrmProviderContent = withFieldGroup({
+  defaultValues,
   props: defaultProps,
   render: function Render({
-    form,
+    group,
     hadInitialHubspotIntegrationCustomer,
     selectedHubspotIntegration,
     isEdition,
   }) {
     const { translate } = useInternationalization()
 
-    const syncWithProvider = useStore(
-      form.store,
-      (state) => state.values.crmCustomer?.syncWithProvider,
-    )
+    const syncWithProvider = useStore(group.store, (state) => state.values.syncWithProvider)
 
-    const targetedObject = useStore(form.store, (state) => state.values.crmCustomer?.targetedObject)
+    const targetedObject = useStore(group.store, (state) => state.values.targetedObject)
 
     const targetedObjectdata = [
       {
@@ -68,12 +77,12 @@ const HubspotCrmProviderContent = withForm({
     const handleSyncWithProviderChange = (value: boolean | undefined) => {
       if (!value || isEdition) return
 
-      form.setFieldValue('crmCustomer.crmCustomerId', '')
+      group.setFieldValue('externalCustomerId', '')
     }
 
     return (
       <>
-        <form.AppField name="crmCustomer.targetedObject">
+        <group.AppField name="targetedObject">
           {(field) => (
             <field.ComboBoxField
               disableClearable
@@ -83,10 +92,10 @@ const HubspotCrmProviderContent = withForm({
               PopperProps={{ displayInDialog: true }}
             />
           )}
-        </form.AppField>
+        </group.AppField>
         {!!targetedObject && (
           <>
-            <form.AppField name="crmCustomer.crmCustomerId">
+            <group.AppField name="externalCustomerId">
               {(field) => (
                 <field.TextInputField
                   disabled={!!syncWithProvider || hadInitialHubspotIntegrationCustomer}
@@ -96,9 +105,9 @@ const HubspotCrmProviderContent = withForm({
                   )}
                 />
               )}
-            </form.AppField>
-            <form.AppField
-              name="crmCustomer.syncWithProvider"
+            </group.AppField>
+            <group.AppField
+              name="syncWithProvider"
               listeners={{
                 onChange: ({ value }) => handleSyncWithProviderChange(value),
               }}
@@ -111,7 +120,7 @@ const HubspotCrmProviderContent = withForm({
                   })}
                 />
               )}
-            </form.AppField>
+            </group.AppField>
           </>
         )}
       </>

--- a/src/pages/createCustomers/externalAppsAccordion/crmProvidersAccordion/SalesforceCrmProviderContent.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/crmProvidersAccordion/SalesforceCrmProviderContent.tsx
@@ -2,8 +2,8 @@ import { useStore } from '@tanstack/react-form'
 
 import { SalesforceIntegration } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { withForm } from '~/hooks/forms/useAppform'
-import { emptyCreateCustomerDefaultValues } from '~/pages/createCustomers/formInitialization/validationSchema'
+import { withFieldGroup } from '~/hooks/forms/useAppform'
+import { connectionFieldGroupDefaultValues } from '~/pages/createCustomers/externalAppsAccordion/common/connectionFieldGroup'
 
 type SalesforceCrmProviderContentProps = {
   hadInitialSalesforceIntegrationCustomer: boolean
@@ -17,31 +17,28 @@ const defaultProps: SalesforceCrmProviderContentProps = {
   isEdition: false,
 }
 
-const SalesforceCrmProviderContent = withForm({
-  defaultValues: emptyCreateCustomerDefaultValues,
+const SalesforceCrmProviderContent = withFieldGroup({
+  defaultValues: connectionFieldGroupDefaultValues,
   props: defaultProps,
   render: function Render({
-    form,
+    group,
     hadInitialSalesforceIntegrationCustomer,
     selectedSalesforceIntegration,
     isEdition,
   }) {
     const { translate } = useInternationalization()
 
-    const syncWithProvider = useStore(
-      form.store,
-      (state) => state.values.crmCustomer?.syncWithProvider,
-    )
+    const syncWithProvider = useStore(group.store, (state) => state.values.syncWithProvider)
 
     const handleSyncWithProviderChange = (value: boolean | undefined) => {
       if (!value || isEdition) return
 
-      form.setFieldValue('crmCustomer.crmCustomerId', '')
+      group.setFieldValue('externalCustomerId', '')
     }
 
     return (
       <>
-        <form.AppField name="crmCustomer.crmCustomerId">
+        <group.AppField name="externalCustomerId">
           {(field) => (
             <field.TextInputField
               disabled={!!syncWithProvider || hadInitialSalesforceIntegrationCustomer}
@@ -49,9 +46,9 @@ const SalesforceCrmProviderContent = withForm({
               placeholder={translate('text_1731677317443j3iga5orbb6')}
             />
           )}
-        </form.AppField>
-        <form.AppField
-          name="crmCustomer.syncWithProvider"
+        </group.AppField>
+        <group.AppField
+          name="syncWithProvider"
           listeners={{
             onChange: ({ value }) => handleSyncWithProviderChange(value),
           }}
@@ -64,7 +61,7 @@ const SalesforceCrmProviderContent = withForm({
               })}
             />
           )}
-        </form.AppField>
+        </group.AppField>
       </>
     )
   },

--- a/src/pages/createCustomers/externalAppsAccordion/crmProvidersAccordion/__tests__/HubspotCrmProviderContent.test.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/crmProvidersAccordion/__tests__/HubspotCrmProviderContent.test.tsx
@@ -34,6 +34,11 @@ const TestHubspotCrmProviderContentWrapper = ({
   return (
     <HubspotCrmProviderContent
       form={form}
+      fields={{
+        externalCustomerId: 'crmCustomer.crmCustomerId',
+        syncWithProvider: 'crmCustomer.syncWithProvider',
+        targetedObject: 'crmCustomer.targetedObject',
+      }}
       hadInitialHubspotIntegrationCustomer={hadInitialHubspotIntegrationCustomer}
       selectedHubspotIntegration={selectedHubspotIntegration}
       isEdition={isEdition}

--- a/src/pages/createCustomers/externalAppsAccordion/crmProvidersAccordion/__tests__/SalesforceCrmProviderContent.test.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/crmProvidersAccordion/__tests__/SalesforceCrmProviderContent.test.tsx
@@ -32,6 +32,10 @@ const TestSalesforceCrmProviderContentWrapper = ({
   return (
     <SalesforceCrmProviderContent
       form={form}
+      fields={{
+        externalCustomerId: 'crmCustomer.crmCustomerId',
+        syncWithProvider: 'crmCustomer.syncWithProvider',
+      }}
       hadInitialSalesforceIntegrationCustomer={hadInitialSalesforceIntegrationCustomer}
       selectedSalesforceIntegration={selectedSalesforceIntegration}
       isEdition={isEdition}

--- a/src/pages/createCustomers/externalAppsAccordion/paymentProvidersAccordion/PaymentProvidersAccordion.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/paymentProvidersAccordion/PaymentProvidersAccordion.tsx
@@ -1,6 +1,7 @@
 import { useStore } from '@tanstack/react-form'
 import { Dispatch, ReactNode, SetStateAction, useMemo } from 'react'
 
+import { buildConnectionComboBoxData } from '~/components/customerConnections/ConnectionComboBox'
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Alert } from '~/components/designSystem/Alert'
 import { Avatar } from '~/components/designSystem/Avatar'
@@ -74,17 +75,14 @@ const PaymentProvidersAccordion = withForm({
     const connectedPaymentProvidersData: ComboboxDataGrouped[] | [] = useMemo(() => {
       if (!paymentProviders?.paymentProviders?.collection.length) return []
 
-      return paymentProviders?.paymentProviders?.collection.map((provider) => ({
-        value: provider.code,
-        label: provider.name,
-        group: provider.__typename.toLocaleLowerCase().replace('provider', ''),
-        labelNode: (
-          <ExternalAppsAccordionLayout.ComboboxItem
-            label={provider.name}
-            subLabel={provider.code}
-          />
-        ),
-      }))
+      return buildConnectionComboBoxData(
+        paymentProviders.paymentProviders.collection.map((provider) => ({
+          value: provider.code,
+          label: provider.name,
+          subLabel: provider.code,
+          group: provider.__typename.toLocaleLowerCase().replace('provider', ''),
+        })),
+      )
     }, [paymentProviders?.paymentProviders?.collection])
 
     const isSyncWithProviderSupported = useMemo(() => {
@@ -236,7 +234,12 @@ const PaymentProvidersAccordion = withForm({
             )}
 
             {paymentProvider === ProviderTypeEnum.Stripe && (
-              <StripePaymentProviderContent form={form} />
+              <StripePaymentProviderContent
+                form={form}
+                fields={{
+                  providerPaymentMethods: 'paymentProviderCustomer.providerPaymentMethods',
+                }}
+              />
             )}
           </div>
         </Accordion>

--- a/src/pages/createCustomers/externalAppsAccordion/paymentProvidersAccordion/StripePaymentProviderContent.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/paymentProvidersAccordion/StripePaymentProviderContent.tsx
@@ -4,45 +4,51 @@ import { Alert } from '~/components/designSystem/Alert'
 import { Typography } from '~/components/designSystem/Typography'
 import { ProviderPaymentMethodsEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { withForm } from '~/hooks/forms/useAppform'
-import { emptyCreateCustomerDefaultValues } from '~/pages/createCustomers/formInitialization/validationSchema'
+import { withFieldGroup } from '~/hooks/forms/useAppform'
 
-const StripePaymentProviderContent = withForm({
-  defaultValues: emptyCreateCustomerDefaultValues,
-  render: function Render({ form }) {
+type StripeConnectionValues = {
+  providerPaymentMethods: Partial<Record<ProviderPaymentMethodsEnum, boolean>> | undefined
+}
+
+const defaultValues: StripeConnectionValues = {
+  providerPaymentMethods: {},
+}
+
+const StripePaymentProviderContent = withFieldGroup({
+  defaultValues,
+  render: function Render({ group }) {
     const { translate } = useInternationalization()
-    const paymentProviderCustomer = useStore(
-      form.store,
-      (state) => state.values.paymentProviderCustomer,
+    const paymentMethods = useStore(
+      group.store,
+      (state) => state.values.providerPaymentMethods || {},
     )
 
-    const paymentMethods = paymentProviderCustomer?.providerPaymentMethods || {}
     const isPaymentMethodUnique = Object.values(paymentMethods).filter(Boolean).length === 1
     const isBankTransferEnabled = paymentMethods[ProviderPaymentMethodsEnum.CustomerBalance]
 
     const handleCardOnChange = (checked: boolean | undefined) => {
       if (!checked) {
         // uncheck link if card is unchecked
-        form.setFieldValue('paymentProviderCustomer.providerPaymentMethods.link', false)
+        group.setFieldValue('providerPaymentMethods.link', false)
 
         return
       }
 
       // uncheck bank transfer
-      form.setFieldValue('paymentProviderCustomer.providerPaymentMethods.customer_balance', false)
+      group.setFieldValue('providerPaymentMethods.customer_balance', false)
     }
 
     const handleCustomerBalanceChange = (checked: boolean | undefined) => {
       if (!checked) return
 
       // uncheck all except for bank transfer
-      form.setFieldValue('paymentProviderCustomer.providerPaymentMethods.card', false)
-      form.setFieldValue('paymentProviderCustomer.providerPaymentMethods.link', false)
-      form.setFieldValue('paymentProviderCustomer.providerPaymentMethods.sepa_debit', false)
-      form.setFieldValue('paymentProviderCustomer.providerPaymentMethods.us_bank_account', false)
-      form.setFieldValue('paymentProviderCustomer.providerPaymentMethods.bacs_debit', false)
-      form.setFieldValue('paymentProviderCustomer.providerPaymentMethods.boleto', false)
-      form.setFieldValue('paymentProviderCustomer.providerPaymentMethods.crypto', false)
+      group.setFieldValue('providerPaymentMethods.card', false)
+      group.setFieldValue('providerPaymentMethods.link', false)
+      group.setFieldValue('providerPaymentMethods.sepa_debit', false)
+      group.setFieldValue('providerPaymentMethods.us_bank_account', false)
+      group.setFieldValue('providerPaymentMethods.bacs_debit', false)
+      group.setFieldValue('providerPaymentMethods.boleto', false)
+      group.setFieldValue('providerPaymentMethods.crypto', false)
     }
 
     return (
@@ -59,8 +65,8 @@ const StripePaymentProviderContent = withForm({
             {translate('text_65e1f90471bc198c0c934d82')}
           </Typography>
           <div className="grid grid-cols-2 gap-4">
-            <form.AppField
-              name="paymentProviderCustomer.providerPaymentMethods.card"
+            <group.AppField
+              name="providerPaymentMethods.card"
               listeners={{
                 onChange: ({ value: checked }) => handleCardOnChange(checked),
               }}
@@ -71,9 +77,9 @@ const StripePaymentProviderContent = withForm({
                   sublabel={translate('text_65e1f90471bc198c0c934d86')}
                 />
               )}
-            </form.AppField>
+            </group.AppField>
             {/* Link can be enabled only if Card is enabled */}
-            <form.AppField name="paymentProviderCustomer.providerPaymentMethods.link">
+            <group.AppField name="providerPaymentMethods.link">
               {(field) => (
                 <field.CheckboxField
                   label={translate('text_6686b316b672a6e75a29eea0')}
@@ -81,10 +87,10 @@ const StripePaymentProviderContent = withForm({
                   disabled={!paymentMethods[ProviderPaymentMethodsEnum.Card]}
                 />
               )}
-            </form.AppField>
+            </group.AppField>
 
-            <form.AppField
-              name="paymentProviderCustomer.providerPaymentMethods.customer_balance"
+            <group.AppField
+              name="providerPaymentMethods.customer_balance"
               listeners={{
                 onChange: ({ value: checked }) => handleCustomerBalanceChange(checked),
               }}
@@ -95,7 +101,7 @@ const StripePaymentProviderContent = withForm({
                   sublabel={translate('text_1739432510045brhda8fxidc')}
                 />
               )}
-            </form.AppField>
+            </group.AppField>
           </div>
         </div>
         <div className="flex flex-col gap-1">
@@ -104,7 +110,7 @@ const StripePaymentProviderContent = withForm({
           </Typography>
 
           <div className="grid grid-cols-2 gap-4">
-            <form.AppField name="paymentProviderCustomer.providerPaymentMethods.sepa_debit">
+            <group.AppField name="providerPaymentMethods.sepa_debit">
               {(field) => (
                 <field.CheckboxField
                   label={translate('text_64aeb7b998c4322918c8420c')}
@@ -115,8 +121,8 @@ const StripePaymentProviderContent = withForm({
                   }
                 />
               )}
-            </form.AppField>
-            <form.AppField name="paymentProviderCustomer.providerPaymentMethods.us_bank_account">
+            </group.AppField>
+            <group.AppField name="providerPaymentMethods.us_bank_account">
               {(field) => (
                 <field.CheckboxField
                   label={translate('text_65e1f90471bc198c0c934d8e')}
@@ -128,8 +134,8 @@ const StripePaymentProviderContent = withForm({
                   }
                 />
               )}
-            </form.AppField>
-            <form.AppField name="paymentProviderCustomer.providerPaymentMethods.bacs_debit">
+            </group.AppField>
+            <group.AppField name="providerPaymentMethods.bacs_debit">
               {(field) => (
                 <field.CheckboxField
                   label={translate('text_65e1f90471bc198c0c934d92')}
@@ -140,8 +146,8 @@ const StripePaymentProviderContent = withForm({
                   }
                 />
               )}
-            </form.AppField>
-            <form.AppField name="paymentProviderCustomer.providerPaymentMethods.boleto">
+            </group.AppField>
+            <group.AppField name="providerPaymentMethods.boleto">
               {(field) => (
                 <field.CheckboxField
                   label={translate('text_1738234109827diqh4eswleu')}
@@ -152,8 +158,8 @@ const StripePaymentProviderContent = withForm({
                   }
                 />
               )}
-            </form.AppField>
-            <form.AppField name="paymentProviderCustomer.providerPaymentMethods.crypto">
+            </group.AppField>
+            <group.AppField name="providerPaymentMethods.crypto">
               {(field) => (
                 <field.CheckboxField
                   label={translate('text_17394287699017cunbdlhnhf')}
@@ -164,7 +170,7 @@ const StripePaymentProviderContent = withForm({
                   }
                 />
               )}
-            </form.AppField>
+            </group.AppField>
           </div>
         </div>
 

--- a/src/pages/createCustomers/externalAppsAccordion/paymentProvidersAccordion/__tests__/StripePaymentProviderContent.test.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/paymentProvidersAccordion/__tests__/StripePaymentProviderContent.test.tsx
@@ -37,7 +37,14 @@ const TestStripePaymentProviderContentWrapper = ({
     } as typeof emptyCreateCustomerDefaultValues,
   })
 
-  return <StripePaymentProviderContent form={form} />
+  return (
+    <StripePaymentProviderContent
+      form={form}
+      fields={{
+        providerPaymentMethods: 'paymentProviderCustomer.providerPaymentMethods',
+      }}
+    />
+  )
 }
 
 describe('StripePaymentProviderContent Integration Tests', () => {

--- a/src/pages/createCustomers/externalAppsAccordion/taxProvidersAccordion/AnrokTaxProviderContent.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/taxProvidersAccordion/AnrokTaxProviderContent.tsx
@@ -2,8 +2,8 @@ import { useStore } from '@tanstack/react-form'
 
 import { AnrokIntegration } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { withForm } from '~/hooks/forms/useAppform'
-import { emptyCreateCustomerDefaultValues } from '~/pages/createCustomers/formInitialization/validationSchema'
+import { withFieldGroup } from '~/hooks/forms/useAppform'
+import { connectionFieldGroupDefaultValues } from '~/pages/createCustomers/externalAppsAccordion/common/connectionFieldGroup'
 
 type AnrokTaxProviderContentProps = {
   hadInitialAnrokIntegrationCustomer: boolean
@@ -17,31 +17,28 @@ const defaultProps: AnrokTaxProviderContentProps = {
   isEdition: false,
 }
 
-const AnrokTaxProviderContent = withForm({
-  defaultValues: emptyCreateCustomerDefaultValues,
+const AnrokTaxProviderContent = withFieldGroup({
+  defaultValues: connectionFieldGroupDefaultValues,
   props: defaultProps,
   render: function Render({
-    form,
+    group,
     hadInitialAnrokIntegrationCustomer,
     selectedAnrokIntegration,
     isEdition,
   }) {
     const { translate } = useInternationalization()
 
-    const syncWithProvider = useStore(
-      form.store,
-      (state) => state.values.taxCustomer?.syncWithProvider,
-    )
+    const syncWithProvider = useStore(group.store, (state) => state.values.syncWithProvider)
 
     const handleSyncWithProviderChange = (value: boolean | undefined) => {
       if (!value || isEdition) return
 
-      form.setFieldValue('taxCustomer.taxCustomerId', '')
+      group.setFieldValue('externalCustomerId', '')
     }
 
     return (
       <>
-        <form.AppField name="taxCustomer.taxCustomerId">
+        <group.AppField name="externalCustomerId">
           {(field) => (
             <field.TextInputField
               disabled={!!syncWithProvider || hadInitialAnrokIntegrationCustomer}
@@ -49,9 +46,9 @@ const AnrokTaxProviderContent = withForm({
               placeholder={translate('text_66b4e77677f8c600c8d50ea5')}
             />
           )}
-        </form.AppField>
-        <form.AppField
-          name="taxCustomer.syncWithProvider"
+        </group.AppField>
+        <group.AppField
+          name="syncWithProvider"
           listeners={{
             onChange: ({ value }) => handleSyncWithProviderChange(value),
           }}
@@ -64,7 +61,7 @@ const AnrokTaxProviderContent = withForm({
               })}
             />
           )}
-        </form.AppField>
+        </group.AppField>
       </>
     )
   },

--- a/src/pages/createCustomers/externalAppsAccordion/taxProvidersAccordion/AvalaraTaxProviderContent.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/taxProvidersAccordion/AvalaraTaxProviderContent.tsx
@@ -2,8 +2,8 @@ import { useStore } from '@tanstack/react-form'
 
 import { AvalaraIntegration } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { withForm } from '~/hooks/forms/useAppform'
-import { emptyCreateCustomerDefaultValues } from '~/pages/createCustomers/formInitialization/validationSchema'
+import { withFieldGroup } from '~/hooks/forms/useAppform'
+import { connectionFieldGroupDefaultValues } from '~/pages/createCustomers/externalAppsAccordion/common/connectionFieldGroup'
 
 type AvalaraTaxProviderContentProps = {
   hadInitialAvalaraIntegrationCustomer: boolean
@@ -17,31 +17,28 @@ const defaultProps: AvalaraTaxProviderContentProps = {
   isEdition: false,
 }
 
-const AvalaraTaxProviderContent = withForm({
-  defaultValues: emptyCreateCustomerDefaultValues,
+const AvalaraTaxProviderContent = withFieldGroup({
+  defaultValues: connectionFieldGroupDefaultValues,
   props: defaultProps,
   render: function Render({
-    form,
+    group,
     hadInitialAvalaraIntegrationCustomer,
     selectedAvalaraIntegration,
     isEdition,
   }) {
     const { translate } = useInternationalization()
 
-    const syncWithProvider = useStore(
-      form.store,
-      (state) => state.values.taxCustomer?.syncWithProvider,
-    )
+    const syncWithProvider = useStore(group.store, (state) => state.values.syncWithProvider)
 
     const handleSyncWithProviderChange = (value: boolean | undefined) => {
       if (!value || isEdition) return
 
-      form.setFieldValue('taxCustomer.taxCustomerId', '')
+      group.setFieldValue('externalCustomerId', '')
     }
 
     return (
       <>
-        <form.AppField name="taxCustomer.taxCustomerId">
+        <group.AppField name="externalCustomerId">
           {(field) => (
             <field.TextInputField
               disabled={!!syncWithProvider || hadInitialAvalaraIntegrationCustomer}
@@ -49,9 +46,9 @@ const AvalaraTaxProviderContent = withForm({
               placeholder={translate('text_1745827156646zoyf7wmog2m')}
             />
           )}
-        </form.AppField>
-        <form.AppField
-          name="taxCustomer.syncWithProvider"
+        </group.AppField>
+        <group.AppField
+          name="syncWithProvider"
           listeners={{
             onChange: ({ value }) => handleSyncWithProviderChange(value),
           }}
@@ -64,7 +61,7 @@ const AvalaraTaxProviderContent = withForm({
               })}
             />
           )}
-        </form.AppField>
+        </group.AppField>
       </>
     )
   },

--- a/src/pages/createCustomers/externalAppsAccordion/taxProvidersAccordion/TaxProvidersAccordion.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/taxProvidersAccordion/TaxProvidersAccordion.tsx
@@ -1,6 +1,7 @@
 import { useStore } from '@tanstack/react-form'
 import { Dispatch, SetStateAction, useMemo } from 'react'
 
+import { buildConnectionComboBoxData } from '~/components/customerConnections/ConnectionComboBox'
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Avatar } from '~/components/designSystem/Avatar'
 import { Typography } from '~/components/designSystem/Typography'
@@ -111,17 +112,14 @@ const TaxProvidersAccordion = withForm({
     const connectedTaxIntegrationsData: ComboboxDataGrouped[] | [] = useMemo(() => {
       if (!allAccountingIntegrationsData?.length) return []
 
-      return allAccountingIntegrationsData?.map((integration) => ({
-        value: integration.code,
-        label: integration.name,
-        group: integration?.__typename?.replace('Integration', '') || '',
-        labelNode: (
-          <ExternalAppsAccordionLayout.ComboboxItem
-            label={integration.name}
-            subLabel={integration.code}
-          />
-        ),
-      }))
+      return buildConnectionComboBoxData(
+        allAccountingIntegrationsData.map((integration) => ({
+          value: integration.code,
+          label: integration.name,
+          subLabel: integration.code,
+          group: integration?.__typename?.replace('Integration', '') || '',
+        })),
+      )
     }, [allAccountingIntegrationsData])
 
     const getAccordionSummaryAvatar = () => {
@@ -199,6 +197,10 @@ const TaxProvidersAccordion = withForm({
             {!!selectedAnrokIntegration && (
               <AnrokTaxProviderContent
                 form={form}
+                fields={{
+                  externalCustomerId: 'taxCustomer.taxCustomerId',
+                  syncWithProvider: 'taxCustomer.syncWithProvider',
+                }}
                 hadInitialAnrokIntegrationCustomer={hadInitialAnrokIntegrationCustomer}
                 selectedAnrokIntegration={selectedAnrokIntegration}
                 isEdition={isEdition}
@@ -208,6 +210,10 @@ const TaxProvidersAccordion = withForm({
             {!!selectedAvalaraIntegration && (
               <AvalaraTaxProviderContent
                 form={form}
+                fields={{
+                  externalCustomerId: 'taxCustomer.taxCustomerId',
+                  syncWithProvider: 'taxCustomer.syncWithProvider',
+                }}
                 hadInitialAvalaraIntegrationCustomer={hadInitialAvalaraIntegrationCustomer}
                 selectedAvalaraIntegration={selectedAvalaraIntegration}
                 isEdition={isEdition}

--- a/src/pages/createCustomers/externalAppsAccordion/taxProvidersAccordion/__tests__/AnrokTaxProviderContent.test.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/taxProvidersAccordion/__tests__/AnrokTaxProviderContent.test.tsx
@@ -34,6 +34,10 @@ const TestAnrokTaxProviderContentWrapper = ({
   return (
     <AnrokTaxProviderContent
       form={form}
+      fields={{
+        externalCustomerId: 'taxCustomer.taxCustomerId',
+        syncWithProvider: 'taxCustomer.syncWithProvider',
+      }}
       hadInitialAnrokIntegrationCustomer={hadInitialAnrokIntegrationCustomer}
       selectedAnrokIntegration={selectedAnrokIntegration}
       isEdition={isEdition}

--- a/src/pages/createCustomers/externalAppsAccordion/taxProvidersAccordion/__tests__/AvalaraTaxProviderContent.test.tsx
+++ b/src/pages/createCustomers/externalAppsAccordion/taxProvidersAccordion/__tests__/AvalaraTaxProviderContent.test.tsx
@@ -35,6 +35,10 @@ const TestAvalaraTaxProviderContentWrapper = ({
   return (
     <AvalaraTaxProviderContent
       form={form}
+      fields={{
+        externalCustomerId: 'taxCustomer.taxCustomerId',
+        syncWithProvider: 'taxCustomer.syncWithProvider',
+      }}
       hadInitialAvalaraIntegrationCustomer={hadInitialAvalaraIntegrationCustomer}
       selectedAvalaraIntegration={selectedAvalaraIntegration}
       isEdition={isEdition}


### PR DESCRIPTION
## Context

First FE step of the multiple-connections-on-customer feature (Milestone 1). Today the per-provider connection forms are hard-wired into the customer create/edit form (`withForm` on the whole customer + absolute field paths), which makes them impossible to reuse on the upcoming surfaces (connection drawers, customer information master-detail, per-object pickers). This PR extracts the reusable, form-agnostic primitives while keeping the UI byte-for-byte identical — no UX change, non-regressive, independently deployable.

## Description

- Convert the 7 per-provider content forms (Stripe, NetSuite, Xero, Anrok, Avalara, Hubspot, Salesforce) from `withForm(customerForm)` + hardcoded paths to `withFieldGroup` bound to a single-connection subtree with relative paths (`externalCustomerId` normalized). The accordions mount them via a `fields` mapping, so the customer form shape is untouched.
- Extract the provider-grouped combobox presentation into shared primitives (`buildConnectionComboBoxData` + `ConnectionComboBoxLabel` in `src/components/customerConnections/`), deduplicating the 4 accordions; `ExternalAppsAccordionLayout.ComboboxItem` now delegates to it.
- Extract the inline "Add a connection" Popper menu into a shared `AddConnectionMenu` component (+ `ConnectionCategory` enum), consumed by `ExternalAppsAccordion` with unchanged behavior.
- Update the 7 content tests to mount through the new `fields` mapping; all snapshots unchanged (466 tests / 69 snapshots green).

Only consumed code ships here: the connection editor drawer + hook land with their first consumer (ING-433).

<!-- Linear link -->
Fixes ING-432