### PR TITLE
fix(quotes): make currency mandatory on quote creation

### DIFF
--- a/src/pages/quotes/__tests__/CreateQuote.test.tsx
+++ b/src/pages/quotes/__tests__/CreateQuote.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { StatusTypeEnum } from '~/generated/graphql'
+import { CurrencyEnum, StatusTypeEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
 import CreateQuote, {
@@ -62,6 +62,47 @@ jest.mock('~/components/dialogs/CentralizedDialog', () => ({
     open: mockDialogOpen,
   }),
 }))
+
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 56,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: String(index),
+        start: index * 56,
+        size: 56,
+      })),
+    scrollToIndex: jest.fn(),
+    measureElement: jest.fn(),
+  }),
+}))
+
+const customersWithAndWithoutCurrency = {
+  customers: {
+    collection: [
+      { id: 'cust-1', displayName: 'Customer One', externalId: 'ext-1', currency: null },
+      {
+        id: 'cust-2',
+        displayName: 'Customer Two',
+        externalId: 'ext-2',
+        currency: CurrencyEnum.Usd,
+      },
+    ],
+  },
+}
+
+const getComboBoxInput = (testId: string): HTMLInputElement =>
+  within(screen.getByTestId(testId)).getByRole('combobox') as HTMLInputElement
+
+const selectComboBoxOption = async (testId: string, optionText: string): Promise<void> => {
+  await userEvent.click(getComboBoxInput(testId))
+
+  const options = await screen.findAllByRole('option')
+  const option = options.find((item) => item.textContent?.startsWith(optionText)) as HTMLElement
+
+  await userEvent.click(option)
+}
 
 describe('CreateQuote', () => {
   beforeEach(() => {
@@ -190,6 +231,114 @@ describe('CreateQuote', () => {
         render(<CreateQuote />)
 
         expect(screen.queryByTestId(CREATE_QUOTE_CURRENCY_COMBOBOX_TEST_ID)).not.toBeInTheDocument()
+      })
+
+      it('THEN should not submit the form', async () => {
+        render(<CreateQuote />)
+
+        await userEvent.click(screen.getByTestId(CREATE_QUOTE_SUBMIT_BUTTON_TEST_ID))
+
+        expect(mockOnSave).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the selected customer has no currency', () => {
+      it('THEN should show an empty and editable currency combobox', async () => {
+        mockCustomersQueryData = customersWithAndWithoutCurrency
+
+        render(<CreateQuote />)
+
+        await selectComboBoxOption(CREATE_QUOTE_CUSTOMER_COMBOBOX_TEST_ID, 'Customer One')
+
+        const currencyInput = getComboBoxInput(CREATE_QUOTE_CURRENCY_COMBOBOX_TEST_ID)
+
+        expect(currencyInput).toHaveValue('')
+        expect(currencyInput).not.toBeDisabled()
+      })
+
+      it('THEN should not submit the form while no currency is picked', async () => {
+        mockCustomersQueryData = customersWithAndWithoutCurrency
+
+        render(<CreateQuote />)
+
+        await selectComboBoxOption(CREATE_QUOTE_CUSTOMER_COMBOBOX_TEST_ID, 'Customer One')
+
+        await userEvent.click(screen.getByTestId(CREATE_QUOTE_SUBMIT_BUTTON_TEST_ID))
+
+        expect(mockOnSave).not.toHaveBeenCalled()
+      })
+
+      it('THEN should flag the currency combobox as invalid after a submit attempt', async () => {
+        mockCustomersQueryData = customersWithAndWithoutCurrency
+
+        render(<CreateQuote />)
+
+        await selectComboBoxOption(CREATE_QUOTE_CUSTOMER_COMBOBOX_TEST_ID, 'Customer One')
+
+        await userEvent.click(screen.getByTestId(CREATE_QUOTE_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(getComboBoxInput(CREATE_QUOTE_CURRENCY_COMBOBOX_TEST_ID)).toHaveAttribute(
+            'aria-invalid',
+            'true',
+          )
+        })
+      })
+
+      it('THEN should submit with the picked currency', async () => {
+        mockCustomersQueryData = customersWithAndWithoutCurrency
+
+        render(<CreateQuote />)
+
+        await selectComboBoxOption(CREATE_QUOTE_CUSTOMER_COMBOBOX_TEST_ID, 'Customer One')
+        await selectComboBoxOption(CREATE_QUOTE_CURRENCY_COMBOBOX_TEST_ID, CurrencyEnum.Eur)
+
+        await userEvent.click(screen.getByTestId(CREATE_QUOTE_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockOnSave).toHaveBeenCalledWith(
+            expect.objectContaining({
+              customerId: 'cust-1',
+              currency: CurrencyEnum.Eur,
+              hasCustomerCurrency: false,
+            }),
+          )
+        })
+      })
+    })
+
+    describe('WHEN the selected customer already has a currency', () => {
+      it('THEN should prefill and lock the currency combobox', async () => {
+        mockCustomersQueryData = customersWithAndWithoutCurrency
+
+        render(<CreateQuote />)
+
+        await selectComboBoxOption(CREATE_QUOTE_CUSTOMER_COMBOBOX_TEST_ID, 'Customer Two')
+
+        const currencyInput = getComboBoxInput(CREATE_QUOTE_CURRENCY_COMBOBOX_TEST_ID)
+
+        expect(currencyInput).toHaveValue(CurrencyEnum.Usd)
+        expect(currencyInput).toBeDisabled()
+      })
+
+      it('THEN should submit with the customer currency', async () => {
+        mockCustomersQueryData = customersWithAndWithoutCurrency
+
+        render(<CreateQuote />)
+
+        await selectComboBoxOption(CREATE_QUOTE_CUSTOMER_COMBOBOX_TEST_ID, 'Customer Two')
+
+        await userEvent.click(screen.getByTestId(CREATE_QUOTE_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockOnSave).toHaveBeenCalledWith(
+            expect.objectContaining({
+              customerId: 'cust-2',
+              currency: CurrencyEnum.Usd,
+              hasCustomerCurrency: true,
+            }),
+          )
+        })
       })
     })
   })

