### PR TITLE
fix(quotes): send base coupon value in discount payload

### DIFF
--- a/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
@@ -61,7 +61,9 @@ jest.mock('~/generated/graphql', () => {
     name: 'Ten Off',
     code: 'COUPON_CODE',
     amountCurrency: actual.CurrencyEnum.Eur,
-    amountCents: 1000,
+    // Real API returns amountCents as a BigInt scalar => a STRING at runtime,
+    // not a number. Mirror that so validation/coercion is exercised faithfully.
+    amountCents: '1000',
     couponType: actual.CouponTypeEnum.FixedAmount,
     percentageRate: null,
     frequency: actual.CouponFrequency.Once,
@@ -538,6 +540,164 @@ describe('useDiscountDrawer', () => {
       frequency: 'once',
       frequencyDuration: null,
     })
+  })
+
+  it('sends the coupon base value in payload while overrides carries the edited value (LAGO-1770)', async () => {
+    const onPersist = jest.fn()
+    const { result } = renderHook(() =>
+      useDiscountDrawer(undefined, { currency: CurrencyEnum.Usd, onPersist }),
+    )
+
+    act(() => {
+      result.current.onDiscountCommand({ onSave: jest.fn() })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(
+      <>
+        {openArgs.children}
+        {openArgs.actions}
+      </>,
+    )
+
+    const comboBoxInput = screen.getByRole('combobox') as HTMLInputElement
+
+    await userEvent.type(comboBoxInput, 'Ten')
+
+    await waitFor(() => {
+      expect(comboBoxInput.getAttribute('aria-controls')).toBeTruthy()
+    })
+
+    const listboxId = comboBoxInput.getAttribute('aria-controls') as string
+    const listbox = document.getElementById(listboxId) as HTMLElement
+
+    await userEvent.click(within(listbox).getByText('Ten Off'))
+
+    // Amount prefills to the base value (1000 cents -> "10"); override it to 50.
+    const amountInput = await screen.findByDisplayValue('10')
+
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '50')
+
+    const saveButton = screen.getByTestId(DISCOUNT_DRAWER_SAVE_TEST_ID)
+
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled()
+    })
+
+    await userEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(onPersist).toHaveBeenCalledTimes(1)
+    })
+
+    const persistedPayload = onPersist.mock.calls[0][0] as {
+      coupons: Array<{
+        payload: {
+          amountCents: number | null
+          percentageRate: number | null
+          frequency: string
+          frequencyDuration: number | null
+        }
+        overrides: { amountCents: number | null }
+      }>
+    }
+
+    const [coupon] = persistedPayload.coupons
+
+    // payload = faithful catalog snapshot (base value, raw cents from the API)
+    expect(coupon.payload.amountCents).toBe(1000)
+    expect(coupon.payload.percentageRate).toBeNull()
+    expect(coupon.payload.frequency).toBe('once')
+    expect(coupon.payload.frequencyDuration).toBeNull()
+
+    // overrides = the user-edited value (50 USD -> 5000 cents)
+    expect(coupon.overrides.amountCents).toBe(5000)
+
+    // Drawer must close on a successful save.
+    expect(mockDrawerClose).toHaveBeenCalled()
+  })
+
+  it('closes the drawer when editing an existing coupon and changing the override', async () => {
+    const initialBillingItems: BillingItemsPayload = {
+      addOns: [],
+      coupons: [
+        {
+          type: 'coupon',
+          id: 'cpn_fixed',
+          localId: 'saved-local',
+          payload: {
+            position: 1,
+            code: 'COUPON_CODE',
+            id: 'cpn_fixed',
+            name: 'Ten Off',
+            type: 'fixed_amount',
+            amountCents: 1000,
+            percentageRate: null,
+            currency: CurrencyEnum.Usd,
+            frequency: 'once',
+            frequencyDuration: null,
+            expirationAt: null,
+            limitedPlans: false,
+            planCodes: [],
+            limitedBillableMetrics: false,
+            billableMetricCodes: [],
+            couponOverrides: null,
+            catalogSnapshot: null,
+            resolvedPayload: null,
+          },
+          overrides: {
+            amountCents: 1000,
+            percentageRate: null,
+            frequency: 'once',
+            frequencyDuration: null,
+          },
+        },
+      ],
+    }
+
+    const onPersist = jest.fn()
+    const { result } = renderHook(() =>
+      useDiscountDrawer(initialBillingItems, { currency: CurrencyEnum.Usd, onPersist }),
+    )
+
+    act(() => {
+      result.current.onDiscountCommand({
+        onSave: jest.fn(),
+        editData: { couponId: 'cpn_fixed', localId: 'saved-local' },
+      })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(
+      <>
+        {openArgs.children}
+        {openArgs.actions}
+      </>,
+    )
+
+    // Prefilled override amount is 10 (1000 cents). Change it to 75.
+    const amountInput = await screen.findByDisplayValue('10')
+
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '75')
+
+    const allSaveButtons = screen.getAllByTestId(DISCOUNT_DRAWER_SAVE_TEST_ID)
+    const saveButton = allSaveButtons[allSaveButtons.length - 1]
+
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled()
+    })
+
+    await userEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(onPersist).toHaveBeenCalledTimes(1)
+    })
+
+    expect(mockDrawerClose).toHaveBeenCalled()
   })
 
   it('persists a typed recurring duration (int formatter yields a number, not a string)', async () => {

--- a/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useDiscountDrawer.test.tsx
@@ -1320,4 +1320,46 @@ describe('useDiscountDrawer', () => {
       })
     })
   })
