### PR TITLE
fix(clipboard): Handle the rejected writeText promise

### DIFF
--- a/src/core/utils/__tests__/copyToClipboard.test.ts
+++ b/src/core/utils/__tests__/copyToClipboard.test.ts
@@ -118,4 +118,139 @@ describe('copyToClipboard', () => {
     mockCreateElement.mockRestore()
     jest.restoreAllMocks()
   })
+
+  describe('GIVEN navigator.clipboard.writeText rejects', () => {
+    const originalClipboard = { ...navigator.clipboard }
+
+    const mockRejectedWriteText = (): void => {
+      Object.assign(navigator.clipboard, {
+        writeText: jest
+          .fn()
+          .mockRejectedValue(
+            new DOMException(
+              "Failed to execute 'writeText' on 'Clipboard': Document is not focused.",
+              'NotAllowedError',
+            ),
+          ),
+      })
+    }
+
+    // The rejection is handled asynchronously: give node a macrotask tick so a leftover
+    // rejection would have time to be reported.
+    const flushRejection = (): Promise<void> =>
+      new Promise((resolve) => {
+        setTimeout(resolve, 0)
+      })
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+      mockRejectedWriteText()
+    })
+
+    afterEach(() => {
+      Object.assign(navigator.clipboard, originalClipboard)
+      jest.restoreAllMocks()
+    })
+
+    describe('WHEN the fallback succeeds', () => {
+      it('THEN should copy the value through the fallback', async () => {
+        document.execCommand = jest.fn().mockImplementation(() => true)
+
+        const textArea = document.createElement('textarea')
+
+        jest.spyOn(document, 'createElement').mockReturnValue(textArea)
+
+        copyToClipboard('async fallback text')
+        await flushRejection()
+
+        expect(document.execCommand).toHaveBeenCalledWith('copy')
+        expect(textArea.value).toBe('async fallback text')
+      })
+
+      it('THEN should not display any toast', async () => {
+        document.execCommand = jest.fn().mockImplementation(() => true)
+
+        copyToClipboard('async fallback text')
+        await flushRejection()
+
+        expect(addToast).not.toHaveBeenCalled()
+      })
+
+      it('THEN should filter out comments', async () => {
+        document.execCommand = jest.fn().mockImplementation(() => true)
+
+        const textArea = document.createElement('textarea')
+
+        jest.spyOn(document, 'createElement').mockReturnValue(textArea)
+
+        const value = `# comment
+    the text that needs to be copied`
+
+        copyToClipboard(value, { ignoreComment: true })
+        await flushRejection()
+
+        expect(textArea.value).toBe('the text that needs to be copied')
+      })
+    })
+
+    describe('WHEN the fallback throws', () => {
+      it('THEN should display the error toast', async () => {
+        document.execCommand = jest.fn().mockImplementation(() => {
+          throw new Error('execCommand failed')
+        })
+
+        copyToClipboard('failing async text')
+        await flushRejection()
+
+        expect(addToast).toHaveBeenCalledWith({
+          severity: 'danger',
+          translateKey: 'text_1745919770448pvibiukolis',
+        })
+      })
+    })
+
+    describe('WHEN the fallback silently fails', () => {
+      it('THEN should treat a false execCommand result as a failure', async () => {
+        document.execCommand = jest.fn().mockImplementation(() => false)
+
+        copyToClipboard('silently failing text')
+        await flushRejection()
+
+        expect(addToast).toHaveBeenCalledWith({
+          severity: 'danger',
+          translateKey: 'text_1745919770448pvibiukolis',
+        })
+      })
+    })
+
+    describe('WHEN the rejection is handled', () => {
+      it.each([
+        ['the fallback succeeds', (): boolean => true],
+        [
+          'the fallback throws',
+          (): boolean => {
+            throw new Error('execCommand failed')
+          },
+        ],
+        ['the fallback returns false', (): boolean => false],
+      ])('THEN should not surface an unhandled rejection when %s', async (_, execCommandImpl) => {
+        const onUnhandledRejection = jest.fn()
+
+        process.on('unhandledRejection', onUnhandledRejection)
+        document.execCommand = jest.fn().mockImplementation(execCommandImpl)
+
+        try {
+          expect(() => {
+            copyToClipboard('unhandled rejection text')
+          }).not.toThrow()
+
+          await flushRejection()
+
+          expect(onUnhandledRejection).not.toHaveBeenCalled()
+        } finally {
+          process.removeListener('unhandledRejection', onUnhandledRejection)
+        }
+      })
+    })
+  })
 })

--- a/src/core/utils/__tests__/copyToClipboard.test.ts
+++ b/src/core/utils/__tests__/copyToClipboard.test.ts
@@ -31,6 +31,14 @@ describe('copyToClipboard', () => {
     )
   })
 
