### PR TITLE
feat(dialogs): keep form dialogs open on submit validation errors

### DIFF
--- a/.agents/skills/migrate-dialog/SKILL.md
+++ b/.agents/skills/migrate-dialog/SKILL.md
@@ -141,15 +141,9 @@ export const useMyDialog = () => {
     },
   })
 
-  const handleSubmit = async (): Promise<DialogResult> => {
+  const submit = async (): Promise<void> => {
     successRef.current = false
     await form.handleSubmit()
-
-    if (!successRef.current) {
-      throw new Error('Submit failed')
-    }
-
-    return { reason: 'success' }
   }
 
   const openMyDialog = (data: MyData) => {
@@ -179,7 +173,8 @@ export const useMyDialog = () => {
         ),
         form: {
           id: MY_FORM_ID,
-          submit: handleSubmit,
+          submit,
+          didSubmitSucceed: () => successRef.current,
         },
       })
       .then((response) => {
@@ -194,27 +189,26 @@ export const useMyDialog = () => {
 }
 ```
 
-**Which success signal to use in `handleSubmit`:**
+**Which success signal to use:**
 
-`FormDialog` only keeps the dialog open when `handleSubmit` **throws** (with `closeOnError: false`); returning any value closes it. So `handleSubmit` must throw on failure — the question is how it detects failure:
+`FormDialog` asks the optional `form.didSubmitSucceed()` once `submit` settles; returning `false` keeps the dialog open (it neither resolves nor hides), so validation errors stay visible. Never throw a synthetic error to keep a dialog open — that path is for real failures only. Two cases:
 
-- **`onSubmit` runs an operation that can fail _without throwing_** (e.g. a mutation that returns GraphQL errors instead of rejecting) → track success with a manual flag (`successRef`) set inside `onSubmit` only on real success, as shown above. `form.state.isSubmitSuccessful` can't see a soft failure — it's `true` whenever `onSubmit` didn't throw, even if the mutation returned errors.
-- **`onSubmit` has no failure mode beyond validation** (e.g. it just calls a callback — no mutation) → drop the `successRef` and read the built-in **`form.state.isSubmitSuccessful`** directly:
+- **`onSubmit` runs an operation that can fail _without throwing_** (e.g. a mutation that returns GraphQL errors instead of rejecting) → track success with a manual flag (`successRef`) set inside `onSubmit` only on real success, and expose it as `didSubmitSucceed`, as shown above. `form.state.isSubmitSuccessful` can't see a soft failure — it's `true` whenever `onSubmit` didn't throw, even if the mutation returned errors. Reset the flag in the `submit` wrapper, not inside `onSubmit`: on a validation failure `onSubmit` never runs, so a stale `true` from an earlier submit would let the dialog close.
+- **`onSubmit` has no failure mode beyond validation** (e.g. it just calls a callback — no mutation) → drop the `successRef` and use the **`dialogFormProps`** helper, which wires `submit` and `didSubmitSucceed` from the form's own state:
 
 ```typescript
-const handleSubmit = async (): Promise<DialogResult> => {
-  await form.handleSubmit()
+import { dialogFormProps } from '~/components/dialogs/dialogFormProps'
 
+formDialog.open({
+  // …
   // isSubmitSuccessful: reset to false at the start of each submit, stays false if
   // validation fails (onSubmit never runs), true only after onSubmit resolves
-  // without throwing. Throw to keep the dialog open (closeOnError: false).
-  if (!form.state.isSubmitSuccessful) {
-    throw new Error('Submit failed')
-  }
-
-  return { reason: 'success' }
-}
+  // without throwing.
+  form: dialogFormProps(MY_FORM_ID, form),
+})
 ```
+
+`closeOnError: false` is unrelated to validation: keep it only when a submit that genuinely **throws** (a rejecting mutation) should leave the dialog open instead of rejecting the `open()` promise.
 
 Do **not** drop `validationLogic` to "simplify" — without `revalidateLogic()` the `onDynamic` validator never runs and the schema is silently skipped. Keep `revalidateLogic()` (the default, submit-first); do not use `revalidateLogic({ mode: 'change' })` unless a field genuinely needs live validation feedback.
 
@@ -412,15 +406,9 @@ export const useMyFormDialog = () => {
     },
   })
 
-  const handleSubmit = async (): Promise<DialogResult> => {
+  const submit = async (): Promise<void> => {
     successRef.current = false
     await form.handleSubmit()
-
-    if (!successRef.current) {
-      throw new Error('Submit failed')
-    }
-
-    return { reason: 'success' }
   }
 
   const openMyFormDialog = (data: MyData) => {
@@ -455,7 +443,8 @@ export const useMyFormDialog = () => {
         ),
         form: {
           id: MY_FORM_ID,
-          submit: handleSubmit,
+          submit,
+          didSubmitSucceed: () => successRef.current,
         },
         // Secondary action button (conditionally shown)
         canOpenDialog: isEdition && !!data.deleteCallback && someCondition,
@@ -519,7 +508,7 @@ export const useMyFormDialog = () => {
 **Handling form submission:**
 
 - Old: `handleSubmit` called `e.preventDefault()` + `form.handleSubmit()`; dialog closed by calling `dialogRef.current?.closeDialog()` inside `onSubmit`
-- New: `handleSubmit` returns a `Promise<DialogResult>`. Use a `successRef` to track whether the mutation succeeded. The dialog auto-closes on success (when the promise resolves). Throw an error to keep the dialog open on failure.
+- New: pass `submit` plus `didSubmitSucceed` in the `form` prop (or `dialogFormProps(id, form)` when validation is the only failure mode). The dialog auto-closes once `submit` settles, unless `didSubmitSucceed()` returns `false` — that keeps it open with the errors visible. Use a `successRef` only when the mutation signals failure without rejecting.
 
 **Handling dialog close/cleanup:**
 
@@ -546,8 +535,8 @@ Add (for FormDialog):
 
 ```typescript
 import { useRef } from 'react'
+import { dialogFormProps } from '~/components/dialogs/dialogFormProps'
 import { useFormDialog } from '~/components/dialogs/FormDialog'
-import { DialogResult } from '~/components/dialogs/types'
 // Only for branch 2a (plain-input-first). Branch 2b (combobox-first/only) does NOT import
 // focusFirstInput — it imports MUI_INPUT_BASE_ROOT_CLASSNAME + a field className from
 // ~/core/constants/form and clicks the combobox MuiInputBase-root in onEntered. See section 2.
@@ -564,8 +553,8 @@ Or (for FormDialogOpeningDialog):
 
 ```typescript
 import { useRef } from 'react'
+import { dialogFormProps } from '~/components/dialogs/dialogFormProps'
 import { useFormDialogOpeningDialog } from '~/components/dialogs/FormDialogOpeningDialog'
-import { DialogResult } from '~/components/dialogs/types'
 // Only for branch 2a (plain-input-first). Branch 2b (combobox-first/only) does NOT import
 // focusFirstInput — it imports MUI_INPUT_BASE_ROOT_CLASSNAME + a field className from
 // ~/core/constants/form and clicks the combobox MuiInputBase-root in onEntered. See section 2.
@@ -687,7 +676,7 @@ type FormDialogProps = {
   cancelOrCloseText?: 'close' | 'cancel'
   closeOnError?: boolean
   onError?: (error: Error) => void
-  form: FormProps  // { id: string; submit: (e: React.FormEvent) => void }
+  form: FormProps // { id: string; submit: () => void; didSubmitSucceed?: () => boolean }
 }
 ```
 
@@ -738,7 +727,7 @@ type FormDialogOpeningDialogProps = FormDialogProps & {
 - [ ] Convert `forwardRef` component to custom hook (`useMyDialog`)
 - [ ] Replace `useState(localData)` with `useRef` (for FormDialog/FormDialogOpeningDialog) or function parameter (for CentralizedDialog)
 - [ ] Replace `Dialog`/`WarningDialog` with `useFormDialog()`, `useCentralizedDialog()`, or `useFormDialogOpeningDialog()`
-- [ ] Implement `handleSubmit` returning `Promise<DialogResult>` (for FormDialog/FormDialogOpeningDialog)
+- [ ] Wire the `form` prop with `dialogFormProps(id, form)`, or with `submit` + `didSubmitSucceed` when a `successRef` is needed (for FormDialog/FormDialogOpeningDialog)
 - [ ] Wrap `children` JSX in a `p-8` padding container (BaseDialog does NOT pad JSX children → flush/misaligned layout otherwise)
 - [ ] **Classify the first editable field before writing `onEntered`** (see section 2 decision table) — this check is mandatory, not optional:
   - [ ] First field is a plain input → `onEntered: focusFirstInput` (branch 2a)

--- a/.agents/skills/migrate-dialog/examples/before-after.md
+++ b/.agents/skills/migrate-dialog/examples/before-after.md
@@ -143,7 +143,6 @@ import { z } from 'zod'
 import { Avatar } from '~/components/designSystem/Avatar'
 import { Typography } from '~/components/designSystem/Typography'
 import { useFormDialog } from '~/components/dialogs/FormDialog'
-import { DialogResult } from '~/components/dialogs/types'
 import { InviteForEditRoleForDialogFragment } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm } from '~/hooks/forms/useAppform'
@@ -192,15 +191,12 @@ export const useEditInviteRoleDialog = () => {
     },
   })
 
