### PR TITLE
fix(quotes): rehydrate discount drawer when billingItems arrives late

### DIFF
--- a/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
@@ -118,6 +118,62 @@ describe('useDiscountDrawer', () => {
     expect(result.current).toHaveProperty('syncDiscountBlocks')
   })
 
+  it('hydrates entities when billingItems arrives late (cold-cache load)', () => {
+    // Cold cache: billingItems is undefined on first render while the quote query
+    // loads, then arrives once it resolves. EditQuote is not remounted, so the hook
+    // must rehydrate its refs/entities from the late billingItems.
+    const savedBillingItems: BillingItemsPayload = {
+      addOns: [],
+      coupons: [
+        {
+          type: 'coupon',
+          id: 'cpn_edit',
+          localId: 'saved-local',
+          payload: {
+            position: 1,
+            code: 'EDIT',
+            id: 'cpn_edit',
+            name: 'Edit Coupon',
+            type: 'fixed_amount',
+            amountCents: 5000,
+            percentageRate: null,
+            currency: CurrencyEnum.Usd,
+            frequency: 'forever',
+            frequencyDuration: null,
+            expirationAt: null,
+            limitedPlans: false,
+            planCodes: [],
+            limitedBillableMetrics: false,
+            billableMetricCodes: [],
+            couponOverrides: null,
+            catalogSnapshot: null,
+            resolvedPayload: null,
+          },
+          overrides: {
+            amountCents: 5000,
+            percentageRate: null,
+            frequency: 'forever',
+            frequencyDuration: null,
+          },
+        },
+      ],
+    }
+
+    const { result, rerender } = renderHook(
+      ({ bi }: { bi: BillingItemsPayload | undefined }) => useDiscountDrawer(bi, options),
+      { initialProps: { bi: undefined as BillingItemsPayload | undefined } },
+    )
+
+    // First render (query still loading): nothing to hydrate.
+    expect(result.current.entities).toEqual({})
+
+    // billingItems resolves → entities rehydrate from the saved coupon.
+    rerender({ bi: savedBillingItems })
+
+    expect(result.current.entities).toHaveProperty('saved-local')
+    expect(result.current.entities['saved-local'].entityType).toBe('coupon')
+  })
+
   it('opens the drawer when onDiscountCommand is called', () => {
     const { result } = renderHook(() => useDiscountDrawer(undefined, options))
 

--- a/src/pages/quotes/hooks/useDiscountDrawer.tsx
+++ b/src/pages/quotes/hooks/useDiscountDrawer.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { revalidateLogic } from '@tanstack/react-form'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { z } from 'zod'
 
 import { Button } from '~/components/designSystem/Button'
@@ -351,6 +351,25 @@ export const useDiscountDrawer = (
   // Ref bridge: a single stable onSubmit reads the pending save target set right
   // before drawer.open, instead of mutating form.options.onSubmit per open.
   const pendingSaveRef = useRef<PendingSave | null>(null)
+
+  // Hydration: the refs above init once, but `billingItems` is undefined on the
+  // first render when the quote query is still loading (cold cache). Re-run
+  // `fromCoupons` when it arrives so saved coupon blocks resolve to preview data
+  // and edit opens the persisted coupon (not a blank form). Idempotent post-save:
+  // committed `billingItems` reproduces the same items — the in-progress edit lives
+  // in TanStack form state (populated by `form.reset` in `onDiscountCommand`), and
+  // `itemsRef`/`originalPayloadsRef` only commit after a successful save, so this
+  // never clobbers an active edit. Mirrors useCreditsDrawer / useSubscriptionPricingDrawer.
+  useEffect(() => {
+    if (!billingItems?.coupons) return
+
+    const result = fromCoupons(billingItems.coupons)
+
+    itemsRef.current = Object.fromEntries(result.discountItems.map((i) => [i.localId, i]))
+    originalPayloadsRef.current = result.originalPayloads
+    entitiesRef.current = result.entities
+    setEntities(result.entities)
+  }, [billingItems])
 
   const rebuild = useCallback((): BillingItemsPayload => {
     const items = Object.values(itemsRef.current)


### PR DESCRIPTION
## Context

On a cold-cache load of an existing quote (hard refresh / deep link), `quote?.currentVersion?.billingItems` is `undefined` on `useDiscountDrawer`'s first render while the quote query is still loading. `EditQuote` is not remounted when the query resolves (its loading skeleton lives inside it), so the drawer's state refs — `itemsRef`, `originalPayloadsRef`, `entitiesRef` / `entities` — stay initialized from the empty value and never rehydrate once `billingItems` arrives.

Symptoms:
- Saved discount (coupon) blocks don't resolve to preview data — `entities` stays empty.
- Editing a saved discount block opens a blank form (`onDiscountCommand` reads an empty `itemsRef.current[localId]` and falls back to a fresh item).

Same bug class already fixed for the credits drawer in 35538bda5 (#3856); this was the deferred, out-of-scope follow-up.

## Description

- Add a hydration `useEffect` keyed on `[billingItems]` that re-runs `fromCoupons(billingItems.coupons)` and repopulates `itemsRef`, `originalPayloadsRef`, `entitiesRef`, and `setEntities(...)`. Mirrors the credits-drawer fix and `useSubscriptionPricingDrawer`.
- Add a hydration test (`undefined` → populated `billingItems`).

Safe against active edits: the discount edit draft lives in TanStack form state (populated by `form.reset` in `onDiscountCommand`), and `itemsRef`/`originalPayloadsRef` only commit after a successful save — so the hydration re-run only re-derives persisted state and can't clobber an in-progress edit.

<!-- Linear link -->
Fixes LAGO-1730

🤖 Generated with [Claude Code](https://claude.com/claude-code)