### PR TITLE
feat(purchase_order_number): Add PO number to Regenerate voided invoice screen

### DIFF
--- a/src/components/invoices/InvoiceCustomerInfos.tsx
+++ b/src/components/invoices/InvoiceCustomerInfos.tsx
@@ -7,7 +7,7 @@ import { generatePath } from 'react-router-dom'
 import { ConditionalWrapper } from '~/components/ConditionalWrapper'
 import { Status, StatusType } from '~/components/designSystem/Status'
 import { Typography } from '~/components/designSystem/Typography'
-import { PO } from '~/components/purchaseOrder/PO'
+import { PurchaseOrder } from '~/components/purchaseOrder/PO'
 import { invoiceStatusMapping, paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
 import { formatAddress } from '~/core/formats/formatAddress'
 import { CUSTOMER_DETAILS_ROUTE, Link } from '~/core/router'
@@ -87,6 +87,33 @@ const InvoiceCustomerInfosComponent = ({
     zipcode: customer?.zipcode,
   })
 
+  const renderPurchaseOrderValue = () => {
+    if (!onPurchaseOrderNumberChange) {
+      return invoice?.purchaseOrderNumber || '-'
+    }
+
+    return (
+      <PurchaseOrder
+        className="flex-row items-center gap-2"
+        value={purchaseOrderNumber}
+        onChange={onPurchaseOrderNumberChange}
+        description={translate('text_1782219771286e8qwitkefxr')}
+      >
+        {purchaseOrderNumber ? (
+          <>
+            <PurchaseOrder.Number variant="body" color="grey700" />
+            <PurchaseOrder.EditButton />
+            <PurchaseOrder.TrashButton />
+          </>
+        ) : (
+          <PurchaseOrder.AddButton>
+            {translate('text_17822197712864tnvgq76xou')}
+          </PurchaseOrder.AddButton>
+        )}
+      </PurchaseOrder>
+    )
+  }
+
   return (
     <DetailsPage.Overview
       leftColumn={
@@ -161,28 +188,7 @@ const InvoiceCustomerInfosComponent = ({
           {!!invoice && (
             <DetailsPage.OverviewLine
               title={translate('text_17822197712867qhfbaf9fpk')}
-              value={
-                onPurchaseOrderNumberChange ? (
-                  <PO
-                    className="flex-row items-center gap-2"
-                    value={purchaseOrderNumber}
-                    onChange={onPurchaseOrderNumberChange}
-                    description={translate('text_1782219771286e8qwitkefxr')}
-                  >
-                    {purchaseOrderNumber ? (
-                      <>
-                        <PO.Number variant="body" color="grey700" />
-                        <PO.EditButton />
-                        <PO.TrashButton />
-                      </>
-                    ) : (
-                      <PO.AddButton>{translate('text_17822197712864tnvgq76xou')}</PO.AddButton>
-                    )}
-                  </PO>
-                ) : (
-                  invoice.purchaseOrderNumber || '-'
-                )
-              }
+              value={renderPurchaseOrderValue()}
             />
           )}
           {invoice?.issuingDate && (

--- a/src/components/invoices/InvoiceCustomerInfos.tsx
+++ b/src/components/invoices/InvoiceCustomerInfos.tsx
@@ -7,6 +7,7 @@ import { generatePath } from 'react-router-dom'
 import { ConditionalWrapper } from '~/components/ConditionalWrapper'
 import { Status, StatusType } from '~/components/designSystem/Status'
 import { Typography } from '~/components/designSystem/Typography'
+import { PO } from '~/components/purchaseOrder/PO'
 import { invoiceStatusMapping, paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
 import { formatAddress } from '~/core/formats/formatAddress'
 import { CUSTOMER_DETAILS_ROUTE, Link } from '~/core/router'
@@ -61,9 +62,18 @@ gql`
 
 interface InvoiceCustomerInfosProps {
   invoice?: InvoiceForInvoiceInfosFragment | null
+  // When provided, the PO number line becomes editable (add/edit/delete + modal).
+  // `purchaseOrderNumber` is the controlled value; omitting `onPurchaseOrderNumberChange`
+  // keeps the line read-only (default everywhere except the regenerate screen).
+  purchaseOrderNumber?: string | null
+  onPurchaseOrderNumberChange?: (value: string | null) => void
 }
 
-export const InvoiceCustomerInfos = memo(({ invoice }: InvoiceCustomerInfosProps) => {
+const InvoiceCustomerInfosComponent = ({
+  invoice,
+  purchaseOrderNumber,
+  onPurchaseOrderNumberChange,
+}: InvoiceCustomerInfosProps) => {
   const { customer } = invoice || {}
   const { formattedDateWithTimezone } = useFormatterDateHelper()
   const { translate } = useInternationalization()
@@ -154,7 +164,28 @@ export const InvoiceCustomerInfos = memo(({ invoice }: InvoiceCustomerInfosProps
           {!!invoice && (
             <DetailsPage.OverviewLine
               title={translate('text_17822197712867qhfbaf9fpk')}
-              value={invoice.purchaseOrderNumber || '-'}
+              value={
+                onPurchaseOrderNumberChange ? (
+                  <PO
+                    className="flex-row items-center gap-2"
+                    value={purchaseOrderNumber}
+                    onChange={onPurchaseOrderNumberChange}
+                    description={translate('text_1782219771286e8qwitkefxr')}
+                  >
+                    {purchaseOrderNumber ? (
+                      <>
+                        <PO.Number variant="body" color="grey700" />
+                        <PO.EditButton />
+                        <PO.TrashButton />
+                      </>
+                    ) : (
+                      <PO.AddButton>{translate('text_17822197712864tnvgq76xou')}</PO.AddButton>
+                    )}
+                  </PO>
+                ) : (
+                  invoice.purchaseOrderNumber || '-'
+                )
+              }
             />
           )}
           {invoice?.issuingDate && (
@@ -221,6 +252,8 @@ export const InvoiceCustomerInfos = memo(({ invoice }: InvoiceCustomerInfosProps
       }
     />
   )
-})
+}
+
+export const InvoiceCustomerInfos = memo(InvoiceCustomerInfosComponent)
 
 InvoiceCustomerInfos.displayName = 'InvoiceCustomerInfos'

--- a/src/components/invoices/InvoiceCustomerInfos.tsx
+++ b/src/components/invoices/InvoiceCustomerInfos.tsx
@@ -62,9 +62,6 @@ gql`
 
 interface InvoiceCustomerInfosProps {
   invoice?: InvoiceForInvoiceInfosFragment | null
-  // When provided, the PO number line becomes editable (add/edit/delete + modal).
-  // `purchaseOrderNumber` is the controlled value; omitting `onPurchaseOrderNumberChange`
-  // keeps the line read-only (default everywhere except the regenerate screen).
   purchaseOrderNumber?: string | null
   onPurchaseOrderNumberChange?: (value: string | null) => void
 }

--- a/src/components/invoices/__tests__/InvoiceCustomerInfos.test.tsx
+++ b/src/components/invoices/__tests__/InvoiceCustomerInfos.test.tsx
@@ -3,6 +3,11 @@ import { Settings } from 'luxon'
 
 import { InvoiceCustomerInfos } from '~/components/invoices/InvoiceCustomerInfos'
 import {
+  PURCHASE_ORDER_ADD_BUTTON_TEST_ID,
+  PURCHASE_ORDER_EDIT_BUTTON_TEST_ID,
+  PURCHASE_ORDER_TRASH_BUTTON_TEST_ID,
+} from '~/components/purchaseOrder/PurchaseOrderButtons'
+import {
   CountryCode,
   CustomerAccountTypeEnum,
   InvoiceForInvoiceInfosFragment,
@@ -257,6 +262,32 @@ describe('InvoiceCustomerInfos', () => {
       render(<InvoiceCustomerInfos invoice={mockInvoice} />)
 
       expect(screen.getByText('PO number').parentElement).toHaveTextContent(/^PO number-$/)
+    })
+
+    it('should render an editable "add" button for the PO number when a change handler is provided and there is no value', () => {
+      const mockInvoice = createMockInvoice({ purchaseOrderNumber: null })
+
+      render(<InvoiceCustomerInfos invoice={mockInvoice} onPurchaseOrderNumberChange={jest.fn()} />)
+
+      expect(screen.getByTestId(PURCHASE_ORDER_ADD_BUTTON_TEST_ID)).toBeInTheDocument()
+      expect(screen.queryByTestId(PURCHASE_ORDER_EDIT_BUTTON_TEST_ID)).not.toBeInTheDocument()
+    })
+
+    it('should render the PO number with edit/delete controls when a change handler and value are provided', () => {
+      const mockInvoice = createMockInvoice()
+
+      render(
+        <InvoiceCustomerInfos
+          invoice={mockInvoice}
+          purchaseOrderNumber="PO-EDITABLE"
+          onPurchaseOrderNumberChange={jest.fn()}
+        />,
+      )
+
+      expect(screen.getByText('PO-EDITABLE')).toBeInTheDocument()
+      expect(screen.getByTestId(PURCHASE_ORDER_EDIT_BUTTON_TEST_ID)).toBeInTheDocument()
+      expect(screen.getByTestId(PURCHASE_ORDER_TRASH_BUTTON_TEST_ID)).toBeInTheDocument()
+      expect(screen.queryByTestId(PURCHASE_ORDER_ADD_BUTTON_TEST_ID)).not.toBeInTheDocument()
     })
 
     it('should handle null invoice gracefully', () => {

--- a/src/components/purchaseOrder/PO.tsx
+++ b/src/components/purchaseOrder/PO.tsx
@@ -11,7 +11,7 @@ import { PurchaseOrderTitle } from './PurchaseOrderTitle'
 
 export { normalizePurchaseOrderNumber } from './utils'
 
-export const PO = Object.assign(PurchaseOrderRoot, {
+export const PurchaseOrder = Object.assign(PurchaseOrderRoot, {
   Title: PurchaseOrderTitle,
   Description: PurchaseOrderDescription,
   Number: PurchaseOrderNumber,

--- a/src/components/purchaseOrder/PurchaseOrderFormBlock.tsx
+++ b/src/components/purchaseOrder/PurchaseOrderFormBlock.tsx
@@ -35,6 +35,49 @@ export const PurchaseOrderFormBlock = ({
     }
   }, [value])
 
+  const renderInputOrAddButton = () => {
+    if (!showInput) {
+      return (
+        <PurchaseOrder.AddButton
+          onClick={() => {
+            setFocusOnReveal(true)
+            setShowInput(true)
+          }}
+        />
+      )
+    }
+
+    // Mirrors the metrics of sibling input+trash rows (e.g. the subscription
+    // name row): medium trash button so both inputs end at the same width.
+    return (
+      <div className="flex items-center gap-3">
+        <TextInput
+          className="grow"
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus={focusOnReveal}
+          value={value || ''}
+          placeholder={translate(PURCHASE_ORDER_TRANSLATIONS.placeholder)}
+          disabled={disabled}
+          error={
+            (value?.length ?? 0) > PURCHASE_ORDER_NUMBER_MAX_LENGTH
+              ? translate(PURCHASE_ORDER_TRANSLATIONS.maxLength)
+              : undefined
+          }
+          onChange={(newValue) => onChange?.(newValue)}
+          data-test={PURCHASE_ORDER_FORM_BLOCK_INPUT_TEST_ID}
+        />
+        <PurchaseOrder.TrashButton
+          size="medium"
+          onClick={() => {
+            onChange?.(null)
+            setShowInput(false)
+            setFocusOnReveal(false)
+          }}
+        />
+      </div>
+    )
+  }
+
   return (
     <PurchaseOrder
       className="gap-3"
@@ -47,42 +90,7 @@ export const PurchaseOrderFormBlock = ({
         <PurchaseOrder.Title />
         <PurchaseOrder.Description />
       </div>
-      {showInput ? (
-        // Mirrors the metrics of sibling input+trash rows (e.g. the subscription
-        // name row): medium trash button so both inputs end at the same width.
-        <div className="flex items-center gap-3">
-          <TextInput
-            className="grow"
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus={focusOnReveal}
-            value={value || ''}
-            placeholder={translate(PURCHASE_ORDER_TRANSLATIONS.placeholder)}
-            disabled={disabled}
-            error={
-              (value?.length ?? 0) > PURCHASE_ORDER_NUMBER_MAX_LENGTH
-                ? translate(PURCHASE_ORDER_TRANSLATIONS.maxLength)
-                : undefined
-            }
-            onChange={(newValue) => onChange?.(newValue)}
-            data-test={PURCHASE_ORDER_FORM_BLOCK_INPUT_TEST_ID}
-          />
-          <PurchaseOrder.TrashButton
-            size="medium"
-            onClick={() => {
-              onChange?.(null)
-              setShowInput(false)
-              setFocusOnReveal(false)
-            }}
-          />
-        </div>
-      ) : (
-        <PurchaseOrder.AddButton
-          onClick={() => {
-            setFocusOnReveal(true)
-            setShowInput(true)
-          }}
-        />
-      )}
+      {renderInputOrAddButton()}
     </PurchaseOrder>
   )
 }

--- a/src/components/purchaseOrder/PurchaseOrderFormBlock.tsx
+++ b/src/components/purchaseOrder/PurchaseOrderFormBlock.tsx
@@ -4,7 +4,7 @@ import { TextInput } from '~/components/form'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 import { PURCHASE_ORDER_NUMBER_MAX_LENGTH, PURCHASE_ORDER_TRANSLATIONS } from './constants'
-import { PO } from './PO'
+import { PurchaseOrder } from './PO'
 import { PurchaseOrderRootProps } from './types'
 import { normalizePurchaseOrderNumber } from './utils'
 
@@ -36,10 +36,16 @@ export const PurchaseOrderFormBlock = ({
   }, [value])
 
   return (
-    <PO className="gap-3" value={value} onChange={onChange} disabled={disabled} {...props}>
+    <PurchaseOrder
+      className="gap-3"
+      value={value}
+      onChange={onChange}
+      disabled={disabled}
+      {...props}
+    >
       <div className="flex flex-col gap-1">
-        <PO.Title />
-        <PO.Description />
+        <PurchaseOrder.Title />
+        <PurchaseOrder.Description />
       </div>
       {showInput ? (
         // Mirrors the metrics of sibling input+trash rows (e.g. the subscription
@@ -60,7 +66,7 @@ export const PurchaseOrderFormBlock = ({
             onChange={(newValue) => onChange?.(newValue)}
             data-test={PURCHASE_ORDER_FORM_BLOCK_INPUT_TEST_ID}
           />
-          <PO.TrashButton
+          <PurchaseOrder.TrashButton
             size="medium"
             onClick={() => {
               onChange?.(null)
@@ -70,13 +76,13 @@ export const PurchaseOrderFormBlock = ({
           />
         </div>
       ) : (
-        <PO.AddButton
+        <PurchaseOrder.AddButton
           onClick={() => {
             setFocusOnReveal(true)
             setShowInput(true)
           }}
         />
       )}
-    </PO>
+    </PurchaseOrder>
   )
 }

--- a/src/components/purchaseOrder/__tests__/PurchaseOrder.test.tsx
+++ b/src/components/purchaseOrder/__tests__/PurchaseOrder.test.tsx
@@ -7,7 +7,7 @@ import { FORM_DIALOG_NAME, FORM_DIALOG_TEST_ID } from '~/components/dialogs/cons
 import FormDialog from '~/components/dialogs/FormDialog'
 import { render } from '~/test-utils'
 
-import { normalizePurchaseOrderNumber, PO } from '../PO'
+import { normalizePurchaseOrderNumber, PurchaseOrder } from '../PO'
 import {
   PURCHASE_ORDER_ADD_BUTTON_TEST_ID,
   PURCHASE_ORDER_EDIT_BUTTON_TEST_ID,
@@ -24,7 +24,7 @@ const NiceModalWrapper = ({ children }: { children: ReactNode }) => (
   <NiceModal.Provider>{children}</NiceModal.Provider>
 )
 
-describe('PO compound component', () => {
+describe('PurchaseOrder compound component', () => {
   afterEach(() => {
     cleanup()
     jest.clearAllMocks()
@@ -33,13 +33,13 @@ describe('PO compound component', () => {
   describe('GIVEN the compound API', () => {
     describe('WHEN accessing its parts', () => {
       it.each([
-        ['Title', PO.Title],
-        ['Description', PO.Description],
-        ['Number', PO.Number],
-        ['AddButton', PO.AddButton],
-        ['EditButton', PO.EditButton],
-        ['TrashButton', PO.TrashButton],
-        ['DynamicInputButton', PO.DynamicInputButton],
+        ['Title', PurchaseOrder.Title],
+        ['Description', PurchaseOrder.Description],
+        ['Number', PurchaseOrder.Number],
+        ['AddButton', PurchaseOrder.AddButton],
+        ['EditButton', PurchaseOrder.EditButton],
+        ['TrashButton', PurchaseOrder.TrashButton],
+        ['DynamicInputButton', PurchaseOrder.DynamicInputButton],
       ])('THEN should expose the %s sub-component', (_, part) => {
         expect(part).toBeDefined()
       })
@@ -55,10 +55,10 @@ describe('PO compound component', () => {
       it('THEN should render the root container', () => {
         render(
           <NiceModalWrapper>
-            <PO value="PO-123">
-              <PO.Title />
-              <PO.Number />
-            </PO>
+            <PurchaseOrder value="PO-123">
+              <PurchaseOrder.Title />
+              <PurchaseOrder.Number />
+            </PurchaseOrder>
           </NiceModalWrapper>,
         )
 
@@ -68,9 +68,9 @@ describe('PO compound component', () => {
       it('THEN should render the title', () => {
         render(
           <NiceModalWrapper>
-            <PO value="PO-123">
-              <PO.Title />
-            </PO>
+            <PurchaseOrder value="PO-123">
+              <PurchaseOrder.Title />
+            </PurchaseOrder>
           </NiceModalWrapper>,
         )
 
@@ -80,9 +80,9 @@ describe('PO compound component', () => {
       it('THEN should render the normalized number value', () => {
         render(
           <NiceModalWrapper>
-            <PO value="  PO-123  ">
-              <PO.Number />
-            </PO>
+            <PurchaseOrder value="  PO-123  ">
+              <PurchaseOrder.Number />
+            </PurchaseOrder>
           </NiceModalWrapper>,
         )
 
@@ -96,9 +96,9 @@ describe('PO compound component', () => {
       it('THEN should render the default placeholder', () => {
         render(
           <NiceModalWrapper>
-            <PO value={null}>
-              <PO.Number />
-            </PO>
+            <PurchaseOrder value={null}>
+              <PurchaseOrder.Number />
+            </PurchaseOrder>
           </NiceModalWrapper>,
         )
 
@@ -108,9 +108,9 @@ describe('PO compound component', () => {
       it('THEN should render a custom placeholder when provided', () => {
         render(
           <NiceModalWrapper>
-            <PO value={null}>
-              <PO.Number placeholder="No PO" />
-            </PO>
+            <PurchaseOrder value={null}>
+              <PurchaseOrder.Number placeholder="No PO" />
+            </PurchaseOrder>
           </NiceModalWrapper>,
         )
 
@@ -124,9 +124,9 @@ describe('PO compound component', () => {
       it('THEN should render the root description', () => {
         render(
           <NiceModalWrapper>
-            <PO value={null} description="Displayed on the invoice">
-              <PO.Description />
-            </PO>
+            <PurchaseOrder value={null} description="Displayed on the invoice">
+              <PurchaseOrder.Description />
+            </PurchaseOrder>
           </NiceModalWrapper>,
         )
 
@@ -140,9 +140,9 @@ describe('PO compound component', () => {
       it('THEN should render the children over the root description', () => {
         render(
           <NiceModalWrapper>
-            <PO value={null} description="Root description">
-              <PO.Description>Override description</PO.Description>
-            </PO>
+            <PurchaseOrder value={null} description="Root description">
+              <PurchaseOrder.Description>Override description</PurchaseOrder.Description>
+            </PurchaseOrder>
           </NiceModalWrapper>,
         )
 
@@ -156,9 +156,9 @@ describe('PO compound component', () => {
       it('THEN should render nothing', () => {
         render(
           <NiceModalWrapper>
-            <PO value={null}>
-              <PO.Description />
-            </PO>
+            <PurchaseOrder value={null}>
+              <PurchaseOrder.Description />
+            </PurchaseOrder>
           </NiceModalWrapper>,
         )
 
@@ -172,9 +172,9 @@ describe('PO compound component', () => {
       it('THEN should disable the add button', () => {
         render(
           <NiceModalWrapper>
-            <PO value={null} disabled>
-              <PO.AddButton />
-            </PO>
+            <PurchaseOrder value={null} disabled>
+              <PurchaseOrder.AddButton />
+            </PurchaseOrder>
           </NiceModalWrapper>,
         )
 
@@ -191,9 +191,9 @@ describe('PO compound component', () => {
 
         render(
           <NiceModalWrapper>
-            <PO value="PO-123" onChange={onChange}>
-              <PO.TrashButton />
-            </PO>
+            <PurchaseOrder value="PO-123" onChange={onChange}>
+              <PurchaseOrder.TrashButton />
+            </PurchaseOrder>
           </NiceModalWrapper>,
         )
 
@@ -211,9 +211,9 @@ describe('PO compound component', () => {
 
         render(
           <NiceModalWrapper>
-            <PO value={null}>
-              <PO.AddButton />
-            </PO>
+            <PurchaseOrder value={null}>
+              <PurchaseOrder.AddButton />
+            </PurchaseOrder>
           </NiceModalWrapper>,
         )
 
@@ -231,9 +231,9 @@ describe('PO compound component', () => {
 
         render(
           <NiceModalWrapper>
-            <PO value="PO-123">
-              <PO.EditButton />
-            </PO>
+            <PurchaseOrder value="PO-123">
+              <PurchaseOrder.EditButton />
+            </PurchaseOrder>
           </NiceModalWrapper>,
         )
 

--- a/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
+++ b/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
@@ -321,6 +321,12 @@ export const SubscriptionInformationFormSection = withForm({
               <PurchaseOrderFormBlock
                 value={field.state.value}
                 description={translate('text_1783511588872qmkjh4n14du')}
+                // PO number is only editable while the subscription is pending or active.
+                disabled={
+                  formType === FORM_TYPE_ENUM.edition &&
+                  subscription?.status !== StatusTypeEnum.Pending &&
+                  subscription?.status !== StatusTypeEnum.Active
+                }
                 onChange={(value) => field.handleChange(value ?? undefined)}
               />
             )}

--- a/src/components/subscriptions/form/__tests__/SubscriptionInformationFormSection.test.tsx
+++ b/src/components/subscriptions/form/__tests__/SubscriptionInformationFormSection.test.tsx
@@ -1,10 +1,11 @@
 import { screen } from '@testing-library/react'
 
+import { PURCHASE_ORDER_ADD_BUTTON_TEST_ID } from '~/components/purchaseOrder/PurchaseOrderButtons'
 import { FORM_TYPE_ENUM } from '~/core/constants/form'
-import { BillingTimeEnum, PlanInterval } from '~/generated/graphql'
+import { BillingTimeEnum, PlanInterval, StatusTypeEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
-import { SubscriptionFormType } from '../buildSubscriptionDefaultValues'
+import { SubscriptionDefaultsSource, SubscriptionFormType } from '../buildSubscriptionDefaultValues'
 import { SubscriptionInformationFormSection } from '../SubscriptionInformationFormSection'
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
@@ -115,6 +116,7 @@ const createMockForm = (values: Record<string, unknown> = {}) => ({
 const renderSection = (
   overrides: Partial<{
     formType: SubscriptionFormType
+    subscription: SubscriptionDefaultsSource
     shouldDisplaySubscriptionExternalId: boolean
     shouldDisplaySubscriptionName: boolean
     selectedPlanInterval: PlanInterval
@@ -125,7 +127,7 @@ const renderSection = (
       // @ts-expect-error — mock form shape
       form={createMockForm()}
       formType={overrides.formType ?? FORM_TYPE_ENUM.creation}
-      subscription={undefined}
+      subscription={overrides.subscription}
       customerTimezone={undefined}
       shouldDisplaySubscriptionExternalId={overrides.shouldDisplaySubscriptionExternalId ?? false}
       setShouldDisplaySubscriptionExternalId={jest.fn()}
@@ -165,5 +167,34 @@ describe('SubscriptionInformationFormSection', () => {
       expect(screen.getByTestId('create-subscription-form-wrapper')).toBeInTheDocument()
       expect(screen.queryByText('text_62ea7cd44cd4b14bb9ac1db7')).not.toBeInTheDocument()
     })
+  })
+
+  describe('PO number editability by subscription status', () => {
+    const subscriptionWith = (status: StatusTypeEnum) =>
+      ({ status }) as unknown as SubscriptionDefaultsSource
+
+    it('THEN keeps the PO field editable during creation (no subscription)', () => {
+      renderSection({ formType: FORM_TYPE_ENUM.creation })
+
+      expect(screen.getByTestId(PURCHASE_ORDER_ADD_BUTTON_TEST_ID)).not.toBeDisabled()
+    })
+
+    it.each([StatusTypeEnum.Pending, StatusTypeEnum.Active])(
+      'THEN keeps the PO field editable when editing a %s subscription',
+      (status) => {
+        renderSection({ formType: FORM_TYPE_ENUM.edition, subscription: subscriptionWith(status) })
+
+        expect(screen.getByTestId(PURCHASE_ORDER_ADD_BUTTON_TEST_ID)).not.toBeDisabled()
+      },
+    )
+
+    it.each([StatusTypeEnum.Terminated, StatusTypeEnum.Canceled, StatusTypeEnum.Incomplete])(
+      'THEN disables the PO field when editing a %s subscription',
+      (status) => {
+        renderSection({ formType: FORM_TYPE_ENUM.edition, subscription: subscriptionWith(status) })
+
+        expect(screen.getByTestId(PURCHASE_ORDER_ADD_BUTTON_TEST_ID)).toBeDisabled()
+      },
+    )
   })
 })

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -8566,6 +8566,7 @@ export type RegenerateInvoiceInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   fees: Array<VoidedInvoiceFeeInput>;
+  purchaseOrderNumber?: InputMaybe<Scalars['String']['input']>;
   voidedInvoiceId: Scalars['ID']['input'];
 };
 

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -13687,7 +13687,7 @@ export type GetInvoiceStatusQueryVariables = Exact<{
 }>;
 
 
-export type GetInvoiceStatusQuery = { __typename?: 'Query', invoice?: { __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum } | null };
+export type GetInvoiceStatusQuery = { __typename?: 'Query', invoice?: { __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, purchaseOrderNumber?: string | null } | null };
 
 export type IntegrationsListForCustomerInvoiceDetailsQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -35890,6 +35890,7 @@ export const GetInvoiceStatusDocument = gql`
   invoice(id: $id) {
     id
     status
+    purchaseOrderNumber
   }
 }
     `;

--- a/src/pages/CreateInvoice.tsx
+++ b/src/pages/CreateInvoice.tsx
@@ -29,7 +29,7 @@ import { InvoiceFormInput, LocalFeeInput } from '~/components/invoices/types'
 import { useEditInvoiceDisplayNameDialog } from '~/components/invoices/useEditInvoiceDisplayName'
 import { PaymentMethodsInvoiceSettings } from '~/components/paymentMethodsInvoiceSettings/PaymentMethodsInvoiceSettings'
 import { ViewTypeEnum } from '~/components/paymentMethodsInvoiceSettings/types'
-import { normalizePurchaseOrderNumber, PO } from '~/components/purchaseOrder/PO'
+import { normalizePurchaseOrderNumber, PurchaseOrder } from '~/components/purchaseOrder/PO'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import {
   ADD_ITEM_FOR_INVOICE_INPUT_NAME,
@@ -722,7 +722,7 @@ const CreateInvoice = () => {
                     </Typography>
                   </div>
 
-                  <PO
+                  <PurchaseOrder
                     className="flex-row items-center gap-4"
                     value={formikProps.values.purchaseOrderNumber}
                     onChange={(value) => {
@@ -730,18 +730,24 @@ const CreateInvoice = () => {
                     }}
                     description={translate('text_1782219771286e8qwitkefxr')}
                   >
-                    <PO.Title className="min-w-[200px]" variant="caption" color="grey600" />
+                    <PurchaseOrder.Title
+                      className="min-w-[200px]"
+                      variant="caption"
+                      color="grey600"
+                    />
 
                     {formikProps.values.purchaseOrderNumber ? (
                       <div className="flex items-center gap-2">
-                        <PO.Number variant="body" color="grey700" />
-                        <PO.EditButton />
-                        <PO.TrashButton />
+                        <PurchaseOrder.Number variant="body" color="grey700" />
+                        <PurchaseOrder.EditButton />
+                        <PurchaseOrder.TrashButton />
                       </div>
                     ) : (
-                      <PO.AddButton>{translate('text_17822197712864tnvgq76xou')}</PO.AddButton>
+                      <PurchaseOrder.AddButton>
+                        {translate('text_17822197712864tnvgq76xou')}
+                      </PurchaseOrder.AddButton>
                     )}
-                  </PO>
+                  </PurchaseOrder>
                 </div>
 
                 <div className="flex flex-row items-start gap-4">

--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -219,6 +219,7 @@ gql`
     invoice(id: $id) {
       id
       status
+      purchaseOrderNumber
     }
   }
 

--- a/src/pages/CustomerInvoiceRegenerate.tsx
+++ b/src/pages/CustomerInvoiceRegenerate.tsx
@@ -9,6 +9,7 @@ import { Typography } from '~/components/designSystem/Typography'
 import { EditFeeDrawer, EditFeeDrawerRef } from '~/components/invoices/details/EditFeeDrawer'
 import { InvoiceDetailsTable } from '~/components/invoices/details/InvoiceDetailsTable'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
+import { normalizePurchaseOrderNumber } from '~/components/purchaseOrder/PO'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { LocalTaxProviderErrorsEnum } from '~/core/constants/form'
 import {
@@ -142,6 +143,12 @@ const CustomerInvoiceRegenerate = () => {
       hasInitializedFees.current = true
     }
   }, [fullFees])
+
+  // `undefined` = untouched → fall back to the invoice's current PO number;
+  // `string`/`null` = edited/cleared by the user.
+  const [purchaseOrderNumber, setPurchaseOrderNumber] = useState<string | null>()
+  const effectivePurchaseOrderNumber =
+    purchaseOrderNumber === undefined ? (invoice?.purchaseOrderNumber ?? null) : purchaseOrderNumber
 
   const [taxProviderTaxesResult, setTaxProviderTaxesResult] =
     useState<FetchDraftInvoiceTaxesMutation['fetchDraftInvoiceTaxes']>(null)
@@ -279,6 +286,7 @@ const CustomerInvoiceRegenerate = () => {
         input: {
           voidedInvoiceId: invoiceId,
           fees: feesInput,
+          purchaseOrderNumber: normalizePurchaseOrderNumber(effectivePurchaseOrderNumber),
         },
       },
     })
@@ -380,6 +388,8 @@ const CustomerInvoiceRegenerate = () => {
                 customer={customer}
                 invoice={invoice}
                 billingEntity={billingEntity}
+                purchaseOrderNumber={effectivePurchaseOrderNumber}
+                onPurchaseOrderNumberChange={setPurchaseOrderNumber}
               />
             )}
             {invoice && customer && (

--- a/src/pages/InvoiceOverview.tsx
+++ b/src/pages/InvoiceOverview.tsx
@@ -294,10 +294,14 @@ export const InvoiceQuickInfo = ({
   invoice,
   billingEntity,
   customer,
+  purchaseOrderNumber,
+  onPurchaseOrderNumberChange,
 }: {
   invoice: AllInvoiceDetailsForCustomerInvoiceDetailsFragment | null | undefined
   billingEntity: Pick<BillingEntity, 'id' | 'name' | 'code' | 'einvoicing'> | null | undefined
   customer?: CustomerForInvoiceOverviewFragment | null
+  purchaseOrderNumber?: string | null
+  onPurchaseOrderNumberChange?: (value: string | null) => void
 }) => {
   const { translate } = useInternationalization()
   const isDraft = invoice?.status === InvoiceStatusTypeEnum.Draft
@@ -343,7 +347,11 @@ export const InvoiceQuickInfo = ({
           </Typography>
         </div>
       )}
-      <InvoiceCustomerInfos invoice={invoice} />
+      <InvoiceCustomerInfos
+        invoice={invoice}
+        purchaseOrderNumber={purchaseOrderNumber}
+        onPurchaseOrderNumberChange={onPurchaseOrderNumberChange}
+      />
     </>
   )
 }

--- a/src/pages/wallet/CreateWalletTopUp.tsx
+++ b/src/pages/wallet/CreateWalletTopUp.tsx
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 import InputAdornment from '@mui/material/InputAdornment'
 import { getIn, useFormik } from 'formik'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 import { boolean, number, object, string } from 'yup'
 
@@ -173,7 +173,7 @@ const CreateWalletTopUp = () => {
       metadata: undefined,
       ignorePaidTopUpLimits: undefined,
       priority: 50,
-      purchaseOrderNumber: undefined,
+      purchaseOrderNumber: voidedInvoice?.invoice?.purchaseOrderNumber || undefined,
     },
     validationSchema: object().shape({
       paidCredits: string().test({
@@ -265,6 +265,17 @@ const CreateWalletTopUp = () => {
       navigateToCustomerWalletTab(wallet.id)
     },
   })
+
+  useEffect(() => {
+    const prefill = voidedInvoice?.invoice?.purchaseOrderNumber
+
+    if (prefill && !formikProps.dirty && formikProps.values.purchaseOrderNumber !== prefill) {
+      formikProps.resetForm({
+        values: { ...formikProps.values, purchaseOrderNumber: prefill },
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot prefill, keyed on the fetched value only
+  }, [voidedInvoice?.invoice?.purchaseOrderNumber])
 
   const updateTransactionType = (type: WalletTransactionType) => {
     setTransactionType(type)

--- a/src/pages/wallet/__tests__/CreateWalletTopUp.test.tsx
+++ b/src/pages/wallet/__tests__/CreateWalletTopUp.test.tsx
@@ -2,6 +2,7 @@ import { MockedResponse } from '@apollo/client/testing'
 import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import { PURCHASE_ORDER_FORM_BLOCK_INPUT_TEST_ID } from '~/components/purchaseOrder/PurchaseOrderFormBlock'
 import {
   CLOSE_CREATE_TOPUP_BUTTON_DATA_TEST,
   CREATE_WALLET_TOP_UP_FORM_TEST_ID,
@@ -119,7 +120,7 @@ const createMutationMock = (
   },
 })
 
-const createInvoiceStatusMock = (): MockedResponse => ({
+const createInvoiceStatusMock = (purchaseOrderNumber: string | null = null): MockedResponse => ({
   request: {
     query: GetInvoiceStatusDocument,
     variables: { id: 'voided-invoice-1' },
@@ -129,6 +130,7 @@ const createInvoiceStatusMock = (): MockedResponse => ({
       invoice: {
         id: 'voided-invoice-1',
         status: 'finalized',
+        purchaseOrderNumber,
       },
     },
   },
@@ -498,6 +500,64 @@ describe('CreateWalletTopUp', () => {
           expect(
             (createCapturedVars as Record<string, Record<string, unknown>>).input.priority,
           ).toBe(50)
+        })
+      })
+    })
+
+    describe('WHEN regenerating a voided invoice that has a PO number', () => {
+      it('THEN should prefill the PO number and send it in the mutation', async () => {
+        const user = userEvent.setup()
+        let createCapturedVars: Record<string, unknown> | undefined
+
+        const useParamsMock = jest.requireMock('react-router-dom').useParams as jest.Mock
+
+        useParamsMock.mockReturnValue({
+          customerId: 'customer-1',
+          walletId: 'wallet-1',
+          voidedInvoiceId: 'voided-invoice-1',
+        })
+
+        const mocks = [
+          createWalletForTopUpMock(),
+          createCustomerInfoMock(),
+          createInvoiceStatusMock('PO-1'),
+          createVoidInvoiceMock(),
+          createMutationMock((vars) => {
+            createCapturedVars = vars
+          }),
+        ] as TestMocksType
+
+        render(<CreateWalletTopUp />, { mocks })
+
+        // The PO number from the voided invoice is prefilled into the input.
+        await waitFor(() => {
+          const poInput = screen
+            .getByTestId(PURCHASE_ORDER_FORM_BLOCK_INPUT_TEST_ID)
+            .querySelector('input') as HTMLInputElement
+
+          expect(poInput).toHaveValue('PO-1')
+        })
+
+        // The prefill must not mark the form dirty — submit stays disabled
+        // until the user actually edits something.
+        expect(screen.getByTestId(SUBMIT_WALLET_DATA_TEST)).toBeDisabled()
+
+        await user.type(getPaidCreditsInput(), '10')
+
+        await waitFor(() => {
+          expect(screen.getByTestId(SUBMIT_WALLET_DATA_TEST)).not.toBeDisabled()
+        })
+
+        await act(async () => {
+          await user.click(screen.getByTestId(SUBMIT_WALLET_DATA_TEST))
+        })
+
+        await waitFor(() => {
+          expect(createCapturedVars).toBeDefined()
+          expect(
+            (createCapturedVars as Record<string, Record<string, unknown>>).input
+              .purchaseOrderNumber,
+          ).toBe('PO-1')
         })
       })
     })


### PR DESCRIPTION
## Context

The purchase order number should be displayed on the Regenerate voided invoice screen. It should be possible to add/edit/delete the PO number for the new invoice.

## Description

Added the new field to the Regenerate voided invoice screen.


<!-- Linear link -->
[BIL-343](https://linear.app/getlago/issue/BIL-343/fe-add-po-number-field-to-regenerate-voided-invoice-flow)