### PR TITLE
fix(plans): stop wiping plan fee on advanced saves

### DIFF
--- a/src/hooks/plans/__tests__/useUpdatePlanWithCascade.test.tsx
+++ b/src/hooks/plans/__tests__/useUpdatePlanWithCascade.test.tsx
@@ -38,7 +38,7 @@ const basePlan = {
   description: null,
   interval: PlanInterval.Monthly,
   amountCurrency: CurrencyEnum.Usd,
-  amountCents: '0',
+  amountCents: '3000',
   payInAdvance: false,
   trialPeriod: 0,
   invoiceDisplayName: null,
@@ -106,6 +106,33 @@ describe('buildUpdatePlanFormDefaults', () => {
     expect(defaults.entitlements[0]).toEqual(
       expect.objectContaining({ featureCode: 'seats', featureName: 'Seats' }),
     )
+  })
+
+  it('hydrates amountCents from the plan in display units', () => {
+    const defaults = buildUpdatePlanFormDefaults({
+      id: 'p1',
+      name: 'P',
+      code: 'p',
+      interval: PlanInterval.Monthly,
+      amountCurrency: CurrencyEnum.Usd,
+      amountCents: '3000',
+      payInAdvance: false,
+    } as PlanDetailsV2Fragment)
+
+    expect(defaults.amountCents).toBe('30')
+  })
+
+  it('falls back to a zero amountCents when the plan has none', () => {
+    const defaults = buildUpdatePlanFormDefaults({
+      id: 'p1',
+      name: 'P',
+      code: 'p',
+      interval: PlanInterval.Monthly,
+      amountCurrency: CurrencyEnum.Usd,
+      payInAdvance: false,
+    } as PlanDetailsV2Fragment)
+
+    expect(defaults.amountCents).toBe('0')
   })
 
   it('defaults to empty advanced fields when the plan has none', () => {
@@ -472,6 +499,62 @@ describe('useUpdatePlanWithCascade', () => {
       })
 
       expect(capturedUpdateInput?.usageThresholds).toEqual([])
+    })
+
+    it('preserves the plan subscription fee when a threshold-only edit is submitted', async () => {
+      const planWithThresholds = {
+        ...basePlan,
+        usageThresholds: [
+          { id: 'u1', amountCents: 10000, recurring: false, thresholdDisplayName: null },
+        ],
+      } as PlanDetailsV2Fragment
+
+      const { result } = renderHook(
+        () => useUpdatePlanWithCascade({ plan: planWithThresholds, includeAdvancedFields: true }),
+        { wrapper: wrapper([capturingUpdateMock]) },
+      )
+
+      await act(async () => {
+        await result.current.applyAndSubmit(() => {
+          result.current.form.setFieldValue('nonRecurringUsageThresholds', [
+            { amountCents: 100, recurring: false, thresholdDisplayName: null },
+            { amountCents: 250, recurring: false, thresholdDisplayName: null },
+          ])
+        })
+      })
+
+      await waitFor(() => {
+        expect(capturedUpdateInput).toBeDefined()
+      })
+
+      expect(capturedUpdateInput?.amountCents).toBe(3000)
+    })
+
+    it('preserves the plan subscription fee when all thresholds are deleted', async () => {
+      const planWithThresholds = {
+        ...basePlan,
+        usageThresholds: [
+          { id: 'u1', amountCents: 10000, recurring: false, thresholdDisplayName: null },
+        ],
+      } as PlanDetailsV2Fragment
+
+      const { result } = renderHook(
+        () => useUpdatePlanWithCascade({ plan: planWithThresholds, includeAdvancedFields: true }),
+        { wrapper: wrapper([capturingUpdateMock]) },
+      )
+
+      await act(async () => {
+        await result.current.applyAndSubmit(() => {
+          result.current.form.setFieldValue('nonRecurringUsageThresholds', undefined)
+          result.current.form.setFieldValue('recurringUsageThreshold', undefined)
+        })
+      })
+
+      await waitFor(() => {
+        expect(capturedUpdateInput).toBeDefined()
+      })
+
+      expect(capturedUpdateInput?.amountCents).toBe(3000)
     })
 
     it('strips display-only entitlement fields from the payload when included', async () => {

--- a/src/hooks/plans/useUpdatePlanWithCascade.ts
+++ b/src/hooks/plans/useUpdatePlanWithCascade.ts
@@ -101,7 +101,12 @@ export const buildUpdatePlanFormDefaults = (plan: PlanDetailsV2Fragment): PlanFo
     // contents.
     fixedCharges: settingsDefaults.fixedCharges as unknown as PlanFormInput['fixedCharges'],
     charges: settingsDefaults.charges as unknown as PlanFormInput['charges'],
-    amountCents: '0',
+    // The subscription fee is not editable from any consumer but
+    // SubscriptionFeeAccordion, yet `amountCents` is non-null on
+    // UpdatePlanInput so every submit ships it. Hydrate it from the plan (in
+    // display units, like the fee drawer) - seeding '0' here wiped the fee on
+    // every threshold / commitment / entitlement / metadata save.
+    amountCents: String(deserializeAmount(plan.amountCents ?? 0, currency)),
     trialPeriod: plan.trialPeriod ?? 0,
     payInAdvance: plan.payInAdvance ?? false,
     invoiceDisplayName: plan.invoiceDisplayName ?? undefined,


### PR DESCRIPTION
Fixes ING-500

## Problem

Editing progressive billing on a plan (from the plan details v2 page) resets the plan's subscription fee to 0.

`buildUpdatePlanFormDefaults` (`useUpdatePlanWithCascade.ts`) seeded the form with a hardcoded `amountCents: '0'`, and `amountCents` is non-null on `UpdatePlanInput` so every submit ships it. `applyAndSubmit` re-resets the form to those defaults before applying the mutator, so the real fee could never survive.

The plan fragment already queried `amountCents` - the value was simply never read.

`SubscriptionFeeAccordion` was unaffected because it patches the field back in before submitting. Every other consumer of the hook inherited the `'0'`:

- progressive billing (save and delete)
- minimum commitment
- entitlements
- metadata
- plan settings drawer (plan mode only; sub mode routes through `updateSubscription`)

## Fix

Hydrate `amountCents` from the plan, in display units, matching `SubscriptionFeeAccordion` and `usePlanForm`.

Audited the rest of the payload for the same pattern: every other field is hydrated from the fragment (`buildPlanSettingsValues` for name/code/description/interval/currency/bill*Monthly/taxes, and explicit hydration for trialPeriod/payInAdvance/invoiceDisplayName/minimumCommitment/usageThresholds/entitlements/metadata). `charges` and `fixedCharges` are deliberately omitted so the API preserves them. `amountCents` was the only wiped field.

## Tests

The hook test fixtures all used `amountCents: '0'`, so no assertion could catch this. Fixture is now `3000` plus two regression tests asserting the fee survives a threshold save and a threshold delete.
