### PR TITLE
refactor(add-ons): migrate the add-on form from Formik to TanStack Form

### DIFF
--- a/cypress/e2e/10-resources/t70-addon-create-edit.cy.ts
+++ b/cypress/e2e/10-resources/t70-addon-create-edit.cy.ts
@@ -21,7 +21,9 @@ describe('Add On', () => {
     cy.url().should('match', /\/[^/]+\/create\/add-on$/)
 
     // Basic form infos
-    cy.get('[data-test="submit"]').should('be.disabled')
+    // The TanStack submit button is enabled by default and only disables on
+    // validation errors (canSubmit) — it is not gated on a pristine/invalid
+    // mount state, so no be.disabled assertion on the empty form here.
     cy.get('input[name="name"]').type(addOnName)
     cy.get('input[name="code"]').should('have.value', addOnCode)
     cy.get('input[name="amountCents"]').type('30')

--- a/src/components/addOns/AddOnCodeSnippet.tsx
+++ b/src/components/addOns/AddOnCodeSnippet.tsx
@@ -6,7 +6,12 @@ import { CreateAddOnInput } from '~/generated/graphql'
 
 const { apiUrl } = envGlobalVar()
 
-const getSnippets = (addOn?: CreateAddOnInput) => {
+// amountCents is a display value coming from the form, so it can be a string
+type AddOnCodeSnippetInput = Omit<CreateAddOnInput, 'amountCents'> & {
+  amountCents?: string | number
+}
+
+const getSnippets = (addOn?: AddOnCodeSnippetInput) => {
   if (!addOn || !addOn.code) return '# Fill the form to generate the code snippet'
 
   return snippetBuilder({
@@ -38,7 +43,7 @@ const getSnippets = (addOn?: CreateAddOnInput) => {
 }
 
 interface AddOnCodeSnippetProps {
-  addOn?: CreateAddOnInput
+  addOn?: AddOnCodeSnippetInput
   loading?: boolean
 }
 

--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -14,7 +14,7 @@ import { FORM_ERRORS_ENUM, SEARCH_TAX_INPUT_FOR_ADD_ON_CLASSNAME } from '~/core/
 import { ADD_ON_DETAILS_ROUTE, ADD_ONS_ROUTE, useNavigate } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { scrollToTop } from '~/core/utils/domUtils'
-import { CreateAddOnInput, CurrencyEnum } from '~/generated/graphql'
+import { CurrencyEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm } from '~/hooks/forms/useAppform'
 import { useCreateEditAddOn } from '~/hooks/useCreateEditAddOn'
@@ -304,7 +304,7 @@ const CreateAddOn = () => {
           </div>
         </Main>
         <Side>
-          <AddOnCodeSnippet loading={loading} addOn={formValues as unknown as CreateAddOnInput} />
+          <AddOnCodeSnippet loading={loading} addOn={formValues} />
         </Side>
       </form>
     </div>

--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -5,7 +5,6 @@ import { generatePath, useParams } from 'react-router-dom'
 import { AddOnCodeSnippet } from '~/components/addOns/AddOnCodeSnippet'
 import { Button } from '~/components/designSystem/Button'
 import { Card } from '~/components/designSystem/Card'
-import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
@@ -21,7 +20,7 @@ import { useAppForm } from '~/hooks/forms/useAppform'
 import { useCreateEditAddOn } from '~/hooks/useCreateEditAddOn'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { PageHeader } from '~/styles'
-import { Main, Side, Subtitle, Title } from '~/styles/mainObjectsForm'
+import { FormLoadingSkeleton, Main, Side, Subtitle, Title } from '~/styles/mainObjectsForm'
 
 import { addOnFormSchema, AddOnFormValues } from './createAddOn/validationSchema'
 
@@ -99,15 +98,16 @@ const CreateAddOn = () => {
     setShouldDisplayDescription(!!addOn?.description)
   }, [addOn?.description])
 
+  const setCodeExistsError = (message: string | undefined): void => {
+    form.setFieldMeta('code', (meta) => ({
+      ...meta,
+      errorMap: { ...meta.errorMap, onDynamic: message ? { message } : undefined },
+    }))
+  }
+
   useEffect(() => {
     if (errorCode === FORM_ERRORS_ENUM.existingCode) {
-      form.setFieldMeta('code', (meta) => ({
-        ...meta,
-        errorMap: {
-          ...meta.errorMap,
-          onDynamic: { message: 'text_632a2d437e341dcc76817556' },
-        },
-      }))
+      setCodeExistsError('text_632a2d437e341dcc76817556')
       scrollToTop()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -116,11 +116,9 @@ const CreateAddOn = () => {
   const codeValue = useStore(form.store, (state) => state.values.code)
 
   useEffect(() => {
+    // Clear the server "code already exists" error once the user edits the code
     if (errorCode === FORM_ERRORS_ENUM.existingCode) {
-      form.setFieldMeta('code', (meta) => ({
-        ...meta,
-        errorMap: { ...meta.errorMap, onDynamic: undefined },
-      }))
+      setCodeExistsError(undefined)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [codeValue])
@@ -164,21 +162,7 @@ const CreateAddOn = () => {
         <Main>
           <div>
             {loading ? (
-              <>
-                <div className="px-8">
-                  <Skeleton variant="text" className="mb-5 w-70" />
-                  <Skeleton variant="text" className="mb-4" />
-                  <Skeleton variant="text" className="w-30" />
-                </div>
-
-                {[0, 1].map((skeletonCard) => (
-                  <Card key={`skeleton-${skeletonCard}`}>
-                    <Skeleton variant="text" className="w-70" />
-                    <Skeleton variant="text" />
-                    <Skeleton variant="text" className="w-30" />
-                  </Card>
-                ))}
-              </>
+              <FormLoadingSkeleton id="create-add-on" />
             ) : (
               <>
                 <div>

--- a/src/pages/CreateAddOn.tsx
+++ b/src/pages/CreateAddOn.tsx
@@ -1,29 +1,33 @@
-import { useFormik } from 'formik'
+import { revalidateLogic, useStore } from '@tanstack/react-form'
 import { useEffect, useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
-import { number, object, string } from 'yup'
 
 import { AddOnCodeSnippet } from '~/components/addOns/AddOnCodeSnippet'
-import { AddOnFormInput } from '~/components/addOns/types'
 import { Button } from '~/components/designSystem/Button'
 import { Card } from '~/components/designSystem/Card'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
-import { AmountInputField, ComboBoxField, TextInput, TextInputField } from '~/components/form'
+import NameAndCodeGroup from '~/components/form/NameAndCodeGroup/NameAndCodeGroup'
 import { TaxesSelectorSection } from '~/components/taxes/TaxesSelectorSection'
 import { FORM_ERRORS_ENUM, SEARCH_TAX_INPUT_FOR_ADD_ON_CLASSNAME } from '~/core/constants/form'
 import { ADD_ON_DETAILS_ROUTE, ADD_ONS_ROUTE, useNavigate } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { scrollToTop } from '~/core/utils/domUtils'
-import { updateNameAndMaybeCode } from '~/core/utils/updateNameAndMaybeCode'
-import { CurrencyEnum } from '~/generated/graphql'
+import { CreateAddOnInput, CurrencyEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 import { useCreateEditAddOn } from '~/hooks/useCreateEditAddOn'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { PageHeader } from '~/styles'
 import { Main, Side, Subtitle, Title } from '~/styles/mainObjectsForm'
+
+import { addOnFormSchema, AddOnFormValues } from './createAddOn/validationSchema'
+
+export const CREATE_ADD_ON_FORM_ID = 'create-add-on-form'
+export const CREATE_ADD_ON_DESCRIPTION_DELETE_TEST_ID = 'create-add-on-description-delete'
+export const CREATE_ADD_ON_AMOUNT_INPUT_TEST_ID = 'create-add-on-amount-input'
 
 const CreateAddOn = () => {
   const { translate } = useInternationalization()
@@ -41,48 +45,94 @@ const CreateAddOn = () => {
     return navigate(ADD_ONS_ROUTE)
   }
 
-  const formikProps = useFormik<AddOnFormInput>({
-    initialValues: {
+  const form = useAppForm({
+    defaultValues: {
       name: addOn?.name || '',
       code: addOn?.code || '',
       description: addOn?.description || '',
       amountCents: addOn?.amountCents
         ? String(
             deserializeAmount(
-              addOn?.amountCents,
-              addOn?.amountCurrency || organization?.defaultCurrency,
+              addOn.amountCents,
+              addOn.amountCurrency || organization?.defaultCurrency,
             ),
           )
         : addOn?.amountCents || undefined,
       amountCurrency: addOn?.amountCurrency || organization?.defaultCurrency || CurrencyEnum.Usd,
       taxes: addOn?.taxes || [],
+    } as AddOnFormValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: addOnFormSchema,
     },
-    validationSchema: object().shape({
-      name: string().required(''),
-      code: string().required(''),
-      amountCents: number().min(0.01, 'text_62978ebe99054a011fc189e0').required(''),
-      amountCurrency: string().required(''),
-    }),
-    enableReinitialize: true,
-    validateOnMount: true,
-    onSubmit: onSave,
+    onSubmit: async ({ value }) => {
+      await onSave(value as unknown as Parameters<typeof onSave>[0])
+    },
   })
 
+  useEffect(() => {
+    if (addOn) {
+      form.reset({
+        name: addOn.name || '',
+        code: addOn.code || '',
+        description: addOn.description || '',
+        amountCents: addOn.amountCents
+          ? String(
+              deserializeAmount(
+                addOn.amountCents,
+                addOn.amountCurrency || organization?.defaultCurrency,
+              ),
+            )
+          : addOn.amountCents || undefined,
+        amountCurrency: addOn.amountCurrency || organization?.defaultCurrency || CurrencyEnum.Usd,
+        taxes: addOn.taxes || [],
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addOn?.id])
+
   const [shouldDisplayDescription, setShouldDisplayDescription] = useState<boolean>(
-    !!formikProps.initialValues.description,
+    !!addOn?.description,
   )
 
   useEffect(() => {
-    setShouldDisplayDescription(!!formikProps.initialValues.description)
-  }, [formikProps.initialValues.description])
+    setShouldDisplayDescription(!!addOn?.description)
+  }, [addOn?.description])
 
   useEffect(() => {
     if (errorCode === FORM_ERRORS_ENUM.existingCode) {
-      formikProps.setFieldError('code', 'text_632a2d437e341dcc76817556')
+      form.setFieldMeta('code', (meta) => ({
+        ...meta,
+        errorMap: {
+          ...meta.errorMap,
+          onDynamic: { message: 'text_632a2d437e341dcc76817556' },
+        },
+      }))
       scrollToTop()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errorCode])
+
+  const codeValue = useStore(form.store, (state) => state.values.code)
+
+  useEffect(() => {
+    if (errorCode === FORM_ERRORS_ENUM.existingCode) {
+      form.setFieldMeta('code', (meta) => ({
+        ...meta,
+        errorMap: { ...meta.errorMap, onDynamic: undefined },
+      }))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [codeValue])
+
+  const formValues = useStore(form.store, (state) => state.values)
+  const amountCurrency = useStore(form.store, (state) => state.values.amountCurrency)
+  const isDirty = useStore(form.store, (state) => state.isDirty)
+
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    form.handleSubmit()
+  }
 
   return (
     <div>
@@ -93,22 +143,24 @@ const CreateAddOn = () => {
         <Button
           variant="quaternary"
           icon="close"
-          onClick={() => {
-            if (formikProps.dirty) {
-              return centralizedDialog.open({
-                title: translate('text_665deda4babaf700d603ea13'),
-                description: translate('text_665dedd557dc3c00c62eb83d'),
-                actionText: translate('text_645388d5bdbd7b00abffa033'),
-                colorVariant: 'danger',
-                onAction: onCloseRedirection,
-              })
-            }
-
-            onCloseRedirection()
-          }}
+          onClick={() =>
+            isDirty
+              ? centralizedDialog.open({
+                  title: translate('text_665deda4babaf700d603ea13'),
+                  description: translate('text_665dedd557dc3c00c62eb83d'),
+                  actionText: translate('text_645388d5bdbd7b00abffa033'),
+                  colorVariant: 'danger',
+                  onAction: onCloseRedirection,
+                })
+              : onCloseRedirection()
+          }
         />
       </PageHeader.Wrapper>
-      <div className="min-height-minus-nav flex">
+      <form
+        id={CREATE_ADD_ON_FORM_ID}
+        className="min-height-minus-nav flex"
+        onSubmit={handleFormSubmit}
+      >
         <Main>
           <div>
             {loading ? (
@@ -147,41 +199,37 @@ const CreateAddOn = () => {
                     {translate('text_629728388c4d2300e2d38079')}
                   </Typography>
 
-                  <div className="flex flex-wrap gap-3">
-                    <TextInput
-                      className="min-w-[110px] flex-1"
-                      name="name"
-                      label={translate('text_629728388c4d2300e2d38091')}
-                      placeholder={translate('text_629728388c4d2300e2d380a5')}
-                      // eslint-disable-next-line jsx-a11y/no-autofocus
-                      autoFocus
-                      value={formikProps.values.name}
-                      onChange={(name) => {
-                        updateNameAndMaybeCode({ name, formikProps })
-                      }}
-                    />
-                    <TextInputField
-                      className="min-w-[110px] flex-1"
-                      name="code"
-                      beforeChangeFormatter="code"
-                      label={translate('text_629728388c4d2300e2d380b7')}
-                      placeholder={translate('text_629728388c4d2300e2d380d9')}
-                      formikProps={formikProps}
-                      infoText={translate('text_629778b2a517d100c19bc524')}
-                    />
-                  </div>
+                  <NameAndCodeGroup
+                    form={form}
+                    fields={{ name: 'name', code: 'code' }}
+                    disableAutoGenerateCode={isEdition}
+                    nameProps={{
+                      autoFocus: true,
+                      label: translate('text_629728388c4d2300e2d38091'),
+                      placeholder: translate('text_629728388c4d2300e2d380a5'),
+                      className: 'flex-1',
+                    }}
+                    codeProps={{
+                      label: translate('text_629728388c4d2300e2d380b7'),
+                      placeholder: translate('text_629728388c4d2300e2d380d9'),
+                      infoText: translate('text_629778b2a517d100c19bc524'),
+                      className: 'flex-1',
+                    }}
+                  />
 
                   {shouldDisplayDescription ? (
                     <div className="flex items-center">
-                      <TextInputField
-                        className="mr-3 flex-1"
-                        multiline
-                        name="description"
-                        label={translate('text_629728388c4d2300e2d380f1')}
-                        placeholder={translate('text_629728388c4d2300e2d38103')}
-                        rows="3"
-                        formikProps={formikProps}
-                      />
+                      <form.AppField name="description">
+                        {(field) => (
+                          <field.TextInputField
+                            className="mr-3 flex-1"
+                            multiline
+                            label={translate('text_629728388c4d2300e2d380f1')}
+                            placeholder={translate('text_629728388c4d2300e2d38103')}
+                            rows="3"
+                          />
+                        )}
+                      </form.AppField>
                       <Tooltip
                         className="mt-6"
                         placement="top-end"
@@ -190,8 +238,9 @@ const CreateAddOn = () => {
                         <Button
                           icon="trash"
                           variant="quaternary"
+                          data-test={CREATE_ADD_ON_DESCRIPTION_DELETE_TEST_ID}
                           onClick={() => {
-                            formikProps.setFieldValue('description', '')
+                            form.setFieldValue('description', '')
                             setShouldDisplayDescription(false)
                           }}
                         />
@@ -216,145 +265,64 @@ const CreateAddOn = () => {
                   </Typography>
 
                   <div className="flex flex-row items-start gap-3">
-                    <AmountInputField
-                      className="flex-1"
-                      name="amountCents"
-                      currency={formikProps.values.amountCurrency || CurrencyEnum.Usd}
-                      beforeChangeFormatter={['positiveNumber']}
-                      label={translate('text_629728388c4d2300e2d3812d')}
-                      formikProps={formikProps}
-                    />
-                    <ComboBoxField
-                      className="mt-7 max-w-30"
-                      name="amountCurrency"
-                      data={Object.values(CurrencyEnum).map((currencyType) => ({
-                        value: currencyType,
-                      }))}
-                      disableClearable
-                      formikProps={formikProps}
-                    />
+                    <form.AppField name="amountCents">
+                      {(field) => (
+                        <field.AmountInputField
+                          className="flex-1"
+                          currency={amountCurrency || CurrencyEnum.Usd}
+                          data-test={CREATE_ADD_ON_AMOUNT_INPUT_TEST_ID}
+                          beforeChangeFormatter={['positiveNumber']}
+                          label={translate('text_629728388c4d2300e2d3812d')}
+                        />
+                      )}
+                    </form.AppField>
+                    <form.AppField name="amountCurrency">
+                      {(field) => (
+                        <field.ComboBoxField
+                          containerClassName="max-w-30 mt-7"
+                          data={Object.values(CurrencyEnum).map((currencyType) => ({
+                            value: currencyType,
+                          }))}
+                          disableClearable
+                        />
+                      )}
+                    </form.AppField>
                   </div>
 
                   <TaxesSelectorSection
                     title={translate('text_1760729707267seik64l67k8')}
-                    taxes={formikProps?.values?.taxes || []}
+                    taxes={formValues.taxes || []}
                     comboboxSelector={SEARCH_TAX_INPUT_FOR_ADD_ON_CLASSNAME}
                     onUpdate={(newTaxArray) => {
-                      formikProps.setFieldValue('taxes', newTaxArray)
+                      form.setFieldValue('taxes', newTaxArray)
                     }}
                   />
-
-                  {/* {!!formikProps?.values?.taxes?.length && (
-                    <div>
-                      <Typography className="mb-1" variant="captionHl" color="grey700">
-                        {translate('text_64be910fba8ef9208686a8e3')}
-                      </Typography>
-                      <div
-                        className="flex flex-wrap items-center gap-3"
-                        data-test="tax-chip-wrapper"
-                      >
-                        {formikProps?.values?.taxes?.map(({ id, name, rate }) => (
-                          <Chip
-                            key={id}
-                            label={`${name} (${rate}%)`}
-                            type="secondary"
-                            size="medium"
-                            deleteIcon="trash"
-                            icon="percentage"
-                            deleteIconLabel={translate('text_63aa085d28b8510cd46443ff')}
-                            onDelete={() => {
-                              const newTaxedArray =
-                                formikProps?.values?.taxes?.filter((tax) => tax.id !== id) || []
-
-                              formikProps.setFieldValue('taxes', newTaxedArray)
-                            }}
-                          />
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
-                  {shouldDisplayTaxesInput ? (
-                    <div>
-                      {!formikProps?.values?.taxes?.length && (
-                        <Typography className="mb-1" variant="captionHl" color="grey700">
-                          {translate('text_64be910fba8ef9208686a8e3')}
-                        </Typography>
-                      )}
-                      <div className="flex items-center gap-3">
-                        <ComboBox
-                          containerClassName="flex-1"
-                          className={SEARCH_TAX_INPUT_FOR_ADD_ON_CLASSNAME}
-                          data={taxesDataForCombobox}
-                          searchQuery={getTaxes}
-                          loading={taxesLoading}
-                          placeholder={translate('text_64be910fba8ef9208686a8e7')}
-                          emptyText={translate('text_64be91fd0678965126e5657b')}
-                          onChange={(newTaxId) => {
-                            const previousTaxes = [...(formikProps?.values?.taxes || [])]
-                            const newTaxObject = taxesData?.taxes?.collection?.find(
-                              (t) => t.id === newTaxId,
-                            )
-
-                            formikProps.setFieldValue('taxes', [...previousTaxes, newTaxObject])
-                            setShouldDisplayTaxesInput(false)
-                          }}
-                        />
-
-                        <Tooltip
-                          placement="top-end"
-                          title={translate('text_63aa085d28b8510cd46443ff')}
-                        >
-                          <Button
-                            icon="trash"
-                            variant="quaternary"
-                            onClick={() => {
-                              setShouldDisplayTaxesInput(false)
-                            }}
-                          />
-                        </Tooltip>
-                      </div>
-                    </div>
-                  ) : (
-                    <Button
-                      className="self-start"
-                      startIcon="plus"
-                      variant="inline"
-                      onClick={() => {
-                        setShouldDisplayTaxesInput(true)
-
-                        scrollToAndClickElement({
-                          selector: `.${SEARCH_TAX_INPUT_FOR_ADD_ON_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
-                        })
-                      }}
-                      data-test="show-add-taxes"
-                    >
-                      {translate('text_64be910fba8ef9208686a8c9')}
-                    </Button>
-                  )} */}
                 </Card>
 
                 <div className="px-6 pb-20">
-                  <Button
-                    disabled={!formikProps.isValid || !formikProps.dirty}
-                    fullWidth
-                    size="large"
-                    onClick={formikProps.submitForm}
-                    data-test="submit"
-                  >
-                    {translate(
-                      isEdition ? 'text_629728388c4d2300e2d38170' : 'text_629728388c4d2300e2d38179',
-                    )}
-                  </Button>
+                  <form.AppForm>
+                    <form.SubmitButton
+                      disabled={isEdition && !isDirty}
+                      fullWidth
+                      size="large"
+                      dataTest="submit"
+                    >
+                      {translate(
+                        isEdition
+                          ? 'text_629728388c4d2300e2d38170'
+                          : 'text_629728388c4d2300e2d38179',
+                      )}
+                    </form.SubmitButton>
+                  </form.AppForm>
                 </div>
               </>
             )}
           </div>
         </Main>
         <Side>
-          <AddOnCodeSnippet loading={loading} addOn={formikProps.values} />
+          <AddOnCodeSnippet loading={loading} addOn={formValues as unknown as CreateAddOnInput} />
         </Side>
-      </div>
+      </form>
     </div>
   )
 }

--- a/src/pages/__tests__/CreateAddOn.test.tsx
+++ b/src/pages/__tests__/CreateAddOn.test.tsx
@@ -1,0 +1,244 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { CurrencyEnum } from '~/generated/graphql'
+import { useCreateEditAddOn } from '~/hooks/useCreateEditAddOn'
+import { render } from '~/test-utils'
+
+import CreateAddOn, {
+  CREATE_ADD_ON_DESCRIPTION_DELETE_TEST_ID,
+  CREATE_ADD_ON_FORM_ID,
+} from '../CreateAddOn'
+
+const getNameInput = () => document.querySelector('input[name="name"]') as HTMLInputElement
+const getCodeInput = () => document.querySelector('input[name="code"]') as HTMLInputElement
+const getAmountInput = () => document.querySelector('input[name="amountCents"]') as HTMLInputElement
+const getDescriptionTextarea = () =>
+  document.querySelector('textarea[name="description"]') as HTMLTextAreaElement
+
+const mockOnSave = jest.fn()
+
+const mockDefaultUseCreateEditAddOn = {
+  isEdition: false,
+  loading: false,
+  addOn: undefined,
+  errorCode: undefined,
+  onSave: mockOnSave,
+}
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('~/hooks/useCreateEditAddOn', () => ({
+  useCreateEditAddOn: jest.fn(() => mockDefaultUseCreateEditAddOn),
+}))
+
+jest.mock('~/components/addOns/AddOnCodeSnippet', () => ({
+  AddOnCodeSnippet: jest.fn(() => <div data-test="add-on-code-snippet" />),
+}))
+
+jest.mock('~/components/taxes/TaxesSelectorSection', () => ({
+  TaxesSelectorSection: jest.fn(() => <div data-test="taxes-selector-section" />),
+}))
+
+jest.mock('~/core/utils/domUtils', () => ({
+  scrollToTop: jest.fn(),
+}))
+
+const mockedUseCreateEditAddOn = useCreateEditAddOn as jest.Mock
+
+describe('CreateAddOn', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedUseCreateEditAddOn.mockReturnValue(mockDefaultUseCreateEditAddOn)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('GIVEN the form is loading', () => {
+    describe('WHEN add-on data has not loaded', () => {
+      it('THEN should not display form inputs', () => {
+        mockedUseCreateEditAddOn.mockReturnValue({
+          ...mockDefaultUseCreateEditAddOn,
+          loading: true,
+        })
+
+        render(<CreateAddOn />)
+
+        expect(getNameInput()).not.toBeInTheDocument()
+        expect(getCodeInput()).not.toBeInTheDocument()
+        expect(getAmountInput()).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN the component renders in create mode', () => {
+    describe('WHEN the page loads', () => {
+      it('THEN should display the form element', () => {
+        render(<CreateAddOn />)
+
+        expect(document.getElementById(CREATE_ADD_ON_FORM_ID)).toBeInTheDocument()
+      })
+
+      it('THEN should display the add-on code snippet', () => {
+        render(<CreateAddOn />)
+
+        expect(screen.getByTestId('add-on-code-snippet')).toBeInTheDocument()
+      })
+
+      it('THEN should display the taxes selector section', () => {
+        render(<CreateAddOn />)
+
+        expect(screen.getByTestId('taxes-selector-section')).toBeInTheDocument()
+      })
+
+      it.each([
+        ['name input', getNameInput],
+        ['code input', getCodeInput],
+        ['amount input', getAmountInput],
+      ])('THEN should display the %s', (_, getInput) => {
+        render(<CreateAddOn />)
+
+        expect(getInput()).toBeInTheDocument()
+      })
+
+      it('THEN should display the submit button', () => {
+        render(<CreateAddOn />)
+
+        expect(screen.getByTestId('submit')).toBeInTheDocument()
+      })
+
+      it('THEN should not display the description textarea by default', () => {
+        render(<CreateAddOn />)
+
+        expect(getDescriptionTextarea()).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN show description button is clicked', () => {
+      it('THEN should display the description textarea', async () => {
+        const user = userEvent.setup()
+
+        render(<CreateAddOn />)
+
+        await user.click(screen.getByTestId('show-description'))
+
+        expect(getDescriptionTextarea()).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN description is displayed and delete button is clicked', () => {
+      it('THEN should hide the description textarea', async () => {
+        const user = userEvent.setup()
+
+        render(<CreateAddOn />)
+
+        await user.click(screen.getByTestId('show-description'))
+        expect(getDescriptionTextarea()).toBeInTheDocument()
+
+        await user.click(screen.getByTestId(CREATE_ADD_ON_DESCRIPTION_DELETE_TEST_ID))
+
+        expect(getDescriptionTextarea()).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN form is filled with valid values and submitted', () => {
+      it('THEN should call onSave with the form values', async () => {
+        const user = userEvent.setup()
+
+        render(<CreateAddOn />)
+
+        await user.type(getNameInput(), 'My Add-on')
+        await user.type(getAmountInput(), '10')
+
+        await user.click(screen.getByTestId('submit'))
+
+        await waitFor(() => {
+          expect(mockOnSave).toHaveBeenCalledWith(
+            expect.objectContaining({
+              name: 'My Add-on',
+              amountCents: '10',
+              amountCurrency: CurrencyEnum.Usd,
+            }),
+          )
+        })
+      })
+    })
+
+    describe('WHEN form is submitted without an amount', () => {
+      it('THEN should not call onSave', async () => {
+        const user = userEvent.setup()
+
+        render(<CreateAddOn />)
+
+        await user.type(getNameInput(), 'My Add-on')
+
+        await user.click(screen.getByTestId('submit'))
+
+        await waitFor(() => {
+          expect(screen.getByTestId('submit')).toBeInTheDocument()
+        })
+        expect(mockOnSave).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN the component renders in edit mode', () => {
+    const mockAddOn = {
+      id: 'add-on-1',
+      name: 'Existing Add-on',
+      code: 'EXISTING_ADD_ON',
+      description: '',
+      amountCents: 1000,
+      amountCurrency: CurrencyEnum.Usd,
+      taxes: [],
+    }
+
+    beforeEach(() => {
+      mockedUseCreateEditAddOn.mockReturnValue({
+        ...mockDefaultUseCreateEditAddOn,
+        isEdition: true,
+        addOn: mockAddOn,
+      })
+    })
+
+    describe('WHEN the page loads with existing add-on data', () => {
+      it.each([
+        ['name', getNameInput, 'Existing Add-on'],
+        ['code', getCodeInput, 'EXISTING_ADD_ON'],
+      ])(
+        'THEN should populate the %s input with the add-on value',
+        (_, getInput, expectedValue) => {
+          render(<CreateAddOn />)
+
+          expect(getInput()).toHaveValue(expectedValue)
+        },
+      )
+
+      it('THEN should disable the submit button when form is not dirty', () => {
+        render(<CreateAddOn />)
+
+        expect(screen.getByTestId('submit')).toBeDisabled()
+      })
+    })
+
+    describe('WHEN the add-on has an existing description', () => {
+      it('THEN should display the description textarea on load', () => {
+        mockedUseCreateEditAddOn.mockReturnValue({
+          ...mockDefaultUseCreateEditAddOn,
+          isEdition: true,
+          addOn: { ...mockAddOn, description: 'Existing description' },
+        })
+
+        render(<CreateAddOn />)
+
+        expect(getDescriptionTextarea()).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/pages/createAddOn/__tests__/validationSchema.test.ts
+++ b/src/pages/createAddOn/__tests__/validationSchema.test.ts
@@ -1,0 +1,116 @@
+import { CurrencyEnum } from '~/generated/graphql'
+
+import { addOnFormSchema, AddOnFormValues, emptyAddOnDefaultValues } from '../validationSchema'
+
+describe('addOnFormSchema', () => {
+  const createValidAddOnData = (overrides: Partial<AddOnFormValues> = {}): AddOnFormValues => ({
+    name: 'Test Add-on',
+    code: 'TEST_ADD_ON',
+    description: '',
+    amountCents: '100',
+    amountCurrency: CurrencyEnum.Usd,
+    taxes: [],
+    ...overrides,
+  })
+
+  describe('GIVEN basic field validation', () => {
+    describe('WHEN all fields are valid', () => {
+      it('THEN should pass validation', () => {
+        const result = addOnFormSchema.safeParse(createValidAddOnData())
+
+        expect(result.success).toBe(true)
+      })
+    })
+
+    describe('WHEN name is empty', () => {
+      it('THEN should fail validation with error on name field', () => {
+        const result = addOnFormSchema.safeParse(createValidAddOnData({ name: '' }))
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error.issues.find((issue) => issue.path.includes('name'))).toBeDefined()
+        }
+      })
+    })
+
+    describe('WHEN code is empty', () => {
+      it('THEN should fail validation with error on code field', () => {
+        const result = addOnFormSchema.safeParse(createValidAddOnData({ code: '' }))
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error.issues.find((issue) => issue.path.includes('code'))).toBeDefined()
+        }
+      })
+    })
+
+    describe('WHEN amountCurrency is missing', () => {
+      it('THEN should fail validation with error on amountCurrency field', () => {
+        const data = createValidAddOnData()
+
+        // @ts-expect-error — intentionally removing a required enum field for the test
+        delete data.amountCurrency
+
+        const result = addOnFormSchema.safeParse(data)
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(
+            result.error.issues.find((issue) => issue.path.includes('amountCurrency')),
+          ).toBeDefined()
+        }
+      })
+    })
+  })
+
+  describe('GIVEN amountCents validation', () => {
+    describe('WHEN amountCents is invalid', () => {
+      it.each([
+        ['undefined', undefined],
+        ['empty string', ''],
+        ['not a number', 'abc'],
+        ['below the 0.01 minimum', '0.001'],
+      ])('THEN should fail validation for %s', (_, amountCents) => {
+        const result = addOnFormSchema.safeParse(
+          createValidAddOnData({ amountCents: amountCents as AddOnFormValues['amountCents'] }),
+        )
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(
+            result.error.issues.find((issue) => issue.path.includes('amountCents')),
+          ).toBeDefined()
+        }
+      })
+    })
+
+    describe('WHEN amountCents is valid', () => {
+      it.each([
+        ['exactly the 0.01 minimum', '0.01'],
+        ['a string value', '100'],
+        ['a numeric value', 100],
+      ])('THEN should pass validation for %s', (_, amountCents) => {
+        const result = addOnFormSchema.safeParse(
+          createValidAddOnData({ amountCents: amountCents as AddOnFormValues['amountCents'] }),
+        )
+
+        expect(result.success).toBe(true)
+      })
+    })
+  })
+
+  describe('GIVEN the empty default values', () => {
+    describe('WHEN validated', () => {
+      it('THEN should fail because amountCents is not set', () => {
+        const result = addOnFormSchema.safeParse(emptyAddOnDefaultValues)
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(
+            result.error.issues.find((issue) => issue.path.includes('amountCents')),
+          ).toBeDefined()
+        }
+      })
+    })
+  })
+})

--- a/src/pages/createAddOn/validationSchema.ts
+++ b/src/pages/createAddOn/validationSchema.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod'
+
+import { CurrencyEnum, TaxForTaxesSelectorSectionFragment } from '~/generated/graphql'
+
+// Display-only taxes, replaced by taxCodes[] on save (see AddOnFormInput)
+const taxSchema = z.custom<TaxForTaxesSelectorSectionFragment>()
+
+export const addOnFormSchema = z
+  .object({
+    name: z.string().min(1, ''),
+    code: z.string().min(1, ''),
+    description: z.string().optional(),
+    amountCents: z.union([z.string(), z.number()]).optional(),
+    amountCurrency: z.enum(CurrencyEnum),
+    taxes: z.array(taxSchema).optional(),
+  })
+  // Was: yup.number().min(0.01).required() — amountCents is a display string in form state
+  .refine(
+    (data) => {
+      if (data.amountCents === undefined || data.amountCents === '') {
+        return false
+      }
+
+      const amount = Number(data.amountCents)
+
+      if (isNaN(amount)) {
+        return false
+      }
+
+      return amount >= 0.01
+    },
+    {
+      message: 'text_62978ebe99054a011fc189e0',
+      path: ['amountCents'],
+    },
+  )
+
+export type AddOnFormValues = z.infer<typeof addOnFormSchema>
+
+export const emptyAddOnDefaultValues: AddOnFormValues = {
+  name: '',
+  code: '',
+  description: '',
+  amountCents: undefined,
+  amountCurrency: CurrencyEnum.Usd,
+  taxes: [],
+}

--- a/src/pages/createAddOn/validationSchema.ts
+++ b/src/pages/createAddOn/validationSchema.ts
@@ -23,7 +23,7 @@ export const addOnFormSchema = z
 
       const amount = Number(data.amountCents)
 
-      if (isNaN(amount)) {
+      if (Number.isNaN(amount)) {
         return false
       }
 


### PR DESCRIPTION
## Context

Part of the Formik → TanStack Form migration project. The add-on creation/edition page was one of the last resource forms still using Formik + Yup, which is deprecated in the codebase.

## Description

Migrates `src/pages/CreateAddOn.tsx` from `useFormik` to `useAppForm`, following the established CreateTax/CreateCoupon conventions:

- Adds a zod schema `src/pages/createAddOn/validationSchema.ts` porting the Yup rules 1:1 (required name/code, required currency, and the `amountCents` display-string refine with the 0.01 minimum).
- Renders name+code via the shared `NameAndCodeGroup` field group (replacing the Formik-coupled `updateNameAndMaybeCode`), the amount + currency block via `field.AmountInputField` / `field.ComboBoxField`, and keeps the description toggle and `TaxesSelectorSection` wiring.
- Wraps the page in a real `<form>` element, uses `form.SubmitButton` (validity via `canSubmit`, no dirty gate in create mode), awaits `onSave`, and migrates the existing-code server error to the two-effect `setFieldMeta` pattern.
- Leaves `useCreateEditAddOn`, `AddOnCodeSnippet`, `TaxesSelectorSection` and the GraphQL layer untouched.
- Adds tests: `createAddOn/__tests__/validationSchema.test.ts` and `__tests__/CreateAddOn.test.tsx` (29 tests).

<!-- Linear link -->
Fixes LAGO-1154