### PR TITLE
feat(purchase_order_number): Add PO number filters

### DIFF
--- a/src/components/designSystem/Filters/FiltersPanelItemTypeSwitch.tsx
+++ b/src/components/designSystem/Filters/FiltersPanelItemTypeSwitch.tsx
@@ -44,6 +44,7 @@ import { FiltersItemPaymentOverdue } from '~/components/designSystem/Filters/fil
 import { FiltersItemPaymentStatus } from '~/components/designSystem/Filters/filtersElements/FiltersItemPaymentStatus'
 import { FiltersItemPeriod } from '~/components/designSystem/Filters/filtersElements/FiltersItemPeriod'
 import { FiltersItemPlanCode } from '~/components/designSystem/Filters/filtersElements/FiltersItemPlanCode'
+import { FiltersItemPurchaseOrderNumber } from '~/components/designSystem/Filters/filtersElements/FiltersItemPurchaseOrderNumber'
 import { FiltersItemQuoteNumber } from '~/components/designSystem/Filters/filtersElements/FiltersItemQuoteNumber'
 import { FiltersItemQuoteOrderType } from '~/components/designSystem/Filters/filtersElements/FiltersItemQuoteOrderType'
 import { FiltersItemQuoteStatus } from '~/components/designSystem/Filters/filtersElements/FiltersItemQuoteStatus'
@@ -131,6 +132,7 @@ export const FiltersPanelItemTypeSwitch = ({
     [AvailableFiltersEnum.paymentStatus]: <FiltersItemPaymentStatus {...props} />,
     [AvailableFiltersEnum.period]: <FiltersItemPeriod {...props} />,
     [AvailableFiltersEnum.planCode]: <FiltersItemPlanCode {...props} />,
+    [AvailableFiltersEnum.purchaseOrderNumber]: <FiltersItemPurchaseOrderNumber {...props} />,
     [AvailableFiltersEnum.requestPaths]: <FiltersItemRequestPath {...props} />,
     [AvailableFiltersEnum.resourceIds]: <FiltersItemResourceIds {...props} />,
     [AvailableFiltersEnum.resourceTypes]: <FiltersItemResourceTypes {...props} />,

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemPurchaseOrderNumber.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemPurchaseOrderNumber.tsx
@@ -16,7 +16,7 @@ export const FiltersItemPurchaseOrderNumber = ({
 
   return (
     <TextInput
-      placeholder={translate('text_17822197712869ou05y6kwt7')}
+      placeholder={translate('text_1741014096283pwl7a5oa69a')}
       value={value}
       onChange={(val) => setFilterValue(val)}
       inputProps={{ maxLength: 255 }}

--- a/src/components/designSystem/Filters/filtersElements/FiltersItemPurchaseOrderNumber.tsx
+++ b/src/components/designSystem/Filters/filtersElements/FiltersItemPurchaseOrderNumber.tsx
@@ -1,0 +1,25 @@
+import { TextInput } from '~/components/form'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+import { FiltersFormValues } from '../types'
+
+type FiltersItemPurchaseOrderNumberProps = {
+  value: FiltersFormValues['filters'][0]['value']
+  setFilterValue: (value: string) => void
+}
+
+export const FiltersItemPurchaseOrderNumber = ({
+  value,
+  setFilterValue,
+}: FiltersItemPurchaseOrderNumberProps) => {
+  const { translate } = useInternationalization()
+
+  return (
+    <TextInput
+      placeholder={translate('text_17822197712869ou05y6kwt7')}
+      value={value}
+      onChange={(val) => setFilterValue(val)}
+      inputProps={{ maxLength: 255 }}
+    />
+  )
+}

--- a/src/components/designSystem/Filters/filtersElements/__tests__/FiltersItemPurchaseOrderNumber.test.tsx
+++ b/src/components/designSystem/Filters/filtersElements/__tests__/FiltersItemPurchaseOrderNumber.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { AllTheProviders } from '~/test-utils'
+
+import { FiltersItemPurchaseOrderNumber } from '../FiltersItemPurchaseOrderNumber'
+
+const mockSetFilterValue = jest.fn()
+
+const renderComponent = (value?: string) => {
+  return render(
+    <FiltersItemPurchaseOrderNumber value={value} setFilterValue={mockSetFilterValue} />,
+    {
+      wrapper: AllTheProviders,
+    },
+  )
+}
+
+describe('FiltersItemPurchaseOrderNumber', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN no initial value', () => {
+    it('THEN displays an empty text input', async () => {
+      renderComponent()
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox')).toHaveValue('')
+      })
+    })
+  })
+
+  describe('GIVEN an initial value', () => {
+    it('THEN displays the value in the text input', async () => {
+      renderComponent('PO-1234')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox')).toHaveValue('PO-1234')
+      })
+    })
+  })
+
+  describe('WHEN the user types a value', () => {
+    it('THEN calls setFilterValue with the typed value', async () => {
+      renderComponent()
+
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'PO-1234' } })
+
+      await waitFor(() => {
+        expect(mockSetFilterValue).toHaveBeenCalledWith('PO-1234')
+      })
+    })
+  })
+
+  it('THEN caps the input at 255 characters', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveAttribute('maxlength', '255')
+    })
+  })
+})

