### PR TITLE
chore(scripts): Clean vite cache on worktree container start

### DIFF
--- a/scripts/lago-worktree.sh
+++ b/scripts/lago-worktree.sh
@@ -291,6 +291,10 @@ services:
     container_name: lago_front_wt_${san}
     stdin_open: true
     restart: unless-stopped
+    # Clear the vite dep-optimizer cache on every container start: the
+    # node_modules volume outlives the mounted worktree sources, so a stale
+    # cache causes "Outdated Optimize Dep" compilation errors in the browser.
+    command: bash -c "rm -rf /app/node_modules/.vite && ./start.dev.sh"
     volumes:
       - ${wt_path}:/app:cached
       - front_nm_wt_${san}:/app/node_modules


### PR DESCRIPTION
## Context

Worktree front containers keep node_modules in a named docker volume that outlives the mounted sources. The vite dep-optimizer cache inside it goes stale whenever another worktree is created or dependencies drift, causing "Outdated Optimize Dep" compilation errors in the browser that require a manual cache wipe and container restart every time.

## Description

Override the front service command in the generated docker-compose.worktree.yml to remove `/app/node_modules/.vite` before running `./start.dev.sh`, so every container start begins with a clean vite cache. Costs a one-time dep re-optimization per start (~seconds), removes the recurring manual cleanup.