### PR TITLE
fix(auth): trim email to prevent whitespace validation failure

### DIFF
--- a/src/formValidation/__tests__/zodCustoms.test.ts
+++ b/src/formValidation/__tests__/zodCustoms.test.ts
@@ -283,6 +283,7 @@ describe('zodCustoms', () => {
         ['user+tag@example.com', 'email with plus'],
         ['name.surname@domain.co.uk', 'email with dots and multi-part TLD'],
         ['u@d.io', 'minimal email'],
+        ['  user@example.com  ', 'email with surrounding whitespace'],
       ])('accepts "%s" (%s)', (value) => {
         const result = zodRequiredEmail.safeParse(value)
 
@@ -291,8 +292,11 @@ describe('zodCustoms', () => {
     })
 
     describe('invalid', () => {
-      it('rejects empty string with required error', () => {
-        const result = zodRequiredEmail.safeParse('')
+      it.each([
+        ['', 'empty string'],
+        ['   ', 'whitespace-only string'],
+      ])('rejects "%s" (%s) with required error', (value) => {
+        const result = zodRequiredEmail.safeParse(value)
 
         expect(result.success).toBe(false)
 
@@ -305,6 +309,7 @@ describe('zodCustoms', () => {
         ['not-an-email', 'plain string'],
         ['user@', 'missing domain'],
         ['@example.com', 'missing local part'],
+        ['a b@example.com', 'internal space'],
       ])('rejects "%s" (%s) with format error', (value) => {
         const result = zodRequiredEmail.safeParse(value)
 

--- a/src/formValidation/zodCustoms.ts
+++ b/src/formValidation/zodCustoms.ts
@@ -64,6 +64,7 @@ export const zodOneOfPermissions = z.string().refine((value) => {
 
 export const zodRequiredEmail = z
   .string()
+  .trim()
   .min(1, { message: 'text_620bc4d4269a55014d493f3d' })
   .refine((val) => EMAIL_REGEX.test(val), 'text_620bc4d4269a55014d493fc3')
 


### PR DESCRIPTION
## Context

In the member invitation modal, entering an email with a leading/trailing space triggered a front-end validation error on submit. The shared `zodRequiredEmail` validator tested the raw string against `EMAIL_REGEX` with no trim, so `"a@b.com "` failed — and validation blocked the submit before the dialog's submit-time `.trim()` could run. The same validator backs the login, sign-up, and forgot-password forms, so they shared the identical latent bug.

## Description

Add zod's `.trim()` to `zodRequiredEmail` (before the length/regex checks) so surrounding whitespace is stripped for validation across the invite modal and all three auth forms. Genuinely invalid addresses (empty/whitespace-only, internal spaces) still fail as before. Added test cases to `zodCustoms.test.ts` covering surrounding-whitespace acceptance, whitespace-only rejection, and internal-space rejection.

<!-- Linear link -->
Fixes LAGO-1617