### PR TITLE
refactor(subscriptions): send purchaseOrderNumber unconditionally again

### DIFF
--- a/src/components/purchaseOrder/utils.ts
+++ b/src/components/purchaseOrder/utils.ts
@@ -6,11 +6,11 @@ export const normalizePurchaseOrderNumber = (value?: string | null) => {
   return trimmed || null
 }
 
-// The API only accepts the `purchaseOrderNumber` key on `updateSubscription`
-// while the subscription is pending or active — otherwise it rejects the whole
-// update with `purchase_order_number_not_editable` (405), on key presence alone
-// and not on an actual value change. Consumers use this both to disable the
-// field and to omit the key from the mutation input.
+// The API only accepts a *change* of `purchaseOrderNumber` on
+// `updateSubscription` while the subscription is pending or active — any other
+// status is rejected with `purchase_order_number_not_editable` (405). The
+// mutation input always carries the key; this rule is what disables the field
+// in the form so the change is never attempted in the first place.
 export const isSubscriptionPurchaseOrderNumberEditable = (
   status?: StatusTypeEnum | null,
 ): boolean => status === StatusTypeEnum.Pending || status === StatusTypeEnum.Active

--- a/src/hooks/customer/__tests__/useAddSubscription.test.tsx
+++ b/src/hooks/customer/__tests__/useAddSubscription.test.tsx
@@ -113,28 +113,16 @@ describe('useAddSubscription', () => {
     mockPathname.current = EDITION_PATHNAME
   })
 
