### PR TITLE
fix(integrations): show integration name in details breadcrumb

### DIFF
--- a/src/pages/settings/AdyenIntegrationDetails.tsx
+++ b/src/pages/settings/AdyenIntegrationDetails.tsx
@@ -107,7 +107,7 @@ const AdyenIntegrationDetails = () => {
             }),
           },
           {
-            label: translate('text_67db6a10cb0b8031ca538909'),
+            label: translate('text_645d071272418a14c1c76a6d'),
             path: generatePath(ADYEN_INTEGRATION_ROUTE, {
               integrationGroup: IntegrationsTabsOptionsEnum.Lago,
             }),

--- a/src/pages/settings/AnrokIntegrationDetails.tsx
+++ b/src/pages/settings/AnrokIntegrationDetails.tsx
@@ -114,7 +114,7 @@ const AnrokIntegrationDetails = () => {
             }),
           },
           {
-            label: translate('text_67db6a10cb0b8031ca538909'),
+            label: translate('text_6668821d94e4da4dfd8b3834'),
             path: generatePath(ANROK_INTEGRATION_ROUTE, {
               integrationGroup: IntegrationsTabsOptionsEnum.Lago,
             }),

--- a/src/pages/settings/AvalaraIntegrationDetails.tsx
+++ b/src/pages/settings/AvalaraIntegrationDetails.tsx
@@ -111,7 +111,7 @@ const AvalaraIntegrationDetails = () => {
             }),
           },
           {
-            label: translate('text_67db6a10cb0b8031ca538909'),
+            label: translate('text_1744293609277s53zn6jcoq4'),
             path: generatePath(AVALARA_INTEGRATION_ROUTE, {
               integrationGroup: IntegrationsTabsOptionsEnum.Lago,
             }),

--- a/src/pages/settings/CashfreeIntegrationDetails.tsx
+++ b/src/pages/settings/CashfreeIntegrationDetails.tsx
@@ -118,7 +118,7 @@ const CashfreeIntegrationDetails = () => {
             }),
           },
           {
-            label: translate('text_67db6a10cb0b8031ca538909'),
+            label: translate('text_17367626793434wkg1rk0114'),
             path: generatePath(CASHFREE_INTEGRATION_ROUTE, {
               integrationGroup: IntegrationsTabsOptionsEnum.Community,
             }),

--- a/src/pages/settings/FlutterwaveIntegrationDetails.tsx
+++ b/src/pages/settings/FlutterwaveIntegrationDetails.tsx
@@ -129,7 +129,7 @@ const FlutterwaveIntegrationDetails = () => {
             }),
           },
           {
-            label: translate('text_67db6a10cb0b8031ca538909'),
+            label: translate('text_1749724395108m0swrna0zt4'),
             path: generatePath(FLUTTERWAVE_INTEGRATION_ROUTE, {
               integrationGroup: IntegrationsTabsOptionsEnum.Community,
             }),

--- a/src/pages/settings/GocardlessIntegrationDetails.tsx
+++ b/src/pages/settings/GocardlessIntegrationDetails.tsx
@@ -116,7 +116,7 @@ const GocardlessIntegrationDetails = () => {
             }),
           },
           {
-            label: translate('text_67db6a10cb0b8031ca538909'),
+            label: translate('text_634ea0ecc6147de10ddb6648'),
             path: generatePath(GOCARDLESS_INTEGRATION_ROUTE, {
               integrationGroup: IntegrationsTabsOptionsEnum.Lago,
             }),

--- a/src/pages/settings/HubspotIntegrationDetails.tsx
+++ b/src/pages/settings/HubspotIntegrationDetails.tsx
@@ -103,7 +103,7 @@ const HubspotIntegrationDetails = () => {
             }),
           },
           {
-            label: translate('text_67db6a10cb0b8031ca538909'),
+            label: translate('text_1727189568053s79ks5q07tr'),
             path: generatePath(HUBSPOT_INTEGRATION_ROUTE, {
               integrationGroup: IntegrationsTabsOptionsEnum.Lago,
             }),

--- a/src/pages/settings/MoneyhashIntegrationDetails.tsx
+++ b/src/pages/settings/MoneyhashIntegrationDetails.tsx
@@ -107,7 +107,7 @@ const MoneyhashIntegrationDetails = () => {
             }),
           },
           {
-            label: translate('text_67db6a10cb0b8031ca538909'),
+            label: translate('text_1733427981129n3wxjui0bex'),
             path: generatePath(MONEYHASH_INTEGRATION_ROUTE, {
               integrationGroup: IntegrationsTabsOptionsEnum.Community,
             }),

--- a/src/pages/settings/NetsuiteIntegrationDetails.tsx
+++ b/src/pages/settings/NetsuiteIntegrationDetails.tsx
@@ -116,7 +116,7 @@ const NetsuiteIntegrationDetails = () => {
             }),
           },
           {
-            label: translate('text_67db6a10cb0b8031ca538909'),
+            label: translate('text_661ff6e56ef7e1b7c542b239'),
             path: generatePath(NETSUITE_INTEGRATION_ROUTE, {
               integrationGroup: IntegrationsTabsOptionsEnum.Lago,
             }),

--- a/src/pages/settings/SalesforceIntegrationDetails.tsx
+++ b/src/pages/settings/SalesforceIntegrationDetails.tsx
@@ -103,7 +103,7 @@ const SalesforceIntegrationDetails = () => {
             }),
           },
           {
-            label: translate('text_67db6a10cb0b8031ca538909'),
+            label: translate('text_1731507195246vu9kt6xnhv6'),
             path: generatePath(SALESFORCE_INTEGRATION_ROUTE, {
               integrationGroup: IntegrationsTabsOptionsEnum.Lago,
             }),

--- a/src/pages/settings/StripeIntegrationDetails.tsx
+++ b/src/pages/settings/StripeIntegrationDetails.tsx
@@ -111,7 +111,7 @@ const StripeIntegrationDetails = () => {
             }),
           },
           {
-            label: translate('text_67db6a10cb0b8031ca538909'),
+            label: translate('text_62b1edddbf5f461ab971277d'),
             path: generatePath(STRIPE_INTEGRATION_ROUTE, {
               integrationGroup: IntegrationsTabsOptionsEnum.Lago,
             }),

--- a/src/pages/settings/XeroIntegrationDetails.tsx
+++ b/src/pages/settings/XeroIntegrationDetails.tsx
@@ -124,7 +124,7 @@ const XeroIntegrationDetails = () => {
             }),
           },
           {
-            label: translate('text_67db6a10cb0b8031ca538909'),
+            label: translate('text_6672ebb8b1b50be550eccaf8'),
             path: generatePath(XERO_INTEGRATION_ROUTE, {
               integrationGroup: IntegrationsTabsOptionsEnum.Lago,
             }),

--- a/translations/base.json
+++ b/translations/base.json
@@ -3809,7 +3809,6 @@
   "text_17730476805600nudrokzkk5": "Security Logs",
   "text_1773415705134l01iamqr6fk": "{{email}} successfully logged in using a new device",
   "text_1773761094529kr57s3qq8j3": "Export credit notes",
-  "text_67db6a10cb0b8031ca538909": "Connections",
   "text_1772536695408i54gtdrmatk": "View alerts",
   "text_1772536695408q802eishgnx": "Status",
   "text_1772536695408sddzumtfq2t": "Wallet name",


### PR DESCRIPTION
## Context

On an integration details page the breadcrumb read `Integrations / Connections` for every provider, which is vague — it never told you whether you were in Stripe, Adyen, or another integration.

## Description

Each of the 12 integration detail pages built its own breadcrumb array with the same hardcoded "Connections" label key. Swapped that second-segment label for each provider's existing name key, so a Stripe page now reads `Integrations / Stripe`, Adyen reads `Integrations / Adyen`, and so on. Paths are unchanged, and the now-orphaned "Connections" translation key was removed.

<!-- Linear link -->
Fixes LAGO-1616