--- a/src/pages/quotes/__tests__/CreateQuote.test.tsx
+++ b/src/pages/quotes/__tests__/CreateQuote.test.tsx
@@ -96,12 +96,27 @@ const getComboBoxInput = (testId: string): HTMLInputElement =>
   within(screen.getByTestId(testId)).getByRole('combobox') as HTMLInputElement
 
 const selectComboBoxOption = async (testId: string, optionText: string): Promise<void> => {
-  await userEvent.click(getComboBoxInput(testId))
+  const input = getComboBoxInput(testId)
 
-  const options = await screen.findAllByRole('option')
-  const option = options.find((item) => item.textContent?.startsWith(optionText)) as HTMLElement
+  await userEvent.click(input)
 
-  await userEvent.click(option)
+  // Retry until the freshly opened popper holds the option, so a leftover popper from a
+  // previously opened combobox is never the one clicked.
+  let option: HTMLElement | undefined
+
+  await waitFor(() => {
+    option = screen.getAllByRole('option').find((item) => item.textContent?.startsWith(optionText))
+
+    expect(option).toBeDefined()
+  })
+
+  await userEvent.click(option as HTMLElement)
+
+  // The popper must be gone before the next interaction, otherwise it swallows the click.
+  await waitFor(() => {
+    expect(input).toHaveValue(optionText)
+    expect(screen.queryAllByRole('option')).toHaveLength(0)
+  })
 }
 
 describe('CreateQuote', () => {

--- a/src/pages/quotes/createQuote/__tests__/validationSchema.test.ts
+++ b/src/pages/quotes/createQuote/__tests__/validationSchema.test.ts
@@ -3,103 +3,106 @@ import { CurrencyEnum, OrderTypeEnum } from '~/generated/graphql'
 import { createQuoteSchema } from '../validationSchema'
 
 describe('createQuoteSchema', () => {
-  it('validates a valid one_off quote', () => {
-    const result = createQuoteSchema.safeParse({
-      customerId: 'customer-123',
-      orderType: OrderTypeEnum.OneOff,
-      subscriptionId: '',
+  describe('GIVEN a complete payload', () => {
+    describe.each([
+      ['one_off', OrderTypeEnum.OneOff, ''],
+      ['subscription_creation', OrderTypeEnum.SubscriptionCreation, ''],
+      ['subscription_amendment', OrderTypeEnum.SubscriptionAmendment, 'sub-456'],
+    ])('WHEN the order type is %s', (_, orderType, subscriptionId) => {
+      it('THEN should pass validation', () => {
+        const result = createQuoteSchema.safeParse({
+          customerId: 'customer-123',
+          orderType,
+          subscriptionId,
+          currency: CurrencyEnum.Usd,
+        })
+
+        expect(result.success).toBe(true)
+      })
     })
 
-    expect(result.success).toBe(true)
+    describe('WHEN owners are provided', () => {
+      it('THEN should pass validation', () => {
+        const result = createQuoteSchema.safeParse({
+          customerId: 'customer-123',
+          orderType: OrderTypeEnum.OneOff,
+          subscriptionId: '',
+          currency: CurrencyEnum.Usd,
+          owners: [{ value: 'user-1' }, { value: 'user-2' }],
+        })
+
+        expect(result.success).toBe(true)
+      })
+    })
+
+    describe('WHEN owners are omitted', () => {
+      it('THEN should pass validation (optional field)', () => {
+        const result = createQuoteSchema.safeParse({
+          customerId: 'customer-123',
+          orderType: OrderTypeEnum.OneOff,
+          subscriptionId: '',
+          currency: CurrencyEnum.Usd,
+        })
+
+        expect(result.success).toBe(true)
+      })
+    })
   })
 
-  it('validates a valid subscription_creation quote', () => {
-    const result = createQuoteSchema.safeParse({
-      customerId: 'customer-123',
-      orderType: OrderTypeEnum.SubscriptionCreation,
-      subscriptionId: '',
-    })
+  describe('GIVEN the customerId field', () => {
+    describe('WHEN customerId is empty', () => {
+      it('THEN should fail validation on the customerId path', () => {
+        const result = createQuoteSchema.safeParse({
+          customerId: '',
+          orderType: OrderTypeEnum.OneOff,
+          subscriptionId: '',
+          currency: CurrencyEnum.Usd,
+        })
 
-    expect(result.success).toBe(true)
+        expect(result.success).toBe(false)
+
+        if (!result.success) {
+          expect(result.error.issues[0].path).toContain('customerId')
+        }
+      })
+    })
   })
 
-  it('validates a valid subscription_amendment quote with subscriptionId', () => {
-    const result = createQuoteSchema.safeParse({
-      customerId: 'customer-123',
-      orderType: OrderTypeEnum.SubscriptionAmendment,
-      subscriptionId: 'sub-456',
+  describe('GIVEN the subscriptionId field', () => {
+    describe('WHEN a subscription_amendment has no subscriptionId', () => {
+      it('THEN should fail validation on the subscriptionId path', () => {
+        const result = createQuoteSchema.safeParse({
+          customerId: 'customer-123',
+          orderType: OrderTypeEnum.SubscriptionAmendment,
+          subscriptionId: '',
+          currency: CurrencyEnum.Usd,
+        })
+
+        expect(result.success).toBe(false)
+
+        if (!result.success) {
+          const paths = result.error.issues.map((issue) => issue.path).flat()
+
+          expect(paths).toContain('subscriptionId')
+        }
+      })
     })
 
-    expect(result.success).toBe(true)
-  })
+    describe.each([
+      ['one_off', OrderTypeEnum.OneOff],
+      ['subscription_creation', OrderTypeEnum.SubscriptionCreation],
+    ])('WHEN the order type is %s without a subscriptionId', (_, orderType) => {
+      it('THEN should pass validation', () => {
+        const result = createQuoteSchema.safeParse({
+          customerId: 'customer-123',
+          orderType,
+          subscriptionId: '',
+          currency: CurrencyEnum.Usd,
+        })
 
-  it('fails when customerId is empty', () => {
-    const result = createQuoteSchema.safeParse({
-      customerId: '',
-      orderType: OrderTypeEnum.OneOff,
-      subscriptionId: '',
+        expect(result.success).toBe(true)
+      })
     })
-
-    expect(result.success).toBe(false)
-    if (!result.success) {
-      expect(result.error.issues[0].path).toContain('customerId')
-    }
-  })
-
-  it('fails when subscription_amendment has no subscriptionId', () => {
-    const result = createQuoteSchema.safeParse({
-      customerId: 'customer-123',
-      orderType: OrderTypeEnum.SubscriptionAmendment,
-      subscriptionId: '',
-    })
-
-    expect(result.success).toBe(false)
-    if (!result.success) {
-      const paths = result.error.issues.map((i) => i.path).flat()
-
-      expect(paths).toContain('subscriptionId')
-    }
-  })
-
-  it('does not require subscriptionId for one_off', () => {
-    const result = createQuoteSchema.safeParse({
-      customerId: 'customer-123',
-      orderType: OrderTypeEnum.OneOff,
-      subscriptionId: '',
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('does not require subscriptionId for subscription_creation', () => {
-    const result = createQuoteSchema.safeParse({
-      customerId: 'customer-123',
-      orderType: OrderTypeEnum.SubscriptionCreation,
-      subscriptionId: '',
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('validates with owners array', () => {
-    const result = createQuoteSchema.safeParse({
-      customerId: 'customer-123',
-      orderType: OrderTypeEnum.OneOff,
-      subscriptionId: '',
-      owners: [{ value: 'user-1' }, { value: 'user-2' }],
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('validates without owners (optional field)', () => {
-    const result = createQuoteSchema.safeParse({
-      customerId: 'customer-123',
-      orderType: OrderTypeEnum.OneOff,
-      subscriptionId: '',
-    })
-
-    expect(result.success).toBe(true)
   })
 
   describe('GIVEN the currency field', () => {
@@ -117,19 +120,25 @@ describe('createQuoteSchema', () => {
     })
 
     describe('WHEN currency is omitted', () => {
-      it('THEN should pass validation (optional field)', () => {
+      it('THEN should fail validation on the currency path', () => {
         const result = createQuoteSchema.safeParse({
           customerId: 'customer-123',
           orderType: OrderTypeEnum.OneOff,
           subscriptionId: '',
         })
 
-        expect(result.success).toBe(true)
+        expect(result.success).toBe(false)
+
+        if (!result.success) {
+          const paths = result.error.issues.map((issue) => issue.path).flat()
+
+          expect(paths).toContain('currency')
+        }
       })
     })
 
     describe('WHEN currency is undefined', () => {
-      it('THEN should pass validation', () => {
+      it('THEN should fail validation on the currency path', () => {
         const result = createQuoteSchema.safeParse({
           customerId: 'customer-123',
           orderType: OrderTypeEnum.OneOff,
@@ -137,7 +146,13 @@ describe('createQuoteSchema', () => {
           currency: undefined,
         })
 
-        expect(result.success).toBe(true)
+        expect(result.success).toBe(false)
+
+        if (!result.success) {
+          const paths = result.error.issues.map((issue) => issue.path).flat()
+
+          expect(paths).toContain('currency')
+        }
       })
     })
 
@@ -151,6 +166,27 @@ describe('createQuoteSchema', () => {
         })
 
         expect(result.success).toBe(false)
+      })
+    })
+  })
+
+  describe('GIVEN a subscription_amendment missing both subscriptionId and currency', () => {
+    describe('WHEN the payload is parsed', () => {
+      it('THEN should report both paths', () => {
+        const result = createQuoteSchema.safeParse({
+          customerId: 'customer-123',
+          orderType: OrderTypeEnum.SubscriptionAmendment,
+          subscriptionId: '',
+        })
+
+        expect(result.success).toBe(false)
+
+        if (!result.success) {
+          const paths = result.error.issues.map((issue) => issue.path).flat()
+
+          expect(paths).toContain('subscriptionId')
+          expect(paths).toContain('currency')
+        }
       })
     })
   })

--- a/src/pages/quotes/createQuote/validationSchema.ts
+++ b/src/pages/quotes/createQuote/validationSchema.ts
@@ -21,5 +21,9 @@ export const createQuoteSchema = z
       message: 'text_1776238919927d6e7f8g9h0i',
     },
   )
+  .refine((data) => !!data.currency, {
+    path: ['currency'],
+    message: 'text_1771342994699klxu2paz7g8',
+  })
 
 export type CreateQuoteFormValues = z.infer<typeof createQuoteSchema>


### PR DESCRIPTION
## Context

After selecting a customer on the quote creation form, the currency field either shows the customer currency or lets the user pick one, which also updates the customer currency. When the selected customer had no currency set, nothing forced the user to pick one, so a quote could be created without any currency.

## Description

- `createQuoteSchema` now requires `currency` through an object-level refine chained after the existing `subscriptionId` one, so the submission is blocked and the currency combobox shows the existing "Field is required" message until a currency is selected. No new translation key.
- The inferred `CreateQuoteFormValues.currency` stays optional, so the form default values and `useCreateQuote` are unchanged.
- Updated the create-quote schema tests for the new requirement, including a case where a subscription amendment misses both `subscriptionId` and `currency`.
- Extended the `CreateQuote` page tests: a customer without a currency gets an empty, editable combobox that blocks submission and is flagged invalid after a submit attempt, while a customer with a currency keeps a prefilled and disabled combobox that submits as before.

<!-- Linear link -->
Fixes LAGO-1786