### PR TITLE
feat(alerts): premium-gate the lifetime usage alert types in the subscription alert form

### DIFF
--- a/src/pages/AlertForm.tsx
+++ b/src/pages/AlertForm.tsx
@@ -1,5 +1,6 @@
 import { gql } from '@apollo/client'
 import { revalidateLogic, useStore } from '@tanstack/react-form'
+import { Icon } from 'lago-design-system'
 import { useCallback, useMemo } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
@@ -10,6 +11,7 @@ import { createThresholdSetters, setCodeAlreadyExistsError } from '~/components/
 import { Button } from '~/components/designSystem/Button'
 import { Chip } from '~/components/designSystem/Chip'
 import { Typography } from '~/components/designSystem/Typography'
+import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
 import { ComboBox, ComboboxItem } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
@@ -32,12 +34,17 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm } from '~/hooks/forms/useAppform'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import {
   mapFormToCreateInput,
   mapFormToUpdateInput,
   mapFromApiToForm,
 } from '~/pages/alertForm/mappers'
-import { isBillableMetricAlertType, isUnitsAlertType } from '~/pages/alertForm/utils'
+import {
+  isAlertTypePremiumLocked,
+  isBillableMetricAlertType,
+  isUnitsAlertType,
+} from '~/pages/alertForm/utils'
 import { subscriptionAlertValidationSchema } from '~/pages/alertForm/validationSchema'
 import { FormLoadingSkeleton } from '~/styles/mainObjectsForm'
 
@@ -45,6 +52,8 @@ const SUBSCRIPTION_ALERT_FORM_ID = 'create-alert'
 
 export const SUBSCRIPTION_ALERT_FORM_TEST_ID = 'subscription-alert-form'
 export const SUBSCRIPTION_ALERT_TYPE_COMBOBOX_TEST_ID = 'subscription-alert-type-combobox'
+export const SUBSCRIPTION_ALERT_TYPE_PREMIUM_OPTION_TEST_ID =
+  'subscription-alert-type-premium-option'
 export const CLOSE_SUBSCRIPTION_ALERT_BUTTON_TEST_ID = 'close-subscription-alert-button'
 export const SUBMIT_SUBSCRIPTION_ALERT_TEST_ID = 'submit-subscription-alert'
 
