### PR TITLE
chore(conductor): team config + container/host/shell run scripts

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -24,3 +24,10 @@ run_mode = "concurrent"
 command = "$LAGO_PATH/front/scripts/conductor-front-container.sh up"
 default = true
 icon = "container"
+
+# Open an interactive shell inside this workspace's running container. Run the
+# `container` script first. Commands here (pnpm codegen, pnpm test, node) use the
+# container's node_modules and network, where `api:3000` resolves.
+[scripts.run.shell]
+command = "$LAGO_PATH/front/scripts/conductor-front-container.sh shell"
+icon = "square-terminal"

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -31,3 +31,12 @@ icon = "container"
 [scripts.run.shell]
 command = "$LAGO_PATH/front/scripts/conductor-front-container.sh shell"
 icon = "square-terminal"
+
+# Run Vite on the HOST instead of in a container: native macOS fsevents give
+# reliable, instant HMR (the in-container watcher relies on polling and drops
+# events under load, breaking hot reload). API is reached over Traefik at
+# api.lago.dev; the script patches the workspace .env accordingly. Use `host`
+# OR `container` for a workspace, not both (same port, strictPort errors).
+[scripts.run.host]
+command = "$LAGO_PATH/front/scripts/conductor-front-container.sh host"
+icon = "flame"

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,26 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+# Shared Conductor config for the whole team. Committed, applies to everyone
+# after merge. Personal, per-machine overrides go in .conductor/settings.local.toml
+# (gitignored). See README "Conductor (parallel workspaces)".
+
+# Enterprise privacy: only account data (email, GitHub integration) is stored
+# server-side. Disables features that call external AI providers (AI chat
+# titles, custom MCP servers). Team-wide default.
+enterprise_data_privacy = true
+
+[git]
+delete_branch_on_archive = true
+
+[scripts]
+setup = "pnpm install"
+archive = "$LAGO_PATH/front/scripts/conductor-front-container.sh down"
+run_mode = "concurrent"
+
+# Run the workspace in its own Docker container on the shared lago stack network.
+# Requires the Docker superproject stack: `lago up -d`, the front_dev image, and
+# the $LAGO_PATH env var (same one used by lago-worktree).
+[scripts.run.container]
+command = "$LAGO_PATH/front/scripts/conductor-front-container.sh up"
+default = true
+icon = "container"

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -32,11 +32,12 @@ icon = "container"
 command = "$LAGO_PATH/front/scripts/conductor-front-container.sh shell"
 icon = "square-terminal"
 
-# Run Vite on the HOST instead of in a container: native macOS fsevents give
-# reliable, instant HMR (the in-container watcher relies on polling and drops
-# events under load, breaking hot reload). API is reached over Traefik at
-# api.lago.dev; the script patches the workspace .env accordingly. Use `host`
-# OR `container` for a workspace, not both (same port, strictPort errors).
+# Run Vite on the HOST instead of in a container: the script disables Vite's
+# watch polling for host runs, so it uses native macOS fsevents for reliable,
+# instant HMR (the in-container watcher polls and drops events under load,
+# breaking hot reload). API is reached over Traefik at api.lago.dev; the script
+# patches the workspace .env accordingly. Use `host` OR `container` for a
+# workspace, not both (same port, strictPort errors).
 [scripts.run.host]
 command = "$LAGO_PATH/front/scripts/conductor-front-container.sh host"
 icon = "flame"

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ docker-compose.worktree.yml
 .claude/scheduled_tasks.lock
 docs/
 .playwright-mcp/
+.conductor/settings.local.toml

