### PR TITLE
refactor(settings): migrate ApplyDunningCampaignDialog to FormDialog and TanStack Form

### DIFF
--- a/src/core/constants/form.ts
+++ b/src/core/constants/form.ts
@@ -49,6 +49,7 @@ export const SEARCH_TAX_INPUT_FOR_INVOICE_ADD_ON_CLASSNAME = 'searchTaxForInvoic
 export const ADD_ITEM_FOR_INVOICE_INPUT_NAME = 'addItemInput'
 // Billing entity
 export const SEARCH_INVOICE_CUSTOM_SECTION_INPUT_CLASSNAME = 'searchInvoiceCustomSectionInput'
+export const SEARCH_DUNNING_CAMPAIGN_INPUT_CLASSNAME = 'searchDunningCampaignInput'
 // Customer
 export const SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME = 'searchTaxForCustomerInput'
 export const SEARCH_COUPON_INPUT_FOR_CUSTOMER_CLASSNAME = 'searchCouponForCustomerInput'

--- a/src/pages/settings/BillingEntity/sections/dunning-campaigns/ApplyDunningCampaignDialog.tsx
+++ b/src/pages/settings/BillingEntity/sections/dunning-campaigns/ApplyDunningCampaignDialog.tsx
@@ -1,17 +1,23 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useMemo, useRef } from 'react'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { ComboBox } from '~/components/form'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
 import { addToast } from '~/core/apolloClient'
