### PR TITLE
fix(router): recover from stale chunk white page

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,25 +1,42 @@
 import { ApolloError } from '@apollo/client'
 import * as Sentry from '@sentry/react'
-import { ReactNode } from 'react'
+import { ReactElement, ReactNode } from 'react'
 
-import { addToast } from '~/core/apolloClient'
+import { ErrorFallback } from '~/components/ErrorFallback'
+import { addToast } from '~/core/apolloClient/reactiveVars/toastVar'
 
 interface ErrorBoundaryProps {
   children: ReactNode
+  /** Value of the `errorBoundary` Sentry tag, to tell scopes apart. */
+  name?: string
+  /** Rendered in place of the crashed subtree. Defaults to the full-screen placeholder. */
+  fallback?: ReactElement
+  /** Disable the danger toast where the fallback already communicates the failure. */
+  showToast?: boolean
 }
 
-export const ErrorBoundary = ({ children }: ErrorBoundaryProps) => {
+export const ErrorBoundary = ({
+  children,
+  name = 'App',
+  fallback,
+  showToast = true,
+}: ErrorBoundaryProps) => {
   return (
     <Sentry.ErrorBoundary
       beforeCapture={(scope) => {
         scope.setTag('component', 'ErrorBoundary')
       }}
       showDialog={false}
+      fallback={fallback ?? <ErrorFallback />}
+      // Sentry derives `handled` from `!!fallback`. Setting it explicitly keeps
+      // caught errors reported as unhandled, as they were before we added a
+      // fallback, so crash-rate numbers stay comparable.
+      handled={false}
       onError={(error, componentStack, eventId) => {
         // Add detailed error info to Sentry context
         Sentry.withScope((scope) => {
           scope.setLevel('error')
-          scope.setTag('errorBoundary', 'App')
+          scope.setTag('errorBoundary', name)
           scope.setTag('errorCategory', 'global')
 
           // Type guard for Error objects
@@ -47,7 +64,7 @@ export const ErrorBoundary = ({ children }: ErrorBoundaryProps) => {
 
         // Only show toast notification if not an Apollo/GraphQL error
         // Apollo errors are already handled in apollo init.ts
-        if (!(error instanceof ApolloError)) {
+        if (showToast && !(error instanceof ApolloError)) {
           addToast({
             severity: 'danger',
             translateKey: 'text_622f7a3dc32ce100c46a5154',

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,0 +1,30 @@
+import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import ErrorImage from '~/public/images/maneki/error.svg'
+
+export const ERROR_FALLBACK_TEST_ID = 'error-fallback'
+
+/**
+ * Full-screen placeholder rendered by `ErrorBoundary` when a subtree crashes,
+ * including a route whose chunk could not be downloaded. It always offers a way
+ * out (refresh) so a stale build can never leave the user on a blank screen.
+ */
+export const ErrorFallback = () => {
+  const { translate } = useInternationalization()
+
+  return (
+    <div
+      className="flex size-full min-h-screen items-center justify-center"
+      data-test={ERROR_FALLBACK_TEST_ID}
+    >
+      <GenericPlaceholder
+        title={translate('text_6250304370f0f700a8fdc270')}
+        subtitle={translate('text_6250304370f0f700a8fdc274')}
+        buttonTitle={translate('text_6250304370f0f700a8fdc278')}
+        buttonVariant="primary"
+        buttonAction={() => window.location.reload()}
+        image={<ErrorImage width="136" height="104" />}
+      />
+    </div>
+  )
+}

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -4,6 +4,8 @@ import { RouteObject, useRoutes } from 'react-router-dom'
 import { Spinner } from '~/components/designSystem/Spinner'
 import { DEVTOOL_ROUTE } from '~/components/developers/devtoolsRoutes'
 import { drawerStack } from '~/components/drawers/drawerStack'
+import { ErrorBoundary } from '~/components/ErrorBoundary'
+import { ErrorFallback } from '~/components/ErrorFallback'
 import { CustomRouteObject, routes, useLocation, useNavigate } from '~/core/router'
 import { NEVER_SLUG_PREFIXES } from '~/core/router/slugPrefixes'
 import { useIsAuthenticated } from '~/hooks/auth/useIsAuthenticated'
@@ -49,10 +51,15 @@ const routesFormatter: (routesToFormat: CustomRouteObject[], loggedIn: boolean) 
   loggedIn,
 ) => {
   return routesToFormat.reduce<RouteObject[]>((acc, route) => {
+    // A route chunk that cannot be downloaded rejects instead of hanging, so the
+    // boundary turns a blank shell into a recoverable placeholder. The toast is
+    // off: the placeholder already says what happened.
     const routeConfig = {
       element: (
         <PageWrapper routeConfig={route}>
-          <Suspense fallback={<Spinner />}>{route.element}</Suspense>
+          <ErrorBoundary name="Route" fallback={<ErrorFallback />} showToast={false}>
+            <Suspense fallback={<Spinner />}>{route.element}</Suspense>
+          </ErrorBoundary>
         </PageWrapper>
       ),
       ...(route?.children ? { children: routesFormatter(route.children, loggedIn) } : {}),

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,122 @@
+import { configure, render, screen } from '@testing-library/react'
+import { createElement, ReactNode } from 'react'
+
+import { ErrorBoundary } from '~/components/ErrorBoundary'
+import { ERROR_FALLBACK_TEST_ID } from '~/components/ErrorFallback'
+
+configure({ testIdAttribute: 'data-test' })
+
+const mockAddToast = jest.fn()
+const mockCaptureException = jest.fn()
+const mockErrorBoundaryProps: Array<Record<string, unknown>> = []
+
+jest.mock('~/core/apolloClient/reactiveVars/toastVar', () => ({
+  addToast: (...args: unknown[]) => mockAddToast(...args),
+}))
+
+jest.mock('@sentry/react', () => {
+  const actual = jest.requireActual('@sentry/react')
+  const { createElement: create } = jest.requireActual('react')
+
+  return {
+    ...actual,
+    captureException: (...args: unknown[]) => mockCaptureException(...args),
+    withScope: (callback: (scope: unknown) => void) =>
+      callback({
+        setLevel: jest.fn(),
+        setTag: jest.fn(),
+        setExtra: jest.fn(),
+      }),
+    // Keep the real boundary behaviour, but record the props we pass to it so
+    // `handled` and `fallback` can be asserted without rendering internals.
+    ErrorBoundary: (props: Record<string, unknown>) => {
+      mockErrorBoundaryProps.push(props)
+
+      return create(actual.ErrorBoundary, props)
+    },
+  }
+})
+
+const Boom = (): ReactNode => {
+  throw new Error('render exploded')
+}
+
+const CustomFallback = () => <div data-test="custom-fallback">custom</div>
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockErrorBoundaryProps.length = 0
+  })
+
+  describe('GIVEN a child that throws during render', () => {
+    describe('WHEN the boundary catches it', () => {
+      it('THEN should render the error fallback instead of an empty tree', () => {
+        render(
+          <ErrorBoundary>
+            <Boom />
+          </ErrorBoundary>,
+        )
+
+        expect(screen.getByTestId(ERROR_FALLBACK_TEST_ID)).toBeInTheDocument()
+      })
+
+      it('THEN should report the error to Sentry and show a toast', () => {
+        render(
+          <ErrorBoundary>
+            <Boom />
+          </ErrorBoundary>,
+        )
+
+        expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error))
+        expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'danger' }))
+      })
+    })
+  })
+
+  describe('GIVEN showToast is disabled', () => {
+    describe('WHEN a child throws', () => {
+      it('THEN should still capture to Sentry but not show a toast', () => {
+        render(
+          <ErrorBoundary showToast={false}>
+            <Boom />
+          </ErrorBoundary>,
+        )
+
+        expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error))
+        expect(mockAddToast).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN a custom fallback', () => {
+    describe('WHEN a child throws', () => {
+      it('THEN should render that fallback', () => {
+        render(
+          <ErrorBoundary fallback={createElement(CustomFallback)}>
+            <Boom />
+          </ErrorBoundary>,
+        )
+
+        expect(screen.getByTestId('custom-fallback')).toBeInTheDocument()
+        expect(screen.queryByTestId(ERROR_FALLBACK_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN the Sentry boundary props', () => {
+    describe('WHEN the boundary renders', () => {
+      it('THEN should keep marking caught errors as unhandled', () => {
+        render(
+          <ErrorBoundary>
+            <div>content</div>
+          </ErrorBoundary>,
+        )
+
+        expect(mockErrorBoundaryProps[0]).toEqual(
+          expect.objectContaining({ handled: false, showDialog: false }),
+        )
+      })
+    })
+  })
+})

--- a/src/components/__tests__/RouteWrapper.test.tsx
+++ b/src/components/__tests__/RouteWrapper.test.tsx
@@ -1,9 +1,19 @@
-import { render, waitFor } from '@testing-library/react'
+import { configure, render, screen, waitFor } from '@testing-library/react'
+import { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 
+import { ERROR_FALLBACK_TEST_ID } from '~/components/ErrorFallback'
 import { RouteWrapper } from '~/components/RouteWrapper'
+import type { CustomRouteObject } from '~/core/router'
+
+configure({ testIdAttribute: 'data-test' })
 
 const mockNavigate = jest.fn()
+const mockAddToast = jest.fn()
+
+jest.mock('~/core/apolloClient/reactiveVars/toastVar', () => ({
+  addToast: (...args: unknown[]) => mockAddToast(...args),
+}))
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -35,8 +45,12 @@ jest.mock('~/hooks/core/useLocationHistory', () => ({
 
 const TEST_SLUG = 'test-slug'
 
+let mockRoutes: CustomRouteObject[] = []
+
 jest.mock('~/core/router', () => ({
-  routes: [],
+  get routes() {
+    return mockRoutes
+  },
   useNavigate: () => mockNavigate,
   useLocation: () => ({
     // First segment of `pathname` is treated as the active org slug by
@@ -50,10 +64,21 @@ jest.mock('~/core/router', () => ({
   }),
 }))
 
+const PAGE_TEST_ID = 'route-page'
+
+const CrashingPage = (): ReactNode => {
+  throw new Error('route render exploded')
+}
+
+// A page that received a GraphQL error from Apollo: `errorPolicy: 'all'` returns
+// it on the hook result instead of throwing, so the page renders its own state.
+const PageWithQueryError = () => <div data-test={PAGE_TEST_ID}>query failed, own placeholder</div>
+
 describe('RouteWrapper', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockMainRouterUrl = ''
+    mockRoutes = []
   })
 
   describe('mainRouterUrl navigation effect', () => {
@@ -151,6 +176,53 @@ describe('RouteWrapper', () => {
           )
 
           expect(container).toBeDefined()
+        })
+      })
+    })
+  })
+
+  describe('route error boundary', () => {
+    describe('GIVEN a route that throws while rendering', () => {
+      describe('WHEN RouteWrapper renders it', () => {
+        it('THEN it should show the error placeholder instead of a blank screen', () => {
+          mockRoutes = [{ path: '*', element: <CrashingPage /> }]
+
+          render(
+            <MemoryRouter>
+              <RouteWrapper />
+            </MemoryRouter>,
+          )
+
+          expect(screen.getByTestId(ERROR_FALLBACK_TEST_ID)).toBeInTheDocument()
+        })
+
+        it('THEN it should not add a toast on top of the placeholder', () => {
+          mockRoutes = [{ path: '*', element: <CrashingPage /> }]
+
+          render(
+            <MemoryRouter>
+              <RouteWrapper />
+            </MemoryRouter>,
+          )
+
+          expect(mockAddToast).not.toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('GIVEN a route whose query returned a GraphQL error', () => {
+      describe('WHEN RouteWrapper renders it', () => {
+        it('THEN it should render the page, not the route error placeholder', () => {
+          mockRoutes = [{ path: '*', element: <PageWithQueryError /> }]
+
+          render(
+            <MemoryRouter>
+              <RouteWrapper />
+            </MemoryRouter>,
+          )
+
+          expect(screen.getByTestId(PAGE_TEST_ID)).toBeInTheDocument()
+          expect(screen.queryByTestId(ERROR_FALLBACK_TEST_ID)).not.toBeInTheDocument()
         })
       })
     })

--- a/src/components/aiAgent/AiAgent.tsx
+++ b/src/components/aiAgent/AiAgent.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react'
 import { tw } from 'lago-design-system'
 import { useState } from 'react'
 import { Panel } from 'react-resizable-panels'
@@ -8,6 +9,7 @@ import { NavigationBar } from '~/components/aiAgent/NavigationBar'
 import { PanelAiAgent } from '~/components/aiAgent/PanelAiAgent'
 import { PanelWrapper } from '~/components/aiAgent/PanelWrapper'
 import { getHiddenAiAgentPaths } from '~/components/aiAgent/utils'
+import { GenericPlaceholder } from '~/components/designSystem/GenericPlaceholder'
 import { useLocation } from '~/core/router'
 import {
   AGENT_TYPE_SHOW_HISTORY,
@@ -19,8 +21,10 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { usePermissions } from '~/hooks/usePermissions'
+import ErrorImage from '~/public/images/maneki/error.svg'
 
 export const AI_AGENT_NAV_TEST_ID = 'ai-agent-nav'
+export const AI_AGENT_ERROR_TEST_ID = 'ai-agent-error'
 
 export const AiAgent = () => {
   const { agentType, panelRef, currentPanelOpened, panelOpen, state, resetConversation } =
@@ -86,6 +90,22 @@ export const AiAgent = () => {
     setIsFullscreen((f) => !f)
   }
 
+  // Scoped to the panel body so an assistant crash cannot blank the app. The
+  // `<Panel>` itself keeps rendering: react-resizable-panels throws when the
+  // panel count stops matching the stored layout.
+  const renderPanelError = ({ resetError }: { resetError: () => void }) => (
+    <div className="flex size-full items-center justify-center" data-test={AI_AGENT_ERROR_TEST_ID}>
+      <GenericPlaceholder
+        title={translate('text_6250304370f0f700a8fdc270')}
+        subtitle={translate('text_6250304370f0f700a8fdc274')}
+        buttonTitle={translate('text_63e27c56dfe64b846474efa3')}
+        buttonVariant="primary"
+        buttonAction={() => resetError()}
+        image={<ErrorImage width="136" height="104" />}
+      />
+    </div>
+  )
+
   return (
     <>
       <div className="relative" data-test={AI_AGENT_NAV_TEST_ID}>
@@ -110,35 +130,47 @@ export const AiAgent = () => {
         )}
       >
         {currentPanelOpened === AIPanelEnum.ai && (
-          <PanelWrapper
-            title={
-              showHistory
-                ? translate('text_17574172258513wv8yozezoz')
-                : (state.messages[0]?.message ?? translate('text_1783590769660p6nhcqws986'))
-            }
-            isBeta={shouldDisplayWelcomeMessage && !showHistory}
-            showBackButton={!shouldDisplayWelcomeMessage || showHistory}
-            onBackButton={onBackButton}
-            showHistoryButton={
-              agentHasHistory && shouldDisplayWelcomeMessage && !showHistory && hasAccessToAiAgent
-            }
-            onShowHistory={() => setShowHistory(true)}
-            onFullscreen={() => onFullscreen()}
-            isFullscreen={isFullscreen}
+          <Sentry.ErrorBoundary
+            beforeCapture={(scope) => {
+              scope.setTag('errorBoundary', 'AiAgent')
+            }}
+            handled={false}
+            showDialog={false}
+            fallback={renderPanelError}
           >
-            <div className="size-full max-w-5xl">
-              {showHistory && (
-                <ChatHistory
-                  isFullscreen={isFullscreen}
-                  hideHistory={() => setShowHistory(false)}
-                />
-              )}
+            <PanelWrapper
+              title={
+                showHistory
+                  ? translate('text_17574172258513wv8yozezoz')
+                  : (state.messages[0]?.message ?? translate('text_1783590769660p6nhcqws986'))
+              }
+              isBeta={shouldDisplayWelcomeMessage && !showHistory}
+              showBackButton={!shouldDisplayWelcomeMessage || showHistory}
+              onBackButton={onBackButton}
+              showHistoryButton={
+                agentHasHistory && shouldDisplayWelcomeMessage && !showHistory && hasAccessToAiAgent
+              }
+              onShowHistory={() => setShowHistory(true)}
+              onFullscreen={() => onFullscreen()}
+              isFullscreen={isFullscreen}
+            >
+              <div className="size-full max-w-5xl">
+                {showHistory && (
+                  <ChatHistory
+                    isFullscreen={isFullscreen}
+                    hideHistory={() => setShowHistory(false)}
+                  />
+                )}
 
-              {!showHistory && (
-                <PanelAiAgent isFullscreen={isFullscreen} hasAccessToAiAgent={hasAccessToAiAgent} />
-              )}
-            </div>
-          </PanelWrapper>
+                {!showHistory && (
+                  <PanelAiAgent
+                    isFullscreen={isFullscreen}
+                    hasAccessToAiAgent={hasAccessToAiAgent}
+                  />
+                )}
+              </div>
+            </PanelWrapper>
+          </Sentry.ErrorBoundary>
         )}
       </Panel>
     </>

--- a/src/components/aiAgent/__tests__/AiAgent.test.tsx
+++ b/src/components/aiAgent/__tests__/AiAgent.test.tsx
@@ -1,7 +1,7 @@
 import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { AI_AGENT_NAV_TEST_ID, AiAgent } from '~/components/aiAgent/AiAgent'
+import { AI_AGENT_ERROR_TEST_ID, AI_AGENT_NAV_TEST_ID, AiAgent } from '~/components/aiAgent/AiAgent'
 import { CHAT_CONVERSATION_TEST_ID } from '~/components/aiAgent/ChatConversation'
 import { CHAT_HISTORY_ITEM_TEST_ID, CHAT_HISTORY_TEST_ID } from '~/components/aiAgent/ChatHistory'
 import { PANEL_AI_AGENT_WELCOME_TEST_ID } from '~/components/aiAgent/PanelAiAgent'
@@ -13,10 +13,31 @@ jest.mock('~/components/aiAgent/llmOutputs', () => ({
   Message: ({ message }: { message: { message: string } }) => <span>{message.message}</span>,
 }))
 
+const PANEL_TEST_ID = 'ai-panel-element'
+
 jest.mock('react-resizable-panels', () => ({
-  Panel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Panel: ({ children }: { children: React.ReactNode }) => (
+    <div data-test="ai-panel-element">{children}</div>
+  ),
   PanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
+
+let mockPanelShouldThrow = false
+
+jest.mock('~/components/aiAgent/PanelWrapper', () => {
+  const actual = jest.requireActual('~/components/aiAgent/PanelWrapper')
+
+  return {
+    ...actual,
+    PanelWrapper: (props: Parameters<typeof actual.PanelWrapper>[0]) => {
+      if (mockPanelShouldThrow) {
+        throw new Error('panel exploded')
+      }
+
+      return actual.PanelWrapper(props)
+    },
+  }
+})
 
 jest.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({
@@ -118,6 +139,7 @@ describe('AiAgent', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     localStorage.clear()
+    mockPanelShouldThrow = false
     window.history.pushState({}, '', '/test-org/analytics')
   })
 
@@ -172,6 +194,21 @@ describe('AiAgent', () => {
 
         expect(screen.getByTestId(PANEL_AI_AGENT_WELCOME_TEST_ID)).toBeInTheDocument()
         expect(getHistoryButton()).toBeUndefined()
+      })
+    })
+  })
+
+  describe('GIVEN the panel body crashes while rendering', () => {
+    describe('WHEN the panel is opened', () => {
+      it('THEN should keep the nav rail and the panel mounted with an in-panel fallback', async () => {
+        mockPanelShouldThrow = true
+
+        await renderAiAgent()
+        await openPanel()
+
+        expect(screen.getByTestId(AI_AGENT_ERROR_TEST_ID)).toBeInTheDocument()
+        expect(screen.getByTestId(AI_AGENT_NAV_TEST_ID)).toBeInTheDocument()
+        expect(screen.getByTestId(PANEL_TEST_ID)).toBeInTheDocument()
       })
     })
   })

--- a/src/core/router/__tests__/utils.test.tsx
+++ b/src/core/router/__tests__/utils.test.tsx
@@ -3,9 +3,21 @@ import { act } from '@testing-library/react'
 import { lazyLoad } from '../utils'
 
 const mockAddToast = jest.fn()
+const mockReloadWithCacheBust = jest.fn()
+const mockCaptureException = jest.fn()
+const mockCaptureMessage = jest.fn()
 
 jest.mock('~/core/apolloClient/reactiveVars/toastVar', () => ({
   addToast: mockAddToast,
+}))
+
+jest.mock('~/core/utils/reloadWithCacheBust', () => ({
+  reloadWithCacheBust: () => mockReloadWithCacheBust(),
+}))
+
+jest.mock('@sentry/react', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
 }))
 
 const DummyComponent = () => <div>loaded</div>
@@ -60,6 +72,9 @@ describe('lazyLoad / retry', () => {
         expect(resolved).toBe(true)
         expect(sessionStorage.getItem('lago_chunk_reload')).toBeNull()
         expect(mockAddToast).not.toHaveBeenCalled()
+        expect(mockReloadWithCacheBust).not.toHaveBeenCalled()
+        expect(mockCaptureMessage).not.toHaveBeenCalled()
+        expect(mockCaptureException).not.toHaveBeenCalled()
       })
     })
   })
@@ -91,13 +106,14 @@ describe('lazyLoad / retry', () => {
 
         expect(resolved).toBe(true)
         expect(sessionStorage.getItem('lago_chunk_reload')).toBeNull()
+        expect(mockReloadWithCacheBust).not.toHaveBeenCalled()
       })
     })
   })
 
   describe('GIVEN all retries fail and no previous reload', () => {
     describe('WHEN retries are exhausted', () => {
-      it('THEN should mark the reload flag in sessionStorage', async () => {
+      it('THEN should mark the reload flag and navigate with a cache-busting URL', async () => {
         const loader = () => Promise.reject(new Error('chunk failed'))
         const LazyComponent = lazyLoad(loader)
 
@@ -110,9 +126,33 @@ describe('lazyLoad / retry', () => {
         })
 
         // sessionStorage timestamp proves the reload branch was taken.
-        // Clock advanced 3s (retries), so markReloaded() wrote FAKE_NOW + 3000.
+        // Clock advanced 2s (retries), so markReloaded() wrote FAKE_NOW + 2000.
         expect(sessionStorage.getItem('lago_chunk_reload')).toBe(String(FAKE_NOW + 2000))
+        expect(mockReloadWithCacheBust).toHaveBeenCalledTimes(1)
         expect(mockAddToast).not.toHaveBeenCalled()
+      })
+
+      it('THEN should report the reload to Sentry', async () => {
+        const loader = () => Promise.reject(new Error('chunk failed'))
+        const LazyComponent = lazyLoad(loader)
+
+        act(() => {
+          triggerLazy(LazyComponent)
+        })
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(3000)
+        })
+
+        expect(mockCaptureMessage).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            level: 'warning',
+            tags: { chunkLoad: true, phase: 'reload' },
+            fingerprint: ['chunk-load-failure'],
+          }),
+        )
+        expect(mockCaptureException).not.toHaveBeenCalled()
       })
     })
   })
@@ -126,7 +166,7 @@ describe('lazyLoad / retry', () => {
         const LazyComponent = lazyLoad(loader)
 
         act(() => {
-          triggerLazy(LazyComponent)
+          triggerLazy(LazyComponent).catch(() => {})
         })
 
         await act(async () => {
@@ -137,6 +177,53 @@ describe('lazyLoad / retry', () => {
           expect.objectContaining({
             severity: 'info',
             autoDismiss: false,
+          }),
+        )
+        expect(mockReloadWithCacheBust).not.toHaveBeenCalled()
+      })
+
+      it('THEN should reject with the original error so the boundary can render', async () => {
+        sessionStorage.setItem('lago_chunk_reload', Date.now().toString())
+
+        const chunkError = new Error('chunk failed')
+        const loader = () => Promise.reject(chunkError)
+        const LazyComponent = lazyLoad(loader)
+        let rejection: unknown
+
+        act(() => {
+          triggerLazy(LazyComponent).catch((error) => {
+            rejection = error
+          })
+        })
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(3000)
+        })
+
+        expect(rejection).toBe(chunkError)
+      })
+
+      it('THEN should report the dead-end to Sentry', async () => {
+        sessionStorage.setItem('lago_chunk_reload', Date.now().toString())
+
+        const chunkError = new Error('chunk failed')
+        const loader = () => Promise.reject(chunkError)
+        const LazyComponent = lazyLoad(loader)
+
+        act(() => {
+          triggerLazy(LazyComponent).catch(() => {})
+        })
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(3000)
+        })
+
+        expect(mockCaptureException).toHaveBeenCalledWith(
+          chunkError,
+          expect.objectContaining({
+            tags: { chunkLoad: true, phase: 'dead-end' },
+            fingerprint: ['chunk-load-failure'],
+            extra: expect.objectContaining({ appVersion: '1.0.0' }),
           }),
         )
       })
@@ -162,6 +249,7 @@ describe('lazyLoad / retry', () => {
 
         // Should take the reload branch — markReloaded() wrote a fresh timestamp
         expect(sessionStorage.getItem('lago_chunk_reload')).toBe(String(FAKE_NOW + 2000))
+        expect(mockReloadWithCacheBust).toHaveBeenCalledTimes(1)
         expect(mockAddToast).not.toHaveBeenCalled()
       })
     })
@@ -178,7 +266,7 @@ describe('lazyLoad / retry', () => {
         const LazyComponent = lazyLoad(loader)
 
         act(() => {
-          triggerLazy(LazyComponent)
+          triggerLazy(LazyComponent).catch(() => {})
         })
 
         await act(async () => {
@@ -191,6 +279,7 @@ describe('lazyLoad / retry', () => {
             autoDismiss: false,
           }),
         )
+        expect(mockReloadWithCacheBust).not.toHaveBeenCalled()
       })
     })
   })
@@ -217,6 +306,7 @@ describe('lazyLoad / retry', () => {
 
         // Toast should NOT be called — we took the reload path, not the toast path
         expect(mockAddToast).not.toHaveBeenCalled()
+        expect(mockReloadWithCacheBust).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/src/core/router/utils.tsx
+++ b/src/core/router/utils.tsx
@@ -1,7 +1,12 @@
+import { captureException, captureMessage } from '@sentry/react'
 import { ComponentType, lazy, LazyExoticComponent } from 'react'
+
+import { envGlobalVar } from '~/core/apolloClient/reactiveVars/envGlobalVar'
+import { reloadWithCacheBust } from '~/core/utils/reloadWithCacheBust'
 
 const CHUNK_RELOAD_KEY = 'lago_chunk_reload'
 const RELOAD_COOLDOWN_MS = 10_000
+const CHUNK_LOAD_FINGERPRINT = 'chunk-load-failure'
 
 function hasReloadedRecently(): boolean {
   try {
@@ -28,43 +33,71 @@ function markReloaded(): void {
   }
 }
 
+function showPersistentToast(): void {
+  import('~/core/apolloClient/reactiveVars/toastVar')
+    .then(({ addToast }) => {
+      addToast({
+        severity: 'info',
+        message:
+          'Something went wrong while loading the page. Please try refreshing or clearing your cache.',
+        autoDismiss: false,
+      })
+    })
+    .catch((error) => {
+      // Toast module also failed to load, nothing more we can do.
+      // The rejected import is already surfaced by the route error boundary.
+      // eslint-disable-next-line no-console
+      console.error('Failed to load fallback toast module', error)
+    })
+}
+
 const retry = (
   fn: () => Promise<{ default: ComponentType<Record<string, never>> }>,
   retriesLeft = 2,
   interval = 1000,
 ): Promise<{ default: ComponentType<Record<string, never>> }> => {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     fn()
       .then(resolve)
-      .catch(() => {
+      .catch((error) => {
         if (retriesLeft > 0) {
           setTimeout(() => {
-            retry(fn, retriesLeft - 1, interval).then(resolve)
+            retry(fn, retriesLeft - 1, interval)
+              .then(resolve)
+              .catch(reject)
           }, interval)
-        } else if (!hasReloadedRecently()) {
+
+          return
+        }
+
+        if (!hasReloadedRecently()) {
           // All retries exhausted — reload silently to get fresh HTML
           markReloaded()
-          window.location.reload()
-        } else {
-          // Already reloaded recently and still failing — show persistent toast.
-          // Promise stays pending so Suspense keeps showing <Spinner />
-          // while the rest of the app (sidebar, header) remains usable.
-          import('~/core/apolloClient/reactiveVars/toastVar')
-            .then(({ addToast }) => {
-              addToast({
-                severity: 'info',
-                message:
-                  'Something went wrong while loading the page. Please try refreshing or clearing your cache.',
-                autoDismiss: false,
-              })
-            })
-            .catch((error) => {
-              // Toast module also failed to load — nothing more we can do.
-              // User still sees <Spinner /> from Suspense.
-              // eslint-disable-next-line no-console
-              console.error('Failed to load fallback toast module', error)
-            })
+          captureMessage('Chunk load failed - reloading with cache-bust', {
+            level: 'warning',
+            tags: { chunkLoad: true, phase: 'reload' },
+            fingerprint: [CHUNK_LOAD_FINGERPRINT],
+          })
+          reloadWithCacheBust()
+
+          return
         }
+
+        // Already reloaded recently and still failing. Report it, keep the
+        // persistent toast, and reject so the route error boundary renders a
+        // recoverable placeholder instead of a spinner that never resolves.
+        captureException(error, {
+          tags: { chunkLoad: true, phase: 'dead-end' },
+          extra: {
+            href: window.location.href,
+            appVersion: envGlobalVar().appVersion,
+          },
+          fingerprint: [CHUNK_LOAD_FINGERPRINT],
+        })
+
+        showPersistentToast()
+
+        reject(error)
       })
   })
 }

--- a/src/core/utils/reloadWithCacheBust.ts
+++ b/src/core/utils/reloadWithCacheBust.ts
@@ -1,0 +1,16 @@
+const CACHE_BUST_PARAM = '_r'
+
+/**
+ * Reload the current document with a unique URL.
+ *
+ * A soft `window.location.reload()` does not bypass the HTTP cache, so after a
+ * deploy it can serve the very same stale `index.html` that references chunk
+ * filenames which no longer exist. Navigating to a URL the cache has never seen
+ * forces a fresh document request.
+ */
+export const reloadWithCacheBust = (): void => {
+  const url = new URL(window.location.href)
+
+  url.searchParams.set(CACHE_BUST_PARAM, Date.now().toString())
+  window.location.replace(url.toString())
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -70,6 +70,22 @@ if (!!sentryDsn && appEnv !== AppEnvEnum.development) {
   })
 }
 
+// Vite fires this when a dynamic import fails to preload, typically a chunk
+// removed by a deploy while the tab was open. Report only: calling
+// `event.preventDefault()` would swallow the rejection the router's `retry()`
+// and the error boundaries rely on to recover.
+window.addEventListener('vite:preloadError', (event) => {
+  Sentry.captureMessage('Chunk preload failed', {
+    level: 'warning',
+    tags: { chunkLoad: true, phase: 'preload' },
+    extra: {
+      reason: event.payload?.message,
+      href: window.location.href,
+      appVersion,
+    },
+  })
+})
+
 if (appEnv !== AppEnvEnum.production) {
   window.Lago = {
     getEnableFeatureFlags: getEnableFeatureFlags,


### PR DESCRIPTION
Fixes BIL-392

A tab opened before a deploy requests chunk filenames the new build no longer serves. `retry()` did 2 retries + one `window.location.reload()`, then showed a toast and **left the import promise pending forever**: Suspense kept a spinner on a blank shell, and nothing reached Sentry. Layout chunks are lazy too, so the whole app shell went white.

What changes:

- `src/core/router/utils.tsx`: the dead-end path rejects instead of hanging, so a boundary can render. The single auto-reload becomes a cache-busting navigation (`location.replace` with `_r=<ts>`) - a soft reload does not bypass the HTTP cache, so it would re-serve the same stale `index.html`. Both paths report to Sentry (`chunkLoad: true`, `phase: reload | dead-end`).
- New `ErrorFallback`: full-screen "Something went wrong / Refresh the page" placeholder, reusing existing translation keys.
- `ErrorBoundary`: gets that fallback (a white page is no longer possible - `@sentry/react` renders `null` without one), plus `name` / `fallback` / `showToast` props. `handled={false}` is passed explicitly: Sentry derives it from `!!fallback`, so adding one would silently flip existing events to handled and move our crash-rate numbers.
- `RouteWrapper`: boundary around the per-route `Suspense`. API errors are unaffected - `errorPolicy: 'all'` returns them on the hook result and `useSuspenseQuery` has no consumers, so only a real render throw reaches it (pinned by a test).
- `AiAgent`: panel-scoped boundary inside the `<Panel>` with a `resetError` retry, so an assistant crash cannot blank the app. It stays inside the `Panel` because react-resizable-panels throws when the panel count stops matching the stored layout.
- `main.tsx`: reports `vite:preloadError` (dynamic imports outside the router). Report only - `preventDefault()` would swallow the rejection the recovery relies on.

Apollo timeout chain (action 7) and the infra fix (keep the previous build's `/assets/*` reachable, BIL-393) are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)