### PR TITLE
fix(subscriptions): stop sending purchaseOrderNumber when it is not editable

### DIFF
--- a/src/components/purchaseOrder/PO.tsx
+++ b/src/components/purchaseOrder/PO.tsx
@@ -9,7 +9,7 @@ import { PurchaseOrderNumber } from './PurchaseOrderNumber'
 import { PurchaseOrderRoot } from './PurchaseOrderRoot'
 import { PurchaseOrderTitle } from './PurchaseOrderTitle'
 
-export { normalizePurchaseOrderNumber } from './utils'
+export { isSubscriptionPurchaseOrderNumberEditable, normalizePurchaseOrderNumber } from './utils'
 
 export const PurchaseOrder = Object.assign(PurchaseOrderRoot, {
   Title: PurchaseOrderTitle,

--- a/src/components/purchaseOrder/__tests__/utils.test.ts
+++ b/src/components/purchaseOrder/__tests__/utils.test.ts
@@ -1,4 +1,6 @@
-import { normalizePurchaseOrderNumber } from '../utils'
+import { StatusTypeEnum } from '~/generated/graphql'
+
+import { isSubscriptionPurchaseOrderNumberEditable, normalizePurchaseOrderNumber } from '../utils'
 
 describe('normalizePurchaseOrderNumber', () => {
   describe('GIVEN an empty-ish value', () => {
@@ -26,6 +28,31 @@ describe('normalizePurchaseOrderNumber', () => {
         ['inner whitespace preserved', '  PO 123 456  ', 'PO 123 456'],
       ])('THEN should return the trimmed value for %s', (_, input, expected) => {
         expect(normalizePurchaseOrderNumber(input)).toBe(expected)
+      })
+    })
+  })
+})
+
+describe('isSubscriptionPurchaseOrderNumberEditable', () => {
+  describe('GIVEN a subscription status', () => {
+    describe('WHEN the subscription is pending or active', () => {
+      it.each([
+        ['pending', StatusTypeEnum.Pending],
+        ['active', StatusTypeEnum.Active],
+      ])('THEN should return true for %s', (_, status) => {
+        expect(isSubscriptionPurchaseOrderNumberEditable(status)).toBe(true)
+      })
+    })
+
+    describe('WHEN the subscription is in any other state', () => {
+      it.each([
+        ['terminated', StatusTypeEnum.Terminated],
+        ['canceled', StatusTypeEnum.Canceled],
+        ['incomplete', StatusTypeEnum.Incomplete],
+        ['undefined', undefined],
+        ['null', null],
+      ])('THEN should return false for %s', (_, status) => {
+        expect(isSubscriptionPurchaseOrderNumberEditable(status)).toBe(false)
       })
     })
   })

--- a/src/components/purchaseOrder/utils.ts
+++ b/src/components/purchaseOrder/utils.ts
@@ -1,5 +1,16 @@
+import { StatusTypeEnum } from '~/generated/graphql'
+
 export const normalizePurchaseOrderNumber = (value?: string | null) => {
   const trimmed = value?.trim()
 
   return trimmed || null
 }
+
+// The API only accepts the `purchaseOrderNumber` key on `updateSubscription`
+// while the subscription is pending or active — otherwise it rejects the whole
+// update with `purchase_order_number_not_editable` (405), on key presence alone
+// and not on an actual value change. Consumers use this both to disable the
+// field and to omit the key from the mutation input.
+export const isSubscriptionPurchaseOrderNumberEditable = (
+  status?: StatusTypeEnum | null,
+): boolean => status === StatusTypeEnum.Pending || status === StatusTypeEnum.Active

--- a/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
+++ b/src/components/subscriptions/form/SubscriptionInformationFormSection.tsx
@@ -6,6 +6,7 @@ import { SubscriptionDatesOffsetHelperComponent } from '~/components/customers/s
 import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
+import { isSubscriptionPurchaseOrderNumberEditable } from '~/components/purchaseOrder/PO'
 import { PurchaseOrderFormBlock } from '~/components/purchaseOrder/PurchaseOrderFormBlock'
 import { SubscriptionActivationRuleSection } from '~/components/subscriptions/SubscriptionActivationRuleSection'
 import { FORM_TYPE_ENUM } from '~/core/constants/form'
@@ -324,8 +325,7 @@ export const SubscriptionInformationFormSection = withForm({
                 // PO number is only editable while the subscription is pending or active.
                 disabled={
                   formType === FORM_TYPE_ENUM.edition &&
-                  subscription?.status !== StatusTypeEnum.Pending &&
-                  subscription?.status !== StatusTypeEnum.Active
+                  !isSubscriptionPurchaseOrderNumberEditable(subscription?.status)
                 }
                 onChange={(value) => field.handleChange(value ?? undefined)}
               />

--- a/src/core/apolloClient/__tests__/errorUtils.test.ts
+++ b/src/core/apolloClient/__tests__/errorUtils.test.ts
@@ -2,7 +2,9 @@ import { ApolloError } from '@apollo/client'
 import { GraphQLFormattedError } from 'graphql'
 
 import {
+  buildGraphQLErrorFingerprint,
   extractThirdPartyErrorMessage,
+  getGraphQLErrorCode,
   hasDefinedGQLError,
   LagoGQLError,
   PspErrorCode,
@@ -154,6 +156,62 @@ describe('Test apollo utils', () => {
       expect(hasDefinedGQLError('UserAlreadyExists', emailError)).toBeTruthy()
       expect(hasDefinedGQLError('Forbidden', emailError)).toBeTruthy()
       expect(hasDefinedGQLError('CurrenciesDoesNotMatch', emailError)).toBeFalsy()
+    })
+  })
+})
+
+describe('getGraphQLErrorCode', () => {
+  describe('GIVEN a GraphQL error extensions object', () => {
+    describe('WHEN it carries a string code', () => {
+      it('THEN should return that code', () => {
+        expect(getGraphQLErrorCode({ code: 'purchase_order_number_not_editable' })).toBe(
+          'purchase_order_number_not_editable',
+        )
+      })
+    })
+
+    describe('WHEN the code is missing or not a string', () => {
+      it.each([
+        ['undefined extensions', undefined],
+        ['empty extensions', {}],
+        ['numeric code', { code: 405 }],
+        ['null code', { code: null }],
+      ])('THEN should return "unknown" for %s', (_, extensions) => {
+        expect(getGraphQLErrorCode(extensions)).toBe('unknown')
+      })
+    })
+  })
+})
+
+describe('buildGraphQLErrorFingerprint', () => {
+  describe('GIVEN an operation name and an error code', () => {
+    describe('WHEN both are known', () => {
+      // Two failures sharing the generic "Method Not Allowed" message must not
+      // collapse into a single Sentry issue.
+      it('THEN should build a fingerprint scoped to the operation and the code', () => {
+        expect(
+          buildGraphQLErrorFingerprint('updateSubscription', 'purchase_order_number_not_editable'),
+        ).toEqual(['graphql-error', 'updateSubscription', 'purchase_order_number_not_editable'])
+      })
+
+      it('THEN should build a different fingerprint for another operation with the same code', () => {
+        expect(buildGraphQLErrorFingerprint('voidInvoice', 'not_voidable')).not.toEqual(
+          buildGraphQLErrorFingerprint('updateSubscription', 'not_voidable'),
+        )
+      })
+    })
+
+    describe('WHEN the operation name is missing', () => {
+      it.each([
+        ['undefined', undefined],
+        ['empty string', ''],
+      ])('THEN should fall back to "unknown" for %s', (_, operationName) => {
+        expect(buildGraphQLErrorFingerprint(operationName, 'not_voidable')).toEqual([
+          'graphql-error',
+          'unknown',
+          'not_voidable',
+        ])
+      })
     })
   })
 })

--- a/src/core/apolloClient/errorUtils.ts
+++ b/src/core/apolloClient/errorUtils.ts
@@ -34,6 +34,21 @@ export const extractThirdPartyErrorMessage = (
   return Array.isArray(errorDetail) ? errorDetail[0] : errorDetail
 }
 
+const UNKNOWN_ERROR_IDENTIFIER = 'unknown'
+
+// `extensions.code` is untyped by the GraphQL spec, so narrow it before using it
+// as a Sentry tag or fingerprint component.
+export const getGraphQLErrorCode = (extensions?: GraphQLFormattedError['extensions']): string =>
+  typeof extensions?.code === 'string' ? extensions.code : UNKNOWN_ERROR_IDENTIFIER
+
+// Sentry groups by the error message by default, so the generic HTTP messages the
+// API returns ("Method Not Allowed", "Unprocessable Entity", ...) collapse unrelated
+// failures into a single issue. Group per operation + error code instead.
+export const buildGraphQLErrorFingerprint = (
+  operationName: string | undefined,
+  errorCode: string,
+): Array<string> => ['graphql-error', operationName || UNKNOWN_ERROR_IDENTIFIER, errorCode]
+
 // --------------------- Graphql errors checker ---------------------
 export const hasDefinedGQLError = (
   errorCode: keyof typeof LagoApiError,

--- a/src/core/apolloClient/init.ts
+++ b/src/core/apolloClient/init.ts
@@ -26,6 +26,7 @@ import { buildAuthHeaders } from './authHeaders'
 import { cache } from './cache'
 import { setupCachePersistor } from './cachePersistor'
 import { omitDeep } from './cacheUtils'
+import { buildGraphQLErrorFingerprint, getGraphQLErrorCode } from './errorUtils'
 import { resolvers, typeDefs } from './graphqlResolvers'
 
 const AUTH_ERRORS = [
@@ -220,14 +221,17 @@ export const initializeApolloClient = async () => {
 
           graphQLError.name = 'GraphQLError'
 
+          const errorCode = getGraphQLErrorCode(extensions)
+
           // Capture in Sentry with operation details
           captureException(graphQLError, {
             tags: {
               errorType: 'GraphQLError',
               operation: operationType,
               operationName: operation.operationName || 'unknown',
-              errorCode: typeof extensions?.code === 'string' ? extensions.code : 'unknown',
+              errorCode,
             },
+            fingerprint: buildGraphQLErrorFingerprint(operation.operationName, errorCode),
             extra: {
               path,
               locations,

--- a/src/hooks/customer/__tests__/useAddSubscription.test.tsx
+++ b/src/hooks/customer/__tests__/useAddSubscription.test.tsx
@@ -1,0 +1,161 @@
+import { MockedProvider, MockedResponse } from '@apollo/client/testing'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { PlanFormInput } from '~/components/plans/types'
+import {
+  CreateSubscriptionDocument,
+  CreateSubscriptionInput,
+  GetSubscriptionForCreateSubscriptionQuery,
+  PlanInterval,
+  StatusTypeEnum,
+  UpdateSubscriptionDocument,
+} from '~/generated/graphql'
+
+import { useAddSubscription } from '../useAddSubscription'
+
+// `useAddSubscription` derives its form type from the pathname, so the router
+// entry is what selects the create vs. update branch.
+const EDITION_PATHNAME = '/update/subscription/sub-1'
+const CREATION_PATHNAME = '/create/subscription'
+
+const mockPathname = { current: EDITION_PATHNAME }
+
+jest.mock('~/core/router', () => ({
+  ...jest.requireActual('~/core/router'),
+  useNavigate: () => jest.fn(),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+jest.mock('~/hooks/useIframeConfig', () => ({
+  useIframeConfig: () => ({
+    emitIframeMessage: jest.fn(),
+    emitSalesForceEvent: jest.fn(),
+    isRunningInIframeContext: false,
+    isRunningInSalesForceIframe: false,
+  }),
+}))
+
+type ExistingSubscription = GetSubscriptionForCreateSubscriptionQuery['subscription']
+
+const existingSubscription = {
+  id: 'sub-1',
+  status: StatusTypeEnum.Active,
+  startedAt: '2026-01-01',
+  externalId: 'ext-1',
+  plan: { id: 'plan-1', name: 'P', code: 'p', interval: PlanInterval.Monthly },
+} as unknown as ExistingSubscription
+
+const formValues = {
+  planId: 'plan-1',
+  purchaseOrderNumber: 'PO-123',
+  name: 'My subscription',
+  subscriptionAt: '2026-01-01',
+} as unknown as Omit<CreateSubscriptionInput, 'customerId'>
+
+const planValues = {} as PlanFormInput
+
+const captureMock = (
+  query: typeof UpdateSubscriptionDocument,
+  capture: (variables: Record<string, unknown>) => void,
+): MockedResponse[] => [
+  {
+    request: { query },
+    variableMatcher: (variables: Record<string, unknown>) => {
+      capture(variables)
+
+      return true
+    },
+    result: { data: null },
+  },
+]
+
+const renderAddSubscriptionHook = (mocks: MockedResponse[], subscription: ExistingSubscription) => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[mockPathname.current]}>
+      <MockedProvider mocks={mocks} addTypename={false}>
+        {children}
+      </MockedProvider>
+    </MemoryRouter>
+  )
+
+  return renderHook(() => useAddSubscription({ existingSubscription: subscription }), { wrapper })
+}
+
+const submitAndCaptureInput = async (
+  query: typeof UpdateSubscriptionDocument,
+  subscription: ExistingSubscription,
+): Promise<Record<string, unknown>> => {
+  let capturedVariables: Record<string, unknown> | undefined
+
+  const { result } = renderAddSubscriptionHook(
+    captureMock(query, (variables) => {
+      capturedVariables = variables
+    }),
+    subscription,
+  )
+
+  await act(async () => {
+    await result.current.onSave('cust-1', formValues, planValues, false)
+  })
+
+  await waitFor(() => expect(capturedVariables).toBeDefined())
+
+  return (capturedVariables as { input: Record<string, unknown> }).input
+}
+
+describe('useAddSubscription', () => {
+  afterEach(() => {
+    mockPathname.current = EDITION_PATHNAME
+  })
+
+  // The API rejects the whole update as soon as the `purchaseOrderNumber` key is
+  // present on a subscription that is neither pending nor active, even when the
+  // value did not change (`purchase_order_number_not_editable`, 405).
+  describe('GIVEN the subscription edition form is submitted', () => {
+    describe.each([
+      ['terminated', StatusTypeEnum.Terminated],
+      ['canceled', StatusTypeEnum.Canceled],
+    ])('WHEN the subscription is %s', (_, status) => {
+      it('THEN should omit the purchaseOrderNumber key from the update input', async () => {
+        const input = await submitAndCaptureInput(UpdateSubscriptionDocument, {
+          ...existingSubscription,
+          status,
+        } as ExistingSubscription)
+
+        expect(input).not.toHaveProperty('purchaseOrderNumber')
+        expect(input).toMatchObject({ id: 'sub-1', name: 'My subscription' })
+      })
+    })
+
+    describe.each([
+      ['pending', StatusTypeEnum.Pending],
+      ['active', StatusTypeEnum.Active],
+    ])('WHEN the subscription is %s', (_, status) => {
+      it('THEN should send the purchaseOrderNumber in the update input', async () => {
+        const input = await submitAndCaptureInput(UpdateSubscriptionDocument, {
+          ...existingSubscription,
+          status,
+        } as ExistingSubscription)
+
+        expect(input).toMatchObject({ purchaseOrderNumber: 'PO-123' })
+      })
+    })
+  })
+
+  describe('GIVEN the subscription creation form is submitted', () => {
+    describe('WHEN the subscription does not exist yet', () => {
+      it('THEN should send the purchaseOrderNumber in the create input', async () => {
+        mockPathname.current = CREATION_PATHNAME
+
+        const input = await submitAndCaptureInput(CreateSubscriptionDocument, undefined)
+
+        expect(input).toMatchObject({ purchaseOrderNumber: 'PO-123' })
+      })
+    })
+  })
+})

--- a/src/hooks/customer/__tests__/useUpdateSubscriptionInformation.test.tsx
+++ b/src/hooks/customer/__tests__/useUpdateSubscriptionInformation.test.tsx
@@ -51,16 +51,21 @@ const expectedInput = {
   purchaseOrderNumber: null,
 }
 
-const renderUpdateHook = (mocks: MockedResponse[], onSuccess: () => void) => {
+const renderUpdateHook = (
+  mocks: MockedResponse[],
+  onSuccess: () => void,
+  subscriptionOverride: SubscriptionForSubscriptionEditFormFragment = subscription,
+) => {
   const wrapper = ({ children }: { children: ReactNode }) => (
     <MockedProvider mocks={mocks} addTypename={false}>
       {children}
     </MockedProvider>
   )
 
-  return renderHook(() => useUpdateSubscriptionInformation({ subscription, onSuccess }), {
-    wrapper,
-  })
+  return renderHook(
+    () => useUpdateSubscriptionInformation({ subscription: subscriptionOverride, onSuccess }),
+    { wrapper },
+  )
 }
 
 describe('useUpdateSubscriptionInformation', () => {
@@ -138,5 +143,114 @@ describe('useUpdateSubscriptionInformation', () => {
 
     expect(mockAddToast).not.toHaveBeenCalled()
     expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  // The API rejects the whole update as soon as the `purchaseOrderNumber` key is
+  // present on a subscription that is neither pending nor active, even when the
+  // value did not change (`purchase_order_number_not_editable`, 405).
+  describe('GIVEN a subscription whose purchase order number is not editable', () => {
+    const captureVariablesMock = (
+      capture: (variables: Record<string, unknown>) => void,
+    ): MockedResponse[] => [
+      {
+        request: { query: UpdateSubscriptionDocument },
+        variableMatcher: (variables: Record<string, unknown>) => {
+          capture(variables)
+
+          return true
+        },
+        result: {
+          data: {
+            updateSubscription: {
+              id: 'sub-1',
+              status: StatusTypeEnum.Terminated,
+              startedAt: '2026-01-01',
+              subscriptionAt: expectedInput.subscriptionAt,
+              endingAt: null,
+              name: 'My subscription',
+              externalId: 'ext-1',
+              paymentMethodType: null,
+              paymentMethod: null,
+              consolidateInvoice: true,
+              skipInvoiceCustomSections: false,
+              selectedInvoiceCustomSections: [],
+              customer: { id: 'cust-1', activeSubscriptionsCount: 1 },
+              plan: { id: 'plan-1', name: 'P', code: 'p', interval: PlanInterval.Monthly },
+            },
+          },
+        },
+      },
+    ]
+
+    describe.each([
+      ['terminated', StatusTypeEnum.Terminated],
+      ['canceled', StatusTypeEnum.Canceled],
+    ])('WHEN the subscription is %s', (_, status) => {
+      it('THEN should omit the purchaseOrderNumber key from the mutation input', async () => {
+        let capturedVariables: Record<string, unknown> | undefined
+
+        const { result } = renderUpdateHook(
+          captureVariablesMock((variables) => {
+            capturedVariables = variables
+          }),
+          jest.fn(),
+          { ...subscription, status },
+        )
+
+        await act(async () => {
+          await result.current.form.handleSubmit()
+        })
+
+        await waitFor(() => expect(capturedVariables).toBeDefined())
+
+        const input = (capturedVariables as { input: Record<string, unknown> }).input
+
+        expect(input).not.toHaveProperty('purchaseOrderNumber')
+        // The rest of the editable fields still go through.
+        expect(input).toEqual({
+          id: expectedInput.id,
+          name: expectedInput.name,
+          subscriptionAt: expectedInput.subscriptionAt,
+          endingAt: expectedInput.endingAt,
+        })
+      })
+    })
+  })
+
+  describe('GIVEN a subscription whose purchase order number is editable', () => {
+    describe.each([
+      ['pending', StatusTypeEnum.Pending],
+      ['active', StatusTypeEnum.Active],
+    ])('WHEN the subscription is %s and the field is empty', (_, status) => {
+      // An explicit `null` is the clear mechanism: `undefined` would be stripped
+      // from the payload and the previous value would persist.
+      it('THEN should keep sending purchaseOrderNumber as null', async () => {
+        let capturedVariables: Record<string, unknown> | undefined
+
+        const mocks: MockedResponse[] = [
+          {
+            request: { query: UpdateSubscriptionDocument },
+            variableMatcher: (variables: Record<string, unknown>) => {
+              capturedVariables = variables
+
+              return true
+            },
+            result: { data: { updateSubscription: null } },
+          },
+        ]
+
+        const { result } = renderUpdateHook(mocks, jest.fn(), { ...subscription, status })
+
+        await act(async () => {
+          await result.current.form.handleSubmit()
+        })
+
+        await waitFor(() => expect(capturedVariables).toBeDefined())
+
+        expect((capturedVariables as { input: Record<string, unknown> }).input).toEqual(
+          expectedInput,
+        )
+      })
+    })
   })
 })

--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import { generatePath, useSearchParams } from 'react-router-dom'
 
 import { PlanFormInput } from '~/components/plans/types'
+import { isSubscriptionPurchaseOrderNumberEditable } from '~/components/purchaseOrder/PO'
 import { REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE } from '~/components/subscriptions/SubscriptionUsageLifetimeGraph'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { FORM_TYPE_ENUM } from '~/core/constants/form'
@@ -388,6 +389,7 @@ export const useAddSubscription: UseAddSubscription = ({
         billingTime,
         paymentMethod,
         billingEntityId,
+        purchaseOrderNumber,
         ...values
       },
       { ...planValues },
@@ -441,6 +443,7 @@ export const useAddSubscription: UseAddSubscription = ({
                   name: name || undefined,
                   externalId: externalId || undefined,
                   paymentMethod: parsedPaymentMethod,
+                  purchaseOrderNumber,
                   ...values,
                   planOverrides,
                 },
@@ -458,6 +461,13 @@ export const useAddSubscription: UseAddSubscription = ({
                   // subscription column, meaning "inherit from customer".
                   billingEntityId: billingEntityId || null,
                   paymentMethod: parsedPaymentMethod,
+                  // Omitted entirely when not editable, otherwise the BE rejects
+                  // the whole update and the rest of the form can no longer be
+                  // edited. When editable the key must stay even as `null` —
+                  // that is the clear mechanism.
+                  ...(isSubscriptionPurchaseOrderNumberEditable(existingSubscription?.status)
+                    ? { purchaseOrderNumber }
+                    : {}),
                   planOverrides,
                 },
               },

--- a/src/hooks/customer/useUpdateSubscriptionInformation.ts
+++ b/src/hooks/customer/useUpdateSubscriptionInformation.ts
@@ -1,6 +1,9 @@
 import { DateTime } from 'luxon'
 
-import { normalizePurchaseOrderNumber } from '~/components/purchaseOrder/PO'
+import {
+  isSubscriptionPurchaseOrderNumberEditable,
+  normalizePurchaseOrderNumber,
+} from '~/components/purchaseOrder/PO'
 import {
   SubscriptionUpdateFormOptions,
   useUpdateSubscriptionForm,
@@ -21,6 +24,11 @@ export const useUpdateSubscriptionInformation = ({
       name: value.name || null,
       subscriptionAt: DateTime.fromISO(value.subscriptionAt).toUTC().toISO(),
       endingAt: value.endingAt ? DateTime.fromISO(value.endingAt).toUTC().toISO() : null,
-      purchaseOrderNumber: normalizePurchaseOrderNumber(value.purchaseOrderNumber),
+      // Omitted entirely when not editable, otherwise the BE rejects the whole
+      // update and name/dates can no longer be edited. When editable the key
+      // must stay even as `null` — that is the clear mechanism.
+      ...(isSubscriptionPurchaseOrderNumberEditable(subscription?.status)
+        ? { purchaseOrderNumber: normalizePurchaseOrderNumber(value.purchaseOrderNumber) }
+        : {}),
     }),
   })


### PR DESCRIPTION
## Context

Editing the information (name / dates) of a subscription that is neither pending nor active — a terminated one, for instance — failed with the generic "an error occurred" toast. The `updateSubscription` mutation was rejected with Method Not Allowed (405), `purchase_order_number_not_editable`.

Since the API restricted PO number editing on subscriptions, `Subscriptions::UpdateService` rejects the *whole* update when the `purchase_order_number` key is present in the params and the subscription is not pending/active. It checks key presence, not a value change — and the front always included `purchaseOrderNumber` in the mutation input (as `null` when empty), even though the UI itself already disables that field for those statuses. A legitimate edit of the name or the dates was therefore refused.

Reported via Sentry FRONT-15T (Epicor user editing `endingAt` on a terminated subscription).

## Description

Front-end only; no backend change is needed, the guard is intentional API behaviour.

- Add `isSubscriptionPurchaseOrderNumberEditable(status)` to `components/purchaseOrder/utils.ts`, the single source of truth for the "pending or active" rule, and re-export it from `PO`.
- Omit the `purchaseOrderNumber` key from the `updateSubscription` input when the subscription status is not pending/active, in both call sites that were sending it: `useUpdateSubscriptionInformation` (the subscription information drawer) and the update branch of `useAddSubscription` (the subscription edition form, where it used to travel through the `...values` spread).
  For editable statuses the key keeps being sent even when `null`, since an explicit `null` is what clears the column while `undefined` gets stripped. Creation and upgrade/downgrade go through `createSubscription`, which has no such guard, and keep sending the field unconditionally.
- `SubscriptionInformationFormSection` now derives its `disabled` prop from the same helper instead of repeating the status comparison inline.

The two other `updateSubscription` callers (`useUpdateSubscriptionSettings`, `useUpdateSubscriptionPlanOverride`) never include the key, so they are unaffected.

Also included, the observability follow-up described in the ticket: the Apollo error link fingerprinted GraphQL errors on the generic message alone, so FRONT-15T actually grouped two unrelated failures (`updateSubscription`/`purchase_order_number_not_editable` and `voidInvoice`/`not_voidable`). Sentry now groups per operation name + error code. The two helpers behind it live in `apolloClient/errorUtils.ts` so they are unit-testable. The ticket suggested it could ship separately — it is here so the issue is closed in one PR.

Tests: the editable/non-editable matrix on both mutation call sites (key omitted when terminated or canceled, still sent as `null` when pending or active, still sent on creation), the new status helper, and the fingerprint helpers.

<!-- Linear link -->
Fixes LAGO-1768

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yfFvUFWYt2TLgN2G3KZnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013yfFvUFWYt2TLgN2G3KZnZ)_