### PR TITLE
refactor(billing-entity): migrate EditBillingEntityGracePeriodDialog to FormDialog

### DIFF
--- a/src/components/settings/invoices/EditBillingEntityGracePeriodDialog.tsx
+++ b/src/components/settings/invoices/EditBillingEntityGracePeriodDialog.tsx
@@ -1,11 +1,12 @@
 import { gql } from '@apollo/client'
 import InputAdornment from '@mui/material/InputAdornment'
-import { revalidateLogic, useStore } from '@tanstack/react-form'
-import { forwardRef, useImperativeHandle, useRef } from 'react'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
 import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
+import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { addToast } from '~/core/apolloClient'
 import { useUpdateBillingEntityGracePeriodMutation } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -24,38 +25,29 @@ gql`
 `
 
 const editBillingEntityGracePeriodValidationSchema = z.object({
-  // Empty input is treated as 0 (see onSubmit coercion below), so it is a valid value.
   invoiceGracePeriod: z.union([
     z.number().max(365, { message: 'text_63bed78ae69de9cad5c348e4' }),
     z.literal(''),
   ]),
 })
 
-export type EditBillingEntityGracePeriodDialogRef = DialogRef
+export const EDIT_BILLING_ENTITY_GRACE_PERIOD_FORM_ID = 'edit-billing-entity-grace-period-form'
 
