### PR TITLE
refactor(invoices): migrate FinalizeInvoiceDialog to useCentralizedDialog

### DIFF
--- a/src/components/customers/CustomerInvoicesList.tsx
+++ b/src/components/customers/CustomerInvoicesList.tsx
@@ -1,6 +1,6 @@
 import { FetchMoreQueryOptions, gql } from '@apollo/client'
 import { IconName } from 'lago-design-system'
-import { FC, useRef } from 'react'
+import { FC } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { createCreditNoteForInvoiceButtonProps } from '~/components/creditNote/utils'
@@ -14,10 +14,7 @@ import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy
 import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { buildInvoiceDocumentData } from '~/components/emails/buildDocumentData'
 import { useUpdateInvoicePaymentStatusDialog } from '~/components/invoices/EditInvoicePaymentStatusDialog'
-import {
-  FinalizeInvoiceDialog,
-  FinalizeInvoiceDialogRef,
-} from '~/components/invoices/FinalizeInvoiceDialog'
+import { useFinalizeInvoiceDialog } from '~/components/invoices/FinalizeInvoiceDialog'
 import { useResendInvoiceForCollectionDialog } from '~/components/invoices/ResendInvoiceForCollectionDialog'
 import { getMostRecentPaymentMethodId } from '~/components/invoices/utils/getMostRecentPaymentMethodId'
 import { addToast } from '~/core/apolloClient'
@@ -193,7 +190,7 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
 
   const { generatePaymentUrl } = useGeneratePaymentUrl()
 
-  const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
+  const { openFinalizeInvoiceDialog } = useFinalizeInvoiceDialog()
   const { openUpdateInvoicePaymentStatusDialog } = useUpdateInvoicePaymentStatusDialog()
 
   return (
@@ -452,9 +449,7 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
                   startIcon: 'checkmark' as IconName,
                   title: translate('text_63a41a8eabb9ae67047c1c08'),
                   onAction: (item) => {
-                    finalizeInvoiceRef.current?.openDialog(
-                      item as InvoiceForFinalizeInvoiceFragment,
-                    )
+                    openFinalizeInvoiceDialog(item as InvoiceForFinalizeInvoiceFragment)
                   },
                 }
               }
@@ -582,7 +577,6 @@ export const CustomerInvoicesList: FC<CustomerInvoicesListProps> = ({
           }}
         />
       </PaginatedContent>
-      <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
     </>
   )
 }

