### PR TITLE
refactor(settings): migrate ApplyTaxDialog to FormDialog and TanStack Form

### DIFF
--- a/cypress/e2e/10-resources/t10-create-taxes.cy.ts
+++ b/cypress/e2e/10-resources/t10-create-taxes.cy.ts
@@ -1,3 +1,4 @@
+import { SEARCH_APPLY_TAX_INPUT_CLASSNAME } from '~/core/constants/form'
 import {
   APPLY_TAX_BUTTON_TEST_ID,
   APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID,
@@ -64,10 +65,15 @@ describe('Create taxes', () => {
       cy.get(`[data-test="${APPLY_TAX_BUTTON_TEST_ID}"]`).click()
       cy.get(`[data-test="${APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID}"]`).should('exist')
 
-      // Search and select the tax in the ComboBox
-      cy.get('input[name="billingEntityApplyTaxes"]').click()
-      cy.get('input[name="billingEntityApplyTaxes"]').type(TAX_TWENTY_NAME)
-      cy.get('[data-option-index="0"]').click()
+      // The dialog auto-opens the ComboBox on entry, so wait for the options
+      // instead of clicking the input (a click would toggle the dropdown shut)
+      cy.get('[data-option-index="0"]', { timeout: 30000 }).should('exist')
+      cy.get(`.${SEARCH_APPLY_TAX_INPUT_CLASSNAME} input`).type(TAX_TWENTY_NAME)
+      // Wait until the search refetch has narrowed the list down to the tax we
+      // typed, so we never click a stale option from the unfiltered list
+      cy.contains('[data-option-index="0"]', TAX_TWENTY_NAME, { timeout: 15000 }).click({
+        force: true,
+      })
 
       // Submit the dialog
       cy.get(`[data-test="${APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID}"]`).click()

--- a/src/core/constants/form.ts
+++ b/src/core/constants/form.ts
@@ -53,6 +53,7 @@ export const RESEND_INVOICE_PAYMENT_METHOD_INPUT_CLASSNAME = 'resendInvoicePayme
 export const SEARCH_INVOICE_CUSTOM_SECTION_INPUT_CLASSNAME = 'searchInvoiceCustomSectionInput'
 export const SEARCH_DUNNING_CAMPAIGN_INPUT_CLASSNAME = 'searchDunningCampaignInput'
 export const FINALIZE_ZERO_AMOUNT_INVOICE_INPUT_CLASSNAME = 'finalizeZeroAmountInvoiceInput'
+export const SEARCH_APPLY_TAX_INPUT_CLASSNAME = 'searchApplyTaxInput'
 // Customer
 export const ADD_PAYMENT_METHOD_PROVIDER_INPUT_CLASSNAME = 'addPaymentMethodProviderInput'
 export const SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME = 'searchTaxForCustomerInput'

--- a/src/pages/settings/BillingEntity/sections/taxes/ApplyTaxDialog.tsx
+++ b/src/pages/settings/BillingEntity/sections/taxes/ApplyTaxDialog.tsx
@@ -1,16 +1,22 @@
 import { gql } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useEffect, useMemo, useRef } from 'react'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { ComboBox } from '~/components/form'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
 import { addToast } from '~/core/apolloClient'
+import {
+  MUI_INPUT_BASE_ROOT_CLASSNAME,
+  SEARCH_APPLY_TAX_INPUT_CLASSNAME,
+} from '~/core/constants/form'
 import {
   useApplyBillingEntityTaxesMutation,
   useGetTaxesForApplyTaxLazyQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm, withForm } from '~/hooks/forms/useAppform'
 import {
   APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID,
   APPLY_TAX_DIALOG_TEST_ID,
@@ -43,25 +49,84 @@ gql`
   }
 `
 
-export type ApplyTaxDialogRef = {
-  openDialog: (billingEntityId: string) => unknown
-  closeDialog: () => unknown
+export const APPLY_TAX_FORM_ID = 'apply-tax-form'
+
+const REQUIRED_TAX_ERROR = 'text_624ea7c29103fd010732ab7d'
+
+const applyTaxValidationSchema = z.object({
+  // The combobox sets the value to undefined when cleared, so the type-level
+  // error needs the same message as the empty-string one.
+  taxCode: z.string({ error: REQUIRED_TAX_ERROR }).min(1, { message: REQUIRED_TAX_ERROR }),
+})
+
+const applyTaxFormOptions = {
+  defaultValues: {
+    taxCode: '',
+  },
+  validationLogic: revalidateLogic(),
+  validators: {
+    onDynamic: applyTaxValidationSchema,
+  },
 }
 
-export const ApplyTaxDialog = forwardRef<ApplyTaxDialogRef>((_, ref) => {
-  const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
+const ApplyTaxDialogContent = withForm({
+  ...applyTaxFormOptions,
+  render: function Render({ form }) {
+    const { translate } = useInternationalization()
+    const [getTaxes, { data, loading }] = useGetTaxesForApplyTaxLazyQuery({
+      variables: {
+        limit: 50,
+      },
+      notifyOnNetworkStatusChange: true,
+    })
 
-  const [getTaxes, { data, loading }] = useGetTaxesForApplyTaxLazyQuery({
-    variables: {
-      limit: 50,
-    },
-    notifyOnNetworkStatusChange: true,
-  })
+    // Eagerly load the taxes on mount so the dropdown has options when the
+    // dialog auto-opens it (searchQuery only fires on typing, not on open).
+    useEffect(() => {
+      getTaxes()
+    }, [getTaxes])
+
+    const taxes = useMemo(
+      () =>
+        data?.taxes?.collection?.map((item) => ({
+          value: item.code,
+          label: item.name,
+          description: item.code,
+        })) || [],
+      [data],
+    )
+
+    return (
+      <div className="p-8" data-test={APPLY_TAX_DIALOG_TEST_ID}>
+        <form.AppField name="taxCode">
+          {(field) => (
+            <field.ComboBoxField
+              className={SEARCH_APPLY_TAX_INPUT_CLASSNAME}
+              label={translate('text_1743241419870gwqt1b54uuq')}
+              loading={loading}
+              data={taxes}
+              searchQuery={getTaxes}
+              placeholder={translate('text_17436000251334xxp8qsljsk')}
+              PopperProps={{ displayInDialog: true }}
+              emptyText={translate('text_1743600025133454kb04evs6')}
+            />
+          )}
+        </form.AppField>
+      </div>
+    )
+  },
+})
+
+export const useApplyTaxDialog = () => {
+  const formDialog = useFormDialog()
+  const { translate } = useInternationalization()
+  const billingEntityIdRef = useRef<string | null>(null)
+  const successRef = useRef(false)
 
   const [applyTax] = useApplyBillingEntityTaxesMutation({
     onCompleted(_data) {
-      if (_data) {
+      if (_data?.billingEntityApplyTaxes) {
+        successRef.current = true
         addToast({
           message: translate('text_1743600025133ouzufhpiyw8'),
           severity: 'success',
@@ -71,78 +136,71 @@ export const ApplyTaxDialog = forwardRef<ApplyTaxDialogRef>((_, ref) => {
     refetchQueries: ['getBillingEntityTaxes'],
   })
 
-  const taxes = useMemo(
-    () =>
-      data?.taxes?.collection?.map((item) => ({
-        value: item.code,
-        label: item.name,
-        description: item.code,
-      })) || [],
-    [data],
-  )
+  const form = useAppForm({
+    ...applyTaxFormOptions,
+    onSubmit: async ({ value }) => {
+      const billingEntityId = billingEntityIdRef.current
 
-  const [billingEntityId, setBillingEntityId] = useState<string | null>(null)
-  const [taxCode, setTaxCode] = useState<string | null>(null)
+      if (!billingEntityId || !value.taxCode) return
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (_billingEntityId) => {
-      setBillingEntityId(_billingEntityId)
-
-      dialogRef.current?.openDialog()
+      await applyTax({
+        variables: {
+          input: {
+            billingEntityId,
+            taxCodes: [value.taxCode],
+          },
+        },
+      })
     },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  })
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      data-test={APPLY_TAX_DIALOG_TEST_ID}
-      title={translate('text_1743600025132l3aadb2il09')}
-      description={<Typography>{translate('text_17436000251322d5x6wtpjq1')}</Typography>}
-      actions={({ closeDialog }) => (
-        <>
-          <Button variant="quaternary" onClick={closeDialog}>
-            {translate('text_63eba8c65a6c8043feee2a14')}
-          </Button>
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-          <Button
-            variant="primary"
-            data-test={APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID}
-            onClick={async () => {
-              if (billingEntityId && taxCode) {
-                applyTax({
-                  variables: {
-                    input: {
-                      billingEntityId,
-                      taxCodes: [taxCode],
-                    },
-                  },
-                })
-              }
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
 
-              closeDialog()
-            }}
-          >
-            {translate('text_1743600025133natje9qmw0q')}
-          </Button>
-        </>
-      )}
-    >
-      <ComboBox
-        name="billingEntityApplyTaxes"
-        label={translate('text_1743241419870gwqt1b54uuq')}
-        className="mb-8"
-        loading={loading}
-        data={taxes}
-        value={taxCode || ''}
-        onChange={(t) => setTaxCode(t)}
-        searchQuery={getTaxes}
-        placeholder={translate('text_17436000251334xxp8qsljsk')}
-        PopperProps={{ displayInDialog: true }}
-        emptyText={translate('text_1743600025133454kb04evs6')}
-      />
-    </Dialog>
-  )
-})
+    return { reason: 'success' }
+  }
 
-ApplyTaxDialog.displayName = 'ApplyTaxDialog'
+  const openApplyTaxDialog = (billingEntityId: string) => {
+    billingEntityIdRef.current = billingEntityId
+    form.reset()
+
+    formDialog
+      .open({
+        title: translate('text_1743600025132l3aadb2il09'),
+        description: <Typography>{translate('text_17436000251322d5x6wtpjq1')}</Typography>,
+        closeOnError: false,
+        onEntered: (container) => {
+          container
+            .querySelector<HTMLElement>(
+              `.${SEARCH_APPLY_TAX_INPUT_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+            )
+            ?.click()
+        },
+        children: <ApplyTaxDialogContent form={form} />,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton dataTest={APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID}>
+              {translate('text_1743600025133natje9qmw0q')}
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: APPLY_TAX_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close') {
+          form.reset()
+          billingEntityIdRef.current = null
+        }
+      })
+  }
+
+  return { openApplyTaxDialog }
+}

--- a/src/pages/settings/BillingEntity/sections/taxes/ApplyTaxDialog.tsx
+++ b/src/pages/settings/BillingEntity/sections/taxes/ApplyTaxDialog.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { revalidateLogic } from '@tanstack/react-form'
-import { useEffect, useMemo, useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import { z } from 'zod'
 
 import { Typography } from '~/components/designSystem/Typography'
@@ -79,12 +79,6 @@ const ApplyTaxDialogContent = withForm({
       },
       notifyOnNetworkStatusChange: true,
     })
-
-    // Eagerly load the taxes on mount so the dropdown has options when the
-    // dialog auto-opens it (searchQuery only fires on typing, not on open).
-    useEffect(() => {
-      getTaxes()
-    }, [getTaxes])
 
     const taxes = useMemo(
       () =>

--- a/src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx
@@ -1,6 +1,5 @@
 import { gql } from '@apollo/client'
 import { Icon } from 'lago-design-system'
-import { useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Avatar } from '~/components/designSystem/Avatar'
@@ -22,10 +21,7 @@ import { BILLING_ENTITY_ROUTE } from '~/core/router/SettingRoutes'
 import { Tax, useGetBillingEntityQuery, useGetBillingEntityTaxesQuery } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { usePermissions } from '~/hooks/usePermissions'
-import {
-  ApplyTaxDialog,
-  ApplyTaxDialogRef,
-} from '~/pages/settings/BillingEntity/sections/taxes/ApplyTaxDialog'
+import { useApplyTaxDialog } from '~/pages/settings/BillingEntity/sections/taxes/ApplyTaxDialog'
 import { APPLY_TAX_BUTTON_TEST_ID } from '~/pages/settings/BillingEntity/sections/taxes/dataTestConstants'
 import { useRemoveTaxDialog } from '~/pages/settings/BillingEntity/sections/taxes/RemoveTaxDialog'
 import ErrorImage from '~/public/images/maneki/error.svg'
@@ -47,7 +43,7 @@ const BillingEntityTaxesSettings = () => {
   const { hasPermissions } = usePermissions()
   const { translate } = useInternationalization()
 
-  const applyTaxDialogRef = useRef<ApplyTaxDialogRef>(null)
+  const { openApplyTaxDialog } = useApplyTaxDialog()
   const { openRemoveTaxDialog } = useRemoveTaxDialog()
 
   const { billingEntityCode } = useParams()
@@ -120,7 +116,7 @@ const BillingEntityTaxesSettings = () => {
                           disabled={loading}
                           onClick={() => {
                             if (billingEntity?.id) {
-                              applyTaxDialogRef?.current?.openDialog(billingEntity.id)
+                              openApplyTaxDialog(billingEntity.id)
                             }
                           }}
                           data-test={APPLY_TAX_BUTTON_TEST_ID}
@@ -206,8 +202,6 @@ const BillingEntityTaxesSettings = () => {
           </>
         )}
       </SettingsPaddedContainer>
-
-      <ApplyTaxDialog ref={applyTaxDialogRef} />
     </>
   )
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -1300,7 +1300,6 @@
   "text_63eba8c65a6c8043feee2a0d": "Update payment status",
   "text_63eba8c65a6c8043feee2a0e": "Please note that updating the payment status of an invoice will not re-trigger the payment collection process.",
   "text_63eba8c65a6c8043feee2a0f": "Payment status",
-  "text_63eba8c65a6c8043feee2a14": "Cancel",
   "text_63eba8c65a6c8043feee2a15": "Update status",
   "text_63aa085d28b8510cd464440d": "{{invoiceGracePeriod}} day (inherit from billing entity)|{{invoiceGracePeriod}} days (inherit from billing entity)",
   "text_638dff9779fb99299bee9126": "Settings",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -1332,7 +1332,6 @@
   "text_63eba8c65a6c8043feee2a0d": "Atualizar status do pagamento",
   "text_63eba8c65a6c8043feee2a0e": "Observe que a atualização do status de pagamento de uma fatura não acionará novamente o processo de cobrança.",
   "text_63eba8c65a6c8043feee2a0f": "Status do pagamento",
-  "text_63eba8c65a6c8043feee2a14": "Cancelar",
   "text_63eba8c65a6c8043feee2a15": "Atualizar status",
   "text_63aa085d28b8510cd464440d": "{{invoiceGracePeriod}} dia (herdar da entidade de faturamento)|{{invoiceGracePeriod}} dias (herdar da entidade de faturamento)",
   "text_638dff9779fb99299bee9126": "Configurações",


### PR DESCRIPTION
## Context

`ApplyTaxDialog` was one of the legacy `forwardRef` + `Dialog` (`~/components/designSystem/Dialog`) consumers flagged by the `no-restricted-imports` ESLint rule. The dialog is a single-field picker (a searchable `ComboBox` selecting a tax) followed by an "Apply" button targeting `billingEntityApplyTaxes`, so `useFormDialog` + TanStack Form is a natural fit.

## Description

- **`src/pages/settings/BillingEntity/sections/taxes/ApplyTaxDialog.tsx`**
  - Replaced the `forwardRef` + `useImperativeHandle` + `Dialog` + local `useState` boilerplate with a `useApplyTaxDialog` hook backed by `useFormDialog` and `useAppForm` + Zod (`min(1)` on `taxCode`).
  - The single field is rendered inline via `form.AppField` + `field.ComboBoxField`, keeping the existing `searchQuery` lazy-load wiring.
  - `handleSubmit` returns `Promise<DialogResult>` using `successRef` (set inside the mutation's `onCompleted` handler) to signal success — throws to keep the dialog open under `closeOnError: false`.
  - Exports a stable `APPLY_TAX_FORM_ID` constant used as the dialog's form id.
  - Since the first field is a `ComboBox`, `onEntered` clicks the `MuiInputBase-root` to open the dropdown on enter (per the migration skill's branch 2b).
  - Existing test ids (`APPLY_TAX_DIALOG_TEST_ID` on the content wrapper, `APPLY_TAX_DIALOG_SUBMIT_BUTTON_TEST_ID` on the submit button) are preserved.
  - Dropped `ApplyTaxDialogRef` and the top-level `Dialog`/`DialogRef` imports.

- **`src/core/constants/form.ts`**
  - Added a dedicated `SEARCH_APPLY_TAX_INPUT_CLASSNAME` constant grouped under the Billing entity comment.

- **`src/pages/settings/BillingEntity/sections/taxes/BillingEntityTaxesSettings.tsx`**
  - Dropped the `applyTaxDialogRef` `useRef` + the trailing `<ApplyTaxDialog ref={…} />` JSX.
  - The "Apply tax" action now calls `openApplyTaxDialog(billingEntityId)` directly.
  - Removed the now-unused `useRef` React import.

## Scope

Strictly scoped to the `no-restricted-imports` warning for `ApplyTaxDialog`. No unrelated cleanup.

## Test plan

- [ ] Billing entity settings → Taxes → "Apply tax" button opens the dialog with the dropdown auto-opened.
- [ ] Searching in the combobox debounces the tax lazy query correctly.
- [ ] Picking a tax and submitting fires `billingEntityApplyTaxes` with the correct `billingEntityId` + `taxCodes` list. Success toast displays.
- [ ] Submit button stays disabled until a tax is picked (validation).
- [ ] Cancel/close → no mutation, dialog resets on reopen.
- [ ] `pnpm exec tsc --noEmit`, `pnpm exec eslint` on the touched files — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sk8iMyEuCscqhQcrKj99h5)_