### PR TITLE
fix(wallets): align delete button of recurring top-up expiration date

### DIFF
--- a/src/components/wallets/tanstackForm/WalletRecurringTopUpFields.tsx
+++ b/src/components/wallets/tanstackForm/WalletRecurringTopUpFields.tsx
@@ -346,7 +346,7 @@ export const WalletRecurringTopUpFields = withForm({
 
             return (
               <div
-                className="flex items-end gap-3 [&>*:first-child]:flex-1"
+                className="flex gap-3 [&>*:first-child]:flex-1"
                 data-test={WALLET_RECURRING_EXPIRATION_SECTION_TEST_ID}
               >
                 <field.DatePickerField
@@ -356,7 +356,7 @@ export const WalletRecurringTopUpFields = withForm({
                   helperText={translate('text_1741689608703zttwsl2nnq2')}
                 />
                 <Tooltip
-                  className="mb-1 h-fit"
+                  className="mt-8 h-fit"
                   placement="top-end"
                   title={translate('text_63aa085d28b8510cd46443ff')}
                 >


### PR DESCRIPTION
## Context

On the wallet recurring top-up rule form, the expiration date field's delete (trash) button sat misaligned — its `DatePickerField` has helper text below the input, and the row used `items-end`, which bottom-anchored the button to helper-text level instead of the input box.

## Description

Top-anchor the row (drop `items-end`) and offset the delete button wrapper with `mt-8` so it lines up with the date input, matching the existing `ChargePercentage` convention for label + input + helperText rows. CSS-only change; delete behavior untouched.

<!-- Linear link -->
Fixes LAGO-1739