### PR TITLE
fix(customers): reword gross revenue tooltip on customer invoices page

### DIFF
--- a/translations/base.json
+++ b/translations/base.json
@@ -1196,7 +1196,7 @@
   "text_655633c844bc8a00577061b9": "No billable metric",
   "text_655633c844bc8a00577061b0": "No add-on",
   "text_65564e8e4af2340050d431be": "Insights",
-  "text_65564e8e4af2340050d431bf": "Total monthly income, covering all financial aspects including taxes, discounts like credit notes, coupons, and credits, for an accurate financial overview.",
+  "text_65564e8e4af2340050d431bf": "Total monthly income, including taxes, coupons, prepaid credits, credit notes applied before invoice finalization, and refunds, for a complete financial overview.",
   "text_666c5b12fea4aa1e1b26bf52": "Outstanding",
   "text_666c5b12fea4aa1e1b26bf55": "Overdue",
   "text_666c5b12fea4aa1e1b26bf70": "There are no overdue invoices.",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -1228,7 +1228,7 @@
   "text_6556309ded468200b9debbd5": "Obtenha insights sobre seu MRR, receita de uso e faturas pendentes.",
   "text_655633c844bc8a00577061b9": "Nenhuma métrica faturável",
   "text_65564e8e4af2340050d431be": "Insights",
-  "text_65564e8e4af2340050d431bf": "Renda mensal total, cobrindo todos os aspectos financeiros, incluindo impostos, descontos como notas de crédito, cupons e créditos, para uma visão financeira precisa.",
+  "text_65564e8e4af2340050d431bf": "Renda mensal total, incluindo impostos, cupons, créditos pré-pagos, notas de crédito aplicadas antes da finalização da fatura e reembolsos, para uma visão financeira completa.",
   "text_666c5b12fea4aa1e1b26bf52": "Pendente",
   "text_666c5b12fea4aa1e1b26bf55": "Vencida",
   "text_666c5b12fea4aa1e1b26bf70": "Não há faturas vencidas.",


### PR DESCRIPTION
## Context

Gross revenue description were not clear enough for our customers

## Description

Update the tooltip description to list which values are contained inside the gross revenue

<!-- Linear link -->
Fixes BIL-237