@@ -116,6 +125,8 @@ const AlertForm = () => {
   const { alertId = '', customerId = '', planId = '', subscriptionId = '' } = useParams()
   const { translate } = useInternationalization()
   const navigate = useNavigate()
+  const { organization: { premiumIntegrations } = {} } = useOrganizationInfos()
+  const { open: openPremiumWarningDialog } = usePremiumWarningDialog()
   const isEdition = !!alertId
 
   const { data: subscriptionData, loading: subscriptionLoading } = useGetSubscriptionInfosQuery({
@@ -337,6 +348,66 @@ const AlertForm = () => {
     }
   }, [existingAlertsData?.subscriptionAlerts?.collection])
 
+  const alertTypeComboboxData = useMemo(() => {
+    const options = [
+      {
+        label: translate('text_1748418710304kqjnk1owpeq'),
+        value: AlertTypeEnum.LifetimeUsageAmount,
+        disabled: hasLifetimeUsageAmountAlert,
+      },
+      {
+        label: translate('text_1748358376584w0qzazvifco'),
+        value: AlertTypeEnum.BillableMetricCurrentUsageUnits,
+      },
+      {
+        label: translate('text_1774295657000uwtohmkfqaom'),
+        value: AlertTypeEnum.BillableMetricLifetimeUsageUnits,
+      },
+      {
+        label: translate('text_1746631350478l8lfdopffh1'),
+        value: AlertTypeEnum.BillableMetricCurrentUsageAmount,
+      },
+      {
+        label: translate('text_1746631350478bwa1swfpwkw'),
+        value: AlertTypeEnum.CurrentUsageAmount,
+        disabled: hasUsageAmountAlert,
+      },
+    ]
+
+    // Premium-gated types stay listed, flagged with the sparkles affordance;
+    // picking one opens the premium dialog instead of applying the value
+    return options.map((option) => {
+      if (!isAlertTypePremiumLocked(option.value, premiumIntegrations)) return option
+
+      return {
+        ...option,
+        labelNode: (
+          <span
+            className="flex items-center gap-2"
+            data-test={`${SUBSCRIPTION_ALERT_TYPE_PREMIUM_OPTION_TEST_ID}-${option.value}`}
+          >
+            {option.label}
+            <Icon name="sparkles" />
+          </span>
+        ),
+      }
+    })
+  }, [translate, hasLifetimeUsageAmountAlert, hasUsageAmountAlert, premiumIntegrations])
+
+  const onAlertTypeChange = (value: string): void => {
+    const newAlertType = value as AlertTypeEnum
+
+    if (isAlertTypePremiumLocked(newAlertType, premiumIntegrations)) {
+      openPremiumWarningDialog()
+
+      return
+    }
+
+    form.setFieldValue('alertType', newAlertType)
+    // Reset billableMetricId when alertType is changed
+    form.setFieldValue('billableMetricId', '')
+  }
+
   const hasAnyNonRecurringThresholdError = useMemo(() => {
     const localNonRecurringThresholds = thresholds.filter((threshold) => !threshold.recurring)
 
@@ -417,35 +488,8 @@ const AlertForm = () => {
                       disabled={isEdition}
                       disableClearable={isEdition}
                       value={alertType}
-                      data={[
-                        {
-                          label: translate('text_1748418710304kqjnk1owpeq'),
-                          value: AlertTypeEnum.LifetimeUsageAmount,
-                          disabled: hasLifetimeUsageAmountAlert,
-                        },
-                        {
-                          label: translate('text_1748358376584w0qzazvifco'),
-                          value: AlertTypeEnum.BillableMetricCurrentUsageUnits,
-                        },
-                        {
-                          label: translate('text_1774295657000uwtohmkfqaom'),
-                          value: AlertTypeEnum.BillableMetricLifetimeUsageUnits,
-                        },
-                        {
-                          label: translate('text_1746631350478l8lfdopffh1'),
-                          value: AlertTypeEnum.BillableMetricCurrentUsageAmount,
-                        },
-                        {
-                          label: translate('text_1746631350478bwa1swfpwkw'),
-                          value: AlertTypeEnum.CurrentUsageAmount,
-                          disabled: hasUsageAmountAlert,
-                        },
-                      ]}
-                      onChange={(value) => {
-                        form.setFieldValue('alertType', value as AlertTypeEnum)
-                        // Reset billableMetricId when alertType is changed
-                        form.setFieldValue('billableMetricId', '')
-                      }}
+                      data={alertTypeComboboxData}
+                      onChange={onAlertTypeChange}
                       data-test={SUBSCRIPTION_ALERT_TYPE_COMBOBOX_TEST_ID}
                     />
 

--- a/src/pages/__tests__/AlertForm.test.tsx
+++ b/src/pages/__tests__/AlertForm.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
-import { AlertTypeEnum, LagoApiError } from '~/generated/graphql'
+import { AlertTypeEnum, LagoApiError, PremiumIntegrationTypeEnum } from '~/generated/graphql'
 import { render, testMockNavigateFn } from '~/test-utils'
 
 import AlertForm, {
@@ -10,6 +10,7 @@ import AlertForm, {
   SUBMIT_SUBSCRIPTION_ALERT_TEST_ID,
   SUBSCRIPTION_ALERT_FORM_TEST_ID,
   SUBSCRIPTION_ALERT_TYPE_COMBOBOX_TEST_ID,
+  SUBSCRIPTION_ALERT_TYPE_PREMIUM_OPTION_TEST_ID,
 } from '../AlertForm'
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
@@ -30,25 +31,32 @@ jest.mock('~/components/form/ComboBox/ComboBox', () => ({
     onChange,
     'data-test': dataTest,
   }: {
-    data: { value: string; label: string; disabled?: boolean }[]
+    data: { value: string; label: string; disabled?: boolean; labelNode?: React.ReactNode }[]
     value?: string
     disabled?: boolean
     onChange: (value: string) => void
     'data-test'?: string
   }) => (
-    <select
-      data-test={dataTest}
-      disabled={disabled}
-      value={value ?? ''}
-      onChange={(event) => onChange(event.target.value)}
-    >
-      <option value="" />
-      {data.map(({ value: optionValue, label, disabled: optionDisabled }) => (
-        <option key={optionValue} value={optionValue} disabled={optionDisabled}>
-          {label}
-        </option>
-      ))}
-    </select>
+    <>
+      <select
+        data-test={dataTest}
+        disabled={disabled}
+        value={value ?? ''}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        <option value="" />
+        {data.map(({ value: optionValue, label, disabled: optionDisabled }) => (
+          <option key={optionValue} value={optionValue} disabled={optionDisabled}>
+            {label}
+          </option>
+        ))}
+      </select>
+      {/* `<option>` cannot host the rich option row, so the label nodes are rendered
+          aside to keep their premium affordance assertable */}
+      {data.map(({ value: optionValue, labelNode }) =>
+        labelNode ? <div key={`label-node-${optionValue}`}>{labelNode}</div> : null,
+      )}
+    </>
   ),
 }))
 
@@ -95,6 +103,20 @@ const mockDialogOpen = jest.fn()
 
 jest.mock('~/components/dialogs/CentralizedDialog', () => ({
   useCentralizedDialog: () => ({ open: mockDialogOpen }),
+}))
+
+const mockOpenPremiumWarningDialog = jest.fn()
+
+jest.mock('~/components/dialogs/PremiumWarningDialog', () => ({
+  usePremiumWarningDialog: () => ({ open: mockOpenPremiumWarningDialog }),
+}))
+
+const mockOrganization: { premiumIntegrations: PremiumIntegrationTypeEnum[] } = {
+  premiumIntegrations: [],
+}
+
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  useOrganizationInfos: () => ({ organization: mockOrganization }),
 }))
 
 // The thresholds table stays form-library agnostic, so it is stubbed down to
