### PR TITLE
refactor(billing-entity): migrate EditFinalizeZeroAmountInvoiceDialog to FormDialog and TanStack Form

### DIFF
--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -500,9 +500,10 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                         disabled={loading}
                         variant="inline"
                         onClick={() =>
+                          customer &&
                           openEditFinalizeZeroAmountInvoiceDialog({
                             entity: customer,
-                            finalizeZeroAmountInvoice: customer?.finalizeZeroAmountInvoice,
+                            finalizeZeroAmountInvoice: customer.finalizeZeroAmountInvoice,
                           })
                         }
                       >
@@ -523,10 +524,12 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                               variant="quaternary"
                               align="left"
                               onClick={() => {
-                                openEditFinalizeZeroAmountInvoiceDialog({
-                                  entity: customer,
-                                  finalizeZeroAmountInvoice: customer?.finalizeZeroAmountInvoice,
-                                })
+                                if (customer) {
+                                  openEditFinalizeZeroAmountInvoiceDialog({
+                                    entity: customer,
+                                    finalizeZeroAmountInvoice: customer.finalizeZeroAmountInvoice,
+                                  })
+                                }
                                 closePopper()
                               }}
                             >

--- a/src/components/customers/CustomerSettings.tsx
+++ b/src/components/customers/CustomerSettings.tsx
@@ -32,10 +32,7 @@ import {
   SettingsListWrapper,
   SettingsPaddedContainer,
 } from '~/components/layouts/Settings'
-import {
-  EditFinalizeZeroAmountInvoiceDialog,
-  EditFinalizeZeroAmountInvoiceDialogRef,
-} from '~/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog'
+import { useEditFinalizeZeroAmountInvoiceDialog } from '~/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog'
 import { useEditNetPaymentTermDialog } from '~/components/settings/invoices/EditNetPaymentTermDialog'
 import {
   INVOICE_ISSUING_DATE_ADJUSTMENT_SETTING_KEYS,
@@ -198,8 +195,7 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
   const { openEditNetPaymentTermDialog } = useEditNetPaymentTermDialog()
   const netPaymentTermDialogDescription = translate('text_64c7a89b6c67eb6c988980eb')
   const { openDeleteCustomerNetPaymentTermDialog } = useDeleteCustomerNetPaymentTermDialog()
-  const editFinalizeZeroAmountInvoiceDialogRef =
-    useRef<EditFinalizeZeroAmountInvoiceDialogRef>(null)
+  const { openEditFinalizeZeroAmountInvoiceDialog } = useEditFinalizeZeroAmountInvoiceDialog()
   const { openDeleteCustomerFinalizeZeroAmountInvoiceDialog } =
     useDeleteCustomerFinalizeZeroAmountInvoiceDialog()
 
@@ -504,7 +500,10 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                         disabled={loading}
                         variant="inline"
                         onClick={() =>
-                          editFinalizeZeroAmountInvoiceDialogRef?.current?.openDialog()
+                          openEditFinalizeZeroAmountInvoiceDialog({
+                            entity: customer,
+                            finalizeZeroAmountInvoice: customer?.finalizeZeroAmountInvoice,
+                          })
                         }
                       >
                         {translate('text_645bb193927b375079d28ad2')}
@@ -524,7 +523,10 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
                               variant="quaternary"
                               align="left"
                               onClick={() => {
-                                editFinalizeZeroAmountInvoiceDialogRef?.current?.openDialog()
+                                openEditFinalizeZeroAmountInvoiceDialog({
+                                  entity: customer,
+                                  finalizeZeroAmountInvoice: customer?.finalizeZeroAmountInvoice,
+                                })
                                 closePopper()
                               }}
                             >
@@ -939,17 +941,10 @@ export const CustomerSettings = ({ customerId }: CustomerSettingsProps) => {
       </SettingsPaddedContainer>
 
       {!!customer && (
-        <>
-          <EditCustomerIssuingDatePolicyDialog
-            ref={editIssuingDatePolicyDialogRef}
-            customer={customer}
-          />
-          <EditFinalizeZeroAmountInvoiceDialog
-            ref={editFinalizeZeroAmountInvoiceDialogRef}
-            entity={customer}
-            finalizeZeroAmountInvoice={customer?.finalizeZeroAmountInvoice}
-          />
-        </>
+        <EditCustomerIssuingDatePolicyDialog
+          ref={editIssuingDatePolicyDialogRef}
+          customer={customer}
+        />
       )}
     </>
   )

--- a/src/components/customers/__tests__/CustomerSettings.test.tsx
+++ b/src/components/customers/__tests__/CustomerSettings.test.tsx
@@ -112,13 +112,11 @@ jest.mock('~/components/settings/invoices/EditNetPaymentTermDialog', () => ({
   }),
 }))
 
