### PR TITLE
fix(auth): mask the SSO client secret input on creation

### DIFF
--- a/src/pages/settings/teamAndSecurity/authentication/dialogs/AddEntraIdDialog.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/dialogs/AddEntraIdDialog.tsx
@@ -81,6 +81,7 @@ const fields: SSOIntegrationField<CreateEntraIdIntegrationInput>[] = [
     name: 'clientSecret',
     labelKey: 'text_17843073442551xjnrw1h4bc',
     placeholderKey: 'text_1784307344255ofy9u1w0hqh',
+    password: true,
   },
   {
     name: 'tenantId',

--- a/src/pages/settings/teamAndSecurity/authentication/dialogs/AddOktaDialog.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/dialogs/AddOktaDialog.tsx
@@ -81,6 +81,7 @@ const fields: SSOIntegrationField<CreateOktaIntegrationInput>[] = [
     name: 'clientSecret',
     labelKey: 'text_664c732c264d7eed1c74fdb2',
     placeholderKey: 'text_664c732c264d7eed1c74fdb7',
+    password: true,
   },
   {
     name: 'organizationName',

--- a/src/pages/settings/teamAndSecurity/authentication/dialogs/AddSSOIntegrationDialog.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/dialogs/AddSSOIntegrationDialog.tsx
@@ -26,6 +26,8 @@ export type SSOIntegrationField<TFormValues> = {
   helperKey?: string
   autoFocus?: boolean
   endAdornmentKey?: string
+  /** Renders the input as a masked secret field with a show/hide toggle. */
+  password?: boolean
 }
 
 export type AddSSOIntegrationDialogData<TIntegration> = {
@@ -216,6 +218,7 @@ export const useAddSSOIntegrationDialog = <
                   <field.TextInputField
                     // eslint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus={fieldConfig.autoFocus}
+                    password={fieldConfig.password}
                     label={translate(fieldConfig.labelKey)}
                     placeholder={translate(fieldConfig.placeholderKey)}
                     helperText={

--- a/src/pages/settings/teamAndSecurity/authentication/dialogs/__tests__/AddEntraIdDialog.test.tsx
+++ b/src/pages/settings/teamAndSecurity/authentication/dialogs/__tests__/AddEntraIdDialog.test.tsx
@@ -88,6 +88,12 @@ describe('AddEntraIdDialog', () => {
     expect(screen.getByLabelText(/Entra ID tenant ID/i)).toBeInTheDocument()
   })
 
+  it('masks the client secret input', async () => {
+    await prepare()
+
+    expect(screen.getByLabelText(/Entra ID client secret/i)).toHaveAttribute('type', 'password')
+  })
+
   it('should accept valid host without protocol', async () => {
     const mocks: TestMocksType = [
       {


### PR DESCRIPTION
## Context

The new Entra SSO is shared with the previous Okta one, but the client secret is not masked during creation. Generates a wrong impression. Edit is fine.

## Description

mask the SSO client secret input on creation 