+
+  it('clears the coupon and its captured base value when the selection is cleared', async () => {
+    const { result } = renderHook(() => useDiscountDrawer(undefined, options))
+
+    act(() => {
+      result.current.onDiscountCommand({ onSave: jest.fn() })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(
+      <>
+        {openArgs.children}
+        {openArgs.actions}
+      </>,
+    )
+
+    const comboBoxInput = screen.getByRole('combobox') as HTMLInputElement
+
+    await userEvent.type(comboBoxInput, 'Ten')
+
+    await waitFor(() => {
+      expect(comboBoxInput.getAttribute('aria-controls')).toBeTruthy()
+    })
+
+    const listboxId = comboBoxInput.getAttribute('aria-controls') as string
+    const listbox = document.getElementById(listboxId) as HTMLElement
+
+    await userEvent.click(within(listbox).getByText('Ten Off'))
+
+    // Selecting captures the base value and surfaces it as the prefilled amount.
+    expect(await screen.findByDisplayValue('10')).toBeInTheDocument()
+
+    // Clearing the combobox runs the `!coupon` branch: couponId and the four
+    // captured base fields reset, so the coupon-dependent amount field unmounts.
+    await userEvent.clear(comboBoxInput)
+    comboBoxInput.blur()
+
+    await waitFor(() => {
+      expect(screen.queryByDisplayValue('10')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/pages/quotes/hooks/useDiscountDrawer.tsx
+++ b/src/pages/quotes/hooks/useDiscountDrawer.tsx
@@ -87,6 +87,14 @@ interface DiscountFormValues {
   percentageRate: string
   frequency: CouponFrequency
   frequencyDuration: string | number
+  // Base catalog values captured from the selected coupon at selection time.
+  // They feed the `payload` snapshot (the faithful catalog reference), kept
+  // separate from the user-editable amount/percentageRate/frequency fields that
+  // feed `overrides`. Raw units — baseAmountCents stays in cents (no serialize).
+  baseAmountCents: number | null
+  basePercentageRate: number | null
+  baseFrequency: CouponFrequency
+  baseFrequencyDuration: number | null
 }
 
 const makeDefaults = (currency: CurrencyEnum): DiscountFormValues => ({
@@ -99,6 +107,10 @@ const makeDefaults = (currency: CurrencyEnum): DiscountFormValues => ({
   percentageRate: '',
   frequency: CouponFrequency.Forever,
   frequencyDuration: '',
+  baseAmountCents: null,
+  basePercentageRate: null,
+  baseFrequency: CouponFrequency.Forever,
+  baseFrequencyDuration: null,
 })
 
 const schema = z
@@ -113,6 +125,11 @@ const schema = z
     frequency: z.nativeEnum(CouponFrequency),
     // number when set via the `int` input formatter, string on prefill/default
     frequencyDuration: z.union([z.string(), z.number()]),
+    // Base catalog values — not user-editable, carried through to the payload snapshot.
+    baseAmountCents: z.number().nullable(),
+    basePercentageRate: z.number().nullable(),
+    baseFrequency: z.nativeEnum(CouponFrequency),
+    baseFrequencyDuration: z.number().nullable(),
   })
   .superRefine((data, ctx) => {
     if (data.couponType === CouponTypeEnum.FixedAmount && !data.amount) {
@@ -181,6 +198,10 @@ const DiscountDrawerContent = withForm({
 
                   if (!coupon) {
                     form.setFieldValue('couponId', '')
+                    form.setFieldValue('baseAmountCents', null)
+                    form.setFieldValue('basePercentageRate', null)
+                    form.setFieldValue('baseFrequency', CouponFrequency.Forever)
+                    form.setFieldValue('baseFrequencyDuration', null)
                     return
                   }
 
@@ -206,6 +227,20 @@ const DiscountDrawerContent = withForm({
                       ? String(coupon.frequencyDuration)
                       : '',
                   )
+
+                  // Capture the coupon's base catalog values for the payload
+                  // snapshot (kept separate from the editable fields above, which
+                  // feed overrides). amountCents is a BigInt scalar (a STRING at
+                  // runtime), so coerce to a number — the payload keeps raw cents.
+                  form.setFieldValue(
+                    'baseAmountCents',
+                    coupon.amountCents !== null && coupon.amountCents !== undefined
+                      ? Number(coupon.amountCents)
+                      : null,
+                  )
+                  form.setFieldValue('basePercentageRate', coupon.percentageRate ?? null)
+                  form.setFieldValue('baseFrequency', coupon.frequency)
+                  form.setFieldValue('baseFrequencyDuration', coupon.frequencyDuration ?? null)
                 }}
               />
 
@@ -447,11 +482,11 @@ export const useDiscountDrawer = (
               id: value.couponId,
               name: value.name,
               type: value.couponType === CouponTypeEnum.Percentage ? 'percentage' : 'fixed_amount',
-              amountCents: null,
-              percentageRate: null,
+              amountCents: value.baseAmountCents,
+              percentageRate: value.basePercentageRate,
               currency,
-              frequency: 'forever',
-              frequencyDuration: null,
+              frequency: value.baseFrequency as CouponPayload['frequency'],
+              frequencyDuration: value.baseFrequencyDuration,
               expirationAt: null,
               limitedPlans: false,
               planCodes: [],
@@ -512,6 +547,7 @@ export const useDiscountDrawer = (
     ({ onSave, editData }) => {
       const localId = editData?.localId ?? crypto.randomUUID()
       const existing = editData ? itemsRef.current[localId] : undefined
+      const existingSnapshot = editData ? originalPayloadsRef.current[localId] : undefined
 
       pendingSaveRef.current = { onSave, localId, isEdit: !!editData }
 
@@ -533,6 +569,18 @@ export const useDiscountDrawer = (
                 existing.frequencyDuration !== null && existing.frequencyDuration !== undefined
                   ? String(existing.frequencyDuration)
                   : '',
+              // Seed base values from the stored snapshot so a later coupon change
+              // rebuilds the payload consistently. Coerce amountCents — a saved
+              // snapshot may carry it as a BigInt string.
+              baseAmountCents:
+                existingSnapshot?.amountCents !== null &&
+                existingSnapshot?.amountCents !== undefined
+                  ? Number(existingSnapshot.amountCents)
+                  : null,
+              basePercentageRate: existingSnapshot?.percentageRate ?? null,
+              baseFrequency:
+                (existingSnapshot?.frequency as CouponFrequency) ?? CouponFrequency.Forever,
+              baseFrequencyDuration: existingSnapshot?.frequencyDuration ?? null,
             }
           : makeDefaults(currency),
         { keepDefaultValues: true },


### PR DESCRIPTION
## Context

In the Quotes editor, inserting a coupon via `/discount` and overriding its value wrote the edited value into `overrides` but left the base catalog values (`amountCents`, `percentageRate`, `frequency`, `frequencyDuration`) as hardcoded `null`/`'forever'` in the coupon `payload` snapshot, which is meant to be a faithful reference to the catalog coupon.

## Description

The coupon `payload` snapshot now carries the selected coupon's base catalog values (kept separate from the user-edited `overrides`). The catalog `amountCents` is a BigInt scalar (a string at runtime), so it is coerced to a number before it reaches the form; without this the submit-time zod validator silently rejected it, blocking `canSubmit` and leaving the drawer open with no visible error. Added regression tests, including a mock that returns `amountCents` as a string to mirror the real API.

Fixes LAGO-1770