### PR TITLE
fix(plans): minimum commitment copy follows subscription interval

### DIFF
--- a/src/components/plans/drawers/minimumCommitment/MinimumCommitmentDrawer.tsx
+++ b/src/components/plans/drawers/minimumCommitment/MinimumCommitmentDrawer.tsx
@@ -8,6 +8,7 @@ import { useFormDrawer } from '~/components/drawers/useDrawer'
 import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { PlanBillingPeriodInfoSection } from '~/components/plans/drawers/common/PlanBillingPeriodInfoSection'
+import { mapChargeIntervalCopy } from '~/components/plans/utils'
 import { TaxesSelectorSection } from '~/components/taxes/TaxesSelectorSection'
 import { PlanFormProvider, usePlanFormContext } from '~/contexts/PlanFormContext'
 import { SEARCH_TAX_INPUT_FOR_MIN_COMMITMENT_CLASSNAME } from '~/core/constants/form'
@@ -98,7 +99,9 @@ export const MinimumCommitmentDrawer = forwardRef<
           <CenteredPage.SectionWrapper>
             <CenteredPage.PageTitle
               title={translate('text_65d601bffb11e0f9d1d9f569')}
-              description={translate('text_177334593394555w48sxw5na')}
+              description={translate('text_6661fc17337de3591e29e451', {
+                interval: translate(mapChargeIntervalCopy(interval, false)).toLocaleLowerCase(),
+              })}
             />
 
             <CenteredPage.SubsectionWrapper>

--- a/translations/base.json
+++ b/translations/base.json
@@ -3867,7 +3867,6 @@
   "text_17744725308411jbq4fvqqbm": "No applied coupons",
   "text_1774472532373ewcnm51b2ms": "This coupon is not yet applied to any customers",
   "text_1775139501035rk0gsr7iflr": "You must have at least one admin in your organization.",
-  "text_177334593394555w48sxw5na": "Agreed monthly minimum usage or payment that the customer is required to fulfill.",
   "text_1773346168045bj2x1626228": "Commitment settings",
   "text_1773346168045bj2x1626229": "Set specific tax rates to apply to this fee",
   "text_1773428494589gq89ubgz99i": "Select a feature as an entitlement",


### PR DESCRIPTION
## Context

When creating/editing a plan with minimum commitment enabled, the drawer's first description line read "Agreed **monthly** minimum usage or payment…" regardless of the plan interval — "monthly" was hardcoded, so it stayed "monthly" even for yearly, quarterly, etc. subscriptions.

## Description

The minimum-commitment section was refactored into `MinimumCommitmentDrawer.tsx` and accidentally wired to the static translation key (`text_177334593394555w48sxw5na`) instead of the interval-aware key (`text_6661fc17337de3591e29e451`) that every other min-commitment site already uses. This swaps it back and interpolates the interval via `mapChargeIntervalCopy(interval, false)`, matching `CommitmentsSection.tsx` and the details accordion; the now-orphaned static key is removed from `base.json`.

<!-- Linear link -->
Fixes LAGO-1751