@@ -250,6 +272,7 @@ describe('AlertForm', () => {
       errors: undefined,
     })
     setParams({ subscriptionId: 'subscription-1', customerId: 'customer-1' })
+    mockOrganization.premiumIntegrations = []
   })
 
   describe('GIVEN loading state', () => {
@@ -412,6 +435,126 @@ describe('AlertForm', () => {
           AlertTypeEnum.CurrentUsageAmount,
         ])
       })
+    })
+
+    describe('WHEN the organization has none of the lifetime usage addons', () => {
+      beforeEach(() => {
+        mockLoadedQueries()
+      })
+
+      it.each([
+        ['lifetime usage amount', AlertTypeEnum.LifetimeUsageAmount],
+        ['billable metric lifetime usage units', AlertTypeEnum.BillableMetricLifetimeUsageUnits],
+      ])('THEN should flag the %s type as premium', (_, alertType) => {
+        render(<AlertForm />)
+
+        expect(
+          screen.getByTestId(`${SUBSCRIPTION_ALERT_TYPE_PREMIUM_OPTION_TEST_ID}-${alertType}`),
+        ).toBeInTheDocument()
+      })
+
+      it.each([
+        ['current usage amount', AlertTypeEnum.CurrentUsageAmount],
+        ['billable metric current usage units', AlertTypeEnum.BillableMetricCurrentUsageUnits],
+        ['billable metric current usage amount', AlertTypeEnum.BillableMetricCurrentUsageAmount],
+      ])('THEN should not flag the %s type as premium', (_, alertType) => {
+        render(<AlertForm />)
+
+        expect(
+          screen.queryByTestId(`${SUBSCRIPTION_ALERT_TYPE_PREMIUM_OPTION_TEST_ID}-${alertType}`),
+        ).not.toBeInTheDocument()
+      })
+
+      it.each([
+        ['lifetime usage amount', AlertTypeEnum.LifetimeUsageAmount],
+        ['billable metric lifetime usage units', AlertTypeEnum.BillableMetricLifetimeUsageUnits],
+      ])(
+        'THEN should open the premium warning dialog instead of picking the %s type',
+        async (_, alertType) => {
+          const user = userEvent.setup()
+
+          render(<AlertForm />)
+
+          await pickAlertType(user, alertType)
+
+          expect(mockOpenPremiumWarningDialog).toHaveBeenCalled()
+          expect(getAlertTypeSelect()).toHaveValue('')
+          expect(screen.queryByTestId(THRESHOLDS_TABLE_TEST_ID)).not.toBeInTheDocument()
+        },
+      )
+
+      it('THEN should keep the ungated types selectable', async () => {
+        const user = userEvent.setup()
+
+        render(<AlertForm />)
+
+        await pickAlertType(user, AlertTypeEnum.CurrentUsageAmount)
+
+        expect(mockOpenPremiumWarningDialog).not.toHaveBeenCalled()
+        expect(getAlertTypeSelect()).toHaveValue(AlertTypeEnum.CurrentUsageAmount)
+      })
+    })
+
+    describe('WHEN the organization has the granular lifetime usage addon', () => {
+      beforeEach(() => {
+        mockOrganization.premiumIntegrations = [PremiumIntegrationTypeEnum.GranularLifetimeUsage]
+        mockLoadedQueries()
+      })
+
+      it('THEN should let the billable metric lifetime usage units type be picked', async () => {
+        const user = userEvent.setup()
+
+        render(<AlertForm />)
+
+        expect(
+          screen.queryByTestId(
+            `${SUBSCRIPTION_ALERT_TYPE_PREMIUM_OPTION_TEST_ID}-${AlertTypeEnum.BillableMetricLifetimeUsageUnits}`,
+          ),
+        ).not.toBeInTheDocument()
+
+        await pickAlertType(user, AlertTypeEnum.BillableMetricLifetimeUsageUnits)
+
+        expect(mockOpenPremiumWarningDialog).not.toHaveBeenCalled()
+        expect(getBillableMetricSelect()).toBeInTheDocument()
+      })
+
+      it('THEN should keep the lifetime usage amount type gated', () => {
+        render(<AlertForm />)
+
+        expect(
+          screen.getByTestId(
+            `${SUBSCRIPTION_ALERT_TYPE_PREMIUM_OPTION_TEST_ID}-${AlertTypeEnum.LifetimeUsageAmount}`,
+          ),
+        ).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the organization uses lifetime usage', () => {
+      it.each([
+        PremiumIntegrationTypeEnum.LifetimeUsage,
+        PremiumIntegrationTypeEnum.ProgressiveBilling,
+      ])(
+        'THEN should let the lifetime usage amount type be picked with the %s addon',
+        async (addon) => {
+          const user = userEvent.setup()
+
+          mockOrganization.premiumIntegrations = [addon]
+          mockLoadedQueries()
+          render(<AlertForm />)
+
+          expect(
+            screen.queryByTestId(
+              `${SUBSCRIPTION_ALERT_TYPE_PREMIUM_OPTION_TEST_ID}-${AlertTypeEnum.LifetimeUsageAmount}`,
+            ),
+          ).not.toBeInTheDocument()
+
+          await pickAlertType(user, AlertTypeEnum.LifetimeUsageAmount)
+
+          expect(mockOpenPremiumWarningDialog).not.toHaveBeenCalled()
+          expect(getAlertTypeSelect()).toHaveValue(AlertTypeEnum.LifetimeUsageAmount)
+          expect(screen.getByTestId(THRESHOLDS_TABLE_TEST_ID)).toBeInTheDocument()
+        },
+      )
     })
 
     describe('WHEN a metric already has an alert of the picked type', () => {

--- a/src/pages/alertForm/__tests__/utils.test.ts
+++ b/src/pages/alertForm/__tests__/utils.test.ts
@@ -1,5 +1,9 @@
-import { AlertTypeEnum } from '~/generated/graphql'
-import { isBillableMetricAlertType, isUnitsAlertType } from '~/pages/alertForm/utils'
+import { AlertTypeEnum, PremiumIntegrationTypeEnum } from '~/generated/graphql'
+import {
+  isAlertTypePremiumLocked,
+  isBillableMetricAlertType,
+  isUnitsAlertType,
+} from '~/pages/alertForm/utils'
 
 describe('isUnitsAlertType', () => {
   describe('GIVEN a subscription alert type', () => {
@@ -37,6 +41,64 @@ describe('isBillableMetricAlertType', () => {
   describe('GIVEN no alert type picked yet', () => {
     it('THEN should return false', () => {
       expect(isBillableMetricAlertType('')).toBe(false)
+    })
+  })
+})
+
+describe('isAlertTypePremiumLocked', () => {
+  describe('GIVEN an organization without any premium addon', () => {
+    it.each([
+      [AlertTypeEnum.BillableMetricLifetimeUsageUnits, true],
+      [AlertTypeEnum.LifetimeUsageAmount, true],
+      [AlertTypeEnum.BillableMetricCurrentUsageUnits, false],
+      [AlertTypeEnum.BillableMetricCurrentUsageAmount, false],
+      [AlertTypeEnum.CurrentUsageAmount, false],
+    ])('THEN should return %s for %s', (alertType, expected) => {
+      expect(isAlertTypePremiumLocked(alertType, [])).toBe(expected)
+    })
+
+    it('THEN should treat a missing premium integration list as no addon', () => {
+      expect(isAlertTypePremiumLocked(AlertTypeEnum.LifetimeUsageAmount, undefined)).toBe(true)
+      expect(isAlertTypePremiumLocked(AlertTypeEnum.LifetimeUsageAmount, null)).toBe(true)
+    })
+  })
+
+  describe('GIVEN an organization with the granular lifetime usage addon', () => {
+    it('THEN should unlock the billable metric lifetime usage units type only', () => {
+      const premiumIntegrations = [PremiumIntegrationTypeEnum.GranularLifetimeUsage]
+
+      expect(
+        isAlertTypePremiumLocked(
+          AlertTypeEnum.BillableMetricLifetimeUsageUnits,
+          premiumIntegrations,
+        ),
+      ).toBe(false)
+      expect(isAlertTypePremiumLocked(AlertTypeEnum.LifetimeUsageAmount, premiumIntegrations)).toBe(
+        true,
+      )
+    })
+  })
+
+  describe('GIVEN an organization using lifetime usage', () => {
+    it.each([
+      PremiumIntegrationTypeEnum.LifetimeUsage,
+      PremiumIntegrationTypeEnum.ProgressiveBilling,
+    ])('THEN should unlock the lifetime usage amount type with the %s addon', (addon) => {
+      expect(isAlertTypePremiumLocked(AlertTypeEnum.LifetimeUsageAmount, [addon])).toBe(false)
+    })
+
+    it('THEN should keep the billable metric lifetime usage units type locked', () => {
+      expect(
+        isAlertTypePremiumLocked(AlertTypeEnum.BillableMetricLifetimeUsageUnits, [
+          PremiumIntegrationTypeEnum.LifetimeUsage,
+        ]),
+      ).toBe(true)
+    })
+  })
+
+  describe('GIVEN no alert type picked yet', () => {
+    it('THEN should return false', () => {
+      expect(isAlertTypePremiumLocked('', [])).toBe(false)
     })
   })
 })

--- a/src/pages/alertForm/utils.ts
+++ b/src/pages/alertForm/utils.ts
@@ -1,4 +1,4 @@
-import { AlertTypeEnum } from '~/generated/graphql'
+import { AlertTypeEnum, PremiumIntegrationTypeEnum } from '~/generated/graphql'
 
 /** Billable-metric units alerts hold units, not amounts: no currency, integer values only. */
 export const isUnitsAlertType = (alertType?: AlertTypeEnum | ''): boolean =>
@@ -10,3 +10,34 @@ export const isBillableMetricAlertType = (alertType?: AlertTypeEnum | ''): boole
   alertType === AlertTypeEnum.BillableMetricCurrentUsageUnits ||
   alertType === AlertTypeEnum.BillableMetricCurrentUsageAmount ||
   alertType === AlertTypeEnum.BillableMetricLifetimeUsageUnits
+
+/**
+ * Alert types the API refuses to create without a premium addon. The org needs
+ * at least one of the listed addons for the type to be selectable, otherwise
+ * the mutation fails with `feature_not_available`.
+ */
+const PREMIUM_ALERT_TYPE_ADDONS: Partial<Record<AlertTypeEnum, PremiumIntegrationTypeEnum[]>> = {
+  [AlertTypeEnum.BillableMetricLifetimeUsageUnits]: [
+    PremiumIntegrationTypeEnum.GranularLifetimeUsage,
+  ],
+  // Mirrors the API `organization.using_lifetime_usage?`, as already done in
+  // `SubscriptionUsageLifetimeGraph`
+  [AlertTypeEnum.LifetimeUsageAmount]: [
+    PremiumIntegrationTypeEnum.LifetimeUsage,
+    PremiumIntegrationTypeEnum.ProgressiveBilling,
+  ],
+}
+
+/** Whether the org lacks the addon(s) unlocking the given alert type. */
+export const isAlertTypePremiumLocked = (
+  alertType: AlertTypeEnum | '',
+  premiumIntegrations?: PremiumIntegrationTypeEnum[] | null,
+): boolean => {
+  if (!alertType) return false
+
+  const requiredAddons = PREMIUM_ALERT_TYPE_ADDONS[alertType]
+
+  if (!requiredAddons) return false
+
+  return !requiredAddons.some((addon) => !!premiumIntegrations?.includes(addon))
+}


### PR DESCRIPTION
## Context

The subscription alert form offers all 5 alert types in the alertType dropdown, but two of them are gated server-side by `UsageMonitoring::CreateAlertService`:

- `billable_metric_lifetime_usage_units` requires the `granular_lifetime_usage` premium addon
- `lifetime_usage_amount` requires `organization.using_lifetime_usage?`

On an organization without the addon, the user filled the whole form, submitted, and the mutation failed with 422 `unprocessable_entity` / `details: { alertType: ["feature_not_available"] }`. The only feedback was the global generic danger toast from the Apollo error link: no field error, no explanation, and nothing prevented the user from picking the type in the first place.

## Description

Follow the established premium-feature pattern (`CustomerAccountTypeQuickFilter`): the gated options stay listed with the sparkles affordance and picking one opens `PremiumWarningDialog` instead of applying the value, so the form can no longer reach the 422 path for this case. Entitled organizations are unaffected, and the global toast stays as the safety net for any other unhandled mutation error.

- `isAlertTypePremiumLocked` in `src/pages/alertForm/utils.ts` maps each gated alert type to the addon(s) unlocking it. `lifetime_usage_amount` mirrors the API `organization.using_lifetime_usage?` as `lifetime_usage` OR `progressive_billing` — the same resolution already used by `SubscriptionUsageLifetimeGraph`. This answers the "verify which addon/license this maps to" question left open in the ticket.
- `AlertForm` reads `premiumIntegrations` from `useOrganizationInfos`, builds the alert type options through a memo that adds the sparkles `labelNode` on locked entries, and intercepts the combobox `onChange` to open the premium dialog rather than setting the field.
- Tests cover the gated and ungated dropdown states, the interception on selection, and each unlocking addon (94% statements on `AlertForm.tsx`, 100% on `alertForm/utils.ts`).

The wallet alert form is untouched — none of its 4 types is gated by this service.

> [!NOTE]
> The ticket asks to confirm the exact dropdown affordance with design before implementing. This was built unattended, so it implements the affordance the ticket itself prescribes (sparkles icon in the option row + `PremiumWarningDialog` on select). If design wants a different treatment, it is a one-place change in the `alertTypeComboboxData` memo.

<!-- Linear link -->
Fixes ING-549

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhfCxCYhTYxkzMoTfy7q5j)_