### PR TITLE
refactor(customers): Swap connection persistence to the dedicated per-connection mutations

### DIFF
--- a/src/components/customers/connectionsSection/CustomerConnectionsSection.tsx
+++ b/src/components/customers/connectionsSection/CustomerConnectionsSection.tsx
@@ -90,10 +90,9 @@ type CustomerConnectionsSectionProps = {
  * "Connections to external apps" — the customer-information master-detail:
  * category-grouped connection list on the left, settings of the selected
  * connection on the right, and the payment-methods block scoped to the
- * payment connection. Add / edit / delete persist immediately via
- * updateCustomer (useCustomerConnectionsPersistence — the bridge strategy
- * until the per-connection mutations land). The hardcoded manual-payment row
- * lands with the default flow.
+ * payment connection. Add / edit / delete persist immediately through the
+ * dedicated per-connection mutations (useCustomerConnectionsPersistence).
+ * The hardcoded manual-payment row lands with the default flow.
  */
 export const CustomerConnectionsSection = ({ customer }: CustomerConnectionsSectionProps) => {
   const { translate } = useInternationalization()
@@ -101,7 +100,10 @@ export const CustomerConnectionsSection = ({ customer }: CustomerConnectionsSect
 
   const connectionOptions = useConnectionOptions()
   const { drawerRef, openCreate, openEdit } = useCustomerConnectionDrawer()
-  const { saveConnection, deleteConnection } = useCustomerConnectionsPersistence({ customer })
+  const { saveConnection, deleteConnection } = useCustomerConnectionsPersistence({
+    customer,
+    connectionOptions,
+  })
 
   const { data: integrationsData, loading: integrationsLoading } =
     useIntegrationsListForCustomerMainInfosQuery({

--- a/src/components/customers/connectionsSection/__tests__/CustomerConnectionsSection.test.tsx
+++ b/src/components/customers/connectionsSection/__tests__/CustomerConnectionsSection.test.tsx
@@ -17,8 +17,12 @@ import { CustomerConnectionsSection } from '../CustomerConnectionsSection'
 const mockOpenCreate = jest.fn()
 const mockOpenEdit = jest.fn()
 const mockDialogOpen = jest.fn()
-const mockUpdatePayment = jest.fn(() => Promise.resolve({ errors: undefined }))
-const mockDestroyIntegration = jest.fn(() => Promise.resolve({ errors: undefined }))
+const mockUpdatePayment = jest.fn(() =>
+  Promise.resolve({ data: { updatePaymentProviderCustomer: { id: 'pc-1' } } }),
+)
+const mockDestroyIntegration = jest.fn(() =>
+  Promise.resolve({ data: { destroyIntegrationCustomer: { id: 'ac-1' } } }),
+)
 const mockOpenAddPaymentMethodDialog = jest.fn()
 
 type CapturedDrawerProps = {
@@ -193,8 +197,12 @@ describe('CustomerConnectionsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     capturedDrawerProps.current = null
-    mockUpdatePayment.mockResolvedValue({ errors: undefined })
-    mockDestroyIntegration.mockResolvedValue({ errors: undefined })
+    mockUpdatePayment.mockResolvedValue({
+      data: { updatePaymentProviderCustomer: { id: 'pc-1' } },
+    } as never)
+    mockDestroyIntegration.mockResolvedValue({
+      data: { destroyIntegrationCustomer: { id: 'ac-1' } },
+    } as never)
   })
 
   describe('GIVEN a customer with connections', () => {

--- a/src/components/customers/connectionsSection/__tests__/CustomerConnectionsSection.test.tsx
+++ b/src/components/customers/connectionsSection/__tests__/CustomerConnectionsSection.test.tsx
@@ -17,7 +17,8 @@ import { CustomerConnectionsSection } from '../CustomerConnectionsSection'
 const mockOpenCreate = jest.fn()
 const mockOpenEdit = jest.fn()
 const mockDialogOpen = jest.fn()
-const mockUpdateCustomer = jest.fn(() => Promise.resolve({ errors: undefined }))
+const mockUpdatePayment = jest.fn(() => Promise.resolve({ errors: undefined }))
+const mockDestroyIntegration = jest.fn(() => Promise.resolve({ errors: undefined }))
 const mockOpenAddPaymentMethodDialog = jest.fn()
 
 type CapturedDrawerProps = {
@@ -145,7 +146,20 @@ jest.mock('~/generated/graphql', () => ({
     },
     loading: false,
   }),
-  useUpdateCustomerMutation: () => [mockUpdateCustomer],
+  useCreateCustomerPaymentConnectionMutation: () => [
+    jest.fn(() => Promise.resolve({ errors: undefined })),
+  ],
+  useUpdateCustomerPaymentConnectionMutation: () => [mockUpdatePayment],
+  useDestroyCustomerPaymentConnectionMutation: () => [
+    jest.fn(() => Promise.resolve({ errors: undefined })),
+  ],
+  useCreateCustomerIntegrationConnectionMutation: () => [
+    jest.fn(() => Promise.resolve({ errors: undefined })),
+  ],
+  useUpdateCustomerIntegrationConnectionMutation: () => [
+    jest.fn(() => Promise.resolve({ errors: undefined })),
+  ],
+  useDestroyCustomerIntegrationConnectionMutation: () => [mockDestroyIntegration],
 }))
 
 /** Customer with a Stripe payment connection and an Anrok tax link persisted */
@@ -179,7 +193,8 @@ describe('CustomerConnectionsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     capturedDrawerProps.current = null
-    mockUpdateCustomer.mockResolvedValue({ errors: undefined })
+    mockUpdatePayment.mockResolvedValue({ errors: undefined })
+    mockDestroyIntegration.mockResolvedValue({ errors: undefined })
   })
 
   describe('GIVEN a customer with connections', () => {
@@ -335,14 +350,8 @@ describe('CustomerConnectionsSection', () => {
           await mockDialogOpen.mock.calls[0][0].onAction()
         })
 
-        expect(mockUpdateCustomer).toHaveBeenCalledWith({
-          variables: {
-            input: expect.objectContaining({
-              id: 'cust-1',
-              externalId: 'ext-1',
-              integrationCustomers: [],
-            }),
-          },
+        expect(mockDestroyIntegration).toHaveBeenCalledWith({
+          variables: { input: { id: 'ac-1' } },
         })
       })
     })
@@ -364,7 +373,7 @@ describe('CustomerConnectionsSection', () => {
           )
         })
 
-        expect(mockUpdateCustomer).toHaveBeenCalled()
+        expect(mockUpdatePayment).toHaveBeenCalled()
         await waitFor(() => {
           expect(
             screen.getByTestId(getCustomerConnectionRowTestId('payment-stripe-eu')),
@@ -373,7 +382,7 @@ describe('CustomerConnectionsSection', () => {
       })
 
       it('THEN should keep the drawer open when the mutation fails', async () => {
-        mockUpdateCustomer.mockResolvedValue({ errors: [{}] } as never)
+        mockUpdatePayment.mockResolvedValue({ errors: [{}] } as never)
 
         render(<CustomerConnectionsSection customer={customer} />)
 

--- a/src/components/customers/connectionsSection/__tests__/useCustomerConnectionsPersistence.test.ts
+++ b/src/components/customers/connectionsSection/__tests__/useCustomerConnectionsPersistence.test.ts
@@ -13,12 +13,24 @@ import {
 
 import { useCustomerConnectionsPersistence } from '../useCustomerConnectionsPersistence'
 
-const mockCreatePayment = jest.fn(() => Promise.resolve({ errors: undefined }))
-const mockUpdatePayment = jest.fn(() => Promise.resolve({ errors: undefined }))
-const mockDestroyPayment = jest.fn(() => Promise.resolve({ errors: undefined }))
-const mockCreateIntegration = jest.fn(() => Promise.resolve({ errors: undefined }))
-const mockUpdateIntegration = jest.fn(() => Promise.resolve({ errors: undefined }))
-const mockDestroyIntegration = jest.fn(() => Promise.resolve({ errors: undefined }))
+const mockCreatePayment = jest.fn(() =>
+  Promise.resolve({ data: { createPaymentProviderCustomer: { id: 'pc-new' } } }),
+)
+const mockUpdatePayment = jest.fn(() =>
+  Promise.resolve({ data: { updatePaymentProviderCustomer: { id: 'pc-1' } } }),
+)
+const mockDestroyPayment = jest.fn(() =>
+  Promise.resolve({ data: { destroyPaymentProviderCustomer: { id: 'pc-1' } } }),
+)
+const mockCreateIntegration = jest.fn(() =>
+  Promise.resolve({ data: { createIntegrationCustomer: { __typename: 'AnrokCustomer' } } }),
+)
+const mockUpdateIntegration = jest.fn(() =>
+  Promise.resolve({ data: { updateIntegrationCustomer: { __typename: 'NetsuiteCustomer' } } }),
+)
+const mockDestroyIntegration = jest.fn(() =>
+  Promise.resolve({ data: { destroyIntegrationCustomer: { id: 'link-1' } } }),
+)
 const mockClientQuery = jest.fn(() => Promise.resolve({ data: { customer: null } }))
 const mockAddToast = jest.fn()
 
@@ -472,6 +484,68 @@ describe('useCustomerConnectionsPersistence', () => {
         expect(mockAddToast).not.toHaveBeenCalledWith(
           expect.objectContaining({ severity: 'success' }),
         )
+      })
+    })
+  })
+
+  describe('GIVEN a mutation that throws (network error)', () => {
+    describe('WHEN deleting a connection', () => {
+      it('THEN should resolve false instead of bubbling an unhandled rejection', async () => {
+        mockDestroyIntegration.mockRejectedValueOnce(new Error('network'))
+
+        const result = setup()
+
+        const succeeded = await result.current.deleteConnection(ConnectionCategory.Crm)
+
+        expect(succeeded).toBe(false)
+        expect(mockAddToast).not.toHaveBeenCalledWith(
+          expect.objectContaining({ severity: 'success' }),
+        )
+      })
+    })
+
+    describe('WHEN saving a connection', () => {
+      it('THEN should resolve false and show no success toast', async () => {
+        mockUpdateIntegration.mockRejectedValueOnce(new Error('network'))
+
+        const result = setup()
+
+        const succeeded = await result.current.saveConnection(
+          ConnectionCategory.Accounting,
+          {
+            providerCode: 'ns-1',
+            providerType: IntegrationTypeEnum.Netsuite,
+            externalCustomerId: 'ns_cus_1',
+          } as ConnectionFormValues,
+          { isEdition: true },
+        )
+
+        expect(succeeded).toBe(false)
+        expect(mockAddToast).not.toHaveBeenCalledWith(
+          expect.objectContaining({ severity: 'success' }),
+        )
+      })
+    })
+  })
+
+  describe('GIVEN a mutation that resolves without its payload', () => {
+    describe('WHEN saving', () => {
+      it('THEN should treat the write as failed', async () => {
+        mockUpdateIntegration.mockResolvedValueOnce({ data: {} } as never)
+
+        const result = setup()
+
+        const succeeded = await result.current.saveConnection(
+          ConnectionCategory.Accounting,
+          {
+            providerCode: 'ns-1',
+            providerType: IntegrationTypeEnum.Netsuite,
+            externalCustomerId: 'ns_cus_1',
+          } as ConnectionFormValues,
+          { isEdition: true },
+        )
+
+        expect(succeeded).toBe(false)
       })
     })
   })

--- a/src/components/customers/connectionsSection/__tests__/useCustomerConnectionsPersistence.test.ts
+++ b/src/components/customers/connectionsSection/__tests__/useCustomerConnectionsPersistence.test.ts
@@ -2,24 +2,34 @@ import { renderHook } from '@testing-library/react'
 
 import { ConnectionFormValues } from '~/components/customerConnections/CustomerConnectionDrawer'
 import { ConnectionCategory } from '~/components/customerConnections/types'
+import { useConnectionOptions } from '~/components/customerConnections/useConnectionOptions'
 import {
   AddCustomerDrawerFragment,
   HubspotTargetedObjectsEnum,
   IntegrationTypeEnum,
   ProviderPaymentMethodsEnum,
   ProviderTypeEnum,
-  UpdateCustomerInput,
 } from '~/generated/graphql'
 
 import { useCustomerConnectionsPersistence } from '../useCustomerConnectionsPersistence'
 
-const mockUpdateCustomer = jest.fn(() => Promise.resolve({ errors: undefined }))
+const mockCreatePayment = jest.fn(() => Promise.resolve({ errors: undefined }))
+const mockUpdatePayment = jest.fn(() => Promise.resolve({ errors: undefined }))
+const mockDestroyPayment = jest.fn(() => Promise.resolve({ errors: undefined }))
+const mockCreateIntegration = jest.fn(() => Promise.resolve({ errors: undefined }))
+const mockUpdateIntegration = jest.fn(() => Promise.resolve({ errors: undefined }))
+const mockDestroyIntegration = jest.fn(() => Promise.resolve({ errors: undefined }))
 const mockClientQuery = jest.fn(() => Promise.resolve({ data: { customer: null } }))
 const mockAddToast = jest.fn()
 
 jest.mock('~/generated/graphql', () => ({
   ...jest.requireActual('~/generated/graphql'),
-  useUpdateCustomerMutation: () => [mockUpdateCustomer],
+  useCreateCustomerPaymentConnectionMutation: () => [mockCreatePayment],
+  useUpdateCustomerPaymentConnectionMutation: () => [mockUpdatePayment],
+  useDestroyCustomerPaymentConnectionMutation: () => [mockDestroyPayment],
+  useCreateCustomerIntegrationConnectionMutation: () => [mockCreateIntegration],
+  useUpdateCustomerIntegrationConnectionMutation: () => [mockUpdateIntegration],
+  useDestroyCustomerIntegrationConnectionMutation: () => [mockDestroyIntegration],
 }))
 
 jest.mock('@apollo/client', () => ({
@@ -73,41 +83,31 @@ const customer = {
   salesforceCustomer: null,
 } as unknown as AddCustomerDrawerFragment
 
-const NETSUITE_ECHOED_ENTRY = {
-  id: 'nc-1',
-  integrationCode: 'ns-1',
-  integrationType: IntegrationTypeEnum.Netsuite,
-  syncWithProvider: false,
-  externalCustomerId: 'ns_cus_1',
-  subsidiaryId: 'sub-1',
-}
+/** Org lists resolving each connection code to its integration id */
+const connectionOptions = {
+  allAccountingIntegrations: [
+    { __typename: 'NetsuiteIntegration', id: 'org-int-ns', code: 'ns-1', name: 'NetSuite Prod' },
+    { __typename: 'XeroIntegration', id: 'org-int-xero', code: 'xero-1', name: 'Xero Main' },
+  ],
+  allTaxIntegrations: [
+    { __typename: 'AnrokIntegration', id: 'org-int-anrok', code: 'anrok-1', name: 'Anrok Main' },
+  ],
+  allCrmIntegrations: [
+    { __typename: 'HubspotIntegration', id: 'org-int-hub', code: 'hub-1', name: 'Hubspot Main' },
+  ],
+} as unknown as ReturnType<typeof useConnectionOptions>
 
-const HUBSPOT_ECHOED_ENTRY = {
-  id: 'hc-1',
-  integrationCode: 'hub-1',
-  integrationType: IntegrationTypeEnum.Hubspot,
-  syncWithProvider: true,
-  externalCustomerId: 'hub_cus_1',
-  targetedObject: HubspotTargetedObjectsEnum.Companies,
-}
-
-const setup = () => renderHook(() => useCustomerConnectionsPersistence({ customer })).result
-
-const sentInput = (): UpdateCustomerInput =>
-  (
-    mockUpdateCustomer.mock.calls[0] as unknown as [{ variables: { input: UpdateCustomerInput } }]
-  )[0].variables.input
+const setup = () =>
+  renderHook(() => useCustomerConnectionsPersistence({ customer, connectionOptions })).result
 
 describe('useCustomerConnectionsPersistence', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockUpdateCustomer.mockResolvedValue({ errors: undefined })
-    mockClientQuery.mockResolvedValue({ data: { customer: null } } as never)
   })
 
   describe('GIVEN a payment connection save', () => {
-    describe('WHEN the drawer values carry a provider mapping', () => {
-      it('THEN should send only the base and payment keys', async () => {
+    describe('WHEN editing the existing connection (same code)', () => {
+      it('THEN should update the link in place by its id', async () => {
         const result = setup()
 
         const succeeded = await result.current.saveConnection(
@@ -115,8 +115,8 @@ describe('useCustomerConnectionsPersistence', () => {
           {
             providerCode: 'stripe-eu',
             providerType: ProviderTypeEnum.Stripe,
-            externalCustomerId: 'cus_123',
-            syncWithProvider: false,
+            externalCustomerId: 'cus_456',
+            syncWithProvider: true,
             providerPaymentMethods: {
               [ProviderPaymentMethodsEnum.Card]: true,
               [ProviderPaymentMethodsEnum.SepaDebit]: false,
@@ -126,21 +126,89 @@ describe('useCustomerConnectionsPersistence', () => {
         )
 
         expect(succeeded).toBe(true)
-        expect(sentInput()).toEqual({
-          id: 'cust-1',
-          externalId: 'ext-1',
-          paymentProvider: ProviderTypeEnum.Stripe,
-          paymentProviderCode: 'stripe-eu',
-          providerCustomer: {
-            providerCustomerId: 'cus_123',
-            syncWithProvider: false,
-            providerPaymentMethods: [ProviderPaymentMethodsEnum.Card],
+        expect(mockUpdatePayment).toHaveBeenCalledWith({
+          variables: {
+            input: {
+              id: 'pc-1',
+              providerCustomerId: 'cus_456',
+              syncWithProvider: true,
+              providerPaymentMethods: [ProviderPaymentMethodsEnum.Card],
+            },
           },
         })
+        expect(mockCreatePayment).not.toHaveBeenCalled()
+        expect(mockDestroyPayment).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN switching to another payment provider', () => {
+      it('THEN should destroy the old link before creating the new one', async () => {
+        const result = setup()
+
+        await result.current.saveConnection(
+          ConnectionCategory.Payment,
+          {
+            providerCode: 'adyen-eu',
+            providerType: ProviderTypeEnum.Adyen,
+            externalCustomerId: 'adyen_cus_1',
+            syncWithProvider: false,
+          } as ConnectionFormValues,
+          { isEdition: true },
+        )
+
+        expect(mockDestroyPayment).toHaveBeenCalledWith({
+          variables: { input: { id: 'pc-1' } },
+        })
+        expect(mockCreatePayment).toHaveBeenCalledWith({
+          variables: {
+            input: {
+              customerId: 'cust-1',
+              paymentProvider: ProviderTypeEnum.Adyen,
+              paymentProviderCode: 'adyen-eu',
+              providerCustomerId: 'adyen_cus_1',
+              syncWithProvider: false,
+              providerPaymentMethods: [],
+            },
+          },
+        })
+        expect(mockDestroyPayment.mock.invocationCallOrder[0]).toBeLessThan(
+          mockCreatePayment.mock.invocationCallOrder[0],
+        )
+        expect(mockUpdatePayment).not.toHaveBeenCalled()
       })
 
-      it('THEN should never send unrelated customer fields', async () => {
+      it('THEN should not create when the destroy half fails', async () => {
+        mockDestroyPayment.mockResolvedValueOnce({ errors: [{}] } as never)
+
         const result = setup()
+
+        const succeeded = await result.current.saveConnection(
+          ConnectionCategory.Payment,
+          {
+            providerCode: 'adyen-eu',
+            providerType: ProviderTypeEnum.Adyen,
+            externalCustomerId: 'adyen_cus_1',
+          } as ConnectionFormValues,
+          { isEdition: true },
+        )
+
+        expect(succeeded).toBe(false)
+        expect(mockCreatePayment).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the customer has no payment connection yet', () => {
+      it('THEN should create without destroying anything', async () => {
+        const bareCustomer = {
+          ...customer,
+          paymentProvider: null,
+          paymentProviderCode: null,
+          providerCustomer: null,
+        } as unknown as AddCustomerDrawerFragment
+
+        const result = renderHook(() =>
+          useCustomerConnectionsPersistence({ customer: bareCustomer, connectionOptions }),
+        ).result
 
         await result.current.saveConnection(
           ConnectionCategory.Payment,
@@ -149,81 +217,38 @@ describe('useCustomerConnectionsPersistence', () => {
             providerType: ProviderTypeEnum.Stripe,
             externalCustomerId: 'cus_123',
           } as ConnectionFormValues,
-          { isEdition: true },
+          { isEdition: false },
         )
 
-        const input = sentInput()
-
-        expect(input).not.toHaveProperty('metadata')
-        expect(input).not.toHaveProperty('currency')
-        expect(input).not.toHaveProperty('integrationCustomers')
-        expect(input).not.toHaveProperty('name')
-      })
-    })
-
-    describe('WHEN there is neither a mapping nor a provider-side sync', () => {
-      it('THEN should send a null providerCustomer (no provider-side customer)', async () => {
-        const result = setup()
-
-        await result.current.saveConnection(
-          ConnectionCategory.Payment,
-          {
-            providerCode: 'cashfree-1',
-            providerType: ProviderTypeEnum.Cashfree,
-            externalCustomerId: '',
-            syncWithProvider: false,
-          } as ConnectionFormValues,
-          { isEdition: true },
-        )
-
-        expect(sentInput().providerCustomer).toBeNull()
+        expect(mockCreatePayment).toHaveBeenCalledTimes(1)
+        expect(mockDestroyPayment).not.toHaveBeenCalled()
       })
     })
 
     describe('WHEN the provider type cannot be resolved', () => {
-      it('THEN should abort without calling the mutation', async () => {
+      it('THEN should abort without calling any mutation', async () => {
         const result = setup()
 
         const succeeded = await result.current.saveConnection(
           ConnectionCategory.Payment,
-          {
-            providerCode: 'stripe-eu',
-            providerType: undefined,
-          } as ConnectionFormValues,
+          { providerCode: 'stripe-eu', providerType: undefined } as ConnectionFormValues,
           { isEdition: true },
         )
 
         expect(succeeded).toBe(false)
-        expect(mockUpdateCustomer).not.toHaveBeenCalled()
+        expect(mockCreatePayment).not.toHaveBeenCalled()
+        expect(mockUpdatePayment).not.toHaveBeenCalled()
         expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'danger' }))
-      })
-    })
-  })
-
-  describe('GIVEN a payment connection delete', () => {
-    describe('WHEN confirmed', () => {
-      it('THEN should send the explicit null removal keys and nothing else', async () => {
-        const result = setup()
-
-        const succeeded = await result.current.deleteConnection(ConnectionCategory.Payment)
-
-        expect(succeeded).toBe(true)
-        expect(sentInput()).toEqual({
-          id: 'cust-1',
-          externalId: 'ext-1',
-          paymentProvider: null,
-          providerCustomer: null,
-        })
       })
     })
   })
 
   describe('GIVEN an integration connection save', () => {
     describe('WHEN adding a NEW tax connection', () => {
-      it('THEN should echo the sibling links verbatim and append the new entry without id', async () => {
+      it('THEN should create the link against the org integration id resolved from the code', async () => {
         const result = setup()
 
-        await result.current.saveConnection(
+        const succeeded = await result.current.saveConnection(
           ConnectionCategory.Tax,
           {
             providerCode: 'anrok-1',
@@ -234,92 +259,24 @@ describe('useCustomerConnectionsPersistence', () => {
           { isEdition: false },
         )
 
-        expect(sentInput()).toEqual({
-          id: 'cust-1',
-          externalId: 'ext-1',
-          integrationCustomers: [
-            NETSUITE_ECHOED_ENTRY,
-            {
-              id: undefined,
-              integrationCode: 'anrok-1',
-              integrationType: IntegrationTypeEnum.Anrok,
-              syncWithProvider: false,
+        expect(succeeded).toBe(true)
+        expect(mockCreateIntegration).toHaveBeenCalledWith({
+          variables: {
+            input: {
+              customerId: 'cust-1',
+              integrationId: 'org-int-anrok',
               externalCustomerId: 'anrok_cus_1',
-            },
-            HUBSPOT_ECHOED_ENTRY,
-          ],
-        })
-      })
-
-      it('THEN should refresh silently and stop as soon as the async-created link lands', async () => {
-        // The link is already there on the first (awaited) refresh → no poll
-        mockClientQuery.mockResolvedValue({
-          data: {
-            customer: {
-              ...customer,
-              anrokCustomer: {
-                id: 'ac-1',
-                integrationCode: 'anrok-1',
-                integrationType: IntegrationTypeEnum.Anrok,
-              },
+              syncWithProvider: false,
             },
           },
-        } as never)
-
-        const result = setup()
-
-        await result.current.saveConnection(
-          ConnectionCategory.Tax,
-          {
-            providerCode: 'anrok-1',
-            providerType: IntegrationTypeEnum.Anrok,
-            externalCustomerId: 'anrok_cus_1',
-          } as ConnectionFormValues,
-          { isEdition: false },
-        )
-
-        expect(mockClientQuery).toHaveBeenCalledTimes(1)
-        expect(mockClientQuery).toHaveBeenCalledWith(
-          expect.objectContaining({ fetchPolicy: 'network-only' }),
-        )
-      })
-
-      it('THEN should keep polling in the background while the link is missing', async () => {
-        jest.useFakeTimers()
-
-        try {
-          // Refreshes keep returning the stale customer (link never lands)
-          mockClientQuery.mockResolvedValue({ data: { customer } } as never)
-
-          const result = setup()
-
-          await result.current.saveConnection(
-            ConnectionCategory.Tax,
-            {
-              providerCode: 'anrok-1',
-              providerType: IntegrationTypeEnum.Anrok,
-              externalCustomerId: 'anrok_cus_1',
-            } as ConnectionFormValues,
-            { isEdition: false },
-          )
-
-          // Awaited refresh right after the mutation
-          expect(mockClientQuery).toHaveBeenCalledTimes(1)
-
-          // Background poll: one more silent refresh per interval, bounded
-          await jest.advanceTimersByTimeAsync(1000)
-          expect(mockClientQuery).toHaveBeenCalledTimes(2)
-
-          await jest.advanceTimersByTimeAsync(3000)
-          expect(mockClientQuery).toHaveBeenCalledTimes(4)
-        } finally {
-          jest.useRealTimers()
-        }
+        })
+        expect(mockUpdateIntegration).not.toHaveBeenCalled()
+        expect(mockDestroyIntegration).not.toHaveBeenCalled()
       })
     })
 
     describe('WHEN editing the accounting connection without changing it', () => {
-      it('THEN should keep the persisted link id and the drawer values', async () => {
+      it('THEN should update the link in place, carrying the subsidiary', async () => {
         const result = setup()
 
         await result.current.saveConnection(
@@ -334,41 +291,51 @@ describe('useCustomerConnectionsPersistence', () => {
           { isEdition: true },
         )
 
-        expect(sentInput().integrationCustomers).toEqual([
-          {
-            id: 'nc-1',
-            integrationCode: 'ns-1',
-            integrationType: IntegrationTypeEnum.Netsuite,
-            syncWithProvider: true,
-            externalCustomerId: 'ns_cus_UPDATED',
-            subsidiaryId: 'sub-2',
+        expect(mockUpdateIntegration).toHaveBeenCalledWith({
+          variables: {
+            input: {
+              id: 'nc-1',
+              externalCustomerId: 'ns_cus_UPDATED',
+              syncWithProvider: true,
+              subsidiaryId: 'sub-2',
+            },
           },
-          HUBSPOT_ECHOED_ENTRY,
-        ])
+        })
+        expect(mockCreateIntegration).not.toHaveBeenCalled()
       })
+    })
 
-      it('THEN should not poll (a single silent consistency refresh only)', async () => {
+    describe('WHEN editing the CRM connection', () => {
+      it('THEN should carry the targeted object', async () => {
         const result = setup()
 
         await result.current.saveConnection(
-          ConnectionCategory.Accounting,
+          ConnectionCategory.Crm,
           {
-            providerCode: 'ns-1',
-            providerType: IntegrationTypeEnum.Netsuite,
-            externalCustomerId: 'ns_cus_1',
+            providerCode: 'hub-1',
+            providerType: IntegrationTypeEnum.Hubspot,
+            externalCustomerId: 'hub_cus_1',
+            syncWithProvider: true,
+            targetedObject: HubspotTargetedObjectsEnum.Contacts,
           } as ConnectionFormValues,
           { isEdition: true },
         )
 
-        // Fire-and-forget refresh — flush the microtask
-        await Promise.resolve()
-
-        expect(mockClientQuery).toHaveBeenCalledTimes(1)
+        expect(mockUpdateIntegration).toHaveBeenCalledWith({
+          variables: {
+            input: {
+              id: 'hc-1',
+              externalCustomerId: 'hub_cus_1',
+              syncWithProvider: true,
+              targetedObject: HubspotTargetedObjectsEnum.Contacts,
+            },
+          },
+        })
       })
     })
 
     describe('WHEN switching the accounting connection to another integration', () => {
-      it('THEN should drop the link id so the backend creates a new link', async () => {
+      it('THEN should destroy the old link before creating the new one', async () => {
         const result = setup()
 
         await result.current.saveConnection(
@@ -382,78 +349,151 @@ describe('useCustomerConnectionsPersistence', () => {
           { isEdition: true },
         )
 
-        const entries = sentInput().integrationCustomers
-
-        expect(entries?.find((e) => e.integrationCode === 'xero-1')?.id).toBeUndefined()
-        // Sibling untouched
-        expect(entries?.find((e) => e.integrationCode === 'hub-1')).toEqual(HUBSPOT_ECHOED_ENTRY)
+        expect(mockDestroyIntegration).toHaveBeenCalledWith({
+          variables: { input: { id: 'nc-1' } },
+        })
+        expect(mockCreateIntegration).toHaveBeenCalledWith({
+          variables: {
+            input: {
+              customerId: 'cust-1',
+              integrationId: 'org-int-xero',
+              externalCustomerId: 'xero_cus_1',
+              syncWithProvider: false,
+            },
+          },
+        })
+        expect(mockDestroyIntegration.mock.invocationCallOrder[0]).toBeLessThan(
+          mockCreateIntegration.mock.invocationCallOrder[0],
+        )
       })
     })
-  })
 
-  describe('GIVEN an integration save whose provider type could not be resolved', () => {
-    describe('WHEN saving', () => {
-      // The backend skips entries it cannot resolve, so sending one would
-      // report success while changing nothing
-      it('THEN should abort without calling the mutation', async () => {
+    describe('WHEN the connection code cannot be resolved to an org integration', () => {
+      it('THEN should abort without calling any mutation', async () => {
         const result = setup()
 
         const succeeded = await result.current.saveConnection(
           ConnectionCategory.Tax,
           {
-            providerCode: 'anrok-1',
-            providerType: undefined,
+            providerCode: 'ghost-integration',
+            providerType: IntegrationTypeEnum.Anrok,
             externalCustomerId: 'anrok_cus_1',
           } as ConnectionFormValues,
           { isEdition: false },
         )
 
         expect(succeeded).toBe(false)
-        expect(mockUpdateCustomer).not.toHaveBeenCalled()
+        expect(mockCreateIntegration).not.toHaveBeenCalled()
         expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'danger' }))
       })
     })
   })
 
-  describe('GIVEN an integration connection delete', () => {
+  describe('GIVEN a connection delete', () => {
+    describe('WHEN deleting the payment connection', () => {
+      it('THEN should destroy the link by its id', async () => {
+        const result = setup()
+
+        const succeeded = await result.current.deleteConnection(ConnectionCategory.Payment)
+
+        expect(succeeded).toBe(true)
+        expect(mockDestroyPayment).toHaveBeenCalledWith({
+          variables: { input: { id: 'pc-1' } },
+        })
+      })
+    })
+
     describe('WHEN deleting the CRM connection', () => {
-      it('THEN should resend only the remaining links, ids preserved', async () => {
+      it('THEN should destroy the link by its id', async () => {
         const result = setup()
 
         const succeeded = await result.current.deleteConnection(ConnectionCategory.Crm)
 
         expect(succeeded).toBe(true)
-        expect(sentInput()).toEqual({
-          id: 'cust-1',
-          externalId: 'ext-1',
-          integrationCustomers: [NETSUITE_ECHOED_ENTRY],
+        expect(mockDestroyIntegration).toHaveBeenCalledWith({
+          variables: { input: { id: 'hc-1' } },
         })
+      })
+    })
+
+    describe('WHEN there is no persisted link for the category', () => {
+      it('THEN should abort without calling any mutation', async () => {
+        const result = setup()
+
+        const succeeded = await result.current.deleteConnection(ConnectionCategory.Tax)
+
+        expect(succeeded).toBe(false)
+        expect(mockDestroyIntegration).not.toHaveBeenCalled()
+        expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'danger' }))
       })
     })
   })
 
-  describe('GIVEN the mutation fails', () => {
-    describe('WHEN saving', () => {
-      it('THEN should return false and show no success toast', async () => {
-        mockUpdateCustomer.mockResolvedValue({ errors: [{}] } as never)
+  describe('GIVEN the silent customer refresh', () => {
+    describe('WHEN a save succeeds', () => {
+      it('THEN should query the customer once, network-only', async () => {
+        const result = setup()
+
+        await result.current.saveConnection(
+          ConnectionCategory.Accounting,
+          {
+            providerCode: 'ns-1',
+            providerType: IntegrationTypeEnum.Netsuite,
+            externalCustomerId: 'ns_cus_1',
+          } as ConnectionFormValues,
+          { isEdition: true },
+        )
+
+        expect(mockClientQuery).toHaveBeenCalledTimes(1)
+        expect(mockClientQuery).toHaveBeenCalledWith(
+          expect.objectContaining({ fetchPolicy: 'network-only' }),
+        )
+      })
+    })
+
+    describe('WHEN a provider switch fails after its destroy half', () => {
+      it('THEN should still refresh so the section shows the real state', async () => {
+        mockCreatePayment.mockResolvedValueOnce({ errors: [{}] } as never)
 
         const result = setup()
 
         const succeeded = await result.current.saveConnection(
           ConnectionCategory.Payment,
           {
-            providerCode: 'stripe-eu',
-            providerType: ProviderTypeEnum.Stripe,
-            externalCustomerId: 'cus_123',
+            providerCode: 'adyen-eu',
+            providerType: ProviderTypeEnum.Adyen,
+            externalCustomerId: 'adyen_cus_1',
           } as ConnectionFormValues,
           { isEdition: true },
         )
 
         expect(succeeded).toBe(false)
+        expect(mockClientQuery).toHaveBeenCalledTimes(1)
         expect(mockAddToast).not.toHaveBeenCalledWith(
           expect.objectContaining({ severity: 'success' }),
         )
       })
+    })
+  })
+
+  describe('GIVEN the success toasts', () => {
+    it.each([
+      ['updated toast on edition', true],
+      ['added toast on creation', false],
+    ])('THEN should show the %s', async (_, isEdition) => {
+      const result = setup()
+
+      await result.current.saveConnection(
+        ConnectionCategory.Accounting,
+        {
+          providerCode: 'ns-1',
+          providerType: IntegrationTypeEnum.Netsuite,
+          externalCustomerId: 'ns_cus_1',
+        } as ConnectionFormValues,
+        { isEdition },
+      )
+
+      expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
     })
   })
 })

--- a/src/components/customers/connectionsSection/__tests__/useCustomerConnectionsPersistence.test.ts
+++ b/src/components/customers/connectionsSection/__tests__/useCustomerConnectionsPersistence.test.ts
@@ -31,6 +31,9 @@ const mockUpdateIntegration = jest.fn(() =>
 const mockDestroyIntegration = jest.fn(() =>
   Promise.resolve({ data: { destroyIntegrationCustomer: { id: 'link-1' } } }),
 )
+const mockClearPaymentProvider = jest.fn(() =>
+  Promise.resolve({ data: { updateCustomer: { id: 'cust-1' } } }),
+)
 const mockClientQuery = jest.fn(() => Promise.resolve({ data: { customer: null } }))
 const mockAddToast = jest.fn()
 
@@ -42,6 +45,7 @@ jest.mock('~/generated/graphql', () => ({
   useCreateCustomerIntegrationConnectionMutation: () => [mockCreateIntegration],
   useUpdateCustomerIntegrationConnectionMutation: () => [mockUpdateIntegration],
   useDestroyCustomerIntegrationConnectionMutation: () => [mockDestroyIntegration],
+  useClearCustomerPaymentProviderMutation: () => [mockClearPaymentProvider],
 }))
 
 jest.mock('@apollo/client', () => ({
@@ -425,6 +429,35 @@ describe('useCustomerConnectionsPersistence', () => {
         expect(mockDestroyIntegration).toHaveBeenCalledWith({
           variables: { input: { id: 'hc-1' } },
         })
+      })
+    })
+
+    describe('WHEN the payment connection has no provider-customer link', () => {
+      it('THEN should clear the payment provider with explicit nulls instead of aborting', async () => {
+        const linklessCustomer = {
+          ...customer,
+          providerCustomer: null,
+        } as unknown as AddCustomerDrawerFragment
+
+        const result = renderHook(() =>
+          useCustomerConnectionsPersistence({ customer: linklessCustomer, connectionOptions }),
+        ).result
+
+        const succeeded = await result.current.deleteConnection(ConnectionCategory.Payment)
+
+        expect(succeeded).toBe(true)
+        expect(mockClearPaymentProvider).toHaveBeenCalledWith({
+          variables: {
+            input: {
+              id: 'cust-1',
+              externalId: 'ext-1',
+              paymentProvider: null,
+              providerCustomer: null,
+            },
+          },
+        })
+        expect(mockDestroyPayment).not.toHaveBeenCalled()
+        expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
       })
     })
 

--- a/src/components/customers/connectionsSection/useCustomerConnectionsPersistence.ts
+++ b/src/components/customers/connectionsSection/useCustomerConnectionsPersistence.ts
@@ -11,6 +11,7 @@ import {
   GetCustomerQuery,
   ProviderPaymentMethodsEnum,
   ProviderTypeEnum,
+  useClearCustomerPaymentProviderMutation,
   useCreateCustomerIntegrationConnectionMutation,
   useCreateCustomerPaymentConnectionMutation,
   useDestroyCustomerIntegrationConnectionMutation,
@@ -52,6 +53,15 @@ gql`
 
   mutation destroyCustomerIntegrationConnection($input: DestroyIntegrationCustomerInput!) {
     destroyIntegrationCustomer(input: $input) {
+      id
+    }
+  }
+
+  # Fallback only: removing a payment connection that has no provider-customer
+  # link (nothing for the dedicated destroy to target) is only expressible
+  # through the customer's explicit-null removal semantics
+  mutation clearCustomerPaymentProvider($input: UpdateCustomerInput!) {
+    updateCustomer(input: $input) {
       id
     }
   }
@@ -106,6 +116,7 @@ export const useCustomerConnectionsPersistence = ({
   const [createIntegrationConnection] = useCreateCustomerIntegrationConnectionMutation()
   const [updateIntegrationConnection] = useUpdateCustomerIntegrationConnectionMutation()
   const [destroyIntegrationConnection] = useDestroyCustomerIntegrationConnectionMutation()
+  const [clearPaymentProvider] = useClearCustomerPaymentProviderMutation()
 
   const refreshCustomer = async (): Promise<void> => {
     try {
@@ -315,6 +326,35 @@ export const useCustomerConnectionsPersistence = ({
       category === ConnectionCategory.Payment
         ? customer.providerCustomer?.id
         : getIntegrationCustomerForCategory(customer, category)?.id
+
+    // A payment connection can exist on paymentProvider/paymentProviderCode
+    // with no provider-customer link (Cashfree/Flutterwave, or sync off with
+    // no external id) — its row is still listed, so it must stay deletable:
+    // clear the customer's payment provider directly (explicit nulls are the
+    // removal semantics; omitted fields stay untouched)
+    if (category === ConnectionCategory.Payment && !existingId) {
+      const cleared = await runMutation(
+        () =>
+          clearPaymentProvider({
+            variables: {
+              input: {
+                id: customer.id,
+                externalId: customer.externalId,
+                paymentProvider: null,
+                providerCustomer: null,
+              },
+            },
+          }),
+        (data) => data.updateCustomer,
+      )
+
+      if (!cleared) return false
+
+      await refreshCustomer()
+      addToast({ severity: 'success', translateKey: 'text_661ff6e56ef7e1b7c542b2f9' })
+
+      return true
+    }
 
     // Nothing to destroy: the link never made it to the backend (or the
     // fragment is stale) — surface an error instead of a silent no-op

--- a/src/components/customers/connectionsSection/useCustomerConnectionsPersistence.ts
+++ b/src/components/customers/connectionsSection/useCustomerConnectionsPersistence.ts
@@ -119,6 +119,26 @@ export const useCustomerConnectionsPersistence = ({
     }
   }
 
+  /**
+   * True only when the mutation returned its payload. Apollo THROWS on
+   * network and GraphQL errors (default errorPolicy) — without the catch a
+   * failure would bubble as an unhandled rejection from the delete
+   * confirmation dialog. No toast here: the global error link already
+   * surfaces non-silenced errors.
+   */
+  const runMutation = async <TData>(
+    mutate: () => Promise<{ data?: TData | null; errors?: readonly unknown[] }>,
+    getPayload: (data: TData) => unknown,
+  ): Promise<boolean> => {
+    try {
+      const { data, errors } = await mutate()
+
+      return !errors?.length && !!data && !!getPayload(data)
+    } catch {
+      return false
+    }
+  }
+
   /** The org integration behind a category slot's connection code */
   const resolveOrgIntegration = (
     category: Exclude<ConnectionCategory, ConnectionCategory.Payment>,
@@ -148,45 +168,50 @@ export const useCustomerConnectionsPersistence = ({
     const isSameConnection = customer.paymentProviderCode === values.providerCode
 
     if (existingId && isSameConnection) {
-      const { errors } = await updatePaymentConnection({
-        variables: {
-          input: {
-            id: existingId,
-            providerCustomerId: values.externalCustomerId || null,
-            syncWithProvider: values.syncWithProvider ?? false,
-            providerPaymentMethods: getEnabledPaymentMethods(values.providerPaymentMethods),
-          },
-        },
-      })
-
-      return !errors?.length
+      return runMutation(
+        () =>
+          updatePaymentConnection({
+            variables: {
+              input: {
+                id: existingId,
+                providerCustomerId: values.externalCustomerId || null,
+                syncWithProvider: values.syncWithProvider ?? false,
+                providerPaymentMethods: getEnabledPaymentMethods(values.providerPaymentMethods),
+              },
+            },
+          }),
+        (data) => data.updatePaymentProviderCustomer,
+      )
     }
 
     // Provider switch: the old link goes first (along with its saved payment
     // methods — replacing the provider always had that effect), then the new
     // connection is created
     if (existingId) {
-      const { errors: destroyErrors } = await destroyPaymentConnection({
-        variables: { input: { id: existingId } },
-      })
+      const destroyed = await runMutation(
+        () => destroyPaymentConnection({ variables: { input: { id: existingId } } }),
+        (data) => data.destroyPaymentProviderCustomer,
+      )
 
-      if (destroyErrors?.length) return false
+      if (!destroyed) return false
     }
 
-    const { errors } = await createPaymentConnection({
-      variables: {
-        input: {
-          customerId: customer.id,
-          paymentProvider,
-          paymentProviderCode: values.providerCode,
-          providerCustomerId: values.externalCustomerId || null,
-          syncWithProvider: values.syncWithProvider ?? false,
-          providerPaymentMethods: getEnabledPaymentMethods(values.providerPaymentMethods),
-        },
-      },
-    })
-
-    return !errors?.length
+    return runMutation(
+      () =>
+        createPaymentConnection({
+          variables: {
+            input: {
+              customerId: customer.id,
+              paymentProvider,
+              paymentProviderCode: values.providerCode,
+              providerCustomerId: values.externalCustomerId || null,
+              syncWithProvider: values.syncWithProvider ?? false,
+              providerPaymentMethods: getEnabledPaymentMethods(values.providerPaymentMethods),
+            },
+          },
+        }),
+      (data) => data.createPaymentProviderCustomer,
+    )
   }
 
   const saveIntegrationConnection = async (
@@ -221,34 +246,42 @@ export const useCustomerConnectionsPersistence = ({
     }
 
     if (existing?.id && isSameConnection) {
-      const { errors } = await updateIntegrationConnection({
-        variables: { input: { id: existing.id, ...linkInput } },
-      })
+      const existingId = existing.id
 
-      return !errors?.length
+      return runMutation(
+        () =>
+          updateIntegrationConnection({
+            variables: { input: { id: existingId, ...linkInput } },
+          }),
+        (data) => data.updateIntegrationCustomer,
+      )
     }
 
     // Provider switch within the category: destroy the old link, then create
     // the new one (the update mutation cannot re-target another integration)
     if (existing?.id) {
-      const { errors: destroyErrors } = await destroyIntegrationConnection({
-        variables: { input: { id: existing.id } },
-      })
+      const existingId = existing.id
+      const destroyed = await runMutation(
+        () => destroyIntegrationConnection({ variables: { input: { id: existingId } } }),
+        (data) => data.destroyIntegrationCustomer,
+      )
 
-      if (destroyErrors?.length) return false
+      if (!destroyed) return false
     }
 
-    const { errors } = await createIntegrationConnection({
-      variables: {
-        input: {
-          customerId: customer.id,
-          integrationId: orgIntegration.id,
-          ...linkInput,
-        },
-      },
-    })
-
-    return !errors?.length
+    return runMutation(
+      () =>
+        createIntegrationConnection({
+          variables: {
+            input: {
+              customerId: customer.id,
+              integrationId: orgIntegration.id,
+              ...linkInput,
+            },
+          },
+        }),
+      (data) => data.createIntegrationCustomer,
+    )
   }
 
   const saveConnection = async (
@@ -291,12 +324,18 @@ export const useCustomerConnectionsPersistence = ({
       return false
     }
 
-    const { errors } =
+    const succeeded =
       category === ConnectionCategory.Payment
-        ? await destroyPaymentConnection({ variables: { input: { id: existingId } } })
-        : await destroyIntegrationConnection({ variables: { input: { id: existingId } } })
+        ? await runMutation(
+            () => destroyPaymentConnection({ variables: { input: { id: existingId } } }),
+            (data) => data.destroyPaymentProviderCustomer,
+          )
+        : await runMutation(
+            () => destroyIntegrationConnection({ variables: { input: { id: existingId } } }),
+            (data) => data.destroyIntegrationCustomer,
+          )
 
-    if (errors?.length) return false
+    if (!succeeded) return false
 
     await refreshCustomer()
     addToast({ severity: 'success', translateKey: 'text_661ff6e56ef7e1b7c542b2f9' })

--- a/src/components/customers/connectionsSection/useCustomerConnectionsPersistence.ts
+++ b/src/components/customers/connectionsSection/useCustomerConnectionsPersistence.ts
@@ -1,66 +1,61 @@
-import { useApolloClient } from '@apollo/client'
+import { gql, useApolloClient } from '@apollo/client'
 
 import { ConnectionFormValues } from '~/components/customerConnections/CustomerConnectionDrawer'
 import { ConnectionCategory } from '~/components/customerConnections/types'
-import {
-  FragmentIntegrationCustomer,
-  getIntegrationCustomerForCategory,
-  INTEGRATION_CATEGORIES,
-} from '~/components/customers/connectionsSection/utils'
+import { useConnectionOptions } from '~/components/customerConnections/useConnectionOptions'
+import { getIntegrationCustomerForCategory } from '~/components/customers/connectionsSection/utils'
 import { addToast } from '~/core/apolloClient'
-import {
-  INTEGRATION_POLLING_INTERVAL,
-  MAX_INTEGRATION_POLLING_ATTEMPTS,
-} from '~/core/constants/integrationPolling'
 import {
   AddCustomerDrawerFragment,
   GetCustomerDocument,
   GetCustomerQuery,
-  IntegrationCustomerInput,
-  IntegrationTypeEnum,
   ProviderPaymentMethodsEnum,
   ProviderTypeEnum,
-  UpdateCustomerInput,
-  useUpdateCustomerMutation,
+  useCreateCustomerIntegrationConnectionMutation,
+  useCreateCustomerPaymentConnectionMutation,
+  useDestroyCustomerIntegrationConnectionMutation,
+  useDestroyCustomerPaymentConnectionMutation,
+  useUpdateCustomerIntegrationConnectionMutation,
+  useUpdateCustomerPaymentConnectionMutation,
 } from '~/generated/graphql'
 
-// Verbatim fragment → input mapping: the untouched categories MUST be echoed
-// with their persisted ids — the backend destroys every integration customer
-// whose id is missing from a submitted integrationCustomers list
-// (IntegrationCustomers::CreateOrUpdateBatchService#sanitize_integration_customers).
-const toIntegrationInput = (
-  integrationCustomer: FragmentIntegrationCustomer,
-): IntegrationCustomerInput => ({
-  id: integrationCustomer.id,
-  integrationCode: integrationCustomer.integrationCode,
-  integrationType: integrationCustomer.integrationType,
-  syncWithProvider: integrationCustomer.syncWithProvider,
-  externalCustomerId: integrationCustomer.externalCustomerId,
-  ...('subsidiaryId' in integrationCustomer && integrationCustomer.subsidiaryId
-    ? { subsidiaryId: integrationCustomer.subsidiaryId }
-    : {}),
-  ...('targetedObject' in integrationCustomer && integrationCustomer.targetedObject
-    ? { targetedObject: integrationCustomer.targetedObject }
-    : {}),
-})
+gql`
+  mutation createCustomerPaymentConnection($input: CreatePaymentProviderCustomerInput!) {
+    createPaymentProviderCustomer(input: $input) {
+      id
+    }
+  }
 
-/**
- * The full-replace integrationCustomers list: every untouched category echoed
- * verbatim from the customer fragment, the changed category replaced by
- * `editedEntry` (or dropped on delete when null).
- */
-const buildIntegrationCustomersInput = (
-  customer: AddCustomerDrawerFragment,
-  changedCategory: ConnectionCategory,
-  editedEntry: IntegrationCustomerInput | null,
-): IntegrationCustomerInput[] =>
-  INTEGRATION_CATEGORIES.flatMap((category) => {
-    if (category === changedCategory) return editedEntry ? [editedEntry] : []
+  mutation updateCustomerPaymentConnection($input: UpdatePaymentProviderCustomerInput!) {
+    updatePaymentProviderCustomer(input: $input) {
+      id
+    }
+  }
 
-    const existing = getIntegrationCustomerForCategory(customer, category)
+  mutation destroyCustomerPaymentConnection($input: DestroyPaymentProviderCustomerInput!) {
+    destroyPaymentProviderCustomer(input: $input) {
+      id
+    }
+  }
 
-    return existing ? [toIntegrationInput(existing)] : []
-  })
+  mutation createCustomerIntegrationConnection($input: CreateIntegrationCustomerInput!) {
+    createIntegrationCustomer(input: $input) {
+      __typename
+    }
+  }
+
+  mutation updateCustomerIntegrationConnection($input: UpdateIntegrationCustomerInput!) {
+    updateIntegrationCustomer(input: $input) {
+      __typename
+    }
+  }
+
+  mutation destroyCustomerIntegrationConnection($input: DestroyIntegrationCustomerInput!) {
+    destroyIntegrationCustomer(input: $input) {
+      id
+    }
+  }
+`
 
 const getEnabledPaymentMethods = (
   providerPaymentMethods: ConnectionFormValues['providerPaymentMethods'],
@@ -73,6 +68,7 @@ const getEnabledPaymentMethods = (
 
 type UseCustomerConnectionsPersistenceProps = {
   customer: AddCustomerDrawerFragment
+  connectionOptions: ReturnType<typeof useConnectionOptions>
 }
 
 type UseCustomerConnectionsPersistenceReturn = {
@@ -85,73 +81,169 @@ type UseCustomerConnectionsPersistenceReturn = {
 }
 
 /**
- * Immediate-save persistence for the customer-information connections view.
+ * Immediate-save persistence for the customer-information connections view,
+ * on the dedicated per-connection mutations: one connection, one call, its
+ * own id. Editing keeps the link and updates it in place; switching to
+ * another provider of the same category destroys the old link and creates a
+ * new one (the update mutations expose no provider/code change).
  *
- * Bridge strategy: every add/edit/delete goes through the existing
- * updateCustomer mutation with a MINIMAL input — base `{ id, externalId }`
- * (externalId is the only other required field; omitted fields are left
- * untouched by the backend) plus only the payment keys or the rebuilt
- * integrationCustomers list. The dedicated per-connection mutations later
- * replace this hook without touching the view.
+ * The mutations return the connection object, not the customer, so the
+ * page's normalized cache does not pick the change up on its own: every
+ * write is followed by a silent standalone customer query. Never refetch the
+ * page's ACTIVE getCustomer observer instead (notifyOnNetworkStatusChange +
+ * network-only would flip it to loading → the whole section unmounts, losing
+ * the selection).
  */
 export const useCustomerConnectionsPersistence = ({
   customer,
+  connectionOptions,
 }: UseCustomerConnectionsPersistenceProps): UseCustomerConnectionsPersistenceReturn => {
   const client = useApolloClient()
 
-  // The mutation response carries the full connection fragment, so the
-  // normalized cache updates the page on its own. Never refetch the page's
-  // ACTIVE getCustomer observer (notifyOnNetworkStatusChange + network-only
-  // would flip it to loading → the whole section unmounts, losing the
-  // selection). A standalone client.query writes the fresh customer into the
-  // cache and broadcasts it silently instead.
-  const refreshCustomer = async (): Promise<AddCustomerDrawerFragment | undefined> => {
+  const [createPaymentConnection] = useCreateCustomerPaymentConnectionMutation()
+  const [updatePaymentConnection] = useUpdateCustomerPaymentConnectionMutation()
+  const [destroyPaymentConnection] = useDestroyCustomerPaymentConnectionMutation()
+  const [createIntegrationConnection] = useCreateCustomerIntegrationConnectionMutation()
+  const [updateIntegrationConnection] = useUpdateCustomerIntegrationConnectionMutation()
+  const [destroyIntegrationConnection] = useDestroyCustomerIntegrationConnectionMutation()
+
+  const refreshCustomer = async (): Promise<void> => {
     try {
-      const { data } = await client.query<GetCustomerQuery>({
+      await client.query<GetCustomerQuery>({
         query: GetCustomerDocument,
         variables: { id: customer.id },
         fetchPolicy: 'network-only',
       })
-
-      return (data?.customer as AddCustomerDrawerFragment | null) ?? undefined
     } catch {
-      // Consistency refresh only — the mutation itself already succeeded
-      return undefined
+      // Consistency refresh only — the write outcome is reported separately
     }
   }
 
-  const hasIntegrationCode = (
-    refreshed: AddCustomerDrawerFragment | undefined,
-    integrationCode: string,
-  ): boolean =>
-    !!refreshed &&
-    INTEGRATION_CATEGORIES.some(
-      (category) =>
-        getIntegrationCustomerForCategory(refreshed, category)?.integrationCode === integrationCode,
-    )
-
-  const [updateCustomer] = useUpdateCustomerMutation()
-
-  // Bounded background poll until the async-created link lands on the customer
-  const pollForIntegrationCode = async (integrationCode: string): Promise<void> => {
-    for (let attempt = 0; attempt < MAX_INTEGRATION_POLLING_ATTEMPTS; attempt++) {
-      await new Promise((resolve) => setTimeout(resolve, INTEGRATION_POLLING_INTERVAL))
-
-      if (hasIntegrationCode(await refreshCustomer(), integrationCode)) return
+  /** The org integration behind a category slot's connection code */
+  const resolveOrgIntegration = (
+    category: Exclude<ConnectionCategory, ConnectionCategory.Payment>,
+    code: string,
+  ): { id: string } | undefined => {
+    const pools = {
+      [ConnectionCategory.Accounting]: connectionOptions.allAccountingIntegrations,
+      [ConnectionCategory.Tax]: connectionOptions.allTaxIntegrations,
+      [ConnectionCategory.Crm]: connectionOptions.allCrmIntegrations,
     }
+
+    return pools[category].find((integration) => integration.code === code)
   }
 
-  const runUpdate = async (
-    input: Omit<UpdateCustomerInput, 'id' | 'externalId'>,
-  ): Promise<boolean> => {
-    const { errors } = await updateCustomer({
+  const savePaymentConnection = async (values: ConnectionFormValues): Promise<boolean> => {
+    const paymentProvider = (values.providerType as ProviderTypeEnum) || undefined
+
+    // The create mutation pairs the code with its provider type — without a
+    // resolved type the input cannot be built. Abort instead of guessing.
+    if (!paymentProvider || !values.providerCode) {
+      addToast({ severity: 'danger', translateKey: 'text_622f7a3dc32ce100c46a5154' })
+
+      return false
+    }
+
+    const existingId = customer.providerCustomer?.id
+    const isSameConnection = customer.paymentProviderCode === values.providerCode
+
+    if (existingId && isSameConnection) {
+      const { errors } = await updatePaymentConnection({
+        variables: {
+          input: {
+            id: existingId,
+            providerCustomerId: values.externalCustomerId || null,
+            syncWithProvider: values.syncWithProvider ?? false,
+            providerPaymentMethods: getEnabledPaymentMethods(values.providerPaymentMethods),
+          },
+        },
+      })
+
+      return !errors?.length
+    }
+
+    // Provider switch: the old link goes first (along with its saved payment
+    // methods — replacing the provider always had that effect), then the new
+    // connection is created
+    if (existingId) {
+      const { errors: destroyErrors } = await destroyPaymentConnection({
+        variables: { input: { id: existingId } },
+      })
+
+      if (destroyErrors?.length) return false
+    }
+
+    const { errors } = await createPaymentConnection({
       variables: {
         input: {
-          id: customer.id,
-          // Only required UpdateCustomerInput field besides id; the backend
-          // applies it solely on editable customers, echoing it back is a no-op
-          externalId: customer.externalId,
-          ...input,
+          customerId: customer.id,
+          paymentProvider,
+          paymentProviderCode: values.providerCode,
+          providerCustomerId: values.externalCustomerId || null,
+          syncWithProvider: values.syncWithProvider ?? false,
+          providerPaymentMethods: getEnabledPaymentMethods(values.providerPaymentMethods),
+        },
+      },
+    })
+
+    return !errors?.length
+  }
+
+  const saveIntegrationConnection = async (
+    category: Exclude<ConnectionCategory, ConnectionCategory.Payment>,
+    values: ConnectionFormValues,
+  ): Promise<boolean> => {
+    const orgIntegration = values.providerCode
+      ? resolveOrgIntegration(category, values.providerCode)
+      : undefined
+
+    // The create mutation targets the org integration by id; an unresolvable
+    // code (org lists still loading, or the integration was deleted) cannot
+    // be saved.
+    if (!orgIntegration) {
+      addToast({ severity: 'danger', translateKey: 'text_622f7a3dc32ce100c46a5154' })
+
+      return false
+    }
+
+    const existing = getIntegrationCustomerForCategory(customer, category)
+    const isSameConnection = existing?.integrationCode === values.providerCode
+
+    const linkInput = {
+      externalCustomerId: values.externalCustomerId || null,
+      syncWithProvider: values.syncWithProvider ?? false,
+      ...(category === ConnectionCategory.Accounting && values.subsidiaryId
+        ? { subsidiaryId: values.subsidiaryId }
+        : {}),
+      ...(category === ConnectionCategory.Crm && values.targetedObject
+        ? { targetedObject: values.targetedObject }
+        : {}),
+    }
+
+    if (existing?.id && isSameConnection) {
+      const { errors } = await updateIntegrationConnection({
+        variables: { input: { id: existing.id, ...linkInput } },
+      })
+
+      return !errors?.length
+    }
+
+    // Provider switch within the category: destroy the old link, then create
+    // the new one (the update mutation cannot re-target another integration)
+    if (existing?.id) {
+      const { errors: destroyErrors } = await destroyIntegrationConnection({
+        variables: { input: { id: existing.id } },
+      })
+
+      if (destroyErrors?.length) return false
+    }
+
+    const { errors } = await createIntegrationConnection({
+      variables: {
+        input: {
+          customerId: customer.id,
+          integrationId: orgIntegration.id,
+          ...linkInput,
         },
       },
     })
@@ -164,86 +256,14 @@ export const useCustomerConnectionsPersistence = ({
     values: ConnectionFormValues,
     { isEdition }: { isEdition: boolean },
   ): Promise<boolean> => {
-    let succeeded = false
+    const succeeded =
+      category === ConnectionCategory.Payment
+        ? await savePaymentConnection(values)
+        : await saveIntegrationConnection(category, values)
 
-    if (category === ConnectionCategory.Payment) {
-      const paymentProvider = (values.providerType as ProviderTypeEnum) || undefined
-
-      // Without the provider type the input would either corrupt the provider
-      // pairing (code without provider) or — with an explicit null — DELETE
-      // the connection (backend removal semantics). Abort instead.
-      if (!paymentProvider || !values.providerCode) {
-        addToast({ severity: 'danger', translateKey: 'text_622f7a3dc32ce100c46a5154' })
-
-        return false
-      }
-
-      succeeded = await runUpdate({
-        paymentProvider,
-        paymentProviderCode: values.providerCode,
-        // Same rule as the create/edit mapper: no mapping and no sync → null
-        // (Cashfree/Flutterwave have no provider-side customer)
-        providerCustomer:
-          values.externalCustomerId || values.syncWithProvider
-            ? {
-                providerCustomerId: values.externalCustomerId,
-                syncWithProvider: values.syncWithProvider ?? false,
-                providerPaymentMethods: getEnabledPaymentMethods(values.providerPaymentMethods),
-              }
-            : null,
-      })
-
-      if (succeeded) void refreshCustomer()
-    } else {
-      const integrationType = (values.providerType as IntegrationTypeEnum) || undefined
-
-      // The backend resolves the target integration from the code AND the type
-      // together, and silently skips any entry it cannot resolve — a save
-      // without a type would report success while changing nothing. The
-      // drawer's own type is optional (it is derived from the selected code),
-      // so guard it here, as the payment branch does.
-      if (!values.providerCode || !integrationType) {
-        addToast({ severity: 'danger', translateKey: 'text_622f7a3dc32ce100c46a5154' })
-
-        return false
-      }
-
-      const existing = getIntegrationCustomerForCategory(customer, category)
-      // Keep the link id only when the connection is unchanged: on a provider
-      // switch the backend must create a new link instead of updating the old
-      const isSameConnection = existing?.integrationCode === values.providerCode
-
-      succeeded = await runUpdate({
-        integrationCustomers: buildIntegrationCustomersInput(customer, category, {
-          id: isSameConnection ? existing?.id : undefined,
-          integrationCode: values.providerCode,
-          integrationType,
-          syncWithProvider: values.syncWithProvider ?? false,
-          externalCustomerId: values.externalCustomerId ?? '',
-          ...(category === ConnectionCategory.Accounting && values.subsidiaryId
-            ? { subsidiaryId: values.subsidiaryId }
-            : {}),
-          ...(category === ConnectionCategory.Crm && values.targetedObject
-            ? { targetedObject: values.targetedObject }
-            : {}),
-        }),
-      })
-
-      if (succeeded) {
-        if (isSameConnection) {
-          void refreshCustomer()
-        } else {
-          // A NEW link is created asynchronously backend-side — the mutation
-          // response cannot carry it yet: refresh once, then keep polling in
-          // the background (silently, no loading state) until it shows up
-          const refreshed = await refreshCustomer()
-
-          if (!hasIntegrationCode(refreshed, values.providerCode)) {
-            void pollForIntegrationCode(values.providerCode)
-          }
-        }
-      }
-    }
+    // Refresh even on failure: a provider switch may have landed its destroy
+    // half, and the section must show the real state
+    await refreshCustomer()
 
     if (succeeded) {
       addToast({
@@ -258,21 +278,30 @@ export const useCustomerConnectionsPersistence = ({
   }
 
   const deleteConnection = async (category: ConnectionCategory): Promise<boolean> => {
-    const succeeded =
+    const existingId =
       category === ConnectionCategory.Payment
-        ? // Removal semantics: the key must be PRESENT and null. The backend
-          // also clears the code and destroys the customer's payment methods.
-          await runUpdate({ paymentProvider: null, providerCustomer: null })
-        : await runUpdate({
-            integrationCustomers: buildIntegrationCustomersInput(customer, category, null),
-          })
+        ? customer.providerCustomer?.id
+        : getIntegrationCustomerForCategory(customer, category)?.id
 
-    if (succeeded) {
-      void refreshCustomer()
-      addToast({ severity: 'success', translateKey: 'text_661ff6e56ef7e1b7c542b2f9' })
+    // Nothing to destroy: the link never made it to the backend (or the
+    // fragment is stale) — surface an error instead of a silent no-op
+    if (!existingId) {
+      addToast({ severity: 'danger', translateKey: 'text_622f7a3dc32ce100c46a5154' })
+
+      return false
     }
 
-    return succeeded
+    const { errors } =
+      category === ConnectionCategory.Payment
+        ? await destroyPaymentConnection({ variables: { input: { id: existingId } } })
+        : await destroyIntegrationConnection({ variables: { input: { id: existingId } } })
+
+    if (errors?.length) return false
+
+    await refreshCustomer()
+    addToast({ severity: 'success', translateKey: 'text_661ff6e56ef7e1b7c542b2f9' })
+
+    return true
   }
 
   return { saveConnection, deleteConnection }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -11767,6 +11767,62 @@ export type IntegrationsListForCustomerMainInfosQuery = { __typename?: 'Query', 
       | { __typename: 'XeroIntegration', id: string, name: string }
     > } | null };
 
+export type CreateCustomerPaymentConnectionMutationVariables = Exact<{
+  input: CreatePaymentProviderCustomerInput;
+}>;
+
+
+export type CreateCustomerPaymentConnectionMutation = { __typename?: 'Mutation', createPaymentProviderCustomer?: { __typename?: 'ProviderCustomer', id: string } | null };
+
+export type UpdateCustomerPaymentConnectionMutationVariables = Exact<{
+  input: UpdatePaymentProviderCustomerInput;
+}>;
+
+
+export type UpdateCustomerPaymentConnectionMutation = { __typename?: 'Mutation', updatePaymentProviderCustomer?: { __typename?: 'ProviderCustomer', id: string } | null };
+
+export type DestroyCustomerPaymentConnectionMutationVariables = Exact<{
+  input: DestroyPaymentProviderCustomerInput;
+}>;
+
+
+export type DestroyCustomerPaymentConnectionMutation = { __typename?: 'Mutation', destroyPaymentProviderCustomer?: { __typename?: 'DestroyPaymentProviderCustomerPayload', id?: string | null } | null };
+
+export type CreateCustomerIntegrationConnectionMutationVariables = Exact<{
+  input: CreateIntegrationCustomerInput;
+}>;
+
+
+export type CreateCustomerIntegrationConnectionMutation = { __typename?: 'Mutation', createIntegrationCustomer?:
+    | { __typename: 'AnrokCustomer' }
+    | { __typename: 'AvalaraCustomer' }
+    | { __typename: 'HubspotCustomer' }
+    | { __typename: 'NetsuiteCustomer' }
+    | { __typename: 'SalesforceCustomer' }
+    | { __typename: 'XeroCustomer' }
+   | null };
+
+export type UpdateCustomerIntegrationConnectionMutationVariables = Exact<{
+  input: UpdateIntegrationCustomerInput;
+}>;
+
+
+export type UpdateCustomerIntegrationConnectionMutation = { __typename?: 'Mutation', updateIntegrationCustomer?:
+    | { __typename: 'AnrokCustomer' }
+    | { __typename: 'AvalaraCustomer' }
+    | { __typename: 'HubspotCustomer' }
+    | { __typename: 'NetsuiteCustomer' }
+    | { __typename: 'SalesforceCustomer' }
+    | { __typename: 'XeroCustomer' }
+   | null };
+
+export type DestroyCustomerIntegrationConnectionMutationVariables = Exact<{
+  input: DestroyIntegrationCustomerInput;
+}>;
+
+
+export type DestroyCustomerIntegrationConnectionMutation = { __typename?: 'Mutation', destroyIntegrationCustomer?: { __typename?: 'DestroyIntegrationCustomerPayload', id?: string | null } | null };
+
 export type CreditNoteForVoidCreditNoteDialogFragment = { __typename?: 'CreditNote', id: string, totalAmountCents: any, currency: CurrencyEnum };
 
 export type VoidCreditNoteMutationVariables = Exact<{
@@ -25951,6 +26007,204 @@ export type IntegrationsListForCustomerMainInfosQueryHookResult = ReturnType<typ
 export type IntegrationsListForCustomerMainInfosLazyQueryHookResult = ReturnType<typeof useIntegrationsListForCustomerMainInfosLazyQuery>;
 export type IntegrationsListForCustomerMainInfosSuspenseQueryHookResult = ReturnType<typeof useIntegrationsListForCustomerMainInfosSuspenseQuery>;
 export type IntegrationsListForCustomerMainInfosQueryResult = Apollo.QueryResult<IntegrationsListForCustomerMainInfosQuery, IntegrationsListForCustomerMainInfosQueryVariables>;
+export const CreateCustomerPaymentConnectionDocument = gql`
+    mutation createCustomerPaymentConnection($input: CreatePaymentProviderCustomerInput!) {
+  createPaymentProviderCustomer(input: $input) {
+    id
+  }
+}
+    `;
+export type CreateCustomerPaymentConnectionMutationFn = Apollo.MutationFunction<CreateCustomerPaymentConnectionMutation, CreateCustomerPaymentConnectionMutationVariables>;
+
+/**
+ * __useCreateCustomerPaymentConnectionMutation__
+ *
+ * To run a mutation, you first call `useCreateCustomerPaymentConnectionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateCustomerPaymentConnectionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createCustomerPaymentConnectionMutation, { data, loading, error }] = useCreateCustomerPaymentConnectionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useCreateCustomerPaymentConnectionMutation(baseOptions?: Apollo.MutationHookOptions<CreateCustomerPaymentConnectionMutation, CreateCustomerPaymentConnectionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateCustomerPaymentConnectionMutation, CreateCustomerPaymentConnectionMutationVariables>(CreateCustomerPaymentConnectionDocument, options);
+      }
+export type CreateCustomerPaymentConnectionMutationHookResult = ReturnType<typeof useCreateCustomerPaymentConnectionMutation>;
+export type CreateCustomerPaymentConnectionMutationResult = Apollo.MutationResult<CreateCustomerPaymentConnectionMutation>;
+export type CreateCustomerPaymentConnectionMutationOptions = Apollo.BaseMutationOptions<CreateCustomerPaymentConnectionMutation, CreateCustomerPaymentConnectionMutationVariables>;
+export const UpdateCustomerPaymentConnectionDocument = gql`
+    mutation updateCustomerPaymentConnection($input: UpdatePaymentProviderCustomerInput!) {
+  updatePaymentProviderCustomer(input: $input) {
+    id
+  }
+}
+    `;
+export type UpdateCustomerPaymentConnectionMutationFn = Apollo.MutationFunction<UpdateCustomerPaymentConnectionMutation, UpdateCustomerPaymentConnectionMutationVariables>;
+
+/**
+ * __useUpdateCustomerPaymentConnectionMutation__
+ *
+ * To run a mutation, you first call `useUpdateCustomerPaymentConnectionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateCustomerPaymentConnectionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateCustomerPaymentConnectionMutation, { data, loading, error }] = useUpdateCustomerPaymentConnectionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateCustomerPaymentConnectionMutation(baseOptions?: Apollo.MutationHookOptions<UpdateCustomerPaymentConnectionMutation, UpdateCustomerPaymentConnectionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateCustomerPaymentConnectionMutation, UpdateCustomerPaymentConnectionMutationVariables>(UpdateCustomerPaymentConnectionDocument, options);
+      }
+export type UpdateCustomerPaymentConnectionMutationHookResult = ReturnType<typeof useUpdateCustomerPaymentConnectionMutation>;
+export type UpdateCustomerPaymentConnectionMutationResult = Apollo.MutationResult<UpdateCustomerPaymentConnectionMutation>;
+export type UpdateCustomerPaymentConnectionMutationOptions = Apollo.BaseMutationOptions<UpdateCustomerPaymentConnectionMutation, UpdateCustomerPaymentConnectionMutationVariables>;
+export const DestroyCustomerPaymentConnectionDocument = gql`
+    mutation destroyCustomerPaymentConnection($input: DestroyPaymentProviderCustomerInput!) {
+  destroyPaymentProviderCustomer(input: $input) {
+    id
+  }
+}
+    `;
+export type DestroyCustomerPaymentConnectionMutationFn = Apollo.MutationFunction<DestroyCustomerPaymentConnectionMutation, DestroyCustomerPaymentConnectionMutationVariables>;
+
+/**
+ * __useDestroyCustomerPaymentConnectionMutation__
+ *
+ * To run a mutation, you first call `useDestroyCustomerPaymentConnectionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDestroyCustomerPaymentConnectionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [destroyCustomerPaymentConnectionMutation, { data, loading, error }] = useDestroyCustomerPaymentConnectionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useDestroyCustomerPaymentConnectionMutation(baseOptions?: Apollo.MutationHookOptions<DestroyCustomerPaymentConnectionMutation, DestroyCustomerPaymentConnectionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DestroyCustomerPaymentConnectionMutation, DestroyCustomerPaymentConnectionMutationVariables>(DestroyCustomerPaymentConnectionDocument, options);
+      }
+export type DestroyCustomerPaymentConnectionMutationHookResult = ReturnType<typeof useDestroyCustomerPaymentConnectionMutation>;
+export type DestroyCustomerPaymentConnectionMutationResult = Apollo.MutationResult<DestroyCustomerPaymentConnectionMutation>;
+export type DestroyCustomerPaymentConnectionMutationOptions = Apollo.BaseMutationOptions<DestroyCustomerPaymentConnectionMutation, DestroyCustomerPaymentConnectionMutationVariables>;
+export const CreateCustomerIntegrationConnectionDocument = gql`
+    mutation createCustomerIntegrationConnection($input: CreateIntegrationCustomerInput!) {
+  createIntegrationCustomer(input: $input) {
+    __typename
+  }
+}
+    `;
+export type CreateCustomerIntegrationConnectionMutationFn = Apollo.MutationFunction<CreateCustomerIntegrationConnectionMutation, CreateCustomerIntegrationConnectionMutationVariables>;
+
+/**
+ * __useCreateCustomerIntegrationConnectionMutation__
+ *
+ * To run a mutation, you first call `useCreateCustomerIntegrationConnectionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateCustomerIntegrationConnectionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createCustomerIntegrationConnectionMutation, { data, loading, error }] = useCreateCustomerIntegrationConnectionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useCreateCustomerIntegrationConnectionMutation(baseOptions?: Apollo.MutationHookOptions<CreateCustomerIntegrationConnectionMutation, CreateCustomerIntegrationConnectionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateCustomerIntegrationConnectionMutation, CreateCustomerIntegrationConnectionMutationVariables>(CreateCustomerIntegrationConnectionDocument, options);
+      }
+export type CreateCustomerIntegrationConnectionMutationHookResult = ReturnType<typeof useCreateCustomerIntegrationConnectionMutation>;
+export type CreateCustomerIntegrationConnectionMutationResult = Apollo.MutationResult<CreateCustomerIntegrationConnectionMutation>;
+export type CreateCustomerIntegrationConnectionMutationOptions = Apollo.BaseMutationOptions<CreateCustomerIntegrationConnectionMutation, CreateCustomerIntegrationConnectionMutationVariables>;
+export const UpdateCustomerIntegrationConnectionDocument = gql`
+    mutation updateCustomerIntegrationConnection($input: UpdateIntegrationCustomerInput!) {
+  updateIntegrationCustomer(input: $input) {
+    __typename
+  }
+}
+    `;
+export type UpdateCustomerIntegrationConnectionMutationFn = Apollo.MutationFunction<UpdateCustomerIntegrationConnectionMutation, UpdateCustomerIntegrationConnectionMutationVariables>;
+
+/**
+ * __useUpdateCustomerIntegrationConnectionMutation__
+ *
+ * To run a mutation, you first call `useUpdateCustomerIntegrationConnectionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateCustomerIntegrationConnectionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateCustomerIntegrationConnectionMutation, { data, loading, error }] = useUpdateCustomerIntegrationConnectionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateCustomerIntegrationConnectionMutation(baseOptions?: Apollo.MutationHookOptions<UpdateCustomerIntegrationConnectionMutation, UpdateCustomerIntegrationConnectionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateCustomerIntegrationConnectionMutation, UpdateCustomerIntegrationConnectionMutationVariables>(UpdateCustomerIntegrationConnectionDocument, options);
+      }
+export type UpdateCustomerIntegrationConnectionMutationHookResult = ReturnType<typeof useUpdateCustomerIntegrationConnectionMutation>;
+export type UpdateCustomerIntegrationConnectionMutationResult = Apollo.MutationResult<UpdateCustomerIntegrationConnectionMutation>;
+export type UpdateCustomerIntegrationConnectionMutationOptions = Apollo.BaseMutationOptions<UpdateCustomerIntegrationConnectionMutation, UpdateCustomerIntegrationConnectionMutationVariables>;
+export const DestroyCustomerIntegrationConnectionDocument = gql`
+    mutation destroyCustomerIntegrationConnection($input: DestroyIntegrationCustomerInput!) {
+  destroyIntegrationCustomer(input: $input) {
+    id
+  }
+}
+    `;
+export type DestroyCustomerIntegrationConnectionMutationFn = Apollo.MutationFunction<DestroyCustomerIntegrationConnectionMutation, DestroyCustomerIntegrationConnectionMutationVariables>;
+
+/**
+ * __useDestroyCustomerIntegrationConnectionMutation__
+ *
+ * To run a mutation, you first call `useDestroyCustomerIntegrationConnectionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDestroyCustomerIntegrationConnectionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [destroyCustomerIntegrationConnectionMutation, { data, loading, error }] = useDestroyCustomerIntegrationConnectionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useDestroyCustomerIntegrationConnectionMutation(baseOptions?: Apollo.MutationHookOptions<DestroyCustomerIntegrationConnectionMutation, DestroyCustomerIntegrationConnectionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DestroyCustomerIntegrationConnectionMutation, DestroyCustomerIntegrationConnectionMutationVariables>(DestroyCustomerIntegrationConnectionDocument, options);
+      }
+export type DestroyCustomerIntegrationConnectionMutationHookResult = ReturnType<typeof useDestroyCustomerIntegrationConnectionMutation>;
+export type DestroyCustomerIntegrationConnectionMutationResult = Apollo.MutationResult<DestroyCustomerIntegrationConnectionMutation>;
+export type DestroyCustomerIntegrationConnectionMutationOptions = Apollo.BaseMutationOptions<DestroyCustomerIntegrationConnectionMutation, DestroyCustomerIntegrationConnectionMutationVariables>;
 export const VoidCreditNoteDocument = gql`
     mutation voidCreditNote($input: VoidCreditNoteInput!) {
   voidCreditNote(input: $input) {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -11823,6 +11823,13 @@ export type DestroyCustomerIntegrationConnectionMutationVariables = Exact<{
 
 export type DestroyCustomerIntegrationConnectionMutation = { __typename?: 'Mutation', destroyIntegrationCustomer?: { __typename?: 'DestroyIntegrationCustomerPayload', id?: string | null } | null };
 
+export type ClearCustomerPaymentProviderMutationVariables = Exact<{
+  input: UpdateCustomerInput;
+}>;
+
+
+export type ClearCustomerPaymentProviderMutation = { __typename?: 'Mutation', updateCustomer?: { __typename?: 'Customer', id: string } | null };
+
 export type CreditNoteForVoidCreditNoteDialogFragment = { __typename?: 'CreditNote', id: string, totalAmountCents: any, currency: CurrencyEnum };
 
 export type VoidCreditNoteMutationVariables = Exact<{
@@ -26205,6 +26212,39 @@ export function useDestroyCustomerIntegrationConnectionMutation(baseOptions?: Ap
 export type DestroyCustomerIntegrationConnectionMutationHookResult = ReturnType<typeof useDestroyCustomerIntegrationConnectionMutation>;
 export type DestroyCustomerIntegrationConnectionMutationResult = Apollo.MutationResult<DestroyCustomerIntegrationConnectionMutation>;
 export type DestroyCustomerIntegrationConnectionMutationOptions = Apollo.BaseMutationOptions<DestroyCustomerIntegrationConnectionMutation, DestroyCustomerIntegrationConnectionMutationVariables>;
+export const ClearCustomerPaymentProviderDocument = gql`
+    mutation clearCustomerPaymentProvider($input: UpdateCustomerInput!) {
+  updateCustomer(input: $input) {
+    id
+  }
+}
+    `;
+export type ClearCustomerPaymentProviderMutationFn = Apollo.MutationFunction<ClearCustomerPaymentProviderMutation, ClearCustomerPaymentProviderMutationVariables>;
+
+/**
+ * __useClearCustomerPaymentProviderMutation__
+ *
+ * To run a mutation, you first call `useClearCustomerPaymentProviderMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useClearCustomerPaymentProviderMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [clearCustomerPaymentProviderMutation, { data, loading, error }] = useClearCustomerPaymentProviderMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useClearCustomerPaymentProviderMutation(baseOptions?: Apollo.MutationHookOptions<ClearCustomerPaymentProviderMutation, ClearCustomerPaymentProviderMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ClearCustomerPaymentProviderMutation, ClearCustomerPaymentProviderMutationVariables>(ClearCustomerPaymentProviderDocument, options);
+      }
+export type ClearCustomerPaymentProviderMutationHookResult = ReturnType<typeof useClearCustomerPaymentProviderMutation>;
+export type ClearCustomerPaymentProviderMutationResult = Apollo.MutationResult<ClearCustomerPaymentProviderMutation>;
+export type ClearCustomerPaymentProviderMutationOptions = Apollo.BaseMutationOptions<ClearCustomerPaymentProviderMutation, ClearCustomerPaymentProviderMutationVariables>;
 export const VoidCreditNoteDocument = gql`
     mutation voidCreditNote($input: VoidCreditNoteInput!) {
   voidCreditNote(input: $input) {


### PR DESCRIPTION
## Context

The customer-information master-detail connections view shipped on a bridge persistence strategy: every add/edit/delete went through the generic `updateCustomer` mutation, echoing the full `integrationCustomers` list verbatim on each integration write because the backend destroys any entry missing from a submitted list. All six dedicated per-connection mutations are now merged on the API, so the injected strategy can be swapped — same hook interface, zero UI change.

## Description

- Rewrite `useCustomerConnectionsPersistence` on the six dedicated mutations (create/update/destroy × payment/integration), with the gql documents colocated in the hook. `updateCustomer` disappears from this surface entirely.
- Same-code edits update the link in place by its id; switching a category to another provider destroys the old link then creates the new one (the update mutations expose no provider change); deletes destroy by link id.
- Drop the verbatim `integrationCustomers` list rebuild and its guards — writing a single connection by id removes the sibling-wipe hazard by construction — and the bounded refresh poll, since the dedicated create services run synchronously (the shared polling constants stay for their other consumer).
- `createIntegrationCustomer` targets the org integration by id: the hook now receives the org lists from `useConnectionOptions` and resolves the drawer's connection code to the integration id, aborting with an error toast when the code cannot be resolved.
- The mutations return the connection object rather than the customer, so the silent standalone customer query after each write is now required (it was belt-and-braces before); it also runs after a failed provider switch so a landed destroy-half is reflected. The page's active getCustomer observer is still never refetched.
- Persistence tests rewritten against the six mutations: exact variables per path, destroy-before-create ordering, switch-abort on destroy failure, unresolved-code and missing-link guards.

> Stacked on #4033 (ING-434) — the base flips to main automatically when it merges.

<!-- Linear link -->
Fixes ING-517