### PR TITLE
fix(quotes): preload customer locale before PDF preview render

### DIFF
--- a/src/hooks/core/__tests__/useContextualLocale.test.tsx
+++ b/src/hooks/core/__tests__/useContextualLocale.test.tsx
@@ -1,0 +1,49 @@
+import { renderHook } from '@testing-library/react'
+
+import { preloadContextualLocale, useContextualLocale } from '~/hooks/core/useContextualLocale'
+
+// `mock`-prefixed so jest allows referencing it inside the hoisted factory.
+const mockGetTranslations = jest.fn(() => Promise.resolve({ text_header_name: 'Nom' }))
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  // AppEnvEnum.production — inlined because jest.mock factories can't reference imports.
+  envGlobalVar: () => ({ appEnv: 'production' }),
+}))
+
+jest.mock('~/core/translations', () => ({
+  ...jest.requireActual('~/core/translations'),
+  getTranslations: () => mockGetTranslations(),
+}))
+
+describe('useContextualLocale()', () => {
+  beforeEach(() => {
+    mockGetTranslations.mockClear()
+  })
+
+  describe('preloadContextualLocale()', () => {
+    it('warms the cache so the hook resolves translations on its first render', async () => {
+      // Preload before render — this is what QuotePdfProvider does before mounting the
+      // off-screen editor so the very first (synchronous) render already has the bundle.
+      await preloadContextualLocale('fr')
+
+      const { result } = renderHook(() => useContextualLocale('fr'))
+
+      // First render (state initializer) already returns the translated value instead of
+      // the empty-string "not ready" sentinel — the fix for LAGO-1686.
+      expect(result.current.translateWithContextualLocal('text_header_name')).toBe('Nom')
+      expect(mockGetTranslations).toHaveBeenCalled()
+    })
+
+    it('does not re-fetch a locale that is already cached', async () => {
+      // Distinct locale so this assertion is independent of the module-level cache
+      // populated by the previous test.
+      await preloadContextualLocale('de')
+      const callsAfterFirst = mockGetTranslations.mock.calls.length
+
+      await preloadContextualLocale('de')
+
+      expect(mockGetTranslations.mock.calls.length).toBe(callsAfterFirst)
+    })
+  })
+})

--- a/src/hooks/core/useContextualLocale.ts
+++ b/src/hooks/core/useContextualLocale.ts
@@ -14,6 +14,18 @@ const { appEnv } = envGlobalVar()
 // Simple module-level cache for contextual translations
 const contextualTranslationCache = new Map<Locale, Translation>()
 
+// Warm the cache for a locale ahead of render. Consumers that render synchronously
+// (e.g. the off-screen quote/order PDF editor) can await this so that
+// `useContextualLocale`'s state initializer resolves the bundle on the very first
+// render instead of returning empty strings until the async import lands.
+export const preloadContextualLocale = async (locale: Locale): Promise<void> => {
+  if (contextualTranslationCache.has(locale)) return
+
+  const loadedTranslations = await getTranslations(locale)
+
+  contextualTranslationCache.set(locale, loadedTranslations)
+}
+
 type UseContextualLocale = (locale: Locale) => {
   translateWithContextualLocal: (key: string, data?: TranslateData, plural?: number) => string
 }
@@ -29,9 +41,8 @@ export const useContextualLocale: UseContextualLocale = (locale) => {
       return
     }
 
-    getTranslations(locale).then((loadedTranslations) => {
-      contextualTranslationCache.set(locale, loadedTranslations)
-      setTranslations(loadedTranslations)
+    preloadContextualLocale(locale).then(() => {
+      setTranslations(contextualTranslationCache.get(locale))
     })
   }, [locale])
 

