### PR TITLE
refactor(dates): migrate remaining DateTime.toFormat display usage to intlFormatDateTime

### DIFF
--- a/src/components/customers/subscriptions/SubscriptionDatesOffsetHelperComponent.tsx
+++ b/src/components/customers/subscriptions/SubscriptionDatesOffsetHelperComponent.tsx
@@ -2,7 +2,7 @@ import { DateTime } from 'luxon'
 import { useCallback } from 'react'
 
 import { Typography } from '~/components/designSystem/Typography'
-import { getTimezoneConfig, TimeZonesConfig } from '~/core/timezone'
+import { intlFormatDateTime, TimeZonesConfig } from '~/core/timezone'
 import { TimezoneEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
@@ -21,22 +21,15 @@ export const SubscriptionDatesOffsetHelperComponent = ({
   ...props
 }: SubscriptionDatesOffsetHelperComponentProps) => {
   const { translate } = useInternationalization()
-  const { timezone: organizationTimezone, timezoneConfig: orgaTimezoneConfig } =
-    useOrganizationInfos()
-  const customerTimezoneConfig = customerTimezone ? getTimezoneConfig(customerTimezone) : undefined
+  const { timezone: organizationTimezone } = useOrganizationInfos()
 
   // subscriptionAt helper text
   const subscriptionAtHelperText = useCallback((): string | undefined => {
     if (!subscriptionAt) return undefined
 
-    const date = DateTime.fromISO(subscriptionAt)
-      .setZone(customerTimezoneConfig?.name || orgaTimezoneConfig.name)
-      .toFormat('LLL. dd, yyyy')
-    const time = `${DateTime.fromISO(subscriptionAt)
-      .setZone(customerTimezoneConfig?.name || orgaTimezoneConfig.name)
-      .setLocale('en')
-      .toFormat('t')}`
-    const offset = TimeZonesConfig[customerTimezone || organizationTimezone].offset
+    const timezone = customerTimezone || organizationTimezone
+    const { date, time } = intlFormatDateTime(subscriptionAt, { timezone })
+    const offset = TimeZonesConfig[timezone].offset
 
     // If date is in the future
     if (DateTime.fromISO(subscriptionAt).diff(DateTime.now().startOf('day'), 'days').days > 0) {
@@ -45,37 +38,18 @@ export const SubscriptionDatesOffsetHelperComponent = ({
 
     // If date is in the past
     return translate('text_64ef81071c6da2010dd24b1d', { date, time, offset })
-  }, [
-    customerTimezone,
-    customerTimezoneConfig?.name,
-    orgaTimezoneConfig.name,
-    organizationTimezone,
-    subscriptionAt,
-    translate,
-  ])
+  }, [customerTimezone, organizationTimezone, subscriptionAt, translate])
 
   // endingAt helper text
   const endingAtHelperText = useCallback((): string => {
     if (!endingAt) return translate('text_64ef81071c6da2010dd24b1e')
 
-    const date = DateTime.fromISO(endingAt)
-      .setZone(customerTimezoneConfig?.name || orgaTimezoneConfig.name)
-      .toFormat('LLL. dd, yyyy')
-    const time = `${DateTime.fromISO(endingAt)
-      .setZone(customerTimezoneConfig?.name || orgaTimezoneConfig.name)
-      .setLocale('en')
-      .toFormat('t')}`
-    const offset = TimeZonesConfig[customerTimezone || organizationTimezone].offset
+    const timezone = customerTimezone || organizationTimezone
+    const { date, time } = intlFormatDateTime(endingAt, { timezone })
+    const offset = TimeZonesConfig[timezone].offset
 
     return translate('text_64ef81071c6da2010dd24b1f', { date, time, offset })
-  }, [
-    customerTimezone,
-    customerTimezoneConfig?.name,
-    endingAt,
-    orgaTimezoneConfig.name,
-    organizationTimezone,
-    translate,
-  ])
+  }, [customerTimezone, endingAt, organizationTimezone, translate])
 
   // If no offset or no date, don't return any text
   if (!subscriptionAt) return null

--- a/src/components/invoices/InvoiceCustomerInfos.tsx
+++ b/src/components/invoices/InvoiceCustomerInfos.tsx
@@ -1,6 +1,5 @@
 import { gql } from '@apollo/client'
 import { Icon } from 'lago-design-system'
-import { DateTime } from 'luxon'
 import { memo } from 'react'
 import { generatePath } from 'react-router-dom'
 
@@ -10,6 +9,7 @@ import { Typography } from '~/components/designSystem/Typography'
 import { invoiceStatusMapping, paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
 import { formatAddress } from '~/core/formats/formatAddress'
 import { CUSTOMER_DETAILS_ROUTE, Link } from '~/core/router'
+import { intlFormatDateTime } from '~/core/timezone'
 import {
   CustomerAccountTypeEnum,
   InvoiceForInvoiceInfosFragment,
@@ -212,7 +212,7 @@ export const InvoiceCustomerInfos = memo(({ invoice }: InvoiceCustomerInfosProps
                 <div className="flex flex-wrap items-center gap-2">
                   <Icon name="warning-filled" color="warning" />
                   {translate('text_66141e30699a0631f0b2ed2c', {
-                    date: DateTime.fromISO(invoice?.paymentDisputeLostAt).toFormat('LLL. dd, yyyy'),
+                    date: intlFormatDateTime(invoice?.paymentDisputeLostAt).date,
                   })}
                 </div>
               }

--- a/src/components/invoices/__tests__/__snapshots__/InvoiceCustomerInfos.test.tsx.snap
+++ b/src/components/invoices/__tests__/__snapshots__/InvoiceCustomerInfos.test.tsx.snap
@@ -994,7 +994,7 @@ United States of America
               fill-rule="evenodd"
             />
           </svg>
-          Dispute lost on Jan. 20, 2024
+          Dispute lost on Jan 20, 2024
         </div>
       </div>
     </div>

--- a/src/components/invoices/details/InvoiceDetailsTable.tsx
+++ b/src/components/invoices/details/InvoiceDetailsTable.tsx
@@ -1,6 +1,5 @@
 import { gql } from '@apollo/client'
 import { tw } from 'lago-design-system'
-import { DateTime } from 'luxon'
 import { FC, Fragment, memo, ReactNode, RefObject } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
@@ -316,7 +315,7 @@ export const InvoiceDetailsTable = memo(
                     displayName={feeDisplayName}
                     succeededDate={
                       invoice.invoiceType === InvoiceTypeEnum.AdvanceCharges
-                        ? DateTime.fromISO(fee.succeededAt).toFormat('LLL. dd, yyyy')
+                        ? intlFormatDateTime(fee.succeededAt).date
                         : undefined
                     }
                     editFeeDrawerRef={editFeeDrawerRef}
@@ -466,7 +465,7 @@ export const InvoiceDetailsTable = memo(
                           />
                           {boundary.fees.map((fee) => {
                             const succeededDate = fee.succeededAt
-                              ? DateTime.fromISO(fee.succeededAt).toLocaleString(DateTime.DATE_MED)
+                              ? intlFormatDateTime(fee.succeededAt).date
                               : undefined
 
                             return (


### PR DESCRIPTION
## Context

Custom luxon `DateTime.toFormat(...)` date-display calls are deprecated in favor of the shared `intlFormatDateTime` helper (`src/core/timezone`); #3447 migrated the bulk and this finishes LAGO-1558 by migrating the remaining display-date sites.

## Description

Migrated the subscription dates offset helper (date + time, timezone-aware), the invoice customer dispute-lost date, and the invoice details succeeded dates (`.toFormat` + one adjacent `.toLocaleString(DateTime.DATE_MED)`) to `intlFormatDateTime`, dropping now-dead `DateTime`/`getTimezoneConfig` imports. Display output standardizes to `DATE_MED` (month period dropped, e.g. `Jan. 20, 2024` → `Jan 20, 2024`), consistent with #3447 — one snapshot updated accordingly. Comparison/join keys (graph month keys, the `february29` check), machine formats (`yyyyMM` doc numbers), and the documented `ViewFeeDetailsDrawer` timezone exception are intentionally left untouched.

<!-- Linear link -->
Fixes LAGO-1558

🤖 Generated with [Claude Code](https://claude.com/claude-code)