-jest.mock('~/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog', () => {
-  const React = jest.requireActual('react')
-  const MockDialog = React.forwardRef(() => null)
-
-  MockDialog.displayName = 'EditFinalizeZeroAmountInvoiceDialog'
-  return { EditFinalizeZeroAmountInvoiceDialog: MockDialog }
-})
+jest.mock('~/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog', () => ({
+  useEditFinalizeZeroAmountInvoiceDialog: () => ({
+    openEditFinalizeZeroAmountInvoiceDialog: jest.fn(),
+  }),
+}))
 
 jest.mock('~/components/dialogs/PremiumWarningDialog', () => ({
   usePremiumWarningDialog: () => ({ open: jest.fn(), close: jest.fn() }),

--- a/src/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog.tsx
+++ b/src/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog.tsx
@@ -1,12 +1,15 @@
 import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
-import { forwardRef } from 'react'
-import { object, string } from 'yup'
+import { revalidateLogic } from '@tanstack/react-form'
+import { useRef } from 'react'
+import { z } from 'zod'
 
-import { Button } from '~/components/designSystem/Button'
-import { Dialog, DialogRef } from '~/components/designSystem/Dialog'
-import { ComboBoxField } from '~/components/form'
+import { useFormDialog } from '~/components/dialogs/FormDialog'
+import { DialogResult } from '~/components/dialogs/types'
 import { addToast } from '~/core/apolloClient'
+import {
+  FINALIZE_ZERO_AMOUNT_INVOICE_INPUT_CLASSNAME,
+  MUI_INPUT_BASE_ROOT_CLASSNAME,
+} from '~/core/constants/form'
 import {
   EditBillingEntityFinalizeZeroAmountInvoiceForDialogFragment,
   EditCustomerFinalizeZeroAmountInvoiceForDialogFragment,
@@ -15,6 +18,7 @@ import {
   useUpdateCustomerFinalizeZeroAmountInvoiceMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 
 gql`
   fragment EditCustomerFinalizeZeroAmountInvoiceForDialog on Customer {
@@ -44,7 +48,19 @@ gql`
   }
 `
 
-type EditFinalizeZeroAmountInvoiceDialogProps = {
+export const EDIT_FINALIZE_ZERO_AMOUNT_INVOICE_FORM_ID = 'edit-finalize-zero-amount-invoice-form'
+
+const validationSchema = z.object({
+  finalizeZeroAmountInvoice: z.string().min(1),
+})
+
+type FormValues = z.infer<typeof validationSchema>
+
+const initialValues: FormValues = {
+  finalizeZeroAmountInvoice: '',
+}
+
+type EditFinalizeZeroAmountInvoiceDialogData = {
   entity?:
     | EditCustomerFinalizeZeroAmountInvoiceForDialogFragment
     | EditBillingEntityFinalizeZeroAmountInvoiceForDialogFragment
@@ -52,18 +68,29 @@ type EditFinalizeZeroAmountInvoiceDialogProps = {
   finalizeZeroAmountInvoice?: FinalizeZeroAmountInvoiceEnum | boolean | null
 }
 
-export type EditFinalizeZeroAmountInvoiceDialogRef = DialogRef
+const getInitialValue = (data: EditFinalizeZeroAmountInvoiceDialogData): string => {
+  const isCustomer = data.entity?.__typename === 'Customer'
 
-export const EditFinalizeZeroAmountInvoiceDialog = forwardRef<
-  EditFinalizeZeroAmountInvoiceDialogRef,
-  EditFinalizeZeroAmountInvoiceDialogProps
->(({ entity, finalizeZeroAmountInvoice }: EditFinalizeZeroAmountInvoiceDialogProps, dialogRef) => {
+  if (isCustomer) {
+    if (data.finalizeZeroAmountInvoice === FinalizeZeroAmountInvoiceEnum.Inherit) return ''
+
+    return (data.finalizeZeroAmountInvoice as FinalizeZeroAmountInvoiceEnum | undefined) ?? ''
+  }
+
+  return data.finalizeZeroAmountInvoice?.toString() ?? ''
+}
+
+export const useEditFinalizeZeroAmountInvoiceDialog = () => {
+  const formDialog = useFormDialog()
   const { translate } = useInternationalization()
+  const dataRef = useRef<EditFinalizeZeroAmountInvoiceDialogData | null>(null)
+  const successRef = useRef(false)
 
   const [updateCustomerFinalizeZeroAmountInvoice] =
     useUpdateCustomerFinalizeZeroAmountInvoiceMutation({
       onCompleted(res) {
         if (res?.updateCustomer) {
+          successRef.current = true
           addToast({
             severity: 'success',
             translateKey: translate('text_1725549671288cyc585wdz35'),
@@ -76,6 +103,7 @@ export const EditFinalizeZeroAmountInvoiceDialog = forwardRef<
     useUpdateBillingEntityFinalizeZeroAmountInvoiceMutation({
       onCompleted(res) {
         if (res?.updateBillingEntity) {
+          successRef.current = true
           addToast({
             severity: 'success',
             translateKey: translate('text_17255496712882bspi9zp0ii'),
@@ -85,108 +113,125 @@ export const EditFinalizeZeroAmountInvoiceDialog = forwardRef<
       refetchQueries: ['getBillingEntitySettings'],
     })
 
-  const isCustomer = entity?.__typename === 'Customer'
-
-  const getInitialValue = () => {
-    if (isCustomer) {
-      return finalizeZeroAmountInvoice === FinalizeZeroAmountInvoiceEnum.Inherit
-        ? ''
-        : finalizeZeroAmountInvoice
-    }
-    return finalizeZeroAmountInvoice?.toString()
-  }
-
-  const initialValue = getInitialValue()
-
-  const formikProps = useFormik({
-    initialValues: {
-      finalizeZeroAmountInvoice: initialValue,
+  const form = useAppForm({
+    defaultValues: initialValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: validationSchema,
     },
-    validationSchema: object().shape({
-      finalizeZeroAmountInvoice: string().required(),
-    }),
-    validateOnMount: true,
-    enableReinitialize: true,
-    onSubmit: async (values) => {
-      if (!values.finalizeZeroAmountInvoice) {
-        return
-      }
+    onSubmit: async ({ value }) => {
+      const data = dataRef.current
+
+      if (!data?.entity || !value.finalizeZeroAmountInvoice) return
+
+      const isCustomer = data.entity.__typename === 'Customer'
 
       if (isCustomer) {
-        return await updateCustomerFinalizeZeroAmountInvoice({
+        const customer = data.entity as EditCustomerFinalizeZeroAmountInvoiceForDialogFragment
+
+        await updateCustomerFinalizeZeroAmountInvoice({
           variables: {
             input: {
-              id: entity?.id || '',
-              externalId: entity.externalId,
-              name: entity?.name || '',
+              id: customer.id,
+              externalId: customer.externalId,
+              name: customer.name || '',
               finalizeZeroAmountInvoice:
-                values?.finalizeZeroAmountInvoice as FinalizeZeroAmountInvoiceEnum,
+                value.finalizeZeroAmountInvoice as FinalizeZeroAmountInvoiceEnum,
             },
           },
         })
+
+        return
       }
 
-      return await updateBillingEntityFinalizeZeroAmountInvoice({
+      const billingEntity =
+        data.entity as EditBillingEntityFinalizeZeroAmountInvoiceForDialogFragment
+
+      await updateBillingEntityFinalizeZeroAmountInvoice({
         variables: {
           input: {
-            id: (entity as EditBillingEntityFinalizeZeroAmountInvoiceForDialogFragment)?.id,
-            finalizeZeroAmountInvoice: values.finalizeZeroAmountInvoice === 'true',
+            id: billingEntity.id,
+            finalizeZeroAmountInvoice: value.finalizeZeroAmountInvoice === 'true',
           },
         },
       })
     },
   })
 
-  const comboBoxData = isCustomer
-    ? [
-        { value: 'finalize', label: translate('text_1725549671287ancbf00edxx') },
-        { value: 'skip', label: translate('text_1725549671288zkq9sr0y46l') },
-      ]
-    : [
-        { value: 'true', label: translate('text_1725549671287ancbf00edxx') },
-        { value: 'false', label: translate('text_1725549671288zkq9sr0y46l') },
-      ]
+  const handleSubmit = async (): Promise<DialogResult> => {
+    successRef.current = false
+    await form.handleSubmit()
 
-  return (
-    <Dialog
-      ref={dialogRef}
-      title={translate('text_17255383402002zmj6x02fx8')}
-      description={translate('text_1725538340200495slgen6ji')}
-      onClose={() => {
-        formikProps.resetForm()
-      }}
-      actions={({ closeDialog }) => (
-        <>
-          <Button variant="quaternary" onClick={closeDialog}>
-            {translate('text_62bb10ad2a10bd182d002031')}
-          </Button>
-          <Button
-            variant="primary"
-            disabled={!formikProps.isValid || !formikProps.dirty}
-            onClick={async () => {
-              await formikProps.submitForm()
-              closeDialog()
-              formikProps.resetForm()
-            }}
-          >
-            {translate('text_17432414198706rdwf76ek3u')}
-          </Button>
-        </>
-      )}
-    >
-      <div className="mb-8 flex flex-col gap-3">
-        <ComboBoxField
-          disableClearable
-          name="finalizeZeroAmountInvoice"
-          placeholder={translate('text_1725550661207stz6kovtzkp')}
-          label={translate('text_1725549671288gcrvgdn7rml')}
-          data={comboBoxData}
-          PopperProps={{ displayInDialog: true }}
-          formikProps={formikProps}
-        />
-      </div>
-    </Dialog>
-  )
-})
+    if (!successRef.current) {
+      throw new Error('Submit failed')
+    }
 
-EditFinalizeZeroAmountInvoiceDialog.displayName = 'forwardRef'
+    return { reason: 'success' }
+  }
+
+  const openEditFinalizeZeroAmountInvoiceDialog = (
+    data: EditFinalizeZeroAmountInvoiceDialogData,
+  ) => {
+    dataRef.current = data
+    form.reset()
+    form.setFieldValue('finalizeZeroAmountInvoice', getInitialValue(data))
+
+    const isCustomer = data.entity?.__typename === 'Customer'
+    const comboBoxData = isCustomer
+      ? [
+          { value: 'finalize', label: translate('text_1725549671287ancbf00edxx') },
+          { value: 'skip', label: translate('text_1725549671288zkq9sr0y46l') },
+        ]
+      : [
+          { value: 'true', label: translate('text_1725549671287ancbf00edxx') },
+          { value: 'false', label: translate('text_1725549671288zkq9sr0y46l') },
+        ]
+
+    formDialog
+      .open({
+        title: translate('text_17255383402002zmj6x02fx8'),
+        description: translate('text_1725538340200495slgen6ji'),
+        closeOnError: false,
+        onEntered: (container) => {
+          container
+            .querySelector<HTMLElement>(
+              `.${FINALIZE_ZERO_AMOUNT_INVOICE_INPUT_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+            )
+            ?.click()
+        },
+        children: (
+          <div className="p-8">
+            <form.AppField name="finalizeZeroAmountInvoice">
+              {(field) => (
+                <field.ComboBoxField
+                  className={FINALIZE_ZERO_AMOUNT_INVOICE_INPUT_CLASSNAME}
+                  disableClearable
+                  placeholder={translate('text_1725550661207stz6kovtzkp')}
+                  label={translate('text_1725549671288gcrvgdn7rml')}
+                  data={comboBoxData}
+                  PopperProps={{ displayInDialog: true }}
+                />
+              )}
+            </form.AppField>
+          </div>
+        ),
+        mainAction: (
+          <form.AppForm>
+            <form.SubmitButton>{translate('text_17432414198706rdwf76ek3u')}</form.SubmitButton>
+          </form.AppForm>
+        ),
+        form: {
+          id: EDIT_FINALIZE_ZERO_AMOUNT_INVOICE_FORM_ID,
+          submit: handleSubmit,
+        },
+      })
+      .then((response) => {
+        if (response.reason === 'close') {
+          form.reset()
+          dataRef.current = null
+        }
+      })
+  }
+
+  return { openEditFinalizeZeroAmountInvoiceDialog }
+}

