### PR TITLE
fix(quotes): stop sending empty addOns on subscription quote saves

### DIFF
--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -275,14 +275,14 @@ const EditQuote = () => {
 
       setSaveStatus('saving')
 
-      // Each drawer owns a single billingItems category and passes a partial
-      // ({ plans } / { addOns } / { coupons }) merged over the current items.
-      // Normalize here so `addOns` is always present on the wire, whichever
-      // drawer saved — keeping the backend payload shape stable.
+      // Each drawer owns a single billingItems category and already merges its
+      // partial ({ plans } / { addOns } / { coupons }) over the current items,
+      // so the payload is sent as-is — no key is fabricated here (a stray
+      // `addOns: []` would otherwise leak onto subscription quotes).
       const payload: UpdateQuoteVersionInput = {
         id: versionId,
         content,
-        billingItems: billingItems && { addOns: [], ...billingItems },
+        billingItems,
       }
 
       failedPayloadRef.current = payload

--- a/src/pages/quotes/__tests__/EditQuote.test.tsx
+++ b/src/pages/quotes/__tests__/EditQuote.test.tsx
@@ -1117,7 +1117,7 @@ describe('EditQuote', () => {
     describe('WHEN discount blocks change and syncDiscountBlocks returns billing items', () => {
       it('THEN should save the updated billing items', async () => {
         // The discount drawer owns only the `coupons` key and returns a partial
-        // without `addOns`; savePricingBlock normalizes `addOns` back in.
+        // without `addOns`; savePricingBlock sends that partial as-is.
         const mockBillingItems = { coupons: [{ id: 'coupon-1', position: 1 }] }
 
         mockSyncDiscountBlocks.mockReturnValue(mockBillingItems)
@@ -1138,7 +1138,7 @@ describe('EditQuote', () => {
         await waitFor(() => {
           expect(mockUpdateQuoteVersion).toHaveBeenCalledWith(
             expect.objectContaining({
-              billingItems: { addOns: [], coupons: [{ id: 'coupon-1', position: 1 }] },
+              billingItems: { coupons: [{ id: 'coupon-1', position: 1 }] },
             }),
             false,
           )


### PR DESCRIPTION
## Context

Saving the pricing block of a subscription-type quote (`SubscriptionCreation` / `SubscriptionAmendment`) wrongly included an empty `addOns: []` key in the `updateQuoteVersion` payload. Subscription quotes have no add-ons, so the key should never be on the wire.

## Description

`savePricingBlock` unconditionally injected `addOns: []` (`{ addOns: [], ...billingItems }`) to homogenize the payload shape. But each pricing drawer already merges its own slice over the current billing items, making the base redundant — and on a subscription quote (which only produces `{ plans }`) it was exactly the stray key. The payload is now sent as-is; one-off quotes still serialize `addOns` from their own drawer, including `[]` when the last add-on is cleared. Updated the one affected `EditQuote` test assertion.

<!-- Linear link -->
Fixes LAGO-XXX