### PR TITLE
fix(quotes): send fixed charge overrides under overrides.fixedCharges

### DIFF
--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
@@ -36,9 +36,14 @@ import { QuoteInvoicingPaymentsSettings } from './QuoteInvoicingPaymentsSettings
 import { useQuotePlanSettingsDrawer } from './useQuotePlanSettingsDrawer'
 import { useSubscriptionSettingsDrawer } from './useSubscriptionSettingsDrawer'
 
+export type ValidatePlanForm = () => Promise<boolean>
+
 interface SubscriptionPricingContentProps {
   stateRef: MutableRefObject<SubscriptionPricingState | null>
   formValuesRef: MutableRefObject<PlanFormInput | null>
+  // Filled with a submit-and-report-validity function so the drawer can refuse to
+  // persist an incomplete plan.
+  validatePlanFormRef?: MutableRefObject<ValidatePlanForm | null>
   initialState?: SubscriptionPricingState | null
   quoteDates?: { startDate?: string; endDate?: string }
   customer?: QuoteCustomer | null
@@ -50,6 +55,7 @@ interface SubscriptionPricingContentProps {
 export function SubscriptionPricingContent({
   stateRef,
   formValuesRef,
+  validatePlanFormRef,
   initialState,
   quoteDates,
   customer,
@@ -78,6 +84,10 @@ export function SubscriptionPricingContent({
     !!selectedPlanId &&
     selectedPlanId !== originalBillingItemPlanId.current
 
+  // Set by the form's own onSubmit, which TanStack only calls once the form-level
+  // `planFormSchema` passed — so it doubles as the validity signal.
+  const planFormValidRef = useRef(false)
+
   // Plan form — fetches plan by ID and creates TanStack form (no Router needed)
   const {
     form: planForm,
@@ -90,7 +100,25 @@ export function SubscriptionPricingContent({
     planIdToFetch: selectedPlanId || undefined,
     billingItemPlan: userSwitchedPlan ? undefined : billingItemPlan,
     subscriptionId,
+    onSubmit: () => {
+      planFormValidRef.current = true
+    },
   })
+
+  useEffect(() => {
+    if (!validatePlanFormRef) return
+
+    validatePlanFormRef.current = async () => {
+      planFormValidRef.current = false
+      await planForm.handleSubmit()
+
+      return planFormValidRef.current
+    }
+
+    return () => {
+      validatePlanFormRef.current = null
+    }
+  }, [planForm, validatePlanFormRef])
 
   // Sync selectedPlanId from resolvedPlanId when billing items or subscription data arrives
   useEffect(() => {

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
@@ -85,19 +85,41 @@ jest.mock('~/generated/graphql', () => ({
 // Mock usePlanFormSetup — returns a mock form + plan when planIdToFetch is set
 let mockFormOverrides: Partial<PlanFormInput> = {}
 
+// Mirrors TanStack: handleSubmit only invokes onSubmit once the form-level
+// validators pass, which is what the component uses as its validity signal.
+let mockFormPassesValidation = true
+
 jest.mock('~/hooks/plans/usePlanFormSetup', () => {
   const { createMockPlanForm } = jest.requireActual('~/test-utils/createMockPlanForm')
 
   return {
-    usePlanFormSetup: jest.fn(({ planIdToFetch }: { planIdToFetch?: string }) => ({
-      form: createMockPlanForm(mockFormOverrides),
-      plan: planIdToFetch ? mockPlan : undefined,
-      formReady: !!planIdToFetch,
-      loading: false,
-      resolvedPlanId: planIdToFetch,
-      subscriptionSettings: undefined,
-      invoicingSettings: undefined,
-    })),
+    usePlanFormSetup: jest.fn(
+      ({
+        planIdToFetch,
+        onSubmit,
+      }: {
+        planIdToFetch?: string
+        onSubmit?: (value: PlanFormInput) => void
+      }) => {
+        const form = createMockPlanForm(mockFormOverrides)
+
+        form.handleSubmit = jest.fn(async () => {
+          if (mockFormPassesValidation) {
+            onSubmit?.(form.state.values)
+          }
+        })
+
+        return {
+          form,
+          plan: planIdToFetch ? mockPlan : undefined,
+          formReady: !!planIdToFetch,
+          loading: false,
+          resolvedPlanId: planIdToFetch,
+          subscriptionSettings: undefined,
+          invoicingSettings: undefined,
+        }
+      },
+    ),
   }
 })
 
@@ -146,6 +168,7 @@ jest.mock('~/components/plans/drawers/subscriptionFee/SubscriptionFeeDrawer', ()
 describe('SubscriptionPricingContent', () => {
   beforeEach(() => {
     mockFormOverrides = {}
+    mockFormPassesValidation = true
     mockOpenSubscriptionSettings.mockClear()
     mockOpenPlanSettings.mockClear()
   })
@@ -528,6 +551,74 @@ describe('SubscriptionPricingContent', () => {
       expect(usePlanFormSetup).toHaveBeenLastCalledWith(
         expect.objectContaining({ billingItemPlan, planIdToFetch: 'plan_1' }),
       )
+    })
+  })
+
+  describe('GIVEN the drawer passes a validatePlanFormRef', () => {
+    const renderWithValidateRef = async () => {
+      const stateRef = { current: null as SubscriptionPricingState | null }
+      const formValuesRef = { current: null as PlanFormInput | null }
+      const validatePlanFormRef = { current: null as (() => Promise<boolean>) | null }
+
+      const rendered = await act(() =>
+        render(
+          <SubscriptionPricingContent
+            stateRef={stateRef}
+            formValuesRef={formValuesRef}
+            validatePlanFormRef={validatePlanFormRef}
+          />,
+        ),
+      )
+
+      return { rendered, validatePlanFormRef }
+    }
+
+    describe('WHEN the component mounts', () => {
+      it('THEN should fill the ref with a validation handle', async () => {
+        const { validatePlanFormRef } = await renderWithValidateRef()
+
+        expect(typeof validatePlanFormRef.current).toBe('function')
+      })
+    })
+
+    describe('WHEN the plan form passes its validators', () => {
+      it('THEN should report the form as valid', async () => {
+        mockFormPassesValidation = true
+
+        const { validatePlanFormRef } = await renderWithValidateRef()
+
+        await expect(validatePlanFormRef.current?.()).resolves.toBe(true)
+      })
+    })
+
+    describe('WHEN the plan form fails its validators', () => {
+      it('THEN should report the form as invalid', async () => {
+        mockFormPassesValidation = false
+
+        const { validatePlanFormRef } = await renderWithValidateRef()
+
+        await expect(validatePlanFormRef.current?.()).resolves.toBe(false)
+      })
+
+      it('THEN should report invalid again on a second attempt', async () => {
+        mockFormPassesValidation = false
+
+        const { validatePlanFormRef } = await renderWithValidateRef()
+
+        await validatePlanFormRef.current?.()
+
+        await expect(validatePlanFormRef.current?.()).resolves.toBe(false)
+      })
+    })
+
+    describe('WHEN the component unmounts', () => {
+      it('THEN should clear the ref', async () => {
+        const { rendered, validatePlanFormRef } = await renderWithValidateRef()
+
+        rendered.unmount()
+
+        expect(validatePlanFormRef.current).toBeNull()
+      })
     })
   })
 })

--- a/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
+++ b/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
@@ -3,6 +3,7 @@ import type {
   LocalUsageChargeInput,
   PlanFormInput,
 } from '~/components/plans/types'
+import { planFormSchema } from '~/formValidation/planFormSchema'
 import {
   AggregationTypeEnum,
   ChargeModelEnum,
@@ -234,10 +235,11 @@ describe('buildPlanOverrides', () => {
     expect(result.invoiceDisplayName).toBe('Platform fee')
   })
 
-  it('merges fixed charges and usage charges into overrides.charges', () => {
+  describe('GIVEN a plan carrying both fixed charges and usage charges', () => {
     const fixedCharge = {
       addOn: { code: 'setup_fee' },
       chargeModel: FixedChargeChargeModelEnum.Standard,
+      units: '5',
       properties: { amount: '100' },
     } as unknown as PlanFormInput['fixedCharges'][number]
     const usageCharge = {
@@ -246,16 +248,116 @@ describe('buildPlanOverrides', () => {
       properties: { amount: '0.01' },
     } as unknown as PlanFormInput['charges'][number]
 
-    const result = buildPlanOverrides({
-      ...baseFormValues,
-      amountCents: '0',
-      fixedCharges: [fixedCharge],
-      charges: [usageCharge],
-    })
+    const buildBoth = () =>
+      buildPlanOverrides({
+        ...baseFormValues,
+        amountCents: '0',
+        fixedCharges: [fixedCharge],
+        charges: [usageCharge],
+      })
 
-    expect(result.charges).toHaveLength(2)
-    expect(result.charges?.[0].billableMetricCode).toBe('setup_fee')
-    expect(result.charges?.[1].billableMetricCode).toBe('api_calls')
+    describe('WHEN the overrides are built', () => {
+      it('THEN should send the fixed charge under overrides.fixedCharges keyed by addOnCode', () => {
+        const result = buildBoth()
+
+        expect(result.fixedCharges).toEqual([
+          { addOnCode: 'setup_fee', units: '5', properties: { amount: '100' } },
+        ])
+      })
+
+      it('THEN should keep overrides.charges limited to usage charges', () => {
+        const result = buildBoth()
+
+        expect(result.charges).toEqual([
+          {
+            billableMetricCode: 'api_calls',
+            chargeModel: ChargeModelEnum.Standard,
+            properties: { amount: '0.01' },
+          },
+        ])
+      })
+
+      it('THEN should not send chargeModel on a fixed charge override', () => {
+        const result = buildBoth()
+
+        expect(result.fixedCharges?.[0]).not.toHaveProperty('chargeModel')
+      })
+    })
+  })
+
+  describe('GIVEN a fixed charge with empty optional values', () => {
+    describe('WHEN the overrides are built', () => {
+      it.each([
+        ['empty string units', ''],
+        ['null units', null],
+        ['undefined units', undefined],
+      ])('THEN should omit units for %s', (_, units) => {
+        const result = buildPlanOverrides({
+          ...baseFormValues,
+          amountCents: '0',
+          fixedCharges: [
+            {
+              addOn: { code: 'setup_fee' },
+              chargeModel: FixedChargeChargeModelEnum.Standard,
+              units,
+              properties: { amount: '100' },
+            } as unknown as PlanFormInput['fixedCharges'][number],
+          ],
+        })
+
+        expect(result.fixedCharges?.[0]).not.toHaveProperty('units')
+      })
+
+      it('THEN should omit an empty invoiceDisplayName and absent properties', () => {
+        const result = buildPlanOverrides({
+          ...baseFormValues,
+          amountCents: '0',
+          fixedCharges: [
+            {
+              addOn: { code: 'setup_fee' },
+              chargeModel: FixedChargeChargeModelEnum.Standard,
+              units: '2',
+              invoiceDisplayName: '',
+            } as unknown as PlanFormInput['fixedCharges'][number],
+          ],
+        })
+
+        expect(result.fixedCharges).toEqual([{ addOnCode: 'setup_fee', units: '2' }])
+      })
+
+      it('THEN should keep a filled invoiceDisplayName', () => {
+        const result = buildPlanOverrides({
+          ...baseFormValues,
+          amountCents: '0',
+          fixedCharges: [
+            {
+              addOn: { code: 'setup_fee' },
+              chargeModel: FixedChargeChargeModelEnum.Standard,
+              units: '2',
+              invoiceDisplayName: 'Onboarding',
+            } as unknown as PlanFormInput['fixedCharges'][number],
+          ],
+        })
+
+        expect(result.fixedCharges?.[0].invoiceDisplayName).toBe('Onboarding')
+      })
+    })
+  })
+
+  describe('GIVEN a plan without fixed charges', () => {
+    describe('WHEN the overrides are built', () => {
+      it('THEN should not add a fixedCharges key at all', () => {
+        const result = buildPlanOverrides({
+          ...baseFormValues,
+          amountCents: '0',
+          fixedCharges: [],
+          charges: [],
+        })
+
+        expect(result).not.toHaveProperty('fixedCharges')
+        expect(result).not.toHaveProperty('charges')
+      })
+    })
   })
 
   it('includes a positive minimum commitment and ignores non-positive ones', () => {
@@ -779,5 +881,69 @@ describe('plan amount cents conversion', () => {
     const deserialized = fromPlanBillingItems(serialized.plans)
 
     expect(deserialized.formValues?.amountCents).toBe('850')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// planFormSchema round-trip — a saved plan must stay re-savable
+// ---------------------------------------------------------------------------
+
+describe('GIVEN a plan billing item saved from the quote drawer', () => {
+  // What `buildDefaultValues` seeds for a plan with neither a negotiated commitment
+  // nor progressive billing — the state the drawer reopens with.
+  const untouchedOptionals: PlanFormInput = {
+    ...baseFormValues,
+    minimumCommitment: {},
+    nonRecurringUsageThresholds: undefined,
+    recurringUsageThreshold: undefined,
+  }
+
+  const roundTrip = (formValues: PlanFormInput): PlanFormInput | null =>
+    fromPlanBillingItems(toPlanBillingItems(basePricingState, formValues).plans).formValues
+
+  describe('WHEN the plan is read back for editing', () => {
+    it('THEN should still satisfy planFormSchema without a commitment or thresholds', () => {
+      const result = planFormSchema.safeParse(roundTrip(untouchedOptionals))
+
+      expect(result.success).toBe(true)
+    })
+
+    it('THEN should not rebuild a phantom zero minimum commitment', () => {
+      expect(roundTrip(untouchedOptionals)?.minimumCommitment).toEqual({})
+    })
+
+    it('THEN should leave progressive billing unset rather than an empty list', () => {
+      expect(roundTrip(untouchedOptionals)?.nonRecurringUsageThresholds).toBeUndefined()
+    })
+
+    it('THEN should still satisfy planFormSchema with a fixed charge', () => {
+      const fixedCharge = {
+        addOn: { id: 'addon_1', name: 'Setup Fee', code: 'setup_fee' },
+        chargeModel: FixedChargeChargeModelEnum.Standard,
+        units: '5',
+        properties: { amount: '100' },
+        taxCodes: [],
+        taxes: [],
+      } as unknown as LocalFixedChargeInput
+
+      const result = planFormSchema.safeParse(
+        roundTrip({ ...untouchedOptionals, fixedCharges: [fixedCharge] }),
+      )
+
+      expect(result.success).toBe(true)
+    })
+
+    it('THEN should preserve a real minimum commitment', () => {
+      const formValues: PlanFormInput = {
+        ...untouchedOptionals,
+        minimumCommitment: {
+          amountCents: '5000',
+          commitmentType: CommitmentTypeEnum.MinimumCommitment,
+        },
+      }
+
+      expect(roundTrip(formValues)?.minimumCommitment?.amountCents).toBe('5000')
+      expect(planFormSchema.safeParse(roundTrip(formValues)).success).toBe(true)
+    })
   })
 })

--- a/src/core/serializers/serializeQuotePlanBillingItems.ts
+++ b/src/core/serializers/serializeQuotePlanBillingItems.ts
@@ -19,6 +19,16 @@ interface PlanChargeOverride {
   properties: Record<string, unknown>
 }
 
+// Fixed charges are keyed by add-on code, and the backend schema forbids any key
+// outside this set (`additionalProperties: {not: {}}`) — notably `chargeModel`,
+// which is only accepted on usage charge overrides.
+interface PlanFixedChargeOverride {
+  addOnCode: string
+  units?: string
+  properties?: Record<string, unknown>
+  invoiceDisplayName?: string
+}
+
 interface PlanMinimumCommitmentOverride {
   amountCents: number
   invoiceDisplayName?: string
@@ -36,6 +46,7 @@ export interface PlanOverrides {
   invoiceDisplayName?: string
   minimumCommitment?: PlanMinimumCommitmentOverride
   charges?: PlanChargeOverride[]
+  fixedCharges?: PlanFixedChargeOverride[]
   usageThresholds?: PlanUsageThresholdOverride[]
 }
 
@@ -261,6 +272,30 @@ const serializeCharge = (charge: LocalUsageChargeInput): SerializedCharge => {
   }
 }
 
+/**
+ * Fixed charge → `overrides.fixedCharges` entry. Only `addOnCode` is mandatory;
+ * the optional keys are omitted rather than sent empty because the backend schema
+ * validates them with `minLength: 1`.
+ */
+const buildFixedChargeOverride = (charge: LocalFixedChargeInput): PlanFixedChargeOverride => {
+  const override: PlanFixedChargeOverride = { addOnCode: charge.addOn?.code ?? '' }
+  const units = charge.units ?? ''
+
+  if (units) {
+    override.units = String(units)
+  }
+
+  if (charge.properties) {
+    override.properties = charge.properties
+  }
+
+  if (charge.invoiceDisplayName) {
+    override.invoiceDisplayName = charge.invoiceDisplayName
+  }
+
+  return override
+}
+
 const serializeFixedCharge = (charge: LocalFixedChargeInput): SerializedFixedCharge => {
   return {
     id: charge.id,
@@ -303,27 +338,20 @@ export const buildPlanOverrides = (formValues: PlanFormInput): PlanOverrides => 
     overrides.invoiceDisplayName = formValues.invoiceDisplayName || undefined
   }
 
-  // Fixed charges
+  // Fixed charges live in their own override collection: the backend resolves
+  // `charges[].billableMetricCode` against the plan's billable metrics, so an add-on
+  // code sent there fails with `charge_not_found`.
   if (formValues.fixedCharges?.length) {
-    overrides.charges = [
-      ...formValues.fixedCharges.map((c) => ({
-        billableMetricCode: c.addOn?.code ?? '',
-        chargeModel: c.chargeModel,
-        properties: c.properties ?? {},
-      })),
-    ]
+    overrides.fixedCharges = formValues.fixedCharges.map(buildFixedChargeOverride)
   }
 
   // Usage charges
   if (formValues.charges?.length) {
-    overrides.charges = [
-      ...(overrides.charges ?? []),
-      ...formValues.charges.map((c) => ({
-        billableMetricCode: c.billableMetric?.code ?? '',
-        chargeModel: c.chargeModel,
-        properties: c.properties ?? {},
-      })),
-    ]
+    overrides.charges = formValues.charges.map((c) => ({
+      billableMetricCode: c.billableMetric?.code ?? '',
+      chargeModel: c.chargeModel,
+      properties: c.properties ?? {},
+    }))
   }
 
   // Minimum commitment
@@ -535,6 +563,44 @@ const deserializeFixedCharge = (charge: SerializedFixedCharge): LocalFixedCharge
   }
 }
 
+/**
+ * A plan with no negotiated commitment is still persisted as a commitment object with an
+ * empty amount, so reading it back verbatim would rebuild a phantom 0 commitment that
+ * `planFormSchema` rejects. `{}` is what `buildDefaultValues` seeds for "no commitment".
+ */
+const deserializeMinimumCommitment = (
+  commitment: SerializedMinimumCommitment | null | undefined,
+  currency: CurrencyEnum,
+): PlanFormInput['minimumCommitment'] => {
+  if (!commitment || !Number(commitment.amountCents)) return {}
+
+  return {
+    id: commitment.id ?? undefined,
+    amountCents: String(deserializeAmount(commitment.amountCents, currency)),
+    invoiceDisplayName: commitment.invoiceDisplayName ?? undefined,
+    commitmentType: commitment.commitmentType as CommitmentTypeEnum,
+    taxCodes: commitment.taxCodes ?? [],
+    taxes: deserializeTaxes(commitment.taxes ?? []),
+  }
+}
+
+/**
+ * `undefined` means "progressive billing not configured"; an empty array is an error state
+ * for `planFormSchema`, and the payload always carries one when the plan has no threshold.
+ */
+const deserializeNonRecurringThresholds = (
+  thresholds: SerializedUsageThreshold[] | null | undefined,
+  currency: CurrencyEnum,
+): PlanFormInput['nonRecurringUsageThresholds'] => {
+  if (!thresholds?.length) return undefined
+
+  return thresholds.map((t) => ({
+    amountCents: deserializeAmount(t.amountCents || 0, currency),
+    thresholdDisplayName: t.thresholdDisplayName ?? undefined,
+    recurring: t.recurring,
+  })) as PlanFormInput['nonRecurringUsageThresholds']
+}
+
 export const fromPlanBillingItems = (plans: BillingItemPlan[]): FromPlanBillingItemsResult => {
   const plan = plans[0]
   const { payload, overrides, id } = plan
@@ -583,23 +649,11 @@ export const fromPlanBillingItems = (plans: BillingItemPlan[]): FromPlanBillingI
       taxes: deserializeTaxes(payload.taxes ?? []),
       charges: (payload.charges ?? []).map(deserializeCharge),
       fixedCharges: (payload.fixedCharges ?? []).map(deserializeFixedCharge),
-      minimumCommitment: payload.minimumCommitment
-        ? {
-            id: payload.minimumCommitment.id ?? undefined,
-            amountCents: String(
-              deserializeAmount(payload.minimumCommitment.amountCents || 0, currency),
-            ),
-            invoiceDisplayName: payload.minimumCommitment.invoiceDisplayName ?? undefined,
-            commitmentType: payload.minimumCommitment.commitmentType as CommitmentTypeEnum,
-            taxCodes: payload.minimumCommitment.taxCodes ?? [],
-            taxes: deserializeTaxes(payload.minimumCommitment.taxes ?? []),
-          }
-        : undefined,
-      nonRecurringUsageThresholds: (payload.nonRecurringUsageThresholds ?? []).map((t) => ({
-        amountCents: deserializeAmount(t.amountCents || 0, currency),
-        thresholdDisplayName: t.thresholdDisplayName ?? undefined,
-        recurring: t.recurring,
-      })) as PlanFormInput['nonRecurringUsageThresholds'],
+      minimumCommitment: deserializeMinimumCommitment(payload.minimumCommitment, currency),
+      nonRecurringUsageThresholds: deserializeNonRecurringThresholds(
+        payload.nonRecurringUsageThresholds,
+        currency,
+      ),
       recurringUsageThreshold: payload.recurringUsageThreshold
         ? {
             amountCents: deserializeAmount(

--- a/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
@@ -22,6 +22,10 @@ const mockDrawerClose = jest.fn()
 // `null` keeps the ref empty (exercises the early-return branch in handleSave).
 let mockInjectedState: SubscriptionPricingState | null = null
 
+// Verdict the mocked content component reports through validatePlanFormRef.
+// `null` leaves the ref unfilled, as when the content component never mounted.
+let mockPlanFormValid: boolean | null = null
+
 jest.mock('~/components/drawers/useDrawer', () => ({
   useFormDrawer: () => ({ open: mockDrawerOpen, close: mockDrawerClose }),
 }))
@@ -39,11 +43,18 @@ jest.mock(
   () => ({
     SubscriptionPricingContent: ({
       stateRef,
+      validatePlanFormRef,
     }: {
       stateRef?: { current: SubscriptionPricingState | null }
+      validatePlanFormRef?: { current: (() => Promise<boolean>) | null }
     }) => {
       if (stateRef) {
         stateRef.current = mockInjectedState
+      }
+
+      if (validatePlanFormRef) {
+        validatePlanFormRef.current =
+          mockPlanFormValid === null ? null : () => Promise.resolve(mockPlanFormValid as boolean)
       }
 
       return null
@@ -55,6 +66,7 @@ describe('useSubscriptionPricingDrawer', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockInjectedState = null
+    mockPlanFormValid = null
   })
 
   it('returns the expected interface', () => {
@@ -308,6 +320,91 @@ describe('useSubscriptionPricingDrawer', () => {
     expect(mockDrawerClose).not.toHaveBeenCalled()
     expect(result.current.entities).not.toHaveProperty('plan_123')
     expect(onDatesChange).not.toHaveBeenCalled()
+  })
+
+  describe('GIVEN the plan form reports its validity', () => {
+    const validState: SubscriptionPricingState = {
+      planId: 'plan_123',
+      planCode: 'enterprise',
+      planName: 'Enterprise Plan',
+      planDescription: '',
+      subscriptionSettings: {
+        externalId: '',
+        subscriptionName: '',
+        billingTime: 'anniversary',
+        startDate: '2023-07-26',
+        endDate: '2024-07-26',
+      },
+      invoicingSettings: { paymentMethodId: '', invoiceCustomFooter: '' },
+      overrides: {},
+    }
+
+    const submitDrawer = async (onSave: jest.Mock) => {
+      const rendered = renderHook(() => useSubscriptionPricingDrawer(undefined))
+
+      act(() => {
+        rendered.result.current.onPricingCommand({ onSave })
+      })
+
+      const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+      render(openArgs.children)
+
+      return { openArgs, result: rendered.result }
+    }
+
+    describe('WHEN the plan form is invalid', () => {
+      beforeEach(() => {
+        mockInjectedState = validState
+        mockPlanFormValid = false
+      })
+
+      it('THEN should not persist the billing item', async () => {
+        const onSave = jest.fn().mockResolvedValue({ ok: true })
+        const { openArgs, result } = await submitDrawer(onSave)
+
+        await act(async () => {
+          await expect(openArgs.form.submit()).rejects.toThrow()
+        })
+
+        expect(onSave).not.toHaveBeenCalled()
+        expect(result.current.entities).not.toHaveProperty('plan_123')
+      })
+
+      it('THEN should toast and keep the drawer open', async () => {
+        const onSave = jest.fn().mockResolvedValue({ ok: true })
+        const { openArgs } = await submitDrawer(onSave)
+
+        await act(async () => {
+          await expect(openArgs.form.submit()).rejects.toThrow()
+        })
+
+        expect(mockAddToast).toHaveBeenCalledWith({
+          severity: 'danger',
+          translateKey: QUOTE_SAVE_FAILED_TOAST_KEY,
+        })
+        expect(mockDrawerClose).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the plan form is valid', () => {
+      beforeEach(() => {
+        mockInjectedState = validState
+        mockPlanFormValid = true
+      })
+
+      it('THEN should persist the billing item', async () => {
+        const onSave = jest.fn().mockResolvedValue({ ok: true })
+        const { openArgs, result } = await submitDrawer(onSave)
+
+        await act(async () => {
+          await openArgs.form.submit()
+        })
+
+        expect(onSave).toHaveBeenCalledTimes(1)
+        expect(result.current.entities).toHaveProperty('plan_123')
+      })
+    })
   })
 
   it('preserves existing coupons in the payload when saving a plan', async () => {

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -6,7 +6,10 @@ import type {
   OnPricingCommand,
 } from '~/components/designSystem/RichTextEditor/common/RichTextEditorContext'
 import type { PricingBlockAttributes } from '~/components/designSystem/RichTextEditor/extensions/PricingBlock.schema'
-import { SubscriptionPricingContent } from '~/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent'
+import {
+  SubscriptionPricingContent,
+  type ValidatePlanForm,
+} from '~/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent'
 import { useFormDrawer } from '~/components/drawers/useDrawer'
 import type { PlanFormInput } from '~/components/plans/types'
 import { addToast } from '~/core/apolloClient'
@@ -56,6 +59,7 @@ export const useSubscriptionPricingDrawer = (
   const initialStateRef = useRef<SubscriptionPricingState | null>(null)
   const subscriptionStateRef = useRef<SubscriptionPricingState | null>(null)
   const formValuesRef = useRef<PlanFormInput | null>(null)
+  const validatePlanFormRef = useRef<ValidatePlanForm | null>(null)
 
   // Latest saved billingItems, kept in a ref so plan saves/syncs can preserve
   // sibling categories (coupons, addons) instead of overwriting billingItems and
@@ -132,6 +136,17 @@ export const useSubscriptionPricingDrawer = (
           throw new Error('Incomplete plan')
         }
 
+        // An unfilled billing item must never reach the quote version, otherwise it
+        // would be approvable and only fail at execution time. The drawer stays open
+        // (`closeOnError: false`) with the invalid fields flagged by the form itself.
+        const isPlanFormValid = (await validatePlanFormRef.current?.()) ?? true
+
+        if (!isPlanFormValid) {
+          addToast({ severity: 'danger', translateKey: QUOTE_SAVE_FAILED_TOAST_KEY })
+
+          throw new Error('Invalid plan')
+        }
+
         const billingItems = toPlanBillingItems(state, formValues ?? undefined)
         const entityData: Record<string, EntityData> = {
           [state.planId]: {
@@ -183,6 +198,7 @@ export const useSubscriptionPricingDrawer = (
           <SubscriptionPricingContent
             stateRef={subscriptionStateRef}
             formValuesRef={formValuesRef}
+            validatePlanFormRef={validatePlanFormRef}
             initialState={initialStateRef.current}
             quoteDates={options?.quoteDates}
             customer={options?.customer}


### PR DESCRIPTION
## Context

Adding a plan that carries a fixed charge to a quote made the save fail with
`billing_items.plans.0.overrides.charges.0.billableMetricCode: charge_not_found`.
The front end pushed fixed charges into `overrides.charges` keyed by
`billableMetricCode: addOn.code`, but the API resolves that field against the
plan's billable metrics, so an add-on code can never match. Fixed charges have
their own override collection in the billing-items contract.

The ticket also asks that a quote whose billing item is not filled cannot be
approved. The pricing drawer only guarded on "no plan selected" and never ran
the plan form's own validation, so an incomplete plan reached the quote version
and became approvable, failing later at execution time.

## Description

- `buildPlanOverrides` now emits `overrides.fixedCharges`, each entry keyed by
  `addOnCode` plus `properties`, and `units` / `invoiceDisplayName` only when
  non-empty (the backend schema validates both with `minLength: 1` and rejects
  any key outside the documented set, `chargeModel` included).
- `overrides.charges` is back to usage charges only; `PlanOverrides` gains a
  typed `fixedCharges`, so a saved override round-trips untouched.
- The subscription pricing drawer refuses to save an invalid plan: the content
  component exposes a submit-and-report-validity handle through
  `validatePlanFormRef`, and `handleSave` toasts and keeps the drawer open
  instead of persisting an unfilled billing item.
- Reading a saved plan back no longer rebuilds values the plan form rejects:
  an empty minimum commitment deserializes to `{}` and an empty progressive
  billing list to `undefined`, matching what a fresh form seeds, so an existing
  quote plan stays re-savable through the new gate.
- Specs cover the override shape, the omitted optional keys, the save gate on
  both branches, and a real save → read-back → `planFormSchema` round-trip.

<!-- Linear link -->
Fixes LAGO-1783