-  // The API rejects the whole update as soon as the `purchaseOrderNumber` key is
-  // present on a subscription that is neither pending nor active, even when the
-  // value did not change (`purchase_order_number_not_editable`, 405).
+  // The API rejects the `purchaseOrderNumber` only when the value actually
+  // changes on a subscription that is neither pending nor active
+  // (`purchase_order_number_not_editable`, 405), so the client always sends the
+  // key and lets the API decide.
   describe('GIVEN the subscription edition form is submitted', () => {
-    describe.each([
-      ['terminated', StatusTypeEnum.Terminated],
-      ['canceled', StatusTypeEnum.Canceled],
-    ])('WHEN the subscription is %s', (_, status) => {
-      it('THEN should omit the purchaseOrderNumber key from the update input', async () => {
-        const input = await submitAndCaptureInput(UpdateSubscriptionDocument, {
-          ...existingSubscription,
-          status,
-        } as ExistingSubscription)
-
-        expect(input).not.toHaveProperty('purchaseOrderNumber')
-        expect(input).toMatchObject({ id: 'sub-1', name: 'My subscription' })
-      })
-    })
-
     describe.each([
       ['pending', StatusTypeEnum.Pending],
       ['active', StatusTypeEnum.Active],
+      ['terminated', StatusTypeEnum.Terminated],
+      ['canceled', StatusTypeEnum.Canceled],
     ])('WHEN the subscription is %s', (_, status) => {
       it('THEN should send the purchaseOrderNumber in the update input', async () => {
         const input = await submitAndCaptureInput(UpdateSubscriptionDocument, {
@@ -142,7 +130,11 @@ describe('useAddSubscription', () => {
           status,
         } as ExistingSubscription)
 
-        expect(input).toMatchObject({ purchaseOrderNumber: 'PO-123' })
+        expect(input).toMatchObject({
+          id: 'sub-1',
+          name: 'My subscription',
+          purchaseOrderNumber: 'PO-123',
+        })
       })
     })
   })

--- a/src/hooks/customer/__tests__/useUpdateSubscriptionInformation.test.tsx
+++ b/src/hooks/customer/__tests__/useUpdateSubscriptionInformation.test.tsx
@@ -145,86 +145,20 @@ describe('useUpdateSubscriptionInformation', () => {
     expect(onSuccess).not.toHaveBeenCalled()
   })
 
-  // The API rejects the whole update as soon as the `purchaseOrderNumber` key is
-  // present on a subscription that is neither pending nor active, even when the
-  // value did not change (`purchase_order_number_not_editable`, 405).
-  describe('GIVEN a subscription whose purchase order number is not editable', () => {
-    const captureVariablesMock = (
-      capture: (variables: Record<string, unknown>) => void,
-    ): MockedResponse[] => [
-      {
-        request: { query: UpdateSubscriptionDocument },
-        variableMatcher: (variables: Record<string, unknown>) => {
-          capture(variables)
-
-          return true
-        },
-        result: {
-          data: {
-            updateSubscription: {
-              id: 'sub-1',
-              status: StatusTypeEnum.Terminated,
-              startedAt: '2026-01-01',
-              subscriptionAt: expectedInput.subscriptionAt,
-              endingAt: null,
-              name: 'My subscription',
-              externalId: 'ext-1',
-              paymentMethodType: null,
-              paymentMethod: null,
-              consolidateInvoice: true,
-              skipInvoiceCustomSections: false,
-              selectedInvoiceCustomSections: [],
-              customer: { id: 'cust-1', activeSubscriptionsCount: 1 },
-              plan: { id: 'plan-1', name: 'P', code: 'p', interval: PlanInterval.Monthly },
-            },
-          },
-        },
-      },
-    ]
-
-    describe.each([
-      ['terminated', StatusTypeEnum.Terminated],
-      ['canceled', StatusTypeEnum.Canceled],
-    ])('WHEN the subscription is %s', (_, status) => {
-      it('THEN should omit the purchaseOrderNumber key from the mutation input', async () => {
-        let capturedVariables: Record<string, unknown> | undefined
-
-        const { result } = renderUpdateHook(
-          captureVariablesMock((variables) => {
-            capturedVariables = variables
-          }),
-          jest.fn(),
-          { ...subscription, status },
-        )
-
-        await act(async () => {
-          await result.current.form.handleSubmit()
-        })
-
-        await waitFor(() => expect(capturedVariables).toBeDefined())
-
-        const input = (capturedVariables as { input: Record<string, unknown> }).input
-
-        expect(input).not.toHaveProperty('purchaseOrderNumber')
-        // The rest of the editable fields still go through.
-        expect(input).toEqual({
-          id: expectedInput.id,
-          name: expectedInput.name,
-          subscriptionAt: expectedInput.subscriptionAt,
-          endingAt: expectedInput.endingAt,
-        })
-      })
-    })
-  })
-
-  describe('GIVEN a subscription whose purchase order number is editable', () => {
+  // The API rejects the `purchaseOrderNumber` only when the value actually
+  // changes on a subscription that is neither pending nor active
+  // (`purchase_order_number_not_editable`, 405), so the client always sends the
+  // key and lets the API decide. An explicit `null` is the clear mechanism:
+  // `undefined` would be stripped from the payload and the previous value would
+  // persist.
+  describe('GIVEN the subscription information form is submitted with an empty purchase order number', () => {
     describe.each([
       ['pending', StatusTypeEnum.Pending],
       ['active', StatusTypeEnum.Active],
-    ])('WHEN the subscription is %s and the field is empty', (_, status) => {
-      // An explicit `null` is the clear mechanism: `undefined` would be stripped
-      // from the payload and the previous value would persist.
-      it('THEN should keep sending purchaseOrderNumber as null', async () => {
+      ['terminated', StatusTypeEnum.Terminated],
+      ['canceled', StatusTypeEnum.Canceled],
+    ])('WHEN the subscription is %s', (_, status) => {
+      it('THEN should send purchaseOrderNumber as null in the mutation input', async () => {
         let capturedVariables: Record<string, unknown> | undefined
 
         const mocks: MockedResponse[] = [

--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react'
 import { generatePath, useSearchParams } from 'react-router-dom'
 
 import { PlanFormInput } from '~/components/plans/types'
-import { isSubscriptionPurchaseOrderNumberEditable } from '~/components/purchaseOrder/PO'
 import { REDIRECTION_ORIGIN_SUBSCRIPTION_USAGE } from '~/components/subscriptions/SubscriptionUsageLifetimeGraph'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { FORM_TYPE_ENUM } from '~/core/constants/form'
@@ -461,13 +460,10 @@ export const useAddSubscription: UseAddSubscription = ({
                   // subscription column, meaning "inherit from customer".
                   billingEntityId: billingEntityId || null,
                   paymentMethod: parsedPaymentMethod,
-                  // Omitted entirely when not editable, otherwise the BE rejects
-                  // the whole update and the rest of the form can no longer be
-                  // edited. When editable the key must stay even as `null` —
-                  // that is the clear mechanism.
-                  ...(isSubscriptionPurchaseOrderNumberEditable(existingSubscription?.status)
-                    ? { purchaseOrderNumber }
-                    : {}),
+                  // Always sent, whatever the status: the BE only rejects an
+                  // actual value change on a non-editable subscription. The key
+                  // must stay even as `null` — that is the clear mechanism.
+                  purchaseOrderNumber,
                   planOverrides,
                 },
               },

--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -460,9 +460,6 @@ export const useAddSubscription: UseAddSubscription = ({
                   // subscription column, meaning "inherit from customer".
                   billingEntityId: billingEntityId || null,
                   paymentMethod: parsedPaymentMethod,
-                  // Always sent, whatever the status: the BE only rejects an
-                  // actual value change on a non-editable subscription. The key
-                  // must stay even as `null` — that is the clear mechanism.
                   purchaseOrderNumber,
                   planOverrides,
                 },

--- a/src/hooks/customer/useUpdateSubscriptionInformation.ts
+++ b/src/hooks/customer/useUpdateSubscriptionInformation.ts
@@ -1,9 +1,6 @@
 import { DateTime } from 'luxon'
 
-import {
-  isSubscriptionPurchaseOrderNumberEditable,
-  normalizePurchaseOrderNumber,
-} from '~/components/purchaseOrder/PO'
+import { normalizePurchaseOrderNumber } from '~/components/purchaseOrder/PO'
 import {
   SubscriptionUpdateFormOptions,
   useUpdateSubscriptionForm,
@@ -24,11 +21,9 @@ export const useUpdateSubscriptionInformation = ({
       name: value.name || null,
       subscriptionAt: DateTime.fromISO(value.subscriptionAt).toUTC().toISO(),
       endingAt: value.endingAt ? DateTime.fromISO(value.endingAt).toUTC().toISO() : null,
-      // Omitted entirely when not editable, otherwise the BE rejects the whole
-      // update and name/dates can no longer be edited. When editable the key
-      // must stay even as `null` — that is the clear mechanism.
-      ...(isSubscriptionPurchaseOrderNumberEditable(subscription?.status)
-        ? { purchaseOrderNumber: normalizePurchaseOrderNumber(value.purchaseOrderNumber) }
-        : {}),
+      // Always sent, whatever the status: the BE only rejects an actual value
+      // change on a non-editable subscription. The key must stay even as `null`
+      // — that is the clear mechanism, `undefined` gets stripped.
+      purchaseOrderNumber: normalizePurchaseOrderNumber(value.purchaseOrderNumber),
     }),
   })

--- a/src/hooks/customer/useUpdateSubscriptionInformation.ts
+++ b/src/hooks/customer/useUpdateSubscriptionInformation.ts
@@ -21,9 +21,6 @@ export const useUpdateSubscriptionInformation = ({
       name: value.name || null,
       subscriptionAt: DateTime.fromISO(value.subscriptionAt).toUTC().toISO(),
       endingAt: value.endingAt ? DateTime.fromISO(value.endingAt).toUTC().toISO() : null,
-      // Always sent, whatever the status: the BE only rejects an actual value
-      // change on a non-editable subscription. The key must stay even as `null`
-      // — that is the clear mechanism, `undefined` gets stripped.
       purchaseOrderNumber: normalizePurchaseOrderNumber(value.purchaseOrderNumber),
     }),
   })


### PR DESCRIPTION
## Context

`Subscriptions::UpdateService` used to reject the whole `updateSubscription`
call as soon as the `purchase_order_number` key was present on a subscription
that is neither pending nor active — it checked key presence, not an actual
value change. Editing the name or the dates of a terminated subscription
therefore failed with `purchase_order_number_not_editable` (405).

The front-end worked around it by omitting the key for those statuses, which
put a per-field authorization rule in the client. The API guard is now
value-aware (getlago/lago-api#6085, merged to main): it rejects only when the
caller actually attempts to change the value. The workaround can go, and the
client goes back to the usual convention — send the full payload, let the API
decide.

## Description

- `useUpdateSubscriptionInformation`: `buildInput` sends
  `purchaseOrderNumber: normalizePurchaseOrderNumber(...)` unconditionally
  again; the status-based conditional spread and the now-unused
  `isSubscriptionPurchaseOrderNumberEditable` import are gone.
- `useAddSubscription`: same in the update branch of the mutation — plain
  `purchaseOrderNumber` instead of the conditional spread. The create branch was
  never guarded and is untouched.
- `isSubscriptionPurchaseOrderNumberEditable` stays in
  `components/purchaseOrder/utils.ts` and keeps being used by
  `SubscriptionInformationFormSection` to disable the field in the UI: the API
  still refuses an actual change on a non-editable subscription, so the form
  must not offer it. Its doc comment is updated to describe the value-aware rule
  rather than the old key-presence one.
- Tests are inverted, not deleted: the terminated/canceled cases in
  `useUpdateSubscriptionInformation.test.tsx` and `useAddSubscription.test.tsx`
  asserted the key was omitted, they now assert it is sent. Since all four
  statuses expect the same payload, each pair of `describe.each` blocks is
  collapsed into a single one covering pending, active, terminated and canceled.
  The explicit `null` case is preserved — that is what clears the column.

The Sentry fingerprinting helpers added by the same earlier PR
(`getGraphQLErrorCode` / `buildGraphQLErrorFingerprint`) are unrelated to this
rule and are left untouched.

<!-- Linear link -->
Fixes BIL-418
