### PR TITLE
refactor(settings): migrate AddXeroDialog to FormDialogOpeningDialog and TanStack Form

### DIFF
--- a/src/components/settings/integrations/AddXeroDialog.tsx
+++ b/src/components/settings/integrations/AddXeroDialog.tsx
@@ -1,28 +1,30 @@
-import { gql } from '@apollo/client'
-import Stack from '@mui/material/Stack'
-import Nango from '@nangohq/frontend'
-import { useFormik } from 'formik'
+import { gql, useApolloClient } from '@apollo/client'
+import { revalidateLogic } from '@tanstack/react-form'
 import { GraphQLFormattedError } from 'graphql'
-import { forwardRef, useId, useImperativeHandle, useRef, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
-import { boolean, object, string } from 'yup'
+import { z } from 'zod'
 
 import { Alert } from '~/components/designSystem/Alert'
-import { Button } from '~/components/designSystem/Button'
 import { Chip } from '~/components/designSystem/Chip'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
 import { Typography } from '~/components/designSystem/Typography'
-import { Checkbox, CheckboxField, TextInputField } from '~/components/form'
+import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
+import { Checkbox } from '~/components/form'
 import { addToast, envGlobalVar, hasDefinedGQLError } from '~/core/apolloClient'
+import { evictFromCache } from '~/core/apolloClient/evictFromCache'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { useNavigate, XERO_INTEGRATION_DETAILS_ROUTE } from '~/core/router'
 import {
-  CreateXeroIntegrationInput,
+  GetXeroIntegrationsListDocument,
   useCreateXeroIntegrationMutation,
+  useDestroyNangoIntegrationMutation,
   useUpdateXeroIntegrationMutation,
   XeroForCreateDialogDialogFragment,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 import { XeroIntegrationDetailsTabs } from '~/pages/settings/XeroIntegrationDetails'
 
 gql`
@@ -50,31 +52,55 @@ gql`
   }
 `
 
-type TAddXeroDialogProps = Partial<{
-  onDelete: (provider: XeroForCreateDialogDialogFragment) => void
-  provider: XeroForCreateDialogDialogFragment
-}>
+const ADD_XERO_FORM_ID = 'form-add-xero-integration'
 
-export interface AddXeroDialogRef {
-  openDialog: (props?: TAddXeroDialogProps) => unknown
-  closeDialog: () => unknown
+type AddXeroFormValues = {
+  name: string
+  code: string
+  syncCreditNotes: boolean
+  syncInvoices: boolean
+  syncPayments: boolean
 }
 
-export const AddXeroDialog = forwardRef<AddXeroDialogRef>((_, ref) => {
+const defaultFormValues: AddXeroFormValues = {
+  name: '',
+  code: '',
+  syncCreditNotes: false,
+  syncInvoices: false,
+  syncPayments: false,
+}
+
+const validationSchema = z.object({
+  name: z.string().min(1),
+  code: z.string().min(1),
+  syncCreditNotes: z.boolean(),
+  syncInvoices: z.boolean(),
+  syncPayments: z.boolean(),
+})
+
+type OpenAddXeroDialogData = {
+  provider?: XeroForCreateDialogDialogFragment
+  deleteDialogCallback?: () => void
+}
+
+export const useAddXeroDialog = () => {
   const componentId = useId()
   const { nangoPublicKey } = envGlobalVar()
 
   const { translate } = useInternationalization()
   const navigate = useNavigate()
-  const dialogRef = useRef<DialogRef>(null)
-  const [localData, setLocalData] = useState<TAddXeroDialogProps | undefined>(undefined)
+  const formDialogOpeningDialog = useFormDialogOpeningDialog()
+  const client = useApolloClient()
+
+  const dataRef = useRef<OpenAddXeroDialogData | null>(null)
+  const successRef = useRef(false)
+
   const [showGlobalError, setShowGlobalError] = useState(false)
-  const xeroProvider = localData?.provider
-  const isEdition = !!xeroProvider
 
   const [createIntegration] = useCreateXeroIntegrationMutation({
     onCompleted({ createXeroIntegration }) {
       if (createXeroIntegration?.id) {
+        successRef.current = true
         navigate(
           generatePath(XERO_INTEGRATION_DETAILS_ROUTE, {
             integrationId: createXeroIntegration.id,
@@ -95,6 +121,7 @@ export const AddXeroDialog = forwardRef<AddXeroDialogRef>((_, ref) => {
   const [updateIntegration] = useUpdateXeroIntegrationMutation({
     onCompleted({ updateXeroIntegration }) {
       if (updateXeroIntegration?.id) {
+        successRef.current = true
         addToast({
           message: translate('text_6672ebb8b1b50be550eccb0b'),
           severity: 'success',
@@ -103,31 +130,33 @@ export const AddXeroDialog = forwardRef<AddXeroDialogRef>((_, ref) => {
     },
   })
 
-  const formikProps = useFormik<Omit<CreateXeroIntegrationInput, 'connectionId'>>({
-    initialValues: {
-      code: xeroProvider?.code || '',
-      name: xeroProvider?.name || '',
-      syncCreditNotes: !!xeroProvider?.syncCreditNotes,
-      syncInvoices: !!xeroProvider?.syncInvoices,
-      syncPayments: !!xeroProvider?.syncPayments,
+  const [deleteXero] = useDestroyNangoIntegrationMutation()
+
+  const form = useAppForm({
+    defaultValues: defaultFormValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: validationSchema,
     },
-    validationSchema: object().shape({
-      name: string().required(''),
-      code: string().required(''),
-      syncCreditNotes: boolean(),
-      syncInvoices: boolean(),
-      syncPayments: boolean(),
-    }),
-    onSubmit: async ({ ...values }, formikBag) => {
+    onSubmit: async ({ value, formApi }) => {
       setShowGlobalError(false)
+
+      const xeroProvider = dataRef.current?.provider
+      const isEdition = !!xeroProvider
 
       const handleError = (errors: readonly GraphQLFormattedError[]) => {
         if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
-          formikBag.setErrors({
-            code: translate('text_632a2d437e341dcc76817556'),
+          formApi.setErrorMap({
+            onDynamic: {
+              fields: {
+                code: {
+                  message: translate('text_632a2d437e341dcc76817556'),
+                  path: ['code'],
+                },
+              },
+            },
           })
 
-          // Scroll to top of modal container
           const modalContainer = document.getElementsByClassName('MuiDialog-container')[0]
 
           if (modalContainer) {
@@ -140,17 +169,18 @@ export const AddXeroDialog = forwardRef<AddXeroDialogRef>((_, ref) => {
         const res = await updateIntegration({
           variables: {
             input: {
-              ...values,
+              ...value,
               id: xeroProvider?.id || '',
             },
           },
         })
 
         if (res.errors) {
-          return handleError(res.errors)
+          handleError(res.errors)
         }
       } else {
         const connectionId = `xero-${componentId.replaceAll(':', '')}-${Date.now()}`
+        const Nango = (await import('@nangohq/frontend')).default
         const nango = new Nango({ publicKey: nangoPublicKey })
 
         try {
@@ -159,241 +189,250 @@ export const AddXeroDialog = forwardRef<AddXeroDialogRef>((_, ref) => {
           if (!!nangoAuthResult) {
             const res = await createIntegration({
               variables: {
-                input: { ...values, connectionId },
+                input: { ...value, connectionId },
               },
             })
 
             if (res.errors) {
-              return handleError(res.errors)
+              handleError(res.errors)
             }
           }
         } catch {
           setShowGlobalError(true)
-          return
         }
       }
-
-      dialogRef.current?.closeDialog()
     },
-    validateOnMount: true,
-    enableReinitialize: true,
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (data) => {
-      setLocalData(data)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate(
-        isEdition ? 'text_661ff6e56ef7e1b7c542b1d0' : 'text_6672ebb8b1b50be550ecca9e',
-        {
-          name: xeroProvider?.name,
-        },
-      )}
-      description={translate(
-        isEdition ? 'text_6672ee6c7b6cb300d6cc31f3' : 'text_6672ebb8b1b50be550eccaa6',
-      )}
-      onClose={formikProps.resetForm}
-      actions={({ closeDialog }) => (
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-          width={isEdition ? '100%' : 'inherit'}
-          spacing={3}
-        >
-          {isEdition && (
-            <Button
-              danger
-              variant="quaternary"
-              onClick={() => {
-                closeDialog()
-                localData?.onDelete?.(xeroProvider)
-              }}
-            >
-              {translate('text_65845f35d7d69c3ab4793dad')}
-            </Button>
-          )}
-          <Stack direction="row" spacing={3} alignItems="center">
-            <Button variant="quaternary" onClick={closeDialog}>
-              {translate('text_63eba8c65a6c8043feee2a14')}
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!formikProps.isValid || !formikProps.dirty}
-              onClick={formikProps.submitForm}
-            >
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
+  }
+
+  const openAddXeroDialog = (data?: OpenAddXeroDialogData) => {
+    setShowGlobalError(false)
+    dataRef.current = data ?? null
+    const xeroProvider = data?.provider
+    const isEdition = !!xeroProvider
+
+    form.reset()
+    if (xeroProvider) {
+      form.setFieldValue('name', xeroProvider.name || '')
+      form.setFieldValue('code', xeroProvider.code || '')
+      form.setFieldValue('syncCreditNotes', !!xeroProvider.syncCreditNotes)
+      form.setFieldValue('syncInvoices', !!xeroProvider.syncInvoices)
+      form.setFieldValue('syncPayments', !!xeroProvider.syncPayments)
+    }
+
+    formDialogOpeningDialog
+      .open({
+        title: translate(
+          isEdition ? 'text_661ff6e56ef7e1b7c542b1d0' : 'text_6672ebb8b1b50be550ecca9e',
+          {
+            name: xeroProvider?.name,
+          },
+        ),
+        description: translate(
+          isEdition ? 'text_6672ee6c7b6cb300d6cc31f3' : 'text_6672ebb8b1b50be550eccaa6',
+        ),
+        children: (
+          <div className="flex flex-col gap-8 p-8">
+            {showGlobalError && (
+              <Alert type="danger">{translate('text_1749562792335fy21gc3sxn0')}</Alert>
+            )}
+
+            <div className="flex flex-row items-start gap-6">
+              <form.AppField name="name">
+                {(field) => (
+                  <field.TextInputField
+                    className="flex-1"
+                    label={translate('text_6419c64eace749372fc72b0f')}
+                    placeholder={translate('text_6584550dc4cec7adf861504f')}
+                  />
+                )}
+              </form.AppField>
+              <form.AppField name="code">
+                {(field) => (
+                  <field.TextInputField
+                    className="flex-1"
+                    beforeChangeFormatter="code"
+                    label={translate('text_62876e85e32e0300e1803127')}
+                    placeholder={translate('text_6584550dc4cec7adf8615053')}
+                  />
+                )}
+              </form.AppField>
+            </div>
+
+            <div className="flex flex-col gap-6">
+              <div>
+                <Typography variant="bodyHl" color="grey700">
+                  {translate('text_6672ebb8b1b50be550eccad6')}
+                </Typography>
+                <Typography variant="caption" color="grey600">
+                  {translate('text_661ff6e56ef7e1b7c542b28e')}
+                </Typography>
+              </div>
+
+              <div className="flex flex-col gap-4">
+                <Checkbox
+                  disabled
+                  label={
+                    <XeroSyncLabel
+                      firstPart={translate('text_6672ebb8b1b50be550eccaee')}
+                      code={translate('text_661ff6e56ef7e1b7c542b2a6')}
+                      lastPart={translate('text_661ff6e56ef7e1b7c542b29e')}
+                    />
+                  }
+                  value={true}
+                />
+                <Checkbox
+                  disabled
+                  label={
+                    <XeroSyncLabel
+                      firstPart={translate('text_6672ebb8b1b50be550eccaee')}
+                      code={translate('text_661ff6e56ef7e1b7c542b2c2')}
+                      lastPart={translate('text_661ff6e56ef7e1b7c542b29e')}
+                    />
+                  }
+                  value={true}
+                />
+                <Checkbox
+                  disabled
+                  label={
+                    <XeroSyncLabel
+                      firstPart={translate('text_6672ebb8b1b50be550eccaee')}
+                      code={translate('text_661ff6e56ef7e1b7c542b2d7')}
+                      lastPart={translate('text_661ff6e56ef7e1b7c542b29e')}
+                    />
+                  }
+                  value={true}
+                />
+                <form.AppField name="syncCreditNotes">
+                  {(field) => (
+                    <field.CheckboxField
+                      label={
+                        <XeroSyncLabel
+                          firstPart={translate('text_6672ebb8b1b50be550eccaee')}
+                          code={translate('text_661ff6e56ef7e1b7c542b2e9')}
+                          lastPart={translate('text_661ff6e56ef7e1b7c542b29e')}
+                        />
+                      }
+                    />
+                  )}
+                </form.AppField>
+                <form.AppField name="syncInvoices">
+                  {(field) => (
+                    <field.CheckboxField
+                      label={
+                        <XeroSyncLabel
+                          firstPart={translate('text_6672ebb8b1b50be550eccaee')}
+                          code={translate('text_661ff6e56ef7e1b7c542b2ff')}
+                          lastPart={translate('text_661ff6e56ef7e1b7c542b29e')}
+                        />
+                      }
+                    />
+                  )}
+                </form.AppField>
+                <form.AppField name="syncPayments">
+                  {(field) => (
+                    <field.CheckboxField
+                      label={
+                        <XeroSyncLabel
+                          firstPart={translate('text_6672ebb8b1b50be550eccaee')}
+                          code={translate('text_661ff6e56ef7e1b7c542b311')}
+                          lastPart={translate('text_661ff6e56ef7e1b7c542b29e')}
+                        />
+                      }
+                    />
+                  )}
+                </form.AppField>
+              </div>
+            </div>
+          </div>
+        ),
+        closeOnError: false,
+        onEntered: isEdition ? undefined : focusFirstInput,
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>
               {translate(
                 isEdition ? 'text_65845f35d7d69c3ab4793dac' : 'text_6672ebb8b1b50be550ecca9e',
               )}
-            </Button>
-          </Stack>
-        </Stack>
-      )}
-    >
-      <Stack spacing={8} marginBottom={8}>
-        {!!showGlobalError && (
-          <Alert type="danger">{translate('text_1749562792335fy21gc3sxn0')}</Alert>
-        )}
+            </form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: ADD_XERO_FORM_ID,
+          submit: handleSubmit,
+        },
+        canOpenDialog: isEdition,
+        openDialogText: translate('text_65845f35d7d69c3ab4793dad'),
+        otherDialogProps: {
+          title: translate('text_658461066530343fe1808cd7', { name: xeroProvider?.name }),
+          description: translate('text_6672ebb8b1b50be550eccada'),
+          colorVariant: 'danger',
+          actionText: translate('text_645d071272418a14c1c76a81'),
+          onAction: async () => {
+            const res = await deleteXero({
+              variables: { input: { id: xeroProvider?.id as string } },
+            })
 
-        <Stack spacing={6}>
-          <div className="flex flex-row items-start gap-6">
-            <TextInputField
-              className="flex-1"
-              // eslint-disable-next-line jsx-a11y/no-autofocus
-              autoFocus={!isEdition}
-              name="name"
-              label={translate('text_6419c64eace749372fc72b0f')}
-              placeholder={translate('text_6584550dc4cec7adf861504f')}
-              formikProps={formikProps}
-            />
-            <TextInputField
-              className="flex-1"
-              name="code"
-              beforeChangeFormatter="code"
-              label={translate('text_62876e85e32e0300e1803127')}
-              placeholder={translate('text_6584550dc4cec7adf8615053')}
-              formikProps={formikProps}
-            />
-          </div>
-        </Stack>
+            const destroyedId = res.data?.destroyIntegration?.id
 
-        <Stack spacing={6}>
-          <div>
-            <Typography variant="bodyHl" color="grey700">
-              {translate('text_6672ebb8b1b50be550eccad6')}
-            </Typography>
-            <Typography variant="caption" color="grey600">
-              {translate('text_661ff6e56ef7e1b7c542b28e')}
-            </Typography>
-          </div>
+            if (destroyedId) {
+              evictFromCache(client, {
+                id: destroyedId,
+                __typename: 'XeroIntegration',
+                listFieldName: 'integrations',
+                listQueryDocument: GetXeroIntegrationsListDocument,
+              })
 
-          <Stack spacing={4}>
-            <Checkbox
-              disabled
-              label={
-                <Stack spacing={1} direction="row" alignItems="center" flexWrap="wrap">
-                  <Typography variant="body" color="grey700">
-                    {translate('text_6672ebb8b1b50be550eccaee')}
-                  </Typography>
-                  <Chip
-                    size="small"
-                    label={translate('text_661ff6e56ef7e1b7c542b2a6')}
-                    color="danger600"
-                  />
-                  <Typography variant="body" color="grey700">
-                    {translate('text_661ff6e56ef7e1b7c542b29e')}
-                  </Typography>
-                </Stack>
-              }
-              value={true}
-            />
-            <Checkbox
-              disabled
-              label={
-                <Stack spacing={1} direction="row" alignItems="center" flexWrap="wrap">
-                  <Typography variant="body" color="grey700">
-                    {translate('text_6672ebb8b1b50be550eccaee')}
-                  </Typography>
-                  <Chip
-                    size="small"
-                    label={translate('text_661ff6e56ef7e1b7c542b2c2')}
-                    color="danger600"
-                  />
-                  <Typography variant="body" color="grey700">
-                    {translate('text_661ff6e56ef7e1b7c542b29e')}
-                  </Typography>
-                </Stack>
-              }
-              value={true}
-            />
-            <Checkbox
-              disabled
-              label={
-                <Stack spacing={1} direction="row" alignItems="center" flexWrap="wrap">
-                  <Typography variant="body" color="grey700">
-                    {translate('text_6672ebb8b1b50be550eccaee')}
-                  </Typography>
-                  <Chip
-                    size="small"
-                    label={translate('text_661ff6e56ef7e1b7c542b2d7')}
-                    color="danger600"
-                  />
-                  <Typography variant="body" color="grey700">
-                    {translate('text_661ff6e56ef7e1b7c542b29e')}
-                  </Typography>
-                </Stack>
-              }
-              value={true}
-            />
-            <CheckboxField
-              name="syncCreditNotes"
-              label={
-                <Stack spacing={1} direction="row" alignItems="center" flexWrap="wrap">
-                  <Typography variant="body" color="grey700">
-                    {translate('text_6672ebb8b1b50be550eccaee')}
-                  </Typography>
-                  <Chip
-                    size="small"
-                    label={translate('text_661ff6e56ef7e1b7c542b2e9')}
-                    color="danger600"
-                  />
-                  <Typography variant="body" color="grey700">
-                    {translate('text_661ff6e56ef7e1b7c542b29e')}
-                  </Typography>
-                </Stack>
-              }
-              formikProps={formikProps}
-            />
-            <CheckboxField
-              name="syncInvoices"
-              label={
-                <Stack spacing={1} direction="row" alignItems="center" flexWrap="wrap">
-                  <Typography variant="body" color="grey700">
-                    {translate('text_6672ebb8b1b50be550eccaee')}
-                  </Typography>
-                  <Chip
-                    size="small"
-                    label={translate('text_661ff6e56ef7e1b7c542b2ff')}
-                    color="danger600"
-                  />
-                  <Typography variant="body" color="grey700">
-                    {translate('text_661ff6e56ef7e1b7c542b29e')}
-                  </Typography>
-                </Stack>
-              }
-              formikProps={formikProps}
-            />
-            <CheckboxField
-              name="syncPayments"
-              label={
-                <Stack spacing={1} direction="row" alignItems="center" flexWrap="wrap">
-                  <Typography variant="body" color="grey700">
-                    {translate('text_6672ebb8b1b50be550eccaee')}
-                  </Typography>
-                  <Chip
-                    size="small"
-                    label={translate('text_661ff6e56ef7e1b7c542b311')}
-                    color="danger600"
-                  />
-                  <Typography variant="body" color="grey700">
-                    {translate('text_661ff6e56ef7e1b7c542b29e')}
-                  </Typography>
-                </Stack>
-              }
-              formikProps={formikProps}
-            />
-          </Stack>
-        </Stack>
-      </Stack>
-    </Dialog>
+              data?.deleteDialogCallback?.()
+
+              addToast({
+                message: translate('text_661ff6e56ef7e1b7c542b2f9'),
+                severity: 'success',
+              })
+            }
+          },
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close' || response.reason === 'open-other-dialog') {
+          form.reset()
+          dataRef.current = null
+          setShowGlobalError(false)
+        }
+      })
+  }
+
+  return { openAddXeroDialog }
+}
+
+const XeroSyncLabel = ({
+  firstPart,
+  code,
+  lastPart,
+}: {
+  firstPart: string
+  code: string
+  lastPart: string
+}) => {
+  return (
+    <div className="flex flex-row flex-wrap items-center gap-1">
+      <Typography variant="body" color="grey700">
+        {firstPart}
+      </Typography>
+      <Chip size="small" label={code} color="danger600" />
+      <Typography variant="body" color="grey700">
+        {lastPart}
+      </Typography>
+    </div>
   )
-})
-
-AddXeroDialog.displayName = 'AddXeroDialog'
+}

--- a/src/components/settings/integrations/AddXeroDialog.tsx
+++ b/src/components/settings/integrations/AddXeroDialog.tsx
@@ -71,8 +71,8 @@ const defaultFormValues: AddXeroFormValues = {
 }
 
 const validationSchema = z.object({
-  name: z.string().min(1),
-  code: z.string().min(1),
+  name: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+  code: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
   syncCreditNotes: z.boolean(),
   syncInvoices: z.boolean(),
   syncPayments: z.boolean(),

--- a/src/components/settings/integrations/XeroIntegrationSettings.tsx
+++ b/src/components/settings/integrations/XeroIntegrationSettings.tsx
@@ -26,8 +26,7 @@ import {
   AddEditDeleteSuccessRedirectUrlDialog,
   AddEditDeleteSuccessRedirectUrlDialogRef,
 } from './AddEditDeleteSuccessRedirectUrlDialog'
-import { AddXeroDialog, AddXeroDialogRef } from './AddXeroDialog'
-import { useDeleteXeroIntegrationDialog } from './DeleteXeroIntegrationDialog'
+import { useAddXeroDialog } from './AddXeroDialog'
 
 const PROVIDER_CONNECTION_LIMIT = 2
 
@@ -95,8 +94,7 @@ const buildEnabledSynchronizedLabelKeys = (integration?: XeroIntegrationSettings
 const XeroIntegrationSettings = () => {
   const navigate = useNavigate()
   const { integrationId = '' } = useParams()
-  const addXeroDialogRef = useRef<AddXeroDialogRef>(null)
-  const { openDeleteXeroIntegrationDialog } = useDeleteXeroIntegrationDialog()
+  const { openAddXeroDialog } = useAddXeroDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
   const { data, loading } = useGetXeroIntegrationsSettingsQuery({
@@ -120,13 +118,6 @@ const XeroIntegrationSettings = () => {
         generatePath(INTEGRATIONS_ROUTE, { integrationGroup: IntegrationsTabsOptionsEnum.Lago }),
       )
     }
-  }
-  const openDeleteDialog = () => {
-    if (!xeroIntegration) return
-    openDeleteXeroIntegrationDialog({
-      provider: xeroIntegration,
-      callback: deleteDialogCallback,
-    })
   }
 
   return (
@@ -158,9 +149,9 @@ const XeroIntegrationSettings = () => {
               variant="inline"
               disabled={loading}
               onClick={() => {
-                addXeroDialogRef.current?.openDialog({
+                openAddXeroDialog({
                   provider: xeroIntegration,
-                  onDelete: openDeleteDialog,
+                  deleteDialogCallback,
                 })
               }}
             >
@@ -198,7 +189,6 @@ const XeroIntegrationSettings = () => {
           </>
         </section>
       </IntegrationsPage.Container>
-      <AddXeroDialog ref={addXeroDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/Integrations.tsx
+++ b/src/pages/settings/Integrations.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { Alert } from '~/components/designSystem/Alert'
@@ -28,7 +27,7 @@ import { useAddMoneyhashDialog } from '~/components/settings/integrations/AddMon
 import { useAddNetsuiteDialog } from '~/components/settings/integrations/AddNetsuiteDialog'
 import { useAddSalesforceDialog } from '~/components/settings/integrations/AddSalesforceDialog'
 import { useAddStripeDialog } from '~/components/settings/integrations/AddStripeDialog'
-import { AddXeroDialog, AddXeroDialogRef } from '~/components/settings/integrations/AddXeroDialog'
+import { useAddXeroDialog } from '~/components/settings/integrations/AddXeroDialog'
 import {
   DOCUMENTATION_AIRBYTE,
   DOCUMENTATION_HIGHTTOUCH,
@@ -150,7 +149,7 @@ const Integrations = () => {
   const { openAddLagoTaxManagementDialog } = useAddLagoTaxManagementDialog()
   const { openAddNetsuiteDialog } = useAddNetsuiteDialog()
   const { openAddSalesforceDialog } = useAddSalesforceDialog()
-  const addXeroDialogRef = useRef<AddXeroDialogRef>(null)
+  const { openAddXeroDialog } = useAddXeroDialog()
   const { openAddFlutterwaveDialog } = useAddFlutterwaveDialog()
   const { openAddHubspotDialog } = useAddHubspotDialog()
   const { openAddMoneyhashDialog } = useAddMoneyhashDialog()
@@ -645,7 +644,7 @@ const Integrations = () => {
                               }),
                             )
                           } else {
-                            addXeroDialogRef.current?.openDialog()
+                            openAddXeroDialog()
                           }
                         }}
                       />
@@ -811,8 +810,6 @@ const Integrations = () => {
       />
 
       <>{activeTabContent}</>
-
-      <AddXeroDialog ref={addXeroDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/XeroIntegrationDetails.tsx
+++ b/src/pages/settings/XeroIntegrationDetails.tsx
@@ -9,7 +9,7 @@ import {
   AddEditDeleteSuccessRedirectUrlDialog,
   AddEditDeleteSuccessRedirectUrlDialogRef,
 } from '~/components/settings/integrations/AddEditDeleteSuccessRedirectUrlDialog'
-import { AddXeroDialog, AddXeroDialogRef } from '~/components/settings/integrations/AddXeroDialog'
+import { useAddXeroDialog } from '~/components/settings/integrations/AddXeroDialog'
 import { useDeleteXeroIntegrationDialog } from '~/components/settings/integrations/DeleteXeroIntegrationDialog'
 import XeroIntegrationItemsList from '~/components/settings/integrations/XeroIntegrationItemsList'
 import XeroIntegrationSettings from '~/components/settings/integrations/XeroIntegrationSettings'
@@ -79,7 +79,7 @@ const XeroIntegrationDetails = () => {
   const navigate = useNavigate()
   const { nangoPublicKey } = envGlobalVar()
   const { integrationId = '' } = useParams()
-  const addXeroDialogRef = useRef<AddXeroDialogRef>(null)
+  const { openAddXeroDialog } = useAddXeroDialog()
   const { openDeleteXeroIntegrationDialog } = useDeleteXeroIntegrationDialog()
   const successRedirectUrlDialogRef = useRef<AddEditDeleteSuccessRedirectUrlDialogRef>(null)
   const { translate } = useInternationalization()
@@ -147,9 +147,9 @@ const XeroIntegrationDetails = () => {
                 {
                   label: translate('text_65845f35d7d69c3ab4793dac'),
                   onClick: (closePopper) => {
-                    addXeroDialogRef.current?.openDialog({
+                    openAddXeroDialog({
                       provider: xeroIntegration,
-                      onDelete: openDeleteDialog,
+                      deleteDialogCallback,
                     })
                     closePopper()
                   },
@@ -212,7 +212,6 @@ const XeroIntegrationDetails = () => {
 
       <>{activeTabContent}</>
 
-      <AddXeroDialog ref={addXeroDialogRef} />
       <AddEditDeleteSuccessRedirectUrlDialog ref={successRedirectUrlDialogRef} />
     </>
   )

--- a/src/pages/settings/XeroIntegrations.tsx
+++ b/src/pages/settings/XeroIntegrations.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import { useRef } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
@@ -7,7 +6,7 @@ import { Popper } from '~/components/designSystem/Popper'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { IntegrationsPage } from '~/components/layouts/Integrations'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
-import { AddXeroDialog, AddXeroDialogRef } from '~/components/settings/integrations/AddXeroDialog'
+import { useAddXeroDialog } from '~/components/settings/integrations/AddXeroDialog'
 import { useDeleteXeroIntegrationDialog } from '~/components/settings/integrations/DeleteXeroIntegrationDialog'
 import { IntegrationsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { INTEGRATIONS_ROUTE, useNavigate, XERO_INTEGRATION_DETAILS_ROUTE } from '~/core/router'
@@ -52,7 +51,7 @@ gql`
 const XeroIntegrations = () => {
   const navigate = useNavigate()
   const { translate } = useInternationalization()
-  const addXeroDialogRef = useRef<AddXeroDialogRef>(null)
+  const { openAddXeroDialog } = useAddXeroDialog()
   const { openDeleteXeroIntegrationDialog } = useDeleteXeroIntegrationDialog()
   const { data, loading } = useGetXeroIntegrationsListQuery({
     variables: { limit: 1000, types: [IntegrationTypeEnum.Xero] },
@@ -103,7 +102,7 @@ const XeroIntegrations = () => {
               label: translate('text_65846763e6140b469140e235'),
               variant: 'primary',
               onClick: () => {
-                addXeroDialogRef.current?.openDialog()
+                openAddXeroDialog()
               },
             },
           ],
@@ -156,9 +155,9 @@ const XeroIntegrations = () => {
                           variant="quaternary"
                           align="left"
                           onClick={() => {
-                            addXeroDialogRef.current?.openDialog({
+                            openAddXeroDialog({
                               provider: connection,
-                              onDelete: openDeleteDialog,
+                              deleteDialogCallback,
                             })
                             closePopper()
                           }}
@@ -184,8 +183,6 @@ const XeroIntegrations = () => {
             })}
         </section>
       </IntegrationsPage.Container>
-
-      <AddXeroDialog ref={addXeroDialogRef} />
     </>
   )
 }

--- a/src/pages/settings/__tests__/Integrations.test.tsx
+++ b/src/pages/settings/__tests__/Integrations.test.tsx
@@ -33,7 +33,7 @@ jest.mock('~/components/settings/integrations/AddNetsuiteDialog', () => ({
   useAddNetsuiteDialog: () => ({ openAddNetsuiteDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/AddXeroDialog', () => ({
-  AddXeroDialog: () => null,
+  useAddXeroDialog: () => ({ openAddXeroDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/AddHubspotDialog', () => ({
   useAddHubspotDialog: () => ({ openAddHubspotDialog: jest.fn() }),

--- a/src/pages/settings/__tests__/XeroIntegrationDetails.test.tsx
+++ b/src/pages/settings/__tests__/XeroIntegrationDetails.test.tsx
@@ -11,7 +11,7 @@ jest.mock('@nangohq/frontend', () => ({
   default: jest.fn(),
 }))
 jest.mock('~/components/settings/integrations/AddXeroDialog', () => ({
-  AddXeroDialog: () => null,
+  useAddXeroDialog: () => ({ openAddXeroDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/DeleteXeroIntegrationDialog', () => ({
   useDeleteXeroIntegrationDialog: () => ({ openDeleteXeroIntegrationDialog: jest.fn() }),

--- a/src/pages/settings/__tests__/XeroIntegrations.test.tsx
+++ b/src/pages/settings/__tests__/XeroIntegrations.test.tsx
@@ -15,7 +15,7 @@ jest.mock('@nangohq/frontend', () => ({
   default: jest.fn(),
 }))
 jest.mock('~/components/settings/integrations/AddXeroDialog', () => ({
-  AddXeroDialog: () => null,
+  useAddXeroDialog: () => ({ openAddXeroDialog: jest.fn() }),
 }))
 jest.mock('~/components/settings/integrations/DeleteXeroIntegrationDialog', () => ({
   useDeleteXeroIntegrationDialog: () => ({ openDeleteXeroIntegrationDialog: jest.fn() }),


### PR DESCRIPTION
## Context

The legacy `AddXeroDialog` uses the deprecated imperative ref-based dialog system (`forwardRef` + `useImperativeHandle` + `~/components/designSystem/Dialog`) and Formik. Consumers trigger warnings from the `no-restricted-imports` ESLint rule, and Formik itself is deprecated in favor of TanStack Form.

## Description

- Rewrote `AddXeroDialog` as a `useAddXeroDialog` hook backed by `useFormDialogOpeningDialog`.
- Migrated the form from Formik + Yup to TanStack Form (`useAppForm`) with a Zod schema and `revalidateLogic()`. Preserved the `ValueAlreadyExist` GraphQL-error handling that sets a field-level error on `code` and scrolls the dialog to the top so the message is visible.
- Preserved the Xero OAuth flow on create (`nango.auth('xero', connectionId)`); the `@nangohq/frontend` module is now imported dynamically inside the submit handler to match the pattern used by the already-migrated `AddAnrokDialog`.
- Inlined the delete confirmation via `otherDialogProps` and the `destroyNangoIntegration` mutation, evicting the removed integration from the `integrations` list cache with `evictFromCache`. Callers now pass `deleteDialogCallback` (post-delete navigation) directly to `openAddXeroDialog`.
- Kept the "global error" alert (`showGlobalError`) shown when Nango auth fails.
- Wrapped children in a `p-8` container. On create the first field is a text input so `onEntered: focusFirstInput` fires; on edit no field is auto-focused (matching the previous `autoFocus={!isEdition}`).
- Updated the three consumers (`XeroIntegrationSettings`, `XeroIntegrationDetails`, `XeroIntegrations`) and the settings-level `Integrations` page to call the hook instead of holding a ref. `XeroIntegrationSettings` no longer needs `useDeleteXeroIntegrationDialog` since the delete confirmation now lives inside the edit dialog.
- Updated Jest mocks in `XeroIntegrations.test.tsx`, `XeroIntegrationDetails.test.tsx`, and `Integrations.test.tsx` to mock the new hook shape.

Resolves the `no-restricted-imports` warnings emitted for `AddXeroDialog` / `AddXeroDialogRef` across all consumers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XnZRMikUZYtSnaxbqCQLwK)_