### PR TITLE
refactor(wallets): migrate VoidWalletDialog to TanStack Form

### DIFF
--- a/src/components/wallets/VoidWalletDialog.tsx
+++ b/src/components/wallets/VoidWalletDialog.tsx
@@ -1,18 +1,18 @@
 import { gql } from '@apollo/client'
 import InputAdornment from '@mui/material/InputAdornment'
-import { useFormik } from 'formik'
+import { revalidateLogic, useStore } from '@tanstack/react-form'
 import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
-import { number, object, string } from 'yup'
+import { z } from 'zod'
 
 import { Button } from '~/components/designSystem/Button'
 import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { AmountInputField, TextInputField } from '~/components/form'
 import { addToast } from '~/core/apolloClient'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { useNavigate, WALLET_DETAILS_ROUTE } from '~/core/router'
 import { CurrencyEnum, useCreateCustomerWalletTransactionMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 import { WalletDetailsTabsOptionsEnum } from '~/pages/wallet/WalletDetails'
 
 gql`
@@ -23,6 +23,39 @@ gql`
     creditsBalance
   }
 `
+
+// Zod v4 renders an empty message as "Invalid input" (Yup's `.required('')` had no
+// visible text). Reuse the shared "required" key so the error stays invisible — the
+// disabled submit button is the only feedback, matching the original behavior.
+const VOID_WALLET_REQUIRED_ERROR = 'text_1771342994699klxu2paz7g8'
+const VOID_WALLET_MAX_CREDITS_ERROR = 'text_662fc2730f9a31fe564e9dbf'
+
+// The max bound depends on the wallet the dialog was opened for (creditsBalance), not
+// on form values, so the schema is a factory rebuilt on every render — mirrors the
+// original Yup schema, which was recreated by useFormik on every render for the same
+// reason.
+type VoidWalletFormValues = {
+  name: string
+  voidCredits: number | string
+}
+
+const getVoidWalletValidationSchema = (creditsBalance: number | undefined) =>
+  z.custom<VoidWalletFormValues>().superRefine((data, ctx) => {
+    const numericVoidCredits = Number(data.voidCredits)
+
+    if (data.voidCredits === '' || isNaN(numericVoidCredits)) {
+      ctx.addIssue({ code: 'custom', message: VOID_WALLET_REQUIRED_ERROR, path: ['voidCredits'] })
+      return
+    }
+
+    if (typeof creditsBalance === 'number' && numericVoidCredits > creditsBalance) {
+      ctx.addIssue({
+        code: 'custom',
+        message: VOID_WALLET_MAX_CREDITS_ERROR,
+        path: ['voidCredits'],
+      })
+    }
+  })
 
 type WalletProps = {
   walletId?: string
@@ -35,6 +68,13 @@ export type VoidWalletDialogRef = {
   openDialog: (props?: WalletProps) => unknown
   closeDialog: () => unknown
 }
+
+const VOID_WALLET_FORM_ID = 'void-wallet-form'
+
+export const VOID_WALLET_NAME_FIELD_TEST_ID = 'void-wallet-name-field'
+export const VOID_WALLET_CREDITS_FIELD_TEST_ID = 'void-wallet-credits-field'
+export const VOID_WALLET_SUBMIT_BUTTON_TEST_ID = 'void-wallet-submit-button'
+export const VOID_WALLET_CANCEL_BUTTON_TEST_ID = 'void-wallet-cancel-button'
 
 export const VoidWalletDialog = forwardRef<VoidWalletDialogRef>((_, ref) => {
   const { translate } = useInternationalization()
@@ -54,35 +94,29 @@ export const VoidWalletDialog = forwardRef<VoidWalletDialogRef>((_, ref) => {
     },
   })
 
-  const formikProps = useFormik({
-    initialValues: {
-      name: undefined,
-      voidCredits: undefined,
+  const form = useAppForm({
+    defaultValues: {
+      name: '',
+      voidCredits: '' as number | string,
     },
-    validationSchema: object().shape({
-      name: string(),
-      voidCredits: number()
-        .required('')
-        .max(
-          localData?.creditsBalance as number,
-          translate('text_662fc2730f9a31fe564e9dbf', { balance: localData?.creditsBalance }),
-        ),
-    }),
-    enableReinitialize: true,
-    validateOnMount: true,
-    isInitialValid: false,
-    onSubmit: async ({ voidCredits, name }) => {
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: getVoidWalletValidationSchema(localData?.creditsBalance),
+    },
+    onSubmit: async ({ value }) => {
       await createVoidTransaction({
         variables: {
           input: {
             walletId: localData?.walletId as string,
-            voidedCredits: String(voidCredits),
-            name: name || undefined,
+            voidedCredits: String(value.voidCredits),
+            name: value.name || undefined,
           },
         },
         refetchQueries: ['getCustomerWalletList', 'getWalletTransactions'],
         notifyOnNetworkStatusChange: true,
       })
+
+      dialogRef.current?.closeDialog()
 
       navigate(
         generatePath(WALLET_DETAILS_ROUTE, {
@@ -93,6 +127,15 @@ export const VoidWalletDialog = forwardRef<VoidWalletDialogRef>((_, ref) => {
       )
     },
   })
+
+  const isDirty = useStore(form.store, (state) => state.isDirty)
+  const canSubmit = useStore(form.store, (state) => state.canSubmit)
+  const voidCredits = useStore(form.store, (state) => state.values.voidCredits)
+
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    form.handleSubmit()
+  }
 
   useImperativeHandle(ref, () => ({
     openDialog: (props) => {
@@ -111,19 +154,23 @@ export const VoidWalletDialog = forwardRef<VoidWalletDialogRef>((_, ref) => {
       ref={dialogRef}
       title={translate('text_63720bd734e1344aea75b7e9')}
       description={translate('text_662fc2730f9a31fe564e9dad')}
-      onClose={() => formikProps.resetForm()}
+      onClose={() => form.reset()}
+      formId={VOID_WALLET_FORM_ID}
+      formSubmit={handleFormSubmit}
       actions={({ closeDialog }) => (
         <>
-          <Button variant="quaternary" onClick={closeDialog}>
+          <Button
+            variant="quaternary"
+            onClick={closeDialog}
+            data-test={VOID_WALLET_CANCEL_BUTTON_TEST_ID}
+          >
             {translate('text_62e79671d23ae6ff149de968')}
           </Button>
           <Button
-            disabled={!formikProps.isValid}
-            onClick={async () => {
-              await formikProps.submitForm()
-              closeDialog()
-            }}
-            danger={formikProps.isValid && formikProps.dirty}
+            type="submit"
+            disabled={!canSubmit}
+            danger={canSubmit && isDirty}
+            data-test={VOID_WALLET_SUBMIT_BUTTON_TEST_ID}
           >
             {translate('text_63720bd734e1344aea75b7e9')}
           </Button>
@@ -131,45 +178,57 @@ export const VoidWalletDialog = forwardRef<VoidWalletDialogRef>((_, ref) => {
       )}
     >
       <div className="mb-8 flex flex-col gap-6">
-        <TextInputField
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus
-          name="name"
-          formikProps={formikProps}
-          label={translate('text_17580145853389xkffv9cs1d')}
-          placeholder={translate('text_17580145853390n3v83gao69')}
-        />
+        <form.AppField name="name">
+          {(field) => (
+            <field.TextInputField
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus
+              data-test={VOID_WALLET_NAME_FIELD_TEST_ID}
+              label={translate('text_17580145853389xkffv9cs1d')}
+              placeholder={translate('text_17580145853390n3v83gao69')}
+            />
+          )}
+        </form.AppField>
 
-        <AmountInputField
-          name="voidCredits"
-          currency={localData?.currency as CurrencyEnum}
-          beforeChangeFormatter={['positiveNumber']}
-          label={translate('text_662fc2730f9a31fe564e9db1')}
-          formikProps={formikProps}
-          error={Boolean(formikProps.errors.voidCredits)}
-          helperText={
-            formikProps.errors.voidCredits
-              ? formikProps.errors.voidCredits
-              : translate('text_662fc2730f9a31fe564e9dbd', {
+        <form.AppField name="voidCredits">
+          {(field) => {
+            const errorMessage = field.state.meta.errors[0]?.message
+
+            return (
+              <field.AmountInputField
+                currency={localData?.currency as CurrencyEnum}
+                beforeChangeFormatter={['positiveNumber']}
+                data-test={VOID_WALLET_CREDITS_FIELD_TEST_ID}
+                label={translate('text_662fc2730f9a31fe564e9db1')}
+                errorOverride={
+                  errorMessage === VOID_WALLET_MAX_CREDITS_ERROR
+                    ? translate(VOID_WALLET_MAX_CREDITS_ERROR, {
+                        balance: localData?.creditsBalance,
+                      })
+                    : false
+                }
+                helperText={translate('text_662fc2730f9a31fe564e9dbd', {
                   credits: intlFormatNumber(
-                    !isNaN(Number(formikProps.values.voidCredits))
-                      ? Number(formikProps.values.voidCredits) * Number(localData?.rateAmount)
+                    !isNaN(Number(voidCredits))
+                      ? Number(voidCredits) * Number(localData?.rateAmount)
                       : 0,
                     {
                       currencyDisplay: 'symbol',
                       currency: localData?.currency,
                     },
                   ),
-                })
-          }
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                {translate('text_62e79671d23ae6ff149de94c')}
-              </InputAdornment>
-            ),
+                })}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      {translate('text_62e79671d23ae6ff149de94c')}
+                    </InputAdornment>
+                  ),
+                }}
+              />
+            )
           }}
-        />
+        </form.AppField>
       </div>
     </Dialog>
   )

--- a/src/components/wallets/__tests__/VoidWalletDialog.test.tsx
+++ b/src/components/wallets/__tests__/VoidWalletDialog.test.tsx
@@ -1,12 +1,21 @@
-import { act, screen } from '@testing-library/react'
+import { act, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createRef } from 'react'
 
 import { CurrencyEnum } from '~/generated/graphql'
-import { render } from '~/test-utils'
+import { render, testMockNavigateFn } from '~/test-utils'
 
-import { VoidWalletDialog, VoidWalletDialogRef } from '../VoidWalletDialog'
+import {
+  VOID_WALLET_CANCEL_BUTTON_TEST_ID,
+  VOID_WALLET_CREDITS_FIELD_TEST_ID,
+  VOID_WALLET_NAME_FIELD_TEST_ID,
+  VOID_WALLET_SUBMIT_BUTTON_TEST_ID,
+  VoidWalletDialog,
+  VoidWalletDialogRef,
+} from '../VoidWalletDialog'
 
 const mockCreateVoidTransaction = jest.fn()
+let capturedOnCompleted: ((res: unknown) => void) | undefined
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({
@@ -16,20 +25,68 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 
 jest.mock('~/generated/graphql', () => ({
   ...jest.requireActual('~/generated/graphql'),
-  useCreateCustomerWalletTransactionMutation: () => [mockCreateVoidTransaction],
+  useCreateCustomerWalletTransactionMutation: (options?: {
+    onCompleted?: (res: unknown) => void
+  }) => {
+    capturedOnCompleted = options?.onCompleted
+
+    return [mockCreateVoidTransaction]
+  },
 }))
+
+const mockAddToast = jest.fn()
 
 jest.mock('~/core/apolloClient', () => ({
   ...jest.requireActual('~/core/apolloClient'),
-  addToast: jest.fn(),
+  addToast: (params: unknown) => mockAddToast(params),
 }))
+
+const WALLET_PROPS = {
+  walletId: 'wallet-1',
+  creditsBalance: 100,
+  currency: CurrencyEnum.Usd,
+  rateAmount: 1,
+}
+
+const getCreditsInput = () =>
+  within(screen.getByTestId(VOID_WALLET_CREDITS_FIELD_TEST_ID)).getByRole('textbox')
+
+const getNameInput = () =>
+  within(screen.getByTestId(VOID_WALLET_NAME_FIELD_TEST_ID)).getByRole('textbox')
+
+const getSubmitButton = () => screen.getByTestId(VOID_WALLET_SUBMIT_BUTTON_TEST_ID)
+
+async function prepare() {
+  const ref = createRef<VoidWalletDialogRef>()
+
+  await act(() => render(<VoidWalletDialog ref={ref} />))
+
+  await act(async () => {
+    ref.current?.openDialog(WALLET_PROPS)
+  })
+
+  await waitFor(() => {
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  return ref
+}
 
 describe('VoidWalletDialog', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+
     const useParamsMock = jest.requireMock('react-router-dom').useParams as jest.Mock
 
     useParamsMock.mockReturnValue({ customerId: 'customer-1' })
+
+    mockCreateVoidTransaction.mockImplementation(async () => {
+      const res = { createCustomerWalletTransaction: { collection: [{ id: 'transaction-1' }] } }
+
+      capturedOnCompleted?.(res)
+
+      return { data: res }
+    })
   })
 
   describe('GIVEN the dialog ref', () => {
@@ -48,21 +105,171 @@ describe('VoidWalletDialog', () => {
     })
 
     describe('WHEN openDialog is called with wallet data', () => {
-      it('THEN should show the dialog', () => {
-        const ref = createRef<VoidWalletDialogRef>()
-
-        render(<VoidWalletDialog ref={ref} />)
-
-        act(() => {
-          ref.current?.openDialog({
-            walletId: 'wallet-1',
-            creditsBalance: 100,
-            currency: CurrencyEnum.Usd,
-            rateAmount: 1,
-          })
-        })
+      it('THEN should show the dialog', async () => {
+        await prepare()
 
         expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN the form validation', () => {
+    describe('WHEN the credits field is empty', () => {
+      it('THEN should not show a visible error message', async () => {
+        await prepare()
+
+        expect(getCreditsInput()).toHaveAttribute('aria-invalid', 'false')
+      })
+    })
+
+    describe('WHEN the credits field is above the wallet credits balance and the user attempts to submit', () => {
+      it('THEN should show the max credits error and disable the submit button', async () => {
+        const user = userEvent.setup()
+
+        await prepare()
+
+        await user.type(getCreditsInput(), '150')
+        // Errors only surface starting from the first submit attempt (TanStack's
+        // revalidateLogic default `mode: 'submit'`), then live afterwards — the
+        // button is not disabled from the very first render like the old Formik
+        // `validateOnMount` used to do.
+        await user.click(getSubmitButton())
+
+        await waitFor(() => {
+          expect(getCreditsInput()).toHaveAttribute('aria-invalid', 'true')
+        })
+        expect(getSubmitButton()).toBeDisabled()
+      })
+    })
+
+    describe('WHEN the credits field is within the wallet credits balance', () => {
+      it('THEN should keep the submit button enabled', async () => {
+        const user = userEvent.setup()
+
+        await prepare()
+
+        await user.type(getCreditsInput(), '50')
+
+        expect(getCreditsInput()).toHaveAttribute('aria-invalid', 'false')
+        expect(getSubmitButton()).not.toBeDisabled()
+      })
+    })
+  })
+
+  describe('GIVEN the form submission', () => {
+    describe('WHEN the user submits a valid amount of credits without a name', () => {
+      it('THEN should call the mutation with the correct variables', async () => {
+        const user = userEvent.setup()
+
+        await prepare()
+
+        await user.type(getCreditsInput(), '50')
+        await user.click(getSubmitButton())
+
+        await waitFor(() => {
+          expect(mockCreateVoidTransaction).toHaveBeenCalledWith(
+            expect.objectContaining({
+              variables: {
+                input: {
+                  walletId: 'wallet-1',
+                  voidedCredits: '50',
+                  name: undefined,
+                },
+              },
+            }),
+          )
+        })
+      })
+
+      it('THEN should show a success toast and close the dialog', async () => {
+        const user = userEvent.setup()
+
+        await prepare()
+
+        await user.type(getCreditsInput(), '50')
+        await user.click(getSubmitButton())
+
+        await waitFor(() => {
+          expect(mockAddToast).toHaveBeenCalledWith(
+            expect.objectContaining({ severity: 'success' }),
+          )
+        })
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+        })
+      })
+
+      it('THEN should navigate to the wallet details page', async () => {
+        const user = userEvent.setup()
+
+        await prepare()
+
+        await user.type(getCreditsInput(), '50')
+        await user.click(getSubmitButton())
+
+        await waitFor(() => {
+          expect(testMockNavigateFn).toHaveBeenCalledWith(expect.stringContaining('wallet-1'))
+        })
+      })
+    })
+
+    describe('WHEN the user submits with a transaction name', () => {
+      it('THEN should call the mutation with the provided name', async () => {
+        const user = userEvent.setup()
+
+        await prepare()
+
+        await user.type(getNameInput(), 'My void transaction')
+        await user.type(getCreditsInput(), '20')
+        await user.click(getSubmitButton())
+
+        await waitFor(() => {
+          expect(mockCreateVoidTransaction).toHaveBeenCalledWith(
+            expect.objectContaining({
+              variables: {
+                input: {
+                  walletId: 'wallet-1',
+                  voidedCredits: '20',
+                  name: 'My void transaction',
+                },
+              },
+            }),
+          )
+        })
+      })
+    })
+
+    describe('WHEN the credits field exceeds the balance and the user clicks submit', () => {
+      it('THEN should not call the mutation and disable the submit button', async () => {
+        const user = userEvent.setup()
+
+        await prepare()
+
+        await user.type(getCreditsInput(), '150')
+        await user.click(getSubmitButton())
+
+        await waitFor(() => {
+          expect(getSubmitButton()).toBeDisabled()
+        })
+
+        expect(mockCreateVoidTransaction).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN the dialog actions', () => {
+    describe('WHEN the cancel button is clicked', () => {
+      it('THEN should close the dialog without calling the mutation', async () => {
+        const user = userEvent.setup()
+
+        await prepare()
+
+        await user.click(screen.getByTestId(VOID_WALLET_CANCEL_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+        })
+        expect(mockCreateVoidTransaction).not.toHaveBeenCalled()
       })
     })
   })


### PR DESCRIPTION
## Context

Part of the ongoing effort to move all remaining Formik/Yup forms to TanStack Form + Zod (see the "Form migration strategy" initiative). `VoidWalletDialog` was picked as it is small, self-contained (no `formikProps` leaking to any other component), and only rendered from a single call site.

## Description

- Replaces `useFormik` + Yup with `useAppForm` + Zod (`revalidateLogic`).
- The "credits to void" max bound depends on the wallet balance the dialog was opened for, so the Zod schema is a factory (`getVoidWalletValidationSchema`) rebuilt on every render from a `superRefine`, mirroring how the previous Yup schema was rebuilt inline by `useFormik` on every render.
- The "required" validation stays invisible (no error text, submit button just stays disabled), matching the original Yup `.required('')` behavior — achieved by reusing the shared silent-required message key already used by the wallet top-up form.
- Kept the existing legacy ref-based `Dialog` component (`DialogRef`, `openDialog`/`closeDialog`) — only the form internals changed, no dialog-system migration. Added `formId`/`formSubmit` so the fields are wrapped in a native `<form>`, which also means the credits/name inputs now submit on Enter, consistent with other migrated forms.
- Added `data-test` attributes to the two fields and the two dialog buttons, and rewrote the test suite to cover validation (required/max-credits) and submission (with/without a transaction name).

Behavioral note for reviewers: like every other form migrated with the established TanStack pattern in this codebase, the submit button is enabled by default until the first submit attempt (TanStack's `revalidateLogic` validates from `mode: 'submit'`, not on mount), whereas the previous Formik form disabled it immediately via `validateOnMount`. Validation rules themselves are unchanged.

<!-- Linear link -->
Fixes LAGO-1181