-  const handleSubmit = async (): Promise<DialogResult> => {
+  // The mutation reports failure through its payload instead of rejecting, so success is
+  // tracked manually and handed to FormDialog via didSubmitSucceed. A form whose onSubmit
+  // can only fail on validation uses dialogFormProps(id, form) instead.
+  const submit = async (): Promise<void> => {
     successRef.current = false
     await form.handleSubmit()
-
-    if (!successRef.current) {
-      throw new Error('Submit failed')
-    }
-
-    return { reason: 'success' }
   }
 
   const openEditInviteRoleDialog = (invite: InviteForEditRoleForDialogFragment) => {
@@ -234,7 +230,8 @@ export const useEditInviteRoleDialog = () => {
         ),
         form: {
           id: EDIT_INVITE_ROLE_FORM_ID,
-          submit: handleSubmit,
+          submit,
+          didSubmitSucceed: () => successRef.current,
         },
       })
       .then((response) => {

--- a/src/components/dialogs/FormDialog.tsx
+++ b/src/components/dialogs/FormDialog.tsx
@@ -46,6 +46,7 @@ const FormDialog = create(
       cancelOrCloseText,
       closeOnError,
       onError,
+      didSubmitSucceed: form.didSubmitSucceed,
     })
 
     const formActions = {

--- a/src/components/dialogs/FormDialogOpeningDialog.tsx
+++ b/src/components/dialogs/FormDialogOpeningDialog.tsx
@@ -47,6 +47,7 @@ const FormDialogOpeningDialog = create(
       cancelOrCloseText,
       closeOnError,
       onError,
+      didSubmitSucceed: form.didSubmitSucceed,
     })
 
     const formActions = {

--- a/src/components/dialogs/__tests__/FormDialog.test.tsx
+++ b/src/components/dialogs/__tests__/FormDialog.test.tsx
@@ -281,6 +281,66 @@ describe('FormDialog', () => {
     })
   })
 
