### PR TITLE
refactor(settings): migrate AddHubspotDialog to FormDialogOpeningDialog and TanStack Form

### DIFF
--- a/src/components/settings/integrations/AddHubspotDialog.tsx
+++ b/src/components/settings/integrations/AddHubspotDialog.tsx
@@ -1,32 +1,32 @@
-import { gql } from '@apollo/client'
-import Nango from '@nangohq/frontend'
-import { useFormik } from 'formik'
+import { gql, useApolloClient } from '@apollo/client'
+import { revalidateLogic } from '@tanstack/react-form'
 import { GraphQLFormattedError } from 'graphql'
-import { forwardRef, useId, useImperativeHandle, useRef, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
-import { boolean, object, string } from 'yup'
+import { z } from 'zod'
 
 import { Alert } from '~/components/designSystem/Alert'
-import { Button } from '~/components/designSystem/Button'
 import { Chip } from '~/components/designSystem/Chip'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { Checkbox, CheckboxField, ComboBoxField, TextInputField } from '~/components/form'
-import { useDeleteHubspotIntegrationDialog } from '~/components/settings/integrations/DeleteHubspotIntegrationDialog'
+import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
+import { Checkbox } from '~/components/form'
 import { addToast, envGlobalVar, hasDefinedGQLError } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import { getHubspotTargetedObjectTranslationKey } from '~/core/constants/form'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { HUBSPOT_INTEGRATION_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import {
-  CreateHubspotIntegrationInput,
-  DeleteHubspotIntegrationDialogFragmentDoc,
+  GetHubspotIntegrationsListDocument,
   HubspotForCreateDialogFragment,
   HubspotTargetedObjectsEnum,
   useCreateHubspotIntegrationMutation,
+  useDestroyNangoIntegrationMutation,
   useUpdateHubspotIntegrationMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
-import { tw } from '~/styles/utils'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 gql`
   fragment HubspotForCreateDialog on HubspotIntegration {
@@ -36,7 +36,6 @@ gql`
     defaultTargetedObject
     syncInvoices
     syncSubscriptions
-    ...DeleteHubspotIntegrationDialog
   }
 
   mutation createHubspotIntegration($input: CreateHubspotIntegrationInput!) {
@@ -50,36 +49,57 @@ gql`
       ...HubspotForCreateDialog
     }
   }
-
-  ${DeleteHubspotIntegrationDialogFragmentDoc}
 `
 
-type TAddHubspotDialogProps = Partial<{
-  provider: HubspotForCreateDialogFragment
-  deleteDialogCallback: () => void
-}>
+const ADD_HUBSPOT_FORM_ID = 'form-add-hubspot-integration'
 
-export interface AddHubspotDialogRef {
-  openDialog: (props?: TAddHubspotDialogProps) => unknown
-  closeDialog: () => unknown
+type AddHubspotFormValues = {
+  name: string
+  code: string
+  defaultTargetedObject: HubspotTargetedObjectsEnum
+  syncInvoices: boolean
+  syncSubscriptions: boolean
 }
 
-export const AddHubspotDialog = forwardRef<AddHubspotDialogRef>((_, ref) => {
+const defaultFormValues: AddHubspotFormValues = {
+  name: '',
+  code: '',
+  defaultTargetedObject: HubspotTargetedObjectsEnum.Companies,
+  syncInvoices: false,
+  syncSubscriptions: false,
+}
+
+const validationSchema = z.object({
+  name: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  code: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  defaultTargetedObject: z.nativeEnum(HubspotTargetedObjectsEnum),
+  syncInvoices: z.boolean(),
+  syncSubscriptions: z.boolean(),
+})
+
+type OpenAddHubspotDialogData = {
+  provider?: HubspotForCreateDialogFragment
+  deleteDialogCallback?: () => void
+}
+
+export const useAddHubspotDialog = () => {
   const componentId = useId()
   const { nangoPublicKey } = envGlobalVar()
 
   const { translate } = useInternationalization()
   const navigate = useNavigate()
-  const dialogRef = useRef<DialogRef>(null)
-  const [localData, setLocalData] = useState<TAddHubspotDialogProps | undefined>(undefined)
+  const formDialogOpeningDialog = useFormDialogOpeningDialog()
+  const client = useApolloClient()
+
+  const dataRef = useRef<OpenAddHubspotDialogData | null>(null)
+  const successRef = useRef(false)
+
   const [showGlobalError, setShowGlobalError] = useState(false)
-  const hubspotProvider = localData?.provider
-  const isEdition = !!hubspotProvider
-  const { openDeleteHubspotIntegrationDialog } = useDeleteHubspotIntegrationDialog()
 
   const [createIntegration] = useCreateHubspotIntegrationMutation({
     onCompleted({ createHubspotIntegration }) {
       if (createHubspotIntegration?.id) {
+        successRef.current = true
         navigate(
           generatePath(HUBSPOT_INTEGRATION_DETAILS_ROUTE, {
             integrationId: createHubspotIntegration.id,
@@ -98,6 +118,7 @@ export const AddHubspotDialog = forwardRef<AddHubspotDialogRef>((_, ref) => {
   const [updateIntegration] = useUpdateHubspotIntegrationMutation({
     onCompleted({ updateHubspotIntegration }) {
       if (updateHubspotIntegration?.id) {
+        successRef.current = true
         addToast({
           message: translate('text_172719004477535rfq4o0j1s'),
           severity: 'success',
@@ -106,32 +127,33 @@ export const AddHubspotDialog = forwardRef<AddHubspotDialogRef>((_, ref) => {
     },
   })
 
-  const formikProps = useFormik<Omit<CreateHubspotIntegrationInput, 'connectionId'>>({
-    initialValues: {
-      name: hubspotProvider?.name || '',
-      code: hubspotProvider?.code || '',
-      defaultTargetedObject:
-        hubspotProvider?.defaultTargetedObject || HubspotTargetedObjectsEnum.Companies,
-      syncInvoices: !!hubspotProvider?.syncInvoices,
-      syncSubscriptions: !!hubspotProvider?.syncSubscriptions,
+  const [deleteHubspot] = useDestroyNangoIntegrationMutation()
+
+  const form = useAppForm({
+    defaultValues: defaultFormValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: validationSchema,
     },
-    validationSchema: object().shape({
-      name: string().required(''),
-      code: string().required(''),
-      defaultTargetedObject: string().required(''),
-      syncInvoices: boolean(),
-      syncSubscriptions: boolean(),
-    }),
-    onSubmit: async ({ ...values }, formikBag) => {
+    onSubmit: async ({ value, formApi }) => {
       setShowGlobalError(false)
+
+      const hubspotProvider = dataRef.current?.provider
+      const isEdition = !!hubspotProvider
 
       const handleError = (errors: readonly GraphQLFormattedError[]) => {
         if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
-          formikBag.setErrors({
-            code: translate('text_632a2d437e341dcc76817556'),
+          formApi.setErrorMap({
+            onDynamic: {
+              fields: {
+                code: {
+                  message: translate('text_632a2d437e341dcc76817556'),
+                  path: ['code'],
+                },
+              },
+            },
           })
 
-          // Scroll to top of modal container
           const modalContainer = document.getElementsByClassName('MuiDialog-container')[0]
 
           if (modalContainer) {
@@ -144,18 +166,18 @@ export const AddHubspotDialog = forwardRef<AddHubspotDialogRef>((_, ref) => {
         const res = await updateIntegration({
           variables: {
             input: {
-              ...values,
+              ...value,
               id: hubspotProvider?.id || '',
             },
           },
         })
 
         if (res.errors) {
-          return handleError(res.errors)
+          handleError(res.errors)
         }
       } else {
         const connectionId = `hubspot-${componentId.replaceAll(':', '')}-${Date.now()}`
-
+        const Nango = (await import('@nangohq/frontend')).default
         const nango = new Nango({ publicKey: nangoPublicKey })
 
         try {
@@ -164,191 +186,237 @@ export const AddHubspotDialog = forwardRef<AddHubspotDialogRef>((_, ref) => {
           if (!!nangoAuthResult) {
             const res = await createIntegration({
               variables: {
-                input: { ...values, connectionId },
+                input: { ...value, connectionId },
               },
             })
 
             if (res.errors) {
-              return handleError(res.errors)
+              handleError(res.errors)
             }
           }
         } catch {
           setShowGlobalError(true)
-          return
         }
       }
-
-      dialogRef.current?.closeDialog()
     },
-    validateOnMount: true,
-    enableReinitialize: true,
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setShowGlobalError(false)
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate(
-        isEdition ? 'text_661ff6e56ef7e1b7c542b1d0' : 'text_1727189568053ifu63v2q1gf',
-        {
-          name: hubspotProvider?.name,
-        },
-      )}
-      description={translate(
-        isEdition ? 'text_1727189568053fu2g4sonout' : 'text_1727189568054z4qhm7flfgh',
-      )}
-      onClose={formikProps.resetForm}
-      actions={({ closeDialog }) => (
-        <div
-          className={tw('flex flex-row items-center justify-between gap-3', isEdition && 'w-full')}
-        >
-          {isEdition && (
-            <Button
-              danger
-              variant="quaternary"
-              onClick={() => {
-                closeDialog()
-                openDeleteHubspotIntegrationDialog({
-                  provider: hubspotProvider,
-                  callback: localData?.deleteDialogCallback,
-                })
-              }}
-            >
-              {translate('text_65845f35d7d69c3ab4793dad')}
-            </Button>
-          )}
-          <div className="flex flex-row items-center gap-3">
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_63eba8c65a6c8043feee2a14')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!formikProps.isValid || !formikProps.dirty}
-              onClick={formikProps.submitForm}
-            >
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openAddHubspotDialog = (data?: OpenAddHubspotDialogData) => {
+    setShowGlobalError(false)
+    dataRef.current = data ?? null
+    const hubspotProvider = data?.provider
+    const isEdition = !!hubspotProvider
+
+    form.reset()
+    if (hubspotProvider) {
+      form.setFieldValue('name', hubspotProvider.name || '')
+      form.setFieldValue('code', hubspotProvider.code || '')
+      form.setFieldValue(
+        'defaultTargetedObject',
+        hubspotProvider.defaultTargetedObject || HubspotTargetedObjectsEnum.Companies,
+      )
+      form.setFieldValue('syncInvoices', !!hubspotProvider.syncInvoices)
+      form.setFieldValue('syncSubscriptions', !!hubspotProvider.syncSubscriptions)
+    }
+
+    formDialogOpeningDialog
+      .open({
+        title: translate(
+          isEdition ? 'text_661ff6e56ef7e1b7c542b1d0' : 'text_1727189568053ifu63v2q1gf',
+          {
+            name: hubspotProvider?.name,
+          },
+        ),
+        description: translate(
+          isEdition ? 'text_1727189568053fu2g4sonout' : 'text_1727189568054z4qhm7flfgh',
+        ),
+        children: (
+          <div className="flex w-full flex-col gap-8 p-8">
+            {showGlobalError && (
+              <Alert type="danger">{translate('text_1749562792335fy21gc3sxn0')}</Alert>
+            )}
+
+            <div className="flex w-full flex-row items-start gap-6 *:flex-1">
+              <form.AppField name="name">
+                {(field) => (
+                  <field.TextInputField
+                    label={translate('text_6419c64eace749372fc72b0f')}
+                    placeholder={translate('text_6584550dc4cec7adf861504f')}
+                  />
+                )}
+              </form.AppField>
+              <form.AppField name="code">
+                {(field) => (
+                  <field.TextInputField
+                    beforeChangeFormatter="code"
+                    label={translate('text_62876e85e32e0300e1803127')}
+                    placeholder={translate('text_6584550dc4cec7adf8615053')}
+                  />
+                )}
+              </form.AppField>
+            </div>
+
+            <div className="flex flex-col gap-12">
+              <form.AppField name="defaultTargetedObject">
+                {(field) => (
+                  <field.ComboBoxField
+                    label={translate('text_17271895680545qv3cvwk1jx')}
+                    data={[
+                      {
+                        label: translate(
+                          getHubspotTargetedObjectTranslationKey[
+                            HubspotTargetedObjectsEnum.Companies
+                          ],
+                        ),
+                        value: HubspotTargetedObjectsEnum.Companies,
+                      },
+                      {
+                        label: translate(
+                          getHubspotTargetedObjectTranslationKey[
+                            HubspotTargetedObjectsEnum.Contacts
+                          ],
+                        ),
+                        value: HubspotTargetedObjectsEnum.Contacts,
+                      },
+                    ]}
+                    PopperProps={{ displayInDialog: true }}
+                  />
+                )}
+              </form.AppField>
+
+              <div className="flex flex-col gap-4">
+                <div>
+                  <Typography variant="bodyHl" color="grey700">
+                    {translate('text_1727190044775k62adpax08b')}
+                  </Typography>
+                  <Typography variant="caption" color="grey600">
+                    {translate('text_661ff6e56ef7e1b7c542b28e')}
+                  </Typography>
+                </div>
+
+                <Checkbox
+                  disabled
+                  label={
+                    <CheckboxLabelWithCode
+                      firstPart={translate('text_1727190044775yssj1flnpe9')}
+                      code={translate('text_1727281892403bkjbojs75t7')}
+                      lastPart={translate('text_1727190044775p6mbfwbzv36')}
+                    />
+                  }
+                  value={true}
+                />
+
+                <Checkbox
+                  disabled
+                  label={
+                    <CheckboxLabelWithCode
+                      firstPart={translate('text_1727190044775yssj1flnpe9')}
+                      code={translate('text_1727281892403m7aoqothh7r')}
+                      lastPart={translate('text_1727190044775p6mbfwbzv36')}
+                    />
+                  }
+                  value={true}
+                />
+
+                <form.AppField name="syncInvoices">
+                  {(field) => (
+                    <field.CheckboxField
+                      label={
+                        <CheckboxLabelWithCode
+                          firstPart={translate('text_1727190044775yssj1flnpe9')}
+                          code={translate('text_1727281892403ljelfgyyupg')}
+                          lastPart={translate('text_172719004477572tu71psqqt')}
+                        />
+                      }
+                    />
+                  )}
+                </form.AppField>
+                <form.AppField name="syncSubscriptions">
+                  {(field) => (
+                    <field.CheckboxField
+                      label={
+                        <CheckboxLabelWithCode
+                          firstPart={translate('text_1727190044775yssj1flnpe9')}
+                          code={translate('text_1727281892403w0qjgmdf8n4')}
+                          lastPart={translate('text_172719004477572tu71psqqt')}
+                        />
+                      }
+                    />
+                  )}
+                </form.AppField>
+              </div>
+            </div>
+          </div>
+        ),
+        closeOnError: false,
+        onEntered: isEdition ? undefined : focusFirstInput,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>
               {translate(
                 isEdition ? 'text_65845f35d7d69c3ab4793dac' : 'text_1727189568053ifu63v2q1gf',
               )}
-            </Button>
-          </div>
-        </div>
-      )}
-    >
-      <div className="mb-8 flex w-full flex-col gap-8">
-        {!!showGlobalError && (
-          <Alert type="danger">{translate('text_1749562792335fy21gc3sxn0')}</Alert>
-        )}
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: ADD_HUBSPOT_FORM_ID,
+          submit: handleSubmit,
+        },
+        canOpenDialog: isEdition,
+        openDialogText: translate('text_65845f35d7d69c3ab4793dad'),
+        otherDialogProps: {
+          title: translate('text_658461066530343fe1808cd7', { name: hubspotProvider?.name }),
+          description: translate('text_1727453876790u9azb7rvhox'),
+          actionText: translate('text_645d071272418a14c1c76a81'),
+          colorVariant: 'danger',
+          onAction: async () => {
+            const res = await deleteHubspot({
+              variables: { input: { id: hubspotProvider?.id as string } },
+            })
 
-        <div className="flex w-full flex-row items-start gap-6 *:flex-1">
-          <TextInputField
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus={!isEdition}
-            name="name"
-            label={translate('text_6419c64eace749372fc72b0f')}
-            placeholder={translate('text_6584550dc4cec7adf861504f')}
-            formikProps={formikProps}
-          />
-          <TextInputField
-            name="code"
-            beforeChangeFormatter="code"
-            label={translate('text_62876e85e32e0300e1803127')}
-            placeholder={translate('text_6584550dc4cec7adf8615053')}
-            formikProps={formikProps}
-          />
-        </div>
+            const destroyedId = res.data?.destroyIntegration?.id
 
-        <div className="flex flex-col gap-12">
-          <ComboBoxField
-            name="defaultTargetedObject"
-            label={translate('text_17271895680545qv3cvwk1jx')}
-            formikProps={formikProps}
-            data={[
-              {
-                label: translate(
-                  getHubspotTargetedObjectTranslationKey[HubspotTargetedObjectsEnum.Companies],
-                ),
-                value: HubspotTargetedObjectsEnum.Companies,
-              },
-              {
-                label: translate(
-                  getHubspotTargetedObjectTranslationKey[HubspotTargetedObjectsEnum.Contacts],
-                ),
-                value: HubspotTargetedObjectsEnum.Contacts,
-              },
-            ]}
-            PopperProps={{ displayInDialog: true }}
-          />
+            if (destroyedId) {
+              evictFromCache(client, {
+                id: destroyedId,
+                __typename: 'HubspotIntegration',
+                listFieldName: 'integrations',
+                listQueryDocument: GetHubspotIntegrationsListDocument,
+              })
 
-          <div className="flex flex-col gap-4">
-            <div>
-              <Typography variant="bodyHl" color="grey700">
-                {translate('text_1727190044775k62adpax08b')}
-              </Typography>
-              <Typography variant="caption" color="grey600">
-                {translate('text_661ff6e56ef7e1b7c542b28e')}
-              </Typography>
-            </div>
+              data?.deleteDialogCallback?.()
 
-            <Checkbox
-              disabled
-              label={
-                <CheckboxLabelWithCode
-                  firstPart={translate('text_1727190044775yssj1flnpe9')}
-                  code={translate('text_1727281892403bkjbojs75t7')}
-                  lastPart={translate('text_1727190044775p6mbfwbzv36')}
-                />
-              }
-              value={true}
-            />
+              addToast({
+                message: translate('text_661ff6e56ef7e1b7c542b2f9'),
+                severity: 'success',
+              })
+            }
+          },
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close' || response.reason === 'open-other-dialog') {
+          form.reset()
+          dataRef.current = null
+          setShowGlobalError(false)
+        }
+      })
+  }
 
-            <Checkbox
-              disabled
-              label={
-                <CheckboxLabelWithCode
-                  firstPart={translate('text_1727190044775yssj1flnpe9')}
-                  code={translate('text_1727281892403m7aoqothh7r')}
-                  lastPart={translate('text_1727190044775p6mbfwbzv36')}
-                />
-              }
-              value={true}
-            />
-
-            <CheckboxField
-              name="syncInvoices"
-              formikProps={formikProps}
-              label={
-                <CheckboxLabelWithCode
-                  firstPart={translate('text_1727190044775yssj1flnpe9')}
-                  code={translate('text_1727281892403ljelfgyyupg')}
-                  lastPart={translate('text_172719004477572tu71psqqt')}
-                />
-              }
-            />
-            <CheckboxField
-              name="syncSubscriptions"
-              formikProps={formikProps}
-              label={
-                <CheckboxLabelWithCode
-                  firstPart={translate('text_1727190044775yssj1flnpe9')}
-                  code={translate('text_1727281892403w0qjgmdf8n4')}
-                  lastPart={translate('text_172719004477572tu71psqqt')}
-                />
-              }
-            />
-          </div>
-        </div>
-      </div>
-    </Dialog>
-  )
-})
+  return { openAddHubspotDialog }
+}
 
 const CheckboxLabelWithCode = ({
   firstPart,
@@ -371,5 +439,3 @@ const CheckboxLabelWithCode = ({
     </div>
   )
 }
-
-AddHubspotDialog.displayName = 'AddHubspotDialog'

--- a/src/pages/settings/HubspotIntegrationDetails.tsx
+++ b/src/pages/settings/HubspotIntegrationDetails.tsx
@@ -1,14 +1,10 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
 import { IntegrationsPage } from '~/components/layouts/Integrations'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import {
-  AddHubspotDialog,
-  AddHubspotDialogRef,
-} from '~/components/settings/integrations/AddHubspotDialog'
+import { useAddHubspotDialog } from '~/components/settings/integrations/AddHubspotDialog'
 import { useDeleteHubspotIntegrationDialog } from '~/components/settings/integrations/DeleteHubspotIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { HUBSPOT_INTEGRATION_ROUTE, INTEGRATIONS_ROUTE, useNavigate } from '~/core/router'
@@ -66,7 +62,7 @@ const HubspotIntegrationDetails = () => {
   const { translate } = useInternationalization()
   const navigate = useNavigate()
 
-  const addHubspotDialogRef = useRef<AddHubspotDialogRef>(null)
+  const { openAddHubspotDialog } = useAddHubspotDialog()
   const { openDeleteHubspotIntegrationDialog } = useDeleteHubspotIntegrationDialog()
 
   const { data, loading } = useGetHubspotIntegrationsDetailsQuery({
@@ -130,7 +126,7 @@ const HubspotIntegrationDetails = () => {
                 {
                   label: translate('text_65845f35d7d69c3ab4793dac'),
                   onClick: (closePopper) => {
-                    addHubspotDialogRef.current?.openDialog({
+                    openAddHubspotDialog({
                       provider: hubspotIntegration,
                       deleteDialogCallback,
                     })
@@ -164,7 +160,7 @@ const HubspotIntegrationDetails = () => {
               variant="inline"
               disabled={loading}
               onClick={() => {
-                addHubspotDialogRef.current?.openDialog({
+                openAddHubspotDialog({
                   provider: hubspotIntegration,
                   deleteDialogCallback,
                 })
@@ -211,8 +207,6 @@ const HubspotIntegrationDetails = () => {
           )}
         </section>
       </IntegrationsPage.Container>
-
-      <AddHubspotDialog ref={addHubspotDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/HubspotIntegrations.tsx
+++ b/src/pages/settings/HubspotIntegrations.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
@@ -7,10 +6,7 @@ import { Popper } from '~/components/designSystem/Popper'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { IntegrationsPage } from '~/components/layouts/Integrations'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import {
-  AddHubspotDialog,
-  AddHubspotDialogRef,
-} from '~/components/settings/integrations/AddHubspotDialog'
+import { useAddHubspotDialog } from '~/components/settings/integrations/AddHubspotDialog'
 import { useDeleteHubspotIntegrationDialog } from '~/components/settings/integrations/DeleteHubspotIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { HUBSPOT_INTEGRATION_DETAILS_ROUTE, INTEGRATIONS_ROUTE, useNavigate } from '~/core/router'
@@ -51,7 +47,7 @@ const HubspotIntegrations = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
 
-  const addHubspotDialogRef = useRef<AddHubspotDialogRef>(null)
+  const { openAddHubspotDialog } = useAddHubspotDialog()
   const { openDeleteHubspotIntegrationDialog } = useDeleteHubspotIntegrationDialog()
 
   const { data, loading } = useGetHubspotIntegrationsListQuery({
@@ -97,7 +93,7 @@ const HubspotIntegrations = () => {
               label: translate('text_65846763e6140b469140e235'),
               variant: 'primary',
               onClick: () => {
-                addHubspotDialogRef.current?.openDialog()
+                openAddHubspotDialog()
               },
             },
           ],
@@ -149,7 +145,7 @@ const HubspotIntegrations = () => {
                           variant="quaternary"
                           align="left"
                           onClick={() => {
-                            addHubspotDialogRef.current?.openDialog({
+                            openAddHubspotDialog({
                               provider: connection,
                               deleteDialogCallback,
                             })
@@ -180,7 +176,6 @@ const HubspotIntegrations = () => {
             })}
         </section>
       </IntegrationsPage.Container>
-      <AddHubspotDialog ref={addHubspotDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -25,10 +25,7 @@ import { useAddAvalaraDialog } from '~/components/settings/integrations/AddAvala
 import { useAddCashfreeDialog } from '~/components/settings/integrations/AddCashfreeDialog'
 import { useAddFlutterwaveDialog } from '~/components/settings/integrations/AddFlutterwaveDialog'
 import { useAddGocardlessDialog } from '~/components/settings/integrations/AddGocardlessDialog'
-import {
-  AddHubspotDialog,
-  AddHubspotDialogRef,
-} from '~/components/settings/integrations/AddHubspotDialog'
+import { useAddHubspotDialog } from '~/components/settings/integrations/AddHubspotDialog'
 import {
   AddLagoTaxManagementDialog,
   AddLagoTaxManagementDialogRef,
@@ -166,9 +163,8 @@ const Integrations = () => {
   const addNetsuiteDialogRef = useRef<AddNetsuiteDialogRef>(null)
   const addSalesforceDialogRef = useRef<AddSalesforceDialogRef>(null)
   const addXeroDialogRef = useRef<AddXeroDialogRef>(null)
-  const addHubspotDialogRef = useRef<AddHubspotDialogRef>(null)
   const { openAddFlutterwaveDialog } = useAddFlutterwaveDialog()
-
+  const { openAddHubspotDialog } = useAddHubspotDialog()
   const { openAddMoneyhashDialog } = useAddMoneyhashDialog()
 
   const { data, loading } = useIntegrationsSettingQuery({
@@ -499,7 +495,7 @@ const Integrations = () => {
                               }),
                             )
                           } else {
-                            addHubspotDialogRef.current?.openDialog()
+                            openAddHubspotDialog()
                           }
                         }}
                         fullWidth
@@ -832,7 +828,6 @@ const Integrations = () => {
       <AddLagoTaxManagementDialog ref={addLagoTaxManagementDialog} />
       <AddNetsuiteDialog ref={addNetsuiteDialogRef} />
       <AddXeroDialog ref={addXeroDialogRef} />
-      <AddHubspotDialog ref={addHubspotDialogRef} />
       <AddSalesforceDialog ref={addSalesforceDialogRef} />
     </>
   )

--- a/src/pages/settings/__tests__/HubspotIntegrationDetails.test.tsx
+++ b/src/pages/settings/__tests__/HubspotIntegrationDetails.test.tsx
@@ -7,7 +7,7 @@ import { renderIntegrationPage } from './integrationTestHelpers'
 import HubspotIntegrationDetails from '../HubspotIntegrationDetails'
 
 jest.mock('~/components/settings/integrations/AddHubspotDialog', () => ({
-  AddHubspotDialog: () => null,
+  useAddHubspotDialog: () => ({ openAddHubspotDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/DeleteHubspotIntegrationDialog', () => ({
   useDeleteHubspotIntegrationDialog: () => ({

--- a/src/pages/settings/__tests__/HubspotIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/HubspotIntegrations.test.tsx
@@ -11,7 +11,7 @@ import {
 import HubspotIntegrations from '../HubspotIntegrations'
 
 jest.mock('~/components/settings/integrations/AddHubspotDialog', () => ({
-  AddHubspotDialog: () => null,
+  useAddHubspotDialog: () => ({ openAddHubspotDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/DeleteHubspotIntegrationDialog', () => ({
   useDeleteHubspotIntegrationDialog: () => ({

--- a/src/pages/settings/__tests__/Integrations.test.tsx
+++ b/src/pages/settings/__tests__/Integrations.test.tsx
@@ -36,7 +36,7 @@ jest.mock('~/components/settings/integrations/AddXeroDialog', () => ({
   AddXeroDialog: () => null,
 }))
 jest.mock('~/components/settings/integrations/AddHubspotDialog', () => ({
-  AddHubspotDialog: () => null,
+  useAddHubspotDialog: () => ({ openAddHubspotDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/AddSalesforceDialog', () => ({
   AddSalesforceDialog: () => null,


### PR DESCRIPTION
## Context

The legacy `AddHubspotDialog` uses the deprecated imperative ref-based dialog system (`forwardRef` + `useImperativeHandle` + `~/components/designSystem/Dialog`) and Formik. Consumers trigger warnings from the `no-restricted-imports` ESLint rule, and Formik itself is deprecated in favor of TanStack Form.

## Description

- Rewrote `AddHubspotDialog` as a `useAddHubspotDialog` hook backed by `useFormDialogOpeningDialog`.
- Migrated the form from Formik + Yup to TanStack Form (`useAppForm`) with a Zod schema (`z.nativeEnum(HubspotTargetedObjectsEnum)` for the targeted-object combobox) and `revalidateLogic()`. Preserved the `ValueAlreadyExist` GraphQL-error handling that sets a field-level error on `code` and scrolls the dialog to the top so the message is visible.
- Preserved the Nango OAuth flow on create (`nango.auth('hubspot', connectionId)`); the `@nangohq/frontend` module is now imported dynamically inside the submit handler to match the pattern used by the already-migrated `AddAnrokDialog`.
- Inlined the delete confirmation via `otherDialogProps` and the `destroyNangoIntegration` mutation, evicting the removed integration from the `integrations` list cache with `evictFromCache`. Callers still pass `deleteDialogCallback` for post-delete navigation.
- Kept the "global error" alert (`showGlobalError`) shown when Nango auth fails.
- Wrapped children in a `p-8` container. On create the first field is a text input so `onEntered: focusFirstInput` fires; on edit no field is auto-focused (matching the previous `autoFocus={!isEdition}`).
- Updated the two consumers (`HubspotIntegrations`, `HubspotIntegrationDetails`) and the settings-level `Integrations` page to call the hook instead of holding a ref.
- Updated Jest mocks in `HubspotIntegrations.test.tsx`, `HubspotIntegrationDetails.test.tsx`, and `Integrations.test.tsx` to mock the new hook shape.

Resolves the `no-restricted-imports` warnings emitted for `AddHubspotDialog` / `AddHubspotDialogRef` across all consumers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XnZRMikUZYtSnaxbqCQLwK)_