--- a/src/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog.tsx
+++ b/src/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog.tsx
@@ -50,6 +50,9 @@ gql`
 
 export const EDIT_FINALIZE_ZERO_AMOUNT_INVOICE_FORM_ID = 'edit-finalize-zero-amount-invoice-form'
 
+export const EDIT_FINALIZE_ZERO_AMOUNT_INVOICE_SUBMIT_BUTTON_TEST_ID =
+  'edit-finalize-zero-amount-invoice-submit-button'
+
 const validationSchema = z.object({
   finalizeZeroAmountInvoice: z.string().min(1),
 })
@@ -217,7 +220,9 @@ export const useEditFinalizeZeroAmountInvoiceDialog = () => {
         ),
         mainAction: (
           <form.AppForm>
-            <form.SubmitButton>{translate('text_17432414198706rdwf76ek3u')}</form.SubmitButton>
+            <form.SubmitButton dataTest={EDIT_FINALIZE_ZERO_AMOUNT_INVOICE_SUBMIT_BUTTON_TEST_ID}>
+              {translate('text_17432414198706rdwf76ek3u')}
+            </form.SubmitButton>
           </form.AppForm>
         ),
         form: {

--- a/src/components/settings/invoices/__tests__/EditFinalizeZeroAmountInvoiceDialog.test.tsx
+++ b/src/components/settings/invoices/__tests__/EditFinalizeZeroAmountInvoiceDialog.test.tsx
@@ -1,0 +1,205 @@
+import NiceModal from '@ebay/nice-modal-react'
+import { act, cleanup, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ReactNode } from 'react'
+
+import { DIALOG_TITLE_TEST_ID, FORM_DIALOG_NAME } from '~/components/dialogs/const'
+import FormDialog from '~/components/dialogs/FormDialog'
+import {
+  EditBillingEntityFinalizeZeroAmountInvoiceForDialogFragment,
+  EditCustomerFinalizeZeroAmountInvoiceForDialogFragment,
+  FinalizeZeroAmountInvoiceEnum,
+} from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import {
+  EDIT_FINALIZE_ZERO_AMOUNT_INVOICE_SUBMIT_BUTTON_TEST_ID,
+  useEditFinalizeZeroAmountInvoiceDialog,
+} from '../EditFinalizeZeroAmountInvoiceDialog'
+
+NiceModal.register(FORM_DIALOG_NAME, FormDialog)
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+const mockAddToast = jest.fn()
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: (...args: unknown[]) => mockAddToast(...args),
+}))
+
+const mockUpdateCustomer = jest.fn()
+const mockUpdateBillingEntity = jest.fn()
+
+let customerCallbacks: { onCompleted?: (data: unknown) => void } = {}
+let billingEntityCallbacks: { onCompleted?: (data: unknown) => void } = {}
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useUpdateCustomerFinalizeZeroAmountInvoiceMutation: (options: typeof customerCallbacks) => {
+    customerCallbacks = options
+    return [mockUpdateCustomer, { loading: false }]
+  },
+  useUpdateBillingEntityFinalizeZeroAmountInvoiceMutation: (
+    options: typeof billingEntityCallbacks,
+  ) => {
+    billingEntityCallbacks = options
+    return [mockUpdateBillingEntity, { loading: false }]
+  },
+}))
+
+const CUSTOMER_ID = 'customer-1'
+const CUSTOMER_EXTERNAL_ID = 'customer-external-1'
+const BILLING_ENTITY_ID = 'billing-entity-1'
+
+const customerEntity: EditCustomerFinalizeZeroAmountInvoiceForDialogFragment = {
+  __typename: 'Customer',
+  id: CUSTOMER_ID,
+  externalId: CUSTOMER_EXTERNAL_ID,
+  name: 'Acme',
+  finalizeZeroAmountInvoice: FinalizeZeroAmountInvoiceEnum.Finalize,
+}
+
+const billingEntity: EditBillingEntityFinalizeZeroAmountInvoiceForDialogFragment = {
+  __typename: 'BillingEntity',
+  id: BILLING_ENTITY_ID,
+  finalizeZeroAmountInvoice: true,
+}
+
+type OpenArgs = Parameters<
+  ReturnType<
+    typeof useEditFinalizeZeroAmountInvoiceDialog
+  >['openEditFinalizeZeroAmountInvoiceDialog']
+>[0]
+
+function TestComponent({ openArgs }: { openArgs: OpenArgs }): ReactNode {
+  const { openEditFinalizeZeroAmountInvoiceDialog } = useEditFinalizeZeroAmountInvoiceDialog()
+
+  return (
+    <button
+      data-test="open-dialog"
+      onClick={() => openEditFinalizeZeroAmountInvoiceDialog(openArgs)}
+    >
+      Open Dialog
+    </button>
+  )
+}
+
+async function renderAndOpenDialog(openArgs: OpenArgs): Promise<void> {
+  await act(() =>
+    render(
+      <NiceModal.Provider>
+        <TestComponent openArgs={openArgs} />
+      </NiceModal.Provider>,
+    ),
+  )
+
+  await act(async () => {
+    screen.getByTestId('open-dialog').click()
+  })
+
+  await waitFor(() => {
+    expect(screen.getByTestId(DIALOG_TITLE_TEST_ID)).toBeInTheDocument()
+  })
+}
+
+describe('EditFinalizeZeroAmountInvoiceDialog', () => {
+  afterEach(() => {
+    cleanup()
+    jest.clearAllMocks()
+    customerCallbacks = {}
+    billingEntityCallbacks = {}
+  })
+
+  describe('Rendering', () => {
+    it('renders the dialog title and the submit button when opened', async () => {
+      await renderAndOpenDialog({
+        entity: customerEntity,
+        finalizeZeroAmountInvoice: customerEntity.finalizeZeroAmountInvoice,
+      })
+
+      expect(screen.getByTestId(DIALOG_TITLE_TEST_ID)).toHaveTextContent(
+        'text_17255383402002zmj6x02fx8',
+      )
+      expect(
+        screen.getByTestId(EDIT_FINALIZE_ZERO_AMOUNT_INVOICE_SUBMIT_BUTTON_TEST_ID),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('Submit for a customer entity', () => {
+    it('calls the customer mutation with the expected input and shows a success toast', async () => {
+      mockUpdateCustomer.mockImplementation(async () => {
+        customerCallbacks.onCompleted?.({
+          updateCustomer: { id: CUSTOMER_ID },
+        })
+
+        return { data: { updateCustomer: { id: CUSTOMER_ID } } }
+      })
+
+      await renderAndOpenDialog({
+        entity: customerEntity,
+        finalizeZeroAmountInvoice: customerEntity.finalizeZeroAmountInvoice,
+      })
+
+      await userEvent.click(
+        screen.getByTestId(EDIT_FINALIZE_ZERO_AMOUNT_INVOICE_SUBMIT_BUTTON_TEST_ID),
+      )
+
+      await waitFor(() => {
+        expect(mockUpdateCustomer).toHaveBeenCalledWith({
+          variables: {
+            input: {
+              id: CUSTOMER_ID,
+              externalId: CUSTOMER_EXTERNAL_ID,
+              name: 'Acme',
+              finalizeZeroAmountInvoice: FinalizeZeroAmountInvoiceEnum.Finalize,
+            },
+          },
+        })
+      })
+
+      expect(mockUpdateBillingEntity).not.toHaveBeenCalled()
+      expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+    })
+  })
+
+  describe('Submit for a billing entity', () => {
+    it('calls the billing entity mutation with a boolean value and shows a success toast', async () => {
+      mockUpdateBillingEntity.mockImplementation(async () => {
+        billingEntityCallbacks.onCompleted?.({
+          updateBillingEntity: { id: BILLING_ENTITY_ID },
+        })
+
+        return { data: { updateBillingEntity: { id: BILLING_ENTITY_ID } } }
+      })
+
+      await renderAndOpenDialog({
+        entity: billingEntity,
+        finalizeZeroAmountInvoice: billingEntity.finalizeZeroAmountInvoice,
+      })
+
+      await userEvent.click(
+        screen.getByTestId(EDIT_FINALIZE_ZERO_AMOUNT_INVOICE_SUBMIT_BUTTON_TEST_ID),
+      )
+
+      await waitFor(() => {
+        expect(mockUpdateBillingEntity).toHaveBeenCalledWith({
+          variables: {
+            input: {
+              id: BILLING_ENTITY_ID,
+              finalizeZeroAmountInvoice: true,
+            },
+          },
+        })
+      })
+
+      expect(mockUpdateCustomer).not.toHaveBeenCalled()
+      expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+    })
+  })
+})

--- a/src/core/constants/form.ts
+++ b/src/core/constants/form.ts
@@ -52,6 +52,7 @@ export const RESEND_INVOICE_PAYMENT_METHOD_INPUT_CLASSNAME = 'resendInvoicePayme
 // Billing entity
 export const SEARCH_INVOICE_CUSTOM_SECTION_INPUT_CLASSNAME = 'searchInvoiceCustomSectionInput'
 export const SEARCH_DUNNING_CAMPAIGN_INPUT_CLASSNAME = 'searchDunningCampaignInput'
+export const FINALIZE_ZERO_AMOUNT_INVOICE_INPUT_CLASSNAME = 'finalizeZeroAmountInvoiceInput'
 // Customer
 export const SEARCH_TAX_INPUT_FOR_CUSTOMER_CLASSNAME = 'searchTaxForCustomerInput'
 export const SEARCH_COUPON_INPUT_FOR_CUSTOMER_CLASSNAME = 'searchCouponForCustomerInput'

--- a/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
@@ -27,10 +27,7 @@ import {
 import { useEditBillingEntityInvoiceNumberingDialog } from '~/components/settings/invoices/EditBillingEntityInvoiceNumberingDialog'
 import { useEditBillingEntityInvoiceTemplateDialog } from '~/components/settings/invoices/EditBillingEntityInvoiceTemplateDialog'
 import { useEditDefaultCurrencyDialog } from '~/components/settings/invoices/EditDefaultCurrencyDialog'
-import {
-  EditFinalizeZeroAmountInvoiceDialog,
-  EditFinalizeZeroAmountInvoiceDialogRef,
-} from '~/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog'
+import { useEditFinalizeZeroAmountInvoiceDialog } from '~/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog'
 import { useEditNetPaymentTermDialog } from '~/components/settings/invoices/EditNetPaymentTermDialog'
 import {
   INVOICE_ISSUING_DATE_ADJUSTMENT_SETTING_KEYS,
@@ -129,8 +126,7 @@ const BillingEntityInvoiceSettings = () => {
   const { openEditBillingEntityDocumentLocaleDialog } = useEditBillingEntityDocumentLocaleDialog()
   const { openEditNetPaymentTermDialog } = useEditNetPaymentTermDialog()
   const netPaymentTermDialogDescription = translate('text_64c7a89b6c67eb6c988980eb')
-  const editFinalizeZeroAmountInvoiceDialogRef =
-    useRef<EditFinalizeZeroAmountInvoiceDialogRef>(null)
+  const { openEditFinalizeZeroAmountInvoiceDialog } = useEditFinalizeZeroAmountInvoiceDialog()
   const premiumWarningDialog = usePremiumWarningDialog()
   const { openEditDefaultCurrencyDialog } = useEditDefaultCurrencyDialog()
   const { openEditBillingEntityInvoiceTemplateDialog } = useEditBillingEntityInvoiceTemplateDialog()
@@ -208,7 +204,12 @@ const BillingEntityInvoiceSettings = () => {
         <Button
           variant="inline"
           disabled={!canEditInvoiceSettings}
-          onClick={() => editFinalizeZeroAmountInvoiceDialogRef?.current?.openDialog()}
+          onClick={() =>
+            openEditFinalizeZeroAmountInvoiceDialog({
+              entity: billingEntity,
+              finalizeZeroAmountInvoice: billingEntity?.finalizeZeroAmountInvoice,
+            })
+          }
         >
           {translate('text_637f819eff19cd55a56d55e4')}
         </Button>
@@ -216,14 +217,6 @@ const BillingEntityInvoiceSettings = () => {
       content: billingEntity?.finalizeZeroAmountInvoice
         ? translate('text_1725549671287ancbf00edxx')
         : translate('text_1725549671288zkq9sr0y46l'),
-
-      dialog: (
-        <EditFinalizeZeroAmountInvoiceDialog
-          ref={editFinalizeZeroAmountInvoiceDialogRef}
-          entity={billingEntity}
-          finalizeZeroAmountInvoice={billingEntity?.finalizeZeroAmountInvoice}
-        />
-      ),
     },
     {
       id: 'invoice-settings-grace-period',

--- a/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
+++ b/src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx
@@ -205,9 +205,10 @@ const BillingEntityInvoiceSettings = () => {
           variant="inline"
           disabled={!canEditInvoiceSettings}
           onClick={() =>
+            billingEntity &&
             openEditFinalizeZeroAmountInvoiceDialog({
               entity: billingEntity,
-              finalizeZeroAmountInvoice: billingEntity?.finalizeZeroAmountInvoice,
+              finalizeZeroAmountInvoice: billingEntity.finalizeZeroAmountInvoice,
             })
           }
         >


### PR DESCRIPTION
## Context

`EditFinalizeZeroAmountInvoiceDialog` was one of the legacy `forwardRef` + `Dialog` + Formik consumers flagged by the `no-restricted-imports` ESLint rule. It's a small combobox-picker dialog shared by two consumers (billing-entity invoice settings and customer settings), so the migration also updates both call sites in the same PR.

## Description

- **`src/components/settings/invoices/EditFinalizeZeroAmountInvoiceDialog.tsx`**
  - Replaced the `forwardRef` + `useImperativeHandle` + `Dialog` + Formik/yup stack with a `useEditFinalizeZeroAmountInvoiceDialog` hook backed by `useFormDialog` + `useAppForm` + Zod (`z.string().min(1)` on `finalizeZeroAmountInvoice`).
  - Data (`entity`, current `finalizeZeroAmountInvoice`) comes in through the open function and is stashed in a `dataRef`; `form.reset()` + `form.setFieldValue()` seeds the form synchronously before the dialog opens.
  - Preserved the Customer vs BillingEntity branching in `onSubmit`: the customer path uses the `FinalizeZeroAmountInvoiceEnum` union (`'finalize'` / `'skip'`), the billing-entity path serializes to a boolean via the `'true'` / `'false'` string values.
  - `handleSubmit` returns `Promise<DialogResult>` using a `successRef` set inside each mutation's `onCompleted` — throws on failure (with `closeOnError: false`) so the dialog stays open; returns `{ reason: 'success' }` on success so it auto-closes.
  - Wrapped `children` in `<div className="p-8">` to match the header/footer gutter (BaseDialog does not auto-pad JSX children).
  - First field is a `ComboBoxField`, so `onEntered` clicks its `MuiInputBase-root` to open the dropdown on enter. Added a dedicated `FINALIZE_ZERO_AMOUNT_INVOICE_INPUT_CLASSNAME` constant in `src/core/constants/form.ts` under the Billing entity group.
  - Exports a stable `EDIT_FINALIZE_ZERO_AMOUNT_INVOICE_FORM_ID` constant used as the dialog's form id.
  - Dropped `EditFinalizeZeroAmountInvoiceDialog` / `EditFinalizeZeroAmountInvoiceDialogRef` exports.

- **`src/pages/settings/BillingEntity/sections/BillingEntityInvoiceSettings.tsx`** and **`src/components/customers/CustomerSettings.tsx`**
  - Dropped the `useRef<EditFinalizeZeroAmountInvoiceDialogRef>` + `<EditFinalizeZeroAmountInvoiceDialog ref={…} />` JSX renders on each consumer.
  - "Edit" buttons now call `openEditFinalizeZeroAmountInvoiceDialog({ entity, finalizeZeroAmountInvoice })` directly.
  - In `CustomerSettings`, the trailing "dialogs" render simplifies to a single element — dropped the now-useless fragment wrapper.

- **`src/components/customers/__tests__/CustomerSettings.test.tsx`**
  - Replaced the `React.forwardRef` stub for `EditFinalizeZeroAmountInvoiceDialog` with the hook shape (`{ openEditFinalizeZeroAmountInvoiceDialog }`) that `CustomerSettings` now consumes. All 33 tests still pass.

## Scope

Strictly scoped to the `no-restricted-imports` warnings for `EditFinalizeZeroAmountInvoiceDialog`. The other three dialogs in the same billing-entity/customer-settings cluster (`EditBillingEntityGracePeriodDialog`, `EditBillingEntityInvoiceIssuingDatePolicyDialog`, `EditCustomerIssuingDatePolicyDialog`) each ship in their own dedicated PRs.

## Test plan

- [ ] Billing entity settings → Invoice settings → "Finalize empty invoices" row → "Edit" opens the dialog with the combobox dropdown auto-opened.
- [ ] Selecting Finalize / Skip and submitting fires `updateBillingEntityFinalizeZeroAmountInvoice` with the correct boolean and displays the success toast. Dialog closes.
- [ ] Customer settings → same row, both the direct "Edit" (Inherit state) and the popper's "Edit" (non-Inherit) open the dialog with the current value preselected. Submitting calls `updateCustomerFinalizeZeroAmountInvoice` with the correct enum value.
- [ ] Submit button stays disabled until a value is picked (validation).
- [ ] Cancel/close does not mutate; the customer popper's "Delete" still opens the delete dialog.
- [ ] `pnpm exec tsc --noEmit`, `pnpm exec eslint` on the touched files — clean.
- [ ] `pnpm test src/components/customers/__tests__/CustomerSettings.test.tsx` — 33/33 passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_0111EcTfY7fC4j1t9oLrSpYW)_