### PR TITLE
fix(plans): stabilize charge array refs in PlanDetailsV2 useMemo deps

### DIFF
--- a/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2FixedChargesSection.tsx
@@ -137,7 +137,7 @@ export const PlanDetailsV2FixedChargesSection = forwardRef<
 
   const { handleSaveCharge, handleDeleteCharge } = fixedChargeMutations
 
-  const fixedCharges = plan.fixedCharges ?? []
+  const fixedCharges = useMemo(() => plan.fixedCharges ?? [], [plan.fixedCharges])
   const isEmpty = fixedCharges.length === 0
   // ISO with the plan form: existing charges lock once the plan has subscriptions.
   // Sub mode keeps its own gating (driven by isInSubscriptionForm), so the

--- a/src/components/plans/details-v2/PlanDetailsV2UsageChargesSection.tsx
+++ b/src/components/plans/details-v2/PlanDetailsV2UsageChargesSection.tsx
@@ -190,7 +190,7 @@ export const PlanDetailsV2UsageChargesSection = forwardRef<
   const { handleSaveCharge, handleDeleteCharge } = chargeMutations
 
   const planCurrency = plan.amountCurrency
-  const charges = plan.charges ?? []
+  const charges = useMemo(() => plan.charges ?? [], [plan.charges])
   const isEmpty = charges.length === 0
   // Mirrors VirtualFilterList's internal branch (default threshold) via the shared
   // predicate. Used to drop content-visibility on the cards only when the list


### PR DESCRIPTION
## Context

Two `react-hooks/exhaustive-deps` warnings remained in the plan details V2 charge sections, unrelated to the Formik→TanStack migration and not covered by any other ticket.

## Description

In both `PlanDetailsV2FixedChargesSection` and `PlanDetailsV2UsageChargesSection`, the `plan.fixedCharges ?? []` / `plan.charges ?? []` fallbacks produced a new array reference on every render, which was then fed into a downstream `useMemo` dependency array — invalidating the memo each render and tripping the lint rule. Wrapping each fallback in its own `useMemo` gives it a stable reference. This resolves both warnings and lets the count memos actually memoize; no behavior change.

<!-- Linear link -->
Fixes LAGO-1782