+import {
+  MUI_INPUT_BASE_ROOT_CLASSNAME,
+  SEARCH_DUNNING_CAMPAIGN_INPUT_CLASSNAME,
+} from '~/core/constants/form'
 import {
   BillingEntity,
   useApplyBillingEntityDunningCampaignMutation,
   useGetDunningCampaignsQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 gql`
   mutation applyBillingEntityDunningCampaign(
@@ -23,50 +29,19 @@ gql`
   }
 `
 
-export type ApplyDunningCampaignDialogRef = {
-  openDialog: (billingEntity: BillingEntity) => unknown
-  closeDialog: () => unknown
-}
+export const APPLY_DUNNING_CAMPAIGN_FORM_ID = 'apply-dunning-campaign-form'
 
-export const ApplyDunningCampaignDialog = forwardRef<ApplyDunningCampaignDialogRef>((_, ref) => {
+const applyDunningCampaignValidationSchema = z.object({
+  appliedDunningCampaignId: z.string().min(1),
+})
+
+export const useApplyDunningCampaignDialog = () => {
+  const formDialog = useFormDialog()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
-  const [billingEntity, setBillingEntity] = useState<BillingEntity | null>(null)
-  const [appliedDunningCampaignId, setAppliedDunningCampaignId] = useState<string | null>(null)
+  const billingEntityRef = useRef<BillingEntity | null>(null)
+  const successRef = useRef(false)
 
   const { data, loading } = useGetDunningCampaignsQuery()
-
-  const clear = () => {
-    setAppliedDunningCampaignId(null)
-    setBillingEntity(null)
-  }
-
-  const [applyBillingEntityDunningCampaign] = useApplyBillingEntityDunningCampaignMutation({
-    onCompleted(_data) {
-      if (_data) {
-        addToast({
-          message: translate('text_1750663218390945tme6j9he'),
-          severity: 'success',
-        })
-      }
-    },
-    refetchQueries: ['getBillingEntity'],
-  })
-
-  useImperativeHandle(ref, () => ({
-    openDialog: (_billingEntity) => {
-      clear()
-
-      setBillingEntity(_billingEntity)
-
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => {
-      clear()
-
-      dialogRef.current?.closeDialog()
-    },
-  }))
 
   const dunningCampaigns = useMemo(
     () =>
@@ -78,54 +53,104 @@ export const ApplyDunningCampaignDialog = forwardRef<ApplyDunningCampaignDialogR
     [data],
   )
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate('text_17506632183903il25h0wuik')}
-      description={<Typography>{translate('text_1750663218390ndvitukei2q')}</Typography>}
-      actions={({ closeDialog }) => (
-        <>
-          <Button variant="quaternary" onClick={closeDialog}>
-            {translate('text_63eba8c65a6c8043feee2a14')}
-          </Button>
+  const [applyBillingEntityDunningCampaign] = useApplyBillingEntityDunningCampaignMutation({
+    onCompleted(_data) {
+      if (_data?.billingEntityUpdateAppliedDunningCampaign) {
+        successRef.current = true
+        addToast({
+          message: translate('text_1750663218390945tme6j9he'),
+          severity: 'success',
+        })
+      }
+    },
+    refetchQueries: ['getBillingEntity'],
+  })
 
-          <Button
-            variant="primary"
-            disabled={!appliedDunningCampaignId}
-            onClick={async () => {
-              if (billingEntity && appliedDunningCampaignId) {
-                applyBillingEntityDunningCampaign({
-                  variables: {
-                    input: {
-                      appliedDunningCampaignId: appliedDunningCampaignId,
-                      billingEntityId: billingEntity.id,
-                    },
-                  },
-                })
-              }
+  const form = useAppForm({
+    defaultValues: {
+      appliedDunningCampaignId: '',
+    },
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: applyDunningCampaignValidationSchema,
+    },
+    onSubmit: async ({ value }) => {
+      const billingEntity = billingEntityRef.current
 
-              closeDialog()
-            }}
-          >
-            {translate('text_1750663218390xxlt86n0fhu')}
-          </Button>
-        </>
-      )}
-    >
-      <ComboBox
-        name="billingEntityApplyDunningCampaign"
-        label={translate('text_1750663218390lixhj94mgbp')}
-        className="mb-8"
-        loading={loading}
-        data={dunningCampaigns}
-        value={appliedDunningCampaignId || ''}
-        onChange={(t) => setAppliedDunningCampaignId(t)}
-        placeholder={translate('text_1750663218390emesat7jusk')}
-        PopperProps={{ displayInDialog: true }}
-        emptyText={translate('text_1750663218390rdqsn5fzioi')}
-      />
-    </Dialog>
-  )
-})
+      if (!billingEntity) return
 
-ApplyDunningCampaignDialog.displayName = 'ApplyDunningCampaignDialog'
+      await applyBillingEntityDunningCampaign({
+        variables: {
+          input: {
+            appliedDunningCampaignId: value.appliedDunningCampaignId,
+            billingEntityId: billingEntity.id,
+          },
+        },
+      })
+    },
+  })
+
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
+
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openApplyDunningCampaignDialog = (billingEntity: BillingEntity) => {
+    billingEntityRef.current = billingEntity
+    form.reset()
+
+    formDialog
+      .open({
+        title: translate('text_17506632183903il25h0wuik'),
+        description: <Typography>{translate('text_1750663218390ndvitukei2q')}</Typography>,
+        closeOnError: false,
+        onEntered: (container) => {
+          container
+            .querySelector<HTMLElement>(
+              `.${SEARCH_DUNNING_CAMPAIGN_INPUT_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+            )
+            ?.click()
+        },
+        children: (
+          <div className="p-8">
+            <form.AppField name="appliedDunningCampaignId">
+              {(field) => (
+                <field.ComboBoxField
+                  className={SEARCH_DUNNING_CAMPAIGN_INPUT_CLASSNAME}
+                  label={translate('text_1750663218390lixhj94mgbp')}
+                  loading={loading}
+                  data={dunningCampaigns}
+                  placeholder={translate('text_1750663218390emesat7jusk')}
+                  PopperProps={{ displayInDialog: true }}
+                  emptyText={translate('text_1750663218390rdqsn5fzioi')}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>{translate('text_1750663218390xxlt86n0fhu')}</form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: APPLY_DUNNING_CAMPAIGN_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close') {
+          form.reset()
+          billingEntityRef.current = null
+        }
+      })
+  }
+
+  return { openApplyDunningCampaignDialog }
+}

--- a/src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx
+++ b/src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx
@@ -1,5 +1,4 @@
 import { Icon } from 'lago-design-system'
-import { useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Avatar } from '~/components/designSystem/Avatar'
@@ -25,10 +24,7 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { usePermissions } from '~/hooks/usePermissions'
-import {
-  ApplyDunningCampaignDialog,
-  ApplyDunningCampaignDialogRef,
-} from '~/pages/settings/BillingEntity/sections/dunning-campaigns/ApplyDunningCampaignDialog'
+import { useApplyDunningCampaignDialog } from '~/pages/settings/BillingEntity/sections/dunning-campaigns/ApplyDunningCampaignDialog'
 import { useRemoveAppliedDunningCampaignDialog } from '~/pages/settings/BillingEntity/sections/dunning-campaigns/RemoveAppliedDunningCampaignDialog'
 import ErrorImage from '~/public/images/maneki/error.svg'
 
