### PR TITLE
fix(sentry): stop alarming on handled not-found redirects

### DIFF
--- a/src/hooks/__tests__/useNotFoundRedirect.test.ts
+++ b/src/hooks/__tests__/useNotFoundRedirect.test.ts
@@ -109,7 +109,7 @@ describe('useNotFoundRedirect', () => {
         })
       })
 
-      it('THEN should report the error to Sentry', async () => {
+      it('THEN should NOT report the error to Sentry', async () => {
         const notFoundError = createNotFoundError()
 
         renderHook(
@@ -122,15 +122,10 @@ describe('useNotFoundRedirect', () => {
         )
 
         await waitFor(() => {
-          expect(captureException).toHaveBeenCalledWith(notFoundError, {
-            level: 'warning',
-            tags: {
-              errorType: 'NotFoundRedirect',
-              fromPath: window.location.pathname,
-              redirectTo: '/resources',
-            },
-          })
+          expect(mockNavigate).toHaveBeenCalledWith('/resources', { replace: true })
         })
+
+        expect(captureException).not.toHaveBeenCalled()
       })
 
       it('THEN should show an info toast with the provided translateKey', async () => {

--- a/src/hooks/useNotFoundRedirect.ts
+++ b/src/hooks/useNotFoundRedirect.ts
@@ -1,5 +1,4 @@
 import { ApolloError } from '@apollo/client'
-import { captureException } from '@sentry/react'
 import { useEffect } from 'react'
 
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
@@ -23,15 +22,6 @@ export const useNotFoundRedirect = ({
 
   useEffect(() => {
     if (loading || !isNotFoundError) return
-
-    captureException(error, {
-      level: 'warning',
-      tags: {
-        errorType: 'NotFoundRedirect',
-        fromPath: window.location.pathname,
-        redirectTo,
-      },
-    })
 
     addToast({
       severity: 'info',


### PR DESCRIPTION
## Context

Opening a deleted customer's detail view correctly returns a 404 and the UI redirects to the list with an info toast — expected, handled behavior — yet it still fired a Sentry alarm (`ApolloError: Resource not found`). The `useNotFoundRedirect` hook captured every NotFound to Sentry at `warning` level, bypassing the per-query `silentErrorCodes` mechanism that already silenced the Apollo `errorLink` path.

## Description

Removed the unconditional `captureException` (and its `@sentry/react` import) from `useNotFoundRedirect`, so handled not-founds across all 10 detail pages (customer, invoice, plan, subscription, coupon, add-on, feature, credit note, billable metric, payment) no longer emit a Sentry event. Genuinely unexpected NotFounds from queries that do not opt out via `silentErrorCodes` are still captured by the canonical `errorLink`. Inverted the hook test to assert Sentry is not called.

<!-- Linear link -->
Fixes ING-444