### PR TITLE
test(e2e): make plan e2e premium-aware so fork PRs stay green

### DIFF
--- a/.agents/docs/testing-practices.md
+++ b/.agents/docs/testing-practices.md
@@ -209,3 +209,40 @@ describe('MyComponent', () => {
 - Set `Settings.defaultZone = 'UTC'` in `beforeAll` or `beforeEach`
 - Always restore the original timezone in `afterAll` or `afterEach` to avoid affecting other tests
 - This applies to any test involving date formatting, especially snapshot tests
+
+### Premium vs non-premium in Cypress e2e
+
+CI enables premium features by booting the API with the `LAGO_LICENSE` **secret**
+(`.github/workflows/cypress.yml` → `ci/docker-compose.ci.yml`). GitHub does **not**
+expose repo secrets to `pull_request` runs originating from **forks**, so
+community/fork PRs run against a **non-premium** org (`currentUser.premium = false`).
+
+A spec that unconditionally clicks a premium-gated control (graduated-percentage
+charge model, percentage per-transaction min/max, spending minimum, minimum
+commitment, progressive billing, subscription plan-override editing, …) gets the
+`PremiumWarningDialog` instead of the expected input, so the assertion times out
+on forks while passing internally — which is exactly what blocked contributions
+in LAGO-1555.
+
+**Rule: any step touching a premium-gated control must branch on premium.**
+`cy.login()` / `cy.signup()` capture the org's premium state from the
+`getCurrentUserInfos` response; read it via the helpers in `cypress/support/e2e.ts`:
+
+```ts
+// Exercise the premium-only control only when licensed.
+cy.whenPremium(() => {
+  cy.get('[data-test="graduated_percentage"]').click({ force: true })
+  // ... fill the tier table, save, assert ...
+})
+
+// Otherwise assert the gate so coverage is meaningful non-premium too.
+cy.whenNotPremium(() => {
+  cy.get(`[data-test="${DIALOG_TITLE_TEST_ID}"]`).should('exist') // PremiumWarningDialog
+})
+
+// Or read the boolean directly.
+cy.getIsPremium().then((isPremium) => { /* ... */ })
+```
+
+Keep assertions that are true regardless of license (URL, plan name, submit)
+**outside** the branches. See `t40-create-plan.cy.ts` for a worked example.

--- a/cypress/e2e/10-resources/t40-create-plan.cy.ts
+++ b/cypress/e2e/10-resources/t40-create-plan.cy.ts
@@ -1,8 +1,10 @@
+import { DIALOG_TITLE_TEST_ID } from '~/components/dialogs/const'
 import { ACTIONS_BLOCK_TEST_ID } from '~/components/MainHeader/mainHeaderTestIds'
 import {
   CHARGE_PERCENTAGE_ADD_FIXED_FEE_TEST_ID,
   CHARGE_PERCENTAGE_REMOVE_FIXED_FEE_TEST_ID,
   GRADUATED_CHARGE_TABLE_ADD_TIER_TEST_ID,
+  GRADUATED_PERCENTAGE_CHARGE_TABLE_ADD_TIER_TEST_ID,
   VOLUME_CHARGE_TABLE_ADD_TIER_TEST_ID,
 } from '~/components/plans/chargeTestIds'
 import { SEARCH_BILLABLE_METRIC_IN_USAGE_CHARGE_DRAWER_INPUT_CLASSNAME } from '~/core/constants/form'
@@ -144,6 +146,52 @@ describe('Create plan', () => {
     cy.get('[data-test="submit"]').click({ force: true })
     cy.url().should('include', '/overview')
     cy.contains(planWithChargesName).should('exist')
+  })
+
+  it('should gate the graduated-percentage charge model behind premium', () => {
+    const randomId = Math.round(Math.random() * 1000)
+    const planName = `plan graduated pct ${randomId}`
+
+    cy.get(`[data-test="${ACTIONS_BLOCK_TEST_ID}"] [data-test="create-plan"]`).click({
+      force: true,
+    })
+    cy.get('input[name="name"]').type(planName)
+
+    // Add a usage charge and open the charge-model dropdown, then pick the
+    // graduated-percentage model.
+    cy.get('[data-test="add-usage-charge"]').scrollIntoView()
+    cy.get('[data-test="add-usage-charge"]').click()
+    selectMeteredBillableMetric('bm count')
+    cy.get('[data-test="charge-model-wrapper"] input[name="chargeModel"]').click({ force: true })
+    cy.get('[data-test="graduated_percentage"]').click({ force: true })
+
+    // Graduated-percentage is premium-only. On non-premium orgs — including
+    // fork/community CI runs, where the LAGO_LICENSE secret is unavailable
+    // (GitHub withholds secrets from fork `pull_request` runs) — selecting it
+    // opens the PremiumWarningDialog and leaves the model unchanged, so the
+    // tier table never renders. On premium orgs the tier table appears and the
+    // charge saves. Branching keeps fork CI green regardless of license.
+    cy.whenNotPremium(() => {
+      cy.get(`[data-test="${DIALOG_TITLE_TEST_ID}"]`).should('exist')
+      cy.get('[data-test="cell-rate-0"]').should('not.exist')
+    })
+
+    cy.whenPremium(() => {
+      cy.get(`[data-test="${GRADUATED_PERCENTAGE_CHARGE_TABLE_ADD_TIER_TEST_ID}"]`).click({
+        force: true,
+      })
+      cy.get('[data-test="cell-rate-0"]').type('1')
+      cy.get('[data-test="cell-rate-1"]').type('1')
+      cy.get('[data-test="cell-rate-2"]').type('1')
+      cy.get('[data-test="usage-charge-drawer-save"]').should('not.be.disabled').click()
+      cy.get('[data-test="base-drawer-paper"]', { timeout: 10000 }).should('not.exist')
+      cy.get('[data-test="usage-charge-selector-0"]', { timeout: 10000 }).should('exist')
+
+      cy.get('[data-test="submit"]', { timeout: 10000 }).should('not.be.disabled')
+      cy.get('[data-test="submit"]').click({ force: true })
+      cy.url().should('include', '/overview')
+      cy.contains(planName).should('exist')
+    })
   })
 
   it('should be able to edit percentage charge without data loss', () => {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -2,6 +2,7 @@
 // This example support/e2e.ts is processed and
 // loaded automatically before your test files.
 // ***********************************************************
+import { AUTH_TOKEN_LS_KEY } from '~/core/apolloClient/reactiveVars/authTokenVar'
 import { NEVER_SLUG_PREFIXES } from '~/core/router/slugPrefixes'
 import { SIGNUP_SUBMIT_BUTTON_TEST_ID } from '~/pages/auth/signUpTestIds'
 
@@ -35,6 +36,58 @@ const PUBLIC_PATHS = [
 const POST_AUTH_URL_RE = /\/[^/]+\/(customers|analytics)/
 
 /**
+ * Module-scoped premium flag for the logged-in org, read by `cy.getIsPremium()`
+ * and the `cy.whenPremium()` / `cy.whenNotPremium()` branch helpers.
+ *
+ * Why this exists: CI enables premium by booting the API with the
+ * `LAGO_LICENSE` secret, but GitHub does not expose secrets to `pull_request`
+ * runs from forks — so community/fork PRs run against a NON-premium org. A spec
+ * that unconditionally clicks a premium-gated control gets the
+ * `PremiumWarningDialog` (not the real input) and times out on forks while
+ * passing internally. Specs must branch premium-gated steps via the helpers
+ * below so fork CI stays green regardless of license.
+ */
+let capturedIsPremium: boolean | undefined
+
+/**
+ * Reads `currentUser.premium` straight from the GraphQL API with the stored
+ * auth token and stores it for later `cy.getIsPremium()` reads.
+ *
+ * Uses `cy.request` (a direct server-side call) rather than intercepting the
+ * app's `getCurrentUserInfos` query: that query is `cache-first` and the app
+ * persists its Apollo cache to IndexedDB, so on the 2nd+ login within a spec it
+ * is served from cache and never hits the network — an intercept+wait would
+ * hang. A direct request is cache-independent and always returns fresh premium.
+ * The `API_URL` the app itself uses is read off the window; `currentUser` is
+ * user-scoped so only the Bearer token (no org header) is required.
+ */
+const captureIsPremium = (): void => {
+  cy.window({ log: false }).then((win) => {
+    const token = win.localStorage.getItem(AUTH_TOKEN_LS_KEY)
+    const apiUrl = (win as unknown as { API_URL?: string }).API_URL || 'http://localhost:3000'
+
+    if (!token) {
+      capturedIsPremium = false
+
+      return
+    }
+
+    cy.request({
+      method: 'POST',
+      url: `${apiUrl}/graphql`,
+      headers: { authorization: `Bearer ${token}` },
+      body: {
+        operationName: 'e2eGetIsPremium',
+        query: 'query e2eGetIsPremium { currentUser { id premium } }',
+      },
+      log: false,
+    }).then((res) => {
+      capturedIsPremium = Boolean(res.body?.data?.currentUser?.premium)
+    })
+  })
+}
+
+/**
  * Module-scoped org slug captured by `cy.login()` / `cy.signup()` and read
  * by `cy.visitApp()`. Preferred over `Cypress.env('orgSlug', value)` because
  * Cypress deprecated the 2-arg setter overload. Module-scoped state is
@@ -64,14 +117,16 @@ Cypress.Commands.add('login', (email = userEmail, password = userPassword) => {
   cy.get('input[name="password"]').type(password)
   cy.get('[data-test="submit"]').click()
   captureOrgSlugFromUrl()
+  captureIsPremium()
 })
 
 Cypress.Commands.add('logout', () => {
   cy.get('[data-test="side-nav-user-infos"]').click()
   cy.get('[data-test="side-nav-logout"]').click()
   cy.url().should('include', '/login')
-  // Clear the captured slug — subsequent login/signup must re-capture it.
+  // Clear the captured slug + premium — subsequent login/signup must re-capture.
   capturedOrgSlug = undefined
+  capturedIsPremium = undefined
 })
 
 Cypress.Commands.add(
@@ -91,8 +146,43 @@ Cypress.Commands.add(
     cy.get('input[name="password"]').type(password)
     cy.get(`[data-test="${SIGNUP_SUBMIT_BUTTON_TEST_ID}"]`).click()
     captureOrgSlugFromUrl()
+    captureIsPremium()
   },
 )
+
+/**
+ * Yields the running org's premium state captured during login/signup.
+ * Defaults to `false` if login/signup hasn't run (fail-safe: treat as the
+ * more constrained non-premium path).
+ */
+Cypress.Commands.add('getIsPremium', () => {
+  return cy.wrap(capturedIsPremium ?? false, { log: false })
+})
+
+/**
+ * Runs `fn` only when the org is premium. Use to wrap e2e steps that click a
+ * premium-gated control (which otherwise opens the `PremiumWarningDialog` on
+ * non-premium / fork CI). Pair with `cy.whenNotPremium()` to assert the gate.
+ */
+Cypress.Commands.add('whenPremium', (fn: () => void) => {
+  cy.getIsPremium().then((isPremium) => {
+    if (isPremium) {
+      fn()
+    }
+  })
+})
+
+/**
+ * Runs `fn` only when the org is NOT premium (e.g. to assert the premium gate /
+ * `PremiumWarningDialog` is shown instead of the premium control).
+ */
+Cypress.Commands.add('whenNotPremium', (fn: () => void) => {
+  cy.getIsPremium().then((isPremium) => {
+    if (!isPremium) {
+      fn()
+    }
+  })
+})
 
 /**
  * Slug-aware wrapper around `cy.visit()`. Prepends `/${orgSlug}` to any

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -48,6 +48,37 @@ declare namespace Cypress {
      * cy.visitApp('/login')                // → /login (public, unchanged)
      */
     visitApp(path: string): Chainable<Cypress.AUTWindow>
+
+    /**
+     * Yields the running org's premium state, captured from the
+     * `getCurrentUserInfos` response during `cy.login()` / `cy.signup()`.
+     * Defaults to `false` if neither has run.
+     *
+     * Premium is off on fork/community PRs because CI enables it via the
+     * `LAGO_LICENSE` secret and GitHub does not pass secrets to fork
+     * `pull_request` runs. Branch premium-gated steps on this so fork CI
+     * stays green regardless of license.
+     * @example
+     * cy.getIsPremium().then((isPremium) => { ... })
+     */
+    getIsPremium(): Chainable<boolean>
+
+    /**
+     * Runs `fn` only when the org is premium. Wrap e2e steps that click a
+     * premium-gated control (graduated-percentage model, percentage min/max,
+     * spending minimum, minimum commitment, progressive billing, …).
+     * @example
+     * cy.whenPremium(() => { cy.get('[data-test="graduated-percentage"]').click() })
+     */
+    whenPremium(fn: () => void): Chainable<unknown>
+
+    /**
+     * Runs `fn` only when the org is NOT premium — typically to assert the
+     * premium gate / `PremiumWarningDialog` shows instead of the control.
+     * @example
+     * cy.whenNotPremium(() => { cy.get('[data-test="premium-warning-dialog"]').should('exist') })
+     */
+    whenNotPremium(fn: () => void): Chainable<unknown>
   }
 
   interface Cypress {


### PR DESCRIPTION
## Context

lago-front e2e enables premium by booting the API with the `LAGO_LICENSE` secret, but GitHub does not expose secrets to `pull_request` runs from forks, so community/fork PRs run against a non-premium org where premium-gated plan steps open `PremiumWarningDialog` instead of the expected input and time out — the failure behind LAGO-1555.

## Description

Adds `cy.getIsPremium()` / `cy.whenPremium()` / `cy.whenNotPremium()` helpers to `cypress/support/e2e.ts` (premium read via a cache-independent `cy.request`, since `getCurrentUserInfos` is `cache-first` and the Apollo cache is IndexedDB-persisted, so an intercept+wait would hang on later logins). Branches the graduated-percentage charge in `t40-create-plan.cy.ts` on premium — premium exercises the tier table and saves, non-premium asserts the premium dialog — and documents the pattern in `.agents/docs/testing-practices.md` so future premium-gated steps keep fork CI green regardless of license.

<!-- Linear link -->
Fixes LAGO-1555