### PR TITLE
fix(order-forms): enlarge created at column

### DIFF
--- a/src/pages/quotes/common/__tests__/useOrderFormsColumns.test.tsx
+++ b/src/pages/quotes/common/__tests__/useOrderFormsColumns.test.tsx
@@ -57,7 +57,7 @@ describe('useOrderFormsColumns', () => {
     const createdAtColumn = result.current[4]
 
     expect(createdAtColumn.key).toBe('createdAt')
-    expect(createdAtColumn.minWidth).toBe(120)
+    expect(createdAtColumn.minWidth).toBe(150)
 
     render(<>{createdAtColumn.content(orderForm)}</>)
     expect(screen.getByText('4/10/2026')).toBeInTheDocument()

--- a/src/pages/quotes/common/useOrderFormsColumns.tsx
+++ b/src/pages/quotes/common/useOrderFormsColumns.tsx
@@ -42,6 +42,6 @@ export const useOrderFormsColumns = (): Array<TableColumn<OrderFormListItemFragm
         </Typography>
       ),
     },
-    getCreatedAtColumn<OrderFormListItemFragment>('text_624efab67eb2570101d117e3', 120),
+    getCreatedAtColumn<OrderFormListItemFragment>('text_624efab67eb2570101d117e3', 150),
   ]
 }


### PR DESCRIPTION
## Context

Created at column on order forms do not display correctly

## Description

Enlarge a bit the column so it displays dates correctly

<!-- Linear link -->
Fixes LAGO-1784