@@ -40,7 +36,7 @@ const BillingEntityDunningCampaigns = () => {
 
   const hasAccessToFeature = premiumIntegrations?.includes(PremiumIntegrationTypeEnum.AutoDunning)
 
-  const applyDunningCampaignDialogRef = useRef<ApplyDunningCampaignDialogRef>(null)
+  const { openApplyDunningCampaignDialog } = useApplyDunningCampaignDialog()
   const { openRemoveAppliedDunningCampaignDialog } = useRemoveAppliedDunningCampaignDialog()
 
   const {
@@ -108,9 +104,7 @@ const BillingEntityDunningCampaigns = () => {
                           disabled={loading || !!appliedDunningCampaign?.id}
                           onClick={() => {
                             if (billingEntity) {
-                              applyDunningCampaignDialogRef?.current?.openDialog(
-                                billingEntity as BillingEntity,
-                              )
+                              openApplyDunningCampaignDialog(billingEntity as BillingEntity)
                             }
                           }}
                           data-test="apply-dunning-campaign-button"
@@ -203,8 +197,6 @@ const BillingEntityDunningCampaigns = () => {
           </>
         )}
       </SettingsPaddedContainer>
-
-      <ApplyDunningCampaignDialog ref={applyDunningCampaignDialogRef} />
     </>
   )
 }


### PR DESCRIPTION
## Context

`ApplyDunningCampaignDialog` was one of the legacy `forwardRef` + `Dialog` (`~/components/designSystem/Dialog`) consumers flagged by the `no-restricted-imports` ESLint rule. The dialog is a single-field picker (a `ComboBox` selecting a dunning campaign) followed by an "Apply" button targeting `billingEntityUpdateAppliedDunningCampaign`, so `useFormDialog` + TanStack Form is a natural fit.

## Description

- **`src/pages/settings/BillingEntity/sections/dunning-campaigns/ApplyDunningCampaignDialog.tsx`**
  - Replaced the `forwardRef` + `useImperativeHandle` + `Dialog` + local `useState` boilerplate with a `useApplyDunningCampaignDialog` hook backed by `useFormDialog` and `useAppForm` + Zod (`min(1)` on `appliedDunningCampaignId`).
  - The single field is rendered inline via `form.AppField` + `field.ComboBoxField`.
  - `handleSubmit` returns `Promise<DialogResult>` using `successRef` (set inside the mutation's `onCompleted` handler) to signal success — throws to keep the dialog open under `closeOnError: false`.
  - Exports a stable `APPLY_DUNNING_CAMPAIGN_FORM_ID` constant used as the dialog's form id.
  - Since the first field is a `ComboBox`, `onEntered` clicks the `MuiInputBase-root` to open the dropdown on enter (per the migration skill's branch 2b).
  - Dropped `ApplyDunningCampaignDialogRef` and the top-level `Dialog`/`DialogRef` imports.

- **`src/core/constants/form.ts`**
  - Added a dedicated `SEARCH_DUNNING_CAMPAIGN_INPUT_CLASSNAME` constant grouped under the Billing entity comment (paired with the existing `SEARCH_INVOICE_CUSTOM_SECTION_INPUT_CLASSNAME`).

- **`src/pages/settings/BillingEntity/sections/dunning-campaigns/BillingEntityDunningCampaigns.tsx`**
  - Dropped the `applyDunningCampaignDialogRef` `useRef` + the trailing `<ApplyDunningCampaignDialog ref={…} />` JSX.
  - The "Apply campaign" action now calls `openApplyDunningCampaignDialog(billingEntity)` directly.
  - Removed the now-unused `useRef` React import.

## Scope

Strictly scoped to the `no-restricted-imports` warning for `ApplyDunningCampaignDialog`. No unrelated cleanup.

## Test plan

- [ ] Billing entity settings → Dunning campaigns → "Apply campaign" button opens the dialog with the dropdown auto-opened.
- [ ] Picking a campaign and submitting fires `billingEntityUpdateAppliedDunningCampaign` with the correct `appliedDunningCampaignId` + `billingEntityId`. Success toast displays.
- [ ] Submit button stays disabled until a campaign is picked (validation).
- [ ] Cancel/close → no mutation, dialog resets on reopen.
- [ ] `pnpm exec tsc --noEmit`, `pnpm exec eslint` on the touched files — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sk8iMyEuCscqhQcrKj99h5)_