+  describe('Submit Validation Guard', () => {
+    it('keeps the dialog open when didSubmitSucceed returns false', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <NiceModalWrapper>
+          <TestComponent
+            dialogProps={{
+              ...defaultProps,
+              form: {
+                id: 'test-form-dialog',
+                submit: jest.fn(),
+                didSubmitSucceed: () => false,
+              },
+              mainAction: <button type="submit">Submit Form</button>,
+            }}
+          />
+        </NiceModalWrapper>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Submit Form')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('Submit Form'))
+
+      expect(screen.getByTestId(FORM_DIALOG_TEST_ID)).toBeInTheDocument()
+    })
+
+    it('closes the dialog when didSubmitSucceed returns true', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <NiceModalWrapper>
+          <TestComponent
+            dialogProps={{
+              ...defaultProps,
+              form: {
+                id: 'test-form-dialog',
+                submit: jest.fn(),
+                didSubmitSucceed: () => true,
+              },
+              mainAction: <button type="submit">Submit Form</button>,
+            }}
+          />
+        </NiceModalWrapper>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Submit Form')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('Submit Form'))
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(FORM_DIALOG_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+  })
+
   describe('Cancel/Close Button', () => {
     it('renders close button by default', async () => {
       render(

--- a/src/components/dialogs/__tests__/FormDialogOpeningDialog.test.tsx
+++ b/src/components/dialogs/__tests__/FormDialogOpeningDialog.test.tsx
@@ -247,6 +247,62 @@ describe('FormDialogOpeningDialog', () => {
         expect(submitFn).toHaveBeenCalled()
       })
     })
+
+    it('keeps the dialog open when didSubmitSucceed returns false', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <NiceModalWrapper>
+          <TestComponent
+            dialogProps={{
+              ...defaultProps,
+              form: {
+                id: 'invalid-test-form',
+                submit: jest.fn(),
+                didSubmitSucceed: () => false,
+              },
+            }}
+          />
+        </NiceModalWrapper>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId(MAIN_ACTION_TEST_ID)).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByTestId(MAIN_ACTION_TEST_ID))
+
+      expect(screen.getByTestId(FORM_DIALOG_OPENING_DIALOG_TEST_ID)).toBeInTheDocument()
+    })
+
+    it('closes the dialog when didSubmitSucceed returns true', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <NiceModalWrapper>
+          <TestComponent
+            dialogProps={{
+              ...defaultProps,
+              form: {
+                id: 'valid-test-form',
+                submit: jest.fn(),
+                didSubmitSucceed: () => true,
+              },
+            }}
+          />
+        </NiceModalWrapper>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId(MAIN_ACTION_TEST_ID)).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByTestId(MAIN_ACTION_TEST_ID))
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(FORM_DIALOG_OPENING_DIALOG_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
   })
 
   describe('Open Other Dialog Button', () => {

--- a/src/components/dialogs/__tests__/dialogFormProps.test.ts
+++ b/src/components/dialogs/__tests__/dialogFormProps.test.ts
@@ -1,0 +1,64 @@
+import { dialogFormProps } from '../dialogFormProps'
+import { SubmittableForm } from '../types'
+
+const FORM_ID = 'my-form'
+
+const createMockForm = (overrides: Partial<SubmittableForm> = {}): SubmittableForm => ({
+  handleSubmit: jest.fn().mockResolvedValue(undefined),
+  state: { isSubmitSuccessful: false },
+  ...overrides,
+})
+
+describe('dialogFormProps', () => {
+  describe('GIVEN a form and an id', () => {
+    describe('WHEN building the dialog form props', () => {
+      it('THEN should forward the given id', () => {
+        const props = dialogFormProps(FORM_ID, createMockForm())
+
+        expect(props.id).toBe(FORM_ID)
+      })
+
+      it('THEN should not submit the form before submit is called', () => {
+        const form = createMockForm()
+
+        dialogFormProps(FORM_ID, form)
+
+        expect(form.handleSubmit).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN the built props are used', () => {
+    describe('WHEN submit is called', () => {
+      it('THEN should submit the form', async () => {
+        const form = createMockForm()
+
+        await dialogFormProps(FORM_ID, form).submit()
+
+        expect(form.handleSubmit).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('WHEN didSubmitSucceed is called', () => {
+      it.each([
+        ['the submit succeeded', true, true],
+        ['the validation failed', false, false],
+      ])('THEN should report %s', (_, isSubmitSuccessful, expected) => {
+        const form = createMockForm({ state: { isSubmitSuccessful } })
+
+        expect(dialogFormProps(FORM_ID, form).didSubmitSucceed?.()).toBe(expected)
+      })
+
+      it('THEN should read the form state on every call rather than capture it', () => {
+        const form = createMockForm()
+        const { didSubmitSucceed } = dialogFormProps(FORM_ID, form)
+
+        expect(didSubmitSucceed?.()).toBe(false)
+
+        form.state.isSubmitSuccessful = true
+
+        expect(didSubmitSucceed?.()).toBe(true)
+      })
+    })
+  })
+})

--- a/src/components/dialogs/__tests__/useDialogActions.test.ts
+++ b/src/components/dialogs/__tests__/useDialogActions.test.ts
@@ -70,6 +70,100 @@ describe('useDialogActions', () => {
       expect(mockModal.hide).toHaveBeenCalled()
     })
 
+    it('keeps modal open and does not resolve when didSubmitSucceed returns false', async () => {
+      const mockModal = createMockModal()
+      const mockOnAction = jest.fn().mockResolvedValue(undefined)
+
+      const { result } = renderHook(() =>
+        useDialogActions({
+          modal: mockModal,
+          onAction: mockOnAction,
+          cancelOrCloseText: 'close',
+          closeOnError: true,
+          didSubmitSucceed: () => false,
+        }),
+      )
+
+      await result.current.handleContinue()
+
+      expect(mockOnAction).toHaveBeenCalled()
+      expect(mockModal.resolve).not.toHaveBeenCalled()
+      expect(mockModal.reject).not.toHaveBeenCalled()
+      expect(mockModal.hide).not.toHaveBeenCalled()
+    })
+
+    it('resolves and hides modal when didSubmitSucceed returns true', async () => {
+      const mockModal = createMockModal()
+      const mockOnAction = jest.fn().mockResolvedValue(undefined)
+
+      const { result } = renderHook(() =>
+        useDialogActions({
+          modal: mockModal,
+          onAction: mockOnAction,
+          cancelOrCloseText: 'close',
+          closeOnError: true,
+          didSubmitSucceed: () => true,
+        }),
+      )
+
+      await result.current.handleContinue()
+
+      expect(mockModal.resolve).toHaveBeenCalledWith({ reason: 'success' })
+      expect(mockModal.hide).toHaveBeenCalled()
+    })
+
+    it('evaluates didSubmitSucceed only after onAction settled', async () => {
+      const mockModal = createMockModal()
+      const callOrder: string[] = []
+      const mockOnAction = jest.fn().mockImplementation(async () => {
+        callOrder.push('onAction')
+      })
+      const didSubmitSucceed = jest.fn().mockImplementation(() => {
+        callOrder.push('didSubmitSucceed')
+
+        return true
+      })
+
+      const { result } = renderHook(() =>
+        useDialogActions({
+          modal: mockModal,
+          onAction: mockOnAction,
+          cancelOrCloseText: 'close',
+          closeOnError: true,
+          didSubmitSucceed,
+        }),
+      )
+
+      await result.current.handleContinue()
+
+      expect(callOrder).toEqual(['onAction', 'didSubmitSucceed'])
+    })
+
+    it('does not evaluate didSubmitSucceed when onAction throws', async () => {
+      const mockModal = createMockModal()
+      const mockError = new Error('Test error')
+      const mockOnAction = jest.fn().mockRejectedValue(mockError)
+      const didSubmitSucceed = jest.fn().mockReturnValue(true)
+
+      const { result } = renderHook(() =>
+        useDialogActions({
+          modal: mockModal,
+          onAction: mockOnAction,
+          cancelOrCloseText: 'close',
+          closeOnError: true,
+          didSubmitSucceed,
+        }),
+      )
+
+      await result.current.handleContinue()
+
+      expect(didSubmitSucceed).not.toHaveBeenCalled()
+      expect(mockModal.reject).toHaveBeenCalledWith({
+        reason: 'error',
+        error: mockError,
+      })
+    })
+
     it('rejects with error object when onAction throws', async () => {
       const mockModal = createMockModal()
       const mockError = new Error('Test error')

--- a/src/components/dialogs/dialogFormProps.ts
+++ b/src/components/dialogs/dialogFormProps.ts
@@ -1,0 +1,20 @@
+import { FormProps, SubmittableForm } from './types'
+
+/**
+ * Builds the `form` prop of `FormDialog` / `FormDialogOpeningDialog` from a TanStack form.
+ *
+ * Submitting an invalid form no longer closes the dialog: `handleSubmit()` resolves
+ * without running `onSubmit`, and the `didSubmitSucceed` guard keeps the dialog open so
+ * the inline field errors stay visible.
+ *
+ * @example
+ * formDialog.open({
+ *   // …
+ *   form: dialogFormProps(MY_FORM_ID, form),
+ * })
+ */
+export const dialogFormProps = (id: string, form: SubmittableForm): FormProps => ({
+  id,
+  submit: () => form.handleSubmit(),
+  didSubmitSucceed: () => form.state.isSubmitSuccessful,
+})

--- a/src/components/dialogs/types.ts
+++ b/src/components/dialogs/types.ts
@@ -20,4 +20,25 @@ export type PremiumWarningHookDialogReturnType<Props> = {
 export type FormProps = {
   id: string
   submit: () => void | Promise<void> | DialogResult | Promise<DialogResult>
+  /**
+   * Evaluated once `submit` settles: returning `false` keeps the dialog open.
+   *
+   * TanStack forms resolve `handleSubmit()` even when validation failed (`onSubmit`
+   * simply never runs), so without this guard the dialog would close on invalid
+   * input and discard the inline field errors it just rendered.
+   *
+   * Use `dialogFormProps()` rather than wiring it by hand.
+   */
+  didSubmitSucceed?: () => boolean
+}
+
+/**
+ * Minimal surface of a TanStack form needed to drive a dialog's submit.
+ * A form returned by `useAppForm` satisfies it.
+ */
+export type SubmittableForm = {
+  handleSubmit: () => Promise<void>
+  state: {
+    isSubmitSuccessful: boolean
+  }
 }

--- a/src/components/dialogs/useDialogActions.ts
+++ b/src/components/dialogs/useDialogActions.ts
@@ -11,6 +11,7 @@ type UseDialogActionsParams = {
   cancelOrCloseText: 'close' | 'cancel'
   closeOnError: boolean
   onError?: (error: Error) => void
+  didSubmitSucceed?: () => boolean
 }
 
 type UseDialogActionsReturn = {
@@ -25,6 +26,7 @@ export const useDialogActions = ({
   cancelOrCloseText,
   closeOnError,
   onError,
+  didSubmitSucceed,
 }: UseDialogActionsParams): UseDialogActionsReturn => {
   const { translate } = useInternationalization()
 
@@ -43,6 +45,10 @@ export const useDialogActions = ({
 
     try {
       const result = await onAction()
+
+      // A failed validation is not an error: the form resolved without submitting, so
+      // keep the dialog open on its inline field errors instead of resolving it.
+      if (didSubmitSucceed && !didSubmitSucceed()) return
 
       const response = result ?? { reason: 'success' }
 

--- a/src/components/exports/ExportDialog.tsx
+++ b/src/components/exports/ExportDialog.tsx
@@ -3,8 +3,8 @@ import { useRef } from 'react'
 import { z } from 'zod'
 
 import { Typography } from '~/components/designSystem/Typography'
+import { dialogFormProps } from '~/components/dialogs/dialogFormProps'
 import { useFormDialog } from '~/components/dialogs/FormDialog'
-import { DialogResult } from '~/components/dialogs/types'
 import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { ExportValues } from '~/components/exports/types'
 import {
@@ -60,16 +60,6 @@ export const useExportDialog = () => {
       })
     },
   })
-
-  const handleSubmit = async (): Promise<DialogResult> => {
-    await form.handleSubmit()
-
-    if (!form.state.isSubmitSuccessful) {
-      throw new Error('Submit failed')
-    }
-
-    return { reason: 'success' }
-  }
 
   const openExportDialog = <T extends ExportTypeEnum>({
     totalCountLabel,
@@ -144,10 +134,7 @@ export const useExportDialog = () => {
             </form.SubmitButton>
           </form.AppForm>
         ),
-        form: {
-          id: FORM_ID,
-          submit: handleSubmit,
-        },
+        form: dialogFormProps(FORM_ID, form),
       })
       .then(() => {
         form.reset()

--- a/src/components/exports/__tests__/ExportDialog.test.tsx
+++ b/src/components/exports/__tests__/ExportDialog.test.tsx
@@ -1,0 +1,158 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { DataExportFormatTypeEnum, InvoiceExportTypeEnum } from '~/generated/graphql'
+import { AllTheProviders } from '~/test-utils'
+
+import { useExportDialog } from '../ExportDialog'
+
+const mockFormDialogOpen = jest.fn()
+
+jest.mock('~/components/dialogs/FormDialog', () => ({
+  ...jest.requireActual('~/components/dialogs/FormDialog'),
+  useFormDialog: () => ({
+    open: mockFormDialogOpen,
+    close: jest.fn(),
+  }),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+jest.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ currentUser: { email: 'user@lago.com' } }),
+}))
+
+const RESOURCE_TYPE_OPTIONS = [
+  { label: 'Invoices', sublabel: 'All invoices', value: InvoiceExportTypeEnum.Invoices },
+  {
+    label: 'Invoice fees',
+    sublabel: 'All invoice fees',
+    value: InvoiceExportTypeEnum.InvoiceFees,
+  },
+]
+
+const openArgs = (onExport = jest.fn()) => ({
+  totalCountLabel: '12 invoices',
+  onExport,
+  resourceTypeOptions: RESOURCE_TYPE_OPTIONS,
+})
+
+describe('useExportDialog', () => {
+  const customWrapper = ({ children }: { children: React.ReactNode }) =>
+    AllTheProviders({ children })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+  })
+
+  describe('GIVEN openExportDialog is called', () => {
+    describe('WHEN opening the dialog', () => {
+      it('THEN should open the form dialog once', () => {
+        const { result } = renderHook(() => useExportDialog(), { wrapper: customWrapper })
+
+        act(() => {
+          result.current.openExportDialog(openArgs())
+        })
+
+        expect(mockFormDialogOpen).toHaveBeenCalledTimes(1)
+      })
+
+      it.each([
+        ['submit', 'function'],
+        ['didSubmitSucceed', 'function'],
+      ])('THEN should pass a %s function through the shared form props', (prop, expectedType) => {
+        const { result } = renderHook(() => useExportDialog(), { wrapper: customWrapper })
+
+        act(() => {
+          result.current.openExportDialog(openArgs())
+        })
+
+        expect(typeof mockFormDialogOpen.mock.calls[0][0].form[prop]).toBe(expectedType)
+      })
+
+      it('THEN should not report a successful submit before the form is submitted', () => {
+        const { result } = renderHook(() => useExportDialog(), { wrapper: customWrapper })
+
+        act(() => {
+          result.current.openExportDialog(openArgs())
+        })
+
+        expect(mockFormDialogOpen.mock.calls[0][0].form.didSubmitSucceed()).toBe(false)
+      })
+    })
+  })
+
+  describe('GIVEN the form is submitted', () => {
+    describe('WHEN the selection is valid', () => {
+      it('THEN should invoke onExport with the selected format and resource type', async () => {
+        const onExport = jest.fn()
+
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useExportDialog(), { wrapper: customWrapper })
+
+        await act(async () => {
+          result.current.openExportDialog(openArgs(onExport))
+        })
+
+        expect(onExport).toHaveBeenCalledWith({
+          format: DataExportFormatTypeEnum.Csv,
+          resourceType: InvoiceExportTypeEnum.Invoices,
+        })
+      })
+
+      it('THEN should report the submit as successful so the dialog can close', async () => {
+        let didSubmitSucceed: boolean | undefined
+
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          didSubmitSucceed = config.form.didSubmitSucceed?.()
+
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useExportDialog(), { wrapper: customWrapper })
+
+        await act(async () => {
+          result.current.openExportDialog(openArgs())
+        })
+
+        expect(didSubmitSucceed).toBe(true)
+      })
+    })
+
+    describe('WHEN onExport fails', () => {
+      it('THEN should not report the submit as successful', async () => {
+        const onExport = jest.fn().mockRejectedValue(new Error('Export failed'))
+        let didSubmitSucceed: boolean | undefined
+
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          try {
+            await config.form.submit()
+          } catch {
+            // FormDialog catches it and, with closeOnError false, keeps the dialog open.
+          }
+
+          didSubmitSucceed = config.form.didSubmitSucceed?.()
+
+          return { reason: 'close' }
+        })
+
+        const { result } = renderHook(() => useExportDialog(), { wrapper: customWrapper })
+
+        await act(async () => {
+          result.current.openExportDialog(openArgs(onExport))
+        })
+
+        expect(onExport).toHaveBeenCalled()
+        expect(didSubmitSucceed).toBe(false)
+      })
+    })
+  })
+})

--- a/src/components/invoices/EditFeeBillingPeriod.tsx
+++ b/src/components/invoices/EditFeeBillingPeriod.tsx
@@ -3,8 +3,8 @@ import { DateTime } from 'luxon'
 import { useRef } from 'react'
 import { z } from 'zod'
 
+import { dialogFormProps } from '~/components/dialogs/dialogFormProps'
 import { useFormDialog } from '~/components/dialogs/FormDialog'
-import { DialogResult } from '~/components/dialogs/types'
 import { DatePicker } from '~/components/form'
 import { dateErrorCodes } from '~/core/constants/form'
 import { getTimezoneConfig } from '~/core/timezone'
@@ -61,19 +61,6 @@ export const useEditFeeBillingPeriodDialog = () => {
       callbackRef.current?.(value.fromDatetime || '', value.toDatetime || '')
     },
   })
-
-  const handleSubmit = async (): Promise<DialogResult> => {
-    await form.handleSubmit()
-
-    // On validation error onSubmit never runs and isSubmitSuccessful stays false:
-    // throw to keep the dialog open (closeOnError: false swallows the error, inline
-    // field errors stay visible). Returning a result would let FormDialog close it.
-    if (!form.state.isSubmitSuccessful) {
-      throw new Error('Submit failed')
-    }
-
-    return { reason: 'success' }
-  }
 
   const openEditFeeBillingPeriodDialog = ({
     fromDatetime,
@@ -138,10 +125,7 @@ export const useEditFeeBillingPeriodDialog = () => {
             <form.SubmitButton>{translate('text_17295436903260tlyb1gp1i7')}</form.SubmitButton>
           </form.AppForm>
         ),
-        form: {
-          id: EDIT_FEE_BILLING_PERIOD_FORM_ID,
-          submit: handleSubmit,
-        },
+        form: dialogFormProps(EDIT_FEE_BILLING_PERIOD_FORM_ID, form),
       })
       .then((response) => {
         if (response.reason === 'close') {

--- a/src/components/invoices/EditInvoiceItemDescriptionDialog.tsx
+++ b/src/components/invoices/EditInvoiceItemDescriptionDialog.tsx
@@ -2,8 +2,8 @@ import { revalidateLogic } from '@tanstack/react-form'
 import { useRef } from 'react'
 import { z } from 'zod'
 
+import { dialogFormProps } from '~/components/dialogs/dialogFormProps'
 import { useFormDialog } from '~/components/dialogs/FormDialog'
-import { DialogResult } from '~/components/dialogs/types'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm } from '~/hooks/forms/useAppform'
 
@@ -39,19 +39,6 @@ export const useEditInvoiceItemDescriptionDialog = () => {
       }
     },
   })
-
-  const handleSubmit = async (): Promise<DialogResult> => {
-    await form.handleSubmit()
-
-    // On validation error onSubmit never runs and isSubmitSuccessful stays false:
-    // throw to keep the dialog open (closeOnError: false swallows the error, inline
-    // field errors stay visible). Returning a result would let FormDialog close it.
-    if (!form.state.isSubmitSuccessful) {
-      throw new Error('Submit failed')
-    }
-
-    return { reason: 'success' }
-  }
 
   const openEditInvoiceItemDescriptionDialog = ({
     description,
@@ -96,10 +83,7 @@ export const useEditInvoiceItemDescriptionDialog = () => {
             <form.SubmitButton>{translate('text_6453819268763979024ad041')}</form.SubmitButton>
           </form.AppForm>
         ),
-        form: {
-          id: EDIT_INVOICE_ITEM_DESCRIPTION_FORM_ID,
-          submit: handleSubmit,
-        },
+        form: dialogFormProps(EDIT_INVOICE_ITEM_DESCRIPTION_FORM_ID, form),
       })
       .then((response) => {
         if (response.reason === 'close') {

--- a/src/components/invoices/EditInvoiceItemTaxDialog.tsx
+++ b/src/components/invoices/EditInvoiceItemTaxDialog.tsx
@@ -6,8 +6,8 @@ import { z } from 'zod'
 import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
+import { dialogFormProps } from '~/components/dialogs/dialogFormProps'
 import { useFormDialog } from '~/components/dialogs/FormDialog'
-import { DialogResult } from '~/components/dialogs/types'
 import { ComboBox, ComboboxItem } from '~/components/form'
 import { SEARCH_TAX_INPUT_FOR_INVOICE_ADD_ON_CLASSNAME } from '~/core/constants/form'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -206,19 +206,6 @@ export const useEditInvoiceItemTaxDialog = () => {
     },
   })
 
-  const handleSubmit = async (): Promise<DialogResult> => {
-    await form.handleSubmit()
-
-    // On validation error onSubmit never runs and isSubmitSuccessful stays false:
-    // throw to keep the dialog open (closeOnError: false swallows the error, inline
-    // field errors stay visible). Returning a result would let FormDialog close it.
-    if (!form.state.isSubmitSuccessful) {
-      throw new Error('Submit failed')
-    }
-
-    return { reason: 'success' }
-  }
-
   const openEditInvoiceItemTaxDialog = ({
     taxes,
     callback,
@@ -240,10 +227,7 @@ export const useEditInvoiceItemTaxDialog = () => {
             </form.SubmitButton>
           </form.AppForm>
         ),
-        form: {
-          id: EDIT_INVOICE_ITEM_TAX_FORM_ID,
-          submit: handleSubmit,
-        },
+        form: dialogFormProps(EDIT_INVOICE_ITEM_TAX_FORM_ID, form),
       })
       .then((response) => {
         if (response.reason === 'close') {

--- a/src/components/invoices/__tests__/EditFeeBillingPeriod.test.tsx
+++ b/src/components/invoices/__tests__/EditFeeBillingPeriod.test.tsx
@@ -151,21 +151,43 @@ describe('useEditFeeBillingPeriodDialog', () => {
 
         expect(callback).toHaveBeenCalledWith(FROM_DATETIME, TO_DATETIME)
       })
+
+      it('THEN should report the submit as successful so the dialog can close', async () => {
+        let didSubmitSucceed: boolean | undefined
+
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          didSubmitSucceed = config.form.didSubmitSucceed?.()
+
+          return { reason: 'success' }
+        })
+
+        const { result } = renderHook(() => useEditFeeBillingPeriodDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditFeeBillingPeriodDialog({
+            fromDatetime: FROM_DATETIME,
+            toDatetime: TO_DATETIME,
+            callback: jest.fn(),
+          })
+        })
+
+        expect(didSubmitSucceed).toBe(true)
+      })
     })
 
     describe('WHEN the to datetime is before the from datetime', () => {
-      it('THEN should not invoke the callback and should throw to keep the dialog open', async () => {
+      it('THEN should not invoke the callback and should report the submit as unsuccessful', async () => {
         const callback = jest.fn()
-        let submitThrew = false
+        let didSubmitSucceed: boolean | undefined
 
-        // Mirror FormDialog's handleContinue: it wraps form.submit() in try/catch,
-        // and with closeOnError: false a throw keeps the dialog open.
+        // Mirror FormDialog's handleContinue: it awaits form.submit(), then asks
+        // didSubmitSucceed whether the dialog may close.
         mockFormDialogOpen.mockImplementation(async (config) => {
-          try {
-            await config.form.submit()
-          } catch {
-            submitThrew = true
-          }
+          await config.form.submit()
+          didSubmitSucceed = config.form.didSubmitSucceed?.()
 
           return { reason: 'close' }
         })
@@ -183,7 +205,7 @@ describe('useEditFeeBillingPeriodDialog', () => {
         })
 
         expect(callback).not.toHaveBeenCalled()
-        expect(submitThrew).toBe(true)
+        expect(didSubmitSucceed).toBe(false)
       })
     })
   })

--- a/src/components/invoices/__tests__/EditInvoiceItemDescriptionDialog.test.tsx
+++ b/src/components/invoices/__tests__/EditInvoiceItemDescriptionDialog.test.tsx
@@ -158,18 +158,15 @@ describe('useEditInvoiceItemDescriptionDialog', () => {
     })
 
     describe('WHEN the description exceeds the max length', () => {
-      it('THEN should not invoke the callback and should throw to keep the dialog open', async () => {
+      it('THEN should not invoke the callback and should report the submit as unsuccessful', async () => {
         const callback = jest.fn()
-        let submitThrew = false
+        let didSubmitSucceed: boolean | undefined
 
-        // Mirror FormDialog's handleContinue: it wraps form.submit() in try/catch,
-        // and with closeOnError: false a throw keeps the dialog open.
+        // Mirror FormDialog's handleContinue: it awaits form.submit(), then asks
+        // didSubmitSucceed whether the dialog may close.
         mockFormDialogOpen.mockImplementation(async (config) => {
-          try {
-            await config.form.submit()
-          } catch {
-            submitThrew = true
-          }
+          await config.form.submit()
+          didSubmitSucceed = config.form.didSubmitSucceed?.()
 
           return { reason: 'close' }
         })
@@ -186,7 +183,7 @@ describe('useEditInvoiceItemDescriptionDialog', () => {
         })
 
         expect(callback).not.toHaveBeenCalled()
-        expect(submitThrew).toBe(true)
+        expect(didSubmitSucceed).toBe(false)
       })
     })
   })

--- a/src/components/invoices/__tests__/EditInvoiceItemTaxDialog.test.tsx
+++ b/src/components/invoices/__tests__/EditInvoiceItemTaxDialog.test.tsx
@@ -165,18 +165,15 @@ describe('useEditInvoiceItemTaxDialog', () => {
     })
 
     describe('WHEN a tax row has no id', () => {
-      it('THEN should not invoke the callback and should throw to keep the dialog open', async () => {
+      it('THEN should not invoke the callback and should report the submit as unsuccessful', async () => {
         const callback = jest.fn()
-        let submitThrew = false
+        let didSubmitSucceed: boolean | undefined
 
-        // Mirror FormDialog's handleContinue: it wraps form.submit() in try/catch,
-        // and with closeOnError: false a throw keeps the dialog open.
+        // Mirror FormDialog's handleContinue: it awaits form.submit(), then asks
+        // didSubmitSucceed whether the dialog may close.
         mockFormDialogOpen.mockImplementation(async (config) => {
-          try {
-            await config.form.submit()
-          } catch {
-            submitThrew = true
-          }
+          await config.form.submit()
+          didSubmitSucceed = config.form.didSubmitSucceed?.()
 
           return { reason: 'close' }
         })
@@ -190,7 +187,7 @@ describe('useEditInvoiceItemTaxDialog', () => {
         })
 
         expect(callback).not.toHaveBeenCalled()
-        expect(submitThrew).toBe(true)
+        expect(didSubmitSucceed).toBe(false)
       })
     })
 
@@ -224,11 +221,7 @@ describe('useEditInvoiceItemTaxDialog', () => {
         expect(screen.queryByText('text_1782385268545ex9rk4gx0rf')).not.toBeInTheDocument()
 
         await act(async () => {
-          try {
-            await captured.form.submit()
-          } catch {
-            // handleSubmit throws on invalid input to keep the dialog open.
-          }
+          await captured.form.submit()
         })
 
         expect(screen.getByText('text_1782385268545ex9rk4gx0rf')).toBeInTheDocument()


### PR DESCRIPTION
## Context

TanStack forms resolve `handleSubmit()` even when validation fails — `onSubmit` simply never runs. `FormDialog` treats that resolution as a success, so submitting an invalid form closed the dialog and threw away the inline field errors it had just rendered.

Four dialogs worked around it individually, each wrapping the submit in a helper that inspects `form.state.isSubmitSuccessful` and throws a synthetic `Error('Submit failed')`, paired with `closeOnError: false` to swallow it. That boilerplate had to be repeated in every migrated form, and any form that forgot it silently regained the bug.

## Description

- `FormProps` gains an optional `didSubmitSucceed?: () => boolean`. `useDialogActions.handleContinue` evaluates it once `submit` settles and, when it returns false, returns early: the dialog neither resolves nor hides, so it stays open on its validation errors. A failed validation is no longer modelled as an error, so it never reaches `modal.reject` / `onError`.
- Wired through both form dialogs (`FormDialog`, `FormDialogOpeningDialog`).
- New `dialogFormProps(id, form)` builds the whole `form` prop from a TanStack form, so a consumer writes `form: dialogFormProps(MY_FORM_ID, form)` and gets the guard for free. `SubmittableForm` describes the minimal form surface it needs.
- Migrated the four dialogs that carried the workaround (`EditFeeBillingPeriod`, `EditInvoiceItemDescriptionDialog`, `EditInvoiceItemTaxDialog`, `ExportDialog`), dropping ~10 lines of throw-based plumbing each. `closeOnError: false` is intentionally kept on them: it now covers only its original concern, a submit that genuinely throws (e.g. a failing export), which should still keep the dialog open.
- Tests: new `dialogFormProps` suite; `useDialogActions` covers the guard in both directions plus its ordering (evaluated after `submit`, skipped when `submit` throws); `FormDialog` / `FormDialogOpeningDialog` assert the dialog stays mounted on an invalid submit and closes on a valid one; the migrated consumers now assert `didSubmitSucceed` instead of the synthetic throw; new `ExportDialog` suite covers its submit wiring.

Drawers are untouched — `FormDrawer` has its own `closeOnSubmitSuccess` opt-out and can adopt the same guard separately.

<!-- Linear link -->
Fixes LAGO-1606

---
_Generated by [Claude Code](https://claude.ai/code/session_013XKPVeXqDbTS1nenPoxKtP)_