### PR TITLE
refactor(settings): migrate AddFlutterwaveDialog to FormDialogOpeningDialog and TanStack Form

### DIFF
--- a/src/components/settings/integrations/AddAdyenDialog.tsx
+++ b/src/components/settings/integrations/AddAdyenDialog.tsx
@@ -104,11 +104,11 @@ const defaultFormValues: AddAdyenPaymentProviderInput = {
 
 const validationSchema = z.object({
   name: z.string(),
-  code: z.string().min(1),
-  apiKey: z.string().min(1),
+  code: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  apiKey: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
   hmacKey: z.string().optional(),
   livePrefix: z.string().optional(),
-  merchantAccount: z.string().min(1),
+  merchantAccount: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
 })
 
 export const useAddAdyenDialog = () => {

--- a/src/components/settings/integrations/AddAvalaraDialog.tsx
+++ b/src/components/settings/integrations/AddAvalaraDialog.tsx
@@ -78,11 +78,11 @@ const defaultFormValues: AvalaraFormValues = {
 }
 
 const validationSchema = z.object({
-  accountId: z.string().min(1),
-  code: z.string().min(1),
-  companyCode: z.string().min(1),
-  licenseKey: z.string().min(1),
-  name: z.string().min(1),
+  accountId: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  code: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  companyCode: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  licenseKey: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  name: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
 })
 
 type NangoErrorHandle = {

--- a/src/components/settings/integrations/AddCashfreeDialog.tsx
+++ b/src/components/settings/integrations/AddCashfreeDialog.tsx
@@ -100,9 +100,9 @@ const defaultFormValues: AddCashfreeFormValues = {
 
 const validationSchema = z.object({
   name: z.string(),
-  code: z.string().min(1),
-  clientId: z.string().min(1),
-  clientSecret: z.string().min(1),
+  code: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  clientId: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  clientSecret: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
   successRedirectUrl: zodOptionalUrl,
 })
 

--- a/src/components/settings/integrations/AddFlutterwaveDialog.tsx
+++ b/src/components/settings/integrations/AddFlutterwaveDialog.tsx
@@ -89,9 +89,9 @@ const defaultFormValues: AddFlutterwaveFormValues = {
 }
 
 const validationSchema = z.object({
-  name: z.string().min(1),
-  code: z.string().min(1),
-  secretKey: z.string().min(1),
+  name: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  code: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  secretKey: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
   successRedirectUrl: zodOptionalUrl,
 })
 

--- a/src/components/settings/integrations/AddFlutterwaveDialog.tsx
+++ b/src/components/settings/integrations/AddFlutterwaveDialog.tsx
@@ -1,24 +1,28 @@
-import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { gql, useApolloClient } from '@apollo/client'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
-import { object, string } from 'yup'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { TextInputField } from '~/components/form'
+import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { addToast } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { FLUTTERWAVE_INTEGRATION_DETAILS_ROUTE, useNavigate } from '~/core/router'
+import { zodOptionalUrl } from '~/formValidation/zodCustoms'
 import {
-  AddFlutterwavePaymentProviderInput,
   FlutterwaveIntegrationDetailsFragment,
+  GetFlutterwaveIntegrationsListDocument,
   LagoApiError,
   useAddFlutterwavePaymentProviderMutation,
+  useDeleteFlutterwaveIntegrationMutation,
   useGetProviderByCodeForFlutterwaveLazyQuery,
   useUpdateFlutterwavePaymentProviderMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 gql`
   fragment AddFlutterwaveProviderDialog on FlutterwaveProvider {
@@ -68,26 +72,47 @@ gql`
   }
 `
 
-type TAddFlutterwaveDialogProps = Partial<{
-  onDelete: (provider: FlutterwaveIntegrationDetailsFragment) => void
-  provider: FlutterwaveIntegrationDetailsFragment
-}>
+const ADD_FLUTTERWAVE_FORM_ID = 'form-add-flutterwave-integration'
 
-export interface AddFlutterwaveDialogRef {
-  openDialog: (props?: TAddFlutterwaveDialogProps) => unknown
-  closeDialog: () => unknown
+type AddFlutterwaveFormValues = {
+  name: string
+  code: string
+  secretKey: string
+  successRedirectUrl: string
 }
 
-export const AddFlutterwaveDialog = forwardRef<AddFlutterwaveDialogRef>((_, ref) => {
+const defaultFormValues: AddFlutterwaveFormValues = {
+  name: '',
+  code: '',
+  secretKey: '',
+  successRedirectUrl: '',
+}
+
+const validationSchema = z.object({
+  name: z.string().min(1),
+  code: z.string().min(1),
+  secretKey: z.string().min(1),
+  successRedirectUrl: zodOptionalUrl,
+})
+
+type OpenAddFlutterwaveDialogData = {
+  provider?: FlutterwaveIntegrationDetailsFragment
+  deleteCallback?: () => void
+}
+
+export const useAddFlutterwaveDialog = () => {
   const { translate } = useInternationalization()
   const navigate = useNavigate()
-  const dialogRef = useRef<DialogRef>(null)
-  const [localData, setLocalData] = useState<TAddFlutterwaveDialogProps | undefined>(undefined)
-  const flutterwaveProvider = localData?.provider
-  const isEdition = !!flutterwaveProvider
+  const formDialogOpeningDialog = useFormDialogOpeningDialog()
+  const client = useApolloClient()
+
+  const dataRef = useRef<OpenAddFlutterwaveDialogData | null>(null)
+  const successRef = useRef(false)
+
   const [addFlutterwaveProvider] = useAddFlutterwavePaymentProviderMutation({
     onCompleted(data) {
       if (data?.addFlutterwavePaymentProvider) {
+        successRef.current = true
         addToast({
           severity: 'success',
           translateKey: 'text_1749803444837pl1ketrhm8a',
@@ -101,9 +126,11 @@ export const AddFlutterwaveDialog = forwardRef<AddFlutterwaveDialogRef>((_, ref)
       }
     },
   })
+
   const [updateFlutterwaveProvider] = useUpdateFlutterwavePaymentProviderMutation({
     onCompleted(data) {
       if (data?.updateFlutterwavePaymentProvider) {
+        successRef.current = true
         addToast({
           severity: 'success',
           translateKey: 'text_174980344483769h5q79g4ap',
@@ -111,32 +138,28 @@ export const AddFlutterwaveDialog = forwardRef<AddFlutterwaveDialogRef>((_, ref)
       }
     },
     onError() {
-      // Handle update errors - typically just display generic error since sensitive fields are not updated
       addToast({
         severity: 'danger',
         translateKey: 'text_629728388c4d2300e2d380d5',
       })
     },
   })
+
   const [getProviderByCode] = useGetProviderByCodeForFlutterwaveLazyQuery()
 
-  const formikProps = useFormik<AddFlutterwavePaymentProviderInput>({
-    initialValues: {
-      name: flutterwaveProvider?.name || '',
-      code: flutterwaveProvider?.code || '',
-      secretKey: flutterwaveProvider?.secretKey || '',
-      successRedirectUrl: flutterwaveProvider?.successRedirectUrl || '',
-    },
-    validationSchema: object().shape({
-      name: string().required(''),
-      code: string().required(''),
-      secretKey: string().required(''),
-      successRedirectUrl: string().url(''),
-    }),
-    onSubmit: async (values, formikBag) => {
-      const { name, code, secretKey, successRedirectUrl } = values
+  const [deleteFlutterwave] = useDeleteFlutterwaveIntegrationMutation()
 
-      // Check if code already exists
+  const form = useAppForm({
+    defaultValues: defaultFormValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: validationSchema,
+    },
+    onSubmit: async ({ value, formApi }) => {
+      const flutterwaveProvider = dataRef.current?.provider
+      const isEdition = !!flutterwaveProvider
+      const { name, code, secretKey, successRedirectUrl } = value
+
       const res = await getProviderByCode({
         context: { silentErrorCodes: [LagoApiError.NotFound] },
         variables: {
@@ -150,7 +173,16 @@ export const AddFlutterwaveDialog = forwardRef<AddFlutterwaveDialogRef>((_, ref)
           res.data?.paymentProvider?.id !== flutterwaveProvider?.id)
 
       if (isNotAllowedToMutate) {
-        formikBag.setFieldError('code', translate('text_632a2d437e341dcc76817556'))
+        formApi.setErrorMap({
+          onDynamic: {
+            fields: {
+              code: {
+                message: translate('text_632a2d437e341dcc76817556'),
+                path: ['code'],
+              },
+            },
+          },
+        })
         return
       }
 
@@ -177,97 +209,134 @@ export const AddFlutterwaveDialog = forwardRef<AddFlutterwaveDialogRef>((_, ref)
           },
         })
       }
-
-      dialogRef.current?.closeDialog()
     },
-    validateOnMount: true,
-    enableReinitialize: true,
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate(
-        isEdition ? 'text_1749725331374i3p14ewcpn5' : 'text_1749725331374clf07sez01f',
-      )}
-      description={translate('text_174972533137460li1pvmw34')}
-      onClose={formikProps.resetForm}
-      actions={({ closeDialog }) => (
-        <div className="flex w-full items-center gap-3">
-          {isEdition && (
-            <Button
-              danger
-              variant="quaternary"
-              onClick={() => {
-                closeDialog()
-                if (flutterwaveProvider) {
-                  localData?.onDelete?.(flutterwaveProvider)
-                }
-              }}
-            >
-              {translate('text_65845f35d7d69c3ab4793dad')}
-            </Button>
-          )}
-          <div className="ml-auto flex items-center gap-3">
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_63eba8c65a6c8043feee2a14')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!formikProps.isValid || !formikProps.dirty}
-              onClick={formikProps.submitForm}
-            >
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openAddFlutterwaveDialog = (data?: OpenAddFlutterwaveDialogData) => {
+    dataRef.current = data ?? null
+    const flutterwaveProvider = data?.provider
+    const isEdition = !!flutterwaveProvider
+
+    form.reset()
+    if (flutterwaveProvider) {
+      form.setFieldValue('name', flutterwaveProvider.name || '')
+      form.setFieldValue('code', flutterwaveProvider.code || '')
+      form.setFieldValue('secretKey', flutterwaveProvider.secretKey || '')
+      form.setFieldValue('successRedirectUrl', flutterwaveProvider.successRedirectUrl || '')
+    }
+
+    formDialogOpeningDialog
+      .open({
+        title: translate(
+          isEdition ? 'text_1749725331374i3p14ewcpn5' : 'text_1749725331374clf07sez01f',
+        ),
+        description: translate('text_174972533137460li1pvmw34'),
+        children: (
+          <div className="flex flex-col gap-6 p-8">
+            <div className="flex items-start gap-6">
+              <form.AppField name="name">
+                {(field) => (
+                  <field.TextInputField
+                    className="flex-1"
+                    label={translate('text_6584550dc4cec7adf861504d')}
+                    placeholder={translate('text_6584550dc4cec7adf861504f')}
+                  />
+                )}
+              </form.AppField>
+              <form.AppField name="code">
+                {(field) => (
+                  <field.TextInputField
+                    className="flex-1"
+                    label={translate('text_6584550dc4cec7adf8615051')}
+                    placeholder={translate('text_6584550dc4cec7adf8615053')}
+                  />
+                )}
+              </form.AppField>
+            </div>
+            <form.AppField name="secretKey">
+              {(field) => (
+                <field.TextInputField
+                  disabled={isEdition}
+                  label={translate('text_17497252876688ai900wowoc')}
+                  placeholder={translate('text_1749725331374uzvwfxs7m82')}
+                />
+              )}
+            </form.AppField>
+            <form.AppField name="successRedirectUrl">
+              {(field) => (
+                <field.TextInputField
+                  label={translate('text_65367cb78324b77fcb6af21c')}
+                  placeholder={translate('text_1733303818769298k0fvsgcz')}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        closeOnError: false,
+        onEntered: focusFirstInput,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>
               {translate(
                 isEdition ? 'text_65845f35d7d69c3ab4793dac' : 'text_1749725331374clf07sez01f',
               )}
-            </Button>
-          </div>
-        </div>
-      )}
-    >
-      <div className="mb-8 flex flex-col gap-6">
-        <div className="flex items-start gap-6">
-          <TextInputField
-            className="flex-1"
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus
-            formikProps={formikProps}
-            name="name"
-            label={translate('text_6584550dc4cec7adf861504d')}
-            placeholder={translate('text_6584550dc4cec7adf861504f')}
-          />
-          <TextInputField
-            className="flex-1"
-            formikProps={formikProps}
-            name="code"
-            label={translate('text_6584550dc4cec7adf8615051')}
-            placeholder={translate('text_6584550dc4cec7adf8615053')}
-          />
-        </div>
-        <TextInputField
-          name="secretKey"
-          disabled={isEdition}
-          label={translate('text_17497252876688ai900wowoc')}
-          placeholder={translate('text_1749725331374uzvwfxs7m82')}
-          formikProps={formikProps}
-        />
-        <TextInputField
-          formikProps={formikProps}
-          name="successRedirectUrl"
-          label={translate('text_65367cb78324b77fcb6af21c')}
-          placeholder={translate('text_1733303818769298k0fvsgcz')}
-        />
-      </div>
-    </Dialog>
-  )
-})
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: ADD_FLUTTERWAVE_FORM_ID,
+          submit: handleSubmit,
+        },
+        canOpenDialog: isEdition,
+        openDialogText: translate('text_65845f35d7d69c3ab4793dad'),
+        otherDialogProps: {
+          title: translate('text_1749799070145vfvz9sq757a', { name: flutterwaveProvider?.name }),
+          description: translate('text_1749799070145zdncdpo3g37'),
+          actionText: translate('text_1749799070145czycjo9guoq'),
+          colorVariant: 'danger',
+          onAction: async () => {
+            const result = await deleteFlutterwave({
+              variables: { input: { id: flutterwaveProvider?.id as string } },
+            })
 
-AddFlutterwaveDialog.displayName = 'AddFlutterwaveDialog'
+            const destroyedId = result.data?.destroyPaymentProvider?.id
+
+            if (destroyedId) {
+              evictFromCache(client, {
+                id: destroyedId,
+                __typename: 'FlutterwaveProvider',
+                listFieldName: 'paymentProviders',
+                listQueryDocument: GetFlutterwaveIntegrationsListDocument,
+              })
+
+              data?.deleteCallback?.()
+
+              addToast({
+                message: translate('text_1749799070145axw96s27789'),
+                severity: 'success',
+              })
+            }
+          },
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close' || response.reason === 'open-other-dialog') {
+          form.reset()
+          dataRef.current = null
+        }
+      })
+  }
+
+  return { openAddFlutterwaveDialog }
+}

--- a/src/components/settings/integrations/AddMoneyhashDialog.tsx
+++ b/src/components/settings/integrations/AddMoneyhashDialog.tsx
@@ -87,10 +87,10 @@ const defaultFormValues: AddMoneyhashPaymentProviderInput = {
 }
 
 const validationSchema = z.object({
-  name: z.string().min(1),
-  code: z.string().min(1),
-  apiKey: z.string().min(1),
-  flowId: z.string().min(1),
+  name: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  code: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  apiKey: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  flowId: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
 })
 
 export const useAddMoneyhashDialog = () => {

--- a/src/components/settings/integrations/AddStripeDialog.tsx
+++ b/src/components/settings/integrations/AddStripeDialog.tsx
@@ -92,8 +92,8 @@ const defaultFormValues: AddStripePaymentProviderInput = {
 
 const validationSchema = z.object({
   name: z.string(),
-  code: z.string().min(1),
-  secretKey: z.string().min(1),
+  code: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  secretKey: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
   supports3ds: z.boolean().optional(),
 })
 

--- a/src/pages/settings/FlutterwaveIntegrationDetails.tsx
+++ b/src/pages/settings/FlutterwaveIntegrationDetails.tsx
@@ -15,10 +15,7 @@ import {
   AddEditDeleteSuccessRedirectUrlDialog,
   AddEditDeleteSuccessRedirectUrlDialogRef,
 } from '~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog'
-import {
-  AddFlutterwaveDialog,
-  AddFlutterwaveDialogRef,
-} from '~/components/settings/integrations/AddFlutterwaveDialog'
+import { useAddFlutterwaveDialog } from '~/components/settings/integrations/AddFlutterwaveDialog'
 import { useDeleteFlutterwaveIntegrationDialog } from '~/components/settings/integrations/DeleteFlutterwaveIntegrationDialog'
 import { addToast, envGlobalVar } from '~/core/apolloClient'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
@@ -69,7 +66,7 @@ const FlutterwaveIntegrationDetails = () => {
   const navigate = useNavigate()
   const { integrationId } = useParams()
   const { hasPermissions } = usePermissions()
-  const addDialogRef = useRef<AddFlutterwaveDialogRef>(null)
+  const { openAddFlutterwaveDialog } = useAddFlutterwaveDialog()
   const { openDeleteFlutterwaveIntegrationDialog } = useDeleteFlutterwaveIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { apiUrl } = envGlobalVar()
@@ -156,13 +153,9 @@ const FlutterwaveIntegrationDetails = () => {
                   label: translate('text_65845f35d7d69c3ab4793dac'),
                   hidden: !canEditIntegration,
                   onClick: (closePopper) => {
-                    addDialogRef.current?.openDialog({
+                    openAddFlutterwaveDialog({
                       provider: flutterwavePaymentProvider,
-                      onDelete: (provider) =>
-                        openDeleteFlutterwaveIntegrationDialog({
-                          provider,
-                          callback: deleteDialogCallback,
-                        }),
+                      deleteCallback: deleteDialogCallback,
                     })
                     closePopper()
                   },
@@ -199,13 +192,9 @@ const FlutterwaveIntegrationDetails = () => {
                 variant="quaternary"
                 align="left"
                 onClick={() => {
-                  addDialogRef.current?.openDialog({
+                  openAddFlutterwaveDialog({
                     provider: flutterwavePaymentProvider,
-                    onDelete: (provider) =>
-                      openDeleteFlutterwaveIntegrationDialog({
-                        provider,
-                        callback: deleteDialogCallback,
-                      }),
+                    deleteCallback: deleteDialogCallback,
                   })
                 }}
               >
@@ -388,7 +377,6 @@ const FlutterwaveIntegrationDetails = () => {
         </section>
       </div>
 
-      <AddFlutterwaveDialog ref={addDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </div>
   )

--- a/src/pages/settings/FlutterwaveIntegrations.tsx
+++ b/src/pages/settings/FlutterwaveIntegrations.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
@@ -7,10 +6,7 @@ import { Popper } from '~/components/designSystem/Popper'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { IntegrationsPage } from '~/components/layouts/Integrations'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import {
-  AddFlutterwaveDialog,
-  AddFlutterwaveDialogRef,
-} from '~/components/settings/integrations/AddFlutterwaveDialog'
+import { useAddFlutterwaveDialog } from '~/components/settings/integrations/AddFlutterwaveDialog'
 import { useDeleteFlutterwaveIntegrationDialog } from '~/components/settings/integrations/DeleteFlutterwaveIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import {
@@ -54,7 +50,7 @@ gql`
 const FlutterwaveIntegrations = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
-  const addDialogRef = useRef<AddFlutterwaveDialogRef>(null)
+  const { openAddFlutterwaveDialog } = useAddFlutterwaveDialog()
   const { openDeleteFlutterwaveIntegrationDialog } = useDeleteFlutterwaveIntegrationDialog()
   const { hasPermissions } = usePermissions()
 
@@ -105,7 +101,7 @@ const FlutterwaveIntegrations = () => {
               variant: 'primary',
               hidden: !canCreateIntegration,
               onClick: () => {
-                addDialogRef.current?.openDialog()
+                openAddFlutterwaveDialog()
               },
             },
           ],
@@ -159,13 +155,9 @@ const FlutterwaveIntegrations = () => {
                               variant="quaternary"
                               align="left"
                               onClick={() => {
-                                addDialogRef.current?.openDialog({
+                                openAddFlutterwaveDialog({
                                   provider: connection,
-                                  onDelete: (provider) =>
-                                    openDeleteFlutterwaveIntegrationDialog({
-                                      provider,
-                                      callback: deleteDialogCallback,
-                                    }),
+                                  deleteCallback: deleteDialogCallback,
                                 })
                                 closePopper()
                               }}
@@ -199,8 +191,6 @@ const FlutterwaveIntegrations = () => {
             })}
         </section>
       </IntegrationsPage.Container>
-
-      <AddFlutterwaveDialog ref={addDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -23,10 +23,7 @@ import {
 } from '~/components/settings/integrations/AddAnrokDialog'
 import { useAddAvalaraDialog } from '~/components/settings/integrations/AddAvalaraDialog'
 import { useAddCashfreeDialog } from '~/components/settings/integrations/AddCashfreeDialog'
-import {
-  AddFlutterwaveDialog,
-  AddFlutterwaveDialogRef,
-} from '~/components/settings/integrations/AddFlutterwaveDialog'
+import { useAddFlutterwaveDialog } from '~/components/settings/integrations/AddFlutterwaveDialog'
 import { useAddGocardlessDialog } from '~/components/settings/integrations/AddGocardlessDialog'
 import {
   AddHubspotDialog,
@@ -170,7 +167,7 @@ const Integrations = () => {
   const addSalesforceDialogRef = useRef<AddSalesforceDialogRef>(null)
   const addXeroDialogRef = useRef<AddXeroDialogRef>(null)
   const addHubspotDialogRef = useRef<AddHubspotDialogRef>(null)
-  const addFlutterwaveDialogRef = useRef<AddFlutterwaveDialogRef>(null)
+  const { openAddFlutterwaveDialog } = useAddFlutterwaveDialog()
 
   const { openAddMoneyhashDialog } = useAddMoneyhashDialog()
 
@@ -758,7 +755,7 @@ const Integrations = () => {
                             const element = document.activeElement as HTMLElement
 
                             element.blur && element.blur()
-                            addFlutterwaveDialogRef.current?.openDialog()
+                            openAddFlutterwaveDialog()
                           }
                         }}
                         fullWidth
@@ -837,7 +834,6 @@ const Integrations = () => {
       <AddXeroDialog ref={addXeroDialogRef} />
       <AddHubspotDialog ref={addHubspotDialogRef} />
       <AddSalesforceDialog ref={addSalesforceDialogRef} />
-      <AddFlutterwaveDialog ref={addFlutterwaveDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/__tests__/FlutterwaveIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/FlutterwaveIntegrations.test.tsx
@@ -11,7 +11,7 @@ import {
 import FlutterwaveIntegrations from '../FlutterwaveIntegrations'
 
 jest.mock('~/components/settings/integrations/AddFlutterwaveDialog', () => ({
-  AddFlutterwaveDialog: () => null,
+  useAddFlutterwaveDialog: () => ({ openAddFlutterwaveDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/DeleteFlutterwaveIntegrationDialog', () => ({
   useDeleteFlutterwaveIntegrationDialog: () => ({

--- a/src/pages/settings/__tests__/Integrations.test.tsx
+++ b/src/pages/settings/__tests__/Integrations.test.tsx
@@ -64,7 +64,7 @@ jest.mock('~/components/settings/integrations/AddLagoTaxManagementDialog', () =>
   AddLagoTaxManagementDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/AddFlutterwaveDialog', () => ({
-  AddFlutterwaveDialog: () => null,
+  useAddFlutterwaveDialog: () => ({ openAddFlutterwaveDialog: jest.fn() }),
 }))
 jest.mock('~/components/dialogs/PremiumWarningDialog', () => ({
   usePremiumWarningDialog: () => ({


### PR DESCRIPTION
## Context

The legacy `AddFlutterwaveDialog` uses the deprecated imperative ref-based dialog system (`forwardRef` + `useImperativeHandle` + `~/components/designSystem/Dialog`) and Formik. Consumers trigger warnings from the `no-restricted-imports` ESLint rule, and Formik itself is deprecated in favor of TanStack Form.

## Description

- Rewrote `AddFlutterwaveDialog` as a `useAddFlutterwaveDialog` hook backed by `useFormDialogOpeningDialog`.
- Migrated the form from Formik + Yup to TanStack Form (`useAppForm`) with a Zod schema and `revalidateLogic()`; `successRedirectUrl` uses `zodOptionalUrl` for the same optional-URL semantics as the previous `.url()` validator. Kept the `getProviderByCodeForFlutterwave` preflight code-uniqueness check, surfacing the error via `formApi.setErrorMap`.
- Inlined the delete confirmation via `otherDialogProps` and the `deleteFlutterwaveIntegration` mutation, evicting the removed provider from the `paymentProviders` list cache with `evictFromCache`. Callers now pass `deleteCallback` (post-delete navigation) directly to `openAddFlutterwaveDialog`.
- Wrapped children in a `p-8` container and wired `onEntered: focusFirstInput` so the first text field auto-focuses (`BaseDialog` no longer pads JSX children).
- Updated the two consumers (`FlutterwaveIntegrations`, `FlutterwaveIntegrationDetails`) and the settings-level `Integrations` page to call the hook instead of holding a ref.
- Updated Jest mocks in `FlutterwaveIntegrations.test.tsx` and `Integrations.test.tsx` to mock the new hook shape.

Resolves the `no-restricted-imports` warnings emitted for `AddFlutterwaveDialog` / `AddFlutterwaveDialogRef` across all consumers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XnZRMikUZYtSnaxbqCQLwK)_