--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ lago-worktree up LAGO-1234
 lago-worktree destroy LAGO-1234
 ```
 
+## Conductor (parallel workspaces)
+
+[Conductor](https://www.conductor.build) runs multiple Claude Code agents in parallel git worktrees. The project's shared Conductor config is committed at `.conductor/settings.toml`, so the whole team gets the same workflow automatically — no per-person setup.
+
+What the shared config provides:
+
+- **`enterprise_data_privacy = true`** — only account data (email, GitHub integration) is stored server-side. Disables features that call external AI providers (AI chat titles, custom MCP servers).
+- **Setup**: `pnpm install` on every new workspace.
+- **Run (`container`)**: runs the workspace in its own Docker container on the shared lago stack network, via `scripts/conductor-front-container.sh`. Requires the Docker superproject stack: `lago up -d`, the `front_dev` image, and the `$LAGO_PATH` env var (same one used by `lago-worktree`, see above).
+- **Git**: deletes the branch when a workspace is archived.
+
+### Personal overrides
+
+Machine-specific tweaks go in `.conductor/settings.local.toml` (gitignored). It overrides the shared config on your Mac only. Leave it empty unless you need to change something locally.
+
 ## License
 
 Lago is open-source under the GNU Affero General Public License Version 3 (AGPLv3) or any later version.

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -167,8 +167,9 @@ cmd_host() {
   echo ""
 
   cd "$WS"
-  # --port overrides the config default (8080) without writing PORT into .env,
-  # which would break the container path (Vite reads PORT from the .env FILE).
+  # --port sets the port explicitly instead of writing PORT into the workspace
+  # .env (.env is host-only tooling config, see patch_env). The container path
+  # gets its port from the compose `environment` overlay, never from .env.
   exec pnpm exec vite --port "$PORT"
 }
 

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -93,8 +93,10 @@ patch_env() {
   rm -f "$env_file.bak"
   {
     echo "API_URL=http://localhost:${PORT}/api"
-    echo "LAGO_API_PROXY_TARGET=http://api.lago.dev"
-    echo "CODEGEN_API=http://api.lago.dev/graphql"
+    # https to match the api.lago.dev health check and stay robust if Traefik
+    # ever forces http->https (cert is valid; Vite proxy sets secure:false).
+    echo "LAGO_API_PROXY_TARGET=https://api.lago.dev"
+    echo "CODEGEN_API=https://api.lago.dev/graphql"
   } >> "$env_file"
 }
 

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -120,11 +120,26 @@ cmd_down() {
   echo "Removed front container for '$NAME'."
 }
 
+cmd_shell() {
+  # Open an interactive shell INSIDE this workspace's front container, so
+  # pnpm/node/codegen run with the container's node_modules and network
+  # (api:3000 resolves, unlike on the host). Wired as [scripts.run.shell].
+  local container="lago_front_ct_${SAN}"
+  if ! docker ps --format '{{.Names}}' | grep -q "^${container}\$"; then
+    echo "Container ${container} is not running." >&2
+    echo "Start it first with the 'container' run script (or: conductor-front-container.sh up)." >&2
+    exit 1
+  fi
+  # -w /app lands in the mounted workspace; bash exists in the front_dev image.
+  exec docker exec -it -w /app "$container" bash
+}
+
 case "$CMD" in
   up) cmd_up ;;
   down) cmd_down ;;
+  shell) cmd_shell ;;
   *)
-    echo "Usage: conductor-front-container.sh {up|down}" >&2
+    echo "Usage: conductor-front-container.sh {up|down|shell}" >&2
     exit 1
     ;;
 esac

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# conductor-front-container.sh — run each Conductor front workspace in its own
+# Docker container (image front_dev), on its Conductor-assigned port, joined to
+# the shared main-stack network (shared API/DB/Redis/PDF).
+#
+# Companion to lago-worktree.sh, but the worktree path comes from Conductor env
+# vars instead of a self-managed worktree layout, so Conductor stays the single
+# owner of worktree create/destroy. Wired from the committed team config
+# .conductor/settings.toml:
+#   [scripts.run.container] command = "$LAGO_PATH/front/scripts/conductor-front-container.sh up"
+#   scripts.archive        = "$LAGO_PATH/front/scripts/conductor-front-container.sh down"
+#
+# Prerequisites:
+#   - the main Lago Docker stack is running (`lago up -d`)
+#   - $LAGO_PATH points at the lago superproject (front/ + api/ + docker-compose)
+
+CMD="${1:-}"
+
+NAME="${CONDUCTOR_WORKSPACE_NAME:?CONDUCTOR_WORKSPACE_NAME is required (run via Conductor)}"
+WS="${CONDUCTOR_WORKSPACE_PATH:?CONDUCTOR_WORKSPACE_PATH is required (run via Conductor)}"
+ROOT="${CONDUCTOR_ROOT_PATH:?CONDUCTOR_ROOT_PATH is required (run via Conductor)}"
+PORT="${CONDUCTOR_PORT:-8080}"
+
+LAGO_PATH="$(cd "$ROOT/.." && pwd)"
+COMPOSE_DIR="$LAGO_PATH/.conductor-front-containers"
+SAN="$(echo "$NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g')"
+COMPOSE_FILE="$COMPOSE_DIR/${SAN}.yml"
+
+gen_compose() {
+  mkdir -p "$COMPOSE_DIR"
+  cat > "$COMPOSE_FILE" <<YAML
+name: lago_front_ct_${SAN}
+
+services:
+  front:
+    image: front_dev
+    pull_policy: never
+    container_name: lago_front_ct_${SAN}
+    stdin_open: true
+    restart: unless-stopped
+    volumes:
+      - ${WS}:/app:cached
+      - front_nm_ct_${SAN}:/app/node_modules
+      - front_dist_ct_${SAN}:/app/dist
+    environment:
+      - NODE_ENV=development
+      - API_URL=http://localhost:${PORT}/api
+      - LAGO_API_PROXY_TARGET=http://api:3000
+      - CODEGEN_API=http://api:3000/graphql
+      - APP_DOMAIN=https://app.lago.dev
+      - PORT=8080
+    ports:
+      - "${PORT}:8080"
+    networks:
+      - lago_net
+
+volumes:
+  front_nm_ct_${SAN}:
+  front_dist_ct_${SAN}:
+
+networks:
+  lago_net:
+    external: true
+    name: lago_dev_default
+YAML
+}
+
+patch_env() {
+  # Vite reads these from the .env FILE (loadEnv), not process.env, and the
+  # mounted workspace .env is /app/.env inside the container. Idempotent: drop
+  # the managed keys then re-append. .env is gitignored, so this stays untracked.
+  local env_file="$WS/.env"
+  touch "$env_file"
+  sed -i.bak '/^API_URL=/d; /^LAGO_API_PROXY_TARGET=/d; /^CODEGEN_API=/d' "$env_file"
+  rm -f "$env_file.bak"
+  {
+    echo "API_URL=http://localhost:${PORT}/api"
+    echo "LAGO_API_PROXY_TARGET=http://api:3000"
+    echo "CODEGEN_API=http://api:3000/graphql"
+  } >> "$env_file"
+}
+
+cmd_up() {
+  if ! docker ps --format '{{.Names}}' | grep -q '^lago_front_dev$'; then
+    echo "Error: main Lago stack is not running. Start it first: lago up -d" >&2
+    exit 1
+  fi
+
+  patch_env
+  gen_compose
+
+  # A hard-killed prior run (SIGKILL) can orphan the container or leave a stale
+  # network endpoint that blocks re-attach ("endpoint ... already exists"); clear
+  # the compose project, the container, and the dangling endpoint before starting.
+  docker compose -f "$COMPOSE_FILE" down >/dev/null 2>&1 || true
+  docker rm -f "lago_front_ct_${SAN}" >/dev/null 2>&1 || true
+  docker network disconnect -f lago_dev_default "lago_front_ct_${SAN}" >/dev/null 2>&1 || true
+
+  cleanup() { docker compose -f "$COMPOSE_FILE" stop >/dev/null 2>&1 || true; }
+  trap cleanup EXIT INT TERM HUP
+
+  docker compose -f "$COMPOSE_FILE" up -d
+
+  echo ""
+  echo "  Front [$NAME] -> http://localhost:${PORT}"
+  echo "  (first boot runs pnpm install in the container; give it a minute)"
+  echo ""
+
+  # Stay in the foreground streaming logs so Conductor shows the script as
+  # running; its stop signal reaches us and the trap stops the container.
+  docker compose -f "$COMPOSE_FILE" logs -f
+}
+
+cmd_down() {
+  [[ -f "$COMPOSE_FILE" ]] || { echo "No front container registered for '$NAME'."; exit 0; }
+  docker compose -f "$COMPOSE_FILE" down -v
+  rm -f "$COMPOSE_FILE"
+  echo "Removed front container for '$NAME'."
+}
+
+case "$CMD" in
+  up) cmd_up ;;
+  down) cmd_down ;;
+  *)
+    echo "Usage: conductor-front-container.sh {up|down}" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -50,9 +50,13 @@ services:
       - LAGO_API_PROXY_TARGET=http://api:3000
       - CODEGEN_API=http://api:3000/graphql
       - APP_DOMAIN=https://app.lago.dev
-      - PORT=8080
+      # Bind vite to the SAME port host-side and container-side so vite's own
+      # "Local: http://localhost:${PORT}/" log line advertises the host-reachable
+      # port. Conductor's browser button scrapes the LAST port seen in run-script
+      # stdout; a mismatched internal port (was 8080) made it flip to the wrong port.
+      - PORT=${PORT}
     ports:
-      - "${PORT}:8080"
+      - "${PORT}:${PORT}"
     networks:
       - lago_net
 

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -68,17 +68,21 @@ YAML
 }
 
 patch_env() {
-  # Vite reads these from the .env FILE (loadEnv), not process.env, and the
-  # mounted workspace .env is /app/.env inside the container. Idempotent: drop
-  # the managed keys then re-append. .env is gitignored, so this stays untracked.
+  # Rewrite the API-target keys in the workspace .env. Vite reads these from the
+  # .env FILE (loadEnv), not process.env. The target differs by run mode:
+  #   container (up):  api:3000        (reachable on the lago_dev_default network)
+  #   host (host):     api.lago.dev    (Traefik route, reachable from the host)
+  # Idempotent: drop the managed keys then re-append. .env is gitignored.
+  local proxy_target="$1"
+  local codegen_api="$2"
   local env_file="$WS/.env"
   touch "$env_file"
   sed -i.bak '/^API_URL=/d; /^LAGO_API_PROXY_TARGET=/d; /^CODEGEN_API=/d' "$env_file"
   rm -f "$env_file.bak"
   {
     echo "API_URL=http://localhost:${PORT}/api"
-    echo "LAGO_API_PROXY_TARGET=http://api:3000"
-    echo "CODEGEN_API=http://api:3000/graphql"
+    echo "LAGO_API_PROXY_TARGET=${proxy_target}"
+    echo "CODEGEN_API=${codegen_api}"
   } >> "$env_file"
 }
 
@@ -88,7 +92,7 @@ cmd_up() {
     exit 1
   fi
 
-  patch_env
+  patch_env "http://api:3000" "http://api:3000/graphql"
   gen_compose
 
   # A hard-killed prior run (SIGKILL) can orphan the container or leave a stale
@@ -134,12 +138,41 @@ cmd_shell() {
   exec docker exec -it -w /app "$container" bash
 }
 
+cmd_host() {
+  # Run Vite on the HOST instead of in a container. macOS native fsevents give
+  # instant, reliable HMR with no in-container polling (the in-container watcher
+  # relies on `usePolling` and drops events under multi-container CPU load, which
+  # is what breaks hot reload and forces a manual container restart).
+  #
+  # The API is reached over Traefik at api.lago.dev (routable from the host);
+  # Vite proxies /api there via LAGO_API_PROXY_TARGET. Requires the main Lago
+  # stack running and host deps installed (Conductor `setup` runs pnpm install).
+  # Use host OR container for a workspace, not both: they bind the same port and
+  # strictPort will error loudly on collision.
+  if ! curl -sfo /dev/null --max-time 3 https://api.lago.dev/health 2>/dev/null \
+    && ! docker ps --format '{{.Names}}' | grep -q '^lago_api_dev$'; then
+    echo "Warning: main Lago stack / api.lago.dev not reachable. Start it: lago up -d" >&2
+  fi
+
+  patch_env "http://api.lago.dev" "http://api.lago.dev/graphql"
+
+  echo ""
+  echo "  Front [$NAME] (host vite, native HMR) -> http://localhost:${PORT}"
+  echo ""
+
+  cd "$WS"
+  # --port overrides the config default (8080) without writing PORT into .env,
+  # which would break the container path (Vite reads PORT from the .env FILE).
+  exec pnpm exec vite --port "$PORT"
+}
+
 case "$CMD" in
   up) cmd_up ;;
   down) cmd_down ;;
   shell) cmd_shell ;;
+  host) cmd_host ;;
   *)
-    echo "Usage: conductor-front-container.sh {up|down|shell}" >&2
+    echo "Usage: conductor-front-container.sh {up|down|shell|host}" >&2
     exit 1
     ;;
 esac

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -50,6 +50,9 @@ services:
       - LAGO_API_PROXY_TARGET=http://api:3000
       - CODEGEN_API=http://api:3000/graphql
       - APP_DOMAIN=https://app.lago.dev
+      # Vite's tab-title helper (vite.config.ts) shows "WT - <name>" in dev when
+      # this is set, so parallel workspaces are distinguishable in the browser.
+      - LAGO_WORKTREE_NAME=${NAME}
       # Bind vite to the SAME port host-side and container-side so vite's own
       # "Local: http://localhost:${PORT}/" log line advertises the host-reachable
       # port. Conductor's browser button scrapes the LAST port seen in run-script
@@ -167,6 +170,9 @@ cmd_host() {
   echo ""
 
   cd "$WS"
+  # Label the browser tab "WT - <name>" (vite.config.ts tab-title helper), same
+  # as the container path, so parallel workspaces are distinguishable.
+  export LAGO_WORKTREE_NAME="$NAME"
   # --port sets the port explicitly instead of writing PORT into the workspace
   # .env (.env is host-only tooling config, see patch_env). The container path
   # gets its port from the compose `environment` overlay, never from .env.

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -41,7 +41,9 @@ services:
     stdin_open: true
     restart: unless-stopped
     volumes:
-      - ${WS}:/app:cached
+      # Quoted so a workspace path containing spaces / YAML-special chars can't
+      # break the volume string parsing.
+      - "${WS}:/app:cached"
       - front_nm_ct_${SAN}:/app/node_modules
       - front_dist_ct_${SAN}:/app/dist
     environment:
@@ -96,7 +98,9 @@ patch_env() {
 }
 
 cmd_up() {
-  if ! docker ps --format '{{.Names}}' | grep -q '^lago_front_dev$'; then
+  # Substring match (not anchored) for parity with lago-worktree.sh and to
+  # tolerate any Compose-added prefix/suffix on the main front container name.
+  if ! docker ps --format '{{.Names}}' | grep -q 'lago_front_dev'; then
     echo "Error: main Lago stack is not running. Start it first: lago up -d" >&2
     exit 1
   fi
@@ -127,9 +131,15 @@ cmd_up() {
 }
 
 cmd_down() {
-  [[ -f "$COMPOSE_FILE" ]] || { echo "No front container registered for '$NAME'."; exit 0; }
-  docker compose -f "$COMPOSE_FILE" down -v
-  rm -f "$COMPOSE_FILE"
+  if [[ -f "$COMPOSE_FILE" ]]; then
+    docker compose -f "$COMPOSE_FILE" down -v
+    rm -f "$COMPOSE_FILE"
+  else
+    # No compose file (e.g. deleted manually) — still remove the container and
+    # its named volumes directly so nothing is left orphaned.
+    docker rm -f "lago_front_ct_${SAN}" >/dev/null 2>&1 || true
+    docker volume rm "front_nm_ct_${SAN}" "front_dist_ct_${SAN}" >/dev/null 2>&1 || true
+  fi
   echo "Removed front container for '$NAME'."
 }
 
@@ -148,10 +158,12 @@ cmd_shell() {
 }
 
 cmd_host() {
-  # Run Vite on the HOST instead of in a container. macOS native fsevents give
-  # instant, reliable HMR with no in-container polling (the in-container watcher
-  # relies on `usePolling` and drops events under multi-container CPU load, which
-  # is what breaks hot reload and forces a manual container restart).
+  # Run Vite on the HOST instead of in a container. vite.config.ts enables watch
+  # polling by default (required for the Docker bind-mount case); host mode sets
+  # LAGO_DISABLE_VITE_POLLING=true (below) to turn it off, so the host watcher
+  # uses native macOS fsevents — instant, reliable HMR with none of the
+  # in-container polling that drops events under multi-container CPU load and
+  # forces manual container restarts.
   #
   # The API is reached over Traefik at api.lago.dev (routable from the host);
   # Vite proxies /api there via LAGO_API_PROXY_TARGET. Requires the main Lago
@@ -159,7 +171,7 @@ cmd_host() {
   # Use host OR container for a workspace, not both: they bind the same port and
   # strictPort will error loudly on collision.
   if ! curl -sfo /dev/null --max-time 3 https://api.lago.dev/health 2>/dev/null \
-    && ! docker ps --format '{{.Names}}' | grep -q '^lago_api_dev$'; then
+    && ! docker ps --format '{{.Names}}' | grep -q 'lago_api_dev'; then
     echo "Warning: main Lago stack / api.lago.dev not reachable. Start it: lago up -d" >&2
   fi
 
@@ -173,6 +185,8 @@ cmd_host() {
   # Label the browser tab "WT - <name>" (vite.config.ts tab-title helper), same
   # as the container path, so parallel workspaces are distinguishable.
   export LAGO_WORKTREE_NAME="$NAME"
+  # Turn off Vite's default watch polling → native macOS fsevents for host HMR.
+  export LAGO_DISABLE_VITE_POLLING=true
   # --port sets the port explicitly instead of writing PORT into the workspace
   # .env (.env is host-only tooling config, see patch_env). The container path
   # gets its port from the compose `environment` overlay, never from .env.

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -72,21 +72,23 @@ YAML
 }
 
 patch_env() {
-  # Rewrite the API-target keys in the workspace .env. Vite reads these from the
-  # .env FILE (loadEnv), not process.env. The target differs by run mode:
-  #   container (up):  api:3000        (reachable on the lago_dev_default network)
-  #   host (host):     api.lago.dev    (Traefik route, reachable from the host)
-  # Idempotent: drop the managed keys then re-append. .env is gitignored.
-  local proxy_target="$1"
-  local codegen_api="$2"
+  # The workspace .env is only ever consulted by HOST-side tooling: `host` mode's
+  # Vite, and `pnpm codegen` / tests run from the host terminal. Inside the
+  # container these same keys are overridden by the compose `environment` block
+  # (api:3000, on the lago_dev_default network) — container Vite via loadEnv
+  # process.env overlay, in-container codegen via the preset process.env. So .env
+  # ALWAYS carries the HOST-reachable targets: the shared API is reached over
+  # Traefik at api.lago.dev (the worktree runs no API of its own). This is what
+  # makes host `pnpm codegen` resolve; `api:3000` in .env would ENOTFOUND on the
+  # host. Idempotent; .env is gitignored.
   local env_file="$WS/.env"
   touch "$env_file"
   sed -i.bak '/^API_URL=/d; /^LAGO_API_PROXY_TARGET=/d; /^CODEGEN_API=/d' "$env_file"
   rm -f "$env_file.bak"
   {
     echo "API_URL=http://localhost:${PORT}/api"
-    echo "LAGO_API_PROXY_TARGET=${proxy_target}"
-    echo "CODEGEN_API=${codegen_api}"
+    echo "LAGO_API_PROXY_TARGET=http://api.lago.dev"
+    echo "CODEGEN_API=http://api.lago.dev/graphql"
   } >> "$env_file"
 }
 
@@ -96,7 +98,7 @@ cmd_up() {
     exit 1
   fi
 
-  patch_env "http://api:3000" "http://api:3000/graphql"
+  patch_env
   gen_compose
 
   # A hard-killed prior run (SIGKILL) can orphan the container or leave a stale
@@ -158,7 +160,7 @@ cmd_host() {
     echo "Warning: main Lago stack / api.lago.dev not reachable. Start it: lago up -d" >&2
   fi
 
-  patch_env "http://api.lago.dev" "http://api.lago.dev/graphql"
+  patch_env
 
   echo ""
   echo "  Front [$NAME] (host vite, native HMR) -> http://localhost:${PORT}"

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -54,7 +54,8 @@ services:
       - APP_DOMAIN=https://app.lago.dev
       # Vite's tab-title helper (vite.config.ts) shows "WT - <name>" in dev when
       # this is set, so parallel workspaces are distinguishable in the browser.
-      - LAGO_WORKTREE_NAME=${NAME}
+      # Quoted so a name with spaces / YAML-special chars can't break parsing.
+      - "LAGO_WORKTREE_NAME=${NAME}"
       # Bind vite to the SAME port host-side and container-side so vite's own
       # "Local: http://localhost:${PORT}/" log line advertises the host-reachable
       # port. Conductor's browser button scrapes the LAST port seen in run-script

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -138,7 +138,11 @@ export default defineConfig(({ mode }) => {
       strictPort: true,
       allowedHosts: ['app.lago.dev'],
       watch: {
-        usePolling: true,
+        // Polling is required when Vite runs inside the Docker container (bind
+        // mount doesn't deliver native fs events reliably). Host runs opt out
+        // via LAGO_DISABLE_VITE_POLLING=true to use native fsevents (instant,
+        // no polling CPU). Default (unset) keeps polling on.
+        usePolling: env.LAGO_DISABLE_VITE_POLLING !== 'true',
         interval: 1000,
         ignored: [
           '**/node_modules/**',


### PR DESCRIPTION
Enables Conductor for the whole team by moving the previously personal, machine-local config into the repo, and adds the run scripts for developing a front worktree against the shared lago Docker stack.

## What
- **`.conductor/settings.toml`** (new, committed) - shared team config:
  - `enterprise_data_privacy = true`: only account data stored server-side; disables external-AI features (AI chat titles, custom MCP).
  - `setup = pnpm install`, `run_mode = concurrent`, `[git] delete_branch_on_archive`.
  - Three run scripts, all referenced via `$LAGO_PATH` (the team env var already used by `lago-worktree`):
    - `container` (default): run the workspace in its own Docker container on the shared lago stack.
    - `shell`: open an interactive shell inside that container (pnpm / codegen / tests resolve `api:3000`).
    - `host`: run Vite on the host for native, reliable HMR (no in-container file-watch polling, which drops events under load and breaks hot reload).
  - `archive`: tears the container down.
- **`scripts/conductor-front-container.sh`** - the workspace runner (`up` / `down` / `shell` / `host`). Moved into the repo (was a personal file outside it). Highlights:
  - Per-workspace container on the shared network, on the Conductor-assigned port; binds Vite to that same port so Conductor's browser button opens the right URL.
  - Patches the gitignored workspace `.env` with host-reachable API targets (`api.lago.dev` via Traefik) so host `pnpm codegen` and host Vite resolve; inside the container these are overridden with `api:3000` via the compose env.
- **`.gitignore`** - ignore `.conductor/settings.local.toml` (personal per-machine overrides). Was only in `.git/info/exclude` (per-machine), so without this teammates would commit their overrides.
- **`README.md`** - new "Conductor (parallel workspaces)" section.

## Notes
- Use `host` OR `container` per workspace, not both (they bind the same port).
- The run scripts execute the root checkout's copy of the script, so `shell` / `host` become available to a workspace once this merges and the root checkout updates.
