### PR TITLE
fix(quotes): focus RichTextEditor on background click below content

### DIFF
--- a/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
@@ -6,7 +6,14 @@ import {
   ReactRenderer,
   useEditor,
 } from '@tiptap/react'
-import { type MutableRefObject, useCallback, useEffect, useMemo, useRef } from 'react'
+import {
+  type MouseEvent,
+  type MutableRefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
 import tippy, { type Instance as TippyInstance } from 'tippy.js'
 
 import type { Locale } from '~/core/translations'
@@ -488,11 +495,27 @@ const RichTextEditor = ({
 
   if (!editor) return null
 
+  const handleContainerMouseDown = (e: MouseEvent<HTMLDivElement>): void => {
+    if (isPreview) return
+    // Only when clicking the container's own empty background, not a child
+    // (ProseMirror content, toolbars, table controls all bubble up as children).
+    if (e.target !== e.currentTarget) return
+
+    e.preventDefault()
+    editor.commands.focus('end')
+  }
+
   return (
     <RichTextEditorProvider value={contextValue}>
+      {/*
+        onMouseDown forwards background clicks to the real contenteditable below;
+        keyboard users tab straight into the editor, so no key handler is needed.
+      */}
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
       <div
         className={`rich-text-editor relative size-full overflow-auto ${isPreview ? '' : 'group/editor'}`}
         data-test={RICH_TEXT_EDITOR_TEST_ID}
+        onMouseDown={handleContainerMouseDown}
       >
         {!isPreview && <Toolbar editor={editor} data-test={RICH_TEXT_EDITOR_TOOLBAR_TEST_ID} />}
         <div className="relative">

--- a/src/components/designSystem/RichTextEditor/__tests__/RichTextEditor.test.tsx
+++ b/src/components/designSystem/RichTextEditor/__tests__/RichTextEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, screen } from '@testing-library/react'
 import { Markdown } from 'tiptap-markdown'
 
 import { render } from '~/test-utils'
@@ -52,6 +52,9 @@ const mockEditor = {
   setEditable: jest.fn(),
   on: jest.fn(),
   off: jest.fn(),
+  commands: {
+    focus: jest.fn(),
+  },
   state: { selection: { from: 0 } },
   view: {
     domAtPos: jest.fn().mockReturnValue({ node: document.createElement('div') }),
@@ -985,6 +988,48 @@ describe('RichTextEditor', () => {
         await act(() => onUpdate?.({ editor: mockDocEmpty }))
 
         expect(onCreditsBlocksChange).toHaveBeenCalledWith([])
+      })
+    })
+  })
+
+  describe('GIVEN a click on the editor background', () => {
+    beforeEach(() => {
+      mockEditor.commands.focus.mockClear()
+    })
+
+    describe('WHEN clicking the container background in edit mode', () => {
+      it('THEN should focus the editor at the end', async () => {
+        await act(() => render(<RichTextEditor />))
+
+        const container = screen.getByTestId(RICH_TEXT_EDITOR_TEST_ID)
+
+        fireEvent.mouseDown(container)
+
+        expect(mockEditor.commands.focus).toHaveBeenCalledWith('end')
+      })
+    })
+
+    describe('WHEN clicking a child element (content) in edit mode', () => {
+      it('THEN should not focus the editor', async () => {
+        await act(() => render(<RichTextEditor />))
+
+        const content = screen.getByTestId(RICH_TEXT_EDITOR_CONTENT_TEST_ID)
+
+        fireEvent.mouseDown(content)
+
+        expect(mockEditor.commands.focus).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN clicking the container background in preview mode', () => {
+      it('THEN should not focus the editor', async () => {
+        await act(() => render(<RichTextEditor mode="preview" />))
+
+        const container = screen.getByTestId(RICH_TEXT_EDITOR_TEST_ID)
+
+        fireEvent.mouseDown(container)
+
+        expect(mockEditor.commands.focus).not.toHaveBeenCalled()
       })
     })
   })


### PR DESCRIPTION
## Context

In the edit-quotes flow the RichTextEditor fills the full height of its scroll area, but only the content-fit block was clickable. Clicking the empty space below the content did nothing — no focus, no cursor — which felt broken.

## Description

Added an `onMouseDown` handler on the editor container that focuses the editor at the document end when the click lands on the container's own empty background (`e.target === e.currentTarget`), edit mode only. Clicks on the content, toolbars, and controls bubble up as children and are ignored, so all existing behavior is unchanged.

<!-- Linear link -->
Fixes LAGO-1740