### PR TITLE
fix(invoices): Round graduated charge units for invoice details

### DIFF
--- a/src/components/invoices/details/InvoiceDetailsTableBodyLineGraduated.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableBodyLineGraduated.tsx
@@ -72,7 +72,10 @@ export const InvoiceDetailsTableBodyLineGraduated = memo(
             </td>
             <td>
               <Typography variant="body" color="grey600">
-                {Number(graduatedRange.units)}
+                {intlFormatNumber(Number(graduatedRange.units) || 0, {
+                  style: 'decimal',
+                  maximumFractionDigits: 6,
+                })}
               </Typography>
             </td>
             <td>

--- a/src/components/invoices/details/InvoiceDetailsTableBodyLineGraduatedPercentage.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTableBodyLineGraduatedPercentage.tsx
@@ -72,7 +72,10 @@ export const InvoiceDetailsTableBodyLineGraduatedPercentage = memo(
             </td>
             <td>
               <Typography variant="body" color="grey600">
-                {Number(graduatedPercentageRange.units)}
+                {intlFormatNumber(Number(graduatedPercentageRange.units) || 0, {
+                  style: 'decimal',
+                  maximumFractionDigits: 6,
+                })}
               </Typography>
             </td>
             {!hideVat && (


### PR DESCRIPTION
## Context
The unit value for _graduated_ charge fees is displayed without rounding (4.77001111111111111111107306)

## Description
This PR fixes this to be consistent with other fee types (rounding to 6 decimals).

<!-- Linear link -->
Fixes [BIL-190](https://linear.app/getlago/issue/BIL-190/invoice-pdf-graduated-charge-units-column-displays-unrounded-values)