### PR TITLE
refactor(api-keys): extract RotateApiKeyDialog test id to sibling constants file

### DIFF
--- a/src/components/developers/apiKeys/RotateApiKeyDialog.tsx
+++ b/src/components/developers/apiKeys/RotateApiKeyDialog.tsx
@@ -7,6 +7,7 @@ import { z } from 'zod'
 
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
+import { ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID } from '~/components/developers/apiKeys/dataTestConstants'
 import { useFormDialog } from '~/components/dialogs/FormDialog'
 import { DialogResult } from '~/components/dialogs/types'
 import { focusFirstInput } from '~/components/drawers/useFocusTrap'
@@ -22,8 +23,6 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm } from '~/hooks/forms/useAppform'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
-
-export const ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID = 'rotate-api-key-submit-button'
 
 const ROTATE_API_KEY_FORM_ID = 'rotate-api-key-form'
 

--- a/src/components/developers/apiKeys/__tests__/RotateApiKeyDialog.test.tsx
+++ b/src/components/developers/apiKeys/__tests__/RotateApiKeyDialog.test.tsx
@@ -3,10 +3,8 @@ import { act, cleanup, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ReactNode } from 'react'
 
-import {
-  ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID,
-  useRotateApiKeyDialog,
-} from '~/components/developers/apiKeys/RotateApiKeyDialog'
+import { ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID } from '~/components/developers/apiKeys/dataTestConstants'
+import { useRotateApiKeyDialog } from '~/components/developers/apiKeys/RotateApiKeyDialog'
 import { DIALOG_TITLE_TEST_ID, FORM_DIALOG_NAME } from '~/components/dialogs/const'
 import FormDialog from '~/components/dialogs/FormDialog'
 import { ApiKeyForRotateApiKeyDialogFragment } from '~/generated/graphql'

--- a/src/components/developers/apiKeys/dataTestConstants.ts
+++ b/src/components/developers/apiKeys/dataTestConstants.ts
@@ -1,0 +1,1 @@
+export const ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID = 'rotate-api-key-submit-button'


### PR DESCRIPTION
## Context

`RotateApiKeyDialog` has already been migrated to the new `useFormDialog` system, but its test file still imports the `ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID` constant from the dialog module. The `no-restricted-imports` rule blocks any non-hook import from a `*Dialog*` file to nudge consumers away from the legacy dialog system, so the constant re-export was surfacing as a lint warning even though the underlying dialog is fine.

## Description

- Created `src/components/developers/apiKeys/dataTestConstants.ts` and moved `ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID` there.
- Updated `RotateApiKeyDialog.tsx` to import the constant from the new sibling module (so nothing about the button's `data-test` attribute changes at runtime).
- Updated the test file to import the constant from the new module as well.

No behavior change; this only re-homes a single test-id constant. Resolves 1 `no-restricted-imports` warning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01631g4uTV4Tt2BuiXuoQAjt)_