### PR TITLE
chore(sonar): fix 5 CRITICAL issues (week of 2026-07-20)

### DIFF
--- a/src/components/settings/dunnings/DefaultCampaignDialog.tsx
+++ b/src/components/settings/dunnings/DefaultCampaignDialog.tsx
@@ -23,8 +23,8 @@ export const useDefaultCampaignDialog = () => {
       actionText: translate(
         type === 'setDefault' ? 'text_1728574726495n9jdse2hnrf' : 'text_1728575305796o7kwackkbj6',
       ),
-      onAction: async () => {
-        await onConfirm()
+      onAction: () => {
+        onConfirm()
       },
     })
   }

--- a/src/pages/settings/AnrokIntegrations.tsx
+++ b/src/pages/settings/AnrokIntegrations.tsx
@@ -15,6 +15,7 @@ import { useDeleteAnrokIntegrationDialog } from '~/components/settings/integrati
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { ANROK_INTEGRATION_DETAILS_ROUTE, INTEGRATIONS_ROUTE, useNavigate } from '~/core/router'
 import {
+  AddAnrokIntegrationDialogFragment,
   AddAnrokIntegrationDialogFragmentDoc,
   AnrokIntegrationsFragment,
   DeleteAnrokIntegrationDialogFragmentDoc,
@@ -72,6 +73,8 @@ const AnrokIntegrations = () => {
             }),
           )
       : undefined