--- a/src/components/designSystem/Filters/types.ts
+++ b/src/components/designSystem/Filters/types.ts
@@ -87,6 +87,7 @@ export enum AvailableFiltersEnum {
   paymentOverdue = 'paymentOverdue',
   paymentStatus = 'paymentStatus',
   planCode = 'planCode',
+  purchaseOrderNumber = 'purchaseOrderNumber',
   orderFormCreatedAt = 'orderFormCreatedAt',
   orderFormNumber = 'orderFormNumber',
   orderFormStatus = 'orderFormStatus',
@@ -130,6 +131,7 @@ export const CreditNoteAvailableFilters = [
   AvailableFiltersEnum.creditNoteRefundStatus,
   AvailableFiltersEnum.selfBilled,
   AvailableFiltersEnum.billingEntityIds,
+  AvailableFiltersEnum.purchaseOrderNumber,
 ]
 
 export const InvoiceAvailableFilters = [
@@ -146,6 +148,7 @@ export const InvoiceAvailableFilters = [
   AvailableFiltersEnum.amount,
   AvailableFiltersEnum.selfBilled,
   AvailableFiltersEnum.billingEntityIds,
+  AvailableFiltersEnum.purchaseOrderNumber,
 ]
 
 export const RevenueStreamsAvailablePopperFilters = [
@@ -397,6 +400,7 @@ const translationMap: Record<AvailableFiltersEnum, string> = {
   [AvailableFiltersEnum.paymentOverdue]: 'text_666c5b12fea4aa1e1b26bf55',
   [AvailableFiltersEnum.paymentStatus]: 'text_63eba8c65a6c8043feee2a0f',
   [AvailableFiltersEnum.planCode]: 'text_642d5eb2783a2ad10d670320',
+  [AvailableFiltersEnum.purchaseOrderNumber]: 'text_17822197712867qhfbaf9fpk',
   [AvailableFiltersEnum.orderFormCreatedAt]: 'text_1776870266380s3zbpmnfrhj',
   [AvailableFiltersEnum.orderFormNumber]: 'text_1781624189693d7zcv2vog4c',
   [AvailableFiltersEnum.orderFormStatus]: 'text_63ac86d797f728a87b2f9fa7',

--- a/src/components/designSystem/Filters/utils.ts
+++ b/src/components/designSystem/Filters/utils.ts
@@ -242,6 +242,7 @@ export const FILTER_VALUE_MAP: Record<AvailableFiltersEnum, Function> = {
   [AvailableFiltersEnum.paymentOverdue]: (value: string) => value === 'true',
   [AvailableFiltersEnum.paymentStatus]: (value: string) => (value as string).split(','),
   [AvailableFiltersEnum.planCode]: (value: string) => value,
+  [AvailableFiltersEnum.purchaseOrderNumber]: (value: string) => value,
   [AvailableFiltersEnum.orderFormCreatedAt]: (value: string) => {
     return {
       createdAtFrom: value.split(',')[0],
@@ -403,6 +404,7 @@ type CreditNotesQueryFilters = Partial<
     | 'types'
     | 'selfBilled'
     | 'billingEntityIds'
+    | 'purchaseOrderNumber'
   >
 >
 
@@ -442,6 +444,7 @@ type InvoiceQueryFilters = Partial<
     | 'amountTo'
     | 'selfBilled'
     | 'billingEntityIds'
+    | 'purchaseOrderNumber'
   >
 >
 
@@ -994,6 +997,8 @@ export const formatActiveFilterValueDisplay = (
     case AvailableFiltersEnum.billingEntityCode:
       return value
     case AvailableFiltersEnum.externalId:
+      return value
+    case AvailableFiltersEnum.purchaseOrderNumber:
       return value
     default:
       return value

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -7730,6 +7730,7 @@ export type QueryCreditNotesArgs = {
   issuingDateTo?: InputMaybe<Scalars['ISO8601Date']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   page?: InputMaybe<Scalars['Int']['input']>;
+  purchaseOrderNumber?: InputMaybe<Scalars['String']['input']>;
   reason?: InputMaybe<Array<CreditNoteReasonEnum>>;
   refundStatus?: InputMaybe<Array<CreditNoteRefundStatusEnum>>;
   searchTerm?: InputMaybe<Scalars['String']['input']>;
@@ -8128,6 +8129,7 @@ export type QueryInvoicesArgs = {
   paymentOverdue?: InputMaybe<Scalars['Boolean']['input']>;
   paymentStatus?: InputMaybe<Array<InvoicePaymentStatusTypeEnum>>;
   positiveDueAmount?: InputMaybe<Scalars['Boolean']['input']>;
+  purchaseOrderNumber?: InputMaybe<Scalars['String']['input']>;
   searchTerm?: InputMaybe<Scalars['String']['input']>;
   selfBilled?: InputMaybe<Scalars['Boolean']['input']>;
   settlements?: InputMaybe<Array<InvoiceSettlementTypeEnum>>;
@@ -13606,6 +13608,7 @@ export type GetCreditNotesListQueryVariables = Exact<{
   currency?: InputMaybe<CurrencyEnum>;
   customerExternalId?: InputMaybe<Scalars['String']['input']>;
   invoiceNumber?: InputMaybe<Scalars['String']['input']>;
+  purchaseOrderNumber?: InputMaybe<Scalars['String']['input']>;
   issuingDateFrom?: InputMaybe<Scalars['ISO8601Date']['input']>;
   issuingDateTo?: InputMaybe<Scalars['ISO8601Date']['input']>;
   reason?: InputMaybe<Array<CreditNoteReasonEnum> | CreditNoteReasonEnum>;
@@ -13872,6 +13875,7 @@ export type GetInvoicesListQueryVariables = Exact<{
   paymentDisputeLost?: InputMaybe<Scalars['Boolean']['input']>;
   paymentOverdue?: InputMaybe<Scalars['Boolean']['input']>;
   paymentStatus?: InputMaybe<Array<InvoicePaymentStatusTypeEnum> | InvoicePaymentStatusTypeEnum>;
+  purchaseOrderNumber?: InputMaybe<Scalars['String']['input']>;
   searchTerm?: InputMaybe<Scalars['String']['input']>;
   settlements?: InputMaybe<Array<InvoiceSettlementTypeEnum> | InvoiceSettlementTypeEnum>;
   status?: InputMaybe<Array<InvoiceStatusTypeEnum> | InvoiceStatusTypeEnum>;
@@ -35501,7 +35505,7 @@ export type CreatePaymentMutationHookResult = ReturnType<typeof useCreatePayment
 export type CreatePaymentMutationResult = Apollo.MutationResult<CreatePaymentMutation>;
 export type CreatePaymentMutationOptions = Apollo.BaseMutationOptions<CreatePaymentMutation, CreatePaymentMutationVariables>;
 export const GetCreditNotesListDocument = gql`
-    query getCreditNotesList($amountFrom: Int, $amountTo: Int, $creditStatus: [CreditNoteCreditStatusEnum!], $currency: CurrencyEnum, $customerExternalId: String, $invoiceNumber: String, $issuingDateFrom: ISO8601Date, $issuingDateTo: ISO8601Date, $reason: [CreditNoteReasonEnum!], $refundStatus: [CreditNoteRefundStatusEnum!], $types: [CreditNoteTypeEnum!], $limit: Int, $page: Int, $searchTerm: String, $selfBilled: Boolean, $billingEntityIds: [ID!]) {
+    query getCreditNotesList($amountFrom: Int, $amountTo: Int, $creditStatus: [CreditNoteCreditStatusEnum!], $currency: CurrencyEnum, $customerExternalId: String, $invoiceNumber: String, $purchaseOrderNumber: String, $issuingDateFrom: ISO8601Date, $issuingDateTo: ISO8601Date, $reason: [CreditNoteReasonEnum!], $refundStatus: [CreditNoteRefundStatusEnum!], $types: [CreditNoteTypeEnum!], $limit: Int, $page: Int, $searchTerm: String, $selfBilled: Boolean, $billingEntityIds: [ID!]) {
   creditNotes(
     amountFrom: $amountFrom
     amountTo: $amountTo
@@ -35509,6 +35513,7 @@ export const GetCreditNotesListDocument = gql`
     currency: $currency
     customerExternalId: $customerExternalId
     invoiceNumber: $invoiceNumber
+    purchaseOrderNumber: $purchaseOrderNumber
     issuingDateFrom: $issuingDateFrom
     issuingDateTo: $issuingDateTo
     reason: $reason
@@ -36670,7 +36675,7 @@ export type OktaAcceptInviteMutationHookResult = ReturnType<typeof useOktaAccept
 export type OktaAcceptInviteMutationResult = Apollo.MutationResult<OktaAcceptInviteMutation>;
 export type OktaAcceptInviteMutationOptions = Apollo.BaseMutationOptions<OktaAcceptInviteMutation, OktaAcceptInviteMutationVariables>;
 export const GetInvoicesListDocument = gql`
-    query getInvoicesList($currency: CurrencyEnum, $customerExternalId: String, $invoiceType: [InvoiceTypeEnum!], $issuingDateFrom: ISO8601Date, $issuingDateTo: ISO8601Date, $limit: Int, $page: Int, $partiallyPaid: Boolean, $paymentDisputeLost: Boolean, $paymentOverdue: Boolean, $paymentStatus: [InvoicePaymentStatusTypeEnum!], $searchTerm: String, $settlements: [InvoiceSettlementTypeEnum!], $status: [InvoiceStatusTypeEnum!], $amountFrom: Int, $amountTo: Int, $selfBilled: Boolean, $billingEntityIds: [ID!]) {
+    query getInvoicesList($currency: CurrencyEnum, $customerExternalId: String, $invoiceType: [InvoiceTypeEnum!], $issuingDateFrom: ISO8601Date, $issuingDateTo: ISO8601Date, $limit: Int, $page: Int, $partiallyPaid: Boolean, $paymentDisputeLost: Boolean, $paymentOverdue: Boolean, $paymentStatus: [InvoicePaymentStatusTypeEnum!], $purchaseOrderNumber: String, $searchTerm: String, $settlements: [InvoiceSettlementTypeEnum!], $status: [InvoiceStatusTypeEnum!], $amountFrom: Int, $amountTo: Int, $selfBilled: Boolean, $billingEntityIds: [ID!]) {
   invoices(
     currency: $currency
     customerExternalId: $customerExternalId
@@ -36683,6 +36688,7 @@ export const GetInvoicesListDocument = gql`
     paymentDisputeLost: $paymentDisputeLost
     paymentOverdue: $paymentOverdue
     paymentStatus: $paymentStatus
+    purchaseOrderNumber: $purchaseOrderNumber
     searchTerm: $searchTerm
     settlements: $settlements
     status: $status

--- a/src/pages/CreditNotesPage.tsx
+++ b/src/pages/CreditNotesPage.tsx
@@ -39,6 +39,7 @@ gql`
     $currency: CurrencyEnum
     $customerExternalId: String
     $invoiceNumber: String
+    $purchaseOrderNumber: String
     $issuingDateFrom: ISO8601Date
     $issuingDateTo: ISO8601Date
     $reason: [CreditNoteReasonEnum!]
@@ -57,6 +58,7 @@ gql`
       currency: $currency
       customerExternalId: $customerExternalId
       invoiceNumber: $invoiceNumber
+      purchaseOrderNumber: $purchaseOrderNumber
       issuingDateFrom: $issuingDateFrom
       issuingDateTo: $issuingDateTo
       reason: $reason
@@ -215,6 +217,7 @@ const CreditNotesPage = () => {
               AvailableFiltersEnum.issuingDate,
               AvailableFiltersEnum.creditNoteReason,
               AvailableFiltersEnum.creditNoteRefundStatus,
+              AvailableFiltersEnum.purchaseOrderNumber,
               ...(hasAccessToRevenueShare ? [AvailableFiltersEnum.selfBilled] : []),
             ]}
           >

--- a/src/pages/InvoicesPage.tsx
+++ b/src/pages/InvoicesPage.tsx
@@ -53,6 +53,7 @@ gql`
     $paymentDisputeLost: Boolean
     $paymentOverdue: Boolean
     $paymentStatus: [InvoicePaymentStatusTypeEnum!]
+    $purchaseOrderNumber: String
     $searchTerm: String
     $settlements: [InvoiceSettlementTypeEnum!]
     $status: [InvoiceStatusTypeEnum!]
@@ -73,6 +74,7 @@ gql`
       paymentDisputeLost: $paymentDisputeLost
       paymentOverdue: $paymentOverdue
       paymentStatus: $paymentStatus
+      purchaseOrderNumber: $purchaseOrderNumber
       searchTerm: $searchTerm
       settlements: $settlements
       status: $status
@@ -278,6 +280,7 @@ const InvoicesPage = () => {
               AvailableFiltersEnum.paymentDisputeLost,
               AvailableFiltersEnum.paymentOverdue,
               AvailableFiltersEnum.settlementType,
+              AvailableFiltersEnum.purchaseOrderNumber,
               ...(hasAccessToRevenueShare ? [AvailableFiltersEnum.selfBilled] : []),
             ]}
           >


### PR DESCRIPTION
## Context

It should be possible to filter invoices and credit notes by purchase order number.
Rules:
- free text field
- case-insensitive
- max length 255
- exact match

## Description

Added PO number to invoices and credit notes filters.

<!-- Linear link -->
[BIL-342](https://linear.app/getlago/issue/BIL-342/fe-add-po-number-to-invoice-and-credit-notes-filters)