### PR TITLE
fix(quotes): send overridden plan name inside overrides

### DIFF
--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
@@ -151,6 +151,12 @@ export function SubscriptionPricingContent({
   const displayCurrency = currency ?? CurrencyEnum.Usd
   const displayInterval = formInterval || PlanInterval.Monthly
 
+  // Base (original) plan name for the payload. On a fresh selection it comes from the
+  // freshly-fetched plan; when editing an existing quote plan the plan query is skipped
+  // (planData is undefined), so fall back to the already-stored base name.
+  const basePlanName =
+    planData?.name ?? billingItemPlan?.payload.name ?? initialState?.basePlanName ?? formName
+
   // Sync to stateRef + formValuesRef. Overrides are no longer computed here:
   // toPlanBillingItems() derives them from formValuesRef (see buildPlanOverrides).
   useEffect(() => {
@@ -163,6 +169,7 @@ export function SubscriptionPricingContent({
       planId: planData?.id ?? selectedPlanId,
       planCode: formCode,
       planName: formName,
+      basePlanName,
       planDescription: formDescription ?? '',
       subscriptionSettings,
       invoicingSettings,
@@ -176,6 +183,7 @@ export function SubscriptionPricingContent({
     subscriptionSettings,
     invoicingSettings,
     formName,
+    basePlanName,
     formDescription,
     formCode,
     formValues,

--- a/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
+++ b/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
@@ -30,6 +30,7 @@ const basePricingState: SubscriptionPricingState = {
   planId: 'plan_123',
   planCode: 'enterprise',
   planName: 'Enterprise Plan',
+  basePlanName: 'Enterprise Plan',
   planDescription: 'Custom enterprise offering',
   subscriptionSettings: {
     ...DEFAULT_SUBSCRIPTION_SETTINGS,
@@ -156,6 +157,25 @@ describe('toPlanBillingItems', () => {
       amountCents: 85000,
       minimumCommitment: { amountCents: 8000000, invoiceDisplayName: undefined },
     })
+  })
+
+  it('keeps the base name in payload.name and sends the renamed plan in overrides.name', () => {
+    const formValues: PlanFormInput = {
+      ...baseFormValues,
+      name: 'Enterprise Plan - Acme',
+    }
+    const result = toPlanBillingItems(basePricingState, formValues)
+
+    // Base (original) name stays in the payload; the override lives in overrides.
+    expect(result.plans[0].payload.name).toBe('Enterprise Plan')
+    expect(result.plans[0].overrides.name).toBe('Enterprise Plan - Acme')
+  })
+
+  it('does not send overrides.name when the plan name is unchanged', () => {
+    const result = toPlanBillingItems(basePricingState, baseFormValues)
+
+    expect(result.plans[0].payload.name).toBe('Enterprise Plan')
+    expect(result.plans[0].overrides.name).toBeUndefined()
   })
 
   it('falls back to state.overrides when no form values are provided', () => {
@@ -299,8 +319,22 @@ describe('fromPlanBillingItems', () => {
     expect(result.planId).toBe('plan_123')
     expect(result.planCode).toBe('enterprise')
     expect(result.planName).toBe('Enterprise Plan')
+    expect(result.basePlanName).toBe('Enterprise Plan')
     expect(result.planDescription).toBe('Custom enterprise offering')
     expect(result.overrides).toEqual({})
+  })
+
+  it('uses overrides.name as the effective name and payload.name as the base', () => {
+    const plan: BillingItemPlan = {
+      ...baseBillingItemPlan,
+      overrides: { name: 'Enterprise Plan - Acme' },
+    }
+    const result = fromPlanBillingItems([plan])
+
+    // Effective/display name is the override; base stays the original payload name.
+    expect(result.planName).toBe('Enterprise Plan - Acme')
+    expect(result.basePlanName).toBe('Enterprise Plan')
+    expect(result.entityData.plan_123.name).toBe('Enterprise Plan - Acme')
   })
 
   it('deserializes subscription settings from payload', () => {
@@ -528,6 +562,24 @@ describe('round-trip: toPlanBillingItems → fromPlanBillingItems', () => {
     expect(recurring?.amountCents).toBe(100000)
     expect(recurring?.thresholdDisplayName).toBe('Monthly Cap')
     expect(recurring?.recurring).toBe(true)
+  })
+
+  it('round-trips an overridden plan name (base in payload, override in overrides)', () => {
+    const formValues: PlanFormInput = {
+      ...baseFormValues,
+      name: 'Enterprise Plan - Acme',
+    }
+
+    const serialized = toPlanBillingItems(basePricingState, formValues)
+
+    expect(serialized.plans[0].payload.name).toBe('Enterprise Plan')
+    expect(serialized.plans[0].overrides.name).toBe('Enterprise Plan - Acme')
+
+    const deserialized = fromPlanBillingItems(serialized.plans)
+
+    expect(deserialized.basePlanName).toBe('Enterprise Plan')
+    expect(deserialized.planName).toBe('Enterprise Plan - Acme')
+    expect(deserialized.formValues?.name).toBe('Enterprise Plan - Acme')
   })
 
   it('backward compat: legacy payload without interval/charges returns null formValues', () => {

--- a/src/core/serializers/serializeQuotePlanBillingItems.ts
+++ b/src/core/serializers/serializeQuotePlanBillingItems.ts
@@ -31,6 +31,7 @@ interface PlanUsageThresholdOverride {
 }
 
 export interface PlanOverrides {
+  name?: string
   amountCents?: number
   invoiceDisplayName?: string
   minimumCommitment?: PlanMinimumCommitmentOverride
@@ -197,7 +198,11 @@ export const DEFAULT_INVOICING_SETTINGS: InvoicingSettings = {
 export interface SubscriptionPricingState {
   planId: string
   planCode: string
+  // Effective/display name shown in the quote doc: the override when set, else the base name.
   planName: string
+  // Original plan name, persisted verbatim to `payload.name`. Optional for backward
+  // compatibility with callers that only carry the effective `planName`.
+  basePlanName?: string
   planDescription: string
   subscriptionSettings: SubscriptionSettings
   invoicingSettings: InvoicingSettings
@@ -364,14 +369,25 @@ export const toPlanBillingItems = (
   const { planId, planCode, planName, planDescription, subscriptionSettings, invoicingSettings } =
     state
 
+  // The base (original) plan name lives in the payload; the effective `planName`
+  // is used only for display. Fall back to `planName` for callers that don't carry a base.
+  const base = state.basePlanName ?? planName
+
   // Derive overrides from the form values (single source of truth). Fall back to
   // any pre-built overrides on the state for callers that serialize without form values.
   const overrides = formValues ? buildPlanOverrides(formValues) : (state.overrides ?? {})
 
+  // The renamed plan goes into `overrides.name` (backend applies plan changes from
+  // `overrides`), and only when it actually differs from the base — mirroring the
+  // conditional handling of the other override fields.
+  if (formValues?.name && formValues.name !== base) {
+    overrides.name = formValues.name
+  }
+
   const payload: PlanPayload = {
     position: 1,
     code: planCode,
-    name: planName,
+    name: base,
     description: planDescription,
     subscriptionExternalId: normalizeOptional(subscriptionSettings.externalId),
     subscriptionName: normalizeOptional(subscriptionSettings.subscriptionName),
@@ -440,7 +456,10 @@ export const toPlanBillingItems = (
 interface FromPlanBillingItemsResult {
   planId: string
   planCode: string
+  // Effective/display name: the override when set, else the base name.
   planName: string
+  // Original plan name (payload.name), used to seed the base for re-serialization.
+  basePlanName: string
   planDescription: string
   subscriptionSettings: SubscriptionSettings
   invoicingSettings: InvoicingSettings
@@ -520,6 +539,9 @@ export const fromPlanBillingItems = (plans: BillingItemPlan[]): FromPlanBillingI
   const plan = plans[0]
   const { payload, overrides, id } = plan
 
+  // Effective/display name: the override takes precedence over the base plan name.
+  const effectiveName = overrides.name ?? payload.name
+
   const subscriptionSettings: SubscriptionSettings = {
     externalId: denormalizeOptional(payload.subscriptionExternalId),
     subscriptionName: denormalizeOptional(payload.subscriptionName),
@@ -589,7 +611,7 @@ export const fromPlanBillingItems = (plans: BillingItemPlan[]): FromPlanBillingI
           }
         : undefined,
       entitlements: [],
-      name: payload.name,
+      name: effectiveName,
       code: payload.code,
       description: payload.description,
     }
@@ -599,7 +621,7 @@ export const fromPlanBillingItems = (plans: BillingItemPlan[]): FromPlanBillingI
     [id]: {
       entityId: id,
       entityType: 'plan',
-      name: payload.name,
+      name: effectiveName,
       code: payload.code,
       plan: buildPlanPreviewData(formValues),
     },
@@ -608,7 +630,8 @@ export const fromPlanBillingItems = (plans: BillingItemPlan[]): FromPlanBillingI
   return {
     planId: id,
     planCode: payload.code,
-    planName: payload.name,
+    planName: effectiveName,
+    basePlanName: payload.name,
     planDescription: payload.description,
     subscriptionSettings,
     invoicingSettings,

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -104,6 +104,7 @@ export const useSubscriptionPricingDrawer = (
       planId: result.planId,
       planCode: result.planCode,
       planName: result.planName,
+      basePlanName: result.basePlanName,
       planDescription: result.planDescription,
       subscriptionSettings: result.subscriptionSettings,
       invoicingSettings: result.invoicingSettings,


### PR DESCRIPTION
## Context

In the Quotes pricing block, renaming a plan wrote the new name to `payload.name` but never to `overrides`. The backend applies plan changes from `overrides`, so the rename was silently dropped.

## Description

Decouple three name concepts: the base (original) plan name stays in `payload.name`, the renamed value is sent in `overrides.name` only when it differs from the base, and the effective name (`overrides.name ?? payload.name`) drives the quote display and round-trips back into the edit form. Since the plan query is skipped while editing an existing quote plan, the base name falls back to the already-stored `payload.name`. Added serializer unit tests plus a round-trip test.

<!-- Linear link -->
Fixes LAGO-1773