### PR TITLE
fix(conductor): locate scripts via CONDUCTOR_WORKSPACE_PATH

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -14,14 +14,15 @@ delete_branch_on_archive = true
 
 [scripts]
 setup = "pnpm install"
-archive = "$LAGO_PATH/front/scripts/conductor-front-container.sh down"
+archive = "$CONDUCTOR_WORKSPACE_PATH/scripts/conductor-front-container.sh down"
 run_mode = "concurrent"
 
 # Run the workspace in its own Docker container on the shared lago stack network.
-# Requires the Docker superproject stack: `lago up -d`, the front_dev image, and
-# the $LAGO_PATH env var (same one used by lago-worktree).
+# Requires the Docker superproject stack: `lago up -d` and the front_dev image.
+# The superproject path is derived from Conductor's $CONDUCTOR_ROOT_PATH, so no
+# $LAGO_PATH shell var is needed (Conductor's script env doesn't source it).
 [scripts.run.container]
-command = "$LAGO_PATH/front/scripts/conductor-front-container.sh up"
+command = "$CONDUCTOR_WORKSPACE_PATH/scripts/conductor-front-container.sh up"
 default = true
 icon = "container"
 
@@ -29,7 +30,7 @@ icon = "container"
 # `container` script first. Commands here (pnpm codegen, pnpm test, node) use the
 # container's node_modules and network, where `api:3000` resolves.
 [scripts.run.shell]
-command = "$LAGO_PATH/front/scripts/conductor-front-container.sh shell"
+command = "$CONDUCTOR_WORKSPACE_PATH/scripts/conductor-front-container.sh shell"
 icon = "square-terminal"
 
 # Run Vite on the HOST instead of in a container: the script disables Vite's
@@ -39,5 +40,5 @@ icon = "square-terminal"
 # patches the workspace .env accordingly. Use `host` OR `container` for a
 # workspace, not both (same port, strictPort errors).
 [scripts.run.host]
-command = "$LAGO_PATH/front/scripts/conductor-front-container.sh host"
+command = "$CONDUCTOR_WORKSPACE_PATH/scripts/conductor-front-container.sh host"
 icon = "flame"

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ What the shared config provides:
 
 - **`enterprise_data_privacy = true`** — only account data (email, GitHub integration) is stored server-side. Disables features that call external AI providers (AI chat titles, custom MCP servers).
 - **Setup**: `pnpm install` on every new workspace.
-- **Run (`container`)**: runs the workspace in its own Docker container on the shared lago stack network, via `scripts/conductor-front-container.sh`. Requires the Docker superproject stack: `lago up -d`, the `front_dev` image, and the `$LAGO_PATH` env var (same one used by `lago-worktree`, see above).
+- **Run (`container`)**: runs the workspace in its own Docker container on the shared lago stack network, via `scripts/conductor-front-container.sh`. Requires the Docker superproject stack: `lago up -d` and the `front_dev` image. The script locates itself and the superproject via Conductor's `$CONDUCTOR_WORKSPACE_PATH` / `$CONDUCTOR_ROOT_PATH`, so no `$LAGO_PATH` shell var is needed (Conductor's headless script env doesn't source your `.zshrc`).
 - **Git**: deletes the branch when a workspace is archived.
 
 ### Personal overrides

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -9,12 +9,17 @@ set -euo pipefail
 # vars instead of a self-managed worktree layout, so Conductor stays the single
 # owner of worktree create/destroy. Wired from the committed team config
 # .conductor/settings.toml:
-#   [scripts.run.container] command = "$LAGO_PATH/front/scripts/conductor-front-container.sh up"
-#   scripts.archive        = "$LAGO_PATH/front/scripts/conductor-front-container.sh down"
+#   [scripts.run.container] command = "$CONDUCTOR_WORKSPACE_PATH/scripts/conductor-front-container.sh up"
+#   scripts.archive        = "$CONDUCTOR_WORKSPACE_PATH/scripts/conductor-front-container.sh down"
+#
+# The script is located via $CONDUCTOR_WORKSPACE_PATH (set by Conductor for every
+# script, including the headless archive hook) rather than a user shell var like
+# $LAGO_PATH, which is not present in Conductor's non-interactive script env.
 #
 # Prerequisites:
 #   - the main Lago Docker stack is running (`lago up -d`)
-#   - $LAGO_PATH points at the lago superproject (front/ + api/ + docker-compose)
+#   - the workspace lives under the lago superproject (front/ + api/ + docker-compose);
+#     the superproject path is derived here from $CONDUCTOR_ROOT_PATH, not $LAGO_PATH.
 
 CMD="${1:-}"
 


### PR DESCRIPTION
## Problem

The Conductor archive hook failed with:

```
no such file or directory: /front/scripts/conductor-front-container.sh
```

`.conductor/settings.toml` located `conductor-front-container.sh` via `$LAGO_PATH/front/scripts/...`. But `$LAGO_PATH` is a **user shell var** (exported in `.zshrc`, per the README). Conductor's archive hook runs in a **headless, non-interactive shell** that never sources `.zshrc`, so `$LAGO_PATH` is empty and the path collapses to `/front/scripts/...` → not found. The `container`/`shell`/`host` run scripts survived only because they open a terminal pane that does source `.zshrc`.

## Fix

Locate the script via `$CONDUCTOR_WORKSPACE_PATH` instead. Conductor sets this for **every** script, including the headless archive hook, and the workspace is still present when `down` runs. This removes the user-env dependency from all 4 commands (archive/container/shell/host).

The script itself needs no change to its logic: it already derives its own `LAGO_PATH` from `$CONDUCTOR_ROOT_PATH` (never reads the env var), so `cmd_down` works headless.

Also refreshed the stale comments in the script header, the settings.toml comment, and the README that claimed a `$LAGO_PATH` env var was required.