### PR TITLE
refactor(alerts): migrate the subscription alert form to TanStack Form

### DIFF
--- a/src/components/alerts/AlertNameAndCodeSection.tsx
+++ b/src/components/alerts/AlertNameAndCodeSection.tsx
@@ -1,0 +1,66 @@
+import { Typography } from '~/components/designSystem/Typography'
+import { formatCodeFromName } from '~/core/utils/formatCodeFromName'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { withFieldGroup } from '~/hooks/forms/useAppform'
+
+export const ALERT_NAME_AND_CODE_GROUP_DEFAULT_VALUES = {
+  name: '',
+  code: '',
+}
+
+type AlertNameAndCodeSectionProps = {
+  /** The name label differs per alert form, so it comes in already translated. */
+  nameLabel: string
+  /** True when the edited alert already has a code: it is never overwritten. */
+  hasExistingCode: boolean
+}
+
+/**
+ * The "alert name and code" section shared by the wallet and subscription
+ * alert forms: same layout, same code placeholder, same name→code derivation.
+ */
+export const AlertNameAndCodeSection = withFieldGroup({
+  defaultValues: ALERT_NAME_AND_CODE_GROUP_DEFAULT_VALUES,
+  props: {
+    nameLabel: '',
+    hasExistingCode: false,
+  } as AlertNameAndCodeSectionProps,
+  render: function AlertNameAndCodeSectionRender({ group, nameLabel, hasExistingCode }) {
+    const { translate } = useInternationalization()
+
+    // The code is derived from the name until the user takes ownership of it,
+    // and never on an alert that already had one (`updateNameAndMaybeCode` parity)
+    const onNameChange = ({ value }: { value: string }) => {
+      if (group.getFieldMeta('code')?.isBlurred || hasExistingCode) return
+
+      group.setFieldValue('code', formatCodeFromName(value))
+    }
+
+    return (
+      <section className="pb-12 shadow-b not-last-child:mb-6">
+        <div className="not-last-child:mb-2">
+          <Typography variant="subhead1">{translate('text_1746629929876zz4937djyc8')}</Typography>
+          <Typography variant="caption">{translate('text_1746629929876gdgxt1v86eq')}</Typography>
+        </div>
+        <div className="flex gap-6 *:flex-1">
+          <group.AppField name="name" listeners={{ onChange: onNameChange }}>
+            {(field) => (
+              <field.TextInputField
+                label={nameLabel}
+                placeholder={translate('text_62876e85e32e0300e1803121')}
+              />
+            )}
+          </group.AppField>
+          <group.AppField name="code">
+            {(field) => (
+              <field.TextInputField
+                label={translate('text_62876e85e32e0300e1803127')}
+                placeholder={translate('text_623b42ff8ee4e000ba87d0c4')}
+              />
+            )}
+          </group.AppField>
+        </div>
+      </section>
+    )
+  },
+})