+  it('should keep comments when ignoreComment is false', () => {
+    const value = `# comment
+    the text that needs to be copied`
+
+    copyToClipboard(value, { ignoreComment: false })
+    expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(value)
+  })
+
   it('should be able to copy when navigator.clipboard is not available', () => {
     // Mock navigator.clipboard to throw error
     const originalClipboard = { ...navigator.clipboard }

--- a/src/core/utils/copyToClipboard.ts
+++ b/src/core/utils/copyToClipboard.ts
@@ -34,9 +34,9 @@ const notifyCopyFailure = (): void => {
 
 export const copyToClipboard: (value: string, options?: { ignoreComment?: boolean }) => void = (
   value,
-  ignoreComment,
+  options,
 ) => {
-  const serializedValue = ignoreComment ? filterComment(value) : value
+  const serializedValue = options?.ignoreComment ? filterComment(value) : value
 
   try {
     // `writeText` rejects asynchronously — with a NotAllowedError when the document is not

--- a/src/core/utils/copyToClipboard.ts
+++ b/src/core/utils/copyToClipboard.ts
@@ -1,13 +1,15 @@
 import { addToast } from '~/core/apolloClient'
 
-const filterComment = (value: string) => {
+const filterComment = (value: string): string => {
   return value
     .split('\n')
     .filter((line) => !line.startsWith('#'))
     .join('\n')
 }
 
-const unsecuredCopyToClipboard = (text: string) => {
+// Returns whether the value could be copied — `execCommand` reports a silent failure with
+// `false` and throws in some browsers.
+const unsecuredCopyToClipboard = (text: string): boolean => {
   const textArea = document.createElement('textarea')
 
   textArea.value = text.trim()
@@ -15,16 +17,19 @@ const unsecuredCopyToClipboard = (text: string) => {
   textArea.focus()
   textArea.select()
   try {
-    document.execCommand('copy')
+    return document.execCommand('copy')
   } catch {
-    addToast({
-      severity: 'danger',
-      translateKey: 'text_1745919770448pvibiukolis',
-    })
-    throw new Error('Unable to copy to clipboard')
+    return false
   } finally {
     document.body.removeChild(textArea)
   }
+}
+
+const notifyCopyFailure = (): void => {
+  addToast({
+    severity: 'danger',
+    translateKey: 'text_1745919770448pvibiukolis',
+  })
 }
 
 export const copyToClipboard: (value: string, options?: { ignoreComment?: boolean }) => void = (
@@ -34,9 +39,21 @@ export const copyToClipboard: (value: string, options?: { ignoreComment?: boolea
   const serializedValue = ignoreComment ? filterComment(value) : value
 
   try {
-    navigator.clipboard.writeText(serializedValue)
+    // `writeText` rejects asynchronously — with a NotAllowedError when the document is not
+    // focused, for instance — so the promise needs its own handler on top of the surrounding
+    // catch. Errors must not escape it either: they would become unhandled rejections.
+    navigator.clipboard.writeText(serializedValue).catch(() => {
+      if (!unsecuredCopyToClipboard(serializedValue)) {
+        notifyCopyFailure()
+      }
+    })
   } catch {
-    unsecuredCopyToClipboard(serializedValue)
+    // The clipboard API itself is unreachable: unsecure context, or no permission at all.
+    if (!unsecuredCopyToClipboard(serializedValue)) {
+      notifyCopyFailure()
+      throw new Error('Unable to copy to clipboard')
+    }
+
     addToast({
       severity: 'info',
       translateKey: 'text_63a5ba11eb4e7e17ef88e9f0',


### PR DESCRIPTION
## Context

Sentry reports a `NotAllowedError` in production —
`Failed to execute 'writeText' on 'Clipboard': Document is not focused.` — raised
from an invoice overview page.

`copyToClipboard` called `navigator.clipboard.writeText()` inside a synchronous
`try/catch`. `writeText` returns a promise, so a rejection (a `NotAllowedError`
when the document is not focused, or a denied permission) was never caught: it
surfaced as an unhandled rejection reported to Sentry, while the user got neither
the copied value nor any feedback.

## Description

- `copyToClipboard` now handles the promise rejection on top of the surrounding
  synchronous catch, routing it to the existing `document.execCommand('copy')`
  fallback. Nothing escapes the handler, so no unhandled rejection is produced.
- `unsecuredCopyToClipboard` returns whether the copy succeeded instead of
  toasting and throwing on its own. `execCommand` reporting a silent failure with
  `false` is now treated as a failure, not a success.
- The error toast moved to a `notifyCopyFailure()` helper, shared by both failure
  paths. The synchronous path keeps its current contract: unsecure-context info
  toast when the fallback works, thrown error when it does not.
- The exported signature is unchanged, so the 33 fire-and-forget call sites are
  untouched. No new translation keys — both existing toast keys are reused.
- Added unit tests for the rejected-promise path: fallback invoked with the
  serialized value, error toast when the fallback fails or returns `false`, and a
  `process.on('unhandledRejection')` guard over all three fallback outcomes. The
  eight new cases fail against the previous implementation.

<!-- Linear link -->
Fixes ING-547