--- a/src/components/invoices/FinalizeInvoiceDialog.tsx
+++ b/src/components/invoices/FinalizeInvoiceDialog.tsx
@@ -1,8 +1,6 @@
 import { gql, useApolloClient } from '@apollo/client'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { addToast, LagoGQLError } from '~/core/apolloClient'
 import {
   AllInvoiceDetailsForCustomerInvoiceDetailsFragmentDoc,
@@ -34,45 +32,20 @@ gql`
   ${AllInvoiceDetailsForCustomerInvoiceDetailsFragmentDoc}
 `
 
-export interface FinalizeInvoiceDialogRef {
-  openDialog: (
-    invoice: InvoiceForFinalizeInvoiceFragment | null | undefined,
-    callback?: () => void,
-  ) => unknown
-  closeDialog: () => unknown
+type FinalizeInvoiceDialogData = {
+  invoice: InvoiceForFinalizeInvoiceFragment | null | undefined
+  callback?: () => void
 }
 
-export const FinalizeInvoiceDialog = forwardRef<FinalizeInvoiceDialogRef>((_, ref) => {
+export const useFinalizeInvoiceDialog = () => {
+  const centralizedDialog = useCentralizedDialog()
   const { translate } = useInternationalization()
   const { formattedDateWithTimezone } = useFormatterDateHelper()
-  const dialogRef = useRef<DialogRef>(null)
-  const [invoice, setInvoice] = useState<InvoiceForFinalizeInvoiceFragment>()
-  const [callback, setCallback] = useState<(() => void) | null>(null)
-
   const client = useApolloClient()
 
   const [finalizeInvoice] = useFinalizeInvoiceMutation({
-    variables: { input: { id: invoice?.id || '' } },
     context: {
       silentErrorCodes: [LagoApiError.UnprocessableEntity, LagoApiError.InternalError],
-    },
-    onCompleted({ finalizeInvoice: finalizeInvoiceRes }) {
-      const isClosed = finalizeInvoiceRes?.status === InvoiceStatusTypeEnum.Closed
-
-      client.refetchQueries({
-        include: isClosed ? ['getCustomerInvoices'] : ['getCustomerInvoices', 'getInvoiceDetails'],
-      })
-
-      if (finalizeInvoiceRes?.id) {
-        addToast({
-          message: translate('text_63a41b3a01db40c7fff551e1'),
-          severity: 'success',
-        })
-      }
-
-      if (isClosed) {
-        callback?.()
-      }
     },
     onError: ({ graphQLErrors }) => {
       graphQLErrors.forEach((graphQLError) => {
@@ -88,45 +61,47 @@ export const FinalizeInvoiceDialog = forwardRef<FinalizeInvoiceDialogRef>((_, re
     },
   })
 
-  useImperativeHandle(ref, () => ({
-    openDialog: (infos, callbackFn) => {
-      !!infos && setInvoice(infos)
-      callbackFn && setCallback(() => callbackFn)
-      dialogRef.current?.openDialog()
-    },
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  const openFinalizeInvoiceDialog = (
+    invoice: InvoiceForFinalizeInvoiceFragment | null | undefined,
+    callback?: () => void,
+  ) => {
+    const data: FinalizeInvoiceDialogData = { invoice, callback }
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate('text_63a4269f72ead1bda4bed106')}
-      description={translate('text_63a4269f72ead1bda4bed108', {
-        issuingDate: invoice?.issuingDate ? formattedDateWithTimezone(invoice?.issuingDate) : '-',
-      })}
-      actions={({ closeDialog }) => (
-        <>
-          <Button
-            variant="quaternary"
-            onClick={() => {
-              closeDialog()
-            }}
-          >
-            {translate('text_63a4269f72ead1bda4bed10a')}
-          </Button>
-          <Button
-            variant="primary"
-            onClick={async () => {
-              await finalizeInvoice()
-              closeDialog()
-            }}
-          >
-            {translate('text_63a4269f72ead1bda4bed10c')}
-          </Button>
-        </>
-      )}
-    />
-  )
-})
+    centralizedDialog.open({
+      title: translate('text_63a4269f72ead1bda4bed106'),
+      description: translate('text_63a4269f72ead1bda4bed108', {
+        issuingDate: data.invoice?.issuingDate
+          ? formattedDateWithTimezone(data.invoice.issuingDate)
+          : '-',
+      }),
+      actionText: translate('text_63a4269f72ead1bda4bed10c'),
+      onAction: async () => {
+        const result = await finalizeInvoice({
+          variables: { input: { id: data.invoice?.id || '' } },
+        })
 
-FinalizeInvoiceDialog.displayName = 'forwardRef'
+        const finalizeInvoiceRes = result.data?.finalizeInvoice
+        const isClosed = finalizeInvoiceRes?.status === InvoiceStatusTypeEnum.Closed
+
+        client.refetchQueries({
+          include: isClosed
+            ? ['getCustomerInvoices']
+            : ['getCustomerInvoices', 'getInvoiceDetails'],
+        })
+
+        if (finalizeInvoiceRes?.id) {
+          addToast({
+            message: translate('text_63a41b3a01db40c7fff551e1'),
+            severity: 'success',
+          })
+        }
+
+        if (isClosed) {
+          data.callback?.()
+        }
+      },
+    })
+  }
+
+  return { openFinalizeInvoiceDialog }
+}

--- a/src/components/invoices/InvoiceOverviewHeaderButtons.tsx
+++ b/src/components/invoices/InvoiceOverviewHeaderButtons.tsx
@@ -1,8 +1,6 @@
-import { RefObject } from 'react'
-
 import { Button } from '~/components/designSystem/Button'
 import { Popper } from '~/components/designSystem/Popper'
-import { FinalizeInvoiceDialogRef } from '~/components/invoices/FinalizeInvoiceDialog'
+import { useFinalizeInvoiceDialog } from '~/components/invoices/FinalizeInvoiceDialog'
 import { envGlobalVar } from '~/core/apolloClient'
 import {
   AllInvoiceDetailsForCustomerInvoiceDetailsFragment,
@@ -30,7 +28,6 @@ interface InvoiceOverviewHeaderButtonsProps {
   retryInvoice: RetryInvoiceMutationFn
   downloadInvoice: DownloadInvoiceItemMutationFn
   downloadInvoiceXml: DownloadInvoiceItemMutationFn
-  finalizeInvoiceRef: RefObject<FinalizeInvoiceDialogRef>
   goToPreviousRoute?: () => void
   invoiceId?: string
 }
@@ -48,11 +45,11 @@ export const InvoiceOverviewHeaderButtons = ({
   retryInvoice,
   downloadInvoice,
   downloadInvoiceXml,
-  finalizeInvoiceRef,
   goToPreviousRoute,
   invoiceId,
 }: InvoiceOverviewHeaderButtonsProps) => {
   const { translate } = useInternationalization()
+  const { openFinalizeInvoiceDialog } = useFinalizeInvoiceDialog()
 
   const isTaxStatusPending = invoice?.taxStatus === InvoiceTaxStatusTypeEnum.Pending
   const canDownloadInvoice = !hasError && !loading && !disablePdfGeneration
@@ -75,7 +72,7 @@ export const InvoiceOverviewHeaderButtons = ({
           variant="quaternary"
           disabled={loading || isTaxStatusPending}
           onClick={() => {
-            finalizeInvoiceRef.current?.openDialog(invoice, goToPreviousRoute)
+            openFinalizeInvoiceDialog(invoice, goToPreviousRoute)
           }}
         >
           {translate('text_638f4d756d899445f18a4a10')}

--- a/src/components/invoices/InvoicesList.tsx
+++ b/src/components/invoices/InvoicesList.tsx
@@ -1,6 +1,6 @@
 import { ApolloError, LazyQueryHookOptions } from '@apollo/client'
 import { IconName } from 'lago-design-system'
-import { useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import { generatePath, useSearchParams } from 'react-router-dom'
 
 import { createCreditNoteForInvoiceButtonProps } from '~/components/creditNote/utils'
@@ -15,10 +15,7 @@ import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy
 import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { buildInvoiceDocumentData } from '~/components/emails/buildDocumentData'
 import { useUpdateInvoicePaymentStatusDialog } from '~/components/invoices/EditInvoicePaymentStatusDialog'
-import {
-  FinalizeInvoiceDialog,
-  FinalizeInvoiceDialogRef,
-} from '~/components/invoices/FinalizeInvoiceDialog'
+import { useFinalizeInvoiceDialog } from '~/components/invoices/FinalizeInvoiceDialog'
 import { useResendInvoiceForCollectionDialog } from '~/components/invoices/ResendInvoiceForCollectionDialog'
 import { getEmptyStateConfig } from '~/components/invoices/utils/emptyStateMapping'
 import { getMostRecentPaymentMethodId } from '~/components/invoices/utils/getMostRecentPaymentMethodId'
@@ -93,7 +90,7 @@ const InvoicesList = ({
 
   const { handleDownloadFile } = useDownloadFile()
 
-  const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
+  const { openFinalizeInvoiceDialog } = useFinalizeInvoiceDialog()
   const { openUpdateInvoicePaymentStatusDialog } = useUpdateInvoicePaymentStatusDialog()
   const { openResendInvoiceForCollectionDialog } = useResendInvoiceForCollectionDialog()
 
@@ -233,7 +230,7 @@ const InvoicesList = ({
             startIcon: 'checkmark',
             title: translate('text_63a41a8eabb9ae67047c1c08'),
             onAction: (item) => {
-              finalizeInvoiceRef.current?.openDialog(item)
+              openFinalizeInvoiceDialog(item)
             },
           }
         : null
@@ -558,8 +555,6 @@ const InvoicesList = ({
           }}
         />
       </PaginatedContent>
-
-      <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
     </>
   )
 }

--- a/src/components/invoices/__tests__/InvoicesList.test.tsx
+++ b/src/components/invoices/__tests__/InvoicesList.test.tsx
@@ -145,6 +145,14 @@ jest.mock('~/components/invoices/ResendInvoiceForCollectionDialog', () => ({
   }),
 }))
 
+const mockOpenFinalizeInvoiceDialog = jest.fn()
+
+jest.mock('~/components/invoices/FinalizeInvoiceDialog', () => ({
+  useFinalizeInvoiceDialog: () => ({
+    openFinalizeInvoiceDialog: mockOpenFinalizeInvoiceDialog,
+  }),
+}))
+
 jest.mock('~/generated/graphql', () => ({
   ...jest.requireActual('~/generated/graphql'),
   useDownloadInvoiceItemMutation: (options: typeof downloadInvoiceCallbacks) => {

--- a/src/pages/CustomerInvoiceDetails.tsx
+++ b/src/pages/CustomerInvoiceDetails.tsx
@@ -12,10 +12,7 @@ import { buildInvoiceDocumentData } from '~/components/emails/buildDocumentData'
 import { AddMetadataDrawer, AddMetadataDrawerRef } from '~/components/invoices/AddMetadataDrawer'
 import { useDisputeInvoiceDialog } from '~/components/invoices/DisputeInvoiceDialog'
 import { useUpdateInvoicePaymentStatusDialog } from '~/components/invoices/EditInvoicePaymentStatusDialog'
-import {
-  FinalizeInvoiceDialog,
-  FinalizeInvoiceDialogRef,
-} from '~/components/invoices/FinalizeInvoiceDialog'
+import { useFinalizeInvoiceDialog } from '~/components/invoices/FinalizeInvoiceDialog'
 import { InvoiceActivityLogs } from '~/components/invoices/InvoiceActivityLogs'
 import { InvoiceCreditNoteList } from '~/components/invoices/InvoiceCreditNoteList'
 import { InvoicePaymentList } from '~/components/invoices/InvoicePaymentList'
@@ -314,7 +311,7 @@ const CustomerInvoiceDetails = () => {
   const { goBack } = useLocationHistory()
   const { isPremium } = useCurrentUser()
   const { hasPermissions } = usePermissions()
-  const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
+  const { openFinalizeInvoiceDialog } = useFinalizeInvoiceDialog()
   const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const { openUpdateInvoicePaymentStatusDialog } = useUpdateInvoicePaymentStatusDialog()
   const addMetadataDrawerDialogRef = useRef<AddMetadataDrawerRef>(null)
@@ -770,7 +767,7 @@ const CustomerInvoiceDetails = () => {
           label: translate('text_63a41a8eabb9ae67047c1c08'),
           hidden: !authorizations.canFinalizeInvoice,
           onClick: (closePopper: () => void) => {
-            finalizeInvoiceRef.current?.openDialog(data?.invoice)
+            openFinalizeInvoiceDialog(data?.invoice)
             closePopper()
           },
         },
@@ -1026,7 +1023,6 @@ const CustomerInvoiceDetails = () => {
         <DetailsPage.Container>{activeTabContent}</DetailsPage.Container>
       )}
 
-      <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
       {!!invoice && <AddMetadataDrawer ref={addMetadataDrawerDialogRef} invoiceId={invoice.id} />}
     </>
   )

--- a/src/pages/InvoiceOverview.tsx
+++ b/src/pages/InvoiceOverview.tsx
@@ -14,10 +14,6 @@ import {
   InvoiceTableSection,
 } from '~/components/invoices/details/InvoiceDetailsTable'
 import { ViewFeeDetailsDrawerProvider } from '~/components/invoices/details/ViewFeeDetailsDrawer'
-import {
-  FinalizeInvoiceDialog,
-  FinalizeInvoiceDialogRef,
-} from '~/components/invoices/FinalizeInvoiceDialog'
 import { InvoiceCustomerInfos } from '~/components/invoices/InvoiceCustomerInfos'
 import { InvoiceOverviewHeaderButtons } from '~/components/invoices/InvoiceOverviewHeaderButtons'
 import { Metadatas } from '~/components/invoices/Metadatas'
@@ -381,7 +377,6 @@ const InvoiceOverview = memo(
     const { invoiceId } = useParams()
 
     const billingEntity = invoice?.billingEntity
-    const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
     const editFeeDrawerRef = useRef<EditFeeDrawerRef>(null)
 
     if (hasError) {
@@ -465,7 +460,6 @@ const InvoiceOverview = memo(
               retryInvoice={retryInvoice}
               downloadInvoice={downloadInvoice}
               downloadInvoiceXml={downloadInvoiceXml}
-              finalizeInvoiceRef={finalizeInvoiceRef}
               goToPreviousRoute={goToPreviousRoute}
               invoiceId={invoiceId}
             />
@@ -815,7 +809,6 @@ const InvoiceOverview = memo(
             </>
           )}
         </>
-        <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
         <EditFeeDrawer ref={editFeeDrawerRef} />
       </ViewFeeDetailsDrawerProvider>
     )

--- a/src/pages/InvoicesPage.tsx
+++ b/src/pages/InvoicesPage.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
 import {
@@ -12,10 +12,6 @@ import {
 import { usePageSearchParam } from '~/components/designSystem/Pagination'
 import { useExportDialog } from '~/components/exports/ExportDialog'
 import { ExportValues } from '~/components/exports/types'
-import {
-  FinalizeInvoiceDialog,
-  FinalizeInvoiceDialogRef,
-} from '~/components/invoices/FinalizeInvoiceDialog'
 import InvoicesList from '~/components/invoices/InvoicesList'
 import { formatCountToMetadata } from '~/components/MainHeader/formatCountToMetadata'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
@@ -146,7 +142,6 @@ const InvoicesPage = () => {
     PremiumIntegrationTypeEnum.RevenueShare,
   )
 
-  const finalizeInvoiceRef = useRef<FinalizeInvoiceDialogRef>(null)
   const { openExportDialog } = useExportDialog()
 
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE)
@@ -333,8 +328,6 @@ const InvoicesPage = () => {
           goToPage(1)
         }}
       />
-
-      <FinalizeInvoiceDialog ref={finalizeInvoiceRef} />
     </>
   )
 }

--- a/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
+++ b/src/pages/__tests__/CustomerInvoiceDetails.test.tsx
@@ -231,7 +231,7 @@ jest.mock('~/pages/InvoiceOverview', () => ({
 }))
 
 jest.mock('~/components/invoices/FinalizeInvoiceDialog', () => ({
-  FinalizeInvoiceDialog: () => null,
+  useFinalizeInvoiceDialog: () => ({ openFinalizeInvoiceDialog: jest.fn() }),
 }))
 
 jest.mock('~/components/invoices/EditInvoicePaymentStatusDialog', () => ({

--- a/src/pages/__tests__/InvoicesPage.test.tsx
+++ b/src/pages/__tests__/InvoicesPage.test.tsx
@@ -80,7 +80,7 @@ jest.mock('~/components/invoices/InvoicesList', () => ({
 }))
 
 jest.mock('~/components/invoices/FinalizeInvoiceDialog', () => ({
-  FinalizeInvoiceDialog: () => null,
+  useFinalizeInvoiceDialog: () => ({ openFinalizeInvoiceDialog: jest.fn() }),
 }))
 
 jest.mock('~/components/exports/ExportDialog', () => ({

--- a/translations/base.json
+++ b/translations/base.json
@@ -1274,7 +1274,6 @@
   "text_63a41b3a01db40c7fff551e1": "Invoice successfully finalized",
   "text_63a4269f72ead1bda4bed106": "Finalize a draft invoice",
   "text_63a4269f72ead1bda4bed108": "You won’t be able to adjust items anymore, the invoice will be generated instantly. Are you sure?   \n\nOtherwise, the invoice will be generated automatically on {{issuingDate}}.",
-  "text_63a4269f72ead1bda4bed10a": "Cancel",
   "text_63a4269f72ead1bda4bed10c": "Finalize invoice",
   "text_63b6f4e9b074e3b8beebb97f": "Coupons, prepaid credits and credit notes will impact the invoice once it’s finalized.",
   "text_634687079be251fdb438338f": "Actions",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -1306,7 +1306,6 @@
   "text_63a41b3a01db40c7fff551e1": "Fatura finalizada com sucesso",
   "text_63a4269f72ead1bda4bed106": "Finalizar um rascunho de fatura",
   "text_63a4269f72ead1bda4bed108": "Você não poderá mais ajustar os itens, a fatura será gerada instantaneamente. Tem certeza? \n\nCaso contrário, a fatura será gerada automaticamente em {{issuingDate}}.",
-  "text_63a4269f72ead1bda4bed10a": "Cancelar",
   "text_63a4269f72ead1bda4bed10c": "Finalizar fatura",
   "text_63b6f4e9b074e3b8beebb97f": "Cupons, créditos pré-pagos e notas de crédito impactarão a fatura assim que ela for finalizada.",
   "text_634687079be251fdb438338f": "Ações",


### PR DESCRIPTION
## Context

`FinalizeInvoiceDialog` was one of the legacy `forwardRef` + `Dialog` (`~/components/designSystem/Dialog`) consumers flagged by the `no-restricted-imports` ESLint rule. The dialog is a simple finalize/cancel confirmation with no form fields, so `useCentralizedDialog` is the natural target. Resolves 11 warnings across the invoice list and invoice detail surfaces.

## Description

- **`src/components/invoices/FinalizeInvoiceDialog.tsx`**
  - Replaced the `forwardRef` + `useImperativeHandle` + `Dialog` + local `useState` boilerplate with a `useFinalizeInvoiceDialog` hook backed by `useCentralizedDialog`.
  - The `finalizeInvoice` mutation moved into the hook; the success toast, the `refetchQueries` branch on `InvoiceStatusTypeEnum.Closed`, the tax-error toast (`onError`), and the `callback?.()` invocation on `Closed` are all preserved.
  - Dropped `FinalizeInvoiceDialogRef`, `FinalizeInvoiceDialog`, the `Dialog` + `Button` imports and the `displayName` assignment.

- **`src/components/invoices/InvoicesList.tsx`**, **`src/components/customers/CustomerInvoicesList.tsx`**, **`src/pages/CustomerInvoiceDetails.tsx`**
  - Replaced the `useRef<FinalizeInvoiceDialogRef>` + `<FinalizeInvoiceDialog ref={…} />` pattern with `const { openFinalizeInvoiceDialog } = useFinalizeInvoiceDialog()` and called it directly at each existing call site. Sibling dialogs (Resend, EditInvoicePaymentStatus, etc.) are untouched.

- **`src/components/invoices/InvoiceOverviewHeaderButtons.tsx`**
  - Dropped the `finalizeInvoiceRef` prop and the `RefObject` import; the component now calls `useFinalizeInvoiceDialog()` directly, matching the pattern of the other hook-based dialogs in the tree.

- **`src/pages/InvoiceOverview.tsx`**
  - Removed the local `useRef` + the trailing `<FinalizeInvoiceDialog ref={…} />` JSX and the `finalizeInvoiceRef` prop threaded into `InvoiceOverviewHeaderButtons` (no longer needed — the header buttons now own the hook call).

- **`src/pages/InvoicesPage.tsx`**
  - Removed a stale `useRef<FinalizeInvoiceDialogRef>` + `<FinalizeInvoiceDialog ref={…} />` that was never wired to an `openDialog(...)` call — `InvoicesList` renders (and now consumes) its own dialog. Also drops the now-unused `useRef` React import.

- **`src/pages/__tests__/InvoicesPage.test.tsx`**, **`src/pages/__tests__/CustomerInvoiceDetails.test.tsx`**
  - Updated the `FinalizeInvoiceDialog` `jest.mock` to stub the `useFinalizeInvoiceDialog` hook instead of the removed component export.

- **`translations/base.json`**, **`translations/pt-BR.json`**
  - Removed the orphaned `text_63a4269f72ead1bda4bed10a` ("Cancel") key — `CentralizedDialog` renders its own default cancel button, so the custom string is no longer referenced. Flagged by the pre-push `translations:inspect` check.

## Scope

Strictly scoped to the `no-restricted-imports` warning for `FinalizeInvoiceDialog`. `ResendInvoiceForCollectionDialog` (which lives in the same two list files) is intentionally left for a follow-up PR.

## Test plan

- [ ] Invoice list (`/invoices`) → row action "Finalize invoice" opens the dialog; confirming fires `finalizeInvoice` and shows the success toast.
- [ ] Customer detail → invoices tab → same action works.
- [ ] Customer invoice detail popper → "Finalize invoice" opens the dialog and finalizes.
- [ ] Draft invoice detail → header "Finalize invoice" button (via `InvoiceOverviewHeaderButtons`) opens the dialog; on `Closed` status the `goToPreviousRoute` callback still runs.
- [ ] Tax-error path (`taxError` on the graphQL error) still shows the danger toast.
- [ ] `pnpm exec tsc --noEmit`, `pnpm exec eslint` on the touched files — clean.
- [ ] `pnpm jest src/pages/__tests__/InvoicesPage.test.tsx src/pages/__tests__/CustomerInvoiceDetails.test.tsx` — passes.