### PR TITLE
feat(purchase_order_number): Display the new field for all invoice types

### DIFF
--- a/src/components/creditNote/CreditNoteDetailsOverview.tsx
+++ b/src/components/creditNote/CreditNoteDetailsOverview.tsx
@@ -26,7 +26,6 @@ import {
   DownloadCreditNoteMutationVariables,
   DownloadCreditNoteXmlMutation,
   DownloadCreditNoteXmlMutationVariables,
-  InvoiceTypeEnum,
   useGetCreditNoteForDetailsOverviewQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -232,10 +231,10 @@ export const CreditNoteDetailsOverview: FC<CreditNoteDetailsOverviewProps> = ({
               </>
             )}
 
-            {creditNote?.invoice?.invoiceType === InvoiceTypeEnum.OneOff && (
+            {!!creditNote?.invoice && (
               <DetailsPage.OverviewLine
                 title={translate('text_17822197712867qhfbaf9fpk')}
-                value={creditNote?.invoice?.purchaseOrderNumber || '-'}
+                value={creditNote.invoice.purchaseOrderNumber || '-'}
               />
             )}
 

--- a/src/components/invoices/InvoiceCustomerInfos.tsx
+++ b/src/components/invoices/InvoiceCustomerInfos.tsx
@@ -14,7 +14,6 @@ import {
   CustomerAccountTypeEnum,
   InvoiceForInvoiceInfosFragment,
   InvoiceStatusTypeEnum,
-  InvoiceTypeEnum,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useFormatterDateHelper } from '~/hooks/helpers/useFormatterDateHelper'
@@ -152,10 +151,10 @@ export const InvoiceCustomerInfos = memo(({ invoice }: InvoiceCustomerInfosProps
               value={invoice?.number}
             />
           )}
-          {invoice?.invoiceType === InvoiceTypeEnum.OneOff && (
+          {!!invoice && (
             <DetailsPage.OverviewLine
               title={translate('text_17822197712867qhfbaf9fpk')}
-              value={invoice?.purchaseOrderNumber || '-'}
+              value={invoice.purchaseOrderNumber || '-'}
             />
           )}
           {invoice?.issuingDate && (

--- a/src/components/invoices/__tests__/InvoiceCustomerInfos.test.tsx
+++ b/src/components/invoices/__tests__/InvoiceCustomerInfos.test.tsx
@@ -200,7 +200,9 @@ describe('InvoiceCustomerInfos', () => {
 
       render(<InvoiceCustomerInfos invoice={mockInvoice} />)
 
-      expect(screen.getByText('-')).toBeInTheDocument()
+      expect(screen.getByText('Payment status').parentElement).toHaveTextContent(
+        /^Payment status-$/,
+      )
     })
 
     it('should format multiple emails with comma and space', () => {
@@ -254,7 +256,7 @@ describe('InvoiceCustomerInfos', () => {
 
       render(<InvoiceCustomerInfos invoice={mockInvoice} />)
 
-      expect(screen.getByText('PO number')).toBeInTheDocument()
+      expect(screen.getByText('PO number').parentElement).toHaveTextContent(/^PO number-$/)
     })
 
     it('should handle null invoice gracefully', () => {

--- a/src/components/invoices/__tests__/InvoiceCustomerInfos.test.tsx
+++ b/src/components/invoices/__tests__/InvoiceCustomerInfos.test.tsx
@@ -232,20 +232,19 @@ describe('InvoiceCustomerInfos', () => {
       ).toBeInTheDocument()
     })
 
-    it.each([
-      InvoiceTypeEnum.OneOff,
-      InvoiceTypeEnum.Subscription,
-      InvoiceTypeEnum.Credit,
-    ])('should render the purchase order number for %s invoices', (invoiceType) => {
-      const mockInvoice = createMockInvoice({
-        invoiceType,
-        purchaseOrderNumber: 'PO-12345',
-      })
+    it.each(Object.values(InvoiceTypeEnum))(
+      'should render the purchase order number for %s invoices',
+      (invoiceType) => {
+        const mockInvoice = createMockInvoice({
+          invoiceType,
+          purchaseOrderNumber: 'PO-12345',
+        })
 
-      render(<InvoiceCustomerInfos invoice={mockInvoice} />)
+        render(<InvoiceCustomerInfos invoice={mockInvoice} />)
 
-      expect(screen.getByText('PO-12345')).toBeInTheDocument()
-    })
+        expect(screen.getByText('PO-12345')).toBeInTheDocument()
+      },
+    )
 
     it('should render a dash for the purchase order number when there is no PO number', () => {
       const mockInvoice = createMockInvoice({

--- a/src/components/invoices/__tests__/InvoiceCustomerInfos.test.tsx
+++ b/src/components/invoices/__tests__/InvoiceCustomerInfos.test.tsx
@@ -232,9 +232,13 @@ describe('InvoiceCustomerInfos', () => {
       ).toBeInTheDocument()
     })
 
-    it('should render purchase order number for one-off invoices', () => {
+    it.each([
+      InvoiceTypeEnum.OneOff,
+      InvoiceTypeEnum.Subscription,
+      InvoiceTypeEnum.Credit,
+    ])('should render the purchase order number for %s invoices', (invoiceType) => {
       const mockInvoice = createMockInvoice({
-        invoiceType: InvoiceTypeEnum.OneOff,
+        invoiceType,
         purchaseOrderNumber: 'PO-12345',
       })
 
@@ -243,16 +247,15 @@ describe('InvoiceCustomerInfos', () => {
       expect(screen.getByText('PO-12345')).toBeInTheDocument()
     })
 
-    it('should not render the purchase order number row for non one-off invoices', () => {
+    it('should render a dash for the purchase order number when there is no PO number', () => {
       const mockInvoice = createMockInvoice({
         invoiceType: InvoiceTypeEnum.Subscription,
-        purchaseOrderNumber: 'PO-12345',
+        purchaseOrderNumber: null,
       })
 
       render(<InvoiceCustomerInfos invoice={mockInvoice} />)
 
-      expect(screen.queryByText('PO number')).not.toBeInTheDocument()
-      expect(screen.queryByText('PO-12345')).not.toBeInTheDocument()
+      expect(screen.getByText('PO number')).toBeInTheDocument()
     })
 
     it('should handle null invoice gracefully', () => {


### PR DESCRIPTION
## Context

As we added a PO number to subscriptions, wallets, and wallet recurring rules, this field should be displayed for all invoice types.

## Description

Deleted restriction by invoice type on Invoice and Credit Note pages.

<!-- Linear link -->
Fixes [BIL-334](https://linear.app/getlago/issue/BIL-334/qa-po-number-is-not-displayed-on-invoice-details-page)