-interface EditBillingEntityGracePeriodDialogProps {
+type EditBillingEntityGracePeriodDialogData = {
   id: string
   invoiceGracePeriod: number
 }
 
-const FORM_ID = 'edit-billing-entity-grace-period-form'
-
-export const EditBillingEntityGracePeriodDialog = forwardRef<
-  DialogRef,
-  EditBillingEntityGracePeriodDialogProps
->(({ id, invoiceGracePeriod }: EditBillingEntityGracePeriodDialogProps, ref) => {
+export const useEditBillingEntityGracePeriodDialog = () => {
+  const formDialog = useFormDialog()
   const { translate } = useInternationalization()
-  const dialogRef = useRef<DialogRef>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  useImperativeHandle(ref, () => ({
-    openDialog: () => dialogRef.current?.openDialog(),
-    closeDialog: () => dialogRef.current?.closeDialog(),
-  }))
+  const dataRef = useRef<EditBillingEntityGracePeriodDialogData | null>(null)
+  const successRef = useRef(false)
 
   const [updateBillingEntityGracePeriod] = useUpdateBillingEntityGracePeriodMutation({
     onCompleted(res) {
       if (res?.updateBillingEntity) {
+        successRef.current = true
         addToast({
           severity: 'success',
           translateKey: 'text_638dc196fb209d551f3d81ba',
@@ -67,7 +59,7 @@ export const EditBillingEntityGracePeriodDialog = forwardRef<
 
   const form = useAppForm({
     defaultValues: {
-      invoiceGracePeriod: (invoiceGracePeriod ?? '') as number | '',
+      invoiceGracePeriod: '' as number | '',
     },
     validationLogic: revalidateLogic(),
     validators: {
@@ -77,69 +69,75 @@ export const EditBillingEntityGracePeriodDialog = forwardRef<
       await updateBillingEntityGracePeriod({
         variables: {
           input: {
-            id,
+            id: dataRef.current?.id as string,
             billingConfiguration: {
               invoiceGracePeriod: Number(value.invoiceGracePeriod) || 0,
             },
           },
         },
       })
-      dialogRef.current?.closeDialog()
     },
   })
 
-  const isDirty = useStore(form.store, (state) => state.isDirty)
-  const canSubmit = useStore(form.store, (state) => state.canSubmit)
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-  const handleFormSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    form.handleSubmit()
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
+
+    return { reason: 'success' }
   }
 
-  const actions = ({ closeDialog }: { closeDialog: () => void }) => (
-    <>
-      <Button variant="quaternary" onClick={closeDialog}>
-        {translate('text_62bb10ad2a10bd182d002031')}
-      </Button>
-      <Button variant="primary" type="submit" disabled={!canSubmit || !isDirty}>
-        {translate('text_17432414198706rdwf76ek3u')}
-      </Button>
-    </>
-  )
+  const openEditBillingEntityGracePeriodDialog = (data: EditBillingEntityGracePeriodDialogData) => {
+    dataRef.current = data
+    form.reset()
+    form.setFieldValue('invoiceGracePeriod', (data.invoiceGracePeriod ?? '') as number | '')
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate('text_638dc196fb209d551f3d8139')}
-      description={translate('text_638dc196fb209d551f3d813b')}
-      onOpen={() => form.reset()}
-      onClose={() => form.reset()}
-      onEntered={() => inputRef.current?.focus()}
-      formId={FORM_ID}
-      formSubmit={handleFormSubmit}
-      actions={actions}
-    >
-      <div className="mb-8">
-        <form.AppField name="invoiceGracePeriod">
-          {(field) => (
-            <field.TextInputField
-              inputRef={inputRef}
-              beforeChangeFormatter={['positiveNumber', 'int']}
-              label={translate('text_638dc196fb209d551f3d819d')}
-              placeholder={translate('text_638dc196fb209d551f3d8147')}
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    {translate('text_638dc196fb209d551f3d814d')}
-                  </InputAdornment>
-                ),
-              }}
-            />
-          )}
-        </form.AppField>
-      </div>
-    </Dialog>
-  )
-})
+    formDialog
+      .open({
+        title: translate('text_638dc196fb209d551f3d8139'),
+        description: translate('text_638dc196fb209d551f3d813b'),
+        closeOnError: false,
+        onEntered: focusFirstInput,
+        children: (
+          <div className="p-8">
+            <form.AppField name="invoiceGracePeriod">
+              {(field) => (
+                <field.TextInputField
+                  beforeChangeFormatter={['positiveNumber', 'int']}
+                  label={translate('text_638dc196fb209d551f3d819d')}
+                  placeholder={translate('text_638dc196fb209d551f3d8147')}
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        {translate('text_638dc196fb209d551f3d814d')}
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>{translate('text_17432414198706rdwf76ek3u')}</form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: EDIT_BILLING_ENTITY_GRACE_PERIOD_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close') {
+          form.reset()
+          dataRef.current = null
+        }
+      })
+  }
 
-EditBillingEntityGracePeriodDialog.displayName = 'EditBillingEntityGracePeriodDialog'
+  return { openEditBillingEntityGracePeriodDialog }
+}

--- a/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
@@ -16,10 +16,7 @@ import {
 } from '~/components/layouts/Settings'
 import { MainHeader } from '~/components/MainHeader/MainHeader'
 import { useEditBillingEntityDocumentLocaleDialog } from '~/components/settings/invoices/EditBillingEntityDocumentLocaleDialog'
-import {
-  EditBillingEntityGracePeriodDialog,
-  EditBillingEntityGracePeriodDialogRef,
-} from '~/components/settings/invoices/EditBillingEntityGracePeriodDialog'
+import { useEditBillingEntityGracePeriodDialog } from '~/components/settings/invoices/EditBillingEntityGracePeriodDialog'
 import {
   EditBillingEntityInvoiceIssuingDatePolicyDialog,
   EditBillingEntityInvoiceIssuingDatePolicyDialogRef,
@@ -125,7 +122,7 @@ const BillingEntityInvoiceSettings = () => {
 
   const editBillingEntityInvoiceIssuingDatePolicyDialogRef =
     useRef<EditBillingEntityInvoiceIssuingDatePolicyDialogRef>(null)
-  const editGracePeriodDialogRef = useRef<EditBillingEntityGracePeriodDialogRef>(null)
+  const { openEditBillingEntityGracePeriodDialog } = useEditBillingEntityGracePeriodDialog()
   const { openEditBillingEntityDocumentLocaleDialog } = useEditBillingEntityDocumentLocaleDialog()
   const { openEditNetPaymentTermDialog } = useEditNetPaymentTermDialog()
   const netPaymentTermDialogDescription = translate('text_64c7a89b6c67eb6c988980eb')
@@ -236,7 +233,10 @@ const BillingEntityInvoiceSettings = () => {
           disabled={!canEditInvoiceSettings}
           onClick={() => {
             isPremium
-              ? editGracePeriodDialogRef?.current?.openDialog()
+              ? openEditBillingEntityGracePeriodDialog({
+                  id: billingEntity?.id as string,
+                  invoiceGracePeriod,
+                })
               : premiumWarningDialog.open()
           }}
         >
@@ -247,13 +247,6 @@ const BillingEntityInvoiceSettings = () => {
         'text_638dc196fb209d551f3d81a2',
         { gracePeriod: invoiceGracePeriod },
         invoiceGracePeriod,
-      ),
-      dialog: (
-        <EditBillingEntityGracePeriodDialog
-          ref={editGracePeriodDialogRef}
-          invoiceGracePeriod={invoiceGracePeriod}
-          id={billingEntity?.id as string}
-        />
       ),
     },
     {


### PR DESCRIPTION
## Context

`EditBillingEntityGracePeriodDialog` was one of the legacy `forwardRef` + `Dialog` (`~/components/designSystem/Dialog`) consumers flagged by the `no-restricted-imports` ESLint rule. Its form was already on TanStack, so this migration is purely about the dialog system.

## Description

- **`src/components/settings/invoices/EditBillingEntityGracePeriodDialog.tsx`**
  - Replaced `forwardRef` + `useImperativeHandle` + `Dialog` + `useRef<DialogRef>` boilerplate with a `useEditBillingEntityGracePeriodDialog` hook backed by `useFormDialog`.
  - Data (`id`, `invoiceGracePeriod`) now comes in through the open function and is stashed in a `dataRef`; `form.reset()` + `form.setFieldValue('invoiceGracePeriod', ...)` seeds the form synchronously before the dialog opens.
  - `handleSubmit` returns `Promise<DialogResult>` and uses a `successRef` (set inside the mutation's `onCompleted`) — throws on failure (with `closeOnError: false`) so the dialog stays open; returns `{ reason: 'success' }` on success so it auto-closes.
  - Wrapped `children` in `<div className="p-8">` to match the header/footer gutter (BaseDialog does not auto-pad JSX children).
  - First field is a `TextInputField`, so `onEntered` uses the shared `focusFirstInput` helper.
  - Preserved the form-id constant, renamed to `EDIT_BILLING_ENTITY_GRACE_PERIOD_FORM_ID` for a stable public export.
  - Dropped `EditBillingEntityGracePeriodDialogRef` / `EditBillingEntityGracePeriodDialog` exports.

- **`src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx`**
  - Dropped the `useRef<EditBillingEntityGracePeriodDialogRef>` and the `<EditBillingEntityGracePeriodDialog ref={…} />` JSX.
  - The "Edit" button on the grace-period row now calls `openEditBillingEntityGracePeriodDialog({ id, invoiceGracePeriod })` directly (still gated behind the `isPremium` premium check).

## Scope

Strictly scoped to the `no-restricted-imports` warnings for `EditBillingEntityGracePeriodDialog`. No unrelated cleanup.

## Test plan

- [ ] Billing entity settings → Invoice settings → "Grace period" row → "Edit" opens the dialog with the input focused and pre-filled with the current value.
- [ ] Typing an integer between 0 and 365 enables submit; > 365 shows the schema error.
- [ ] Submitting calls `updateBillingEntity` with `billingConfiguration.invoiceGracePeriod`, dialog closes on success, toast displays.
- [ ] Cancel/close does not mutate.
- [ ] Non-premium user still gets the premium warning dialog instead of the grace-period dialog.
- [ ] `pnpm exec tsc --noEmit`, `pnpm exec eslint` on the touched files — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_0111EcTfY7fC4j1t9oLrSpYW)_