--- a/src/pages/quotes/common/QuotePdfProvider.tsx
+++ b/src/pages/quotes/common/QuotePdfProvider.tsx
@@ -12,6 +12,7 @@ import {
 import { printHtmlContent } from '~/components/designSystem/RichTextEditor/common/printHtmlContent'
 import RichTextEditor from '~/components/designSystem/RichTextEditor/RichTextEditor'
 import { addToast } from '~/core/apolloClient'
+import { preloadContextualLocale } from '~/hooks/core/useContextualLocale'
 
 import type { QuotePreviewProps } from './buildQuotePreviewProps'
 import { QuotePdfHeader } from './QuotePdfHeader'
@@ -50,28 +51,34 @@ export const QuotePdfProvider = ({ children }: { children: ReactNode }) => {
   const download = useCallback((previewProps: QuotePreviewProps): Promise<void> => {
     if (!previewProps.content) return Promise.resolve()
 
-    const promise = new Promise<void>((resolve, reject) => {
-      requestIdRef.current += 1
-      const request: PendingRequest = {
-        id: requestIdRef.current,
-        props: previewProps,
-        resolve,
-        reject,
-      }
+    // Warm the customer-locale translation bundle before mounting the off-screen
+    // preview editor. The editor snapshots its DOM two animation frames after mount,
+    // which is faster than the async locale import resolves — so without this, a
+    // first-time non-English render captures empty pricing-table headers (LAGO-1686).
+    const result = preloadContextualLocale(previewProps.customerLocale).then(() => {
+      return new Promise<void>((resolve, reject) => {
+        requestIdRef.current += 1
+        const request: PendingRequest = {
+          id: requestIdRef.current,
+          props: previewProps,
+          resolve,
+          reject,
+        }
 
-      if (currentRef.current) {
-        queueRef.current.push(request)
-      } else {
-        currentRef.current = request
-        setCurrent(request)
-      }
+        if (currentRef.current) {
+          queueRef.current.push(request)
+        } else {
+          currentRef.current = request
+          setCurrent(request)
+        }
+      })
     })
 
     // Mark the rejection handled so fire-and-forget callers don't trigger an
     // unhandled-rejection warning; callers that await still receive it.
-    promise.catch(() => {})
+    result.catch(() => {})
 
-    return promise
+    return result
   }, [])
 
   const handleReady = useCallback(

--- a/src/pages/quotes/common/__tests__/QuotePdfProvider.test.tsx
+++ b/src/pages/quotes/common/__tests__/QuotePdfProvider.test.tsx
@@ -32,6 +32,16 @@ jest.mock('~/components/designSystem/RichTextEditor/common/printHtmlContent', ()
   printHtmlContent: jest.fn(),
 }))
 
+// Controllable preload mock so tests can hold back the editor mount until the
+// locale bundle "resolves" and assert the preload-before-mount ordering.
+const mockPreloadContextualLocale = jest.fn<Promise<void>, [locale: string]>(() =>
+  Promise.resolve(),
+)
+
+jest.mock('~/hooks/core/useContextualLocale', () => ({
+  preloadContextualLocale: (locale: string) => mockPreloadContextualLocale(locale),
+}))
+
 jest.mock('~/core/apolloClient', () => ({
   ...jest.requireActual('~/core/apolloClient'),
   addToast: jest.fn(),
@@ -104,7 +114,7 @@ describe('QuotePdfProvider', () => {
     expect(printHtmlContent).not.toHaveBeenCalled()
   })
 
-  it('shows an error toast and tears down the preview on timeout', () => {
+  it('shows an error toast and tears down the preview on timeout', async () => {
     jest.useFakeTimers()
 
     try {
@@ -117,6 +127,8 @@ describe('QuotePdfProvider', () => {
       act(() => {
         screen.getByTestId('trigger').click()
       })
+      // Flush the locale-preload microtask that now gates the editor mount.
+      await act(async () => {})
 
       expect(screen.getByTestId('hidden-preview')).toBeInTheDocument()
 
@@ -168,6 +180,8 @@ describe('QuotePdfProvider', () => {
     act(() => {
       screen.getByTestId('trigger').click()
     })
+    // Flush the locale-preload microtask that now gates the editor mount.
+    await act(async () => {})
 
     await act(async () => {
       ;(capturedEditorProps.onPreviewReady as (html: string) => void)('<p>rendered</p>')
@@ -234,5 +248,125 @@ describe('QuotePdfProvider', () => {
     )
 
     expect(mockMountedContents).toEqual(['<p>A</p>', '<p>B</p>'])
+  })
+
+  it('waits for the customer-locale bundle before mounting the preview editor', async () => {
+    let resolvePreload = () => {}
+
+    mockPreloadContextualLocale.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePreload = resolve
+        }),
+    )
+
+    render(
+      <QuotePdfProvider>
+        <Consumer props={{ ...PROPS, customerLocale: 'fr' }} />
+      </QuotePdfProvider>,
+    )
+
+    await userEvent.click(screen.getByTestId('trigger'))
+
+    expect(mockPreloadContextualLocale).toHaveBeenCalledWith('fr')
+    // The bundle is still loading: the off-screen editor must not mount yet,
+    // otherwise its DOM snapshot would capture untranslated (empty) headers.
+    expect(screen.queryByTestId('hidden-preview')).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolvePreload()
+    })
+
+    expect(screen.getByTestId('hidden-preview')).toBeInTheDocument()
+  })
+
+  it('does not preload a locale when the content is empty', async () => {
+    render(
+      <QuotePdfProvider>
+        <Consumer props={{ ...PROPS, content: '' }} />
+      </QuotePdfProvider>,
+    )
+
+    await userEvent.click(screen.getByTestId('trigger'))
+
+    expect(mockPreloadContextualLocale).not.toHaveBeenCalled()
+  })
+
+  it('rejects the promise returned to awaiting callers when the render times out', async () => {
+    jest.useFakeTimers()
+
+    let downloadPromise: Promise<void> | undefined
+
+    const Capture = () => {
+      const { download } = useDownloadQuotePdf()
+
+      return (
+        <button
+          data-test="trigger"
+          onClick={() => {
+            downloadPromise = download(PROPS)
+          }}
+        >
+          download
+        </button>
+      )
+    }
+
+    try {
+      render(
+        <QuotePdfProvider>
+          <Capture />
+        </QuotePdfProvider>,
+      )
+
+      act(() => {
+        screen.getByTestId('trigger').click()
+      })
+      await act(async () => {})
+
+      act(() => {
+        jest.advanceTimersByTime(5000)
+      })
+
+      await expect(downloadPromise).rejects.toThrow('Quote preview render timed out')
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it('does not surface an unhandled rejection when a fire-and-forget download times out', async () => {
+    const onUnhandledRejection = jest.fn()
+
+    process.on('unhandledRejection', onUnhandledRejection)
+    jest.useFakeTimers()
+
+    try {
+      render(
+        <QuotePdfProvider>
+          <Consumer props={PROPS} />
+        </QuotePdfProvider>,
+      )
+
+      // Fire-and-forget: the consumer ignores the returned promise, mirroring the
+      // `void download(...)` call sites in useOrderActions/useOrderFormActions.
+      act(() => {
+        screen.getByTestId('trigger').click()
+      })
+      await act(async () => {})
+
+      act(() => {
+        jest.advanceTimersByTime(5000)
+      })
+
+      jest.useRealTimers()
+      // Give node a macrotask tick to emit `unhandledRejection` if the returned
+      // promise's rejection were left unhandled.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(onUnhandledRejection).not.toHaveBeenCalled()
+    } finally {
+      jest.useRealTimers()
+      process.removeListener('unhandledRejection', onUnhandledRejection)
+    }
   })
 })


### PR DESCRIPTION
## Context

Fixes [LAGO-1686](https://linear.app/getlago/issue/LAGO-1686) — blank pricing-table headers in downloaded Quote/Order PDFs for non-English customer locales.

## Root cause

`QuotePdfProvider` renders the PDF preview in an off-screen `RichTextEditor` and snapshots its DOM two animation frames (~32ms) after mount. The pricing-table headers come from `useContextualLocale(customerLocale)`, which loads locale bundles via an async dynamic `import()`. On the first download for a non-English locale the bundle isn't loaded within the snapshot window, so `translateKey` returns `''` and the PDF captures empty `<th>` headers. Retries work because the bundle is then cached — which is why the bug looked intermittent.

## Fix

- `useContextualLocale.ts`: new exported `preloadContextualLocale(locale)` warms the shared module-level translation cache; the hook's effect reuses it.
- `QuotePdfProvider.tsx`: `download` awaits `preloadContextualLocale(customerLocale)` before mounting the off-screen editor, so the very first render resolves translations synchronously from the cache.
- The fire-and-forget unhandled-rejection guard is attached to the promise actually returned to callers (all three production call sites are fire-and-forget), so a preview-render timeout no longer surfaces an `unhandledrejection` event.

## Tests

- `useContextualLocale.test.tsx` (new): preload warms the cache so the hook resolves translations on its first render; cached locales aren't re-fetched.
- `QuotePdfProvider.test.tsx`: preload-before-mount ordering (editor doesn't mount until the bundle resolves), no preload for empty content, timeout rejection still reaches awaiting callers, and no unhandled rejection for fire-and-forget callers (verified this test fails against the unguarded version).

## Manual validation

French customer, order with a pricing block, hard-refresh, first "Download PDF" → headers render in French.

🤖 Generated with [Claude Code](https://claude.com/claude-code)