### PR TITLE
fix(wallet): redirect to transactions tab after creating a top-up

### DIFF
--- a/src/pages/wallet/CreateWalletTopUp.tsx
+++ b/src/pages/wallet/CreateWalletTopUp.tsx
@@ -210,7 +210,7 @@ const CreateWalletTopUp = () => {
         notifyOnNetworkStatusChange: true,
       })
 
-      navigateToCustomerWalletTab(wallet.id)
+      navigateToCustomerWalletTab(wallet.id, WalletDetailsTabsOptionsEnum.transactions)
     },
   })
 
@@ -251,13 +251,13 @@ const CreateWalletTopUp = () => {
   )
 
   const navigateToCustomerWalletTab = useCallback(
-    (id?: string) => {
+    (id?: string, tab: WalletDetailsTabsOptionsEnum = WalletDetailsTabsOptionsEnum.overview) => {
       if (id) {
         return navigate(
           generatePath(WALLET_DETAILS_ROUTE, {
             walletId: id,
             customerId: customerId,
-            tab: WalletDetailsTabsOptionsEnum.overview,
+            tab,
           }),
         )
       }


### PR DESCRIPTION
## Context

After creating a wallet top-up, the app redirected the user to the wallet **overview** tab, where the new transaction is not visible — they had to manually switch to the **transactions** tab to see it.

## Description

The success handler now lands the user on the wallet **transactions** tab so the freshly created transaction is immediately visible. `navigateToCustomerWalletTab` gains an optional `tab` param (default `overview`), so the dirty-discard warning still navigates to overview. No GraphQL or translation changes.

Fixes LAGO-1726

🤖 Generated with [Claude Code](https://claude.com/claude-code)