+  const handleDeleteFromAddDialog = (provider: AddAnrokIntegrationDialogFragment) =>
+    openDeleteAnrokIntegrationDialog({ provider, callback: deleteDialogCallback })
 
   return (
     <>
@@ -154,11 +157,7 @@ const AnrokIntegrations = () => {
                           onClick={() => {
                             addAnrokDialogRef.current?.openDialog({
                               integration: connection,
-                              onDelete: (provider) =>
-                                openDeleteAnrokIntegrationDialog({
-                                  provider,
-                                  callback: deleteDialogCallback,
-                                }),
+                              onDelete: handleDeleteFromAddDialog,
                             })
                             closePopper()
                           }}

--- a/src/pages/settings/FlutterwaveIntegrations.tsx
+++ b/src/pages/settings/FlutterwaveIntegrations.tsx
@@ -20,6 +20,7 @@ import {
 } from '~/core/router'
 import {
   DeleteFlutterwaveIntegrationDialogFragmentDoc,
+  FlutterwaveIntegrationDetailsFragment,
   FlutterwaveProvider,
   ProviderTypeEnum,
   useGetFlutterwaveIntegrationsListQuery,
@@ -73,6 +74,8 @@ const FlutterwaveIntegrations = () => {
             }),
           )
       : undefined
+  const handleDeleteFromAddDialog = (provider: FlutterwaveIntegrationDetailsFragment) =>
+    openDeleteFlutterwaveIntegrationDialog({ provider, callback: deleteDialogCallback })
 
   const canCreateIntegration = hasPermissions(['organizationIntegrationsCreate'])
   const canEditIntegration = hasPermissions(['organizationIntegrationsUpdate'])
@@ -161,11 +164,7 @@ const FlutterwaveIntegrations = () => {
                               onClick={() => {
                                 addDialogRef.current?.openDialog({
                                   provider: connection,
-                                  onDelete: (provider) =>
-                                    openDeleteFlutterwaveIntegrationDialog({
-                                      provider,
-                                      callback: deleteDialogCallback,
-                                    }),
+                                  onDelete: handleDeleteFromAddDialog,
                                 })
                                 closePopper()
                               }}

--- a/src/pages/settings/NetsuiteIntegrations.tsx
+++ b/src/pages/settings/NetsuiteIntegrations.tsx
@@ -17,6 +17,7 @@ import { INTEGRATIONS_ROUTE, NETSUITE_INTEGRATION_DETAILS_ROUTE, useNavigate } f
 import {
   DeleteNetsuiteIntegrationDialogFragmentDoc,
   IntegrationTypeEnum,
+  NetsuiteForCreateDialogDialogFragment,
   NetsuiteForCreateDialogDialogFragmentDoc,
   NetsuiteIntegrationsFragment,
   useGetNetsuiteIntegrationsListQuery,
@@ -72,6 +73,8 @@ const NetsuiteIntegrations = () => {
             }),
           )
       : undefined
+  const handleDeleteFromAddDialog = (provider: NetsuiteForCreateDialogDialogFragment) =>
+    openDeleteNetsuiteIntegrationDialog({ provider, callback: deleteDialogCallback })
 
   return (
     <>
@@ -154,11 +157,7 @@ const NetsuiteIntegrations = () => {
                           onClick={() => {
                             addNetsuiteDialogRef.current?.openDialog({
                               provider: connection,
-                              onDelete: (provider) =>
-                                openDeleteNetsuiteIntegrationDialog({
-                                  provider,
-                                  callback: deleteDialogCallback,
-                                }),
+                              onDelete: handleDeleteFromAddDialog,
                             })
                             closePopper()
                           }}

--- a/src/pages/settings/SalesforceIntegrations.tsx
+++ b/src/pages/settings/SalesforceIntegrations.tsx
@@ -21,6 +21,7 @@ import {
 import {
   DeleteSalesforceIntegrationDialogFragmentDoc,
   IntegrationTypeEnum,
+  SalesforceForCreateDialogFragment,
   SalesforceForCreateDialogFragmentDoc,
   SalesforceIntegrationsFragment,
   useGetSalesforceIntegrationsListQuery,
@@ -77,6 +78,8 @@ const SalesforceIntegrations = () => {
             }),
           )
       : undefined
+  const handleDeleteFromAddDialog = (provider: SalesforceForCreateDialogFragment) =>
+    openDeleteSalesforceIntegrationDialog({ provider, callback: deleteDialogCallback })
 
   return (
     <>
@@ -154,11 +157,7 @@ const SalesforceIntegrations = () => {
                           onClick={() => {
                             addSalesforceDialogRef.current?.openDialog({
                               provider: connection,
-                              onDelete: (provider) =>
-                                openDeleteSalesforceIntegrationDialog({
-                                  provider,
-                                  callback: deleteDialogCallback,
-                                }),
+                              onDelete: handleDeleteFromAddDialog,
                             })
                             closePopper()
                           }}


### PR DESCRIPTION
Automated weekly SonarCloud cleanup. Minimal, behavior-preserving fixes to the highest-severity open issues.

## Fixed

| SonarCloud key | Rule | File:line | Change |
| --- | --- | --- | --- |
| AZ87lC05-2m66ciTUb18 | typescript:S2004 | src/pages/settings/AnrokIntegrations.tsx:157 | Extracted `onDelete` inline arrow into a component-scoped `handleDeleteFromAddDialog` to reduce function nesting depth |
| AZ87lLFPMWESBjyf6M1D | typescript:S2004 | src/pages/settings/NetsuiteIntegrations.tsx:157 | Same extraction pattern |
| AZ87lSVmao8bZEaMLXY0 | typescript:S2004 | src/pages/settings/SalesforceIntegrations.tsx:157 | Same extraction pattern |
| AZ8ToaGRuHpGDjjnPvz5 | typescript:S2004 | src/pages/settings/FlutterwaveIntegrations.tsx:164 | Same extraction pattern |
| AZ9rkZc3Xta6bE9G8hJd | typescript:S4123 | src/components/settings/dunnings/DefaultCampaignDialog.tsx:27 | Dropped `await` of non-Promise `onConfirm()` (typed `() => void`) and made the handler synchronous |

All fixes are pure structural refactors — no runtime behavior change.

## Verification
- `pnpm run types` — clean
- ESLint on the 5 changed files — 0 errors (only pre-existing deprecated-import warnings)
- Jest: AnrokIntegrations / NetsuiteIntegrations / SalesforceIntegrations / FlutterwaveIntegrations suites — 8/8 pass

## Skipped — needs human decision

Cognitive-complexity (S3776) and remaining S2004 issues that require non-trivial refactors, product knowledge, or touch behavior:

| SonarCloud key | Rule | File:line |
| --- | --- | --- |
| AZ260M7lIVRKjySJ_aoa | S3776 | src/components/wallets/WalletDetailsDrawer.tsx:189 |
| AZ0aP266NWh-T1cKnl9M | S3776 | src/pages/CustomerInvoiceDetails.tsx:310 |
| AZqhmDFJQjpDlMIZd0dZ | S3776 | src/hooks/plans/useChargeForm.tsx:153 |
| AZqhmDFJQjpDlMIZd0dc | S3776 | src/hooks/plans/useChargeForm.tsx:206 |
| AZqhmDFWQjpDlMIZd0df | S3776 | src/hooks/customer/useAddSubscription.tsx:393 |
| AZqhmDhmQjpDlMIZd0me | S3776 | src/pages/CreateCoupon.tsx:53 |
| AZ9HXacMngfXv4og_v_w | S3776 | src/components/wallets/WalletInformations.tsx:66 |
| AZqhmDfbQjpDlMIZd0l8 | S3776 | src/pages/InvoiceOverview.tsx:378 |
| AZqhmEfaQjpDlMIZd03h | S3776 | src/components/subscriptions/SubscriptionUsageLifetimeGraph.tsx:102 |
| AZ9l5YZM08rbaouJX-JN | S3776 | src/pages/wallet/formInitialization/validationSchema.ts:145 |
| AZqhmDJaQjpDlMIZd0eu | S3776 | src/pages/settings/integrations/common/handleIntegrationMappingCreateUpdateDelete.ts:80 |
| AZqhmDA7QjpDlMIZd0au | S3776 | src/core/serializers/serializePlanInput.ts:62 |
| AZqhmDJlQjpDlMIZd0e2 | S3776 | src/pages/settings/integrations/common/getParametersFromProvider.ts:47 |
| AZqhmETaQjpDlMIZd00V | S3776 | src/components/form/TextInput/TextInput.tsx:62 |
| AZqhmDh2QjpDlMIZd0mt | S3776 | src/pages/CreateBillableMetric.tsx:84 |
| AZqhmDltQjpDlMIZd0ok | S3776 | src/components/customers/CustomerSettings.tsx:176 |
| AZy5sN3QeQ3KK-4RADMl | S2819 | src/hooks/useIframeConfig.ts:42 (postMessage target origin — security/behavior) |
| AZy5sN3QeQ3KK-4RADMm | S2819 | src/hooks/useIframeConfig.ts:46 (postMessage target origin — security/behavior) |

Note: several previously-flagged S2004 issues (e.g. `TransactionMetadataGroup.tsx`) point at files that no longer exist on `main` — stale scan entries, not addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
