### PR TITLE
refactor(plans): migrate leftover charge-form test scaffolds off Formik

### DIFF
--- a/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
@@ -1,8 +1,9 @@
+import { useForm } from '@tanstack/react-form'
 import { act, renderHook } from '@testing-library/react'
-import { useFormik } from 'formik'
 
 import { PlanFormInput } from '~/components/plans/types'
 import { transformFilterObjectToString } from '~/components/plans/utils'
+import { usePropertyValues } from '~/contexts/ChargeFormContext'
 import {
   AggregationTypeEnum,
   ChargeModelEnum,
@@ -31,8 +32,8 @@ const prepare = async ({
   const propertyType = typeof filterIndex === 'number' ? 'filters' : 'properties'
 
   const { result } = renderHook(() => {
-    const formikProps = useFormik<PlanFormInput>({
-      initialValues: {
+    const form = useForm({
+      defaultValues: {
         amountCents: 1,
         amountCurrency: CurrencyEnum.Usd,
         code: 'graduated',
@@ -71,30 +72,19 @@ const prepare = async ({
                 : undefined,
           },
         ],
-      },
+      } as PlanFormInput,
       onSubmit: () => {},
     })
-    const localCharge = formikProps.values.charges[chargeIndex]
     const propertyCursor =
-      propertyType === 'filters' ? `filters.${filterIndex}.properties` : 'properties'
-    const valuePointer =
       propertyType === 'filters'
-        ? localCharge?.filters?.[filterIndex || 0].properties
-        : localCharge?.properties
-
-    const wrappedSetFieldValue = (path: string, value: unknown) => {
-      formikProps.setFieldValue(`charges.${chargeIndex}.${path}`, value)
-    }
-
-    // Create a mock form object that bridges to formik
-    const mockForm = {
-      setFieldValue: (path: string, value: unknown) => wrappedSetFieldValue(path, value),
-    }
+        ? `charges.${chargeIndex}.filters.${filterIndex}.properties`
+        : `charges.${chargeIndex}.properties`
+    const valuePointer = usePropertyValues(form, propertyCursor)
 
     return useGraduatedChargeForm({
       disabled,
       propertyCursor,
-      form: mockForm,
+      form,
       valuePointer,
     })
   })

--- a/src/hooks/plans/__tests__/useGraduatedPercentageChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useGraduatedPercentageChargeForm.test.tsx
@@ -1,8 +1,9 @@
+import { useForm } from '@tanstack/react-form'
 import { act, renderHook } from '@testing-library/react'
-import { useFormik } from 'formik'
 
 import { PlanFormInput } from '~/components/plans/types'
 import { transformFilterObjectToString } from '~/components/plans/utils'
+import { usePropertyValues } from '~/contexts/ChargeFormContext'
 import {
   AggregationTypeEnum,
   ChargeModelEnum,
@@ -31,8 +32,8 @@ const prepare = async ({
   const propertyType = typeof filterIndex === 'number' ? 'filters' : 'properties'
 
   const { result } = renderHook(() => {
-    const formikProps = useFormik<PlanFormInput>({
-      initialValues: {
+    const form = useForm({
+      defaultValues: {
         amountCents: 1,
         amountCurrency: CurrencyEnum.Usd,
         code: 'graduated',
@@ -71,30 +72,19 @@ const prepare = async ({
                 : undefined,
           },
         ],
-      },
+      } as PlanFormInput,
       onSubmit: () => {},
     })
-    const localCharge = formikProps.values.charges[chargeIndex]
     const propertyCursor =
-      propertyType === 'filters' ? `filters.${filterIndex}.properties` : 'properties'
-    const valuePointer =
       propertyType === 'filters'
-        ? localCharge?.filters?.[filterIndex || 0].properties
-        : localCharge?.properties
-
-    const wrappedSetFieldValue = (path: string, value: unknown) => {
-      formikProps.setFieldValue(`charges.${chargeIndex}.${path}`, value)
-    }
-
-    // Create a mock form object that bridges to formik
-    const mockForm = {
-      setFieldValue: (path: string, value: unknown) => wrappedSetFieldValue(path, value),
-    }
+        ? `charges.${chargeIndex}.filters.${filterIndex}.properties`
+        : `charges.${chargeIndex}.properties`
+    const valuePointer = usePropertyValues(form, propertyCursor)
 
     return useGraduatedPercentageChargeForm({
       disabled,
       propertyCursor,
-      form: mockForm,
+      form,
       valuePointer,
     })
   })

--- a/src/hooks/plans/__tests__/useVolumeChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useVolumeChargeForm.test.tsx
@@ -1,8 +1,9 @@
+import { useForm } from '@tanstack/react-form'
 import { act, renderHook } from '@testing-library/react'
-import { useFormik } from 'formik'
 
 import { PlanFormInput } from '~/components/plans/types'
 import { transformFilterObjectToString } from '~/components/plans/utils'
+import { usePropertyValues } from '~/contexts/ChargeFormContext'
 import {
   AggregationTypeEnum,
   ChargeModelEnum,
@@ -28,8 +29,8 @@ const prepare = async ({
   const propertyType = typeof filterIndex === 'number' ? 'filters' : 'properties'
 
   const { result } = renderHook(() => {
-    const formikProps = useFormik<PlanFormInput>({
-      initialValues: {
+    const form = useForm({
+      defaultValues: {
         amountCents: 1,
         amountCurrency: CurrencyEnum.Usd,
         code: 'volume',
@@ -68,30 +69,19 @@ const prepare = async ({
                 : undefined,
           },
         ],
-      },
+      } as PlanFormInput,
       onSubmit: () => {},
     })
-    const localCharge = formikProps.values.charges[chargeIndex]
     const propertyCursor =
-      propertyType === 'filters' ? `filters.${filterIndex}.properties` : 'properties'
-    const valuePointer =
       propertyType === 'filters'
-        ? localCharge?.filters?.[filterIndex || 0].properties
-        : localCharge?.properties
-
-    const wrappedSetFieldValue = (path: string, value: unknown) => {
-      formikProps.setFieldValue(`charges.${chargeIndex}.${path}`, value)
-    }
-
-    // Create a mock form object that bridges to formik
-    const mockForm = {
-      setFieldValue: (path: string, value: unknown) => wrappedSetFieldValue(path, value),
-    }
+        ? `charges.${chargeIndex}.filters.${filterIndex}.properties`
+        : `charges.${chargeIndex}.properties`
+    const valuePointer = usePropertyValues(form, propertyCursor)
 
     return useVolumeChargeForm({
       disabled,
       propertyCursor,
-      form: mockForm,
+      form,
       valuePointer,
     })
   })


### PR DESCRIPTION
## Context

Parent ticket LAGO-1235 migrated the src/hooks/plans/ domain charge-form hooks from Formik to TanStack Form, but three sibling test files under src/hooks/plans/__tests__/ still imported `formik` (useFormik) purely as a state-container scaffold in their prepare() helper — tripping the eslint no-restricted-imports rule that flags the deprecated dependency.

## Description

Rewrite the prepare() scaffold in the three charge-form test files to use a real TanStack form instead of Formik, mirroring the production pattern in src/components/plans/VolumeChargeTable.tsx:

- useGraduatedChargeForm.test.tsx
- useGraduatedPercentageChargeForm.test.tsx
- useVolumeChargeForm.test.tsx

Each scaffold now:
- replaces `useFormik` with the plain `@tanstack/react-form` `useForm` primitive (not useAppForm, which drags in the field-component graph),
- derives valuePointer reactively via usePropertyValues(form, cursor) from ~/contexts/ChargeFormContext,
- uses a full-path cursor (charges.N.properties / charges.N.filters.M.properties), dropping the old relative-cursor + mockForm/wrappedSetFieldValue bridge.

Test-only change: the hooks and all assertions are untouched; only the state container behind form/valuePointer swaps Formik to TanStack. All 38 tests pass.

<!-- Linear link -->
Fixes LAGO-1781