### PR TITLE
refactor(settings): migrate AddGocardlessDialog to FormDialogOpeningDialog and TanStack Form

### DIFF
--- a/src/components/settings/integrations/AddGocardlessDialog.tsx
+++ b/src/components/settings/integrations/AddGocardlessDialog.tsx
@@ -1,28 +1,28 @@
-import { gql } from '@apollo/client'
-import Stack from '@mui/material/Stack'
-import { useFormik } from 'formik'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
-import { object, string } from 'yup'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { TextInputField } from '~/components/form'
+import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { addToast, envGlobalVar } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import { buildGocardlessAuthUrl } from '~/core/constants/externalUrls'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { GOCARDLESS_INTEGRATION_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import {
-  AddGocardlessPaymentProviderInput,
   AddGocardlessProviderDialogFragment,
+  GetGocardlessIntegrationsListDocument,
   GocardlessIntegrationDetailsFragmentDoc,
   LagoApiError,
+  useDeleteGocardlessMutation,
   useGetProviderByCodeForGocardlessLazyQuery,
   useUpdateGocardlessApiKeyMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-
-import { useDeleteGocardlessIntegrationDialog } from './DeleteGocardlessIntegrationDialog'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 gql`
   fragment AddGocardlessProviderDialog on GocardlessProvider {
@@ -65,30 +65,42 @@ gql`
   ${GocardlessIntegrationDetailsFragmentDoc}
 `
 
-type TAddGocardlessDialogProps = Partial<{
-  provider: AddGocardlessProviderDialogFragment
-  deleteDialogCallback: () => void
-}>
+const ADD_GOCARDLESS_FORM_ID = 'form-add-gocardless-integration'
 
-export interface AddGocardlessDialogRef {
-  openDialog: (props?: TAddGocardlessDialogProps) => unknown
-  closeDialog: () => unknown
+type AddGocardlessFormValues = {
+  name: string
+  code: string
 }
 
-export const AddGocardlessDialog = forwardRef<AddGocardlessDialogRef>((_, ref) => {
-  const navigate = useNavigate()
-  const dialogRef = useRef<DialogRef>(null)
-  const { lagoOauthProxyUrl } = envGlobalVar()
+const defaultFormValues: AddGocardlessFormValues = {
+  name: '',
+  code: '',
+}
 
+const validationSchema = z.object({
+  name: z.string(),
+  code: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+})
+
+type OpenAddGocardlessDialogData = {
+  provider?: AddGocardlessProviderDialogFragment
+  deleteDialogCallback?: () => void
+}
+
+export const useAddGocardlessDialog = () => {
+  const navigate = useNavigate()
+  const formDialogOpeningDialog = useFormDialogOpeningDialog()
+  const { lagoOauthProxyUrl } = envGlobalVar()
   const { translate } = useInternationalization()
-  const [localData, setLocalData] = useState<TAddGocardlessDialogProps | undefined>(undefined)
-  const gocardlessProvider = localData?.provider
-  const isEdition = !!gocardlessProvider
-  const { openDeleteGocardlessIntegrationDialog } = useDeleteGocardlessIntegrationDialog()
+  const client = useApolloClient()
+
+  const dataRef = useRef<OpenAddGocardlessDialogData | null>(null)
+  const successRef = useRef(false)
 
   const [updateApiKey] = useUpdateGocardlessApiKeyMutation({
     onCompleted({ updateGocardlessPaymentProvider }) {
       if (updateGocardlessPaymentProvider?.id) {
+        successRef.current = true
         navigate(
           generatePath(GOCARDLESS_INTEGRATION_DETAILS_ROUTE, {
             integrationId: updateGocardlessPaymentProvider.id,
@@ -96,10 +108,12 @@ export const AddGocardlessDialog = forwardRef<AddGocardlessDialogRef>((_, ref) =
           }),
         )
 
+        const toastKey = dataRef.current?.provider
+          ? 'Edit gocardless success toast'
+          : 'Add gocardless success toast'
+
         addToast({
-          message: translate(
-            isEdition ? 'Edit gocardless success toast' : 'Add gocardless success toast',
-          ),
+          message: translate(toastKey),
           severity: 'success',
         })
       }
@@ -108,20 +122,22 @@ export const AddGocardlessDialog = forwardRef<AddGocardlessDialogRef>((_, ref) =
 
   const [getGocardlessProviderByCode] = useGetProviderByCodeForGocardlessLazyQuery()
 
-  const formikProps = useFormik<AddGocardlessPaymentProviderInput>({
-    initialValues: {
-      code: gocardlessProvider?.code || '',
-      name: gocardlessProvider?.name || '',
+  const [deleteGocardless] = useDeleteGocardlessMutation()
+
+  const form = useAppForm({
+    defaultValues: defaultFormValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: validationSchema,
     },
-    validationSchema: object().shape({
-      name: string(),
-      code: string().required(''),
-    }),
-    onSubmit: async (values, formikBag) => {
+    onSubmit: async ({ value, formApi }) => {
+      const gocardlessProvider = dataRef.current?.provider
+      const isEdition = !!gocardlessProvider
+
       const res = await getGocardlessProviderByCode({
         context: { silentErrorCodes: [LagoApiError.NotFound] },
         variables: {
-          code: values.code,
+          code: value.code,
         },
       })
       const isNotAllowedToMutate =
@@ -131,127 +147,153 @@ export const AddGocardlessDialog = forwardRef<AddGocardlessDialogRef>((_, ref) =
           res.data?.paymentProvider?.id !== gocardlessProvider?.id)
 
       if (isNotAllowedToMutate) {
-        formikBag.setFieldError('code', translate('text_632a2d437e341dcc76817556'))
+        formApi.setErrorMap({
+          onDynamic: {
+            fields: {
+              code: {
+                message: translate('text_632a2d437e341dcc76817556'),
+                path: ['code'],
+              },
+            },
+          },
+        })
         return
       }
 
       if (isEdition) {
         await updateApiKey({
           variables: {
-            input: { ...values, id: gocardlessProvider?.id || '' },
+            input: { ...value, id: gocardlessProvider?.id || '' },
           },
         })
-
-        dialogRef.current?.closeDialog()
       } else {
-        setTimeout(() => {
-          const myWindow = window.open('', '_blank')
+        const myWindow = window.open('', '_blank')
 
-          if (myWindow?.location?.href) {
-            myWindow.location.href = buildGocardlessAuthUrl(
-              lagoOauthProxyUrl,
-              values.name,
-              values.code,
-            )
-            dialogRef.current?.closeDialog()
-            return myWindow?.focus()
-          }
+        if (myWindow?.location?.href) {
+          myWindow.location.href = buildGocardlessAuthUrl(lagoOauthProxyUrl, value.name, value.code)
+          myWindow?.focus()
+          successRef.current = true
+          return
+        }
 
-          myWindow?.close()
-          addToast({
-            severity: 'danger',
-            translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-          })
-        }, 0)
+        myWindow?.close()
+        addToast({
+          severity: 'danger',
+          translateKey: 'text_62b31e1f6a5b8b1b745ece48',
+        })
       }
     },
-    validateOnMount: true,
-    enableReinitialize: true,
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate(
-        isEdition ? 'text_658461066530343fe1808cd9' : 'text_658466afe6140b469140e1f9',
-        {
-          name: gocardlessProvider?.name,
-        },
-      )}
-      description={translate(
-        isEdition ? 'text_658461066530343fe1808cdd' : 'text_658466afe6140b469140e1fb',
-      )}
-      onClose={() => {
-        formikProps.resetForm()
-      }}
-      actions={({ closeDialog }) => (
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-          width={isEdition ? '100%' : 'inherit'}
-          spacing={3}
-        >
-          {isEdition && (
-            <Button
-              danger
-              variant="quaternary"
-              onClick={() => {
-                closeDialog()
-                openDeleteGocardlessIntegrationDialog({
-                  provider: gocardlessProvider,
-                  callback: localData?.deleteDialogCallback,
-                })
-              }}
-            >
-              {translate('text_65845f35d7d69c3ab4793dad')}
-            </Button>
-          )}
-          <Stack direction="row" spacing={3} alignItems="center">
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_62b1edddbf5f461ab971276d')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!formikProps.isValid || !formikProps.dirty}
-              onClick={formikProps.submitForm}
-            >
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openAddGocardlessDialog = (data?: OpenAddGocardlessDialogData) => {
+    dataRef.current = data ?? null
+    const gocardlessProvider = data?.provider
+    const isEdition = !!gocardlessProvider
+
+    form.reset()
+    if (gocardlessProvider) {
+      form.setFieldValue('name', gocardlessProvider.name || '')
+      form.setFieldValue('code', gocardlessProvider.code || '')
+    }
+
+    formDialogOpeningDialog
+      .open({
+        title: translate(
+          isEdition ? 'text_658461066530343fe1808cd9' : 'text_658466afe6140b469140e1f9',
+          {
+            name: gocardlessProvider?.name,
+          },
+        ),
+        description: translate(
+          isEdition ? 'text_658461066530343fe1808cdd' : 'text_658466afe6140b469140e1fb',
+        ),
+        children: (
+          <div className="flex flex-row items-start gap-6 p-8">
+            <form.AppField name="name">
+              {(field) => (
+                <field.TextInputField
+                  className="flex-1"
+                  label={translate('text_6584550dc4cec7adf861504d')}
+                  placeholder={translate('text_6584550dc4cec7adf861504f')}
+                />
+              )}
+            </form.AppField>
+            <form.AppField name="code">
+              {(field) => (
+                <field.TextInputField
+                  className="flex-1"
+                  label={translate('text_6584550dc4cec7adf8615051')}
+                  placeholder={translate('text_6584550dc4cec7adf8615053')}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        closeOnError: false,
+        onEntered: focusFirstInput,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>
               {translate(
                 isEdition ? 'text_65845f35d7d69c3ab4793dac' : 'text_658466afe6140b469140e207',
               )}
-            </Button>
-          </Stack>
-        </Stack>
-      )}
-    >
-      <div className="mb-8 flex flex-row items-start gap-6">
-        <TextInputField
-          className="flex-1"
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus
-          formikProps={formikProps}
-          name="name"
-          label={translate('text_6584550dc4cec7adf861504d')}
-          placeholder={translate('text_6584550dc4cec7adf861504f')}
-        />
-        <TextInputField
-          className="flex-1"
-          formikProps={formikProps}
-          name="code"
-          label={translate('text_6584550dc4cec7adf8615051')}
-          placeholder={translate('text_6584550dc4cec7adf8615053')}
-        />
-      </div>
-    </Dialog>
-  )
-})
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: ADD_GOCARDLESS_FORM_ID,
+          submit: handleSubmit,
+        },
+        canOpenDialog: isEdition,
+        openDialogText: translate('text_65845f35d7d69c3ab4793dad'),
+        otherDialogProps: {
+          title: translate('text_658461066530343fe1808cd7', { name: gocardlessProvider?.name }),
+          description: translate('text_65846181a741a1401ecdddb7'),
+          actionText: translate('text_659d5de7c9b7f51394f7f3fd'),
+          colorVariant: 'danger',
+          onAction: async () => {
+            const res = await deleteGocardless({
+              variables: { input: { id: gocardlessProvider?.id as string } },
+            })
 
-AddGocardlessDialog.displayName = 'AddGocardlessDialog'
+            const destroyedId = res.data?.destroyPaymentProvider?.id
+
+            if (destroyedId) {
+              evictFromCache(client, {
+                id: destroyedId,
+                __typename: 'GocardlessProvider',
+                listFieldName: 'paymentProviders',
+                listQueryDocument: GetGocardlessIntegrationsListDocument,
+              })
+
+              data?.deleteDialogCallback?.()
+
+              addToast({
+                message: translate('text_62b1edddbf5f461ab9712758'),
+                severity: 'success',
+              })
+            }
+          },
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close' || response.reason === 'open-other-dialog') {
+          form.reset()
+          dataRef.current = null
+        }
+      })
+  }
+
+  return { openAddGocardlessDialog }
+}

--- a/src/pages/settings/GocardlessIntegrationDetails.tsx
+++ b/src/pages/settings/GocardlessIntegrationDetails.tsx
@@ -14,10 +14,7 @@ import {
   AddEditDeleteSuccessRedirectUrlDialog,
   AddEditDeleteSuccessRedirectUrlDialogRef,
 } from '~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog'
-import {
-  AddGocardlessDialog,
-  AddGocardlessDialogRef,
-} from '~/components/settings/integrations/AddGocardlessDialog'
+import { useAddGocardlessDialog } from '~/components/settings/integrations/AddGocardlessDialog'
 import { useDeleteGocardlessIntegrationDialog } from '~/components/settings/integrations/DeleteGocardlessIntegrationDialog'
 import { addToast, envGlobalVar } from '~/core/apolloClient'
 import { buildGocardlessAuthUrl } from '~/core/constants/externalUrls'
@@ -75,7 +72,7 @@ const GocardlessIntegrationDetails = () => {
   const { integrationId } = useParams()
   const { lagoOauthProxyUrl } = envGlobalVar()
   const { hasPermissions } = usePermissions()
-  const addDialogRef = useRef<AddGocardlessDialogRef>(null)
+  const { openAddGocardlessDialog } = useAddGocardlessDialog()
   const { openDeleteGocardlessIntegrationDialog } = useDeleteGocardlessIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
@@ -145,7 +142,7 @@ const GocardlessIntegrationDetails = () => {
                   label: translate('text_65845f35d7d69c3ab4793dac'),
                   hidden: !canEditIntegration,
                   onClick: (closePopper) => {
-                    addDialogRef.current?.openDialog({
+                    openAddGocardlessDialog({
                       provider: gocardlessPaymentProvider,
                       deleteDialogCallback,
                     })
@@ -203,7 +200,7 @@ const GocardlessIntegrationDetails = () => {
                 variant="inline"
                 align="left"
                 onClick={() => {
-                  addDialogRef.current?.openDialog({
+                  openAddGocardlessDialog({
                     provider: gocardlessPaymentProvider,
                     deleteDialogCallback,
                   })
@@ -364,7 +361,6 @@ const GocardlessIntegrationDetails = () => {
           )}
         </section>
       </IntegrationsPage.Container>
-      <AddGocardlessDialog ref={addDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </div>
   )

--- a/src/pages/settings/GocardlessIntegrations.tsx
+++ b/src/pages/settings/GocardlessIntegrations.tsx
@@ -11,10 +11,7 @@ import {
   AddEditDeleteSuccessRedirectUrlDialog,
   AddEditDeleteSuccessRedirectUrlDialogRef,
 } from '~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog'
-import {
-  AddGocardlessDialog,
-  AddGocardlessDialogRef,
-} from '~/components/settings/integrations/AddGocardlessDialog'
+import { useAddGocardlessDialog } from '~/components/settings/integrations/AddGocardlessDialog'
 import { useDeleteGocardlessIntegrationDialog } from '~/components/settings/integrations/DeleteGocardlessIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import {
@@ -63,7 +60,7 @@ gql`
 const GocardlessIntegrations = () => {
   const navigate = useNavigate()
   const { hasPermissions } = usePermissions()
-  const addGocardlessDialogRef = useRef<AddGocardlessDialogRef>(null)
+  const { openAddGocardlessDialog } = useAddGocardlessDialog()
   const { openDeleteGocardlessIntegrationDialog } = useDeleteGocardlessIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
@@ -112,7 +109,7 @@ const GocardlessIntegrations = () => {
               variant: 'primary',
               hidden: !canCreateIntegration,
               onClick: () => {
-                addGocardlessDialogRef.current?.openDialog()
+                openAddGocardlessDialog()
               },
             },
           ],
@@ -166,7 +163,7 @@ const GocardlessIntegrations = () => {
                               variant="quaternary"
                               align="left"
                               onClick={() => {
-                                addGocardlessDialogRef.current?.openDialog({
+                                openAddGocardlessDialog({
                                   provider: connection,
                                   deleteDialogCallback,
                                 })
@@ -203,7 +200,6 @@ const GocardlessIntegrations = () => {
         </section>
       </IntegrationsPage.Container>
 
-      <AddGocardlessDialog ref={addGocardlessDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -27,10 +27,7 @@ import {
   AddFlutterwaveDialog,
   AddFlutterwaveDialogRef,
 } from '~/components/settings/integrations/AddFlutterwaveDialog'
-import {
-  AddGocardlessDialog,
-  AddGocardlessDialogRef,
-} from '~/components/settings/integrations/AddGocardlessDialog'
+import { useAddGocardlessDialog } from '~/components/settings/integrations/AddGocardlessDialog'
 import {
   AddHubspotDialog,
   AddHubspotDialogRef,
@@ -166,7 +163,7 @@ const Integrations = () => {
   const { openAddAvalaraDialog } = useAddAvalaraDialog()
   const { openAddStripeDialog } = useAddStripeDialog()
   const { openAddAdyenDialog } = useAddAdyenDialog()
-  const addGocardlessDialogRef = useRef<AddGocardlessDialogRef>(null)
+  const { openAddGocardlessDialog } = useAddGocardlessDialog()
   const { openAddCashfreeDialog } = useAddCashfreeDialog()
   const addLagoTaxManagementDialog = useRef<AddLagoTaxManagementDialogRef>(null)
   const addNetsuiteDialogRef = useRef<AddNetsuiteDialogRef>(null)
@@ -453,7 +450,7 @@ const Integrations = () => {
                               }),
                             )
                           } else {
-                            addGocardlessDialogRef.current?.openDialog()
+                            openAddGocardlessDialog()
                           }
                         }}
                         fullWidth
@@ -835,7 +832,6 @@ const Integrations = () => {
       <>{activeTabContent}</>
 
       <AddAnrokDialog ref={addAnrokDialogRef} />
-      <AddGocardlessDialog ref={addGocardlessDialogRef} />
       <AddLagoTaxManagementDialog ref={addLagoTaxManagementDialog} />
       <AddNetsuiteDialog ref={addNetsuiteDialogRef} />
       <AddXeroDialog ref={addXeroDialogRef} />

--- a/src/pages/settings/__tests__/GocardlessIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/GocardlessIntegrations.test.tsx
@@ -11,7 +11,7 @@ import {
 import GocardlessIntegrations from '../GocardlessIntegrations'
 
 jest.mock('~/components/settings/integrations/AddGocardlessDialog', () => ({
-  AddGocardlessDialog: () => null,
+  useAddGocardlessDialog: () => ({ openAddGocardlessDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/DeleteGocardlessIntegrationDialog', () => ({
   useDeleteGocardlessIntegrationDialog: () => ({

--- a/src/pages/settings/__tests__/Integrations.test.tsx
+++ b/src/pages/settings/__tests__/Integrations.test.tsx
@@ -48,7 +48,7 @@ jest.mock('~/components/settings/integrations/AddStripeDialog', () => ({
   useAddStripeDialog: () => ({ openAddStripeDialog: () => null }),
 }))
 jest.mock('~/components/settings/integrations/AddGocardlessDialog', () => ({
-  AddGocardlessDialog: () => null,
+  useAddGocardlessDialog: () => ({ openAddGocardlessDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/AddCashfreeDialog', () => ({
   useAddCashfreeDialog: () => ({


### PR DESCRIPTION
## Context

The legacy `AddGocardlessDialog` uses the deprecated imperative ref-based dialog system (`forwardRef` + `useImperativeHandle` + `~/components/designSystem/Dialog`) and Formik. Consumers trigger warnings from the `no-restricted-imports` ESLint rule, and Formik itself is deprecated in favor of TanStack Form.

## Description

- Rewrote `AddGocardlessDialog` as a `useAddGocardlessDialog` hook backed by `useFormDialogOpeningDialog`.
- Migrated the form from Formik + Yup to TanStack Form (`useAppForm`) with a Zod schema and `revalidateLogic()`. Kept the `getProviderByCodeForGocardless` preflight code-uniqueness check, surfacing the error via `formApi.setErrorMap`.
- Inlined the delete confirmation via `otherDialogProps` and the `deleteGocardless` mutation, evicting the removed provider from the `paymentProviders` list cache with `evictFromCache`. Callers still pass `deleteDialogCallback` for post-delete navigation.
- Preserved the create flow that opens GoCardless OAuth in a new tab (`buildGocardlessAuthUrl`) and the edit flow that runs `updateGocardlessApiKey`.
- Wrapped children in a `p-8` container and wired `onEntered: focusFirstInput` so the first text field auto-focuses (`BaseDialog` no longer pads JSX children).
- Updated the two consumers (`GocardlessIntegrations`, `GocardlessIntegrationDetails`) and the settings-level `Integrations` page to call the hook instead of holding a ref.
- Updated Jest mocks in `GocardlessIntegrations.test.tsx` and `Integrations.test.tsx` to mock the new hook shape.

Resolves the `no-restricted-imports` warnings emitted for `AddGocardlessDialog` / `AddGocardlessDialogRef` across all consumers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XnZRMikUZYtSnaxbqCQLwK)_