### PR TITLE
refactor(settings): migrate AddAnrokDialog to FormDialogOpeningDialog and TanStack Form

### DIFF
--- a/src/components/settings/integrations/AddAnrokDialog.tsx
+++ b/src/components/settings/integrations/AddAnrokDialog.tsx
@@ -68,9 +68,9 @@ const defaultFormValues: AddAnrokFormValues = {
 }
 
 const validationSchema = z.object({
-  name: z.string().min(1),
-  code: z.string().min(1),
-  apiKey: z.string().min(1),
+  name: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  code: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  apiKey: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
 })
 
 type OpenAddAnrokDialogData = {

--- a/src/components/settings/integrations/AddAnrokDialog.tsx
+++ b/src/components/settings/integrations/AddAnrokDialog.tsx
@@ -1,27 +1,29 @@
-import { FetchResult, gql } from '@apollo/client'
-import Stack from '@mui/material/Stack'
-import { useFormik } from 'formik'
-import { forwardRef, useId, useImperativeHandle, useRef, useState } from 'react'
+import { FetchResult, gql, useApolloClient } from '@apollo/client'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useId, useRef } from 'react'
 import { generatePath } from 'react-router-dom'
-import { object, string } from 'yup'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { TextInputField } from '~/components/form'
+import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { addToast, envGlobalVar, hasDefinedGQLError } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { ANROK_INTEGRATION_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import {
   AddAnrokIntegrationDialogFragment,
   AnrokIntegrationDetailsFragmentDoc,
-  CreateAnrokIntegrationInput,
   CreateAnrokIntegrationMutation,
+  GetAnrokIntegrationsListDocument,
   LagoApiError,
   UpdateAnrokIntegrationMutation,
   useCreateAnrokIntegrationMutation,
+  useDestroyNangoIntegrationMutation,
   useUpdateAnrokIntegrationMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 import { AnrokIntegrationDetailsTabs } from '~/pages/settings/AnrokIntegrationDetails'
 
 gql`
@@ -51,29 +53,46 @@ gql`
   ${AnrokIntegrationDetailsFragmentDoc}
 `
 
-type TAddAnrokDialogProps = Partial<{
-  onDelete: (provider: AddAnrokIntegrationDialogFragment) => void
-  integration: AddAnrokIntegrationDialogFragment
-}>
+const ADD_ANROK_FORM_ID = 'form-add-anrok-integration'
 
-export interface AddAnrokDialogRef {
-  openDialog: (props?: TAddAnrokDialogProps) => unknown
-  closeDialog: () => unknown
+type AddAnrokFormValues = {
+  name: string
+  code: string
+  apiKey: string
 }
 
-export const AddAnrokDialog = forwardRef<AddAnrokDialogRef>((_, ref) => {
+const defaultFormValues: AddAnrokFormValues = {
+  name: '',
+  code: '',
+  apiKey: '',
+}
+
+const validationSchema = z.object({
+  name: z.string().min(1),
+  code: z.string().min(1),
+  apiKey: z.string().min(1),
+})
+
+type OpenAddAnrokDialogData = {
+  integration?: AddAnrokIntegrationDialogFragment
+  deleteCallback?: () => void
+}
+
+export const useAddAnrokDialog = () => {
   const componentId = useId()
   const { nangoPublicKey } = envGlobalVar()
   const navigate = useNavigate()
-  const dialogRef = useRef<DialogRef>(null)
+  const formDialogOpeningDialog = useFormDialogOpeningDialog()
   const { translate } = useInternationalization()
-  const [localData, setLocalData] = useState<TAddAnrokDialogProps | undefined>(undefined)
-  const anrokIntegration = localData?.integration
-  const isEdition = !!anrokIntegration
+  const client = useApolloClient()
+
+  const dataRef = useRef<OpenAddAnrokDialogData | null>(null)
+  const successRef = useRef(false)
 
   const [addAnrok] = useCreateAnrokIntegrationMutation({
     onCompleted({ createAnrokIntegration }) {
       if (createAnrokIntegration?.id) {
+        successRef.current = true
         navigate(
           generatePath(ANROK_INTEGRATION_DETAILS_ROUTE, {
             integrationId: createAnrokIntegration.id,
@@ -93,29 +112,29 @@ export const AddAnrokDialog = forwardRef<AddAnrokDialogRef>((_, ref) => {
   const [updateApiKey] = useUpdateAnrokIntegrationMutation({
     onCompleted({ updateAnrokIntegration }) {
       if (updateAnrokIntegration?.id) {
+        successRef.current = true
         addToast({
           message: translate('text_6668821d94e4da4dfd8b38f3'),
           severity: 'success',
         })
-
-        dialogRef.current?.closeDialog()
       }
     },
   })
 
-  const formikProps = useFormik<Omit<CreateAnrokIntegrationInput, 'connectionId'>>({
-    initialValues: {
-      apiKey: anrokIntegration?.apiKey || '',
-      code: anrokIntegration?.code || '',
-      name: anrokIntegration?.name || '',
+  const [deleteAnrok] = useDestroyNangoIntegrationMutation()
+
+  const form = useAppForm({
+    defaultValues: defaultFormValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: validationSchema,
     },
-    validationSchema: object().shape({
-      name: string().required(''),
-      code: string().required(''),
-      apiKey: string().required(''),
-    }),
-    onSubmit: async ({ apiKey, ...values }, formikBag) => {
-      let res
+    onSubmit: async ({ value, formApi }) => {
+      const anrokIntegration = dataRef.current?.integration
+      const isEdition = !!anrokIntegration
+      const { apiKey, ...values } = value
+
+      let res: FetchResult<CreateAnrokIntegrationMutation | UpdateAnrokIntegrationMutation> = {}
 
       if (isEdition) {
         res = await updateApiKey({
@@ -141,118 +160,156 @@ export const AddAnrokDialog = forwardRef<AddAnrokDialogRef>((_, ref) => {
 
           res = await addAnrok({
             variables: {
-              input: { ...values, apiKey, connectionId: nangoApiKeyConnection?.connectionId || '' },
+              input: {
+                ...values,
+                apiKey,
+                connectionId: nangoApiKeyConnection?.connectionId || '',
+              },
             },
             context: { silentErrorCodes: [LagoApiError.UnprocessableEntity] },
           })
         } catch {
-          // Nothing is supposed to happen here
+          // Nango auth failed — nothing to report to the form
         }
       }
 
-      const { errors } = res as
-        FetchResult<UpdateAnrokIntegrationMutation> | FetchResult<CreateAnrokIntegrationMutation>
-
-      if (!errors) dialogRef.current?.closeDialog()
-
-      if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
-        formikBag.setErrors({
-          code: translate('text_632a2d437e341dcc76817556'),
+      if (hasDefinedGQLError('ValueAlreadyExist', res.errors)) {
+        formApi.setErrorMap({
+          onDynamic: {
+            fields: {
+              code: {
+                message: translate('text_632a2d437e341dcc76817556'),
+                path: ['code'],
+              },
+            },
+          },
         })
       }
     },
-    validateOnMount: true,
-    enableReinitialize: true,
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate(
-        isEdition ? 'text_658461066530343fe1808cd9' : 'text_666887f6c4d092aa1e1a8477',
-        {
-          name: anrokIntegration?.name,
-        },
-      )}
-      description={translate(
-        isEdition ? 'text_666889d43a2ea34eb2aa3e55' : 'text_666887f6c4d092aa1e1a8478',
-      )}
-      onClose={formikProps.resetForm}
-      actions={({ closeDialog }) => (
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-          width={isEdition ? '100%' : 'inherit'}
-          spacing={3}
-        >
-          {isEdition && (
-            <Button
-              danger
-              variant="quaternary"
-              onClick={() => {
-                closeDialog()
-                localData?.onDelete?.(anrokIntegration)
-              }}
-            >
-              {translate('text_65845f35d7d69c3ab4793dad')}
-            </Button>
-          )}
-          <Stack direction="row" spacing={3} alignItems="center">
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_62b1edddbf5f461ab971276d')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!formikProps.isValid || !formikProps.dirty}
-              onClick={formikProps.submitForm}
-            >
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openAddAnrokDialog = (data?: OpenAddAnrokDialogData) => {
+    dataRef.current = data ?? null
+    const anrokIntegration = data?.integration
+    const isEdition = !!anrokIntegration
+
+    form.reset()
+    if (anrokIntegration) {
+      form.setFieldValue('name', anrokIntegration.name || '')
+      form.setFieldValue('code', anrokIntegration.code || '')
+      form.setFieldValue('apiKey', anrokIntegration.apiKey || '')
+    }
+
+    formDialogOpeningDialog
+      .open({
+        title: translate(
+          isEdition ? 'text_658461066530343fe1808cd9' : 'text_666887f6c4d092aa1e1a8477',
+          {
+            name: anrokIntegration?.name,
+          },
+        ),
+        description: translate(
+          isEdition ? 'text_666889d43a2ea34eb2aa3e55' : 'text_666887f6c4d092aa1e1a8478',
+        ),
+        children: (
+          <div className="flex flex-col gap-6 p-8">
+            <div className="flex flex-row items-start gap-6">
+              <form.AppField name="name">
+                {(field) => (
+                  <field.TextInputField
+                    className="flex-1"
+                    label={translate('text_6584550dc4cec7adf861504d')}
+                    placeholder={translate('text_6584550dc4cec7adf861504f')}
+                  />
+                )}
+              </form.AppField>
+              <form.AppField name="code">
+                {(field) => (
+                  <field.TextInputField
+                    className="flex-1"
+                    label={translate('text_6584550dc4cec7adf8615051')}
+                    placeholder={translate('text_6584550dc4cec7adf8615053')}
+                  />
+                )}
+              </form.AppField>
+            </div>
+
+            <form.AppField name="apiKey">
+              {(field) => (
+                <field.TextInputField
+                  disabled={isEdition}
+                  label={translate('text_6668821d94e4da4dfd8b38d5')}
+                  placeholder={translate('text_666887f6c4d092aa1e1a847e')}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        closeOnError: false,
+        onEntered: focusFirstInput,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>
               {translate(
                 isEdition ? 'text_664c732c264d7eed1c74fdaa' : 'text_666887f6c4d092aa1e1a8477',
               )}
-            </Button>
-          </Stack>
-        </Stack>
-      )}
-    >
-      <div className="mb-8 flex flex-col gap-6">
-        <div className="flex flex-row items-start gap-6">
-          <TextInputField
-            className="flex-1"
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus
-            formikProps={formikProps}
-            name="name"
-            label={translate('text_6584550dc4cec7adf861504d')}
-            placeholder={translate('text_6584550dc4cec7adf861504f')}
-          />
-          <TextInputField
-            className="flex-1"
-            formikProps={formikProps}
-            name="code"
-            label={translate('text_6584550dc4cec7adf8615051')}
-            placeholder={translate('text_6584550dc4cec7adf8615053')}
-          />
-        </div>
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: ADD_ANROK_FORM_ID,
+          submit: handleSubmit,
+        },
+        canOpenDialog: isEdition,
+        openDialogText: translate('text_65845f35d7d69c3ab4793dad'),
+        otherDialogProps: {
+          title: translate('text_658461066530343fe1808cd7', { name: anrokIntegration?.name }),
+          description: translate('text_6668870bc8bdb352948ffb5f'),
+          colorVariant: 'danger',
+          actionText: translate('text_645d071272418a14c1c76a81'),
+          onAction: async () => {
+            const res = await deleteAnrok({
+              variables: { input: { id: anrokIntegration?.id as string } },
+            })
 
-        <TextInputField
-          name="apiKey"
-          disabled={isEdition}
-          label={translate('text_6668821d94e4da4dfd8b38d5')}
-          placeholder={translate('text_666887f6c4d092aa1e1a847e')}
-          formikProps={formikProps}
-        />
-      </div>
-    </Dialog>
-  )
-})
+            const destroyedId = res.data?.destroyIntegration?.id
 
-AddAnrokDialog.displayName = 'AddAnrokDialog'
+            if (destroyedId) {
+              evictFromCache(client, {
+                id: destroyedId,
+                __typename: 'AnrokIntegration',
+                listFieldName: 'integrations',
+                listQueryDocument: GetAnrokIntegrationsListDocument,
+              })
+
+              data?.deleteCallback?.()
+
+              addToast({
+                message: translate('text_661ff6e56ef7e1b7c542b2f9'),
+                severity: 'success',
+              })
+            }
+          },
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close' || response.reason === 'open-other-dialog') {
+          form.reset()
+          dataRef.current = null
+        }
+      })
+  }
+
+  return { openAddAnrokDialog }
+}

--- a/src/components/settings/integrations/AnrokIntegrationSettings.tsx
+++ b/src/components/settings/integrations/AnrokIntegrationSettings.tsx
@@ -1,6 +1,5 @@
 import { gql } from '@apollo/client'
 import Stack from '@mui/material/Stack'
-import { useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Alert } from '~/components/designSystem/Alert'
@@ -27,8 +26,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { AnrokIntegrationDetailsTabs } from '~/pages/settings/AnrokIntegrationDetails'
 import { theme } from '~/styles'
 
-import { AddAnrokDialog, AddAnrokDialogRef } from './AddAnrokDialog'
-import { useDeleteAnrokIntegrationDialog } from './DeleteAnrokIntegrationDialog'
+import { useAddAnrokDialog } from './AddAnrokDialog'
 
 const PROVIDER_CONNECTION_LIMIT = 2
 
@@ -76,8 +74,7 @@ gql`
 const AnrokIntegrationSettings = () => {
   const navigate = useNavigate()
   const { integrationId = '' } = useParams()
-  const addAnrokDialogRef = useRef<AddAnrokDialogRef>(null)
-  const { openDeleteAnrokIntegrationDialog } = useDeleteAnrokIntegrationDialog()
+  const { openAddAnrokDialog } = useAddAnrokDialog()
   const { translate } = useInternationalization()
   const [retryAllInvoices] = useRetryAllInvoicesMutation({
     onCompleted(result) {
@@ -113,118 +110,108 @@ const AnrokIntegrationSettings = () => {
   }
 
   return (
-    <>
-      <IntegrationsPage.Container className="my-4 md:my-8">
-        {!!anrokIntegration && !anrokIntegration?.hasMappingsConfigured && (
-          <Alert
-            type="warning"
-            ButtonProps={{
-              label: translate('text_661ff6e56ef7e1b7c542b20a'),
-              onClick: () => {
-                navigate(
-                  generatePath(ANROK_INTEGRATION_DETAILS_ROUTE, {
-                    integrationId,
-                    tab: AnrokIntegrationDetailsTabs.Items,
-                    integrationGroup: IntegrationsTabsOptionsEnum.Lago,
-                  }),
-                )
-              },
-            }}
-          >
-            {translate('text_6668821d94e4da4dfd8b3888')}
-          </Alert>
-        )}
-
-        <section>
-          <IntegrationsPage.Headline label={translate('text_661ff6e56ef7e1b7c542b232')}>
-            <Button
-              variant="inline"
-              disabled={loading}
-              onClick={() => {
-                addAnrokDialogRef.current?.openDialog({
-                  integration: anrokIntegration,
-                  onDelete: (provider) =>
-                    openDeleteAnrokIntegrationDialog({
-                      provider,
-                      callback: deleteDialogCallback,
-                    }),
-                })
-              }}
-            >
-              {translate('text_62b1edddbf5f461ab9712787')}
-            </Button>
-          </IntegrationsPage.Headline>
-
-          <>
-            {loading &&
-              [0, 1, 2].map((i) => (
-                <IntegrationsPage.ItemSkeleton key={`item-skeleton-item-${i}`} />
-              ))}
-            {!loading && (
-              <>
-                <IntegrationsPage.DetailsItem
-                  icon="text"
-                  label={translate('text_626162c62f790600f850b76a')}
-                  value={anrokIntegration?.name}
-                />
-                <IntegrationsPage.DetailsItem
-                  icon="id"
-                  label={translate('text_62876e85e32e0300e1803127')}
-                  value={anrokIntegration?.code}
-                />
-                <IntegrationsPage.DetailsItem
-                  icon="info-circle"
-                  label={translate('text_6668821d94e4da4dfd8b38d5')}
-                  value={anrokIntegration?.apiKey}
-                />
-              </>
-            )}
-          </>
-        </section>
-
-        <Stack
-          direction="row"
-          gap={4}
-          justifyContent="space-between"
-          alignItems="baseline"
-          paddingBottom={6}
-          sx={{ boxShadow: theme.shadows[7] }}
+    <IntegrationsPage.Container className="my-4 md:my-8">
+      {!!anrokIntegration && !anrokIntegration?.hasMappingsConfigured && (
+        <Alert
+          type="warning"
+          ButtonProps={{
+            label: translate('text_661ff6e56ef7e1b7c542b20a'),
+            onClick: () => {
+              navigate(
+                generatePath(ANROK_INTEGRATION_DETAILS_ROUTE, {
+                  integrationId,
+                  tab: AnrokIntegrationDetailsTabs.Items,
+                  integrationGroup: IntegrationsTabsOptionsEnum.Lago,
+                }),
+              )
+            },
+          }}
         >
-          <Stack flex={1}>
-            <Typography variant="bodyHl" color="grey700">
-              {translate('text_66ba5a76e614f000a738c97a')}
-            </Typography>
-            {loading && <Skeleton className="mb-1 mt-2" variant="text" />}
-            {!loading && !!anrokIntegration?.failedInvoicesCount && (
-              <Typography variant="caption" color="grey600">
-                {translate(
-                  'text_1746004262383fhhy4jl1g6o',
-                  {
-                    failedInvoicesCount: anrokIntegration?.failedInvoicesCount,
-                  },
-                  anrokIntegration?.failedInvoicesCount,
-                )}
-              </Typography>
-            )}
-            {!loading && !anrokIntegration?.failedInvoicesCount && (
-              <Typography variant="caption" color="grey600">
-                {translate('text_66ba5ca33713b600c4e8fcf1')}
-              </Typography>
-            )}
-          </Stack>
+          {translate('text_6668821d94e4da4dfd8b3888')}
+        </Alert>
+      )}
 
+      <section>
+        <IntegrationsPage.Headline label={translate('text_661ff6e56ef7e1b7c542b232')}>
           <Button
             variant="inline"
-            disabled={!anrokIntegration?.failedInvoicesCount}
-            onClick={async () => await retryAllInvoices({ variables: { input: {} } })}
+            disabled={loading}
+            onClick={() => {
+              openAddAnrokDialog({
+                integration: anrokIntegration,
+                deleteCallback: deleteDialogCallback,
+              })
+            }}
           >
-            {translate('text_66ba5a76e614f000a738c97e')}
+            {translate('text_62b1edddbf5f461ab9712787')}
           </Button>
-        </Stack>
-      </IntegrationsPage.Container>
+        </IntegrationsPage.Headline>
 
-      <AddAnrokDialog ref={addAnrokDialogRef} />
-    </>
+        <>
+          {loading &&
+            [0, 1, 2].map((i) => <IntegrationsPage.ItemSkeleton key={`item-skeleton-item-${i}`} />)}
+          {!loading && (
+            <>
+              <IntegrationsPage.DetailsItem
+                icon="text"
+                label={translate('text_626162c62f790600f850b76a')}
+                value={anrokIntegration?.name}
+              />
+              <IntegrationsPage.DetailsItem
+                icon="id"
+                label={translate('text_62876e85e32e0300e1803127')}
+                value={anrokIntegration?.code}
+              />
+              <IntegrationsPage.DetailsItem
+                icon="info-circle"
+                label={translate('text_6668821d94e4da4dfd8b38d5')}
+                value={anrokIntegration?.apiKey}
+              />
+            </>
+          )}
+        </>
+      </section>
+
+      <Stack
+        direction="row"
+        gap={4}
+        justifyContent="space-between"
+        alignItems="baseline"
+        paddingBottom={6}
+        sx={{ boxShadow: theme.shadows[7] }}
+      >
+        <Stack flex={1}>
+          <Typography variant="bodyHl" color="grey700">
+            {translate('text_66ba5a76e614f000a738c97a')}
+          </Typography>
+          {loading && <Skeleton className="mb-1 mt-2" variant="text" />}
+          {!loading && !!anrokIntegration?.failedInvoicesCount && (
+            <Typography variant="caption" color="grey600">
+              {translate(
+                'text_1746004262383fhhy4jl1g6o',
+                {
+                  failedInvoicesCount: anrokIntegration?.failedInvoicesCount,
+                },
+                anrokIntegration?.failedInvoicesCount,
+              )}
+            </Typography>
+          )}
+          {!loading && !anrokIntegration?.failedInvoicesCount && (
+            <Typography variant="caption" color="grey600">
+              {translate('text_66ba5ca33713b600c4e8fcf1')}
+            </Typography>
+          )}
+        </Stack>
+
+        <Button
+          variant="inline"
+          disabled={!anrokIntegration?.failedInvoicesCount}
+          onClick={async () => await retryAllInvoices({ variables: { input: {} } })}
+        >
+          {translate('text_66ba5a76e614f000a738c97e')}
+        </Button>
+      </Stack>
+    </IntegrationsPage.Container>
   )
 }
 

--- a/src/pages/settings/AnrokIntegrationDetails.tsx
+++ b/src/pages/settings/AnrokIntegrationDetails.tsx
@@ -4,10 +4,7 @@ import { generatePath, useParams } from 'react-router-dom'
 
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { useMainHeaderTabContent } from '~/components/MainHeader/useMainHeaderTabContent'
-import {
-  AddAnrokDialog,
-  AddAnrokDialogRef,
-} from '~/components/settings/integrations/AddAnrokDialog'
+import { useAddAnrokDialog } from '~/components/settings/integrations/AddAnrokDialog'
 import {
   AddEditDeleteSuccessRedirectUrlDialog,
   AddEditDeleteSuccessRedirectUrlDialogRef,
@@ -78,7 +75,7 @@ gql`
 const AnrokIntegrationDetails = () => {
   const navigate = useNavigate()
   const { integrationId = '' } = useParams()
-  const addAnrokDialogRef = useRef<AddAnrokDialogRef>(null)
+  const { openAddAnrokDialog } = useAddAnrokDialog()
   const { openDeleteAnrokIntegrationDialog } = useDeleteAnrokIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
@@ -140,13 +137,9 @@ const AnrokIntegrationDetails = () => {
                 {
                   label: translate('text_65845f35d7d69c3ab4793dac'),
                   onClick: (closePopper) => {
-                    addAnrokDialogRef.current?.openDialog({
+                    openAddAnrokDialog({
                       integration: anrokIntegration,
-                      onDelete: (provider) =>
-                        openDeleteAnrokIntegrationDialog({
-                          provider,
-                          callback: deleteDialogCallback,
-                        }),
+                      deleteCallback: deleteDialogCallback,
                     })
                     closePopper()
                   },
@@ -188,7 +181,6 @@ const AnrokIntegrationDetails = () => {
         ]}
       />
       <>{activeTabContent}</>
-      <AddAnrokDialog ref={addAnrokDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/AnrokIntegrations.tsx
+++ b/src/pages/settings/AnrokIntegrations.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
@@ -7,10 +6,7 @@ import { Popper } from '~/components/designSystem/Popper'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { IntegrationsPage } from '~/components/layouts/Integrations'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import {
-  AddAnrokDialog,
-  AddAnrokDialogRef,
-} from '~/components/settings/integrations/AddAnrokDialog'
+import { useAddAnrokDialog } from '~/components/settings/integrations/AddAnrokDialog'
 import { useDeleteAnrokIntegrationDialog } from '~/components/settings/integrations/DeleteAnrokIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { ANROK_INTEGRATION_DETAILS_ROUTE, INTEGRATIONS_ROUTE, useNavigate } from '~/core/router'
@@ -55,7 +51,7 @@ gql`
 const AnrokIntegrations = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
-  const addAnrokDialogRef = useRef<AddAnrokDialogRef>(null)
+  const { openAddAnrokDialog } = useAddAnrokDialog()
   const { openDeleteAnrokIntegrationDialog } = useDeleteAnrokIntegrationDialog()
   const { data, loading } = useGetAnrokIntegrationsListQuery({
     variables: { limit: 1000, types: [IntegrationTypeEnum.Anrok] },
@@ -99,7 +95,7 @@ const AnrokIntegrations = () => {
               label: translate('text_65846763e6140b469140e235'),
               variant: 'primary',
               onClick: () => {
-                addAnrokDialogRef.current?.openDialog()
+                openAddAnrokDialog()
               },
             },
           ],
@@ -152,13 +148,9 @@ const AnrokIntegrations = () => {
                           variant="quaternary"
                           align="left"
                           onClick={() => {
-                            addAnrokDialogRef.current?.openDialog({
+                            openAddAnrokDialog({
                               integration: connection,
-                              onDelete: (provider) =>
-                                openDeleteAnrokIntegrationDialog({
-                                  provider,
-                                  callback: deleteDialogCallback,
-                                }),
+                              deleteCallback: deleteDialogCallback,
                             })
                             closePopper()
                           }}
@@ -187,7 +179,6 @@ const AnrokIntegrations = () => {
             })}
         </section>
       </IntegrationsPage.Container>
-      <AddAnrokDialog ref={addAnrokDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -17,10 +17,7 @@ import {
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { useMainHeaderTabContent } from '~/components/MainHeader/useMainHeaderTabContent'
 import { useAddAdyenDialog } from '~/components/settings/integrations/AddAdyenDialog'
-import {
-  AddAnrokDialog,
-  AddAnrokDialogRef,
-} from '~/components/settings/integrations/AddAnrokDialog'
+import { useAddAnrokDialog } from '~/components/settings/integrations/AddAnrokDialog'
 import { useAddAvalaraDialog } from '~/components/settings/integrations/AddAvalaraDialog'
 import { useAddCashfreeDialog } from '~/components/settings/integrations/AddCashfreeDialog'
 import { useAddFlutterwaveDialog } from '~/components/settings/integrations/AddFlutterwaveDialog'
@@ -144,7 +141,7 @@ const Integrations = () => {
   const { organization: { premiumIntegrations } = {} } = useOrganizationInfos()
 
   const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
-  const addAnrokDialogRef = useRef<AddAnrokDialogRef>(null)
+  const { openAddAnrokDialog } = useAddAnrokDialog()
   const { openAddAvalaraDialog } = useAddAvalaraDialog()
   const { openAddStripeDialog } = useAddStripeDialog()
   const { openAddAdyenDialog } = useAddAdyenDialog()
@@ -353,7 +350,7 @@ const Integrations = () => {
                               }),
                             )
                           } else {
-                            addAnrokDialogRef.current?.openDialog()
+                            openAddAnrokDialog()
                           }
                         }}
                       />
@@ -815,7 +812,6 @@ const Integrations = () => {
 
       <>{activeTabContent}</>
 
-      <AddAnrokDialog ref={addAnrokDialogRef} />
       <AddXeroDialog ref={addXeroDialogRef} />
     </>
   )

--- a/src/pages/settings/__tests__/AnrokIntegrationDetails.test.tsx
+++ b/src/pages/settings/__tests__/AnrokIntegrationDetails.test.tsx
@@ -7,7 +7,7 @@ import { renderIntegrationPage } from './integrationTestHelpers'
 import AnrokIntegrationDetails from '../AnrokIntegrationDetails'
 
 jest.mock('~/components/settings/integrations/AddAnrokDialog', () => ({
-  AddAnrokDialog: () => null,
+  useAddAnrokDialog: () => ({ openAddAnrokDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/DeleteAnrokIntegrationDialog', () => ({
   useDeleteAnrokIntegrationDialog: () => ({ openDeleteAnrokIntegrationDialog: jest.fn() }),

--- a/src/pages/settings/__tests__/AnrokIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/AnrokIntegrations.test.tsx
@@ -11,7 +11,7 @@ import {
 import AnrokIntegrations from '../AnrokIntegrations'
 
 jest.mock('~/components/settings/integrations/AddAnrokDialog', () => ({
-  AddAnrokDialog: () => null,
+  useAddAnrokDialog: () => ({ openAddAnrokDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/DeleteAnrokIntegrationDialog', () => ({
   useDeleteAnrokIntegrationDialog: () => ({ openDeleteAnrokIntegrationDialog: jest.fn() }),

--- a/src/pages/settings/__tests__/Integrations.test.tsx
+++ b/src/pages/settings/__tests__/Integrations.test.tsx
@@ -22,7 +22,7 @@ import Integrations from '../Integrations'
 
 // Mock dialog components that transitively import @nangohq/frontend (ESM)
 jest.mock('~/components/settings/integrations/AddAnrokDialog', () => ({
-  AddAnrokDialog: () => null,
+  useAddAnrokDialog: () => ({ openAddAnrokDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/AddAvalaraDialog', () => ({
   useAddAvalaraDialog: () => ({

--- a/translations/base.json
+++ b/translations/base.json
@@ -1653,7 +1653,6 @@
   "text_62b1edddbf5f461ab97127ad": "Connected",
   "text_62b1edddbf5f461ab9712748": "API secret key",
   "text_62b1edddbf5f461ab9712756": "Type an API secret key",
-  "text_62b1edddbf5f461ab971276d": "Cancel",
   "text_62b1edddbf5f461ab9712773": "Connect to Stripe",
   "text_62b1edddbf5f461ab9712743": "Stripe connection successfully created",
   "text_62b1edddbf5f461ab9712707": "Stripe",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -1686,7 +1686,6 @@
   "text_62b1edddbf5f461ab97127ad": "Conectado",
   "text_62b1edddbf5f461ab9712748": "Chave secreta da API",
   "text_62b1edddbf5f461ab9712756": "Digite uma chave secreta da API",
-  "text_62b1edddbf5f461ab971276d": "Cancelar",
   "text_62b1edddbf5f461ab9712773": "Conectar ao Stripe",
   "text_62b1edddbf5f461ab9712743": "Conexão Stripe criada com sucesso",
   "text_62b1edddbf5f461ab9712707": "Stripe",


### PR DESCRIPTION
## Context

The legacy `AddAnrokDialog` uses the deprecated imperative ref-based dialog system (`forwardRef` + `useImperativeHandle` + `~/components/designSystem/Dialog`) and Formik. Consumers trigger warnings from the `no-restricted-imports` ESLint rule, and Formik itself is deprecated in favor of TanStack Form.

## Description

- Rewrote `AddAnrokDialog` as a `useAddAnrokDialog` hook backed by `useFormDialogOpeningDialog`.
- Migrated the form from Formik + Yup to TanStack Form (`useAppForm`) with a Zod schema and `revalidateLogic()`.
- Inlined the delete confirmation via `otherDialogProps` and the `destroyNangoIntegration` mutation, evicting the removed integration from the `integrations` list cache with `evictFromCache`. Consumers that already had a `deleteCallback` (post-delete navigation) now pass it directly to `openAddAnrokDialog`.
- Wrapped the dialog children in a `p-8` container and wired `onEntered: focusFirstInput` so the first text field auto-focuses (`BaseDialog` no longer pads JSX children).
- Updated the three consumers (`AnrokIntegrationSettings`, `AnrokIntegrationDetails`, `AnrokIntegrations`) and the settings-level `Integrations` page to call the hook instead of holding a ref. Removed the now-useless single-child `<>…</>` fragment left in `AnrokIntegrationSettings`.
- Updated Jest mocks in the three affected test files to mock the new hook shape.

Resolves the `no-restricted-imports` warnings emitted for `AddAnrokDialog` / `AddAnrokDialogRef` across all consumers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XnZRMikUZYtSnaxbqCQLwK)_