### PR TITLE
fix(quotes): flip wallet recurring top-up date picker above input

### DIFF
--- a/src/components/wallets/tanstackForm/WalletRecurringTopUpFields.tsx
+++ b/src/components/wallets/tanstackForm/WalletRecurringTopUpFields.tsx
@@ -291,6 +291,7 @@ export const WalletRecurringTopUpFields = withForm({
                     {(field) => (
                       <field.DatePickerField
                         className="flex-1"
+                        placement="top-end"
                         label={translate('text_66599bfb69fba1010535c5c2')}
                         placeholder={translate('text_62d18855b22699e5cf55f899')}
                       />
@@ -351,6 +352,7 @@ export const WalletRecurringTopUpFields = withForm({
               >
                 <field.DatePickerField
                   disablePast
+                  placement="top-end"
                   label={translate('text_62d18855b22699e5cf55f897')}
                   placeholder={translate('text_62d18855b22699e5cf55f899')}
                   helperText={translate('text_1741689608703zttwsl2nnq2')}


### PR DESCRIPTION
## Context

In the Quotes credits drawer, the recurring top-up rule config opens a nested drawer that sits low in the viewport. The date picker defaulted to `bottom-end` placement, so the calendar popper opened off-screen/clipped and the expiration and start dates couldn't be selected.

## Description

Pin both `DatePickerField`s (expiration + interval start date) in `WalletRecurringTopUpFields` to `placement="top-end"`. The popper now opens above the input, aligned to it, and stays within the drawer instead of overflowing.

Fixes LAGO-1738

🤖 Generated with [Claude Code](https://claude.com/claude-code)