### PR TITLE
refactor: remove unused exported type re-exports

### DIFF
--- a/src/components/customers/usage/SubscriptionUsageDetailDrawer.tsx
+++ b/src/components/customers/usage/SubscriptionUsageDetailDrawer.tsx
@@ -27,7 +27,6 @@ export {
   isBreakdownRow,
   makeBreakdownRows,
   sumBreakdownUnits,
-  type PresentationBreakdownRow,
   type SubscriptionUsageDetailDrawerUsage,
 } from '~/components/customers/usage/usageDetailsHelpers'
 

--- a/src/components/designSystem/RichTextEditor/extensions/CreditsBlock.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/CreditsBlock.ts
@@ -4,8 +4,6 @@ import { CreditsBlockSchema } from './CreditsBlock.schema'
 
 import { CreditsBlockView } from '../CreditsBlock/CreditsBlockView'
 
-export type { CreditsBlockAttributes } from './CreditsBlock.schema'
-
 export const CreditsBlock = CreditsBlockSchema.extend({
   addNodeView() {
     return ReactNodeViewRenderer(CreditsBlockView)

--- a/src/components/designSystem/RichTextEditor/extensions/DiscountBlock.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/DiscountBlock.ts
@@ -4,8 +4,6 @@ import { DiscountBlockSchema } from './DiscountBlock.schema'
 
 import { DiscountBlockView } from '../DiscountBlock/DiscountBlockView'
 
-export type { DiscountBlockAttributes } from './DiscountBlock.schema'
-
 export const DiscountBlock = DiscountBlockSchema.extend({
   addNodeView() {
     return ReactNodeViewRenderer(DiscountBlockView)

--- a/src/pages/analytics/Invoices.tsx
+++ b/src/pages/analytics/Invoices.tsx
@@ -97,9 +97,6 @@ gql`
   }
 `
 
-export type TInvoiceCollectionsDataResult =
-  GetInvoiceCollectionsForAnalyticsQuery['invoiceCollections']['collection']
-
 const GRAPH_COLORS = [
   theme.palette.success[400],
   theme.palette.secondary[400],


### PR DESCRIPTION
## Context

Routine dead-code cleanup. Several modules re-export a type from the file that actually declares it (a common barrel-export convenience), but every real consumer already imports the type directly from its declaring module, leaving the re-export path dead.

## Description

Removed the following unused type re-exports. In each case the underlying type itself stays untouched and remains in active use — only the dead re-export line was removed:

- `PresentationBreakdownRow` re-export in `SubscriptionUsageDetailDrawer.tsx` (real type lives in and is consumed from `usageDetailsHelpers.ts`; the sibling re-exports `isBreakdownRow`, `makeBreakdownRows`, `sumBreakdownUnits`, `SubscriptionUsageDetailDrawerUsage` are still used and were left in place)
- `CreditsBlockAttributes` re-export in `RichTextEditor/extensions/CreditsBlock.ts` (real type lives in and is consumed from `CreditsBlock.schema.ts`)
- `DiscountBlockAttributes` re-export in `RichTextEditor/extensions/DiscountBlock.ts` (real type lives in and is consumed from `DiscountBlock.schema.ts`)
- `TInvoiceCollectionsDataResult` in `pages/analytics/Invoices.tsx` — unused even within its own declaring file, which spells out the equivalent type inline instead

No behavior change. `pnpm run code:style` passes with no new errors or warnings.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SdvY5NZS5L1YG3fMLbUtyP)_