### PR TITLE
fix(quotes): restore deleted custom blocks on Cmd+Z

### DIFF
--- a/src/pages/quotes/hooks/__tests__/useCreditsDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useCreditsDrawer.test.tsx
@@ -110,6 +110,32 @@ describe('useCreditsDrawer', () => {
       expect(updated?.coupons).toEqual(withOneWallet.coupons)
     })
 
+    it('THEN re-hydrates a pruned wallet (with overrides) when its block re-appears (undo)', () => {
+      const { result } = renderHook(
+        () => useCreditsDrawer(withOneWallet, { currency: CurrencyEnum.Usd }),
+        { wrapper },
+      )
+
+      let updated: BillingItemsPayload | undefined
+
+      // Delete: no block references wl_1, so it is pruned (and cached).
+      act(() => {
+        updated = result.current.syncCreditsBlocks([])
+      })
+
+      expect(updated?.walletCredits).toEqual([])
+      expect(result.current.entities).not.toHaveProperty('wl_1')
+
+      // Undo: the block re-appears referencing the same localId.
+      act(() => {
+        updated = result.current.syncCreditsBlocks([{ localId: 'wl_1' }])
+      })
+
+      // Wallet is rehydrated and re-persisted identically (overrides round-trip).
+      expect(result.current.entities).toHaveProperty('wl_1')
+      expect(updated?.walletCredits).toEqual(withOneWallet.walletCredits)
+    })
+
     it('THEN does not carry a previous payload once billingItems becomes null', () => {
       const { result, rerender } = renderHook(
         ({ bi }: { bi: BillingItemsPayload | null }) =>

--- a/src/pages/quotes/hooks/__tests__/useCreditsDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useCreditsDrawer.test.tsx
@@ -136,6 +136,36 @@ describe('useCreditsDrawer', () => {
       expect(updated?.walletCredits).toEqual(withOneWallet.walletCredits)
     })
 
+    it('THEN re-persists restored wallets in document order (position follows the doc)', () => {
+      const withTwoWallets: BillingItemsPayload = {
+        walletCredits: toWallets(
+          [persistableWallet('wl_a'), persistableWallet('wl_b')],
+          CurrencyEnum.Usd,
+        ),
+      }
+
+      const { result } = renderHook(
+        () => useCreditsDrawer(withTwoWallets, { currency: CurrencyEnum.Usd }),
+        { wrapper },
+      )
+
+      let updated: BillingItemsPayload | undefined
+
+      // Delete the FIRST wallet; only wl_b remains referenced.
+      act(() => {
+        updated = result.current.syncCreditsBlocks([{ localId: 'wl_b' }])
+      })
+
+      // Undo re-inserts wl_a ahead of wl_b (document order).
+      act(() => {
+        updated = result.current.syncCreditsBlocks([{ localId: 'wl_a' }, { localId: 'wl_b' }])
+      })
+
+      // Positions follow the doc order, not the restore-append order.
+      expect(updated?.walletCredits?.map((w) => w.localId)).toEqual(['wl_a', 'wl_b'])
+      expect(updated?.walletCredits?.map((w) => w.payload.position)).toEqual([1, 2])
+    })
+
     it('THEN does not carry a previous payload once billingItems becomes null', () => {
       const { result, rerender } = renderHook(
         ({ bi }: { bi: BillingItemsPayload | null }) =>

--- a/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
@@ -334,6 +334,75 @@ describe('useDiscountDrawer', () => {
     expect(payload?.coupons).toEqual([])
   })
 
+  it('re-hydrates a pruned coupon (with overrides) when its block re-appears (undo)', () => {
+    const initialBillingItems: BillingItemsPayload = {
+      addOns: [],
+      coupons: [
+        {
+          type: 'coupon',
+          id: 'cpn_edit',
+          localId: 'saved-local',
+          payload: {
+            position: 1,
+            code: 'EDIT',
+            id: 'cpn_edit',
+            name: 'Edit Coupon',
+            type: 'fixed_amount',
+            amountCents: 5000,
+            percentageRate: null,
+            currency: CurrencyEnum.Usd,
+            frequency: 'recurring',
+            frequencyDuration: 3,
+            expirationAt: null,
+            limitedPlans: false,
+            planCodes: [],
+            limitedBillableMetrics: false,
+            billableMetricCodes: [],
+            couponOverrides: null,
+            catalogSnapshot: null,
+            resolvedPayload: null,
+          },
+          overrides: {
+            amountCents: 4200,
+            percentageRate: null,
+            frequency: 'recurring',
+            frequencyDuration: 6,
+          },
+        },
+      ],
+    }
+
+    const { result } = renderHook(() => useDiscountDrawer(initialBillingItems, options))
+
+    expect(result.current.entities).toHaveProperty('saved-local')
+
+    let payload: BillingItemsPayload | undefined
+
+    // Delete: no block references the coupon, so it is pruned (and cached).
+    act(() => {
+      payload = result.current.syncDiscountBlocks([])
+    })
+
+    expect(payload?.coupons).toEqual([])
+    expect(result.current.entities).not.toHaveProperty('saved-local')
+
+    // Undo: the block re-appears referencing the same localId.
+    act(() => {
+      payload = result.current.syncDiscountBlocks([
+        { couponId: 'cpn_edit', localId: 'saved-local' },
+      ])
+    })
+
+    // Coupon is rehydrated and re-persisted with its overrides intact.
+    expect(result.current.entities).toHaveProperty('saved-local')
+    expect(payload?.coupons).toEqual([
+      expect.objectContaining({
+        localId: 'saved-local',
+        overrides: expect.objectContaining({ amountCents: 4200, frequencyDuration: 6 }),
+      }),
+    ])
+  })
+
   it('calls onPersist with billingItems containing coupon overrides on add', async () => {
     const onPersist = jest.fn()
     const { result } = renderHook(() =>

--- a/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
@@ -403,6 +403,70 @@ describe('useDiscountDrawer', () => {
     ])
   })
 
+  it('re-persists restored coupons in document order (position follows the doc)', () => {
+    const makeCoupon = (
+      id: string,
+      localId: string,
+      position: number,
+    ): NonNullable<BillingItemsPayload['coupons']>[number] => ({
+      type: 'coupon',
+      id,
+      localId,
+      payload: {
+        position,
+        code: 'C',
+        id,
+        name: 'Coupon',
+        type: 'fixed_amount',
+        amountCents: 5000,
+        percentageRate: null,
+        currency: CurrencyEnum.Usd,
+        frequency: 'once',
+        frequencyDuration: null,
+        expirationAt: null,
+        limitedPlans: false,
+        planCodes: [],
+        limitedBillableMetrics: false,
+        billableMetricCodes: [],
+        couponOverrides: null,
+        catalogSnapshot: null,
+        resolvedPayload: null,
+      },
+      overrides: {
+        amountCents: 5000,
+        percentageRate: null,
+        frequency: 'once',
+        frequencyDuration: null,
+      },
+    })
+
+    const initialBillingItems: BillingItemsPayload = {
+      addOns: [],
+      coupons: [makeCoupon('cpn_a', 'local-a', 1), makeCoupon('cpn_b', 'local-b', 2)],
+    }
+
+    const { result } = renderHook(() => useDiscountDrawer(initialBillingItems, options))
+
+    let payload: BillingItemsPayload | undefined
+
+    // Delete the FIRST coupon; only local-b remains referenced.
+    act(() => {
+      payload = result.current.syncDiscountBlocks([{ couponId: 'cpn_b', localId: 'local-b' }])
+    })
+
+    // Undo re-inserts local-a ahead of local-b (document order).
+    act(() => {
+      payload = result.current.syncDiscountBlocks([
+        { couponId: 'cpn_a', localId: 'local-a' },
+        { couponId: 'cpn_b', localId: 'local-b' },
+      ])
+    })
+
+    // Positions follow the doc order, not the restore-append order.
+    expect(payload?.coupons?.map((c) => c.localId)).toEqual(['local-a', 'local-b'])
+    expect(payload?.coupons?.map((c) => c.payload.position)).toEqual([1, 2])
+  })
+
   it('calls onPersist with billingItems containing coupon overrides on add', async () => {
     const onPersist = jest.fn()
     const { result } = renderHook(() =>

--- a/src/pages/quotes/hooks/__tests__/useOneOffPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useOneOffPricingDrawer.test.tsx
@@ -624,6 +624,89 @@ describe('useOneOffPricingDrawer', () => {
       })
     })
 
+    describe('WHEN a deleted add-on block re-appears (undo / Cmd+Z)', () => {
+      it('THEN should re-hydrate the add-on from the removed cache, preserving overrides', () => {
+        mockedFromBillingItems.mockReturnValue({
+          entities: {
+            'local-uuid-1': {
+              entityId: 'local-uuid-1',
+              entityType: 'addOn',
+              name: 'Setup Fee',
+              code: 'setup',
+              units: '2',
+              unitAmountCents: '2000',
+              totalAmount: '4000',
+            },
+          },
+          originalPayloads: {
+            'local-uuid-1': mockAddOnPayload,
+          },
+          addOnItems: [
+            { localId: 'local-uuid-1', addOnId: 'addon-1', name: 'Setup Fee', code: 'setup' },
+          ],
+        })
+
+        // Delete rebuild has no survivors; undo rebuild carries the restored add-on.
+        mockedToBillingItems
+          .mockReturnValueOnce({ addOns: [] })
+          .mockReturnValueOnce({ addOns: [{ type: 'add_on', id: 'addon-1' }] })
+
+        const billingItemsWithOne = {
+          addOns: [
+            {
+              type: 'add_on' as const,
+              id: 'addon-1',
+              payload: mockAddOnPayload,
+              overrides: {},
+            },
+          ],
+        }
+
+        const { result } = renderHook(() => useOneOffPricingDrawer(billingItemsWithOne), {
+          wrapper,
+        })
+
+        // Delete: no block references the add-on, so it is pruned (and cached).
+        act(() => {
+          result.current.syncEntitiesWithBlocks([
+            { pricingType: 'addOns' as const, entityIds: [], localEntityIds: [] },
+          ])
+        })
+
+        expect(result.current.entities).not.toHaveProperty('local-uuid-1')
+        expect(result.current.entities).not.toHaveProperty('addon-1')
+
+        // Undo: TipTap re-inserts the block referencing local-uuid-1.
+        act(() => {
+          result.current.syncEntitiesWithBlocks([
+            {
+              pricingType: 'addOns' as const,
+              entityIds: ['addon-1'],
+              localEntityIds: ['local-uuid-1'],
+            },
+          ])
+        })
+
+        // Entity is back (NodeView resolves again) and the rebuild ran with the
+        // restored add-on carrying its edited overrides, not catalog defaults.
+        expect(result.current.entities).toHaveProperty('local-uuid-1')
+
+        const lastCall = mockedToBillingItems.mock.calls.at(-1)
+        const survivingItems = lastCall?.[0]
+        const payloads = lastCall?.[1]
+
+        expect(survivingItems).toHaveLength(1)
+        expect(survivingItems[0]).toMatchObject({
+          localId: 'local-uuid-1',
+          addOnId: 'addon-1',
+          units: '2',
+          unitAmountCents: '2000',
+          totalAmount: '4000',
+        })
+        expect(payloads).toHaveProperty('local-uuid-1')
+      })
+    })
+
     describe('WHEN there are no entities at all', () => {
       it('THEN should return null', () => {
         const { result } = renderHook(() => useOneOffPricingDrawer(), { wrapper })

--- a/src/pages/quotes/hooks/__tests__/useOneOffPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useOneOffPricingDrawer.test.tsx
@@ -707,6 +707,96 @@ describe('useOneOffPricingDrawer', () => {
       })
     })
 
+    describe('WHEN a restored add-on block re-appears ahead of a survivor (undo)', () => {
+      it('THEN should rebuild add-ons in document order (position follows the doc)', () => {
+        const secondPayload = {
+          ...mockAddOnPayload,
+          position: 2,
+          code: 'onboarding',
+          name: 'Onboarding Fee',
+        }
+
+        mockedFromBillingItems.mockReturnValue({
+          entities: {
+            'local-uuid-1': {
+              entityId: 'local-uuid-1',
+              entityType: 'addOn',
+              name: 'Setup Fee',
+              code: 'setup',
+            },
+            'local-uuid-2': {
+              entityId: 'local-uuid-2',
+              entityType: 'addOn',
+              name: 'Onboarding Fee',
+              code: 'onboarding',
+            },
+          },
+          originalPayloads: {
+            'local-uuid-1': mockAddOnPayload,
+            'local-uuid-2': secondPayload,
+          },
+          addOnItems: [
+            { localId: 'local-uuid-1', addOnId: 'addon-1', name: 'Setup Fee', code: 'setup' },
+            {
+              localId: 'local-uuid-2',
+              addOnId: 'addon-2',
+              name: 'Onboarding Fee',
+              code: 'onboarding',
+            },
+          ],
+        })
+
+        // Once (not persistent) so the return does not leak into sibling tests.
+        mockedToBillingItems.mockReturnValueOnce({ addOns: [] }).mockReturnValueOnce({ addOns: [] })
+
+        const billingItemsWithTwo = {
+          addOns: [
+            { type: 'add_on' as const, id: 'addon-1', payload: mockAddOnPayload, overrides: {} },
+            { type: 'add_on' as const, id: 'addon-2', payload: secondPayload, overrides: {} },
+          ],
+        }
+
+        const { result } = renderHook(() => useOneOffPricingDrawer(billingItemsWithTwo), {
+          wrapper,
+        })
+
+        // Delete the FIRST add-on; only local-uuid-2 remains referenced.
+        act(() => {
+          result.current.syncEntitiesWithBlocks([
+            {
+              pricingType: 'addOns' as const,
+              entityIds: ['addon-2'],
+              localEntityIds: ['local-uuid-2'],
+            },
+          ])
+        })
+
+        // Undo re-inserts local-uuid-1 ahead of local-uuid-2 (document order).
+        act(() => {
+          result.current.syncEntitiesWithBlocks([
+            {
+              pricingType: 'addOns' as const,
+              entityIds: ['addon-1'],
+              localEntityIds: ['local-uuid-1'],
+            },
+            {
+              pricingType: 'addOns' as const,
+              entityIds: ['addon-2'],
+              localEntityIds: ['local-uuid-2'],
+            },
+          ])
+        })
+
+        // survivingItems passed to toBillingItems follow doc order, not append order.
+        const survivingItems = mockedToBillingItems.mock.calls.at(-1)?.[0]
+
+        expect(survivingItems.map((i: { localId: string }) => i.localId)).toEqual([
+          'local-uuid-1',
+          'local-uuid-2',
+        ])
+      })
+    })
+
     describe('WHEN there are no entities at all', () => {
       it('THEN should return null', () => {
         const { result } = renderHook(() => useOneOffPricingDrawer(), { wrapper })

--- a/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
@@ -156,6 +156,68 @@ describe('useSubscriptionPricingDrawer', () => {
     expect(result.current.entities).not.toHaveProperty('plan_123')
   })
 
+  it('syncEntitiesWithBlocks re-hydrates a pruned plan when its block re-appears (undo)', () => {
+    const initialBillingItems: BillingItemsPayload = {
+      addOns: [],
+      plans: [
+        {
+          type: 'plan',
+          id: 'plan_123',
+          payload: {
+            position: 1,
+            code: 'enterprise',
+            name: 'Enterprise Plan',
+            description: '',
+            subscriptionExternalId: null,
+            subscriptionName: null,
+            billingTime: 'anniversary',
+            startDate: '2023-07-26',
+            endDate: null,
+            paymentMethodId: null,
+            invoiceCustomFooter: null,
+          },
+          overrides: {},
+        },
+      ],
+    }
+
+    const { result } = renderHook(() => useSubscriptionPricingDrawer(initialBillingItems))
+
+    // Delete: the block leaves the doc, so the plan is pruned and the payload
+    // clears the plan slice for the autosave.
+    let afterDelete: BillingItemsPayload | null = null
+
+    act(() => {
+      afterDelete = result.current.syncEntitiesWithBlocks([])
+    })
+
+    expect(afterDelete).toEqual(expect.objectContaining({ plans: [] }))
+    expect(result.current.entities).not.toHaveProperty('plan_123')
+
+    // Undo: TipTap re-inserts the block, so the same id re-appears in the doc.
+    let afterUndo: BillingItemsPayload | null = null
+
+    act(() => {
+      afterUndo = result.current.syncEntitiesWithBlocks([
+        { pricingType: 'plan', entityIds: ['plan_123'] },
+      ])
+    })
+
+    // Entity is rehydrated (NodeView resolves again) and the plan item — with its
+    // overrides — is re-persisted, restoring server state.
+    expect(result.current.entities).toHaveProperty('plan_123')
+    expect(afterUndo).toEqual(
+      expect.objectContaining({
+        plans: [
+          expect.objectContaining({
+            id: 'plan_123',
+            payload: expect.objectContaining({ name: 'Enterprise Plan' }),
+          }),
+        ],
+      }),
+    )
+  })
+
   it('commits entities and propagates dates on success', async () => {
     mockInjectedState = {
       planId: 'plan_123',

--- a/src/pages/quotes/hooks/useCreditsDrawer.tsx
+++ b/src/pages/quotes/hooks/useCreditsDrawer.tsx
@@ -61,6 +61,11 @@ export const useCreditsDrawer = (
   const itemsRef = useRef<Record<string, WalletFormItem>>(
     Object.fromEntries(initial.walletItems.map((w) => [w.localId, w])),
   )
+  // Session cache of wallet items removed from the doc, keyed by localId, so a
+  // Cmd+Z that re-inserts the credits block restores the wallet (with its
+  // overrides) instead of dropping it. Captured at prune time, before the
+  // rebuild-autosave clears the wallet from the persisted billingItems.
+  const removedItemsRef = useRef<Record<string, WalletFormItem>>({})
   const [entities, setEntities] = useState<Record<string, EntityData>>(initial.entities)
   // Latest full payload — spread so sibling categories are never dropped.
   const latestBillingItemsRef = useRef<BillingItemsPayload | undefined>(billingItems ?? undefined)
@@ -196,9 +201,22 @@ export const useCreditsDrawer = (
       const present = new Set(blocks.map((b) => b.localId).filter(Boolean))
       let changed = false
 
+      // Prune: stash the wallet item before removing, so a later undo can rebuild
+      // it without re-fetching.
       for (const key of Object.keys(itemsRef.current)) {
         if (!present.has(key)) {
+          removedItemsRef.current[key] = itemsRef.current[key]
           delete itemsRef.current[key]
+          changed = true
+        }
+      }
+
+      // Restore: a wallet whose block re-appeared (Cmd+Z) comes back from the
+      // cache with its overrides intact.
+      for (const key of present) {
+        if (key && !itemsRef.current[key] && removedItemsRef.current[key]) {
+          itemsRef.current[key] = removedItemsRef.current[key]
+          delete removedItemsRef.current[key]
           changed = true
         }
       }

--- a/src/pages/quotes/hooks/useCreditsDrawer.tsx
+++ b/src/pages/quotes/hooks/useCreditsDrawer.tsx
@@ -223,6 +223,19 @@ export const useCreditsDrawer = (
 
       if (!changed) return undefined
 
+      // Re-key itemsRef in document order so toWallets assigns positions that
+      // match the block order — a restored wallet would otherwise land at the
+      // end of the map and persist a different ordering than the doc.
+      const orderedItems: Record<string, WalletFormItem> = {}
+
+      for (const { localId } of blocks) {
+        if (localId && itemsRef.current[localId]) {
+          orderedItems[localId] = itemsRef.current[localId]
+        }
+      }
+
+      itemsRef.current = orderedItems
+
       return rebuild()
     },
     [rebuild],

--- a/src/pages/quotes/hooks/useDiscountDrawer.tsx
+++ b/src/pages/quotes/hooks/useDiscountDrawer.tsx
@@ -603,6 +603,22 @@ export const useDiscountDrawer = (
 
       if (!changed) return undefined
 
+      // Re-key the refs in document order so toCoupons assigns positions that
+      // match the block order — a restored coupon would otherwise land at the
+      // end of the map and persist a different ordering than the doc.
+      const orderedItems: Record<string, DiscountFormItem> = {}
+      const orderedPayloads: Record<string, CouponPayload> = {}
+
+      for (const { localId } of blocks) {
+        if (localId && itemsRef.current[localId]) {
+          orderedItems[localId] = itemsRef.current[localId]
+          orderedPayloads[localId] = originalPayloadsRef.current[localId]
+        }
+      }
+
+      itemsRef.current = orderedItems
+      originalPayloadsRef.current = orderedPayloads
+
       return rebuild()
     },
     [rebuild],

--- a/src/pages/quotes/hooks/useDiscountDrawer.tsx
+++ b/src/pages/quotes/hooks/useDiscountDrawer.tsx
@@ -348,6 +348,14 @@ export const useDiscountDrawer = (
   const [entities, setEntities] = useState<Record<string, EntityData>>(initial.entities)
   const entitiesRef = useRef<Record<string, EntityData>>(initial.entities)
 
+  // Session cache of coupon items removed from the doc, keyed by localId, so a
+  // Cmd+Z that re-inserts the discount block restores the coupon (with its
+  // overrides) instead of dropping it. Captured at prune time, before the
+  // rebuild-autosave clears the coupon from the persisted billingItems.
+  const removedItemsRef = useRef<
+    Record<string, { item: DiscountFormItem; payload: CouponPayload }>
+  >({})
+
   // Ref bridge: a single stable onSubmit reads the pending save target set right
   // before drawer.open, instead of mutating form.options.onSubmit per open.
   const pendingSaveRef = useRef<PendingSave | null>(null)
@@ -568,10 +576,27 @@ export const useDiscountDrawer = (
       const present = new Set(blocks.map((b) => b.localId))
       let changed = false
 
+      // Prune: stash the coupon item + payload before removing, so a later undo
+      // can rebuild them without re-fetching.
       for (const key of Object.keys(itemsRef.current)) {
         if (!present.has(key)) {
+          removedItemsRef.current[key] = {
+            item: itemsRef.current[key],
+            payload: originalPayloadsRef.current[key],
+          }
           delete itemsRef.current[key]
           delete originalPayloadsRef.current[key]
+          changed = true
+        }
+      }
+
+      // Restore: a coupon whose block re-appeared (Cmd+Z) comes back from the
+      // cache with its overrides intact.
+      for (const key of present) {
+        if (key && !itemsRef.current[key] && removedItemsRef.current[key]) {
+          itemsRef.current[key] = removedItemsRef.current[key].item
+          originalPayloadsRef.current[key] = removedItemsRef.current[key].payload
+          delete removedItemsRef.current[key]
           changed = true
         }
       }

--- a/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
@@ -463,6 +463,37 @@ export const useOneOffPricingDrawer = (
       payloadsRef.current = updatedPayloads
       setEntities(updatedEntities)
 
+      // Re-key catalogIdMapRef in document order so toBillingItems assigns
+      // positions matching the block order — a restored add-on would otherwise
+      // land at the end of the map and persist a different ordering than the doc.
+      const orderedCatalogIdMap: Record<string, string> = {}
+
+      for (const block of blocks) {
+        const refIds = block.localEntityIds?.length ? block.localEntityIds : block.entityIds
+
+        for (const refId of refIds ?? []) {
+          const localId = catalogIdMapRef.current[refId]
+            ? refId
+            : Object.keys(catalogIdMapRef.current).find(
+                (key) => catalogIdMapRef.current[key] === refId,
+              )
+
+          if (localId && catalogIdMapRef.current[localId] && !orderedCatalogIdMap[localId]) {
+            orderedCatalogIdMap[localId] = catalogIdMapRef.current[localId]
+          }
+        }
+      }
+
+      // Safety net: keep any residual keys (there should be none post-prune) so a
+      // survivor is never silently dropped from the rebuild.
+      for (const localId of Object.keys(catalogIdMapRef.current)) {
+        if (!orderedCatalogIdMap[localId]) {
+          orderedCatalogIdMap[localId] = catalogIdMapRef.current[localId]
+        }
+      }
+
+      catalogIdMapRef.current = orderedCatalogIdMap
+
       // Rebuild the surviving billing items through toBillingItems so the user's
       // overrides (units, unit price, dates, names) are preserved — rebuilding
       // straight from the catalog payloads would reset them to catalog defaults.

--- a/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
@@ -50,6 +50,136 @@ export interface UseOneOffPricingDrawerReturn {
   syncEntitiesWithBlocks: (blocks: PricingBlockAttributes[]) => BillingItemsPayload | null
 }
 
+// One entry of the removed-add-on session cache (see removedAddOnsRef). Holds
+// both the localId-keyed entity/payload and their backward-compat alias copies.
+type RemovedAddOn = {
+  addOnId: string
+  entity: EntityData
+  aliasEntity?: EntityData
+  payload?: AddOnPayload
+  aliasPayload?: AddOnPayload
+}
+
+// Prune deleted add-ons from local state, stashing each (entity + payload +
+// alias) in the removed cache so a later undo can rebuild them. Mutates the
+// passed-in maps in place.
+const stashRemovedAddOns = (
+  removedLocalIds: string[],
+  catalogIdMap: Record<string, string>,
+  entities: Record<string, EntityData>,
+  payloads: Record<string, AddOnPayload>,
+  removedCache: Record<string, RemovedAddOn>,
+): void => {
+  for (const localId of removedLocalIds) {
+    const addOnId = catalogIdMap[localId]
+
+    removedCache[localId] = {
+      addOnId,
+      entity: entities[localId],
+      aliasEntity: entities[addOnId],
+      payload: payloads[localId],
+      aliasPayload: payloads[addOnId],
+    }
+
+    delete entities[localId]
+    delete entities[addOnId]
+    delete payloads[localId]
+    delete payloads[addOnId]
+    delete catalogIdMap[localId]
+  }
+}
+
+// Restore add-ons whose block re-appeared (undo): re-key the entity, payload and
+// alias from the removed cache. Overrides survive because both the entity (edited
+// values) and payload (baseline) come from the cache, not the catalog.
+const restoreAddOns = (
+  restoredLocalIds: string[],
+  catalogIdMap: Record<string, string>,
+  entities: Record<string, EntityData>,
+  payloads: Record<string, AddOnPayload>,
+  removedCache: Record<string, RemovedAddOn>,
+): void => {
+  for (const localId of restoredLocalIds) {
+    const { addOnId, entity, aliasEntity, payload, aliasPayload } = removedCache[localId]
+
+    catalogIdMap[localId] = addOnId
+    entities[localId] = entity
+
+    if (aliasEntity) entities[addOnId] = aliasEntity
+    if (payload) payloads[localId] = payload
+    if (aliasPayload) payloads[addOnId] = aliasPayload
+
+    delete removedCache[localId]
+  }
+}
+
+// Re-key a catalog-id map in document (block) order so downstream position
+// assignment (index + 1 in toBillingItems) follows the doc, not insertion order.
+// A restored add-on would otherwise land at the end of the map.
+const orderCatalogIdMapByBlocks = (
+  catalogIdMap: Record<string, string>,
+  blocks: PricingBlockAttributes[],
+): Record<string, string> => {
+  const ordered: Record<string, string> = {}
+
+  // A block references an add-on by its localId or its catalog alias.
+  const resolveLocalId = (refId: string): string | undefined =>
+    catalogIdMap[refId]
+      ? refId
+      : Object.keys(catalogIdMap).find((key) => catalogIdMap[key] === refId)
+
+  for (const block of blocks) {
+    const refIds = block.localEntityIds?.length ? block.localEntityIds : block.entityIds
+
+    for (const refId of refIds ?? []) {
+      const localId = resolveLocalId(refId)
+
+      if (localId && catalogIdMap[localId] && !ordered[localId]) {
+        ordered[localId] = catalogIdMap[localId]
+      }
+    }
+  }
+
+  // Safety net: keep any residual keys (there should be none post-prune) so a
+  // survivor is never silently dropped from the rebuild.
+  for (const localId of Object.keys(catalogIdMap)) {
+    if (!ordered[localId]) {
+      ordered[localId] = catalogIdMap[localId]
+    }
+  }
+
+  return ordered
+}
+
+// Rebuild the surviving add-on items from the (ordered) catalog map, carrying
+// each entity's user overrides so toBillingItems doesn't reset them to catalog
+// defaults. Items whose entity is gone are dropped.
+const buildSurvivingAddOnItems = (
+  catalogIdMap: Record<string, string>,
+  entities: Record<string, EntityData>,
+): AddOnItem[] =>
+  Object.keys(catalogIdMap)
+    .map((localId): AddOnItem | null => {
+      const entity = entities[localId]
+
+      if (!entity) return null
+
+      return {
+        localId,
+        addOnId: catalogIdMap[localId],
+        name: entity.name,
+        invoiceDisplayName: entity.invoiceDisplayName ?? '',
+        code: entity.code,
+        description: entity.description ?? '',
+        units: entity.units ?? '',
+        unitAmountCents: entity.unitAmountCents ?? '',
+        totalAmount: entity.totalAmount ?? '',
+        fromDatetime: entity.fromDatetime ?? '',
+        toDatetime: entity.toDatetime ?? '',
+      }
+    })
+    .filter((item): item is AddOnItem => item !== null)
+
 export const useOneOffPricingDrawer = (
   initialBillingItems?: unknown,
   quoteCurrency?: CurrencyEnum | null,
@@ -75,18 +205,7 @@ export const useOneOffPricingDrawer = (
   // payload and alias — preserving the user's overrides (rebuilt from the cached
   // entity/payload, never re-fetched from the catalog). Captured at prune time,
   // before the delete-autosave clears the add-on from the persisted billingItems.
-  const removedAddOnsRef = useRef<
-    Record<
-      string,
-      {
-        addOnId: string
-        entity: EntityData
-        aliasEntity?: EntityData
-        payload?: AddOnPayload
-        aliasPayload?: AddOnPayload
-      }
-    >
-  >({})
+  const removedAddOnsRef = useRef<Record<string, RemovedAddOn>>({})
   const onSaveRef = useRef<
     | ((
         attrs: PricingBlockAttributes,
@@ -414,110 +533,34 @@ export const useOneOffPricingDrawer = (
       const updatedEntities = { ...entitiesRef.current }
       const updatedPayloads = { ...payloadsRef.current }
 
-      // Prune the deleted add-ons (and their alias keys) from local state, but
-      // stash them (entity + payload + alias) so a later undo can rebuild them.
-      for (const localId of removedLocalIds) {
-        const addOnId = catalogIdMapRef.current[localId]
-
-        removedAddOnsRef.current[localId] = {
-          addOnId,
-          entity: updatedEntities[localId],
-          aliasEntity: updatedEntities[addOnId],
-          payload: updatedPayloads[localId],
-          aliasPayload: updatedPayloads[addOnId],
-        }
-
-        delete updatedEntities[localId]
-        delete updatedEntities[addOnId]
-        delete updatedPayloads[localId]
-        delete updatedPayloads[addOnId]
-        delete catalogIdMapRef.current[localId]
-      }
-
-      // Restore add-ons whose block re-appeared: re-key the entity, payload and
-      // alias from the removed cache. Overrides survive because both the entity
-      // (edited values) and payload (baseline) come from the cache, not catalog.
-      for (const localId of restoredLocalIds) {
-        const { addOnId, entity, aliasEntity, payload, aliasPayload } =
-          removedAddOnsRef.current[localId]
-
-        catalogIdMapRef.current[localId] = addOnId
-        updatedEntities[localId] = entity
-
-        if (aliasEntity) {
-          updatedEntities[addOnId] = aliasEntity
-        }
-
-        if (payload) {
-          updatedPayloads[localId] = payload
-        }
-
-        if (aliasPayload) {
-          updatedPayloads[addOnId] = aliasPayload
-        }
-
-        delete removedAddOnsRef.current[localId]
-      }
+      // Prune deleted add-ons (stashing them for undo), then restore any whose
+      // block re-appeared. Both mutate the working copies + shared refs in place.
+      stashRemovedAddOns(
+        removedLocalIds,
+        catalogIdMapRef.current,
+        updatedEntities,
+        updatedPayloads,
+        removedAddOnsRef.current,
+      )
+      restoreAddOns(
+        restoredLocalIds,
+        catalogIdMapRef.current,
+        updatedEntities,
+        updatedPayloads,
+        removedAddOnsRef.current,
+      )
 
       entitiesRef.current = updatedEntities
       payloadsRef.current = updatedPayloads
       setEntities(updatedEntities)
 
       // Re-key catalogIdMapRef in document order so toBillingItems assigns
-      // positions matching the block order — a restored add-on would otherwise
-      // land at the end of the map and persist a different ordering than the doc.
-      const orderedCatalogIdMap: Record<string, string> = {}
+      // positions matching the block order (a restored add-on would otherwise
+      // land at the end of the map), then rebuild the surviving items — carrying
+      // overrides — through toBillingItems.
+      catalogIdMapRef.current = orderCatalogIdMapByBlocks(catalogIdMapRef.current, blocks)
 
-      for (const block of blocks) {
-        const refIds = block.localEntityIds?.length ? block.localEntityIds : block.entityIds
-
-        for (const refId of refIds ?? []) {
-          const localId = catalogIdMapRef.current[refId]
-            ? refId
-            : Object.keys(catalogIdMapRef.current).find(
-                (key) => catalogIdMapRef.current[key] === refId,
-              )
-
-          if (localId && catalogIdMapRef.current[localId] && !orderedCatalogIdMap[localId]) {
-            orderedCatalogIdMap[localId] = catalogIdMapRef.current[localId]
-          }
-        }
-      }
-
-      // Safety net: keep any residual keys (there should be none post-prune) so a
-      // survivor is never silently dropped from the rebuild.
-      for (const localId of Object.keys(catalogIdMapRef.current)) {
-        if (!orderedCatalogIdMap[localId]) {
-          orderedCatalogIdMap[localId] = catalogIdMapRef.current[localId]
-        }
-      }
-
-      catalogIdMapRef.current = orderedCatalogIdMap
-
-      // Rebuild the surviving billing items through toBillingItems so the user's
-      // overrides (units, unit price, dates, names) are preserved — rebuilding
-      // straight from the catalog payloads would reset them to catalog defaults.
-      const survivingItems: AddOnItem[] = Object.keys(catalogIdMapRef.current)
-        .map((localId): AddOnItem | null => {
-          const entity = updatedEntities[localId]
-
-          if (!entity) return null
-
-          return {
-            localId,
-            addOnId: catalogIdMapRef.current[localId],
-            name: entity.name,
-            invoiceDisplayName: entity.invoiceDisplayName ?? '',
-            code: entity.code,
-            description: entity.description ?? '',
-            units: entity.units ?? '',
-            unitAmountCents: entity.unitAmountCents ?? '',
-            totalAmount: entity.totalAmount ?? '',
-            fromDatetime: entity.fromDatetime ?? '',
-            toDatetime: entity.toDatetime ?? '',
-          }
-        })
-        .filter((item): item is AddOnItem => item !== null)
+      const survivingItems = buildSurvivingAddOnItems(catalogIdMapRef.current, updatedEntities)
 
       return toBillingItems(survivingItems, payloadsRef.current, currencyRef.current)
     },

--- a/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
@@ -69,6 +69,24 @@ export const useOneOffPricingDrawer = (
   const [entities, setEntities] = useState<Record<string, EntityData>>({})
   const payloadsRef = useRef<Record<string, AddOnPayload>>({})
   const catalogIdMapRef = useRef<Record<string, string>>({})
+
+  // Session cache of add-ons removed from the doc, keyed by localId, so a Cmd+Z
+  // that re-inserts the pricing block can re-hydrate the entity, its catalog
+  // payload and alias — preserving the user's overrides (rebuilt from the cached
+  // entity/payload, never re-fetched from the catalog). Captured at prune time,
+  // before the delete-autosave clears the add-on from the persisted billingItems.
+  const removedAddOnsRef = useRef<
+    Record<
+      string,
+      {
+        addOnId: string
+        entity: EntityData
+        aliasEntity?: EntityData
+        payload?: AddOnPayload
+        aliasPayload?: AddOnPayload
+      }
+    >
+  >({})
   const onSaveRef = useRef<
     | ((
         attrs: PricingBlockAttributes,
@@ -384,20 +402,61 @@ export const useOneOffPricingDrawer = (
           !activeRefIds.has(localId) && !activeRefIds.has(catalogIdMapRef.current[localId]),
       )
 
-      if (removedLocalIds.length === 0) return null
+      // A Cmd+Z can re-insert a block whose add-on was previously pruned; it is
+      // referenced by its localId or its catalog alias but is no longer active.
+      const restoredLocalIds = Object.keys(removedAddOnsRef.current).filter(
+        (localId) =>
+          activeRefIds.has(localId) || activeRefIds.has(removedAddOnsRef.current[localId].addOnId),
+      )
 
-      // Prune the deleted add-ons (and their alias keys) from local state.
+      if (removedLocalIds.length === 0 && restoredLocalIds.length === 0) return null
+
       const updatedEntities = { ...entitiesRef.current }
       const updatedPayloads = { ...payloadsRef.current }
 
+      // Prune the deleted add-ons (and their alias keys) from local state, but
+      // stash them (entity + payload + alias) so a later undo can rebuild them.
       for (const localId of removedLocalIds) {
         const addOnId = catalogIdMapRef.current[localId]
+
+        removedAddOnsRef.current[localId] = {
+          addOnId,
+          entity: updatedEntities[localId],
+          aliasEntity: updatedEntities[addOnId],
+          payload: updatedPayloads[localId],
+          aliasPayload: updatedPayloads[addOnId],
+        }
 
         delete updatedEntities[localId]
         delete updatedEntities[addOnId]
         delete updatedPayloads[localId]
         delete updatedPayloads[addOnId]
         delete catalogIdMapRef.current[localId]
+      }
+
+      // Restore add-ons whose block re-appeared: re-key the entity, payload and
+      // alias from the removed cache. Overrides survive because both the entity
+      // (edited values) and payload (baseline) come from the cache, not catalog.
+      for (const localId of restoredLocalIds) {
+        const { addOnId, entity, aliasEntity, payload, aliasPayload } =
+          removedAddOnsRef.current[localId]
+
+        catalogIdMapRef.current[localId] = addOnId
+        updatedEntities[localId] = entity
+
+        if (aliasEntity) {
+          updatedEntities[addOnId] = aliasEntity
+        }
+
+        if (payload) {
+          updatedPayloads[localId] = payload
+        }
+
+        if (aliasPayload) {
+          updatedPayloads[addOnId] = aliasPayload
+        }
+
+        delete removedAddOnsRef.current[localId]
       }
 
       entitiesRef.current = updatedEntities

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -21,6 +21,8 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import type { SavePricingResult } from '~/pages/quotes/EditQuote'
 import { QUOTE_SAVE_FAILED_TOAST_KEY } from '~/pages/quotes/utils/quoteSaveErrorKeys'
 
+type PlanBillingItem = NonNullable<BillingItemsPayload['plans']>[number]
+
 interface UseSubscriptionPricingDrawerReturn {
   onPricingCommand: OnPricingCommand
   isPricingDisabled: () => boolean
@@ -59,6 +61,13 @@ export const useSubscriptionPricingDrawer = (
   // sibling categories (coupons, addons) instead of overwriting billingItems and
   // dropping them — each drawer only owns its own slice of billingItems.
   const latestBillingItemsRef = useRef<BillingItemsPayload | undefined>(undefined)
+
+  // Session cache of entities/plan-items removed from the doc, so a Cmd+Z that
+  // re-inserts the pricing block can re-hydrate them (with the user's overrides)
+  // instead of leaving the restored node unresolved. Captured at prune time,
+  // before the delete-autosave clears the plan from `latestBillingItemsRef`.
+  const removedEntitiesRef = useRef<Record<string, EntityData>>({})
+  const removedPlanItemsRef = useRef<Record<string, PlanBillingItem>>({})
 
   useEffect(() => {
     latestBillingItemsRef.current =
@@ -192,22 +201,60 @@ export const useSubscriptionPricingDrawer = (
     (blocks: PricingBlockAttributes[]): BillingItemsPayload | null => {
       const activeEntityIds = new Set(blocks.flatMap((b) => b.entityIds))
       const currentKeys = Object.keys(entitiesRef.current)
-      const orphanedKeys = currentKeys.filter((id) => !activeEntityIds.has(id))
 
-      if (orphanedKeys.length === 0) return null
+      // Ids that left the doc (deleted) vs. ids that re-appeared in the doc but
+      // are no longer active (a Cmd+Z re-inserting a previously-removed block).
+      const orphanedKeys = currentKeys.filter((id) => !activeEntityIds.has(id))
+      const restoredKeys = [...activeEntityIds].filter(
+        (id) => !entitiesRef.current[id] && removedEntitiesRef.current[id],
+      )
+
+      if (orphanedKeys.length === 0 && restoredKeys.length === 0) return null
 
       const updatedEntities = { ...entitiesRef.current }
+      // Plan items indexed by id: the current saved slice, plus anything we
+      // restore below (whose item lives only in the removed cache once the
+      // delete-autosave has cleared it from `latestBillingItemsRef`).
+      const planItemsById: Record<string, PlanBillingItem> = {}
 
+      for (const item of latestBillingItemsRef.current?.plans ?? []) {
+        planItemsById[item.id] = item
+      }
+
+      // Prune: stash the entity + its plan item (with overrides) before removing,
+      // so a later undo can rebuild them without re-fetching.
       for (const key of orphanedKeys) {
+        removedEntitiesRef.current[key] = updatedEntities[key]
+
+        if (planItemsById[key]) {
+          removedPlanItemsRef.current[key] = planItemsById[key]
+        }
+
         delete updatedEntities[key]
+      }
+
+      // Restore: pull the entity + plan item back out of the removed cache.
+      for (const key of restoredKeys) {
+        updatedEntities[key] = removedEntitiesRef.current[key]
+
+        if (removedPlanItemsRef.current[key]) {
+          planItemsById[key] = removedPlanItemsRef.current[key]
+        }
+
+        delete removedEntitiesRef.current[key]
+        delete removedPlanItemsRef.current[key]
       }
 
       entitiesRef.current = updatedEntities
       setEntities(updatedEntities)
 
-      // Only the plan is this drawer's responsibility; sibling categories
-      // (coupons, addons) are carried through untouched.
-      return { ...latestBillingItemsRef.current, plans: [] }
+      // Rebuild the plan slice from the active set; sibling categories
+      // (coupons, addons) are carried through untouched via the spread.
+      const activePlans = Object.keys(updatedEntities)
+        .map((id) => planItemsById[id])
+        .filter((item): item is PlanBillingItem => Boolean(item))
+
+      return { ...latestBillingItemsRef.current, plans: activePlans }
     },
     [],
   )


### PR DESCRIPTION
## Context

In the Quotes / Order-Forms editor, pricing blocks (plan, one-off add-on, discount coupon, credits wallet) are atomic TipTap nodes whose resolved data + billing payload live in external React state, synced one-way on each doc change. Deleting a block destructively pruned that state and autosaved the removal, so pressing Cmd+Z re-inserted the node but left it rendering the unresolved fallback and the server still had it deleted. Fixes LAGO-1576.

## Description

Each drawer hook's `syncEntitiesWithBlocks` / `syncDiscountBlocks` / `syncCreditsBlocks` is now a bidirectional reconciler driven by the doc as source of truth: on prune it snapshots the removed entity + payload (with the user's overrides) into a session cache instead of dropping them, and when a block re-appears in the doc (undo/redo) it restores them and rebuilds the owned billing slice so the existing autosave re-persists it. Overrides survive because the cached item/payload feed each drawer's existing serializer round-trip rather than a catalog re-fetch, and `isPricingDisabled` / the wallet cap still read only the active set. Added one delete→undo round-trip test per block type (73 tests pass across the 4 drawer suites); `tsc` and ESLint clean.

Fixes LAGO-1576