### PR TITLE
docs: Auto-load TypeScript conventions in every session

### DIFF
--- a/.agents/docs/typescript-conventions.md
+++ b/.agents/docs/typescript-conventions.md
@@ -82,29 +82,60 @@ function getStatus(user) {
 
 ### Prefer Logic Out of JSX
 
-Extract any logic above, when it starts to be complex.
+Extract non-trivial conditional rendering out of the JSX into a `renderX()`
+helper declared above the `return`, using early returns. Apply this when a
+ternary is nested (deeper than 1 level) or when a branch spans multiple JSX
+lines. Leave a trivial single-line `cond ? a : b` inline, do not over-extract.
 
 ```tsx
-// ❌ Bad
+// ❌ Bad - nested ternary inlined in JSX
 return (
   <div>
     {score > 80 ? "High" : score > 50 ? "Medium" : "Low"}
   </div>
 );
 
-// ✅ Good
-let label;
-if (score > 80) {
-  label = "High";
-} else if (score > 50) {
-  label = "Medium";
-} else {
-  label = "Low";
+// ✅ Good - helper with early returns
+const getLabel = () => {
+  if (score > 80) return "High"
+  if (score > 50) return "Medium"
+
+  return "Low"
 }
 
+return <div>{getLabel()}</div>
+```
+
+The same applies when the branches return JSX, not just a value. A render
+helper with an early return reads far better than a ternary nested inside a
+prop:
+
+```tsx
+// ❌ Bad - multi-line JSX branches inlined in the render
 return (
-  <div>
-    {label}
-  </div>
-);
+  <Line
+    value={
+      isEditable ? (
+        <Editor value={value} onChange={onChange}>
+          {value ? <Display /> : <AddButton />}
+        </Editor>
+      ) : (
+        value || "-"
+      )
+    }
+  />
+)
+
+// ✅ Good - render helper above the return, early return first
+const renderValue = () => {
+  if (!isEditable) return value || "-"
+
+  return (
+    <Editor value={value} onChange={onChange}>
+      {value ? <Display /> : <AddButton />}
+    </Editor>
+  )
+}
+
+return <Line value={renderValue()} />
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,11 +263,16 @@ and Apollo cache automatically).
   probing legacy-URL behavior (e.g. testing the auth-guard redirect from a
   slug-less path to `/login`). Always add an inline comment explaining why.
 
-## Detailed Guidelines (read on demand)
+## Detailed Guidelines
 
-When working on these areas, read the relevant file first:
+TypeScript conventions are small and broadly applicable, so they are imported
+automatically into every session (bare `@` reference, not backtick-wrapped):
 
-- **TypeScript conventions**: `@.agents/docs/typescript-conventions.md`
+@.agents/docs/typescript-conventions.md
+
+Read these on demand when working on the relevant area (backtick-wrapped so they
+are referenced, not auto-loaded):
+
 - **Folder architecture**: `@.agents/docs/folder-architecture.md`
 - **Library documentation**: `@.agents/docs/documentation.md`
 - **GraphQL fragments & type safety**: `@.agents/docs/graphql-fragments.md`


### PR DESCRIPTION
## What
- Import `.agents/docs/typescript-conventions.md` into every session via a bare `@` reference in `CLAUDE.md`. The previous reference was backtick-wrapped, so it was inert (referenced, not loaded).
- Strengthen that doc's "Prefer Logic Out of JSX": explicit threshold plus a JSX-returning render-helper example.

## Why
The extraction guidance (and the rest of the TS conventions) already existed but rarely reached sessions because the doc only loaded on demand. Auto-importing the whole doc keeps every convention always-on, without scattering one-off rules into the root `CLAUDE.md`.

The doc is small (~140 lines), so the extra per-session token cost is minimal.

## Rule (in the doc)
Extract non-trivial conditional rendering into a `renderX()` helper with early returns when a ternary is nested (deeper than 1 level) or a branch spans multiple JSX lines; leave trivial single-line `cond ? a : b` inline.