--- a/src/components/alerts/__tests__/utils.test.ts
+++ b/src/components/alerts/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
-import { sortAndFormatThresholds } from '~/components/alerts/utils'
-import { AlertThreshold, CurrencyEnum } from '~/generated/graphql'
+import { patchThreshold, sortAndFormatThresholds } from '~/components/alerts/utils'
+import { AlertThreshold, CurrencyEnum, ThresholdInput } from '~/generated/graphql'
 
 const threshold = (overrides: Partial<AlertThreshold> = {}): AlertThreshold => ({
   code: 'threshold-code',
@@ -79,6 +79,60 @@ describe('sortAndFormatThresholds', () => {
     describe('WHEN formatting the thresholds', () => {
       it('THEN should return an empty list', () => {
         expect(sortAndFormatThresholds([], CurrencyEnum.Usd, false)).toEqual([])
+      })
+    })
+  })
+})
+
+describe('patchThreshold', () => {
+  const baseThreshold: ThresholdInput = { code: 'initial-code', recurring: false, value: '100' }
+
+  describe('GIVEN a code cell', () => {
+    describe('WHEN it receives a value', () => {
+      it('THEN should store it and leave the other fields untouched', () => {
+        expect(patchThreshold(baseThreshold, 'code', 'new-code')).toEqual({
+          code: 'new-code',
+          recurring: false,
+          value: '100',
+        })
+      })
+    })
+
+    describe('WHEN it is emptied', () => {
+      it('THEN should store no code rather than the "undefined" string', () => {
+        expect(patchThreshold(baseThreshold, 'code', undefined).code).toBeUndefined()
+      })
+    })
+  })
+
+  describe('GIVEN a value cell', () => {
+    describe('WHEN it receives a value', () => {
+      it('THEN should store it as a string', () => {
+        expect(patchThreshold(baseThreshold, 'value', 250).value).toBe('250')
+      })
+    })
+
+    describe('WHEN it is emptied', () => {
+      it('THEN should store an empty string, as the API type requires one', () => {
+        expect(patchThreshold(baseThreshold, 'value', undefined).value).toBe('')
+      })
+    })
+  })
+
+  describe('GIVEN the recurring flag', () => {
+    describe('WHEN it is toggled', () => {
+      it('THEN should store a real boolean', () => {
+        expect(patchThreshold(baseThreshold, 'recurring', true).recurring).toBe(true)
+      })
+    })
+  })
+
+  describe('GIVEN any patch', () => {
+    describe('WHEN it is applied', () => {
+      it('THEN should not mutate the original threshold', () => {
+        patchThreshold(baseThreshold, 'value', '999')
+
+        expect(baseThreshold.value).toBe('100')
       })
     })
   })

--- a/src/components/alerts/useAlertFormLeaveGuards.ts
+++ b/src/components/alerts/useAlertFormLeaveGuards.ts
@@ -1,0 +1,54 @@
+import { ApolloError } from '@apollo/client'
+import { useEffect } from 'react'
+
+import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
+import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+type UseAlertFormLeaveGuardsParams = {
+  isEdition: boolean
+  alertLoading: boolean
+  alertError?: ApolloError
+  onLeave: (options?: { replace?: boolean }) => void
+}
+
+type UseAlertFormLeaveGuardsReturn = {
+  openDirtyAttributesWarning: () => void
+}
+
+/**
+ * The two leave paths shared by the wallet and subscription alert forms: the
+ * dirty-form confirmation dialog, and the redirect to the alerts list when the
+ * edited alert is not found (e.g., deleted while on the edit page).
+ */
+export const useAlertFormLeaveGuards = ({
+  isEdition,
+  alertLoading,
+  alertError,
+  onLeave,
+}: UseAlertFormLeaveGuardsParams): UseAlertFormLeaveGuardsReturn => {
+  const { translate } = useInternationalization()
+  const centralizedDialog = useCentralizedDialog()
+
+  const openDirtyAttributesWarning = () =>
+    centralizedDialog.open({
+      title: translate('text_6244277fe0975300fe3fb940'),
+      description: translate('text_1746623860224gh7o1exyjch'),
+      actionText: translate('text_6244277fe0975300fe3fb94c'),
+      colorVariant: 'danger',
+      onAction: () => onLeave(),
+    })
+
+  useEffect(() => {
+    if (isEdition && !alertLoading && hasDefinedGQLError('NotFound', alertError)) {
+      addToast({
+        severity: 'info',
+        translateKey: 'text_1737477631498hwm4np3kbnd',
+      })
+      // Use replace to prevent back button from returning to this deleted alert page
+      onLeave({ replace: true })
+    }
+  }, [isEdition, alertLoading, alertError, onLeave])
+
+  return { openDirtyAttributesWarning }
+}

--- a/src/components/alerts/utils.ts
+++ b/src/components/alerts/utils.ts
@@ -54,3 +54,60 @@ export const patchThreshold = (
 
   return { ...threshold, value: asString ?? '' }
 }
+
+/** The slice of an alert form the thresholds table adapter relies on. */
+type ThresholdsFormApi = {
+  setFieldValue: (
+    field: 'thresholds',
+    updater: ThresholdInput[] | ((current: ThresholdInput[]) => ThresholdInput[]),
+  ) => void
+}
+
+type ThresholdSetters = {
+  setThresholds: (newThresholds: ThresholdInput[]) => void
+  setThresholdValue: (params: {
+    index: number
+    key: keyof ThresholdInput
+    newValue: unknown
+  }) => void
+}
+
+/**
+ * The two callbacks the form-library-agnostic thresholds table needs, bound to
+ * an alert form. The per-cell patch always rewrites the whole array: a
+ * bracket-index write would turn it into a plain object if the base value were
+ * ever missing.
+ */
+export const createThresholdSetters = (form: ThresholdsFormApi): ThresholdSetters => ({
+  setThresholds: (newThresholds) => {
+    form.setFieldValue('thresholds', newThresholds)
+  },
+  setThresholdValue: ({ index, key, newValue }) => {
+    form.setFieldValue('thresholds', (currentThresholds) =>
+      currentThresholds.map((threshold, i) =>
+        i === index ? patchThreshold(threshold, key, newValue) : threshold,
+      ),
+    )
+  },
+})
+
+/** The slice of an alert form the duplicate-code error handler relies on. */
+type CodeErrorFormApi = {
+  setErrorMap: (errorMap: {
+    onDynamic: { fields: { code: { message: string; path: ['code'] } } }
+  }) => void
+}
+
+/**
+ * Marks the code field with the "value already exists" error and scrolls back
+ * to it, as both alert forms do when the API rejects a duplicate code.
+ */
+export const setCodeAlreadyExistsError = (formApi: CodeErrorFormApi): void => {
+  formApi.setErrorMap({
+    onDynamic: {
+      fields: { code: { message: 'text_632a2d437e341dcc76817556', path: ['code'] } },
+    },
+  })
+
+  document.getElementById('root')?.scrollTo({ top: 0 })
+}

--- a/src/components/alerts/utils.ts
+++ b/src/components/alerts/utils.ts
@@ -1,5 +1,5 @@
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
-import { AlertThreshold, CurrencyEnum } from '~/generated/graphql'
+import { AlertThreshold, CurrencyEnum, ThresholdInput } from '~/generated/graphql'
 
 /**
  * Turns the API thresholds of an alert into the shape the thresholds table
@@ -31,4 +31,26 @@ export const sortAndFormatThresholds = (
 
   // Combine the recurring threshold with the sorted non-recurring thresholds
   return [...sortedNonRecurringThresholds, ...(!!recurringThreshold ? [recurringThreshold] : [])]
+}
+
+/**
+ * The thresholds table is form-library agnostic: it patches a single cell with
+ * an untyped value. This is the one boundary where that value is turned back
+ * into a typed threshold, one key at a time.
+ *
+ * An emptied cell arrives as `undefined`; `value` is stored as `''` instead
+ * since the API type requires a string, and both are equally empty for the
+ * validation, the inputs and the serialized payload.
+ */
+export const patchThreshold = (
+  threshold: ThresholdInput,
+  key: keyof ThresholdInput,
+  newValue: unknown,
+): ThresholdInput => {
+  const asString = newValue === undefined || newValue === null ? undefined : String(newValue)
+
+  if (key === 'code') return { ...threshold, code: asString }
+  if (key === 'recurring') return { ...threshold, recurring: !!newValue }
+
+  return { ...threshold, value: asString ?? '' }
 }

--- a/src/pages/AlertForm.tsx
+++ b/src/pages/AlertForm.tsx
@@ -1,16 +1,15 @@
 import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
+import { revalidateLogic, useStore } from '@tanstack/react-form'
 import { useCallback, useEffect, useMemo } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
-import { array, boolean, number, object, string } from 'yup'
 
 import AlertThresholds, { isThresholdValueValid } from '~/components/alerts/Thresholds'
-import { sortAndFormatThresholds } from '~/components/alerts/utils'
+import { patchThreshold } from '~/components/alerts/utils'
 import { Button } from '~/components/designSystem/Button'
 import { Chip } from '~/components/designSystem/Chip'
 import { Typography } from '~/components/designSystem/Typography'
 import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
-import { ComboBox, ComboBoxField, ComboboxItem, TextInput, TextInputField } from '~/components/form'
+import { ComboBox, ComboboxItem } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { CustomerSubscriptionDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
@@ -19,11 +18,9 @@ import {
   PLAN_SUBSCRIPTION_DETAILS_ROUTE,
   useNavigate,
 } from '~/core/router'
-import { serializeAmount } from '~/core/serializers/serializeAmount'
-import { updateNameAndMaybeCode } from '~/core/utils/updateNameAndMaybeCode'
+import { formatCodeFromName } from '~/core/utils/formatCodeFromName'
 import {
   AlertTypeEnum,
-  CreateSubscriptionAlertInput,
   CurrencyEnum,
   LagoApiError,
   ThresholdInput,
@@ -35,7 +32,22 @@ import {
   useUpdateSubscriptionAlertMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
+import {
+  mapFormToCreateInput,
+  mapFormToUpdateInput,
+  mapFromApiToForm,
+} from '~/pages/alertForm/mappers'
+import { isBillableMetricAlertType, isUnitsAlertType } from '~/pages/alertForm/utils'
+import { subscriptionAlertValidationSchema } from '~/pages/alertForm/validationSchema'
 import { FormLoadingSkeleton } from '~/styles/mainObjectsForm'
+
+const SUBSCRIPTION_ALERT_FORM_ID = 'create-alert'
+
+export const SUBSCRIPTION_ALERT_FORM_TEST_ID = 'subscription-alert-form'
+export const SUBSCRIPTION_ALERT_TYPE_COMBOBOX_TEST_ID = 'subscription-alert-type-combobox'
+export const CLOSE_SUBSCRIPTION_ALERT_BUTTON_TEST_ID = 'close-subscription-alert-button'
+export const SUBMIT_SUBSCRIPTION_ALERT_TEST_ID = 'submit-subscription-alert'
 
 gql`
   query getSubscriptionInfos($id: ID!) {
@@ -100,15 +112,6 @@ gql`
     }
   }
 `
-
-const isUnitsAlertType = (type?: AlertTypeEnum | string): boolean =>
-  type === AlertTypeEnum.BillableMetricCurrentUsageUnits ||
-  type === AlertTypeEnum.BillableMetricLifetimeUsageUnits
-
-const isBillableMetricAlertType = (type?: AlertTypeEnum | string): boolean =>
-  type === AlertTypeEnum.BillableMetricCurrentUsageUnits ||
-  type === AlertTypeEnum.BillableMetricCurrentUsageAmount ||
-  type === AlertTypeEnum.BillableMetricLifetimeUsageUnits
 
 const AlertForm = () => {
   const { alertId = '', customerId = '', planId = '', subscriptionId = '' } = useParams()
@@ -192,15 +195,14 @@ const AlertForm = () => {
     [customerId, navigate, planId, subscriptionId],
   )
 
-  const warnLeaving = useCallback(() => {
+  const openDirtyAttributesWarning = () =>
     centralizedDialog.open({
       title: translate('text_6244277fe0975300fe3fb940'),
       description: translate('text_1746623860224gh7o1exyjch'),
       actionText: translate('text_6244277fe0975300fe3fb94c'),
       colorVariant: 'danger',
-      onAction: onLeave,
+      onAction: () => onLeave(),
     })
-  }, [centralizedDialog, onLeave, translate])
 
   // Redirect to alerts list if alert is not found (e.g., deleted while on edit page)
   useEffect(() => {
@@ -214,128 +216,97 @@ const AlertForm = () => {
     }
   }, [isEdition, alertLoading, alertError, onLeave])
 
-  const [updateAlert, { error: updateError }] = useUpdateSubscriptionAlertMutation({
-    onCompleted({ updateSubscriptionAlert }) {
-      if (!!updateSubscriptionAlert?.id) {
+  const [updateAlert] = useUpdateSubscriptionAlertMutation()
+  const [createAlert] = useCreateSubscriptionAlertMutation()
+
+  const defaultValues = useMemo(
+    () =>
+      mapFromApiToForm({
+        currency,
+        alert: existingAlert,
+      }),
+    [currency, existingAlert],
+  )
+
+  const form = useAppForm({
+    defaultValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: subscriptionAlertValidationSchema,
+    },
+    onSubmit: async ({ value, formApi }) => {
+      const { alertType: valueAlertType } = value
+
+      // Guaranteed by the schema, narrows the type for the mappers
+      if (!valueAlertType) return
+
+      const validatedValues = { ...value, alertType: valueAlertType }
+
+      const onCodeAlreadyExists = () => {
+        formApi.setErrorMap({
+          onDynamic: {
+            fields: { code: { message: 'text_632a2d437e341dcc76817556', path: ['code'] } },
+          },
+        })
+
+        document.getElementById('root')?.scrollTo({ top: 0 })
+      }
+
+      if (!!existingAlert?.id) {
+        const { data: updateData, errors } = await updateAlert({
+          variables: {
+            input: mapFormToUpdateInput(validatedValues, existingAlert.id, currency),
+          },
+        })
+
+        if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
+          onCodeAlreadyExists()
+
+          return
+        }
+
+        if (!updateData?.updateSubscriptionAlert?.id) return
+
         addToast({
           severity: 'success',
           translateKey: 'text_1746623860224qwhtxyuophr',
         })
+      } else {
+        const { data: createData, errors } = await createAlert({
+          variables: {
+            input: mapFormToCreateInput(validatedValues, subscriptionId, currency),
+          },
+        })
 
-        onLeave()
-      }
-    },
-  })
+        if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
+          onCodeAlreadyExists()
 
-  const [createAlert, { error: createError }] = useCreateSubscriptionAlertMutation({
-    onCompleted({ createSubscriptionAlert }) {
-      if (!!createSubscriptionAlert?.id) {
+          return
+        }
+
+        if (!createData?.createSubscriptionAlert?.id) return
+
         addToast({
           severity: 'success',
           translateKey: 'text_1746611635509ov7jepx55bz',
         })
-
-        onLeave()
       }
+
+      onLeave()
     },
   })
 
-  const formikProps = useFormik<CreateSubscriptionAlertInput>({
-    initialValues: {
-      name: existingAlert?.name || '',
-      code: existingAlert?.code || '',
-      // @ts-expect-error alertType is mandatory but default value should be empty string
-      alertType: existingAlert?.alertType || '',
-      billableMetricId: existingAlert?.billableMetric?.id || '',
-      // Note: we need to sort the thresholds by value and recuring last.
-      // We don't really know how the backend will return the thresholds as we don't check the order if they are saved via API
-      thresholds: !!existingAlert?.thresholds?.length
-        ? sortAndFormatThresholds(
-            existingAlert?.thresholds,
-            currency,
-            isUnitsAlertType(existingAlert?.alertType),
-          )
-        : [
-            {
-              code: '',
-              recurring: false,
-              value: '',
-            },
-          ],
-    },
-    validationSchema: object().shape({
-      name: string(),
-      code: string().required(''),
-      alertType: string().required(''),
-      billableMetricId: string(),
-      thresholds: array()
-        .of(
-          object().shape({
-            code: string(),
-            recurring: boolean().required(''),
-            value: number().required(''),
-          }),
-        )
-        .nullable(),
-    }),
-    enableReinitialize: true,
-    validateOnMount: true,
-    onSubmit: async ({ billableMetricId, alertType, thresholds, ...values }) => {
-      const formattedThresholds = thresholds?.map((threshold) => ({
-        ...threshold,
-        value: isUnitsAlertType(alertType)
-          ? threshold.value.split('.')[0]
-          : String(serializeAmount(threshold.value, currency)),
-      }))
-
-      // Edition
-      if (!!existingAlert?.id) {
-        await updateAlert({
-          variables: {
-            input: {
-              ...values,
-              id: existingAlert.id,
-              billableMetricId: billableMetricId || undefined,
-              thresholds: formattedThresholds || undefined,
-            },
-          },
-        })
-      } else {
-        await createAlert({
-          variables: {
-            input: {
-              ...values,
-              alertType,
-              subscriptionId: subscriptionId,
-              billableMetricId: billableMetricId || undefined,
-              thresholds: formattedThresholds || undefined,
-            },
-          },
-        })
-      }
-    },
-  })
-
-  useEffect(() => {
-    if (hasDefinedGQLError('ValueAlreadyExist', createError || updateError)) {
-      formikProps.setFieldError('code', 'text_632a2d437e341dcc76817556')
-      const rootElement = document.getElementById('root')
-
-      if (!rootElement) return
-      rootElement.scrollTo({ top: 0 })
-    }
-
-    return undefined
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [createError, formikProps.setFieldError, updateError])
+  const isDirty = useStore(form.store, (state) => state.isDirty)
+  const alertType = useStore(form.store, (state) => state.values.alertType)
+  const billableMetricId = useStore(form.store, (state) => state.values.billableMetricId)
+  const thresholds = useStore(form.store, (state) => state.values.thresholds)
 
   const showThresholdTable = useMemo(
     () =>
-      formikProps.values.alertType === AlertTypeEnum.CurrentUsageAmount ||
-      formikProps.values.alertType === AlertTypeEnum.LifetimeUsageAmount ||
-      (isBillableMetricAlertType(formikProps.values.alertType) &&
-        !!formikProps.values.billableMetricId),
-    [formikProps.values.alertType, formikProps.values.billableMetricId],
+      alertType === AlertTypeEnum.CurrentUsageAmount ||
+      alertType === AlertTypeEnum.LifetimeUsageAmount ||
+      (isBillableMetricAlertType(alertType) && !!billableMetricId),
+    [alertType, billableMetricId],
   )
 
   const comboboxData = useMemo(() => {
@@ -343,8 +314,7 @@ const AlertForm = () => {
       const { id, code, name } = item
 
       const hasAlertOnBillableMetric = existingAlertsData?.subscriptionAlerts?.collection.some(
-        (alert) =>
-          alert.billableMetricId === id && alert.alertType === formikProps.values.alertType,
+        (alert) => alert.billableMetricId === id && alert.alertType === alertType,
       )
 
       return {
@@ -366,7 +336,7 @@ const AlertForm = () => {
   }, [
     subscriptionBillableMetricsData?.billableMetrics?.collection,
     existingAlertsData?.subscriptionAlerts?.collection,
-    formikProps.values.alertType,
+    alertType,
   ])
 
   const { hasUsageAmountAlert, hasLifetimeUsageAmountAlert } = useMemo(() => {
@@ -390,19 +360,19 @@ const AlertForm = () => {
   }, [existingAlertsData?.subscriptionAlerts?.collection])
 
   const hasAnyNonRecurringThresholdError = useMemo(() => {
-    const localNonRecurringThresholds = formikProps.values.thresholds.filter(
-      (threshold) => !threshold.recurring,
-    )
+    const localNonRecurringThresholds = thresholds.filter((threshold) => !threshold.recurring)
 
     return localNonRecurringThresholds.some((threshold, i) =>
       isThresholdValueValid(i, threshold.value, localNonRecurringThresholds),
     )
-  }, [formikProps.values.thresholds])
+  }, [thresholds])
 
-  const setThresholds = (thresholds: ThresholdInput[]) => {
-    formikProps.setFieldValue('thresholds', thresholds)
+  const setThresholds = (newThresholds: ThresholdInput[]) => {
+    form.setFieldValue('thresholds', newThresholds)
   }
 
+  // Always rewrite the whole array: a bracket-index write would turn it into a
+  // plain object if the base value were ever missing
   const setThresholdValue = ({
     index,
     key,
@@ -412,12 +382,36 @@ const AlertForm = () => {
     key: keyof ThresholdInput
     newValue: unknown
   }) => {
-    formikProps.setFieldValue(`thresholds.${index}.${key}`, newValue)
+    form.setFieldValue('thresholds', (currentThresholds) =>
+      currentThresholds.map((threshold, i) =>
+        i === index ? patchThreshold(threshold, key, newValue) : threshold,
+      ),
+    )
+  }
+
+  // The code is derived from the name until the user takes ownership of it,
+  // and never on an alert that already had one (`updateNameAndMaybeCode` parity)
+  const onNameChange = ({ value }: { value: string }) => {
+    if (form.getFieldMeta('code')?.isBlurred || !!existingAlert?.code) return
+
+    form.setFieldValue('code', formatCodeFromName(value))
+  }
+
+  const onAbort = () => (isDirty ? openDirtyAttributesWarning() : onLeave())
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    form.handleSubmit()
   }
 
   return (
-    <>
-      <CenteredPage.Wrapper>
+    <CenteredPage.Wrapper>
+      <form
+        id={SUBSCRIPTION_ALERT_FORM_ID}
+        className="flex size-full min-h-full flex-col overflow-auto"
+        onSubmit={handleSubmit}
+        data-test={SUBSCRIPTION_ALERT_FORM_TEST_ID}
+      >
         <CenteredPage.Header>
           <div className="flex gap-3">
             <Typography variant="bodyHl" color="textSecondary" noWrap>
@@ -430,12 +424,13 @@ const AlertForm = () => {
           <Button
             variant="quaternary"
             icon="close"
-            onClick={() => (formikProps.dirty ? warnLeaving() : onLeave())}
+            onClick={onAbort}
+            data-test={CLOSE_SUBSCRIPTION_ALERT_BUTTON_TEST_ID}
           />
         </CenteredPage.Header>
 
         <CenteredPage.Container>
-          {isLoading && <FormLoadingSkeleton id="create-alert" />}
+          {isLoading && <FormLoadingSkeleton id={SUBSCRIPTION_ALERT_FORM_ID} />}
           {!isLoading && (
             <>
               <div className="not-last-child:mb-1">
@@ -458,22 +453,22 @@ const AlertForm = () => {
                     </Typography>
                   </div>
                   <div className="flex gap-6 *:flex-1">
-                    <TextInput
-                      name="name"
-                      label={translate('text_1732286530467zstzwbegfiq')}
-                      placeholder={translate('text_62876e85e32e0300e1803121')}
-                      value={formikProps.values.name || ''}
-                      onChange={(name) => {
-                        updateNameAndMaybeCode({ name, formikProps })
-                      }}
-                    />
-                    <TextInputField
-                      name="code"
-                      label={translate('text_62876e85e32e0300e1803127')}
-                      placeholder={translate('text_623b42ff8ee4e000ba87d0c4')}
-                      formikProps={formikProps}
-                      error={formikProps.errors.code}
-                    />
+                    <form.AppField name="name" listeners={{ onChange: onNameChange }}>
+                      {(field) => (
+                        <field.TextInputField
+                          label={translate('text_1732286530467zstzwbegfiq')}
+                          placeholder={translate('text_62876e85e32e0300e1803121')}
+                        />
+                      )}
+                    </form.AppField>
+                    <form.AppField name="code">
+                      {(field) => (
+                        <field.TextInputField
+                          label={translate('text_62876e85e32e0300e1803127')}
+                          placeholder={translate('text_623b42ff8ee4e000ba87d0c4')}
+                        />
+                      )}
+                    </form.AppField>
                   </div>
                 </section>
 
@@ -493,7 +488,7 @@ const AlertForm = () => {
                       placeholder={translate('text_1746631350478bwa1swfpwky')}
                       disabled={isEdition}
                       disableClearable={isEdition}
-                      value={formikProps.values.alertType}
+                      value={alertType}
                       data={[
                         {
                           label: translate('text_1748418710304kqjnk1owpeq'),
@@ -519,37 +514,33 @@ const AlertForm = () => {
                         },
                       ]}
                       onChange={(value) => {
-                        const newFormikValues = {
-                          ...formikProps.values,
-                          alertType: value as AlertTypeEnum,
-                          // Reset billableMetricId when alertType is changed
-                          billableMetricId: '',
-                        }
-
-                        formikProps.setValues(newFormikValues)
+                        form.setFieldValue('alertType', value as AlertTypeEnum)
+                        // Reset billableMetricId when alertType is changed
+                        form.setFieldValue('billableMetricId', '')
                       }}
+                      data-test={SUBSCRIPTION_ALERT_TYPE_COMBOBOX_TEST_ID}
                     />
 
-                    {isBillableMetricAlertType(formikProps.values.alertType) && (
-                      <>
-                        <ComboBoxField
-                          name="billableMetricId"
-                          label={translate('text_1746780648463scppfjbhd1b')}
-                          placeholder={translate('text_1746780648463n39xfvr772k')}
-                          disabled={isEdition}
-                          data={comboboxData}
-                          formikProps={formikProps}
-                        />
-                      </>
+                    {isBillableMetricAlertType(alertType) && (
+                      <form.AppField name="billableMetricId">
+                        {(field) => (
+                          <field.ComboBoxField
+                            label={translate('text_1746780648463scppfjbhd1b')}
+                            placeholder={translate('text_1746780648463n39xfvr772k')}
+                            disabled={isEdition}
+                            data={comboboxData}
+                          />
+                        )}
+                      </form.AppField>
                     )}
 
                     {showThresholdTable && (
                       <AlertThresholds
-                        thresholds={formikProps.values.thresholds}
+                        thresholds={thresholds}
                         setThresholds={setThresholds}
                         setThresholdValue={setThresholdValue}
                         currency={currency}
-                        shouldHandleUnits={isUnitsAlertType(formikProps.values.alertType)}
+                        shouldHandleUnits={isUnitsAlertType(alertType)}
                       />
                     )}
                   </div>
@@ -560,29 +551,23 @@ const AlertForm = () => {
         </CenteredPage.Container>
 
         <CenteredPage.StickyFooter>
-          <Button
-            variant="quaternary"
-            onClick={() => (formikProps.dirty ? warnLeaving() : onLeave())}
-          >
+          <Button variant="quaternary" onClick={onAbort}>
             {translate('text_6411e6b530cb47007488b027')}
           </Button>
-          <Button
-            variant="primary"
-            disabled={
-              !formikProps.isValid ||
-              !formikProps.dirty ||
-              isLoading ||
-              hasAnyNonRecurringThresholdError
-            }
-            onClick={formikProps.submitForm}
-          >
-            {translate(
-              isEdition ? 'text_17432414198706rdwf76ek3u' : 'text_1747917472538el8fg31n3i8',
-            )}
-          </Button>
+          <form.AppForm>
+            <form.SubmitButton
+              variant="primary"
+              disabled={isLoading || hasAnyNonRecurringThresholdError}
+              dataTest={SUBMIT_SUBSCRIPTION_ALERT_TEST_ID}
+            >
+              {translate(
+                isEdition ? 'text_17432414198706rdwf76ek3u' : 'text_1747917472538el8fg31n3i8',
+              )}
+            </form.SubmitButton>
+          </form.AppForm>
         </CenteredPage.StickyFooter>
-      </CenteredPage.Wrapper>
-    </>
+      </form>
+    </CenteredPage.Wrapper>
   )
 }
 

--- a/src/pages/AlertForm.tsx
+++ b/src/pages/AlertForm.tsx
@@ -1,14 +1,15 @@
 import { gql } from '@apollo/client'
 import { revalidateLogic, useStore } from '@tanstack/react-form'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
+import { AlertNameAndCodeSection } from '~/components/alerts/AlertNameAndCodeSection'
 import AlertThresholds, { isThresholdValueValid } from '~/components/alerts/Thresholds'
-import { patchThreshold } from '~/components/alerts/utils'
+import { useAlertFormLeaveGuards } from '~/components/alerts/useAlertFormLeaveGuards'
+import { createThresholdSetters, setCodeAlreadyExistsError } from '~/components/alerts/utils'
 import { Button } from '~/components/designSystem/Button'
 import { Chip } from '~/components/designSystem/Chip'
 import { Typography } from '~/components/designSystem/Typography'
-import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { ComboBox, ComboboxItem } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
@@ -18,12 +19,10 @@ import {
   PLAN_SUBSCRIPTION_DETAILS_ROUTE,
   useNavigate,
 } from '~/core/router'
-import { formatCodeFromName } from '~/core/utils/formatCodeFromName'
 import {
   AlertTypeEnum,
   CurrencyEnum,
   LagoApiError,
-  ThresholdInput,
   useCreateSubscriptionAlertMutation,
   useGetExistingAlertsOfSubscriptionQuery,
   useGetSubscriptionAlertToEditQuery,
@@ -117,7 +116,6 @@ const AlertForm = () => {
   const { alertId = '', customerId = '', planId = '', subscriptionId = '' } = useParams()
   const { translate } = useInternationalization()
   const navigate = useNavigate()
-  const centralizedDialog = useCentralizedDialog()
   const isEdition = !!alertId
 
   const { data: subscriptionData, loading: subscriptionLoading } = useGetSubscriptionInfosQuery({
@@ -195,26 +193,12 @@ const AlertForm = () => {
     [customerId, navigate, planId, subscriptionId],
   )
 
-  const openDirtyAttributesWarning = () =>
-    centralizedDialog.open({
-      title: translate('text_6244277fe0975300fe3fb940'),
-      description: translate('text_1746623860224gh7o1exyjch'),
-      actionText: translate('text_6244277fe0975300fe3fb94c'),
-      colorVariant: 'danger',
-      onAction: () => onLeave(),
-    })
-
-  // Redirect to alerts list if alert is not found (e.g., deleted while on edit page)
-  useEffect(() => {
-    if (isEdition && !alertLoading && hasDefinedGQLError('NotFound', alertError)) {
-      addToast({
-        severity: 'info',
-        translateKey: 'text_1737477631498hwm4np3kbnd',
-      })
-      // Use replace to prevent back button from returning to this deleted alert page
-      onLeave({ replace: true })
-    }
-  }, [isEdition, alertLoading, alertError, onLeave])
+  const { openDirtyAttributesWarning } = useAlertFormLeaveGuards({
+    isEdition,
+    alertLoading,
+    alertError,
+    onLeave,
+  })
 
   const [updateAlert] = useUpdateSubscriptionAlertMutation()
   const [createAlert] = useCreateSubscriptionAlertMutation()
@@ -242,16 +226,6 @@ const AlertForm = () => {
 
       const validatedValues = { ...value, alertType: valueAlertType }
 
-      const onCodeAlreadyExists = () => {
-        formApi.setErrorMap({
-          onDynamic: {
-            fields: { code: { message: 'text_632a2d437e341dcc76817556', path: ['code'] } },
-          },
-        })
-
-        document.getElementById('root')?.scrollTo({ top: 0 })
-      }
-
       if (!!existingAlert?.id) {
         const { data: updateData, errors } = await updateAlert({
           variables: {
@@ -260,7 +234,7 @@ const AlertForm = () => {
         })
 
         if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
-          onCodeAlreadyExists()
+          setCodeAlreadyExistsError(formApi)
 
           return
         }
@@ -279,7 +253,7 @@ const AlertForm = () => {
         })
 
         if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
-          onCodeAlreadyExists()
+          setCodeAlreadyExistsError(formApi)
 
           return
         }
@@ -367,35 +341,7 @@ const AlertForm = () => {
     )
   }, [thresholds])
 
-  const setThresholds = (newThresholds: ThresholdInput[]) => {
-    form.setFieldValue('thresholds', newThresholds)
-  }
-
-  // Always rewrite the whole array: a bracket-index write would turn it into a
-  // plain object if the base value were ever missing
-  const setThresholdValue = ({
-    index,
-    key,
-    newValue,
-  }: {
-    index: number
-    key: keyof ThresholdInput
-    newValue: unknown
-  }) => {
-    form.setFieldValue('thresholds', (currentThresholds) =>
-      currentThresholds.map((threshold, i) =>
-        i === index ? patchThreshold(threshold, key, newValue) : threshold,
-      ),
-    )
-  }
-
-  // The code is derived from the name until the user takes ownership of it,
-  // and never on an alert that already had one (`updateNameAndMaybeCode` parity)
-  const onNameChange = ({ value }: { value: string }) => {
-    if (form.getFieldMeta('code')?.isBlurred || !!existingAlert?.code) return
-
-    form.setFieldValue('code', formatCodeFromName(value))
-  }
+  const { setThresholds, setThresholdValue } = useMemo(() => createThresholdSetters(form), [form])
 
   const onAbort = () => (isDirty ? openDirtyAttributesWarning() : onLeave())
 
@@ -443,34 +389,12 @@ const AlertForm = () => {
               </div>
 
               <div className="flex flex-col gap-12">
-                <section className="pb-12 shadow-b not-last-child:mb-6">
-                  <div className="not-last-child:mb-2">
-                    <Typography variant="subhead1">
-                      {translate('text_1746629929876zz4937djyc8')}
-                    </Typography>
-                    <Typography variant="caption">
-                      {translate('text_1746629929876gdgxt1v86eq')}
-                    </Typography>
-                  </div>
-                  <div className="flex gap-6 *:flex-1">
-                    <form.AppField name="name" listeners={{ onChange: onNameChange }}>
-                      {(field) => (
-                        <field.TextInputField
-                          label={translate('text_1732286530467zstzwbegfiq')}
-                          placeholder={translate('text_62876e85e32e0300e1803121')}
-                        />
-                      )}
-                    </form.AppField>
-                    <form.AppField name="code">
-                      {(field) => (
-                        <field.TextInputField
-                          label={translate('text_62876e85e32e0300e1803127')}
-                          placeholder={translate('text_623b42ff8ee4e000ba87d0c4')}
-                        />
-                      )}
-                    </form.AppField>
-                  </div>
-                </section>
+                <AlertNameAndCodeSection
+                  form={form}
+                  fields={{ name: 'name', code: 'code' }}
+                  nameLabel={translate('text_1732286530467zstzwbegfiq')}
+                  hasExistingCode={!!existingAlert?.code}
+                />
 
                 <section className="not-last-child:mb-6">
                   <div className="not-last-child:mb-2">

--- a/src/pages/__tests__/AlertForm.test.tsx
+++ b/src/pages/__tests__/AlertForm.test.tsx
@@ -1,0 +1,758 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
+import { AlertTypeEnum } from '~/generated/graphql'
+import { render, testMockNavigateFn } from '~/test-utils'
+
+import AlertForm, {
+  CLOSE_SUBSCRIPTION_ALERT_BUTTON_TEST_ID,
+  SUBMIT_SUBSCRIPTION_ALERT_TEST_ID,
+  SUBSCRIPTION_ALERT_FORM_TEST_ID,
+  SUBSCRIPTION_ALERT_TYPE_COMBOBOX_TEST_ID,
+} from '../AlertForm'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+// The combobox list is virtualized, so jsdom renders no option. Swap the
+// unbound alert type combobox for a native select: the option list, the
+// per-option disabled state and the reset-on-change wiring stay real, only the
+// MUI popper is out of the picture.
+jest.mock('~/components/form/ComboBox/ComboBox', () => ({
+  ComboBox: ({
+    data,
+    value,
+    disabled,
+    onChange,
+    'data-test': dataTest,
+  }: {
+    data: { value: string; label: string; disabled?: boolean }[]
+    value?: string
+    disabled?: boolean
+    onChange: (value: string) => void
+    'data-test'?: string
+  }) => (
+    <select
+      data-test={dataTest}
+      disabled={disabled}
+      value={value ?? ''}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      <option value="" />
+      {data.map(({ value: optionValue, label, disabled: optionDisabled }) => (
+        <option key={optionValue} value={optionValue} disabled={optionDisabled}>
+          {label}
+        </option>
+      ))}
+    </select>
+  ),
+}))
+
+// Same virtualization constraint for the billable metric field wrapper
+const BILLABLE_METRIC_COMBOBOX_TEST_ID = 'mock-billable-metric-combobox'
+
+jest.mock('~/components/form/ComboBox/ComboBoxFieldForTanstack', () => {
+  const { useFieldContext } = jest.requireActual<typeof import('~/hooks/forms/formContext')>(
+    '~/hooks/forms/formContext',
+  )
+
+  return {
+    __esModule: true,
+    default: function MockComboBoxField({
+      data,
+      disabled,
+    }: {
+      data: { value: string; label: string; disabled?: boolean }[]
+      disabled?: boolean
+    }) {
+      const field = useFieldContext<string | undefined>()
+
+      return (
+        <select
+          data-test="mock-billable-metric-combobox"
+          name={field.name}
+          disabled={disabled}
+          value={field.state.value ?? ''}
+          onChange={(event) => field.handleChange(event.target.value)}
+        >
+          <option value="" />
+          {data.map(({ value, label, disabled: optionDisabled }) => (
+            <option key={value} value={value} disabled={optionDisabled}>
+              {label}
+            </option>
+          ))}
+        </select>
+      )
+    },
+  }
+})
+
+const mockDialogOpen = jest.fn()
+
+jest.mock('~/components/dialogs/CentralizedDialog', () => ({
+  useCentralizedDialog: () => ({ open: mockDialogOpen }),
+}))
+
+// The thresholds table stays form-library agnostic, so it is stubbed down to
+// the two callbacks the form adapter has to honour
+const THRESHOLDS_TABLE_TEST_ID = 'mock-alert-thresholds'
+const SET_THRESHOLDS_BUTTON = 'mock-set-thresholds'
+const SET_THRESHOLD_VALUE_BUTTON = 'mock-set-threshold-value'
+
+jest.mock('~/components/alerts/Thresholds', () => ({
+  __esModule: true,
+  default: ({
+    setThresholds,
+    setThresholdValue,
+  }: {
+    setThresholds: (thresholds: unknown[]) => void
+    setThresholdValue: (params: { index: number; key: string; newValue: unknown }) => void
+  }) => (
+    <div data-test="mock-alert-thresholds">
+      <button
+        type="button"
+        data-test={SET_THRESHOLDS_BUTTON}
+        onClick={() => setThresholds([{ code: 'first', recurring: false, value: '10' }])}
+      />
+      <button
+        type="button"
+        data-test={SET_THRESHOLD_VALUE_BUTTON}
+        onClick={() => setThresholdValue({ index: 0, key: 'value', newValue: '25' })}
+      />
+    </div>
+  ),
+  isThresholdValueValid: () => false,
+}))
+
+jest.mock('~/styles/mainObjectsForm', () => ({
+  FormLoadingSkeleton: ({ id }: { id: string }) => (
+    <div data-test={`form-loading-skeleton-${id}`} />
+  ),
+}))
+
+const mockUseGetSubscriptionInfosQuery = jest.fn()
+const mockUseGetSubscriptionAlertToEditQuery = jest.fn()
+const mockUseGetExistingAlertsOfSubscriptionQuery = jest.fn()
+const mockUseGetSubscriptionBillableMetricsQuery = jest.fn()
+const mockCreateSubscriptionAlert = jest.fn()
+const mockUpdateSubscriptionAlert = jest.fn()
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useGetSubscriptionInfosQuery: (...args: unknown[]) => mockUseGetSubscriptionInfosQuery(...args),
+  useGetSubscriptionAlertToEditQuery: (...args: unknown[]) =>
+    mockUseGetSubscriptionAlertToEditQuery(...args),
+  useGetExistingAlertsOfSubscriptionQuery: (...args: unknown[]) =>
+    mockUseGetExistingAlertsOfSubscriptionQuery(...args),
+  useGetSubscriptionBillableMetricsQuery: (...args: unknown[]) =>
+    mockUseGetSubscriptionBillableMetricsQuery(...args),
+  useCreateSubscriptionAlertMutation: () => [mockCreateSubscriptionAlert],
+  useUpdateSubscriptionAlertMutation: () => [mockUpdateSubscriptionAlert],
+}))
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: jest.fn(),
+  hasDefinedGQLError: jest.fn(() => false),
+}))
+
+const existingAlert = {
+  id: 'alert-1',
+  alertType: AlertTypeEnum.BillableMetricCurrentUsageUnits,
+  billableMetric: { id: 'bm-1', code: 'bm_code', name: 'BM One' },
+  code: 'my-alert',
+  name: 'My alert',
+  thresholds: [{ code: 'first', recurring: false, value: '12' }],
+}
+
+const mockLoadedQueries = ({
+  alert,
+  existingAlerts = [],
+}: {
+  alert?: typeof existingAlert
+  existingAlerts?: { alertType: AlertTypeEnum; billableMetricId?: string }[]
+} = {}) => {
+  mockUseGetSubscriptionInfosQuery.mockReturnValue({
+    data: {
+      subscription: {
+        id: 'subscription-1',
+        externalId: 'sub-ext-1',
+        plan: { id: 'plan-1', amountCurrency: 'USD' },
+      },
+    },
+    loading: false,
+  })
+  mockUseGetSubscriptionAlertToEditQuery.mockReturnValue({
+    data: alert ? { subscriptionAlert: alert } : undefined,
+    loading: false,
+    error: undefined,
+  })
+  mockUseGetExistingAlertsOfSubscriptionQuery.mockReturnValue({
+    data: {
+      subscriptionAlerts: {
+        collection: existingAlerts.map(({ alertType, billableMetricId }, index) => ({
+          id: `existing-${index}`,
+          alertType,
+          billableMetricId: billableMetricId ?? null,
+        })),
+      },
+    },
+    loading: false,
+  })
+  mockUseGetSubscriptionBillableMetricsQuery.mockReturnValue({
+    data: {
+      billableMetrics: {
+        collection: [
+          { id: 'bm-1', code: 'bm_code', name: 'BM One' },
+          { id: 'bm-2', code: 'bm_code_2', name: 'BM Two' },
+        ],
+      },
+    },
+    loading: false,
+  })
+}
+
+const setParams = (params: Record<string, string>) => {
+  const useParamsMock = jest.requireMock('react-router-dom').useParams as jest.Mock
+
+  useParamsMock.mockReturnValue(params)
+}
+
+const getInput = (name: string) =>
+  document.querySelector(`input[name="${name}"]`) as HTMLInputElement
+
+const getAlertTypeSelect = () =>
+  screen.getByTestId(SUBSCRIPTION_ALERT_TYPE_COMBOBOX_TEST_ID) as HTMLSelectElement
+
+const getBillableMetricSelect = () =>
+  screen.getByTestId(BILLABLE_METRIC_COMBOBOX_TEST_ID) as HTMLSelectElement
+
+const pickAlertType = async (
+  user: ReturnType<typeof userEvent.setup>,
+  alertType: AlertTypeEnum,
+) => {
+  await user.selectOptions(getAlertTypeSelect(), alertType)
+}
+
+describe('AlertForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCreateSubscriptionAlert.mockResolvedValue({
+      data: { createSubscriptionAlert: { id: 'alert-1' } },
+      errors: undefined,
+    })
+    mockUpdateSubscriptionAlert.mockResolvedValue({
+      data: { updateSubscriptionAlert: { id: 'alert-1' } },
+      errors: undefined,
+    })
+    setParams({ subscriptionId: 'subscription-1', customerId: 'customer-1' })
+  })
+
+  describe('GIVEN loading state', () => {
+    beforeEach(() => {
+      mockUseGetSubscriptionInfosQuery.mockReturnValue({ data: undefined, loading: true })
+      mockUseGetSubscriptionAlertToEditQuery.mockReturnValue({
+        data: undefined,
+        loading: false,
+        error: undefined,
+      })
+      mockUseGetExistingAlertsOfSubscriptionQuery.mockReturnValue({
+        data: undefined,
+        loading: true,
+      })
+      mockUseGetSubscriptionBillableMetricsQuery.mockReturnValue({
+        data: undefined,
+        loading: false,
+      })
+    })
+
+    describe('WHEN queries are loading', () => {
+      it('THEN should show loading skeleton', () => {
+        render(<AlertForm />)
+
+        expect(screen.getByTestId('form-loading-skeleton-create-alert')).toBeInTheDocument()
+      })
+
+      it('THEN should disable the submit button', () => {
+        render(<AlertForm />)
+
+        expect(screen.getByTestId(SUBMIT_SUBSCRIPTION_ALERT_TEST_ID)).toBeDisabled()
+      })
+    })
+  })
+
+  describe('GIVEN create mode', () => {
+    describe('WHEN the form is loaded', () => {
+      beforeEach(() => {
+        mockLoadedQueries()
+      })
+
+      it('THEN should render the form without loading skeleton', () => {
+        render(<AlertForm />)
+
+        expect(screen.queryByTestId('form-loading-skeleton-create-alert')).not.toBeInTheDocument()
+      })
+
+      it.each([
+        ['form', SUBSCRIPTION_ALERT_FORM_TEST_ID],
+        ['alert type combobox', SUBSCRIPTION_ALERT_TYPE_COMBOBOX_TEST_ID],
+        ['submit button', SUBMIT_SUBSCRIPTION_ALERT_TEST_ID],
+        ['close button', CLOSE_SUBSCRIPTION_ALERT_BUTTON_TEST_ID],
+      ])('THEN should display the %s', (_, testId) => {
+        render(<AlertForm />)
+
+        expect(screen.getByTestId(testId)).toBeInTheDocument()
+      })
+
+      it.each([
+        ['name', 'name'],
+        ['code', 'code'],
+      ])('THEN should display an empty %s input', (_, name) => {
+        render(<AlertForm />)
+
+        expect(getInput(name)).toHaveValue('')
+      })
+
+      it('THEN should offer every subscription alert type', () => {
+        render(<AlertForm />)
+
+        expect(getAlertTypeSelect().querySelectorAll('option[value]:not([value=""])')).toHaveLength(
+          5,
+        )
+      })
+
+      it('THEN should not display the thresholds table until a type is picked', () => {
+        render(<AlertForm />)
+
+        expect(screen.queryByTestId(THRESHOLDS_TABLE_TEST_ID)).not.toBeInTheDocument()
+      })
+
+      it('THEN should not display the billable metric combobox until a metric type is picked', () => {
+        render(<AlertForm />)
+
+        expect(screen.queryByTestId(BILLABLE_METRIC_COMBOBOX_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN picking an amount alert type', () => {
+      it('THEN should display the thresholds table right away', async () => {
+        const user = userEvent.setup()
+
+        mockLoadedQueries()
+        render(<AlertForm />)
+
+        await pickAlertType(user, AlertTypeEnum.CurrentUsageAmount)
+
+        expect(screen.getByTestId(THRESHOLDS_TABLE_TEST_ID)).toBeInTheDocument()
+        expect(screen.queryByTestId(BILLABLE_METRIC_COMBOBOX_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN picking a billable-metric alert type', () => {
+      beforeEach(() => {
+        mockLoadedQueries()
+      })
+
+      it('THEN should display the billable metric combobox but no thresholds table yet', async () => {
+        const user = userEvent.setup()
+
+        render(<AlertForm />)
+
+        await pickAlertType(user, AlertTypeEnum.BillableMetricCurrentUsageUnits)
+
+        expect(getBillableMetricSelect()).toBeInTheDocument()
+        expect(screen.queryByTestId(THRESHOLDS_TABLE_TEST_ID)).not.toBeInTheDocument()
+      })
+
+      it('THEN should display the thresholds table once a metric is picked', async () => {
+        const user = userEvent.setup()
+
+        render(<AlertForm />)
+
+        await pickAlertType(user, AlertTypeEnum.BillableMetricCurrentUsageUnits)
+        await user.selectOptions(getBillableMetricSelect(), 'bm-1')
+
+        expect(screen.getByTestId(THRESHOLDS_TABLE_TEST_ID)).toBeInTheDocument()
+      })
+
+      it('THEN should reset the picked metric when the alert type changes', async () => {
+        const user = userEvent.setup()
+
+        render(<AlertForm />)
+
+        await pickAlertType(user, AlertTypeEnum.BillableMetricCurrentUsageUnits)
+        await user.selectOptions(getBillableMetricSelect(), 'bm-1')
+        await pickAlertType(user, AlertTypeEnum.BillableMetricCurrentUsageAmount)
+
+        expect(getBillableMetricSelect()).toHaveValue('')
+        expect(screen.queryByTestId(THRESHOLDS_TABLE_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the subscription already has amount alerts', () => {
+      it('THEN should disable the taken amount alert types', () => {
+        mockLoadedQueries({
+          existingAlerts: [
+            { alertType: AlertTypeEnum.CurrentUsageAmount },
+            { alertType: AlertTypeEnum.LifetimeUsageAmount },
+          ],
+        })
+        render(<AlertForm />)
+
+        const disabledOptions = Array.from(
+          getAlertTypeSelect().querySelectorAll('option[disabled]'),
+        ).map((option) => option.getAttribute('value'))
+
+        expect(disabledOptions).toEqual([
+          AlertTypeEnum.LifetimeUsageAmount,
+          AlertTypeEnum.CurrentUsageAmount,
+        ])
+      })
+    })
+
+    describe('WHEN a metric already has an alert of the picked type', () => {
+      it('THEN should disable that metric row only', async () => {
+        const user = userEvent.setup()
+
+        mockLoadedQueries({
+          existingAlerts: [
+            {
+              alertType: AlertTypeEnum.BillableMetricCurrentUsageUnits,
+              billableMetricId: 'bm-1',
+            },
+          ],
+        })
+        render(<AlertForm />)
+
+        await pickAlertType(user, AlertTypeEnum.BillableMetricCurrentUsageUnits)
+
+        const disabledOptions = Array.from(
+          getBillableMetricSelect().querySelectorAll('option[disabled]'),
+        ).map((option) => option.getAttribute('value'))
+
+        expect(disabledOptions).toEqual(['bm-1'])
+      })
+
+      it('THEN should keep the metric enabled for another alert type', async () => {
+        const user = userEvent.setup()
+
+        mockLoadedQueries({
+          existingAlerts: [
+            {
+              alertType: AlertTypeEnum.BillableMetricCurrentUsageUnits,
+              billableMetricId: 'bm-1',
+            },
+          ],
+        })
+        render(<AlertForm />)
+
+        await pickAlertType(user, AlertTypeEnum.BillableMetricCurrentUsageAmount)
+
+        expect(getBillableMetricSelect().querySelectorAll('option[disabled]')).toHaveLength(0)
+      })
+    })
+
+    describe('WHEN typing a name', () => {
+      beforeEach(() => {
+        mockLoadedQueries()
+      })
+
+      it('THEN should derive the code from it', async () => {
+        const user = userEvent.setup()
+
+        render(<AlertForm />)
+
+        await user.type(getInput('name'), 'My alert')
+
+        expect(getInput('code')).toHaveValue('my_alert')
+      })
+
+      it('THEN should stop deriving it once the code has been edited', async () => {
+        const user = userEvent.setup()
+
+        render(<AlertForm />)
+
+        await user.type(getInput('code'), 'custom-code')
+        await user.tab()
+        await user.type(getInput('name'), 'My alert')
+
+        expect(getInput('code')).toHaveValue('custom-code')
+      })
+    })
+
+    describe('WHEN submitting a valid form', () => {
+      beforeEach(() => {
+        mockLoadedQueries()
+      })
+
+      it('THEN should create the alert with the serialized thresholds', async () => {
+        const user = userEvent.setup()
+
+        render(<AlertForm />)
+
+        await user.type(getInput('code'), 'my-alert')
+        await pickAlertType(user, AlertTypeEnum.CurrentUsageAmount)
+        await user.click(screen.getByTestId(SET_THRESHOLDS_BUTTON))
+        await user.click(screen.getByTestId(SUBMIT_SUBSCRIPTION_ALERT_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockCreateSubscriptionAlert).toHaveBeenCalledWith({
+            variables: {
+              input: {
+                name: '',
+                code: 'my-alert',
+                alertType: AlertTypeEnum.CurrentUsageAmount,
+                subscriptionId: 'subscription-1',
+                billableMetricId: undefined,
+                thresholds: [{ code: 'first', recurring: false, value: '1000' }],
+              },
+            },
+          })
+        })
+      })
+
+      it('THEN should carry the picked billable metric in the create input', async () => {
+        const user = userEvent.setup()
+
+        render(<AlertForm />)
+
+        await user.type(getInput('code'), 'my-alert')
+        await pickAlertType(user, AlertTypeEnum.BillableMetricCurrentUsageUnits)
+        await user.selectOptions(getBillableMetricSelect(), 'bm-1')
+        await user.click(screen.getByTestId(SET_THRESHOLDS_BUTTON))
+        await user.click(screen.getByTestId(SUBMIT_SUBSCRIPTION_ALERT_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockCreateSubscriptionAlert).toHaveBeenCalledWith(
+            expect.objectContaining({
+              variables: {
+                input: expect.objectContaining({
+                  alertType: AlertTypeEnum.BillableMetricCurrentUsageUnits,
+                  billableMetricId: 'bm-1',
+                  thresholds: [{ code: 'first', recurring: false, value: '10' }],
+                }),
+              },
+            }),
+          )
+        })
+      })
+
+      it('THEN should show a success toast and leave the form', async () => {
+        const user = userEvent.setup()
+
+        render(<AlertForm />)
+
+        await user.type(getInput('code'), 'my-alert')
+        await pickAlertType(user, AlertTypeEnum.CurrentUsageAmount)
+        await user.click(screen.getByTestId(SET_THRESHOLDS_BUTTON))
+        await user.click(screen.getByTestId(SUBMIT_SUBSCRIPTION_ALERT_TEST_ID))
+
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+        })
+        expect(testMockNavigateFn).toHaveBeenCalled()
+      })
+
+      it('THEN should send the value patched on a single threshold cell', async () => {
+        const user = userEvent.setup()
+
+        render(<AlertForm />)
+
+        await user.type(getInput('code'), 'my-alert')
+        await pickAlertType(user, AlertTypeEnum.CurrentUsageAmount)
+        await user.click(screen.getByTestId(SET_THRESHOLDS_BUTTON))
+        await user.click(screen.getByTestId(SET_THRESHOLD_VALUE_BUTTON))
+        await user.click(screen.getByTestId(SUBMIT_SUBSCRIPTION_ALERT_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockCreateSubscriptionAlert).toHaveBeenCalledWith(
+            expect.objectContaining({
+              variables: {
+                input: expect.objectContaining({
+                  thresholds: [{ code: 'first', recurring: false, value: '2500' }],
+                }),
+              },
+            }),
+          )
+        })
+      })
+    })
+
+    describe('WHEN submitting without a required field', () => {
+      it('THEN should not call the mutation', async () => {
+        const user = userEvent.setup()
+
+        mockLoadedQueries()
+        render(<AlertForm />)
+
+        await user.click(screen.getByTestId(SUBMIT_SUBSCRIPTION_ALERT_TEST_ID))
+
+        await waitFor(() => {
+          expect(screen.getByTestId(SUBMIT_SUBSCRIPTION_ALERT_TEST_ID)).toBeDisabled()
+        })
+        expect(mockCreateSubscriptionAlert).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the code already exists', () => {
+      it('THEN should keep the user on the form', async () => {
+        const user = userEvent.setup()
+
+        mockLoadedQueries()
+        mockCreateSubscriptionAlert.mockResolvedValue({
+          data: undefined,
+          errors: [{ message: 'ValueAlreadyExist' }],
+        })
+        ;(hasDefinedGQLError as jest.Mock).mockImplementation(
+          (code: string) => code === 'ValueAlreadyExist',
+        )
+
+        render(<AlertForm />)
+
+        await user.type(getInput('code'), 'my-alert')
+        await pickAlertType(user, AlertTypeEnum.CurrentUsageAmount)
+        await user.click(screen.getByTestId(SET_THRESHOLDS_BUTTON))
+        await user.click(screen.getByTestId(SUBMIT_SUBSCRIPTION_ALERT_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockCreateSubscriptionAlert).toHaveBeenCalled()
+        })
+        expect(testMockNavigateFn).not.toHaveBeenCalled()
+        expect(addToast).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN edition mode', () => {
+    beforeEach(() => {
+      setParams({
+        subscriptionId: 'subscription-1',
+        customerId: 'customer-1',
+        alertId: 'alert-1',
+      })
+      mockLoadedQueries({ alert: existingAlert })
+    })
+
+    describe('WHEN the form is loaded', () => {
+      it.each([
+        ['name', 'name', 'My alert'],
+        ['code', 'code', 'my-alert'],
+      ])('THEN should prefill the %s input', async (_, name, expected) => {
+        render(<AlertForm />)
+
+        await waitFor(() => {
+          expect(getInput(name)).toHaveValue(expected)
+        })
+      })
+
+      it('THEN should lock the alert type', () => {
+        render(<AlertForm />)
+
+        expect(getAlertTypeSelect()).toBeDisabled()
+      })
+
+      it('THEN should lock the billable metric and prefill it', () => {
+        render(<AlertForm />)
+
+        expect(getBillableMetricSelect()).toBeDisabled()
+        expect(getBillableMetricSelect()).toHaveValue('bm-1')
+      })
+
+      it('THEN should display the thresholds table', () => {
+        render(<AlertForm />)
+
+        expect(screen.getByTestId(THRESHOLDS_TABLE_TEST_ID)).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN submitting the form', () => {
+      it('THEN should update the alert without the immutable fields', async () => {
+        const user = userEvent.setup()
+
+        render(<AlertForm />)
+
+        await waitFor(() => {
+          expect(getInput('code')).toHaveValue('my-alert')
+        })
+
+        await user.clear(getInput('code'))
+        await user.type(getInput('code'), 'renamed-alert')
+        await user.click(screen.getByTestId(SUBMIT_SUBSCRIPTION_ALERT_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockUpdateSubscriptionAlert).toHaveBeenCalledWith({
+            variables: {
+              input: {
+                id: 'alert-1',
+                name: 'My alert',
+                code: 'renamed-alert',
+                billableMetricId: 'bm-1',
+                thresholds: [{ code: 'first', recurring: false, value: '12' }],
+              },
+            },
+          })
+        })
+      })
+    })
+
+    describe('WHEN the alert has been deleted meanwhile', () => {
+      it('THEN should notify the user and redirect without a history entry', async () => {
+        mockUseGetSubscriptionAlertToEditQuery.mockReturnValue({
+          data: undefined,
+          loading: false,
+          error: { message: 'NotFound' },
+        })
+        ;(hasDefinedGQLError as jest.Mock).mockImplementation((code: string) => code === 'NotFound')
+
+        render(<AlertForm />)
+
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'info' }))
+        })
+        expect(testMockNavigateFn).toHaveBeenCalledWith(
+          expect.stringContaining('subscription-1'),
+          expect.objectContaining({ replace: true }),
+        )
+      })
+    })
+  })
+
+  describe('GIVEN a dirty form', () => {
+    describe('WHEN closing it', () => {
+      it('THEN should ask the user to confirm', async () => {
+        const user = userEvent.setup()
+
+        mockLoadedQueries()
+        render(<AlertForm />)
+
+        await user.type(getInput('name'), 'My alert')
+        await user.click(screen.getByTestId(CLOSE_SUBSCRIPTION_ALERT_BUTTON_TEST_ID))
+
+        expect(mockDialogOpen).toHaveBeenCalledWith(
+          expect.objectContaining({ colorVariant: 'danger' }),
+        )
+        expect(testMockNavigateFn).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN a pristine form', () => {
+    describe('WHEN closing it', () => {
+      it('THEN should leave without confirmation', async () => {
+        const user = userEvent.setup()
+
+        mockLoadedQueries()
+        render(<AlertForm />)
+
+        await user.click(screen.getByTestId(CLOSE_SUBSCRIPTION_ALERT_BUTTON_TEST_ID))
+
+        expect(mockDialogOpen).not.toHaveBeenCalled()
+        expect(testMockNavigateFn).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/pages/alertForm/__tests__/mappers.test.ts
+++ b/src/pages/alertForm/__tests__/mappers.test.ts
@@ -1,0 +1,234 @@
+import { AlertTypeEnum, CurrencyEnum, GetSubscriptionAlertToEditQuery } from '~/generated/graphql'
+import {
+  mapFormToCreateInput,
+  mapFormToUpdateInput,
+  mapFromApiToForm,
+} from '~/pages/alertForm/mappers'
+import { TValidatedSubscriptionAlertForm } from '~/pages/alertForm/validationSchema'
+
+type ExistingAlert = NonNullable<GetSubscriptionAlertToEditQuery['subscriptionAlert']>
+
+const existingAlert = (overrides: Partial<ExistingAlert> = {}): ExistingAlert => ({
+  __typename: 'Alert',
+  id: 'alert-1',
+  alertType: AlertTypeEnum.CurrentUsageAmount,
+  billableMetric: null,
+  code: 'my-alert',
+  name: 'My alert',
+  thresholds: [{ __typename: 'AlertThreshold', code: 'first', recurring: false, value: '1000' }],
+  ...overrides,
+})
+
+const formValues = (
+  overrides: Partial<TValidatedSubscriptionAlertForm> = {},
+): TValidatedSubscriptionAlertForm => ({
+  name: 'My alert',
+  code: 'my-alert',
+  alertType: AlertTypeEnum.CurrentUsageAmount,
+  billableMetricId: '',
+  thresholds: [{ code: 'first', recurring: false, value: '10' }],
+  ...overrides,
+})
+
+describe('mapFromApiToForm', () => {
+  describe('GIVEN no existing alert', () => {
+    describe('WHEN building the form values', () => {
+      it('THEN should return empty values with a single empty threshold', () => {
+        expect(mapFromApiToForm({ currency: CurrencyEnum.Usd, alert: undefined })).toEqual({
+          name: '',
+          code: '',
+          alertType: '',
+          billableMetricId: '',
+          thresholds: [{ code: '', recurring: false, value: '' }],
+        })
+      })
+    })
+  })
+
+  describe('GIVEN an existing amount alert', () => {
+    describe('WHEN building the form values', () => {
+      it('THEN should prefill the fields and deserialize the threshold amount', () => {
+        expect(
+          mapFromApiToForm({
+            currency: CurrencyEnum.Usd,
+            alert: existingAlert(),
+          }),
+        ).toEqual({
+          name: 'My alert',
+          code: 'my-alert',
+          alertType: AlertTypeEnum.CurrentUsageAmount,
+          billableMetricId: '',
+          thresholds: [{ code: 'first', recurring: false, value: '10' }],
+        })
+      })
+
+      it('THEN should drop the __typename of the edit query', () => {
+        const { thresholds } = mapFromApiToForm({
+          currency: CurrencyEnum.Usd,
+          alert: existingAlert(),
+        })
+
+        expect(thresholds[0]).not.toHaveProperty('__typename')
+      })
+    })
+  })
+
+  describe('GIVEN an existing billable-metric alert', () => {
+    describe('WHEN building the form values', () => {
+      it('THEN should prefill the billable metric id', () => {
+        const { billableMetricId } = mapFromApiToForm({
+          currency: CurrencyEnum.Usd,
+          alert: existingAlert({
+            alertType: AlertTypeEnum.BillableMetricCurrentUsageAmount,
+            billableMetric: {
+              __typename: 'BillableMetric',
+              id: 'bm-1',
+              code: 'bm_code',
+              name: 'BM One',
+            },
+          }),
+        })
+
+        expect(billableMetricId).toBe('bm-1')
+      })
+
+      it('THEN should truncate a units threshold instead of deserializing it', () => {
+        const { thresholds } = mapFromApiToForm({
+          currency: CurrencyEnum.Usd,
+          alert: existingAlert({
+            alertType: AlertTypeEnum.BillableMetricCurrentUsageUnits,
+            thresholds: [
+              { __typename: 'AlertThreshold', code: 'first', recurring: false, value: '12.99' },
+            ],
+          }),
+        })
+
+        expect(thresholds).toEqual([{ code: 'first', recurring: false, value: '12' }])
+      })
+    })
+  })
+})
+
+describe('mapFormToCreateInput', () => {
+  describe('GIVEN an amount alert', () => {
+    describe('WHEN building the create input', () => {
+      it('THEN should serialize the thresholds to cents and omit the empty billable metric', () => {
+        expect(mapFormToCreateInput(formValues(), 'subscription-1', CurrencyEnum.Usd)).toEqual({
+          name: 'My alert',
+          code: 'my-alert',
+          alertType: AlertTypeEnum.CurrentUsageAmount,
+          subscriptionId: 'subscription-1',
+          billableMetricId: undefined,
+          thresholds: [{ code: 'first', recurring: false, value: '1000' }],
+        })
+      })
+    })
+  })
+
+  describe('GIVEN a units alert', () => {
+    describe('WHEN building the create input', () => {
+      it('THEN should truncate the thresholds to integers and carry the billable metric', () => {
+        expect(
+          mapFormToCreateInput(
+            formValues({
+              alertType: AlertTypeEnum.BillableMetricCurrentUsageUnits,
+              billableMetricId: 'bm-1',
+              thresholds: [{ code: 'first', recurring: false, value: '12.99' }],
+            }),
+            'subscription-1',
+            CurrencyEnum.Usd,
+          ),
+        ).toEqual({
+          name: 'My alert',
+          code: 'my-alert',
+          alertType: AlertTypeEnum.BillableMetricCurrentUsageUnits,
+          subscriptionId: 'subscription-1',
+          billableMetricId: 'bm-1',
+          thresholds: [{ code: 'first', recurring: false, value: '12' }],
+        })
+      })
+    })
+  })
+
+  describe('GIVEN a billable-metric amount alert', () => {
+    describe('WHEN building the create input', () => {
+      it('THEN should serialize the thresholds to cents', () => {
+        const { thresholds } = mapFormToCreateInput(
+          formValues({
+            alertType: AlertTypeEnum.BillableMetricCurrentUsageAmount,
+            billableMetricId: 'bm-1',
+          }),
+          'subscription-1',
+          CurrencyEnum.Usd,
+        )
+
+        expect(thresholds).toEqual([{ code: 'first', recurring: false, value: '1000' }])
+      })
+    })
+  })
+
+  describe('GIVEN a recurring threshold', () => {
+    describe('WHEN building the create input', () => {
+      it('THEN should keep its recurring flag', () => {
+        const { thresholds } = mapFormToCreateInput(
+          formValues({
+            thresholds: [
+              { code: 'first', recurring: false, value: '10' },
+              { code: 'recurring', recurring: true, value: '5' },
+            ],
+          }),
+          'subscription-1',
+          CurrencyEnum.Usd,
+        )
+
+        expect(thresholds).toEqual([
+          { code: 'first', recurring: false, value: '1000' },
+          { code: 'recurring', recurring: true, value: '500' },
+        ])
+      })
+    })
+  })
+})
+
+describe('mapFormToUpdateInput', () => {
+  describe('GIVEN an existing alert', () => {
+    describe('WHEN building the update input', () => {
+      it('THEN should carry the id and omit the immutable alertType and subscriptionId', () => {
+        expect(mapFormToUpdateInput(formValues(), 'alert-1', CurrencyEnum.Usd)).toEqual({
+          id: 'alert-1',
+          name: 'My alert',
+          code: 'my-alert',
+          billableMetricId: undefined,
+          thresholds: [{ code: 'first', recurring: false, value: '1000' }],
+        })
+      })
+
+      it('THEN should carry the billable metric id when the alert has one', () => {
+        const { billableMetricId } = mapFormToUpdateInput(
+          formValues({
+            alertType: AlertTypeEnum.BillableMetricCurrentUsageAmount,
+            billableMetricId: 'bm-1',
+          }),
+          'alert-1',
+          CurrencyEnum.Usd,
+        )
+
+        expect(billableMetricId).toBe('bm-1')
+      })
+
+      it('THEN should still use the alert type to serialize the thresholds', () => {
+        const { thresholds } = mapFormToUpdateInput(
+          formValues({
+            alertType: AlertTypeEnum.BillableMetricLifetimeUsageUnits,
+            billableMetricId: 'bm-1',
+            thresholds: [{ code: 'first', recurring: false, value: '12.99' }],
+          }),
+          'alert-1',
+          CurrencyEnum.Usd,
+        )
+
+        expect(thresholds).toEqual([{ code: 'first', recurring: false, value: '12' }])
+      })
+    })
+  })
+})

--- a/src/pages/alertForm/__tests__/utils.test.ts
+++ b/src/pages/alertForm/__tests__/utils.test.ts
@@ -1,0 +1,42 @@
+import { AlertTypeEnum } from '~/generated/graphql'
+import { isBillableMetricAlertType, isUnitsAlertType } from '~/pages/alertForm/utils'
+
+describe('isUnitsAlertType', () => {
+  describe('GIVEN a subscription alert type', () => {
+    it.each([
+      [AlertTypeEnum.BillableMetricCurrentUsageUnits, true],
+      [AlertTypeEnum.BillableMetricLifetimeUsageUnits, true],
+      [AlertTypeEnum.BillableMetricCurrentUsageAmount, false],
+      [AlertTypeEnum.CurrentUsageAmount, false],
+      [AlertTypeEnum.LifetimeUsageAmount, false],
+    ])('THEN should return %s for %s', (alertType, expected) => {
+      expect(isUnitsAlertType(alertType)).toBe(expected)
+    })
+  })
+
+  describe('GIVEN no alert type picked yet', () => {
+    it('THEN should return false', () => {
+      expect(isUnitsAlertType('')).toBe(false)
+    })
+  })
+})
+
+describe('isBillableMetricAlertType', () => {
+  describe('GIVEN a subscription alert type', () => {
+    it.each([
+      [AlertTypeEnum.BillableMetricCurrentUsageUnits, true],
+      [AlertTypeEnum.BillableMetricCurrentUsageAmount, true],
+      [AlertTypeEnum.BillableMetricLifetimeUsageUnits, true],
+      [AlertTypeEnum.CurrentUsageAmount, false],
+      [AlertTypeEnum.LifetimeUsageAmount, false],
+    ])('THEN should return %s for %s', (alertType, expected) => {
+      expect(isBillableMetricAlertType(alertType)).toBe(expected)
+    })
+  })
+
+  describe('GIVEN no alert type picked yet', () => {
+    it('THEN should return false', () => {
+      expect(isBillableMetricAlertType('')).toBe(false)
+    })
+  })
+})

--- a/src/pages/alertForm/__tests__/validationSchema.test.ts
+++ b/src/pages/alertForm/__tests__/validationSchema.test.ts
@@ -1,0 +1,135 @@
+import { AlertTypeEnum } from '~/generated/graphql'
+import {
+  subscriptionAlertValidationSchema,
+  TSubscriptionAlertForm,
+} from '~/pages/alertForm/validationSchema'
+
+const REQUIRED_ERROR = 'text_1771342994699klxu2paz7g8'
+
+const validValues = (overrides: Partial<TSubscriptionAlertForm> = {}): TSubscriptionAlertForm => ({
+  name: 'My alert',
+  code: 'my-alert',
+  alertType: AlertTypeEnum.CurrentUsageAmount,
+  billableMetricId: '',
+  thresholds: [{ code: 'threshold-code', recurring: false, value: '100' }],
+  ...overrides,
+})
+
+const errorsOf = (values: unknown): { path: string; message: string }[] => {
+  const result = subscriptionAlertValidationSchema.safeParse(values)
+
+  if (result.success) return []
+
+  return result.error.issues.map((issue) => ({
+    path: issue.path.join('.'),
+    message: issue.message,
+  }))
+}
+
+describe('subscriptionAlertValidationSchema', () => {
+  describe('GIVEN a fully filled form', () => {
+    describe('WHEN validating it', () => {
+      it('THEN should report no error', () => {
+        expect(errorsOf(validValues())).toEqual([])
+      })
+    })
+  })
+
+  describe('GIVEN an optional field', () => {
+    describe('WHEN the name is left empty', () => {
+      it('THEN should report no error', () => {
+        expect(errorsOf(validValues({ name: '' }))).toEqual([])
+      })
+    })
+
+    describe('WHEN a threshold has no code', () => {
+      it('THEN should report no error', () => {
+        expect(errorsOf(validValues({ thresholds: [{ recurring: false, value: '100' }] }))).toEqual(
+          [],
+        )
+      })
+    })
+
+    describe('WHEN no billable metric is picked', () => {
+      it('THEN should report no error, since the gate on it is indirect', () => {
+        expect(
+          errorsOf(
+            validValues({
+              alertType: AlertTypeEnum.BillableMetricCurrentUsageUnits,
+              billableMetricId: '',
+            }),
+          ),
+        ).toEqual([])
+      })
+    })
+  })
+
+  describe('GIVEN a required field left empty', () => {
+    describe('WHEN the code is empty', () => {
+      it('THEN should report the generic required error on the code', () => {
+        expect(errorsOf(validValues({ code: '' }))).toEqual([
+          { path: 'code', message: REQUIRED_ERROR },
+        ])
+      })
+    })
+
+    describe.each([
+      ['not picked yet', ''],
+      ['cleared from the combobox', undefined],
+    ])('WHEN the alert type is %s', (_, alertType) => {
+      it('THEN should report the generic required error on the alert type', () => {
+        expect(errorsOf(validValues({ alertType: alertType as '' | undefined }))).toEqual([
+          { path: 'alertType', message: REQUIRED_ERROR },
+        ])
+      })
+    })
+  })
+
+  describe('GIVEN a threshold value', () => {
+    describe.each([
+      ['empty', ''],
+      ['not a number', 'abc'],
+    ])('WHEN it is %s', (_, value) => {
+      it('THEN should report the generic required error on that row', () => {
+        expect(errorsOf(validValues({ thresholds: [{ recurring: false, value }] }))).toEqual([
+          { path: 'thresholds.0.value', message: REQUIRED_ERROR },
+        ])
+      })
+    })
+
+    describe.each([
+      ['a plain number', '100'],
+      ['a decimal', '10.5'],
+      ['zero', '0'],
+    ])('WHEN it is %s', (_, value) => {
+      it('THEN should report no error', () => {
+        expect(errorsOf(validValues({ thresholds: [{ recurring: false, value }] }))).toEqual([])
+      })
+    })
+
+    describe('WHEN a later row is empty', () => {
+      it('THEN should report the error on that row only', () => {
+        expect(
+          errorsOf(
+            validValues({
+              thresholds: [
+                { recurring: false, value: '100' },
+                { recurring: false, value: '' },
+              ],
+            }),
+          ),
+        ).toEqual([{ path: 'thresholds.1.value', message: REQUIRED_ERROR }])
+      })
+    })
+  })
+
+  describe('GIVEN a threshold without a recurring flag', () => {
+    describe('WHEN validating it', () => {
+      it('THEN should report the generic required error on the flag', () => {
+        expect(errorsOf(validValues({ thresholds: [{ recurring: null, value: '100' }] }))).toEqual([
+          { path: 'thresholds.0.recurring', message: REQUIRED_ERROR },
+        ])
+      })
+    })
+  })
+})

--- a/src/pages/alertForm/mappers.ts
+++ b/src/pages/alertForm/mappers.ts
@@ -1,0 +1,98 @@
+import { sortAndFormatThresholds } from '~/components/alerts/utils'
+import { serializeAmount } from '~/core/serializers/serializeAmount'
+import {
+  AlertTypeEnum,
+  CreateSubscriptionAlertInput,
+  CurrencyEnum,
+  GetSubscriptionAlertToEditQuery,
+  ThresholdInput,
+  UpdateSubscriptionAlertInput,
+} from '~/generated/graphql'
+import { isUnitsAlertType } from '~/pages/alertForm/utils'
+import {
+  EMPTY_SUBSCRIPTION_ALERT_THRESHOLD,
+  TSubscriptionAlertForm,
+  TValidatedSubscriptionAlertForm,
+} from '~/pages/alertForm/validationSchema'
+
+type ExistingSubscriptionAlert = GetSubscriptionAlertToEditQuery['subscriptionAlert']
+
+export const mapFromApiToForm = ({
+  currency,
+  alert,
+}: {
+  currency: CurrencyEnum
+  alert?: ExistingSubscriptionAlert
+}): TSubscriptionAlertForm => ({
+  name: alert?.name || '',
+  code: alert?.code || '',
+  alertType: alert?.alertType || '',
+  billableMetricId: alert?.billableMetric?.id || '',
+  // The API does not guarantee the thresholds order (they can be saved via
+  // API), so they are sorted by value with the recurring one last. Only the
+  // input fields are kept, so the `__typename` of the edit query never
+  // reaches the mutation payload.
+  thresholds: !!alert?.thresholds?.length
+    ? sortAndFormatThresholds(alert.thresholds, currency, isUnitsAlertType(alert.alertType)).map(
+        ({ code, recurring, value }) => ({ code, recurring, value }),
+      )
+    : [EMPTY_SUBSCRIPTION_ALERT_THRESHOLD],
+})
+
+/**
+ * Units thresholds are truncated to an integer, as the API expects no
+ * decimals. Amount thresholds are serialized to cents.
+ */
+const mapThresholdToInput = ({
+  threshold,
+  alertType,
+  currency,
+}: {
+  threshold: ThresholdInput
+  alertType: AlertTypeEnum | ''
+  currency: CurrencyEnum
+}): ThresholdInput => {
+  const value = threshold.value ?? ''
+
+  return {
+    code: threshold.code,
+    recurring: threshold.recurring,
+    value: isUnitsAlertType(alertType)
+      ? value.split('.')[0]
+      : String(serializeAmount(value, currency)),
+  }
+}
+
+export const mapFormToCreateInput = (
+  { name, code, alertType, billableMetricId, thresholds }: TValidatedSubscriptionAlertForm,
+  subscriptionId: string,
+  currency: CurrencyEnum,
+): CreateSubscriptionAlertInput => ({
+  name,
+  code,
+  alertType,
+  subscriptionId,
+  billableMetricId: billableMetricId || undefined,
+  thresholds: thresholds.map((threshold) =>
+    mapThresholdToInput({ threshold, alertType, currency }),
+  ),
+})
+
+/**
+ * The API rejects `alertType` and `subscriptionId` on update: both are
+ * immutable. `billableMetricId` is still part of the input — it is disabled on
+ * edition, so it carries the unchanged value (or is omitted when empty).
+ */
+export const mapFormToUpdateInput = (
+  { name, code, alertType, billableMetricId, thresholds }: TValidatedSubscriptionAlertForm,
+  id: string,
+  currency: CurrencyEnum,
+): UpdateSubscriptionAlertInput => ({
+  id,
+  name,
+  code,
+  billableMetricId: billableMetricId || undefined,
+  thresholds: thresholds.map((threshold) =>
+    mapThresholdToInput({ threshold, alertType, currency }),
+  ),
+})

--- a/src/pages/alertForm/utils.ts
+++ b/src/pages/alertForm/utils.ts
@@ -1,0 +1,12 @@
+import { AlertTypeEnum } from '~/generated/graphql'
+
+/** Billable-metric units alerts hold units, not amounts: no currency, integer values only. */
+export const isUnitsAlertType = (alertType?: AlertTypeEnum | ''): boolean =>
+  alertType === AlertTypeEnum.BillableMetricCurrentUsageUnits ||
+  alertType === AlertTypeEnum.BillableMetricLifetimeUsageUnits
+
+/** These alert types are scoped to a billable metric the user has to pick. */
+export const isBillableMetricAlertType = (alertType?: AlertTypeEnum | ''): boolean =>
+  alertType === AlertTypeEnum.BillableMetricCurrentUsageUnits ||
+  alertType === AlertTypeEnum.BillableMetricCurrentUsageAmount ||
+  alertType === AlertTypeEnum.BillableMetricLifetimeUsageUnits

--- a/src/pages/alertForm/validationSchema.ts
+++ b/src/pages/alertForm/validationSchema.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod'
+
+import { AlertTypeEnum, ThresholdInput } from '~/generated/graphql'
+
+/**
+ * Zod re-map of the legacy Yup schema that lived inline in `AlertForm.tsx`.
+ * Semantics are a 1:1 parity port — do not "fix" behaviours here:
+ * - Formik ran Yup on `prepareDataForValidation(values)`, which turns every
+ *   empty string into `undefined`, so `''` failed the `required()` rules and a
+ *   `number()` cast never saw it. Each rule below rejects `''` explicitly for
+ *   the same result.
+ * - every rule was declared as `required('')`, i.e. "turn the field invalid
+ *   without a visible label". Zod v4 replaces an empty message with its own
+ *   "Invalid input" default, which would then render, so each one carries the
+ *   generic required key instead. Only `code` and `alertType` can surface it:
+ *   the thresholds table is not form-aware, so its errors gate the submit
+ *   button without ever being displayed.
+ * - `name` is optional.
+ * - `billableMetricId` is intentionally optional: the real gate is indirect
+ *   (the thresholds table stays hidden until a metric is picked, and the
+ *   default threshold `value: ''` keeps the form invalid meanwhile). Making it
+ *   required here would change when the submit button unlocks.
+ * - the threshold `value` was a `number().required('')`, so a numeric-looking
+ *   string passes and anything else fails.
+ *
+ * The Yup array was additionally `.nullable()`; the form values type guarantees
+ * an array (the table always leaves at least one row), so that branch was
+ * unreachable and is not carried over.
+ */
+
+/** "Field is required" */
+const REQUIRED_ERROR = 'text_1771342994699klxu2paz7g8'
+
+const thresholdSchema = z.object({
+  code: z.string().nullish(),
+  // `boolean().required('')` — the table always writes a real boolean
+  recurring: z
+    .boolean()
+    .nullish()
+    .refine((value) => typeof value === 'boolean', {
+      message: REQUIRED_ERROR,
+    }),
+  // `number().required('')` on a string cell
+  value: z.string().refine((value) => value !== '' && !Number.isNaN(Number(value)), {
+    message: REQUIRED_ERROR,
+  }),
+})
+
+export const subscriptionAlertValidationSchema = z.object({
+  name: z.string(),
+  code: z.string().min(1, { message: REQUIRED_ERROR }),
+  // `''` before a type is picked, `undefined` once the combobox is cleared
+  alertType: z
+    .union([z.enum(AlertTypeEnum), z.literal('')])
+    .optional()
+    .refine((value) => !!value, { message: REQUIRED_ERROR }),
+  billableMetricId: z.string(),
+  thresholds: z.array(thresholdSchema),
+})
+
+/**
+ * Mirrors `CreateSubscriptionAlertInput` minus the enum strictness:
+ * `alertType` is empty until the user picks one, exactly like the Formik
+ * initial values (which cast `''` to the enum through a `@ts-expect-error`).
+ */
+export type TSubscriptionAlertForm = {
+  name: string
+  code: string
+  alertType?: AlertTypeEnum | ''
+  billableMetricId: string
+  thresholds: ThresholdInput[]
+}
+
+/**
+ * The values once the schema has run: `alertType` is guaranteed to be set, so
+ * the mappers building the mutation inputs need no cast.
+ */
+export type TValidatedSubscriptionAlertForm = TSubscriptionAlertForm & {
+  alertType: AlertTypeEnum
+}
+
+export const EMPTY_SUBSCRIPTION_ALERT_THRESHOLD: ThresholdInput = {
+  code: '',
+  recurring: false,
+  value: '',
+}

--- a/src/pages/wallet/WalletAlertForm.tsx
+++ b/src/pages/wallet/WalletAlertForm.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import AlertThresholds, { isThresholdValueValid } from '~/components/alerts/Thresholds'
+import { patchThreshold } from '~/components/alerts/utils'
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
 import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
@@ -35,11 +36,7 @@ import {
   mapFormToUpdateInput,
   mapFromApiToForm,
 } from '~/pages/wallet/walletAlertForm/mappers'
-import {
-  isWalletCreditsAlert,
-  isWalletOngoingAlert,
-  patchThreshold,
-} from '~/pages/wallet/walletAlertForm/utils'
+import { isWalletCreditsAlert, isWalletOngoingAlert } from '~/pages/wallet/walletAlertForm/utils'
 import { walletAlertValidationSchema } from '~/pages/wallet/walletAlertForm/validationSchema'
 import { WalletDetailsTabsOptionsEnum } from '~/pages/wallet/WalletDetails'
 import { FormLoadingSkeleton } from '~/styles/mainObjectsForm'

--- a/src/pages/wallet/WalletAlertForm.tsx
+++ b/src/pages/wallet/WalletAlertForm.tsx
@@ -1,13 +1,14 @@
 import { gql } from '@apollo/client'
 import { revalidateLogic, useStore } from '@tanstack/react-form'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
+import { AlertNameAndCodeSection } from '~/components/alerts/AlertNameAndCodeSection'
 import AlertThresholds, { isThresholdValueValid } from '~/components/alerts/Thresholds'
-import { patchThreshold } from '~/components/alerts/utils'
+import { useAlertFormLeaveGuards } from '~/components/alerts/useAlertFormLeaveGuards'
+import { createThresholdSetters, setCodeAlreadyExistsError } from '~/components/alerts/utils'
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
-import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import {
   CLOSE_WALLET_ALERT_BUTTON_DATA_TEST,
@@ -17,12 +18,10 @@ import {
 } from '~/components/wallets/utils/dataTestConstants'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { useNavigate, WALLET_DETAILS_ROUTE } from '~/core/router'
-import { formatCodeFromName } from '~/core/utils/formatCodeFromName'
 import {
   AlertTypeEnum,
   CurrencyEnum,
   LagoApiError,
-  ThresholdInput,
   useCreateWalletAlertMutation,
   useGetWalletAlertsQuery,
   useGetWalletAlertToEditQuery,
@@ -76,7 +75,6 @@ const WalletAlertForm = () => {
   const { alertId = '', customerId = '', walletId = '' } = useParams()
   const { translate } = useInternationalization()
   const navigate = useNavigate()
-  const centralizedDialog = useCentralizedDialog()
   const isEdition = !!alertId
 
   const { data, loading } = useGetWalletDetailsQuery({
@@ -126,26 +124,12 @@ const WalletAlertForm = () => {
     [customerId, navigate, walletId],
   )
 
-  const openDirtyAttributesWarning = () =>
-    centralizedDialog.open({
-      title: translate('text_6244277fe0975300fe3fb940'),
-      description: translate('text_1746623860224gh7o1exyjch'),
-      actionText: translate('text_6244277fe0975300fe3fb94c'),
-      colorVariant: 'danger',
-      onAction: () => onLeave(),
-    })
-
-  // Redirect to alerts list if alert is not found (e.g., deleted while on edit page)
-  useEffect(() => {
-    if (isEdition && !alertLoading && hasDefinedGQLError('NotFound', alertError)) {
-      addToast({
-        severity: 'info',
-        translateKey: 'text_1737477631498hwm4np3kbnd',
-      })
-      // Use replace to prevent back button from returning to this deleted alert page
-      onLeave({ replace: true })
-    }
-  }, [isEdition, alertLoading, alertError, onLeave])
+  const { openDirtyAttributesWarning } = useAlertFormLeaveGuards({
+    isEdition,
+    alertLoading,
+    alertError,
+    onLeave,
+  })
 
   const [updateAlert] = useUpdateWalletAlertMutation()
   const [createAlert] = useCreateWalletAlertMutation()
@@ -174,16 +158,6 @@ const WalletAlertForm = () => {
 
       const validatedValues = { ...value, alertType }
 
-      const onCodeAlreadyExists = () => {
-        formApi.setErrorMap({
-          onDynamic: {
-            fields: { code: { message: 'text_632a2d437e341dcc76817556', path: ['code'] } },
-          },
-        })
-
-        document.getElementById('root')?.scrollTo({ top: 0 })
-      }
-
       if (!!existingAlert?.id) {
         const { data: updateData, errors } = await updateAlert({
           variables: {
@@ -192,7 +166,7 @@ const WalletAlertForm = () => {
         })
 
         if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
-          onCodeAlreadyExists()
+          setCodeAlreadyExistsError(formApi)
 
           return
         }
@@ -211,7 +185,7 @@ const WalletAlertForm = () => {
         })
 
         if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
-          onCodeAlreadyExists()
+          setCodeAlreadyExistsError(formApi)
 
           return
         }
@@ -240,35 +214,7 @@ const WalletAlertForm = () => {
     )
   }, [thresholds])
 
-  const setThresholds = (newThresholds: ThresholdInput[]) => {
-    form.setFieldValue('thresholds', newThresholds)
-  }
-
-  // Always rewrite the whole array: a bracket-index write would turn it into a
-  // plain object if the base value were ever missing
-  const setThresholdValue = ({
-    index,
-    key,
-    newValue,
-  }: {
-    index: number
-    key: keyof ThresholdInput
-    newValue: unknown
-  }) => {
-    form.setFieldValue('thresholds', (currentThresholds) =>
-      currentThresholds.map((threshold, i) =>
-        i === index ? patchThreshold(threshold, key, newValue) : threshold,
-      ),
-    )
-  }
-
-  // The code is derived from the name until the user takes ownership of it,
-  // and never on an alert that already had one (`updateNameAndMaybeCode` parity)
-  const onNameChange = ({ value }: { value: string }) => {
-    if (form.getFieldMeta('code')?.isBlurred || !!existingAlert?.code) return
-
-    form.setFieldValue('code', formatCodeFromName(value))
-  }
+  const { setThresholds, setThresholdValue } = useMemo(() => createThresholdSetters(form), [form])
 
   const defaultTypesData = useMemo(
     () => [
@@ -344,34 +290,12 @@ const WalletAlertForm = () => {
               </div>
 
               <div className="flex flex-col gap-12">
-                <section className="pb-12 shadow-b not-last-child:mb-6">
-                  <div className="not-last-child:mb-2">
-                    <Typography variant="subhead1">
-                      {translate('text_1746629929876zz4937djyc8')}
-                    </Typography>
-                    <Typography variant="caption">
-                      {translate('text_1746629929876gdgxt1v86eq')}
-                    </Typography>
-                  </div>
-                  <div className="flex gap-6 *:flex-1">
-                    <form.AppField name="name" listeners={{ onChange: onNameChange }}>
-                      {(field) => (
-                        <field.TextInputField
-                          label={translate('text_1773063868176dy5v3kvne2l')}
-                          placeholder={translate('text_62876e85e32e0300e1803121')}
-                        />
-                      )}
-                    </form.AppField>
-                    <form.AppField name="code">
-                      {(field) => (
-                        <field.TextInputField
-                          label={translate('text_62876e85e32e0300e1803127')}
-                          placeholder={translate('text_623b42ff8ee4e000ba87d0c4')}
-                        />
-                      )}
-                    </form.AppField>
-                  </div>
-                </section>
+                <AlertNameAndCodeSection
+                  form={form}
+                  fields={{ name: 'name', code: 'code' }}
+                  nameLabel={translate('text_1773063868176dy5v3kvne2l')}
+                  hasExistingCode={!!existingAlert?.code}
+                />
 
                 <section className="not-last-child:mb-6">
                   <div className="not-last-child:mb-2">

--- a/src/pages/wallet/walletAlertForm/__tests__/utils.test.ts
+++ b/src/pages/wallet/walletAlertForm/__tests__/utils.test.ts
@@ -1,9 +1,5 @@
-import { AlertTypeEnum, ThresholdInput } from '~/generated/graphql'
-import {
-  isWalletCreditsAlert,
-  isWalletOngoingAlert,
-  patchThreshold,
-} from '~/pages/wallet/walletAlertForm/utils'
+import { AlertTypeEnum } from '~/generated/graphql'
+import { isWalletCreditsAlert, isWalletOngoingAlert } from '~/pages/wallet/walletAlertForm/utils'
 
 describe('isWalletCreditsAlert', () => {
   describe('GIVEN a wallet alert type', () => {
@@ -39,60 +35,6 @@ describe('isWalletOngoingAlert', () => {
   describe('GIVEN no alert type picked yet', () => {
     it('THEN should return false', () => {
       expect(isWalletOngoingAlert('')).toBe(false)
-    })
-  })
-})
-
-describe('patchThreshold', () => {
-  const threshold: ThresholdInput = { code: 'initial-code', recurring: false, value: '100' }
-
-  describe('GIVEN a code cell', () => {
-    describe('WHEN it receives a value', () => {
-      it('THEN should store it and leave the other fields untouched', () => {
-        expect(patchThreshold(threshold, 'code', 'new-code')).toEqual({
-          code: 'new-code',
-          recurring: false,
-          value: '100',
-        })
-      })
-    })
-
-    describe('WHEN it is emptied', () => {
-      it('THEN should store no code rather than the "undefined" string', () => {
-        expect(patchThreshold(threshold, 'code', undefined).code).toBeUndefined()
-      })
-    })
-  })
-
-  describe('GIVEN a value cell', () => {
-    describe('WHEN it receives a value', () => {
-      it('THEN should store it as a string', () => {
-        expect(patchThreshold(threshold, 'value', 250).value).toBe('250')
-      })
-    })
-
-    describe('WHEN it is emptied', () => {
-      it('THEN should store an empty string, as the API type requires one', () => {
-        expect(patchThreshold(threshold, 'value', undefined).value).toBe('')
-      })
-    })
-  })
-
-  describe('GIVEN the recurring flag', () => {
-    describe('WHEN it is toggled', () => {
-      it('THEN should store a real boolean', () => {
-        expect(patchThreshold(threshold, 'recurring', true).recurring).toBe(true)
-      })
-    })
-  })
-
-  describe('GIVEN any patch', () => {
-    describe('WHEN it is applied', () => {
-      it('THEN should not mutate the original threshold', () => {
-        patchThreshold(threshold, 'value', '999')
-
-        expect(threshold.value).toBe('100')
-      })
     })
   })
 })

--- a/src/pages/wallet/walletAlertForm/utils.ts
+++ b/src/pages/wallet/walletAlertForm/utils.ts
@@ -1,4 +1,4 @@
-import { AlertTypeEnum, ThresholdInput } from '~/generated/graphql'
+import { AlertTypeEnum } from '~/generated/graphql'
 
 /** Credits alerts hold units, not amounts: no currency, integer values only. */
 export const isWalletCreditsAlert = (alertType: AlertTypeEnum | ''): boolean =>
@@ -9,25 +9,3 @@ export const isWalletCreditsAlert = (alertType: AlertTypeEnum | ''): boolean =>
 export const isWalletOngoingAlert = (alertType: AlertTypeEnum | ''): boolean =>
   alertType === AlertTypeEnum.WalletOngoingBalanceAmount ||
   alertType === AlertTypeEnum.WalletCreditsOngoingBalance
-
-/**
- * The thresholds table is form-library agnostic: it patches a single cell with
- * an untyped value. This is the one boundary where that value is turned back
- * into a typed threshold, one key at a time.
- *
- * An emptied cell arrives as `undefined`; `value` is stored as `''` instead
- * since the API type requires a string, and both are equally empty for the
- * validation, the inputs and the serialized payload.
- */
-export const patchThreshold = (
-  threshold: ThresholdInput,
-  key: keyof ThresholdInput,
-  newValue: unknown,
-): ThresholdInput => {
-  const asString = newValue === undefined || newValue === null ? undefined : String(newValue)
-
-  if (key === 'code') return { ...threshold, code: asString }
-  if (key === 'recurring') return { ...threshold, recurring: !!newValue }
-
-  return { ...threshold, value: asString ?? '' }
-}


### PR DESCRIPTION
## Context

The subscription alert create/edit form was the last alert form on the legacy Formik + Yup stack. Migrating it to TanStack Form + Zod (mirroring the wallet alert migration that precedes it) unblocks the Alert Resolution feature UI, which adds a per-threshold notify-on column to the shared thresholds table.

> Stacked on #4061 (wallet alert migration) — base branch is `claude/happy-bohr-8kpjui`; only the subscription-form work is in this diff.

## Description

- Migrate `src/pages/AlertForm.tsx` from `useFormik` to `useAppForm` with `revalidateLogic()` and a Zod `onDynamic` validator; the UI stays identical.
- Extract the schema, the API↔form mappers and the alert-type guards to a new `src/pages/alertForm/` module (mirror of `walletAlertForm/`), with a 1:1 parity port of every Yup rule — `billableMetricId` intentionally stays optional (the gate on it is indirect), threshold values reject `''` and non-numeric strings with the generic required key.
- Keep the alertType combobox unbound with explicit `form.setFieldValue` calls so picking a type still resets the billable metric; per-option and per-metric disabled states, the `showThresholdTable` rule, the ascending threshold ordering gate and the edit-mode locks are preserved.
- Move the mutations to awaited results: `ValueAlreadyExist` sets the code field error via `setErrorMap` and scrolls to top, NotFound-on-edit keeps the toast + replace redirect.
- Replace `updateNameAndMaybeCode` (Formik-typed, untouched for its 8 other consumers) with a local name→code listener with the same take-ownership semantics.
- Re-home `patchThreshold` from `walletAlertForm/utils.ts` to the shared `src/components/alerts/utils.ts` next to `sortAndFormatThresholds`; update the wallet imports and move its tests.
- Add the missing AlertForm page test plus schema/mappers/utils suites.

⚠️ Behaviour change to flag to QA: the `!dirty` submit gate is dropped per the TanStack convention — the submit button is enabled on a pristine form and validation surfaces on the submit attempt.

<!-- Linear link -->
Fixes ING-538