### PR TITLE
fix(subscriptions): strip plan metadata from planOverrides payload

### DIFF
--- a/src/hooks/__tests__/useAddSubscription.test.ts
+++ b/src/hooks/__tests__/useAddSubscription.test.ts
@@ -18,6 +18,7 @@ describe('cleanPlanValues', () => {
     description: 'Test Description',
     interval: PlanInterval.Monthly,
     entitlements: [],
+    metadata: [{ key: 'product_group', value: 'Premium Suite' }],
     amountCents: '1000',
     amountCurrency: CurrencyEnum.Usd,
     trialPeriod: 7,
@@ -136,6 +137,7 @@ describe('cleanPlanValues', () => {
     expect(result.billFixedChargesMonthly).toBeUndefined()
     expect(result.cascadeUpdates).toBeUndefined()
     expect(result.entitlements).toBeUndefined()
+    expect(result.metadata).toBeUndefined()
     expect(result.usageThresholds).toBeUndefined()
 
     // Should clean charges

--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -184,6 +184,7 @@ export const cleanPlanValues = (planValues: PlanOverridesInput) => {
     billFixedChargesMonthly: undefined,
     cascadeUpdates: undefined,
     entitlements: undefined,
+    metadata: undefined,
     usageThresholds: undefined,
     charges: planValues?.charges?.map((charge) => ({
       ...charge,


### PR DESCRIPTION
## Context

Sentry FRONT-170: `createSubscription` fails with `Variable $input ... invalid value for planOverrides.metadata (Field is not defined on PlanOverridesInput)`. Since #3964 the plan form always initializes `metadata` in its values; when a subscription is created/updated with an edited plan, `buildPlanOverridesInput` serializes the full plan form values and `cleanPlanValues` didn't strip the new field, so every plan-override payload was rejected by the API.

## Description

Add `metadata: undefined` to `cleanPlanValues`, next to the other plan-only fields (`entitlements`, `usageThresholds`, …): plan metadata is not overridable per subscription and must never reach `PlanOverridesInput`. Test updated to cover the stripping.

<!-- Linear link -->
Fixes ING-491