### PR TITLE
feat(activity-logs): support rate card resource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.26
 
 # --- deps stage: install node_modules only ---------------------------------
-FROM node:24.18.1-alpine AS deps
+FROM node:24.19.0-alpine AS deps
 
 WORKDIR /app
 
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked \
 
 
 # --- build stage: compile the app ------------------------------------------
-FROM node:24.18.1-alpine AS build
+FROM node:24.19.0-alpine AS build
 
 WORKDIR /app
 ENV NODE_OPTIONS="--max-old-space-size=4096"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:24.18.1-alpine
+FROM node:24.19.0-alpine
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-tailwindcss": "3.18.3",
     "gettext-extractor": "4.0.6",
     "glob": "13.0.6",
-    "globals": "17.8.0",
+    "globals": "17.9.0",
     "husky": "9.1.7",
     "jest": "30.4.2",
     "jest-environment-jsdom": "30.4.1",

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-tailwindcss": "3.18.3",
-    "globals": "17.8.0",
+    "globals": "17.9.0",
     "prettier": "3.9.6",
     "prettier-plugin-tailwindcss": "0.8.1",
     "tailwindcss": "3.4.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,8 +368,8 @@ importers:
         specifier: 13.0.6
         version: 13.0.6
       globals:
-        specifier: 17.8.0
-        version: 17.8.0
+        specifier: 17.9.0
+        version: 17.9.0
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -461,8 +461,8 @@ importers:
         specifier: 3.18.3
         version: 3.18.3(tailwindcss@3.4.19(ts-node@10.9.2(@swc/core@1.15.46)(@swc/wasm@1.13.20)(@types/node@24.13.3)(typescript@6.0.3)))
       globals:
-        specifier: 17.8.0
-        version: 17.8.0
+        specifier: 17.9.0
+        version: 17.9.0
       prettier:
         specifier: 3.9.6
         version: 3.9.6
@@ -5553,8 +5553,8 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
-  globals@17.8.0:
-    resolution: {integrity: sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==}
+  globals@17.9.0:
+    resolution: {integrity: sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -14363,7 +14363,7 @@ snapshots:
 
   globals@14.0.0: {}
 
-  globals@17.8.0: {}
+  globals@17.9.0: {}
 
   globalthis@1.0.4:
     dependencies:

--- a/src/components/aiAgent/ChatPromptEditor.tsx
+++ b/src/components/aiAgent/ChatPromptEditor.tsx
@@ -1,14 +1,14 @@
-import { FormikConfig, useFormik } from 'formik'
+import { useStore } from '@tanstack/react-form'
 import { Icon, tw } from 'lago-design-system'
 import { FC, useEffect, useState } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { Popper } from '~/components/designSystem/Popper'
 import { Typography } from '~/components/designSystem/Typography'
-import { TextInputField } from '~/components/form'
 import { CreateAiConversationInput } from '~/generated/graphql'
 import { AGENT_TYPE_LABELS, AiAgentTypeEnum, useAiAgent } from '~/hooks/aiAgent/useAiAgent'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 import { MenuPopper } from '~/styles'
 
 export const CHAT_PROMPT_EDITOR_TEST_ID = 'chat-prompt-editor'
@@ -20,7 +20,7 @@ export const CHAT_PROMPT_EDITOR_AGENT_SELECTOR_TEST_ID = 'chat-prompt-editor-age
 
 interface ChatPromptEditorProps {
   disabled?: boolean
-  onSubmit: FormikConfig<CreateAiConversationInput>['onSubmit']
+  onSubmit: (values: CreateAiConversationInput) => void
 }
 
 export const ChatPromptEditor: FC<ChatPromptEditorProps> = ({
@@ -45,27 +45,29 @@ export const ChatPromptEditor: FC<ChatPromptEditorProps> = ({
     return () => observer.disconnect()
   }, [textareaElement])
 
-  const formikProps = useFormik({
-    initialValues: {
+  const form = useAppForm({
+    defaultValues: {
       message: '',
     },
-    onSubmit: (values, props) => {
-      if (!values.message || state.isLoading || state.isStreaming) return
+    onSubmit: ({ value, formApi }) => {
+      if (!value.message || state.isLoading || state.isStreaming) return
 
-      handleSubmit(values, props)
-      formikProps.resetForm()
+      handleSubmit(value)
+      formApi.reset()
     },
   })
+
+  const message = useStore(form.store, (formState) => formState.values.message)
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault()
-      formikProps.handleSubmit()
+      form.handleSubmit()
     }
   }
 
   const isWaitingForResponse = state.isLoading || state.isStreaming
-  const canSubmit = !!formikProps.values.message && !isWaitingForResponse && !disabled
+  const canSubmit = !!message && !isWaitingForResponse && !disabled
 
   const agentOptions = Object.values(AiAgentTypeEnum).map((value) => ({
     value,
@@ -77,7 +79,11 @@ export const ChatPromptEditor: FC<ChatPromptEditorProps> = ({
   return (
     <form
       className="relative mx-6 mb-6 mt-0 flex w-[calc(100%-16px*3)] shrink-0 flex-col gap-4"
-      onSubmit={formikProps.handleSubmit}
+      onSubmit={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        form.handleSubmit()
+      }}
       data-test={CHAT_PROMPT_EDITOR_TEST_ID}
     >
       <div className="h-30 w-full" />
@@ -90,29 +96,31 @@ export const ChatPromptEditor: FC<ChatPromptEditorProps> = ({
             data-test={CHAT_PROMPT_EDITOR_GRADIENT_TEST_ID}
           />
         )}
-        <TextInputField
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus
-          className="rounded-xl bg-white"
-          inputRef={setTextareaElement}
-          onKeyDown={handleKeyDown}
-          multiline
-          id="message"
-          name="message"
-          formikProps={formikProps}
-          placeholder={translate('text_1757417225851xkstj2u16q5')}
-          InputProps={{
-            // Bottom padding on the non-scrolling root reserves the agent selector + submit row,
-            // so scrolled text clips above it instead of sliding underneath (120px → 428px total)
-            className: '!px-0 !pb-13 !pt-3',
-          }}
-          inputProps={{
-            className:
-              '!resize-none w-full !px-4 !py-0 !min-h-14 !max-h-[364px] !overflow-y-auto text-sm',
-            'data-test': CHAT_PROMPT_EDITOR_INPUT_TEST_ID,
-          }}
-          disabled={isWaitingForResponse || disabled}
-        />
+        <form.AppField name="message">
+          {(field) => (
+            <field.TextInputField
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus
+              className="rounded-xl bg-white"
+              inputRef={setTextareaElement}
+              onKeyDown={handleKeyDown}
+              multiline
+              id="message"
+              placeholder={translate('text_1757417225851xkstj2u16q5')}
+              InputProps={{
+                // Bottom padding on the non-scrolling root reserves the agent selector + submit row,
+                // so scrolled text clips above it instead of sliding underneath (120px → 428px total)
+                className: '!px-0 !pb-13 !pt-3',
+              }}
+              inputProps={{
+                className:
+                  '!resize-none w-full !px-4 !py-0 !min-h-14 !max-h-[364px] !overflow-y-auto text-sm',
+                'data-test': CHAT_PROMPT_EDITOR_INPUT_TEST_ID,
+              }}
+              disabled={isWaitingForResponse || disabled}
+            />
+          )}
+        </form.AppField>
 
         <div className="absolute bottom-3 right-4 flex items-center gap-2">
           {showAgentSelector && (

--- a/src/components/aiAgent/__tests__/ChatPromptEditor.test.tsx
+++ b/src/components/aiAgent/__tests__/ChatPromptEditor.test.tsx
@@ -128,7 +128,7 @@ describe('ChatPromptEditor', () => {
         await userEvent.type(getInput(), 'hello')
         await userEvent.click(getSubmitButton())
 
-        expect(onSubmit).toHaveBeenCalledWith({ message: 'hello' }, expect.anything())
+        expect(onSubmit).toHaveBeenCalledWith({ message: 'hello' })
         expect(getInput()).toHaveValue('')
       })
     })
@@ -141,7 +141,7 @@ describe('ChatPromptEditor', () => {
 
         await userEvent.type(getInput(), 'hello{Enter}')
 
-        expect(onSubmit).toHaveBeenCalledWith({ message: 'hello' }, expect.anything())
+        expect(onSubmit).toHaveBeenCalledWith({ message: 'hello' })
       })
     })
 

--- a/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
+++ b/src/components/designSystem/RichTextEditor/DiscountBlock/DiscountBlockView.tsx
@@ -15,11 +15,11 @@ export const DISCOUNT_BLOCK_VIEW_EMPTY_TEST_ID = 'discount-block-view-empty'
 export const DISCOUNT_BLOCK_VIEW_UNRESOLVED_TEST_ID = 'discount-block-view-unresolved'
 
 export const DiscountBlockView = ({ node, updateAttributes }: NodeViewProps) => {
-  const { entities, onDiscountCommand, mode, customerLocale, customerCurrency } =
+  const { entities, onDiscountCommand, mode, customerLocale, documentCurrency } =
     useRichTextEditorContext()
   const { translate } = useInternationalization()
   const { organization } = useOrganizationInfos()
-  const currency = customerCurrency ?? organization?.defaultCurrency ?? CurrencyEnum.Usd
+  const currency = documentCurrency ?? organization?.defaultCurrency ?? CurrencyEnum.Usd
 
   const effectiveLocale: Locale = (customerLocale ?? 'en') as Locale
   const { translateWithContextualLocal } = useContextualLocale(effectiveLocale)

--- a/src/components/designSystem/RichTextEditor/PricingBlock/PricingBlockView.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/PricingBlockView.tsx
@@ -70,11 +70,11 @@ const PricingBlockPreview = ({
 }
 
 export const PricingBlockView = ({ node, updateAttributes }: NodeViewProps) => {
-  const { entities, onPricingCommand, mode, customerLocale, customerCurrency } =
+  const { entities, onPricingCommand, mode, customerLocale, documentCurrency } =
     useRichTextEditorContext()
   const { translate } = useInternationalization()
   const { organization } = useOrganizationInfos()
-  const currency = customerCurrency ?? organization?.defaultCurrency ?? CurrencyEnum.Usd
+  const currency = documentCurrency ?? organization?.defaultCurrency ?? CurrencyEnum.Usd
 
   const effectiveLocale: Locale = (customerLocale ?? 'en') as Locale
   const { translateWithContextualLocal } = useContextualLocale(effectiveLocale)

--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
@@ -44,6 +44,7 @@ interface SubscriptionPricingContentProps {
   // Filled with a submit-and-report-validity function so the drawer can refuse to
   // persist an incomplete plan.
   validatePlanFormRef?: MutableRefObject<ValidatePlanForm | null>
+  basePlanFormValuesRef: MutableRefObject<PlanFormInput | null>
   initialState?: SubscriptionPricingState | null
   quoteDates?: { startDate?: string; endDate?: string }
   customer?: QuoteCustomer | null
@@ -56,6 +57,7 @@ export function SubscriptionPricingContent({
   stateRef,
   formValuesRef,
   validatePlanFormRef,
+  basePlanFormValuesRef,
   initialState,
   quoteDates,
   customer,
@@ -94,6 +96,7 @@ export function SubscriptionPricingContent({
     plan: planData,
     formReady,
     resolvedPlanId,
+    basePlanFormValues,
     subscriptionSettings: billingItemSubscriptionSettings,
     invoicingSettings: billingItemInvoicingSettings,
   } = usePlanFormSetup({
@@ -185,8 +188,9 @@ export function SubscriptionPricingContent({
   const basePlanName =
     planData?.name ?? billingItemPlan?.payload.name ?? initialState?.basePlanName ?? formName
 
-  // Sync to stateRef + formValuesRef. Overrides are no longer computed here:
-  // toPlanBillingItems() derives them from formValuesRef (see buildPlanOverrides).
+  // Sync to stateRef + formValuesRef + basePlanFormValuesRef. Overrides are no longer
+  // computed here: toPlanBillingItems() derives them from the two form value refs
+  // (see buildPlanOverrides).
   useEffect(() => {
     if (!formReady || !selectedPlanId) {
       stateRef.current = null
@@ -204,6 +208,7 @@ export function SubscriptionPricingContent({
     }
 
     formValuesRef.current = formValues
+    basePlanFormValuesRef.current = basePlanFormValues ?? null
   }, [
     formReady,
     planData,
@@ -215,8 +220,10 @@ export function SubscriptionPricingContent({
     formDescription,
     formCode,
     formValues,
+    basePlanFormValues,
     stateRef,
     formValuesRef,
+    basePlanFormValuesRef,
   ])
 
   // ComboBox data

--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
@@ -48,7 +48,14 @@ interface SubscriptionPricingContentProps {
   initialState?: SubscriptionPricingState | null
   quoteDates?: { startDate?: string; endDate?: string }
   customer?: QuoteCustomer | null
+  /** Currency used to display amounts — may be a customer/organization fallback. */
   currency?: CurrencyEnum | null
+  /**
+   * Whether `currency` is the quote's own currency. When it is, the quote owns
+   * the currency and the plan's own picker is locked; when it is not, the plan
+   * is free to define it (and will seed the quote currency on save).
+   */
+  hasQuoteCurrency?: boolean
   billingItemPlan?: BillingItemPlan
   subscriptionId?: string
 }
@@ -62,6 +69,7 @@ export function SubscriptionPricingContent({
   quoteDates,
   customer,
   currency,
+  hasQuoteCurrency,
   billingItemPlan,
   subscriptionId,
 }: Readonly<SubscriptionPricingContentProps>) {
@@ -101,6 +109,10 @@ export function SubscriptionPricingContent({
     invoicingSettings: billingItemInvoicingSettings,
   } = usePlanFormSetup({
     planIdToFetch: selectedPlanId || undefined,
+    // When the quote owns a currency it is the source of truth for every amount
+    // here, so the plan form (de)serializes with it. Without one, the plan keeps
+    // its own currency and seeds the quote's on save.
+    initialCurrency: hasQuoteCurrency ? (currency ?? undefined) : undefined,
     billingItemPlan: userSwitchedPlan ? undefined : billingItemPlan,
     subscriptionId,
     onSubmit: () => {
@@ -151,7 +163,9 @@ export function SubscriptionPricingContent({
     !!subscriptionId,
   )
   const showInvoicingSection = Boolean(customer?.externalId || customer?.id)
-  const planSettingsDrawer = useQuotePlanSettingsDrawer(planForm)
+  const planSettingsDrawer = useQuotePlanSettingsDrawer(planForm, {
+    disableCurrencyInput: hasQuoteCurrency,
+  })
 
   // Subscription fee drawer (grouped with plan settings section)
   const subscriptionFeeDrawerRef = useRef<SubscriptionFeeDrawerRef>(null)

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/PricingBlockView.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/PricingBlockView.test.tsx
@@ -60,14 +60,14 @@ const renderPricingBlockView = ({
   entities = {} as Record<string, EntityData>,
   onPricingCommand = jest.fn() as OnPricingCommand,
   customerLocale,
-  customerCurrency,
+  documentCurrency,
 }: {
   attrs?: Record<string, unknown>
   mode?: 'edit' | 'preview'
   entities?: Record<string, EntityData>
   onPricingCommand?: OnPricingCommand
   customerLocale?: Locale
-  customerCurrency?: CurrencyEnum
+  documentCurrency?: CurrencyEnum
 } = {}) => {
   const nodeProps = createNodeProps(attrs)
 
@@ -81,7 +81,7 @@ const renderPricingBlockView = ({
           images: {},
           onPricingCommand,
           customerLocale,
-          customerCurrency,
+          documentCurrency,
         }}
       >
         <PricingBlockView {...nodeProps} />
@@ -455,7 +455,7 @@ describe('PricingBlockView', () => {
       })
     })
 
-    describe('WHEN customerCurrency is provided', () => {
+    describe('WHEN documentCurrency is provided', () => {
       it('THEN should render the preview table using that currency', () => {
         renderPricingBlockView({
           mode: 'preview',
@@ -469,7 +469,7 @@ describe('PricingBlockView', () => {
               totalAmount: '100',
             },
           },
-          customerCurrency: CurrencyEnum.Eur,
+          documentCurrency: CurrencyEnum.Eur,
         })
 
         expect(screen.getByTestId(ONE_OFF_ADDONS_PREVIEW_TABLE_TEST_ID)).toBeInTheDocument()

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
@@ -84,6 +84,7 @@ jest.mock('~/generated/graphql', () => ({
 
 // Mock usePlanFormSetup — returns a mock form + plan when planIdToFetch is set
 let mockFormOverrides: Partial<PlanFormInput> = {}
+let mockBasePlanFormValues: PlanFormInput | undefined
 
 // Mirrors TanStack: handleSubmit only invokes onSubmit once the form-level
 // validators pass, which is what the component uses as its validity signal.
@@ -112,6 +113,7 @@ jest.mock('~/hooks/plans/usePlanFormSetup', () => {
         return {
           form,
           plan: planIdToFetch ? mockPlan : undefined,
+          basePlanFormValues: mockBasePlanFormValues,
           formReady: !!planIdToFetch,
           loading: false,
           resolvedPlanId: planIdToFetch,
@@ -169,6 +171,7 @@ describe('SubscriptionPricingContent', () => {
   beforeEach(() => {
     mockFormOverrides = {}
     mockFormPassesValidation = true
+    mockBasePlanFormValues = undefined
     mockOpenSubscriptionSettings.mockClear()
     mockOpenPlanSettings.mockClear()
   })
@@ -176,9 +179,16 @@ describe('SubscriptionPricingContent', () => {
   it('shows plan selection ComboBox without initial data', async () => {
     const stateRef = { current: null as SubscriptionPricingState | null }
     const formValuesRef = { current: null as PlanFormInput | null }
+    const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
     await act(() =>
-      render(<SubscriptionPricingContent stateRef={stateRef} formValuesRef={formValuesRef} />),
+      render(
+        <SubscriptionPricingContent
+          stateRef={stateRef}
+          formValuesRef={formValuesRef}
+          basePlanFormValuesRef={basePlanFormValuesRef}
+        />,
+      ),
     )
 
     // Should show ComboBox for plan selection
@@ -190,6 +200,7 @@ describe('SubscriptionPricingContent', () => {
   it('shows sections when initial plan is provided', async () => {
     const stateRef = { current: null as SubscriptionPricingState | null }
     const formValuesRef = { current: null as PlanFormInput | null }
+    const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
     const initialState: SubscriptionPricingState = {
       planId: 'plan_1',
@@ -206,6 +217,7 @@ describe('SubscriptionPricingContent', () => {
         <SubscriptionPricingContent
           stateRef={stateRef}
           formValuesRef={formValuesRef}
+          basePlanFormValuesRef={basePlanFormValuesRef}
           initialState={initialState}
         />,
       ),
@@ -222,6 +234,7 @@ describe('SubscriptionPricingContent', () => {
   it('syncs state to stateRef when plan is selected', async () => {
     const stateRef = { current: null as SubscriptionPricingState | null }
     const formValuesRef = { current: null as PlanFormInput | null }
+    const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
     const initialState: SubscriptionPricingState = {
       planId: 'plan_1',
@@ -238,6 +251,7 @@ describe('SubscriptionPricingContent', () => {
         <SubscriptionPricingContent
           stateRef={stateRef}
           formValuesRef={formValuesRef}
+          basePlanFormValuesRef={basePlanFormValuesRef}
           initialState={initialState}
         />,
       ),
@@ -251,9 +265,16 @@ describe('SubscriptionPricingContent', () => {
     it('WHEN rendered without initialState THEN stateRef remains null', async () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       await act(() =>
-        render(<SubscriptionPricingContent stateRef={stateRef} formValuesRef={formValuesRef} />),
+        render(
+          <SubscriptionPricingContent
+            stateRef={stateRef}
+            formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
+          />,
+        ),
       )
 
       // formReady is false and selectedPlanId is empty => stateRef.current = null (line 153-154)
@@ -292,6 +313,7 @@ describe('SubscriptionPricingContent', () => {
 
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       const initialState: SubscriptionPricingState = {
         planId: 'plan_1',
@@ -307,6 +329,7 @@ describe('SubscriptionPricingContent', () => {
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
           />,
         ),
@@ -328,6 +351,7 @@ describe('SubscriptionPricingContent', () => {
 
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       const initialState: SubscriptionPricingState = {
         planId: 'plan_1',
@@ -343,6 +367,7 @@ describe('SubscriptionPricingContent', () => {
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
           />,
         ),
@@ -360,6 +385,7 @@ describe('SubscriptionPricingContent', () => {
 
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       const initialState: SubscriptionPricingState = {
         planId: 'plan_1',
@@ -375,6 +401,7 @@ describe('SubscriptionPricingContent', () => {
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
           />,
         ),
@@ -400,12 +427,14 @@ describe('SubscriptionPricingContent', () => {
     it('WHEN a plan is selected THEN the invoicing & payments component is rendered', async () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       await act(() =>
         render(
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
             customer={mockCustomer}
           />,
@@ -418,12 +447,14 @@ describe('SubscriptionPricingContent', () => {
     it('WHEN no customer is provided THEN the invoicing & payments component is hidden', async () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       await act(() =>
         render(
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
           />,
         ),
@@ -448,12 +479,14 @@ describe('SubscriptionPricingContent', () => {
       const user = userEvent.setup()
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       await act(() =>
         render(
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
           />,
         ),
@@ -497,12 +530,14 @@ describe('SubscriptionPricingContent', () => {
     it('WHEN the user switches to a different plan THEN billingItemPlan is dropped so prices reset', async () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       await act(() =>
         render(
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
             billingItemPlan={billingItemPlan}
           />,
@@ -535,12 +570,14 @@ describe('SubscriptionPricingContent', () => {
     it('WHEN the user re-selects the original plan THEN billingItemPlan is preserved', async () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       await act(() =>
         render(
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
             billingItemPlan={billingItemPlan}
           />,
@@ -559,6 +596,7 @@ describe('SubscriptionPricingContent', () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
       const validatePlanFormRef = { current: null as (() => Promise<boolean>) | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       const rendered = await act(() =>
         render(
@@ -566,6 +604,7 @@ describe('SubscriptionPricingContent', () => {
             stateRef={stateRef}
             formValuesRef={formValuesRef}
             validatePlanFormRef={validatePlanFormRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
           />,
         ),
       )
@@ -619,6 +658,75 @@ describe('SubscriptionPricingContent', () => {
 
         expect(validatePlanFormRef.current).toBeNull()
       })
+    })
+  })
+
+  describe('GIVEN the override diff baseline', () => {
+    const initialState: SubscriptionPricingState = {
+      planId: 'plan_1',
+      planCode: 'starter',
+      planName: 'Starter',
+      planDescription: '',
+      subscriptionSettings: DEFAULT_SUBSCRIPTION_SETTINGS,
+      invoicingSettings: DEFAULT_INVOICING_SETTINGS,
+      overrides: {},
+    }
+
+    // Seed the base ref (optionally with a stale leftover) and render, returning the
+    // refs so each test can assert how the sync effect wrote them.
+    const renderWithRefs = async (basePlanFormValuesInit: PlanFormInput | null = null) => {
+      const stateRef = { current: null as SubscriptionPricingState | null }
+      const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: basePlanFormValuesInit }
+
+      await act(() =>
+        render(
+          <SubscriptionPricingContent
+            stateRef={stateRef}
+            formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
+            initialState={initialState}
+          />,
+        ),
+      )
+
+      return { stateRef, basePlanFormValuesRef }
+    }
+
+    it('WHEN the catalog plan values are available THEN basePlanFormValuesRef captures them', async () => {
+      mockBasePlanFormValues = {
+        name: 'Starter',
+        code: 'starter',
+        interval: PlanInterval.Monthly,
+        amountCents: '5000',
+        amountCurrency: CurrencyEnum.Usd,
+        charges: [],
+        fixedCharges: [],
+        entitlements: [],
+      } as unknown as PlanFormInput
+
+      const { basePlanFormValuesRef } = await renderWithRefs()
+
+      expect(basePlanFormValuesRef.current).toEqual(mockBasePlanFormValues)
+    })
+
+    it('WHEN no catalog plan values are available THEN the ref is cleared, not left stale', async () => {
+      // A leftover value from a previous plan: the sync must overwrite it, otherwise a
+      // stale baseline would be diffed against the new plan.
+      const { stateRef, basePlanFormValuesRef } = await renderWithRefs({
+        name: 'Previous plan',
+      } as unknown as PlanFormInput)
+
+      expect(stateRef.current).not.toBeNull()
+      expect(basePlanFormValuesRef.current).toBeNull()
+    })
+
+    it('WHEN the baseline has not arrived yet THEN the pricing sections still render', async () => {
+      await renderWithRefs()
+
+      // The plan query is cache-and-network, so it reports loading on every open —
+      // the drawer must not blank out waiting for the diff baseline.
+      expect(screen.getByTestId('fixed-charges-section')).toBeInTheDocument()
     })
   })
 })

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
@@ -140,8 +140,14 @@ jest.mock('../QuoteInvoicingPaymentsSettings', () => ({
   ),
 }))
 
+const mockUseQuotePlanSettingsDrawer = jest.fn()
+
 jest.mock('../useQuotePlanSettingsDrawer', () => ({
-  useQuotePlanSettingsDrawer: () => ({ openDrawer: mockOpenPlanSettings }),
+  useQuotePlanSettingsDrawer: (...args: unknown[]) => {
+    mockUseQuotePlanSettingsDrawer(...args)
+
+    return { openDrawer: mockOpenPlanSettings }
+  },
 }))
 
 // Mock reused section components
@@ -588,6 +594,48 @@ describe('SubscriptionPricingContent', () => {
       expect(usePlanFormSetup).toHaveBeenLastCalledWith(
         expect.objectContaining({ billingItemPlan, planIdToFetch: 'plan_1' }),
       )
+    })
+  })
+
+  describe('GIVEN the quote owns a currency', () => {
+    const renderWithQuoteCurrency = async (hasQuoteCurrency: boolean) => {
+      const stateRef = { current: null as SubscriptionPricingState | null }
+      const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
+
+      await act(() =>
+        render(
+          <SubscriptionPricingContent
+            stateRef={stateRef}
+            formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
+            currency={CurrencyEnum.Eur}
+            hasQuoteCurrency={hasQuoteCurrency}
+          />,
+        ),
+      )
+    }
+
+    it('WHEN it does THEN the plan form uses it and its currency picker is locked', async () => {
+      await renderWithQuoteCurrency(true)
+
+      expect(usePlanFormSetup).toHaveBeenLastCalledWith(
+        expect.objectContaining({ initialCurrency: CurrencyEnum.Eur }),
+      )
+      expect(mockUseQuotePlanSettingsDrawer).toHaveBeenLastCalledWith(expect.anything(), {
+        disableCurrencyInput: true,
+      })
+    })
+
+    it('WHEN it does not THEN the plan keeps its own currency and picker', async () => {
+      await renderWithQuoteCurrency(false)
+
+      expect(usePlanFormSetup).toHaveBeenLastCalledWith(
+        expect.objectContaining({ initialCurrency: undefined }),
+      )
+      expect(mockUseQuotePlanSettingsDrawer).toHaveBeenLastCalledWith(expect.anything(), {
+        disableCurrencyInput: false,
+      })
     })
   })
 

--- a/src/components/designSystem/RichTextEditor/PricingBlock/useQuotePlanSettingsDrawer.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/useQuotePlanSettingsDrawer.tsx
@@ -9,7 +9,10 @@ import type { PlanFormType } from '~/hooks/plans/usePlanForm'
 
 export const PLAN_SETTINGS_DRAWER_SAVE_TEST_ID = 'plan-settings-drawer-save'
 
-export const useQuotePlanSettingsDrawer = (planForm: PlanFormType) => {
+export const useQuotePlanSettingsDrawer = (
+  planForm: PlanFormType,
+  { disableCurrencyInput }: { disableCurrencyInput?: boolean } = {},
+) => {
   const { translate } = useInternationalization()
   const drawer = useDrawer()
 
@@ -21,7 +24,13 @@ export const useQuotePlanSettingsDrawer = (planForm: PlanFormType) => {
 
     drawer.open({
       title: translate('text_642d5eb2783a2ad10d67031a'),
-      children: <PlanSettingsSection form={planForm} isInSubscriptionForm />,
+      children: (
+        <PlanSettingsSection
+          form={planForm}
+          isInSubscriptionForm
+          disableCurrencyInput={disableCurrencyInput}
+        />
+      ),
       actions: (
         <div className="flex items-center justify-end gap-3">
           <Button
@@ -39,7 +48,7 @@ export const useQuotePlanSettingsDrawer = (planForm: PlanFormType) => {
         </div>
       ),
     })
-  }, [drawer, planForm, translate])
+  }, [drawer, planForm, translate, disableCurrencyInput])
 
   return { openDrawer }
 }

--- a/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
@@ -79,7 +79,7 @@ interface RichTextEditorProps {
   isCreditsDisabled?: () => boolean
   onCreditsBlocksChange?: (blocks: CreditsBlockAttributes[]) => void
   customerLocale?: Locale
-  customerCurrency?: CurrencyEnum
+  documentCurrency?: CurrencyEnum
   images?: Record<string, string>
   onImageUpload?: (base64: string) => Promise<string>
   isCompact?: boolean
@@ -284,7 +284,7 @@ const RichTextEditor = ({
   onCreditsBlocksChange,
   onChange,
   customerLocale,
-  customerCurrency,
+  documentCurrency,
   images = {},
   onImageUpload,
   isCompact,
@@ -427,7 +427,7 @@ const RichTextEditor = ({
       onDiscountCommand,
       onCreditsCommand,
       customerLocale,
-      customerCurrency,
+      documentCurrency,
     }),
     [
       mode,
@@ -439,7 +439,7 @@ const RichTextEditor = ({
       onDiscountCommand,
       onCreditsCommand,
       customerLocale,
-      customerCurrency,
+      documentCurrency,
     ],
   )
 

--- a/src/components/designSystem/RichTextEditor/__tests__/RichTextEditor.test.tsx
+++ b/src/components/designSystem/RichTextEditor/__tests__/RichTextEditor.test.tsx
@@ -664,18 +664,18 @@ describe('RichTextEditor', () => {
       })
     })
 
-    describe('WHEN customerCurrency is provided', () => {
+    describe('WHEN documentCurrency is provided', () => {
       it('THEN should render without errors', async () => {
-        await act(() => render(<RichTextEditor customerCurrency={'EUR' as never} />))
+        await act(() => render(<RichTextEditor documentCurrency={'EUR' as never} />))
 
         expect(screen.getByTestId(RICH_TEXT_EDITOR_TEST_ID)).toBeInTheDocument()
       })
     })
 
-    describe('WHEN both customerLocale and customerCurrency are provided', () => {
+    describe('WHEN both customerLocale and documentCurrency are provided', () => {
       it('THEN should render without errors', async () => {
         await act(() =>
-          render(<RichTextEditor customerLocale="fr" customerCurrency={'EUR' as never} />),
+          render(<RichTextEditor customerLocale="fr" documentCurrency={'EUR' as never} />),
         )
 
         expect(screen.getByTestId(RICH_TEXT_EDITOR_TEST_ID)).toBeInTheDocument()

--- a/src/components/designSystem/RichTextEditor/common/RichTextEditorContext.tsx
+++ b/src/components/designSystem/RichTextEditor/common/RichTextEditorContext.tsx
@@ -40,6 +40,11 @@ interface PricingCommandParams {
     attrs: PricingBlockAttributes,
     entityData: Record<string, EntityData>,
     billingItems?: BillingItemsPayload,
+    /**
+     * Currency of the selected billing item, forwarded only when the quote has
+     * no currency of its own yet — the first plan/add-on then defines it.
+     */
+    currency?: CurrencyEnum,
   ) => void | Promise<unknown>
   editData?: { pricingType: PricingType; entityIds: string[]; localEntityIds?: string[] }
 }
@@ -70,7 +75,12 @@ interface RichTextEditorContextValue {
   onDiscountCommand?: OnDiscountCommand
   onCreditsCommand?: OnCreditsCommand
   customerLocale?: Locale
-  customerCurrency?: CurrencyEnum
+  /**
+   * Currency the document prices in. For a quote this is the quote's own
+   * currency, which can differ from the customer's — do not pass the customer
+   * currency here unless the document has none of its own.
+   */
+  documentCurrency?: CurrencyEnum
 }
 
 const RichTextEditorContext = createContext<RichTextEditorContextValue>({

--- a/src/components/developers/activityLogs/ActivityLogDetails.tsx
+++ b/src/components/developers/activityLogs/ActivityLogDetails.tsx
@@ -96,6 +96,9 @@ gql`
       ... on ProductFilter {
         id
       }
+      ... on RateCard {
+        id
+      }
       ... on PaymentRequest {
         id
       }

--- a/src/components/form/CurrencyPicker.tsx
+++ b/src/components/form/CurrencyPicker.tsx
@@ -2,7 +2,7 @@ import { ComboBox } from '~/components/form/ComboBox/ComboBox'
 import { ComboBoxProps } from '~/components/form/ComboBox/types'
 import { CurrencyEnum } from '~/generated/graphql'
 
-const CURRENCY_DATA = Object.values(CurrencyEnum).map((value) => ({ value }))
+export const CURRENCY_DATA = Object.values(CurrencyEnum).map((value) => ({ value }))
 
 // ComboBoxProps is a union (basic | grouped). We narrow to the basic branch
 // — discriminated by `renderGroupHeader?: never` — and then strip the props

--- a/src/components/plans/PlanSettingsSection.tsx
+++ b/src/components/plans/PlanSettingsSection.tsx
@@ -70,6 +70,8 @@ type PlanSettingsSectionProps = {
   isInSubscriptionForm?: boolean
   subscriptionFormType?: keyof typeof FORM_TYPE_ENUM
   isEdition?: boolean
+  /** Locks the currency picker when an outer scope (e.g. a quote) already owns it. */
+  disableCurrencyInput?: boolean
 }
 
 export const PlanSettingsSection = ({
@@ -78,6 +80,7 @@ export const PlanSettingsSection = ({
   isInSubscriptionForm,
   subscriptionFormType,
   isEdition,
+  disableCurrencyInput,
 }: PlanSettingsSectionProps) => {
   const { translate } = useInternationalization()
   const description = useStore(form.store, (s) => s.values.description)
@@ -200,7 +203,9 @@ export const PlanSettingsSection = ({
             data={CURRENCY_DATA}
             disableClearable
             disabled={
-              subscriptionFormType === FORM_TYPE_ENUM.edition || (isEdition && !canBeEdited)
+              disableCurrencyInput ||
+              subscriptionFormType === FORM_TYPE_ENUM.edition ||
+              (isEdition && !canBeEdited)
             }
             label={translate('text_642d5eb2783a2ad10d67032e')}
           />

--- a/src/components/plans/__tests__/PlanSettingsSection.test.tsx
+++ b/src/components/plans/__tests__/PlanSettingsSection.test.tsx
@@ -346,6 +346,23 @@ describe('PlanSettingsSection', () => {
         expect(currencyInput).toBeDisabled()
       })
     })
+
+    describe.each([
+      ['disableCurrencyInput is set', true, true],
+      ['disableCurrencyInput is not set', false, false],
+    ])('WHEN %s', (_, disableCurrencyInput, expectedDisabled) => {
+      it(`THEN should render the currency field ${expectedDisabled ? 'disabled' : 'enabled'}`, async () => {
+        const { container } = await act(() =>
+          render(<PlanSettingsSectionWrapper disableCurrencyInput={disableCurrencyInput} />),
+        )
+
+        const currencyInput = container.querySelector(
+          '.MuiAutocomplete-root input',
+        ) as HTMLInputElement
+
+        expect(currencyInput.disabled).toBe(expectedDisabled)
+      })
+    })
   })
 
   describe('GIVEN the bill-monthly switches', () => {

--- a/src/components/subscriptions/SubscriptionInformationFields.tsx
+++ b/src/components/subscriptions/SubscriptionInformationFields.tsx
@@ -94,7 +94,9 @@ const SubscriptionEndOrTerminatedAt = ({
   const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
 
   if (subscription?.status === StatusTypeEnum.Terminated) {
-    return intlFormatDateTimeOrgaTZ(subscription?.terminatedAt ?? '').date
+    if (!subscription.terminatedAt) return '-'
+
+    return intlFormatDateTimeOrgaTZ(subscription.terminatedAt).date
   }
 
   if (subscription?.endingAt) {
@@ -226,11 +228,13 @@ const getSubscriptionInformationGrid = ({
     },
     {
       label: translate('text_65201c5a175a4b0238abf29e'),
-      value: intlFormatDateTimeOrgaTZ(subscription?.startedAt ?? '').date,
+      value: subscription?.startedAt ? intlFormatDateTimeOrgaTZ(subscription.startedAt).date : '-',
     },
     {
       label: translate('text_1781859135627z59hpfpa8pt'),
-      value: intlFormatDateTimeOrgaTZ(subscription?.subscriptionAt ?? '').date,
+      value: subscription?.subscriptionAt
+        ? intlFormatDateTimeOrgaTZ(subscription.subscriptionAt).date
+        : '-',
     },
     {
       label: translate('text_65201c5a175a4b0238abf2a0'),

--- a/src/components/subscriptions/__tests__/SubscriptionInformationFields.test.tsx
+++ b/src/components/subscriptions/__tests__/SubscriptionInformationFields.test.tsx
@@ -96,6 +96,33 @@ describe('SubscriptionInformationFields', () => {
     ).toBeInTheDocument()
   })
 
+  it('shows "-" instead of an invalid date when the subscription has no start date', () => {
+    render(<SubscriptionInformationFields subscription={baseSubscription({ startedAt: null })} />)
+
+    expect(getValueUnderLabel(START_DATE_LABEL).getByText('-')).toBeInTheDocument()
+  })
+
+  it('shows "-" instead of an invalid date when the subscription has no billing anchor date', () => {
+    render(
+      <SubscriptionInformationFields subscription={baseSubscription({ subscriptionAt: null })} />,
+    )
+
+    expect(getValueUnderLabel(BILLING_ANCHOR_LABEL).getByText('-')).toBeInTheDocument()
+  })
+
+  it('shows "-" for the end date when the subscription is terminated without a terminated date', () => {
+    render(
+      <SubscriptionInformationFields
+        subscription={baseSubscription({
+          status: StatusTypeEnum.Terminated,
+          terminatedAt: null,
+        })}
+      />,
+    )
+
+    expect(getValueUnderLabel(END_DATE_LABEL).getByText('-')).toBeInTheDocument()
+  })
+
   it('shows "-" for the end date when the subscription is active without an ending date', () => {
     render(<SubscriptionInformationFields subscription={baseSubscription()} />)
 

--- a/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
+++ b/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
@@ -411,6 +411,198 @@ describe('buildPlanOverrides', () => {
 })
 
 // ---------------------------------------------------------------------------
+// buildPlanOverrides — diff against the catalog plan baseline (LAGO-1789)
+// ---------------------------------------------------------------------------
+
+describe('buildPlanOverrides with a catalog plan baseline', () => {
+  const fixedCharge = {
+    addOn: { code: 'setup_fee' },
+    chargeModel: FixedChargeChargeModelEnum.Standard,
+    properties: { amount: '100' },
+  } as unknown as PlanFormInput['fixedCharges'][number]
+
+  const usageCharge = {
+    billableMetric: { code: 'api_calls' },
+    chargeModel: ChargeModelEnum.Standard,
+    properties: { amount: '0.01' },
+  } as unknown as PlanFormInput['charges'][number]
+
+  // A plan carrying every overridable field, so an untouched save proves each one
+  // is diffed and not blindly forwarded.
+  const fullyConfiguredPlan: PlanFormInput = {
+    ...baseFormValues,
+    invoiceDisplayName: 'Platform fee',
+    fixedCharges: [fixedCharge],
+    charges: [usageCharge],
+    minimumCommitment: {
+      amountCents: '5000',
+      invoiceDisplayName: 'Annual minimum',
+      commitmentType: CommitmentTypeEnum.MinimumCommitment,
+    },
+    nonRecurringUsageThresholds: [
+      { amountCents: 10000, thresholdDisplayName: 'Tier 1', recurring: false },
+    ] as PlanFormInput['nonRecurringUsageThresholds'],
+    recurringUsageThreshold: {
+      amountCents: 50000,
+      thresholdDisplayName: 'Monthly cap',
+      recurring: true,
+    } as PlanFormInput['recurringUsageThreshold'],
+  }
+
+  it('returns no overrides when the form matches the catalog plan', () => {
+    expect(buildPlanOverrides(baseFormValues, baseFormValues)).toEqual({})
+  })
+
+  it('returns no overrides for an untouched plan that configures every field', () => {
+    expect(buildPlanOverrides(fullyConfiguredPlan, fullyConfiguredPlan)).toEqual({})
+  })
+
+  it('emits only the subscription fee when only the fee changed', () => {
+    const result = buildPlanOverrides(
+      { ...fullyConfiguredPlan, amountCents: '900.00' },
+      fullyConfiguredPlan,
+    )
+
+    expect(result).toEqual({ amountCents: 90000 })
+  })
+
+  it('emits only the invoice display name when only that changed', () => {
+    const result = buildPlanOverrides(
+      { ...fullyConfiguredPlan, invoiceDisplayName: 'Acme platform fee' },
+      fullyConfiguredPlan,
+    )
+
+    expect(result).toEqual({ invoiceDisplayName: 'Acme platform fee' })
+  })
+
+  it('emits the whole charges array when a single charge property changed', () => {
+    const result = buildPlanOverrides(
+      {
+        ...fullyConfiguredPlan,
+        charges: [
+          { ...usageCharge, properties: { amount: '0.02' } } as PlanFormInput['charges'][number],
+        ],
+      },
+      fullyConfiguredPlan,
+    )
+
+    // The backend replaces the whole usage charge set, so a single edit sends them
+    // all. Fixed charges live under overrides.fixedCharges and stay untouched here.
+    expect(Object.keys(result)).toEqual(['charges'])
+    expect(result.charges).toHaveLength(1)
+    expect(result.charges?.[0]).toEqual({
+      billableMetricCode: 'api_calls',
+      chargeModel: ChargeModelEnum.Standard,
+      properties: { amount: '0.02' },
+    })
+  })
+
+  it('emits only the minimum commitment when only that changed', () => {
+    const result = buildPlanOverrides(
+      {
+        ...fullyConfiguredPlan,
+        minimumCommitment: {
+          amountCents: '7000',
+          invoiceDisplayName: 'Annual minimum',
+          commitmentType: CommitmentTypeEnum.MinimumCommitment,
+        },
+      },
+      fullyConfiguredPlan,
+    )
+
+    expect(result).toEqual({
+      minimumCommitment: { amountCents: 700000, invoiceDisplayName: 'Annual minimum' },
+    })
+  })
+
+  it('emits only the usage thresholds when only those changed', () => {
+    const result = buildPlanOverrides(
+      {
+        ...fullyConfiguredPlan,
+        recurringUsageThreshold: {
+          amountCents: 60000,
+          thresholdDisplayName: 'Monthly cap',
+          recurring: true,
+        } as PlanFormInput['recurringUsageThreshold'],
+      },
+      fullyConfiguredPlan,
+    )
+
+    expect(Object.keys(result)).toEqual(['usageThresholds'])
+    expect(result.usageThresholds).toEqual([
+      { amountCents: 1000000, recurring: false, thresholdDisplayName: 'Tier 1' },
+      { amountCents: 6000000, recurring: true, thresholdDisplayName: 'Monthly cap' },
+    ])
+  })
+
+  it('keeps every configured field when no baseline is provided', () => {
+    const result = buildPlanOverrides(fullyConfiguredPlan)
+
+    expect(result.amountCents).toBe(85000)
+    expect(result.invoiceDisplayName).toBe('Platform fee')
+    expect(result.charges).toHaveLength(1)
+    expect(result.fixedCharges).toHaveLength(1)
+    expect(result.minimumCommitment).toBeDefined()
+    expect(result.usageThresholds).toHaveLength(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// toPlanBillingItems — baseline forwarding (LAGO-1789)
+// ---------------------------------------------------------------------------
+
+describe('toPlanBillingItems with a catalog plan baseline', () => {
+  it('produces empty overrides for an unedited plan', () => {
+    const result = toPlanBillingItems(basePricingState, baseFormValues, baseFormValues)
+
+    expect(result.plans[0].overrides).toEqual({})
+  })
+
+  it('keeps the payload snapshot even when nothing is overridden', () => {
+    const result = toPlanBillingItems(basePricingState, baseFormValues, baseFormValues)
+
+    expect(result.plans[0].payload.amountCents).toBe('85000')
+    expect(result.plans[0].payload.interval).toBe(PlanInterval.Monthly)
+  })
+
+  it('still emits the renamed plan alongside an otherwise unedited form', () => {
+    const result = toPlanBillingItems(
+      basePricingState,
+      { ...baseFormValues, name: 'Enterprise Plan - Acme' },
+      baseFormValues,
+    )
+
+    expect(result.plans[0].overrides).toEqual({ name: 'Enterprise Plan - Acme' })
+  })
+
+  // The real edit flow never compares two copies of the same object: the form values
+  // come back from the stored quote payload (a JSON round-trip that dropped every
+  // explicitly-undefined key) while the baseline comes straight from the plan query
+  // (which carries __typename and keeps those keys). Both must still read as unchanged.
+  it('produces empty overrides when the form is a payload round-trip of the baseline', () => {
+    const baselineCharge = {
+      billableMetric: { code: 'api_calls', __typename: 'BillableMetric' },
+      chargeModel: ChargeModelEnum.Graduated,
+      properties: {
+        amount: undefined,
+        graduatedRanges: [
+          { fromValue: 0, toValue: 10, perUnitAmount: '1', flatAmount: '0', __typename: 'Range' },
+        ],
+        __typename: 'Properties',
+      },
+    } as unknown as PlanFormInput['charges'][number]
+
+    const baseline: PlanFormInput = { ...baseFormValues, charges: [baselineCharge] }
+    // What fromPlanBillingItems hands back after the payload was stored as JSON.
+    const roundTripped: PlanFormInput = JSON.parse(JSON.stringify(baseline))
+
+    const result = toPlanBillingItems(basePricingState, roundTripped, baseline)
+
+    expect(result.plans[0].overrides).toEqual({})
+  })
+})
+
+// ---------------------------------------------------------------------------
 // fromPlanBillingItems — existing tests
 // ---------------------------------------------------------------------------
 

--- a/src/core/serializers/serializeQuotePlanBillingItems.ts
+++ b/src/core/serializers/serializeQuotePlanBillingItems.ts
@@ -4,6 +4,7 @@ import type {
   LocalUsageChargeInput,
   PlanFormInput,
 } from '~/components/plans/types'
+import { comparable } from '~/core/utils/comparableValue'
 import { CommitmentTypeEnum, CurrencyEnum } from '~/generated/graphql'
 
 import { buildPlanPreviewData } from './buildPlanPreviewData'
@@ -317,13 +318,14 @@ const serializeFixedCharge = (charge: LocalFixedChargeInput): SerializedFixedCha
 }
 
 /**
- * Builds the camelCase `overrides` payload from the plan form state.
+ * Maps the plan form state to the camelCase `overrides` payload, with no regard
+ * for what the catalog plan holds.
  *
  * This is the single source of truth for the form → override mapping: it is
  * derived from the same `PlanFormInput` that feeds the plan `payload`, so the
  * two can't silently drift when a charge field is added.
  */
-export const buildPlanOverrides = (formValues: PlanFormInput): PlanOverrides => {
+const buildRawPlanOverrides = (formValues: PlanFormInput): PlanOverrides => {
   const overrides: PlanOverrides = {}
 
   // Form amounts are in currency units (e.g. "10" for $10); the backend
@@ -331,9 +333,9 @@ export const buildPlanOverrides = (formValues: PlanFormInput): PlanOverrides => 
   const currency = (formValues.amountCurrency as CurrencyEnum) ?? CurrencyEnum.Usd
 
   // Subscription fee
-  overrides.amountCents = Number(formValues.amountCents)
-    ? serializeAmount(formValues.amountCents, currency)
-    : undefined
+  if (Number(formValues.amountCents)) {
+    overrides.amountCents = serializeAmount(formValues.amountCents, currency)
+  }
   if (formValues.invoiceDisplayName) {
     overrides.invoiceDisplayName = formValues.invoiceDisplayName || undefined
   }
@@ -390,9 +392,52 @@ export const buildPlanOverrides = (formValues: PlanFormInput): PlanOverrides => 
   return overrides
 }
 
+/**
+ * Builds the `overrides` payload the backend uses to decide whether the quote
+ * creates an overridden subscription — so it must contain ONLY the fields the
+ * user actually changed relative to the catalog plan. Without `basePlanFormValues`
+ * every configured field is sent and every quoted subscription ends up
+ * overridden (LAGO-1789).
+ *
+ * Both sides run through `buildRawPlanOverrides` on purpose: the current form
+ * values and the baseline reach this function from different origins (a saved
+ * quote payload vs. a freshly fetched plan), and mapping them identically makes
+ * their representation differences cancel out instead of reading as changes.
+ * `comparable` finishes the job on the differences the mapping can't erase —
+ * `__typename` on the fetched side, keys the stored JSON dropped because their
+ * value was `undefined` on the payload side.
+ *
+ * Fields are dropped from the raw result rather than copied into a fresh object,
+ * so a new override field added to `buildRawPlanOverrides` is diffed without
+ * having to be repeated here. Every field is all-or-nothing (the backend replaces
+ * the whole charge set, so a single edited charge means sending them all).
+ */
+export const buildPlanOverrides = (
+  formValues: PlanFormInput,
+  basePlanFormValues?: PlanFormInput,
+): PlanOverrides => {
+  const overrides = buildRawPlanOverrides(formValues)
+
+  // With a baseline, drop the fields that match the catalog plan. Without one
+  // (catalog not loaded, or a caller that has none) keep the every-field
+  // behavior rather than silently dropping real overrides.
+  if (basePlanFormValues) {
+    const base = buildRawPlanOverrides(basePlanFormValues)
+
+    for (const key of Object.keys(overrides) as Array<keyof PlanOverrides>) {
+      if (comparable(overrides[key]) === comparable(base[key])) {
+        delete overrides[key]
+      }
+    }
+  }
+
+  return overrides
+}
+
 export const toPlanBillingItems = (
   state: SubscriptionPricingState,
   formValues?: PlanFormInput,
+  basePlanFormValues?: PlanFormInput,
 ): { plans: BillingItemPlan[] } => {
   const { planId, planCode, planName, planDescription, subscriptionSettings, invoicingSettings } =
     state
@@ -403,7 +448,9 @@ export const toPlanBillingItems = (
 
   // Derive overrides from the form values (single source of truth). Fall back to
   // any pre-built overrides on the state for callers that serialize without form values.
-  const overrides = formValues ? buildPlanOverrides(formValues) : (state.overrides ?? {})
+  const overrides = formValues
+    ? buildPlanOverrides(formValues, basePlanFormValues)
+    : (state.overrides ?? {})
 
   // The renamed plan goes into `overrides.name` (backend applies plan changes from
   // `overrides`), and only when it actually differs from the base — mirroring the

--- a/src/core/utils/__tests__/comparableValue.test.ts
+++ b/src/core/utils/__tests__/comparableValue.test.ts
@@ -1,0 +1,79 @@
+import { comparable, sortedWithoutTypename } from '../comparableValue'
+
+describe('sortedWithoutTypename', () => {
+  describe('GIVEN an object graph', () => {
+    describe('WHEN it carries __typename keys', () => {
+      it('THEN should drop them at every depth', () => {
+        const result = sortedWithoutTypename({
+          __typename: 'Plan',
+          charges: [{ __typename: 'Charge', properties: { __typename: 'Props', amount: '1' } }],
+        })
+
+        expect(result).toEqual({ charges: [{ properties: { amount: '1' } }] })
+      })
+    })
+
+    describe('WHEN keys are declared in different orders', () => {
+      it('THEN should produce the same sorted shape', () => {
+        expect(sortedWithoutTypename({ b: 1, a: 2 })).toEqual(sortedWithoutTypename({ a: 2, b: 1 }))
+        expect(Object.keys(sortedWithoutTypename({ b: 1, a: 2 }) as object)).toEqual(['a', 'b'])
+      })
+    })
+
+    describe('WHEN it holds primitives and null', () => {
+      it.each([
+        ['a string', 'value'],
+        ['a number', 42],
+        ['a boolean', true],
+        ['null', null],
+        ['undefined', undefined],
+      ])('THEN should return %s unchanged', (_, value) => {
+        expect(sortedWithoutTypename(value)).toBe(value)
+      })
+    })
+
+    describe('WHEN arrays hold objects', () => {
+      it('THEN should preserve array order', () => {
+        const result = sortedWithoutTypename([{ b: 1, a: 2 }, { c: 3 }])
+
+        expect(result).toEqual([{ a: 2, b: 1 }, { c: 3 }])
+      })
+    })
+  })
+})
+
+describe('comparable', () => {
+  describe('GIVEN two values built by different code paths', () => {
+    describe('WHEN they differ only by key order', () => {
+      it('THEN should compare equal', () => {
+        expect(comparable({ a: 1, b: 2 })).toBe(comparable({ b: 2, a: 1 }))
+      })
+    })
+
+    describe('WHEN one side carries __typename', () => {
+      it('THEN should compare equal', () => {
+        expect(comparable({ code: 'api', __typename: 'Metric' })).toBe(comparable({ code: 'api' }))
+      })
+    })
+
+    describe('WHEN one side has an explicitly-undefined key the other dropped', () => {
+      it('THEN should compare equal', () => {
+        // This is the JSON round-trip a stored quote payload goes through.
+        expect(comparable({ amount: '1', rate: undefined })).toBe(comparable({ amount: '1' }))
+      })
+    })
+
+    describe('WHEN a value really differs', () => {
+      it('THEN should compare unequal', () => {
+        expect(comparable({ amount: '1' })).not.toBe(comparable({ amount: '2' }))
+      })
+    })
+
+    describe('WHEN a key is missing on one side with a null value on the other', () => {
+      it('THEN should compare unequal', () => {
+        // null survives JSON, so it stays a real difference — unlike undefined.
+        expect(comparable({ amount: null })).not.toBe(comparable({}))
+      })
+    })
+  })
+})

--- a/src/core/utils/comparableValue.ts
+++ b/src/core/utils/comparableValue.ts
@@ -1,0 +1,29 @@
+/**
+ * Recursively drops `__typename` and sorts object keys so two values produced by
+ * the same serialization compare equal regardless of key order / `__typename`.
+ */
+export const sortedWithoutTypename = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(sortedWithoutTypename)
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => key !== '__typename')
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, entry]) => [key, sortedWithoutTypename(entry)]),
+    )
+  }
+
+  return value
+}
+
+/**
+ * A stable string form of `value`, suitable for equality checks between two
+ * values that describe the same thing but were built by different code paths.
+ *
+ * On top of key order and `__typename`, the `JSON.stringify` also erases
+ * explicitly-`undefined` keys — which is what makes a value rebuilt from a
+ * stored JSON payload (where those keys were dropped on write) compare equal to
+ * a freshly built one (where they are present and `undefined`).
+ */
+export const comparable = (value: unknown): string => JSON.stringify(sortedWithoutTypename(value))

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -2227,7 +2227,6 @@ export type CreateQuoteInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   content?: InputMaybe<Scalars['String']['input']>;
-  currency?: InputMaybe<Scalars['String']['input']>;
   customerId: Scalars['ID']['input'];
   endDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
   orderType: OrderTypeEnum;
@@ -6930,7 +6929,7 @@ export type Order = {
   __typename?: 'Order';
   billingSnapshot: Scalars['JSON']['output'];
   createdAt: Scalars['ISO8601DateTime']['output'];
-  currency?: Maybe<Scalars['String']['output']>;
+  currency?: Maybe<CurrencyEnum>;
   customer: Customer;
   executeAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   executedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -6966,10 +6965,13 @@ export enum OrderExecutionModeEnum {
 
 export type OrderExecutionRecord = {
   __typename?: 'OrderExecutionRecord';
+  appliedCouponIds: Array<Scalars['ID']['output']>;
   errors: Array<Scalars['String']['output']>;
   executedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   executionMode?: Maybe<OrderExecutionModeEnum>;
   invoiceId?: Maybe<Scalars['ID']['output']>;
+  subscriptionIds: Array<Scalars['ID']['output']>;
+  walletIds: Array<Scalars['ID']['output']>;
 };
 
 export type OrderForm = {
@@ -9169,7 +9171,7 @@ export type QuoteVersion = {
   billingItems?: Maybe<Scalars['JSON']['output']>;
   content?: Maybe<Scalars['String']['output']>;
   createdAt: Scalars['ISO8601DateTime']['output'];
-  currency?: Maybe<Scalars['String']['output']>;
+  currency?: Maybe<CurrencyEnum>;
   endDate?: Maybe<Scalars['ISO8601Date']['output']>;
   id: Scalars['ID']['output'];
   mentionVariables: Scalars['JSON']['output'];
@@ -10814,7 +10816,7 @@ export type UpdateQuoteVersionInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   content?: InputMaybe<Scalars['String']['input']>;
-  currency?: InputMaybe<Scalars['String']['input']>;
+  currency?: InputMaybe<CurrencyEnum>;
   endDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
   id: Scalars['ID']['input'];
   startDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
@@ -15207,7 +15209,7 @@ export type GetCustomersForCreateQuoteQueryVariables = Exact<{
 }>;
 
 
-export type GetCustomersForCreateQuoteQuery = { __typename?: 'Query', customers: { __typename?: 'CustomerCollection', collection: Array<{ __typename?: 'Customer', id: string, displayName: string, externalId: string, currency?: CurrencyEnum | null }> } };
+export type GetCustomersForCreateQuoteQuery = { __typename?: 'Query', customers: { __typename?: 'CustomerCollection', collection: Array<{ __typename?: 'Customer', id: string, displayName: string, externalId: string }> } };
 
 export type GetCustomerSubscriptionsForCreateQuoteQueryVariables = Exact<{
   customerId: Scalars['ID']['input'];
@@ -15229,7 +15231,7 @@ export type GetOrderForEditQueryVariables = Exact<{
 }>;
 
 
-export type GetOrderForEditQuery = { __typename?: 'Query', order?: { __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, orderType: OrderTypeEnum, executeAt?: any | null, executionMode?: OrderExecutionModeEnum | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null, mentionVariables: any } } } } | null };
+export type GetOrderForEditQuery = { __typename?: 'Query', order?: { __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, orderType: OrderTypeEnum, executeAt?: any | null, executionMode?: OrderExecutionModeEnum | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: CurrencyEnum | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null, mentionVariables: any } } } } | null };
 
 export type UpdateOrderMutationVariables = Exact<{
   input: UpdateOrderInput;
@@ -15243,7 +15245,7 @@ export type GetOrderForExecuteQueryVariables = Exact<{
 }>;
 
 
-export type GetOrderForExecuteQuery = { __typename?: 'Query', order?: { __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, orderType: OrderTypeEnum, executeAt?: any | null, executionMode?: OrderExecutionModeEnum | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null, mentionVariables: any } } } } | null };
+export type GetOrderForExecuteQuery = { __typename?: 'Query', order?: { __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, orderType: OrderTypeEnum, executeAt?: any | null, executionMode?: OrderExecutionModeEnum | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: CurrencyEnum | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null, mentionVariables: any } } } } | null };
 
 export type ExecuteOrderMutationVariables = Exact<{
   input: ExecuteOrderInput;
@@ -15257,7 +15259,7 @@ export type GetOrderFormForSignQueryVariables = Exact<{
 }>;
 
 
-export type GetOrderFormForSignQuery = { __typename?: 'Query', orderForm?: { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, quote: { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null, mentionVariables: any } } } | null };
+export type GetOrderFormForSignQuery = { __typename?: 'Query', orderForm?: { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string }, quote: { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: CurrencyEnum | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null, mentionVariables: any } } } | null };
 
 export type MarkOrderFormAsSignedMutationVariables = Exact<{
   input: MarkOrderFormAsSignedInput;
@@ -15271,7 +15273,7 @@ export type GetOrderFormForVoidQueryVariables = Exact<{
 }>;
 
 
-export type GetOrderFormForVoidQuery = { __typename?: 'Query', orderForm?: { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } } | null };
+export type GetOrderFormForVoidQuery = { __typename?: 'Query', orderForm?: { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, customer: { __typename?: 'Customer', id: string, name?: string | null, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', version: number, content?: string | null, billingItems?: any | null, mentionVariables: any, currency?: CurrencyEnum | null } } } | null };
 
 export type VoidOrderFormMutationVariables = Exact<{
   input: VoidOrderFormInput;
@@ -15315,13 +15317,6 @@ export type CreateQuoteMutationVariables = Exact<{
 
 export type CreateQuoteMutation = { __typename?: 'Mutation', createQuote?: { __typename?: 'Quote', id: string, currentVersion: { __typename?: 'QuoteVersion', id: string } } | null };
 
-export type UpdateCustomerCurrencyForQuoteMutationVariables = Exact<{
-  input: UpdateCustomerInput;
-}>;
-
-
-export type UpdateCustomerCurrencyForQuoteMutation = { __typename?: 'Mutation', updateCustomer?: { __typename?: 'Customer', id: string, currency?: CurrencyEnum | null } | null };
-
 export type GetCouponsForDiscountDrawerQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -15337,9 +15332,9 @@ export type GetOrderFormDetailsQueryVariables = Exact<{
 }>;
 
 
-export type GetOrderFormDetailsQuery = { __typename?: 'Query', orderForm?: { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, expiresAt?: any | null, signedDocumentUrl?: string | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } } | null };
+export type GetOrderFormDetailsQuery = { __typename?: 'Query', orderForm?: { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, expiresAt?: any | null, signedDocumentUrl?: string | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any, currency?: CurrencyEnum | null } } } | null };
 
-export type OrderFormListItemFragment = { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } };
+export type OrderFormListItemFragment = { __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any, currency?: CurrencyEnum | null } } };
 
 export type GetOrderFormsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -15354,9 +15349,9 @@ export type GetOrderFormsQueryVariables = Exact<{
 }>;
 
 
-export type GetOrderFormsQuery = { __typename?: 'Query', orderForms: { __typename?: 'OrderFormCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } }> } };
+export type GetOrderFormsQuery = { __typename?: 'Query', orderForms: { __typename?: 'OrderFormCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'OrderForm', id: string, number: string, status: OrderFormStatusEnum, createdAt: any, expiresAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any, currency?: CurrencyEnum | null } } }> } };
 
-export type OrderListItemFragment = { __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executeAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } } };
+export type OrderListItemFragment = { __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executeAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any, currency?: CurrencyEnum | null } } } };
 
 export type GetOrdersQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -15372,27 +15367,27 @@ export type GetOrdersQueryVariables = Exact<{
 }>;
 
 
-export type GetOrdersQuery = { __typename?: 'Query', orders: { __typename?: 'OrderCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executeAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any } } } }> } };
+export type GetOrdersQuery = { __typename?: 'Query', orders: { __typename?: 'OrderCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Order', id: string, number: string, status: OrderStatusEnum, executionMode?: OrderExecutionModeEnum | null, executeAt?: any | null, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, orderForm: { __typename?: 'OrderForm', id: string, number: string, quote: { __typename?: 'Quote', id: string, number: string, images: any, currentVersion: { __typename?: 'QuoteVersion', id: string, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any, currency?: CurrencyEnum | null } } } }> } };
 
-export type QuotePreviewVersionFragment = { __typename?: 'QuoteVersion', content?: string | null, billingItems?: any | null, mentionVariables: any };
+export type QuotePreviewVersionFragment = { __typename?: 'QuoteVersion', content?: string | null, billingItems?: any | null, mentionVariables: any, currency?: CurrencyEnum | null };
 
 export type QuotePreviewCustomerFragment = { __typename?: 'Customer', currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null };
 
-export type QuoteDetailItemFragment = { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null, mentionVariables: any } };
+export type QuoteDetailItemFragment = { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: CurrencyEnum | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null, mentionVariables: any } };
 
 export type GetQuoteQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetQuoteQuery = { __typename?: 'Query', quote?: { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: string | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null, mentionVariables: any } } | null };
+export type GetQuoteQuery = { __typename?: 'Query', quote?: { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, createdAt: any }>, customer: { __typename?: 'Customer', id: string, displayName: string, externalId: string, netPaymentTerm?: number | null, currency?: CurrencyEnum | null, billingEntity: { __typename?: 'BillingEntity', id: string, code: string, name: string, netPaymentTerm: number }, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, owners?: Array<{ __typename?: 'User', id: string, email?: string | null }> | null, subscription?: { __typename?: 'Subscription', id: string, name?: string | null, externalId: string, subscriptionAt?: any | null, plan: { __typename?: 'Plan', id: string, name: string } } | null, currentVersion: { __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, currency?: CurrencyEnum | null, startDate?: any | null, endDate?: any | null, createdAt: any, content?: string | null, billingItems?: any | null, mentionVariables: any } } | null };
 
 export type GetQuotePreviewQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetQuotePreviewQuery = { __typename?: 'Query', quote?: { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any }> } | null };
+export type GetQuotePreviewQuery = { __typename?: 'Query', quote?: { __typename?: 'Quote', id: string, number: string, images: any, orderType: OrderTypeEnum, customer: { __typename?: 'Customer', id: string, displayName: string, currency?: CurrencyEnum | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null }, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number, content?: string | null, billingItems?: any | null, mentionVariables: any, currency?: CurrencyEnum | null }> } | null };
 
 export type QuoteListItemFragment = { __typename?: 'Quote', id: string, number: string, orderType: OrderTypeEnum, createdAt: any, versions: Array<{ __typename?: 'QuoteVersion', id: string, status: StatusEnum, version: number }>, customer: { __typename?: 'Customer', id: string, displayName: string } };
 
@@ -15416,7 +15411,7 @@ export type UpdateQuoteVersionMutationVariables = Exact<{
 }>;
 
 
-export type UpdateQuoteVersionMutation = { __typename?: 'Mutation', updateQuoteVersion?: { __typename?: 'QuoteVersion', id: string } | null };
+export type UpdateQuoteVersionMutation = { __typename?: 'Mutation', updateQuoteVersion?: { __typename?: 'QuoteVersion', id: string, currency?: CurrencyEnum | null } | null };
 
 export type UpdateQuoteMutationVariables = Exact<{
   input: UpdateQuoteInput;
@@ -21475,6 +21470,7 @@ export const QuotePreviewVersionFragmentDoc = gql`
   content
   billingItems
   mentionVariables
+  currency
 }
     `;
 export const OrderFormListItemFragmentDoc = gql`
@@ -40127,7 +40123,6 @@ export const GetCustomersForCreateQuoteDocument = gql`
       id
       displayName
       externalId
-      currency
     }
   }
 }
@@ -40822,40 +40817,6 @@ export function useCreateQuoteMutation(baseOptions?: Apollo.MutationHookOptions<
 export type CreateQuoteMutationHookResult = ReturnType<typeof useCreateQuoteMutation>;
 export type CreateQuoteMutationResult = Apollo.MutationResult<CreateQuoteMutation>;
 export type CreateQuoteMutationOptions = Apollo.BaseMutationOptions<CreateQuoteMutation, CreateQuoteMutationVariables>;
-export const UpdateCustomerCurrencyForQuoteDocument = gql`
-    mutation updateCustomerCurrencyForQuote($input: UpdateCustomerInput!) {
-  updateCustomer(input: $input) {
-    id
-    currency
-  }
-}
-    `;
-export type UpdateCustomerCurrencyForQuoteMutationFn = Apollo.MutationFunction<UpdateCustomerCurrencyForQuoteMutation, UpdateCustomerCurrencyForQuoteMutationVariables>;
-
-/**
- * __useUpdateCustomerCurrencyForQuoteMutation__
- *
- * To run a mutation, you first call `useUpdateCustomerCurrencyForQuoteMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUpdateCustomerCurrencyForQuoteMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [updateCustomerCurrencyForQuoteMutation, { data, loading, error }] = useUpdateCustomerCurrencyForQuoteMutation({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useUpdateCustomerCurrencyForQuoteMutation(baseOptions?: Apollo.MutationHookOptions<UpdateCustomerCurrencyForQuoteMutation, UpdateCustomerCurrencyForQuoteMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateCustomerCurrencyForQuoteMutation, UpdateCustomerCurrencyForQuoteMutationVariables>(UpdateCustomerCurrencyForQuoteDocument, options);
-      }
-export type UpdateCustomerCurrencyForQuoteMutationHookResult = ReturnType<typeof useUpdateCustomerCurrencyForQuoteMutation>;
-export type UpdateCustomerCurrencyForQuoteMutationResult = Apollo.MutationResult<UpdateCustomerCurrencyForQuoteMutation>;
-export type UpdateCustomerCurrencyForQuoteMutationOptions = Apollo.BaseMutationOptions<UpdateCustomerCurrencyForQuoteMutation, UpdateCustomerCurrencyForQuoteMutationVariables>;
 export const GetCouponsForDiscountDrawerDocument = gql`
     query getCouponsForDiscountDrawer($page: Int, $limit: Int, $status: CouponStatusEnum, $searchTerm: String) {
   coupons(page: $page, limit: $limit, status: $status, searchTerm: $searchTerm) {
@@ -41290,6 +41251,7 @@ export const UpdateQuoteVersionDocument = gql`
     mutation updateQuoteVersion($input: UpdateQuoteVersionInput!) {
   updateQuoteVersion(input: $input) {
     id
+    currency
   }
 }
     `;

--- a/src/hooks/activityLogs/useActivityLogsInformation.ts
+++ b/src/hooks/activityLogs/useActivityLogsInformation.ts
@@ -67,6 +67,9 @@ const activityTypeTranslations: Record<ActivityTypeEnum, string> = {
   [ActivityTypeEnum.ProductFilterCreated]: 'text_1786365890845d2vq3ufddsd',
   [ActivityTypeEnum.ProductFilterDeleted]: 'text_1786365890845pml4uzbtp7c',
   [ActivityTypeEnum.ProductFilterUpdated]: 'text_1786365890845pt4roxdajsk',
+  [ActivityTypeEnum.RateCardCreated]: 'text_1786367738116xtz2r6c9eoz',
+  [ActivityTypeEnum.RateCardDeleted]: 'text_1786367738117541mevhwa63',
+  [ActivityTypeEnum.RateCardUpdated]: 'text_1786367738117gbjclk29or1',
   [ActivityTypeEnum.SubscriptionCanceled]: 'text_1777471747994p4c7cm9pri6',
   [ActivityTypeEnum.SubscriptionIncomplete]: 'text_17774717479940xot2f14xbr',
   [ActivityTypeEnum.SubscriptionStarted]: 'text_1747404806714xgkold0s07a',
@@ -90,6 +93,7 @@ const resourceTypeTranslations: Record<string, string> = {
   Product: 'text_1786365890845gfq9jteut9u',
   ProductCategory: 'text_1786365890846dgl39wcqgik',
   ProductFilter: 'text_1786365890846v53b5wwzxjh',
+  RateCard: 'text_1786367738117s1n9lpwf97k',
   PaymentRequest: 'text_17495622741665lrk6dp6czk',
   Subscription: 'text_1728472697691k6k2e9m5ibb',
   Wallet: 'text_62d175066d2dbf1d50bc9384',
@@ -240,6 +244,13 @@ export const useActivityLogsInformation = () => {
       case ActivityTypeEnum.ProductFilterUpdated:
         parameters = {
           productFilterCode: activityObject.code,
+        }
+        break
+      case ActivityTypeEnum.RateCardCreated:
+      case ActivityTypeEnum.RateCardDeleted:
+      case ActivityTypeEnum.RateCardUpdated:
+        parameters = {
+          rateCardCode: activityObject.code,
         }
         break
       case ActivityTypeEnum.PaymentRequestCreated:

--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -16,6 +16,7 @@ import {
   useNavigate,
 } from '~/core/router'
 import { serializePlanInput } from '~/core/serializers'
+import { comparable } from '~/core/utils/comparableValue'
 import {
   BillingTimeEnum,
   CreateSubscriptionInput,
@@ -137,25 +138,6 @@ type UseAddSubscription = (args: {
   billingTime?: BillingTimeEnum
   subscriptionAt?: string
 }) => UseAddSubscriptionReturn
-
-// Recursively drops __typename and sorts object keys so two values produced by
-// the same serialization compare equal regardless of key order / __typename.
-const sortedWithoutTypename = (value: unknown): unknown => {
-  if (Array.isArray(value)) return value.map(sortedWithoutTypename)
-
-  if (value !== null && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .filter(([key]) => key !== '__typename')
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([key, entry]) => [key, sortedWithoutTypename(entry)]),
-    )
-  }
-
-  return value
-}
-
-const comparable = (value: unknown): string => JSON.stringify(sortedWithoutTypename(value))
 
 // The override-meaningful content of a (serialized + cleaned) fixed charge,
 // excluding `units` (compared separately) and identity fields. The edit drawer

--- a/src/hooks/plans/__tests__/usePlanFormSetup.test.ts
+++ b/src/hooks/plans/__tests__/usePlanFormSetup.test.ts
@@ -388,6 +388,92 @@ describe('usePlanFormSetup', () => {
     })
   })
 
+  describe('GIVEN the override diff baseline (LAGO-1789)', () => {
+    describe('WHEN a plan id resolves', () => {
+      it('THEN should query the catalog plan even though the form query is skipped', () => {
+        const billingItemPlan = { id: 'plan-from-billing', payload: {}, overrides: {} }
+
+        mockFromPlanBillingItems.mockReturnValue({
+          formValues: { name: 'From Billing' },
+          subscriptionSettings: {},
+          invoicingSettings: {},
+        })
+
+        renderHook(() => usePlanFormSetup({ billingItemPlan: billingItemPlan as never }))
+
+        expect(mockUseGetSinglePlanQuery).toHaveBeenCalledWith(
+          expect.objectContaining({ skip: false, variables: { id: 'plan-from-billing' } }),
+        )
+      })
+
+      it('THEN should build the baseline with the catalog plan own currency', () => {
+        const billingItemPlan = { id: 'plan-from-billing', payload: {}, overrides: {} }
+
+        mockFromPlanBillingItems.mockReturnValue({
+          formValues: { name: 'From Billing' },
+          subscriptionSettings: {},
+          invoicingSettings: {},
+        })
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: { plan: { ...mockPlan, amountCurrency: 'EUR' } },
+          loading: false,
+          error: undefined,
+        })
+
+        renderHook(() => usePlanFormSetup({ billingItemPlan: billingItemPlan as never }))
+
+        // The form side is hydrated from the billing item (no plan, USD default), so an
+        // EUR call can only come from the baseline.
+        expect(mockBuildDefaultValues).toHaveBeenCalledWith(
+          expect.objectContaining({ amountCurrency: 'EUR' }),
+          FORM_TYPE_ENUM.creation,
+          CurrencyEnum.Eur,
+          false,
+        )
+      })
+    })
+
+    describe('WHEN no plan id resolves', () => {
+      it('THEN should skip the baseline query and expose no baseline', () => {
+        const { result } = renderHook(() => usePlanFormSetup({}))
+
+        expect(result.current.basePlanFormValues).toBeUndefined()
+        expect(mockUseGetSinglePlanQuery).toHaveBeenCalledWith(
+          expect.objectContaining({ skip: true }),
+        )
+      })
+    })
+
+    describe('WHEN the form query already fetched the plan (case 4)', () => {
+      it('THEN should not fire a second query for the baseline', () => {
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: { plan: mockPlan },
+          loading: false,
+          error: undefined,
+        })
+
+        renderHook(() => usePlanFormSetup({ planIdToFetch: 'plan-123' }))
+
+        const skipFlags = mockUseGetSinglePlanQuery.mock.calls.map((call) => call[0].skip)
+
+        // One live query (the form's) — the baseline reuses its result.
+        expect(skipFlags.filter((skip) => skip === false)).toHaveLength(1)
+      })
+
+      it('THEN should still expose a baseline built from that plan', () => {
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: { plan: mockPlan },
+          loading: false,
+          error: undefined,
+        })
+
+        const { result } = renderHook(() => usePlanFormSetup({ planIdToFetch: 'plan-123' }))
+
+        expect(result.current.basePlanFormValues).toEqual({ name: 'default-plan' })
+      })
+    })
+  })
+
   describe('GIVEN the hook returns error from plan query', () => {
     describe('WHEN the plan query errors', () => {
       it('THEN should expose the error', () => {

--- a/src/hooks/plans/usePlanFormSetup.ts
+++ b/src/hooks/plans/usePlanFormSetup.ts
@@ -119,6 +119,26 @@ export const usePlanFormSetup = ({
   const currency =
     initialCurrency || (effectivePlan?.amountCurrency as CurrencyEnum) || CurrencyEnum.Usd
 
+  // Baseline: the catalog plan untouched by the form, used by the quote serializer
+  // to emit only the fields the user really overrode (LAGO-1789). Case 4 already has
+  // it in `plan`; only cases 2 and 3 — which hydrate the form from a quote payload or
+  // a subscription and skip the query above — need to fetch it.
+  const { data: basePlanData } = useGetSinglePlanQuery({
+    context: { silentError: LagoApiError.NotFound },
+    variables: { id: resolvedPlanId as string },
+    skip: !resolvedPlanId || !skipPlanQuery,
+  })
+  const basePlan = plan ?? basePlanData?.plan
+  const baseCurrency =
+    initialCurrency || (basePlan?.amountCurrency as CurrencyEnum) || CurrencyEnum.Usd
+  const basePlanFormValues = useMemo(
+    () =>
+      basePlan
+        ? buildDefaultValues(basePlan, formType, baseCurrency, hasAnyPricingUnitConfigured)
+        : undefined,
+    [basePlan, formType, baseCurrency, hasAnyPricingUnitConfigured],
+  )
+
   const form = useAppForm({
     defaultValues:
       billingItemData?.formValues ??
@@ -170,6 +190,7 @@ export const usePlanFormSetup = ({
   return {
     form,
     plan: effectivePlan as EditPlanFragment | undefined,
+    basePlanFormValues,
     formReady,
     loading,
     error,

--- a/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
+++ b/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
@@ -3,6 +3,7 @@ import { gql, useApolloClient } from '@apollo/client'
 import { LocalFixedChargeInput } from '~/components/plans/types'
 import { addToast } from '~/core/apolloClient'
 import { serializeFixedChargeProperties } from '~/core/serializers/serializePlanInput'
+import { sortedWithoutTypename } from '~/core/utils/comparableValue'
 import {
   FixedChargeForDetailsV2Fragment,
   UpdateSubscriptionFixedChargeInput,
@@ -42,24 +43,6 @@ type Args = {
   // row showing the stale plan default. When absent, falls back to the
   // name-based refresh.
   refetchOverrides?: () => Promise<unknown>
-}
-
-// Recursively drops __typename and sorts object keys, so cached values
-// (with __typename, selection-set key order) compare equal to drawer values
-// (no __typename, form key order) when nothing changed.
-const sortedWithoutTypename = (value: unknown): unknown => {
-  if (Array.isArray(value)) return value.map(sortedWithoutTypename)
-
-  if (value !== null && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .filter(([key]) => key !== '__typename')
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([key, entry]) => [key, sortedWithoutTypename(entry)]),
-    )
-  }
-
-  return value
 }
 
 const comparableProperties = (

--- a/src/pages/quotes/CreateQuote.tsx
+++ b/src/pages/quotes/CreateQuote.tsx
@@ -9,7 +9,6 @@ import { ComboboxItem } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { QUOTES_LIST_ROUTE, useNavigate } from '~/core/router'
 import {
-  CurrencyEnum,
   OrderTypeEnum,
   StatusTypeEnum,
   useGetCustomersForCreateQuoteLazyQuery,
@@ -26,7 +25,6 @@ import { useCreateQuote } from './hooks/useCreateQuote'
 
 export const CREATE_QUOTE_CUSTOMER_COMBOBOX_TEST_ID = 'create-quote-customer-combobox'
 export const CREATE_QUOTE_ORDER_TYPE_TEST_ID = 'create-quote-order-type'
-export const CREATE_QUOTE_CURRENCY_COMBOBOX_TEST_ID = 'create-quote-currency-combobox'
 export const CREATE_QUOTE_SUBSCRIPTION_COMBOBOX_TEST_ID = 'create-quote-subscription-combobox'
 export const CREATE_QUOTE_OWNERS_COMBOBOX_TEST_ID = 'create-quote-owners-combobox'
 export const CREATE_QUOTE_SUBMIT_BUTTON_TEST_ID = 'create-quote-submit-button'
@@ -38,7 +36,6 @@ gql`
         id
         displayName
         externalId
-        currency
       }
     }
   }
@@ -78,7 +75,6 @@ const defaultValues: CreateQuoteFormValues = {
   orderType: OrderTypeEnum.SubscriptionCreation,
   subscriptionId: '',
   owners: undefined,
-  currency: undefined,
 }
 
 const CreateQuote = (): JSX.Element => {
@@ -111,9 +107,6 @@ const CreateQuote = (): JSX.Element => {
         orderType: value.orderType,
         subscriptionId: value.subscriptionId || undefined,
         owners: value.owners?.map((owner) => owner.value),
-        currency: value.currency,
-        customerExternalId: selectedCustomer?.externalId ?? '',
-        hasCustomerCurrency,
       })
     },
   })
@@ -142,20 +135,6 @@ const CreateQuote = (): JSX.Element => {
       value: customer.id,
     }))
   }, [customersData?.customers?.collection])
-
-  const selectedCustomer = useMemo(() => {
-    if (!customerId || !customersData?.customers?.collection) return null
-    return customersData.customers.collection.find((c) => c.id === customerId) ?? null
-  }, [customerId, customersData?.customers?.collection])
-
-  const hasCustomerCurrency = !!selectedCustomer?.currency
-
-  const currencyOptions = useMemo(() => {
-    if (!selectedCustomer?.currency) {
-      return Object.values(CurrencyEnum).map((currencyType) => ({ value: currencyType }))
-    }
-    return [{ value: selectedCustomer.currency }]
-  }, [selectedCustomer?.currency])
 
   const comboboxOwnersData = useMemo(() => {
     if (!membersData?.memberships?.collection) return []
@@ -278,13 +257,6 @@ const CreateQuote = (): JSX.Element => {
 
                       if (value) {
                         getCustomerSubscriptions({ variables: { customerId: value } })
-                        const customer = customersData?.customers?.collection?.find(
-                          (c) => c.id === value,
-                        )
-
-                        form.setFieldValue('currency', customer?.currency ?? undefined)
-                      } else {
-                        form.setFieldValue('currency', undefined)
                       }
                     },
                   }}
@@ -300,20 +272,6 @@ const CreateQuote = (): JSX.Element => {
                     />
                   )}
                 </form.AppField>
-
-                {customerId && (
-                  <form.AppField name="currency">
-                    {(field) => (
-                      <field.ComboBoxField
-                        dataTest={CREATE_QUOTE_CURRENCY_COMBOBOX_TEST_ID}
-                        disabled={hasCustomerCurrency}
-                        disableClearable
-                        label={translate('text_632b4acf0c41206cbcb8c324')}
-                        data={currencyOptions}
-                      />
-                    )}
-                  </form.AppField>
-                )}
 
                 <form.AppField
                   name="orderType"

--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -26,6 +26,7 @@ import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBilli
 import type { Locale } from '~/core/translations'
 import { CurrencyEnum, OrderTypeEnum, type UpdateQuoteVersionInput } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 import { QUOTE_MENTION_VARIABLES } from '~/pages/quotes/common/mentionVariables'
 
 import EditQuoteAside from './editQuote/EditQuoteAside'
@@ -49,6 +50,7 @@ const EditQuote = () => {
   const navigate = useNavigate()
   const { quoteId } = useParams()
   const { quote, loading, refetch: refetchQuote } = useQuote(quoteId)
+  const { organization } = useOrganizationInfos()
 
   const { addQuoteImage } = useAddQuoteImage()
   // quote.images is the single source of truth — useAddQuoteImage writes each
@@ -110,6 +112,16 @@ const EditQuote = () => {
     quote?.orderType === OrderTypeEnum.SubscriptionCreation ||
     quote?.orderType === OrderTypeEnum.SubscriptionAmendment
 
+  // The quote version currency is the source of truth for every amount shown or
+  // serialized in this quote. Until it is set (legacy quotes, or before the
+  // backfill below lands), fall back to the customer's, then the organization's.
+  const quoteVersionCurrency = quote?.currentVersion?.currency as CurrencyEnum | undefined
+  const effectiveQuoteCurrency =
+    quoteVersionCurrency ??
+    quote?.customer?.currency ??
+    organization?.defaultCurrency ??
+    CurrencyEnum.Usd
+
   const subscriptionPricing = useSubscriptionPricingDrawer(quote?.currentVersion?.billingItems, {
     quoteDates: {
       startDate:
@@ -119,29 +131,25 @@ const EditQuote = () => {
     onDatesChange: handleSubscriptionDatesChange,
     customer: quote?.customer,
     subscriptionId: quote?.subscription?.id,
-    currency: quote?.currentVersion?.currency as CurrencyEnum | undefined,
+    currency: effectiveQuoteCurrency,
+    hasQuoteCurrency: !!quoteVersionCurrency,
   })
-  const oneOffPricing = useOneOffPricingDrawer(
-    quote?.currentVersion?.billingItems,
-    quote?.currentVersion?.currency as CurrencyEnum | undefined,
-  )
+  const oneOffPricing = useOneOffPricingDrawer(quote?.currentVersion?.billingItems, {
+    currency: effectiveQuoteCurrency,
+    hasQuoteCurrency: !!quoteVersionCurrency,
+  })
 
   const { onPricingCommand, isPricingDisabled, entities, syncEntitiesWithBlocks } =
     isSubscriptionOrder ? subscriptionPricing : oneOffPricing
 
-  // Discount + credits drawers price in the quote's own currency (matches the
-  // pricing drawers), not the customer's — the quote version currency is the
-  // source of truth for amounts shown/serialized in this quote.
-  const quoteCurrency = (quote?.currentVersion?.currency as CurrencyEnum) ?? CurrencyEnum.Usd
-
   // Stable ref so useDiscountDrawer can call savePricingBlock without a
   // forward-declaration error (savePricingBlock is defined below).
   const savePricingBlockRef = useRef<
-    (billingItems?: BillingItemsPayload) => Promise<SavePricingResult>
+    (billingItems?: BillingItemsPayload, currency?: CurrencyEnum) => Promise<SavePricingResult>
   >(async () => ({ ok: true }))
 
   const discount = useDiscountDrawer(quote?.currentVersion?.billingItems, {
-    currency: quoteCurrency,
+    currency: effectiveQuoteCurrency,
     onPersist: (billingItems) => savePricingBlockRef.current(billingItems),
     onRemoveBlock: (localId) => {
       isRollingBackRef.current = true
@@ -151,7 +159,7 @@ const EditQuote = () => {
   })
 
   const credits = useCreditsDrawer(quote?.currentVersion?.billingItems, {
-    currency: quoteCurrency,
+    currency: effectiveQuoteCurrency,
     onPersist: (billingItems) => savePricingBlockRef.current(billingItems),
     onRemoveBlock: (localId) => {
       isRollingBackRef.current = true
@@ -193,6 +201,22 @@ const EditQuote = () => {
   const updateQuoteVersionRef = useRef(updateQuoteVersion)
 
   updateQuoteVersionRef.current = updateQuoteVersion
+
+  // Quotes are no longer given a currency at creation time, so the edit page is
+  // where one gets materialized: persist the customer's (or the organization's)
+  // currency once, so every amount below has a real currency behind it.
+  const backfilledVersionIdRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!versionId || quoteVersionCurrency) return
+    if (backfilledVersionIdRef.current === versionId) return
+
+    backfilledVersionIdRef.current = versionId
+
+    updateQuoteVersionRef
+      .current({ id: versionId, currency: effectiveQuoteCurrency }, false)
+      .catch(() => undefined)
+  }, [versionId, quoteVersionCurrency, effectiveQuoteCurrency])
 
   const debouncedSave = useMemo(
     () =>
@@ -266,7 +290,10 @@ const EditQuote = () => {
   // Keep the ref in sync with the latest savePricingBlock so the stable wrapper
   // passed to useDiscountDrawer always calls the current version.
   const savePricingBlock = useCallback(
-    async (billingItems?: BillingItemsPayload): Promise<SavePricingResult> => {
+    async (
+      billingItems?: BillingItemsPayload,
+      currency?: CurrencyEnum,
+    ): Promise<SavePricingResult> => {
       if (!versionId) return { ok: true }
 
       const content = getMarkdownRef.current?.()
@@ -283,6 +310,9 @@ const EditQuote = () => {
         id: versionId,
         content,
         billingItems,
+        // Set only when the selected billing item is defining the quote currency
+        // — an existing currency is never overwritten from here.
+        ...(currency ? { currency } : {}),
       }
 
       failedPayloadRef.current = payload
@@ -317,12 +347,12 @@ const EditQuote = () => {
   const handlePricingCommand = useCallback<OnPricingCommand>(
     ({ onSave, editData }) => {
       onPricingCommand({
-        onSave: async (attrs, entityData, billingItems) => {
+        onSave: async (attrs, entityData, billingItems, currency) => {
           // 1. Insert/update the TipTap node (needed so the save serializes it).
           onSave(attrs, entityData, billingItems)
 
-          // 2. Unified save: content + billingItems together.
-          const result = await savePricingBlock(billingItems)
+          // 2. Unified save: content + billingItems (+ the seeded currency) together.
+          const result = await savePricingBlock(billingItems, currency)
 
           // 3. Roll back only a *newly inserted* node on failure — remove the
           // phantom block that never saved. When editing an existing block
@@ -519,7 +549,7 @@ const EditQuote = () => {
             onDiscountBlocksChange={handleDiscountBlocksChange}
             {...subscriptionEditorProps}
             customerLocale={customerLocale}
-            customerCurrency={quote?.customer?.currency ?? undefined}
+            documentCurrency={effectiveQuoteCurrency}
             variableItems={mentionItems}
             mentionValues={mentionValues}
             images={images}

--- a/src/pages/quotes/__tests__/ApproveQuote.test.tsx
+++ b/src/pages/quotes/__tests__/ApproveQuote.test.tsx
@@ -518,7 +518,7 @@ describe('ApproveQuote', () => {
 
   describe('GIVEN the customer has a currency', () => {
     describe('WHEN currency is set', () => {
-      it('THEN should pass customerCurrency to RichTextEditor', () => {
+      it('THEN should pass documentCurrency to RichTextEditor', () => {
         mockUseQuote.mockReturnValue({
           quote: {
             ...mockQuote,
@@ -538,12 +538,12 @@ describe('ApproveQuote', () => {
 
         renderPage()
 
-        expect(capturedRichTextEditorProps.customerCurrency).toBe(CurrencyEnum.Eur)
+        expect(capturedRichTextEditorProps.documentCurrency).toBe(CurrencyEnum.Eur)
       })
     })
 
     describe('WHEN currency is null', () => {
-      it('THEN should pass undefined customerCurrency to RichTextEditor', () => {
+      it('THEN should pass undefined documentCurrency to RichTextEditor', () => {
         mockUseQuote.mockReturnValue({
           quote: {
             ...mockQuote,
@@ -559,7 +559,7 @@ describe('ApproveQuote', () => {
 
         renderPage()
 
-        expect(capturedRichTextEditorProps.customerCurrency).toBeUndefined()
+        expect(capturedRichTextEditorProps.documentCurrency).toBeUndefined()
       })
     })
   })

--- a/src/pages/quotes/__tests__/CreateQuote.test.tsx
+++ b/src/pages/quotes/__tests__/CreateQuote.test.tsx
@@ -5,7 +5,6 @@ import { StatusTypeEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
 import CreateQuote, {
-  CREATE_QUOTE_CURRENCY_COMBOBOX_TEST_ID,
   CREATE_QUOTE_CUSTOMER_COMBOBOX_TEST_ID,
   CREATE_QUOTE_ORDER_TYPE_TEST_ID,
   CREATE_QUOTE_SUBMIT_BUTTON_TEST_ID,
@@ -171,8 +170,8 @@ describe('CreateQuote', () => {
         mockCustomersQueryData = {
           customers: {
             collection: [
-              { id: 'cust-1', displayName: 'Customer One', externalId: 'ext-1', currency: null },
-              { id: 'cust-2', displayName: '', externalId: 'ext-2', currency: 'USD' },
+              { id: 'cust-1', displayName: 'Customer One', externalId: 'ext-1' },
+              { id: 'cust-2', displayName: '', externalId: 'ext-2' },
             ],
           },
         }
@@ -184,12 +183,21 @@ describe('CreateQuote', () => {
     })
   })
 
-  describe('GIVEN the currency field', () => {
-    describe('WHEN no customer is selected', () => {
-      it('THEN should not show the currency combobox', () => {
+  describe('GIVEN the currency is no longer picked at creation', () => {
+    describe.each([
+      ['no customer is loaded', undefined],
+      [
+        'customers are loaded',
+        { customers: { collection: [{ id: 'cust-1', displayName: 'One', externalId: 'ext-1' }] } },
+      ],
+    ])('WHEN %s', (_, customersData) => {
+      it('THEN should not render a currency field', () => {
+        mockCustomersQueryData = customersData
+
         render(<CreateQuote />)
 
-        expect(screen.queryByTestId(CREATE_QUOTE_CURRENCY_COMBOBOX_TEST_ID)).not.toBeInTheDocument()
+        // text_632b4acf0c41206cbcb8c324 is the "Currency" label
+        expect(screen.queryByText('text_632b4acf0c41206cbcb8c324')).not.toBeInTheDocument()
       })
     })
   })

--- a/src/pages/quotes/__tests__/EditQuote.test.tsx
+++ b/src/pages/quotes/__tests__/EditQuote.test.tsx
@@ -34,7 +34,7 @@ let capturedOnDiscountBlocksChange: ((blocks: unknown[]) => void) | undefined
 let capturedOnCreditsCommand: ((params: unknown) => void) | undefined
 let capturedOnCreditsBlocksChange: ((blocks: unknown[]) => void) | undefined
 let capturedEditorCustomerLocale: string | undefined
-let capturedEditorCustomerCurrency: string | undefined
+let capturedEditorDocumentCurrency: string | undefined
 let capturedRemoveBlockRef: { current: ((localId: string) => void) | null } | undefined
 
 // --- Mocks ---
@@ -66,7 +66,7 @@ jest.mock('~/components/designSystem/RichTextEditor/RichTextEditor', () => {
     onCreditsCommand,
     onCreditsBlocksChange,
     customerLocale,
-    customerCurrency,
+    documentCurrency,
   }: {
     getMarkdownRef?: React.MutableRefObject<(() => string) | null>
     removeBlockRef?: React.MutableRefObject<((localId: string) => void) | null>
@@ -78,7 +78,7 @@ jest.mock('~/components/designSystem/RichTextEditor/RichTextEditor', () => {
     onCreditsCommand?: (params: unknown) => void
     onCreditsBlocksChange?: (blocks: unknown[]) => void
     customerLocale?: string
-    customerCurrency?: string
+    documentCurrency?: string
   }) => {
     React.useEffect(() => {
       if (getMarkdownRef) {
@@ -92,7 +92,7 @@ jest.mock('~/components/designSystem/RichTextEditor/RichTextEditor', () => {
       capturedOnCreditsCommand = onCreditsCommand
       capturedOnCreditsBlocksChange = onCreditsBlocksChange
       capturedEditorCustomerLocale = customerLocale
-      capturedEditorCustomerCurrency = customerCurrency
+      capturedEditorDocumentCurrency = documentCurrency
       capturedRemoveBlockRef = removeBlockRef
 
       return () => {
@@ -111,7 +111,7 @@ jest.mock('~/components/designSystem/RichTextEditor/RichTextEditor', () => {
       onCreditsCommand,
       onCreditsBlocksChange,
       customerLocale,
-      customerCurrency,
+      documentCurrency,
     ])
 
     return <div data-test="mock-rich-text-editor" />
@@ -199,7 +199,7 @@ const mockQuote = {
     status: 'draft',
     version: 1,
     content: 'Some content',
-    currency: null,
+    currency: 'USD',
     startDate: null,
     endDate: null,
     createdAt: '2026-01-01',
@@ -294,7 +294,7 @@ describe('EditQuote', () => {
     capturedOnCreditsCommand = undefined
     capturedOnCreditsBlocksChange = undefined
     capturedEditorCustomerLocale = undefined
-    capturedEditorCustomerCurrency = undefined
+    capturedEditorDocumentCurrency = undefined
     capturedRemoveBlockRef = undefined
     capturedPricingDrawerArgs = []
     capturedDiscountDrawerOptions = undefined
@@ -991,7 +991,7 @@ describe('EditQuote', () => {
     })
   })
 
-  describe('GIVEN customer locale and currency props', () => {
+  describe('GIVEN the customer locale and document currency props', () => {
     describe('WHEN the customer has a document locale', () => {
       it('THEN should pass customerLocale to RichTextEditor', () => {
         mockUseQuote.mockReturnValue({
@@ -1020,15 +1020,13 @@ describe('EditQuote', () => {
       })
     })
 
-    describe('WHEN the customer has a currency', () => {
-      it('THEN should pass customerCurrency to RichTextEditor', () => {
+    describe('WHEN the version currency differs from the customer one', () => {
+      it('THEN should price the editor in the version currency', () => {
         mockUseQuote.mockReturnValue({
           quote: {
             ...mockQuote,
-            customer: {
-              ...mockQuote.customer,
-              currency: 'EUR',
-            },
+            customer: { ...mockQuote.customer, currency: 'EUR' },
+            currentVersion: { ...mockQuote.currentVersion, currency: 'JPY' },
           },
           loading: false,
           refetch: mockRefetchQuote,
@@ -1036,15 +1034,25 @@ describe('EditQuote', () => {
 
         render(<EditQuote />)
 
-        expect(capturedEditorCustomerCurrency).toBe('EUR')
+        expect(capturedEditorDocumentCurrency).toBe('JPY')
       })
     })
 
-    describe('WHEN the customer has no currency', () => {
-      it('THEN should pass undefined customerCurrency to RichTextEditor', () => {
+    describe('WHEN the version has no currency', () => {
+      it('THEN should fall back to the customer currency', () => {
+        mockUseQuote.mockReturnValue({
+          quote: {
+            ...mockQuote,
+            customer: { ...mockQuote.customer, currency: 'EUR' },
+            currentVersion: { ...mockQuote.currentVersion, currency: null },
+          },
+          loading: false,
+          refetch: mockRefetchQuote,
+        })
+
         render(<EditQuote />)
 
-        expect(capturedEditorCustomerCurrency).toBeUndefined()
+        expect(capturedEditorDocumentCurrency).toBe('EUR')
       })
     })
 
@@ -1299,6 +1307,132 @@ describe('EditQuote', () => {
         // mergeWalletCredits unit tests (serializeQuoteBillingItems.test.ts)
         // and by useCreditsDrawer.test.tsx's "rebuild (create/edit path)" test,
         // which exercise the exact same rebuild -> mergeWalletCredits route.
+      })
+    })
+  })
+
+  describe('GIVEN the quote currency', () => {
+    const renderWithCurrencies = (
+      versionCurrency: string | null,
+      customerCurrency: string | null,
+    ) => {
+      mockUseQuote.mockReturnValue({
+        quote: {
+          ...mockQuote,
+          customer: { ...mockQuote.customer, currency: customerCurrency },
+          currentVersion: { ...mockQuote.currentVersion, currency: versionCurrency },
+        },
+        loading: false,
+        refetch: mockRefetchQuote,
+      })
+
+      return render(<EditQuote />)
+    }
+
+    describe('WHEN the version has no currency and the customer has one', () => {
+      it('THEN should backfill the version with the customer currency, once', async () => {
+        const { rerender } = renderWithCurrencies(null, 'EUR')
+
+        await waitFor(() => {
+          expect(mockUpdateQuoteVersion).toHaveBeenCalledWith(
+            { id: 'version-1', currency: 'EUR' },
+            false,
+          )
+        })
+
+        rerender(<EditQuote />)
+
+        expect(
+          mockUpdateQuoteVersion.mock.calls.filter(([payload]) => 'currency' in payload),
+        ).toHaveLength(1)
+      })
+    })
+
+    describe('WHEN the version already has a currency', () => {
+      it('THEN should not backfill it', async () => {
+        renderWithCurrencies('USD', 'EUR')
+
+        await waitFor(() => {
+          expect(capturedPricingDrawerArgs).not.toHaveLength(0)
+        })
+
+        expect(mockUpdateQuoteVersion).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the pricing drawers are built', () => {
+      it.each([
+        ['the version currency when it has one', 'USD', 'EUR', 'USD', true],
+        ['the customer currency as a fallback', null, 'EUR', 'EUR', false],
+      ])(
+        'THEN should use %s',
+        async (_, versionCurrency, customerCurrency, expected, hasQuoteCurrency) => {
+          renderWithCurrencies(versionCurrency, customerCurrency)
+
+          const options = capturedPricingDrawerArgs[1] as {
+            currency?: string
+            hasQuoteCurrency?: boolean
+          }
+
+          expect(options.currency).toBe(expected)
+          expect(options.hasQuoteCurrency).toBe(hasQuoteCurrency)
+        },
+      )
+    })
+
+    describe('WHEN a pricing drawer save seeds a currency', () => {
+      it('THEN should persist it alongside the billing items in a single mutation', async () => {
+        mockUpdateQuoteVersion.mockResolvedValue({
+          data: { updateQuoteVersion: { id: 'version-1' } },
+        })
+        renderWithCurrencies('USD', null)
+
+        act(() => {
+          capturedOnPricingCommand?.({ onSave: jest.fn() })
+        })
+
+        const wrappedOnSave = mockDrawerOnPricingCommand.mock.calls[0][0].onSave
+        const billingItems = { addOns: [{ addOnId: 'addon-1' }] }
+
+        await act(async () => {
+          await wrappedOnSave(
+            { pricingType: 'addOns', entityIds: ['addon-1'] },
+            {},
+            billingItems,
+            'JPY',
+          )
+        })
+
+        await waitFor(() => {
+          expect(mockUpdateQuoteVersion).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'version-1', billingItems, currency: 'JPY' }),
+            false,
+          )
+        })
+      })
+    })
+
+    describe('WHEN a pricing drawer save seeds no currency', () => {
+      it('THEN should leave the currency out of the payload', async () => {
+        mockUpdateQuoteVersion.mockResolvedValue({
+          data: { updateQuoteVersion: { id: 'version-1' } },
+        })
+        renderWithCurrencies('USD', null)
+
+        act(() => {
+          capturedOnPricingCommand?.({ onSave: jest.fn() })
+        })
+
+        const wrappedOnSave = mockDrawerOnPricingCommand.mock.calls[0][0].onSave
+
+        await act(async () => {
+          await wrappedOnSave({ pricingType: 'addOns', entityIds: ['addon-1'] }, {}, {})
+        })
+
+        await waitFor(() => {
+          expect(mockUpdateQuoteVersion).toHaveBeenCalled()
+        })
+        expect(mockUpdateQuoteVersion.mock.calls[0][0]).not.toHaveProperty('currency')
       })
     })
   })

--- a/src/pages/quotes/common/QuotePdfProvider.tsx
+++ b/src/pages/quotes/common/QuotePdfProvider.tsx
@@ -134,7 +134,7 @@ export const QuotePdfProvider = ({ children }: { children: ReactNode }) => {
             mentionValues={current.props.mentionValues}
             images={current.props.images}
             customerLocale={current.props.customerLocale}
-            customerCurrency={current.props.customerCurrency}
+            documentCurrency={current.props.documentCurrency}
             onPreviewReady={handleReady}
           />
         </div>

--- a/src/pages/quotes/common/__tests__/QuotePdfProvider.test.tsx
+++ b/src/pages/quotes/common/__tests__/QuotePdfProvider.test.tsx
@@ -56,7 +56,7 @@ const PROPS: QuotePreviewProps = {
   content: '<p>Doc</p>',
   entities: { 'addon-1': { entityId: 'addon-1', entityType: 'addOn', name: 'A', code: 'a' } },
   customerLocale: 'en',
-  customerCurrency: undefined,
+  documentCurrency: undefined,
   mentionValues: {},
   images: {},
 }

--- a/src/pages/quotes/common/__tests__/buildQuotePreviewProps.test.ts
+++ b/src/pages/quotes/common/__tests__/buildQuotePreviewProps.test.ts
@@ -27,7 +27,7 @@ describe('buildQuotePreviewProps', () => {
       content: '<p>Hi</p>',
       entities: { 'addon-1': { entityId: 'addon-1' } },
       customerLocale: 'fr',
-      customerCurrency: CurrencyEnum.Eur,
+      documentCurrency: CurrencyEnum.Eur,
       mentionValues: {},
       images: {},
     })
@@ -41,7 +41,7 @@ describe('buildQuotePreviewProps', () => {
       content: '',
       entities: {},
       customerLocale: 'en',
-      customerCurrency: undefined,
+      documentCurrency: undefined,
       mentionValues: {},
       images: {},
     })
@@ -54,7 +54,7 @@ describe('buildQuotePreviewProps', () => {
     const result = buildQuotePreviewProps({ version, customer })
 
     expect(result.customerLocale).toBe('en')
-    expect(result.customerCurrency).toBeUndefined()
+    expect(result.documentCurrency).toBeUndefined()
     expect(result.entities).toEqual({})
   })
 
@@ -113,5 +113,38 @@ describe('buildQuotePreviewProps', () => {
     const result = buildQuotePreviewProps({ version: null, customer: null })
 
     expect(result.images).toEqual({})
+  })
+
+  describe('GIVEN the version has its own currency', () => {
+    const version = {
+      content: '<p>Hi</p>',
+      billingItems: { addOns: [] },
+      mentionVariables: {},
+      currency: CurrencyEnum.Jpy,
+    }
+
+    it('THEN should price the preview in it rather than the customer currency', () => {
+      const customer = {
+        currency: CurrencyEnum.Eur,
+        billingConfiguration: { documentLocale: 'fr' },
+      }
+
+      const result = buildQuotePreviewProps({ version, customer })
+
+      expect(result.documentCurrency).toBe(CurrencyEnum.Jpy)
+      expect(buildPreviewEntities).toHaveBeenCalledWith({ addOns: [] }, CurrencyEnum.Jpy)
+    })
+
+    it('THEN should still fall back to the customer currency when the version has none', () => {
+      const customer = {
+        currency: CurrencyEnum.Eur,
+        billingConfiguration: { documentLocale: 'fr' },
+      }
+
+      const result = buildQuotePreviewProps({ version: { ...version, currency: null }, customer })
+
+      expect(result.documentCurrency).toBe(CurrencyEnum.Eur)
+      expect(buildPreviewEntities).toHaveBeenCalledWith({ addOns: [] }, CurrencyEnum.Eur)
+    })
   })
 })

--- a/src/pages/quotes/common/buildQuotePreviewProps.ts
+++ b/src/pages/quotes/common/buildQuotePreviewProps.ts
@@ -19,7 +19,8 @@ export interface QuotePreviewProps {
   content: string
   entities: Record<string, EntityData>
   customerLocale: Locale
-  customerCurrency?: CurrencyEnum
+  /** The quote's own currency, which can differ from the customer's. */
+  documentCurrency?: CurrencyEnum
   mentionValues: Record<string, string>
   images: Record<string, string>
   header?: QuotePdfHeaderData
@@ -35,17 +36,24 @@ export const buildQuotePreviewProps = ({
   customer: QuotePreviewCustomerFragment | null | undefined
   images?: Record<string, string>
   header?: QuotePdfHeaderData
-}): QuotePreviewProps => ({
-  content: version?.content ?? '',
-  entities: version?.billingItems
-    ? buildPreviewEntities(
-        version.billingItems as BillingItemsPayload,
-        customer?.currency ?? undefined,
-      )
-    : {},
-  customerLocale: (customer?.billingConfiguration?.documentLocale ?? 'en') as Locale,
-  customerCurrency: customer?.currency ?? undefined,
-  mentionValues: (version?.mentionVariables ?? {}) as Record<string, string>,
-  images,
-  header,
-})
+}): QuotePreviewProps => {
+  // The version currency is the document's own currency and wins over the
+  // customer's — the two can differ now that a quote's currency is editable.
+  // The customer's remains the fallback for versions created before that.
+  // The schema types the version currency as a plain String, hence the cast —
+  // same as every other quote-version currency read.
+  const currency =
+    (version?.currency as CurrencyEnum | undefined) ?? customer?.currency ?? undefined
+
+  return {
+    content: version?.content ?? '',
+    entities: version?.billingItems
+      ? buildPreviewEntities(version.billingItems as BillingItemsPayload, currency)
+      : {},
+    customerLocale: (customer?.billingConfiguration?.documentLocale ?? 'en') as Locale,
+    documentCurrency: currency,
+    mentionValues: (version?.mentionVariables ?? {}) as Record<string, string>,
+    images,
+    header,
+  }
+}

--- a/src/pages/quotes/createQuote/__tests__/validationSchema.test.ts
+++ b/src/pages/quotes/createQuote/__tests__/validationSchema.test.ts
@@ -102,9 +102,9 @@ describe('createQuoteSchema', () => {
     expect(result.success).toBe(true)
   })
 
-  describe('GIVEN the currency field', () => {
-    describe('WHEN a valid CurrencyEnum value is provided', () => {
-      it('THEN should pass validation', () => {
+  describe('GIVEN the currency is no longer part of the creation form', () => {
+    describe('WHEN a currency is passed anyway', () => {
+      it('THEN should validate and strip it from the parsed values', () => {
         const result = createQuoteSchema.safeParse({
           customerId: 'customer-123',
           orderType: OrderTypeEnum.OneOff,
@@ -113,44 +113,7 @@ describe('createQuoteSchema', () => {
         })
 
         expect(result.success).toBe(true)
-      })
-    })
-
-    describe('WHEN currency is omitted', () => {
-      it('THEN should pass validation (optional field)', () => {
-        const result = createQuoteSchema.safeParse({
-          customerId: 'customer-123',
-          orderType: OrderTypeEnum.OneOff,
-          subscriptionId: '',
-        })
-
-        expect(result.success).toBe(true)
-      })
-    })
-
-    describe('WHEN currency is undefined', () => {
-      it('THEN should pass validation', () => {
-        const result = createQuoteSchema.safeParse({
-          customerId: 'customer-123',
-          orderType: OrderTypeEnum.OneOff,
-          subscriptionId: '',
-          currency: undefined,
-        })
-
-        expect(result.success).toBe(true)
-      })
-    })
-
-    describe('WHEN an invalid currency value is provided', () => {
-      it('THEN should fail validation', () => {
-        const result = createQuoteSchema.safeParse({
-          customerId: 'customer-123',
-          orderType: OrderTypeEnum.OneOff,
-          subscriptionId: '',
-          currency: 'INVALID_CURRENCY',
-        })
-
-        expect(result.success).toBe(false)
+        expect(result.data).not.toHaveProperty('currency')
       })
     })
   })

--- a/src/pages/quotes/createQuote/validationSchema.ts
+++ b/src/pages/quotes/createQuote/validationSchema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { CurrencyEnum, OrderTypeEnum } from '~/generated/graphql'
+import { OrderTypeEnum } from '~/generated/graphql'
 
 export const createQuoteSchema = z
   .object({
@@ -8,7 +8,6 @@ export const createQuoteSchema = z
     orderType: z.nativeEnum(OrderTypeEnum),
     subscriptionId: z.string(),
     owners: z.array(z.looseObject({ value: z.string() })).optional(),
-    currency: z.nativeEnum(CurrencyEnum).optional(),
   })
   .refine(
     (data) => {

--- a/src/pages/quotes/editQuote/EditQuoteAside.tsx
+++ b/src/pages/quotes/editQuote/EditQuoteAside.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
+import { CURRENCY_DATA } from '~/components/form/CurrencyPicker'
 import {
   type CurrencyEnum,
   OrderTypeEnum,
@@ -32,6 +33,7 @@ export const EDIT_QUOTE_ASIDE_CUSTOMER_INPUT_TEST_ID = 'edit-quote-aside-custome
 export const EDIT_QUOTE_ASIDE_BILLING_ENTITY_INPUT_TEST_ID = 'edit-quote-aside-billing-entity'
 export const EDIT_QUOTE_ASIDE_SUBSCRIPTION_INPUT_TEST_ID = 'edit-quote-aside-subscription'
 export const EDIT_QUOTE_ASIDE_CURRENCY_INPUT_TEST_ID = 'edit-quote-aside-currency'
+export const EDIT_QUOTE_ASIDE_CURRENCY_COMBOBOX_TEST_ID = 'edit-quote-aside-currency-combobox'
 export const EDIT_QUOTE_ASIDE_START_DATE_TEST_ID = 'edit-quote-aside-start-date'
 export const EDIT_QUOTE_ASIDE_END_DATE_TEST_ID = 'edit-quote-aside-end-date'
 export const EDIT_QUOTE_ASIDE_PAYMENT_TERM_TEST_ID = 'edit-quote-aside-payment-term'
@@ -114,10 +116,7 @@ const EditQuoteAsideForm = ({
       orderTypeLabel: translate(getQuoteOrderTypeTranslationKey(quote.orderType)),
       customerName: quote.customer.displayName,
       billingEntityId: quote.customer.billingEntity?.id ?? '',
-      currency:
-        quote.customer.currency ??
-        (quote.currentVersion.currency as CurrencyEnum | undefined) ??
-        undefined,
+      currency: (quote.currentVersion.currency as CurrencyEnum | undefined) ?? undefined,
       subscriptionLabel: quote.subscription
         ? `${quote.subscription.plan?.name ?? ''} - ${quote.subscription.externalId}`
         : undefined,
@@ -151,6 +150,43 @@ const EditQuoteAsideForm = ({
   updateQuoteVersionRef.current = updateQuoteVersion
   onSaveStartRef.current = onSaveStart
   onSaveErrorRef.current = onSaveError
+
+  const versionCurrency = (quote.currentVersion.currency as CurrencyEnum | undefined) ?? undefined
+  // Last currency known to be persisted, so the field listener can tell a user
+  // pick apart from a programmatic sync (mount backfill, billing-item seeding)
+  // and only fire a mutation for the former.
+  const persistedCurrencyRef = useRef(versionCurrency)
+
+  useEffect(() => {
+    persistedCurrencyRef.current = versionCurrency
+
+    if (versionCurrency && form.getFieldValue('currency') !== versionCurrency) {
+      form.setFieldValue('currency', versionCurrency)
+    }
+  }, [versionCurrency, form])
+
+  // Currency is a discrete pick, not typing — save it right away instead of
+  // going through the dates' debounce.
+  const handleCurrencyChange = async (currency: CurrencyEnum | undefined): Promise<void> => {
+    if (!versionId || !currency) return
+    if (currency === persistedCurrencyRef.current) return
+
+    persistedCurrencyRef.current = currency
+
+    const payload: UpdateQuoteVersionInput = { id: versionId, currency }
+
+    onSaveStartRef.current?.()
+
+    try {
+      const result = await updateQuoteVersionRef.current(payload, false)
+
+      if (!result.data?.updateQuoteVersion) {
+        onSaveErrorRef.current?.(payload)
+      }
+    } catch {
+      onSaveErrorRef.current?.(payload)
+    }
+  }
 
   const debouncedSaveDates = useMemo(
     () =>
@@ -275,17 +311,20 @@ const EditQuoteAsideForm = ({
           >
             {translate('text_632b4acf0c41206cbcb8c324')}
           </Typography>
-          <form.AppField name="currency">
+          <form.AppField
+            name="currency"
+            listeners={{
+              onChange: ({ value }) => {
+                handleCurrencyChange(value)
+              },
+            }}
+          >
             {(field) => (
               <field.ComboBoxField
-                disabled
+                dataTest={EDIT_QUOTE_ASIDE_CURRENCY_COMBOBOX_TEST_ID}
                 disableClearable
-                data={[
-                  ...(quote.customer.currency ? [{ value: quote.customer.currency }] : []),
-                  ...(quote.currentVersion.currency && !quote.customer.currency
-                    ? [{ value: quote.currentVersion.currency }]
-                    : []),
-                ]}
+                placeholder={translate('text_632c6e59b73f9a54d4c7224b')}
+                data={CURRENCY_DATA}
               />
             )}
           </form.AppField>

--- a/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
+++ b/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import {
   CurrencyEnum,
@@ -11,6 +12,7 @@ import { render } from '~/test-utils'
 import EditQuoteAside, {
   EDIT_QUOTE_ASIDE_APPROVE_TEST_ID,
   EDIT_QUOTE_ASIDE_BILLING_ENTITY_INPUT_TEST_ID,
+  EDIT_QUOTE_ASIDE_CURRENCY_COMBOBOX_TEST_ID,
   EDIT_QUOTE_ASIDE_CURRENCY_INPUT_TEST_ID,
   EDIT_QUOTE_ASIDE_CUSTOMER_INPUT_TEST_ID,
   EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID,
@@ -39,12 +41,30 @@ jest.mock('~/generated/graphql', () => ({
   ...jest.requireActual('~/generated/graphql'),
 }))
 
+const mockUpdateQuoteVersion = jest.fn()
+
 jest.mock('~/pages/quotes/hooks/useUpdateQuote', () => ({
   useUpdateQuote: () => ({
-    updateQuoteVersion: jest.fn(),
+    updateQuoteVersion: mockUpdateQuoteVersion,
     isUpdatingQuoteVersion: false,
     updateQuote: jest.fn(),
     isUpdatingQuote: false,
+  }),
+}))
+
+// The currency ComboBox renders its options through a virtualized list.
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 56,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, i) => ({
+        index: i,
+        key: String(i),
+        start: i * 56,
+        size: 56,
+      })),
+    scrollToIndex: jest.fn(),
+    measureElement: jest.fn(),
   }),
 }))
 
@@ -115,6 +135,7 @@ describe('EditQuoteAside', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockHasPermissions.mockReturnValue(true)
+    mockUpdateQuoteVersion.mockResolvedValue({ data: { updateQuoteVersion: { id: 'version-1' } } })
   })
 
   describe('GIVEN a quote is provided', () => {
@@ -347,33 +368,112 @@ describe('EditQuoteAside', () => {
     })
   })
 
-  describe('GIVEN a quote where customer has no currency but currentVersion does', () => {
-    describe('WHEN the component renders', () => {
-      it('THEN should render the currency field using currentVersion currency', () => {
-        const quoteWithVersionCurrency = {
-          ...mockQuote,
-          customer: { ...mockQuote.customer, currency: null },
-          currentVersion: { ...mockQuote.currentVersion, currency: CurrencyEnum.Eur },
-        }
+  describe('GIVEN the quote currency', () => {
+    const renderWithCurrency = (currency: CurrencyEnum | null) =>
+      render(
+        <EditQuoteAside
+          quote={{
+            ...mockQuote,
+            // The customer currency no longer feeds this field — only the version's does.
+            customer: { ...mockQuote.customer, currency: CurrencyEnum.Gbp },
+            currentVersion: { ...mockQuote.currentVersion, currency },
+          }}
+        />,
+      )
 
-        render(<EditQuoteAside quote={quoteWithVersionCurrency} />)
+    describe('WHEN the version has a currency', () => {
+      it('THEN should show it in an editable combobox', () => {
+        renderWithCurrency(CurrencyEnum.Eur)
 
-        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_CURRENCY_INPUT_TEST_ID)).toBeInTheDocument()
+        const input = screen
+          .getByTestId(EDIT_QUOTE_ASIDE_CURRENCY_COMBOBOX_TEST_ID)
+          .querySelector('input') as HTMLInputElement
+
+        expect(input).toHaveValue(CurrencyEnum.Eur)
+        expect(input).not.toBeDisabled()
       })
     })
-  })
 
-  describe('GIVEN a quote where customer has a currency set', () => {
-    describe('WHEN the component renders', () => {
-      it('THEN should render the currency field using customer currency', () => {
-        const quoteWithCustomerCurrency = {
-          ...mockQuote,
-          customer: { ...mockQuote.customer, currency: CurrencyEnum.Eur },
-        }
+    describe('WHEN the version has no currency', () => {
+      it('THEN should show an empty combobox rather than the customer currency', () => {
+        renderWithCurrency(null)
 
-        render(<EditQuoteAside quote={quoteWithCustomerCurrency} />)
+        const input = screen
+          .getByTestId(EDIT_QUOTE_ASIDE_CURRENCY_COMBOBOX_TEST_ID)
+          .querySelector('input') as HTMLInputElement
 
-        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_CURRENCY_INPUT_TEST_ID)).toBeInTheDocument()
+        expect(input).toHaveValue('')
+        expect(input).not.toBeDisabled()
+      })
+    })
+
+    describe('WHEN the user picks a different currency', () => {
+      it('THEN should persist it immediately, without waiting for a debounce', async () => {
+        // No inter-event delay: the full currency list is ~140 options, and
+        // userEvent's default pacing makes driving the popper slow enough to
+        // trip the default jest timeout when suites run in parallel.
+        const user = userEvent.setup({ delay: null })
+        const onSaveStart = jest.fn()
+
+        render(
+          <EditQuoteAside
+            quote={{
+              ...mockQuote,
+              currentVersion: { ...mockQuote.currentVersion, currency: CurrencyEnum.Eur },
+            }}
+            onSaveStart={onSaveStart}
+          />,
+        )
+
+        const input = screen
+          .getByTestId(EDIT_QUOTE_ASIDE_CURRENCY_COMBOBOX_TEST_ID)
+          .querySelector('input') as HTMLInputElement
+
+        // Filter down to the single AUD option, then let the Autocomplete select
+        // it via the keyboard. Clicking a popper node instead means holding an
+        // element reference across re-renders, which is what made this flake.
+        await user.clear(input)
+        await user.type(input, CurrencyEnum.Aud)
+
+        await waitFor(() => {
+          expect(screen.getAllByRole('option')).toHaveLength(1)
+        })
+
+        await user.keyboard('{ArrowDown}{Enter}')
+
+        await waitFor(() => {
+          expect(mockUpdateQuoteVersion).toHaveBeenCalledWith(
+            { id: 'version-1', currency: CurrencyEnum.Aud },
+            false,
+          )
+        })
+        expect(onSaveStart).toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the version currency changes outside the form', () => {
+      it('THEN should sync the field without issuing another save', async () => {
+        const { rerender } = renderWithCurrency(null)
+
+        rerender(
+          <EditQuoteAside
+            quote={{
+              ...mockQuote,
+              customer: { ...mockQuote.customer, currency: CurrencyEnum.Gbp },
+              currentVersion: { ...mockQuote.currentVersion, currency: CurrencyEnum.Jpy },
+            }}
+          />,
+        )
+
+        await waitFor(() => {
+          const input = screen
+            .getByTestId(EDIT_QUOTE_ASIDE_CURRENCY_COMBOBOX_TEST_ID)
+            .querySelector('input') as HTMLInputElement
+
+          expect(input).toHaveValue(CurrencyEnum.Jpy)
+        })
+
+        expect(mockUpdateQuoteVersion).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/pages/quotes/hooks/__tests__/useCreateQuote.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useCreateQuote.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { ReactNode } from 'react'
 
 import { addToast } from '~/core/apolloClient'
-import { CurrencyEnum, OrderTypeEnum } from '~/generated/graphql'
+import { OrderTypeEnum } from '~/generated/graphql'
 import { AllTheProviders } from '~/test-utils'
 
 import { useCreateQuote } from '../useCreateQuote'
@@ -27,7 +27,6 @@ jest.mock('~/core/apolloClient', () => ({
 
 let capturedMutationOnCompleted: ((data: Record<string, unknown>) => void) | undefined
 const mockCreateQuote = jest.fn()
-const mockUpdateCustomerCurrency = jest.fn()
 
 jest.mock('~/generated/graphql', () => ({
   ...jest.requireActual('~/generated/graphql'),
@@ -35,7 +34,6 @@ jest.mock('~/generated/graphql', () => ({
     capturedMutationOnCompleted = options?.onCompleted
     return [mockCreateQuote, { loading: false }]
   },
-  useUpdateCustomerCurrencyForQuoteMutation: () => [mockUpdateCustomerCurrency],
 }))
 
 const wrapper = ({ children }: { children: ReactNode }) => (
@@ -80,7 +78,6 @@ describe('useCreateQuote', () => {
               orderType: OrderTypeEnum.OneOff,
               subscriptionId: undefined,
               owners: undefined,
-              currency: undefined,
             },
           },
         })
@@ -108,7 +105,6 @@ describe('useCreateQuote', () => {
               orderType: OrderTypeEnum.SubscriptionAmendment,
               subscriptionId: 'sub-789',
               owners: undefined,
-              currency: undefined,
             },
           },
         })
@@ -136,7 +132,6 @@ describe('useCreateQuote', () => {
               orderType: OrderTypeEnum.OneOff,
               subscriptionId: undefined,
               owners: ['user-1', 'user-2'],
-              currency: undefined,
             },
           },
         })
@@ -163,18 +158,14 @@ describe('useCreateQuote', () => {
               orderType: OrderTypeEnum.OneOff,
               subscriptionId: undefined,
               owners: undefined,
-              currency: undefined,
             },
           },
         })
       })
     })
 
-    describe('WHEN called with currency and customer had no prior currency', () => {
-      it('THEN should call updateCustomerCurrency then createQuote with currency', async () => {
-        mockUpdateCustomerCurrency.mockResolvedValue({
-          data: { updateCustomer: { id: 'customer-123', currency: CurrencyEnum.Eur } },
-        })
+    describe('WHEN called for any quote', () => {
+      it('THEN should never send a currency nor touch the customer', async () => {
         mockCreateQuote.mockResolvedValue({ data: { createQuote: { id: 'quote-5' } } })
 
         const { result } = renderHook(() => useCreateQuote(), { wrapper })
@@ -183,65 +174,12 @@ describe('useCreateQuote', () => {
           await result.current.onSave({
             customerId: 'customer-123',
             orderType: OrderTypeEnum.OneOff,
-            currency: CurrencyEnum.Eur,
-            customerExternalId: 'ext-123',
-            hasCustomerCurrency: false,
           })
         })
 
-        expect(mockUpdateCustomerCurrency).toHaveBeenCalledWith({
-          variables: {
-            input: {
-              id: 'customer-123',
-              externalId: 'ext-123',
-              currency: CurrencyEnum.Eur,
-            },
-          },
-        })
+        const input = mockCreateQuote.mock.calls[0][0].variables.input
 
-        expect(mockCreateQuote).toHaveBeenCalledWith({
-          variables: {
-            input: {
-              customerId: 'customer-123',
-              orderType: OrderTypeEnum.OneOff,
-              subscriptionId: undefined,
-              owners: undefined,
-              currency: CurrencyEnum.Eur,
-            },
-          },
-        })
-      })
-    })
-
-    describe('WHEN called with currency and customer already had currency', () => {
-      it('THEN should NOT call updateCustomerCurrency but should pass currency', async () => {
-        mockCreateQuote.mockResolvedValue({ data: { createQuote: { id: 'quote-6' } } })
-
-        const { result } = renderHook(() => useCreateQuote(), { wrapper })
-
-        await act(async () => {
-          await result.current.onSave({
-            customerId: 'customer-456',
-            orderType: OrderTypeEnum.OneOff,
-            currency: CurrencyEnum.Usd,
-            customerExternalId: 'ext-456',
-            hasCustomerCurrency: true,
-          })
-        })
-
-        expect(mockUpdateCustomerCurrency).not.toHaveBeenCalled()
-
-        expect(mockCreateQuote).toHaveBeenCalledWith({
-          variables: {
-            input: {
-              customerId: 'customer-456',
-              orderType: OrderTypeEnum.OneOff,
-              subscriptionId: undefined,
-              owners: undefined,
-              currency: CurrencyEnum.Usd,
-            },
-          },
-        })
+        expect(input).not.toHaveProperty('currency')
       })
     })
   })

--- a/src/pages/quotes/hooks/__tests__/useOneOffPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useOneOffPricingDrawer.test.tsx
@@ -924,12 +924,13 @@ describe('useOneOffPricingDrawer', () => {
     })
   })
 
-  describe('GIVEN customerCurrency is provided', () => {
+  describe('GIVEN a quote currency is provided', () => {
     describe('WHEN onPricingCommand is called', () => {
-      it('THEN should pass the customerCurrency to the drawer content instead of organization default', () => {
-        const { result } = renderHook(() => useOneOffPricingDrawer(undefined, CurrencyEnum.Eur), {
-          wrapper,
-        })
+      it('THEN should pass it to the drawer content instead of the organization default', () => {
+        const { result } = renderHook(
+          () => useOneOffPricingDrawer(undefined, { currency: CurrencyEnum.Eur }),
+          { wrapper },
+        )
 
         act(() => {
           result.current.onPricingCommand({
@@ -945,9 +946,11 @@ describe('useOneOffPricingDrawer', () => {
       })
     })
 
-    describe('WHEN customerCurrency is null', () => {
+    describe('WHEN the quote currency is null', () => {
       it('THEN should fall back to organization defaultCurrency', () => {
-        const { result } = renderHook(() => useOneOffPricingDrawer(undefined, null), { wrapper })
+        const { result } = renderHook(() => useOneOffPricingDrawer(undefined, { currency: null }), {
+          wrapper,
+        })
 
         act(() => {
           result.current.onPricingCommand({
@@ -963,7 +966,7 @@ describe('useOneOffPricingDrawer', () => {
       })
     })
 
-    describe('WHEN customerCurrency is not provided', () => {
+    describe('WHEN the quote currency is not provided', () => {
       it('THEN should use organization defaultCurrency', () => {
         const { result } = renderHook(() => useOneOffPricingDrawer(), { wrapper })
 
@@ -1037,6 +1040,8 @@ describe('useOneOffPricingDrawer', () => {
             }),
           }),
           undefined, // toBillingItems is mocked, returns undefined
+          // No add-on payload was captured in this test, so nothing seeds the currency.
+          undefined,
         )
 
         // Entities should be updated (keyed by localId)
@@ -1154,7 +1159,80 @@ describe('useOneOffPricingDrawer', () => {
             'local-uuid-new': expect.objectContaining({ entityId: 'local-uuid-new' }),
           }),
           undefined, // toBillingItems is mocked, returns undefined
+          // The quote has no currency of its own: the add-on's seeds it.
+          'USD',
         )
+      })
+    })
+
+    describe('WHEN the quote already owns a currency', () => {
+      it('THEN should not forward the add-on currency', () => {
+        const { result } = renderHook(
+          () =>
+            useOneOffPricingDrawer(undefined, {
+              currency: CurrencyEnum.Eur,
+              hasQuoteCurrency: true,
+            }),
+          { wrapper },
+        )
+
+        act(() => {
+          result.current.onPricingCommand({ onSave: jest.fn(), editData: undefined })
+        })
+
+        const captureCallback =
+          mockFormDrawerOpen.mock.calls[0][0].children.props.onAddOnPayloadCapture
+
+        act(() => {
+          captureCallback('local-uuid-new', {
+            id: 'addon-new',
+            code: 'onboarding',
+            name: 'Onboarding Fee',
+            description: 'One-time onboarding',
+            amountCents: '7500',
+            amountCurrency: 'USD',
+            invoiceDisplayName: 'Onboarding',
+            taxes: [],
+          })
+        })
+
+        mockFormValues = {
+          planId: '',
+          addOnItems: [
+            {
+              localId: 'local-uuid-new',
+              addOnId: 'addon-new',
+              name: 'Onboarding Fee',
+              invoiceDisplayName: 'Onboarding',
+              code: 'onboarding',
+              description: 'One-time onboarding',
+              units: '1',
+              unitAmountCents: '7500',
+              totalAmount: '7500',
+              fromDatetime: '2026-01-01',
+              toDatetime: '2026-01-31',
+            },
+          ],
+        }
+
+        const mockOnSave = jest.fn()
+
+        act(() => {
+          result.current.onPricingCommand({
+            onSave: mockOnSave,
+            editData: {
+              pricingType: 'addOns',
+              entityIds: ['addon-new'],
+              localEntityIds: ['local-uuid-new'],
+            },
+          })
+        })
+
+        act(() => {
+          capturedOnSubmit?.({ value: mockFormValues })
+        })
+
+        expect(mockOnSave.mock.calls[0][3]).toBeUndefined()
       })
     })
   })

--- a/src/pages/quotes/hooks/__tests__/useOrderActions.test.ts
+++ b/src/pages/quotes/hooks/__tests__/useOrderActions.test.ts
@@ -68,9 +68,10 @@ describe('useOrderActions', () => {
       const actions = result.current.getActions(createMockOrder())
 
       expect(actions).toHaveLength(3)
-      expect(actions[0].icon).toBe('pen')
-      expect(actions[1].icon).toBe('download')
-      expect(actions[2].icon).toBe('flash')
+      // Execute manually comes first in the popper
+      expect(actions[0].icon).toBe('flash')
+      expect(actions[1].icon).toBe('pen')
+      expect(actions[2].icon).toBe('download')
     })
   })
 
@@ -102,7 +103,7 @@ describe('useOrderActions', () => {
       const { result } = renderHook(() => useOrderActions())
       const actions = result.current.getActions(createMockOrder({ id: 'order-42' }))
 
-      actions[0].onAction()
+      actions.find((a) => a.icon === 'pen')?.onAction()
 
       expect(testMockNavigateFn).toHaveBeenCalledWith('/order/order-42/edit')
     })

--- a/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
@@ -290,6 +290,7 @@ describe('useSubscriptionPricingDrawer', () => {
       // The drawer owns only the `plans` key; `addOns` is normalized in by the
       // save funnel (savePricingBlock), not by this drawer.
       expect.objectContaining({ plans: expect.any(Array) }),
+      undefined,
     )
     expect(onDatesChange).toHaveBeenCalledWith('2023-07-26', '2024-07-26')
     expect(result.current.entities).toHaveProperty('plan_123')
@@ -476,6 +477,7 @@ describe('useSubscriptionPricingDrawer', () => {
       expect.anything(),
       expect.anything(),
       expect.objectContaining({ plans: expect.any(Array), coupons: [existingCoupon] }),
+      undefined,
     )
   })
 
@@ -635,6 +637,65 @@ describe('useSubscriptionPricingDrawer', () => {
       const plan = await saveAndReadPlan()
 
       expect(plan.overrides).toEqual({ amountCents: 85000 })
+    })
+
+    describe('seeding the quote currency', () => {
+      const saveAndReadSeededCurrency = async (
+        hasQuoteCurrency: boolean,
+      ): Promise<CurrencyEnum | undefined> => {
+        const onSave = jest.fn().mockResolvedValue({ ok: true })
+        const { result } = renderHook(() =>
+          useSubscriptionPricingDrawer(undefined, {
+            currency: CurrencyEnum.Eur,
+            hasQuoteCurrency,
+          }),
+        )
+
+        act(() => {
+          result.current.onPricingCommand({ onSave })
+        })
+
+        const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+        render(openArgs.children)
+
+        await act(async () => {
+          await openArgs.form.submit()
+        })
+
+        return onSave.mock.calls[0][3]
+      }
+
+      beforeEach(() => {
+        mockInjectedState = planState
+        mockInjectedFormValues = catalogFormValues
+        mockInjectedBasePlanFormValues = catalogFormValues
+      })
+
+      it("forwards the plan's currency when the quote has none of its own", async () => {
+        expect(await saveAndReadSeededCurrency(false)).toBe(CurrencyEnum.Usd)
+      })
+
+      it('forwards nothing when the quote already owns a currency', async () => {
+        expect(await saveAndReadSeededCurrency(true)).toBeUndefined()
+      })
+
+      it('locks the plan currency picker only when the quote owns a currency', () => {
+        const { result } = renderHook(() =>
+          useSubscriptionPricingDrawer(undefined, {
+            currency: CurrencyEnum.Eur,
+            hasQuoteCurrency: true,
+          }),
+        )
+
+        act(() => {
+          result.current.onPricingCommand({ onSave: jest.fn() })
+        })
+
+        expect(mockDrawerOpen.mock.calls[0][0].children.props).toEqual(
+          expect.objectContaining({ currency: CurrencyEnum.Eur, hasQuoteCurrency: true }),
+        )
+      })
     })
   })
 })

--- a/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
@@ -1,8 +1,10 @@
 import { act, renderHook } from '@testing-library/react'
 
+import type { PlanFormInput } from '~/components/plans/types'
 import { addToast } from '~/core/apolloClient'
 import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBillingItems'
 import type { SubscriptionPricingState } from '~/core/serializers/serializeQuotePlanBillingItems'
+import { CurrencyEnum, PlanInterval } from '~/generated/graphql'
 import { QUOTE_SAVE_FAILED_TOAST_KEY } from '~/pages/quotes/utils/quoteSaveErrorKeys'
 import { render } from '~/test-utils'
 
@@ -21,6 +23,8 @@ const mockDrawerClose = jest.fn()
 // State the mocked content component hydrates into the hook's stateRef on render.
 // `null` keeps the ref empty (exercises the early-return branch in handleSave).
 let mockInjectedState: SubscriptionPricingState | null = null
+let mockInjectedFormValues: PlanFormInput | null = null
+let mockInjectedBasePlanFormValues: PlanFormInput | null = null
 
 // Verdict the mocked content component reports through validatePlanFormRef.
 // `null` leaves the ref unfilled, as when the content component never mounted.
@@ -37,19 +41,30 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 }))
 
 // Mock SubscriptionPricingContent — on render it hydrates the shared stateRef
-// so the drawer's submit handler has a subscription state to serialize.
+// so the drawer's submit handler has a subscription state to serialize, plus the
+// form values and their catalog-plan baseline used to diff the overrides.
 jest.mock(
   '~/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent',
   () => ({
     SubscriptionPricingContent: ({
       stateRef,
+      formValuesRef,
+      basePlanFormValuesRef,
       validatePlanFormRef,
     }: {
       stateRef?: { current: SubscriptionPricingState | null }
+      formValuesRef?: { current: PlanFormInput | null }
+      basePlanFormValuesRef?: { current: PlanFormInput | null }
       validatePlanFormRef?: { current: (() => Promise<boolean>) | null }
     }) => {
       if (stateRef) {
         stateRef.current = mockInjectedState
+      }
+      if (formValuesRef) {
+        formValuesRef.current = mockInjectedFormValues
+      }
+      if (basePlanFormValuesRef) {
+        basePlanFormValuesRef.current = mockInjectedBasePlanFormValues
       }
 
       if (validatePlanFormRef) {
@@ -67,6 +82,8 @@ describe('useSubscriptionPricingDrawer', () => {
     jest.clearAllMocks()
     mockInjectedState = null
     mockPlanFormValid = null
+    mockInjectedFormValues = null
+    mockInjectedBasePlanFormValues = null
   })
 
   it('returns the expected interface', () => {
@@ -536,6 +553,88 @@ describe('useSubscriptionPricingDrawer', () => {
     expect(mockAddToast).toHaveBeenCalledWith({
       severity: 'danger',
       translateKey: QUOTE_SAVE_FAILED_TOAST_KEY,
+    })
+  })
+
+  describe('override diff baseline (LAGO-1789)', () => {
+    const planState: SubscriptionPricingState = {
+      planId: 'plan_123',
+      planCode: 'enterprise',
+      planName: 'Enterprise Plan',
+      basePlanName: 'Enterprise Plan',
+      planDescription: '',
+      subscriptionSettings: {
+        externalId: '',
+        subscriptionName: '',
+        billingTime: 'anniversary',
+        startDate: '2023-07-26',
+        endDate: '',
+      },
+      invoicingSettings: { paymentMethodId: '', invoiceCustomFooter: '' },
+      overrides: {},
+    }
+
+    const catalogFormValues = {
+      name: 'Enterprise Plan',
+      code: 'enterprise',
+      description: '',
+      interval: PlanInterval.Monthly,
+      amountCents: '850.00',
+      amountCurrency: CurrencyEnum.Usd,
+      payInAdvance: false,
+      trialPeriod: 0,
+      charges: [],
+      fixedCharges: [],
+      entitlements: [],
+    } as unknown as PlanFormInput
+
+    const saveAndReadPlan = async (): Promise<{ overrides: Record<string, unknown> }> => {
+      const onSave = jest.fn().mockResolvedValue({ ok: true })
+      const { result } = renderHook(() => useSubscriptionPricingDrawer(undefined))
+
+      act(() => {
+        result.current.onPricingCommand({ onSave })
+      })
+
+      const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+      render(openArgs.children)
+
+      await act(async () => {
+        await openArgs.form.submit()
+      })
+
+      return onSave.mock.calls[0][2].plans[0]
+    }
+
+    it('sends no overrides when the form matches the catalog plan', async () => {
+      mockInjectedState = planState
+      mockInjectedFormValues = catalogFormValues
+      mockInjectedBasePlanFormValues = catalogFormValues
+
+      const plan = await saveAndReadPlan()
+
+      expect(plan.overrides).toEqual({})
+    })
+
+    it('sends only the edited field when the form differs from the catalog plan', async () => {
+      mockInjectedState = planState
+      mockInjectedFormValues = { ...catalogFormValues, amountCents: '900.00' }
+      mockInjectedBasePlanFormValues = catalogFormValues
+
+      const plan = await saveAndReadPlan()
+
+      expect(plan.overrides).toEqual({ amountCents: 90000 })
+    })
+
+    it('falls back to sending every configured field when no baseline is available', async () => {
+      mockInjectedState = planState
+      mockInjectedFormValues = catalogFormValues
+      mockInjectedBasePlanFormValues = null
+
+      const plan = await saveAndReadPlan()
+
+      expect(plan.overrides).toEqual({ amountCents: 85000 })
     })
   })
 })

--- a/src/pages/quotes/hooks/useCreateQuote.ts
+++ b/src/pages/quotes/hooks/useCreateQuote.ts
@@ -3,12 +3,7 @@ import { generatePath } from 'react-router-dom'
 
 import { addToast } from '~/core/apolloClient'
 import { EDIT_QUOTE_ROUTE, useNavigate } from '~/core/router'
-import {
-  CreateQuoteInput,
-  CurrencyEnum,
-  useCreateQuoteMutation,
-  useUpdateCustomerCurrencyForQuoteMutation,
-} from '~/generated/graphql'
+import { CreateQuoteInput, useCreateQuoteMutation } from '~/generated/graphql'
 
 gql`
   mutation createQuote($input: CreateQuoteInput!) {
@@ -19,13 +14,6 @@ gql`
       }
     }
   }
-
-  mutation updateCustomerCurrencyForQuote($input: UpdateCustomerInput!) {
-    updateCustomer(input: $input) {
-      id
-      currency
-    }
-  }
 `
 
 interface CreateQuoteValues {
@@ -33,9 +21,6 @@ interface CreateQuoteValues {
   orderType: CreateQuoteInput['orderType']
   subscriptionId?: string
   owners?: string[]
-  currency?: CurrencyEnum
-  customerExternalId?: string
-  hasCustomerCurrency?: boolean
 }
 
 interface UseCreateQuoteReturn {
@@ -45,8 +30,6 @@ interface UseCreateQuoteReturn {
 
 export const useCreateQuote = (): UseCreateQuoteReturn => {
   const navigate = useNavigate()
-
-  const [updateCustomerCurrency] = useUpdateCustomerCurrencyForQuoteMutation()
 
   const [createQuote, { loading }] = useCreateQuoteMutation({
     onCompleted({ createQuote: createdQuote }) {
@@ -68,18 +51,6 @@ export const useCreateQuote = (): UseCreateQuoteReturn => {
 
   const onSave = async (values: CreateQuoteValues): Promise<void> => {
     try {
-      if (!values.hasCustomerCurrency && values.currency && values.customerExternalId) {
-        await updateCustomerCurrency({
-          variables: {
-            input: {
-              id: values.customerId,
-              externalId: values.customerExternalId,
-              currency: values.currency,
-            },
-          },
-        })
-      }
-
       await createQuote({
         variables: {
           input: {
@@ -87,7 +58,6 @@ export const useCreateQuote = (): UseCreateQuoteReturn => {
             orderType: values.orderType,
             subscriptionId: values.subscriptionId || undefined,
             owners: values.owners,
-            currency: values.currency || undefined,
           },
         },
       })

--- a/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useOneOffPricingDrawer.tsx
@@ -180,9 +180,16 @@ const buildSurvivingAddOnItems = (
     })
     .filter((item): item is AddOnItem => item !== null)
 
+export interface OneOffPricingDrawerOptions {
+  /** Currency used to display amounts — may be a customer/organization fallback. */
+  currency?: CurrencyEnum | null
+  /** Whether `currency` is the quote's own currency rather than a fallback. */
+  hasQuoteCurrency?: boolean
+}
+
 export const useOneOffPricingDrawer = (
   initialBillingItems?: unknown,
-  quoteCurrency?: CurrencyEnum | null,
+  options?: OneOffPricingDrawerOptions,
 ): UseOneOffPricingDrawerReturn => {
   const { translate } = useInternationalization()
   const { organization } = useOrganizationInfos()
@@ -191,7 +198,11 @@ export const useOneOffPricingDrawer = (
   // The quote currency drives amount cents (de)serialization. Kept in a ref so
   // the stable callbacks (form onSubmit, syncEntitiesWithBlocks) always read the
   // latest value without depending on it.
-  const currency = quoteCurrency ?? organization?.defaultCurrency ?? CurrencyEnum.Usd
+  const currency = options?.currency ?? organization?.defaultCurrency ?? CurrencyEnum.Usd
+  const hasQuoteCurrency = !!options?.hasQuoteCurrency
+  const hasQuoteCurrencyRef = useRef(hasQuoteCurrency)
+
+  hasQuoteCurrencyRef.current = hasQuoteCurrency
   const currencyRef = useRef(currency)
 
   currencyRef.current = currency
@@ -199,6 +210,9 @@ export const useOneOffPricingDrawer = (
   const [entities, setEntities] = useState<Record<string, EntityData>>({})
   const payloadsRef = useRef<Record<string, AddOnPayload>>({})
   const catalogIdMapRef = useRef<Record<string, string>>({})
+  // Catalog currency of each selected add-on, used to seed the quote currency
+  // when the quote has none of its own yet.
+  const addOnCurrencyMapRef = useRef<Record<string, CurrencyEnum>>({})
 
   // Session cache of add-ons removed from the doc, keyed by localId, so a Cmd+Z
   // that re-inserts the pricing block can re-hydrate the entity, its catalog
@@ -211,6 +225,7 @@ export const useOneOffPricingDrawer = (
         attrs: PricingBlockAttributes,
         entityData: Record<string, EntityData>,
         billingItems?: BillingItemsPayload,
+        currency?: CurrencyEnum,
       ) => void | Promise<unknown>)
     | null
   >(null)
@@ -254,6 +269,7 @@ export const useOneOffPricingDrawer = (
   const captureAddOnPayload = useCallback(
     (localId: string, addOn: AddOnForPricingSectionFragment) => {
       catalogIdMapRef.current[localId] = addOn.id
+      addOnCurrencyMapRef.current[localId] = addOn.amountCurrency
       payloadsRef.current[localId] = {
         position: 0, // will be set correctly by toBillingItems
         code: addOn.code,
@@ -388,8 +404,17 @@ export const useOneOffPricingDrawer = (
         localEntityIds: confirmedItems.map((item) => item.localId),
       }
 
-      const result = (await onSaveRef.current?.(attrs, entityData, billingItems)) as
-        SavePricingResult | undefined
+      // The quote has no currency of its own yet: the first add-on defines it.
+      const seededCurrency = hasQuoteCurrencyRef.current
+        ? undefined
+        : addOnCurrencyMapRef.current[confirmedItems[0]?.localId]
+
+      const result = (await onSaveRef.current?.(
+        attrs,
+        entityData,
+        billingItems,
+        seededCurrency,
+      )) as SavePricingResult | undefined
 
       lastSaveResultRef.current = result ?? { ok: true }
 

--- a/src/pages/quotes/hooks/useOrderActions.ts
+++ b/src/pages/quotes/hooks/useOrderActions.ts
@@ -24,6 +24,15 @@ export const useOrderActions = () => {
   const getActions = (order: OrderListItemFragment): OrderAction[] => {
     const actions: OrderAction[] = []
 
+    // Execute manually — only for created (not yet executed) orders, requires ordersExecute
+    if (order.status === OrderStatusEnum.Created && hasPermissions(['ordersExecute'])) {
+      actions.push({
+        icon: 'flash',
+        label: translate('text_17836939541574skv5dmaj06'),
+        onAction: () => navigate(generatePath(EXECUTE_ORDER_ROUTE, { orderId: order.id })),
+      })
+    }
+
     // Edit — only for created (not yet executed) orders, requires ordersUpdate permission
     if (order.status === OrderStatusEnum.Created && hasPermissions(['ordersUpdate'])) {
       actions.push({
@@ -53,15 +62,6 @@ export const useOrderActions = () => {
             }),
           ).catch(() => undefined)
         },
-      })
-    }
-
-    // Execute manually — only for created (not yet executed) orders, requires ordersExecute
-    if (order.status === OrderStatusEnum.Created && hasPermissions(['ordersExecute'])) {
-      actions.push({
-        icon: 'flash',
-        label: translate('text_17836939541574skv5dmaj06'),
-        onAction: () => navigate(generatePath(EXECUTE_ORDER_ROUTE, { orderId: order.id })),
       })
     }
 

--- a/src/pages/quotes/hooks/useQuote.ts
+++ b/src/pages/quotes/hooks/useQuote.ts
@@ -7,6 +7,7 @@ gql`
     content
     billingItems
     mentionVariables
+    currency
   }
 
   fragment QuotePreviewCustomer on Customer {

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -44,7 +44,10 @@ export interface SubscriptionPricingDrawerOptions {
   onDatesChange?: (startDate?: string, endDate?: string) => void
   customer?: QuoteCustomer | null
   subscriptionId?: string
+  /** Currency used to display amounts — may be a customer/organization fallback. */
   currency?: CurrencyEnum | null
+  /** Whether `currency` is the quote's own currency rather than a fallback. */
+  hasQuoteCurrency?: boolean
 }
 
 export const useSubscriptionPricingDrawer = (
@@ -93,6 +96,7 @@ export const useSubscriptionPricingDrawer = (
         attrs: PricingBlockAttributes,
         entityData: Record<string, EntityData>,
         billingItems?: BillingItemsPayload,
+        currency?: CurrencyEnum,
       ) => void | Promise<unknown>)
     | null
   >(null)
@@ -164,6 +168,11 @@ export const useSubscriptionPricingDrawer = (
           },
         }
 
+        // The quote has no currency of its own yet: the selected plan defines it.
+        const seededCurrency = options?.hasQuoteCurrency
+          ? undefined
+          : (formValues?.amountCurrency as CurrencyEnum | undefined)
+
         const result = (await onSaveRef.current?.(
           { pricingType: 'plan', entityIds: [state.planId] },
           entityData,
@@ -171,6 +180,7 @@ export const useSubscriptionPricingDrawer = (
             ...latestBillingItemsRef.current,
             ...billingItems,
           },
+          seededCurrency,
         )) as SavePricingResult | undefined
 
         if (result?.ok === false) {
@@ -211,6 +221,7 @@ export const useSubscriptionPricingDrawer = (
             quoteDates={options?.quoteDates}
             customer={options?.customer}
             currency={options?.currency}
+            hasQuoteCurrency={options?.hasQuoteCurrency}
             billingItemPlan={billingItemPlan}
             subscriptionId={billingItemPlan ? undefined : options?.subscriptionId}
           />

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -60,6 +60,9 @@ export const useSubscriptionPricingDrawer = (
   const subscriptionStateRef = useRef<SubscriptionPricingState | null>(null)
   const formValuesRef = useRef<PlanFormInput | null>(null)
   const validatePlanFormRef = useRef<ValidatePlanForm | null>(null)
+  // The catalog plan's own form values, used to serialize only the fields the user
+  // really changed instead of overriding the plan wholesale (LAGO-1789).
+  const basePlanFormValuesRef = useRef<PlanFormInput | null>(null)
 
   // Latest saved billingItems, kept in a ref so plan saves/syncs can preserve
   // sibling categories (coupons, addons) instead of overwriting billingItems and
@@ -147,7 +150,11 @@ export const useSubscriptionPricingDrawer = (
           throw new Error('Invalid plan')
         }
 
-        const billingItems = toPlanBillingItems(state, formValues ?? undefined)
+        const billingItems = toPlanBillingItems(
+          state,
+          formValues ?? undefined,
+          basePlanFormValuesRef.current ?? undefined,
+        )
         const entityData: Record<string, EntityData> = {
           [state.planId]: {
             entityId: state.planId,
@@ -199,6 +206,7 @@ export const useSubscriptionPricingDrawer = (
             stateRef={subscriptionStateRef}
             formValuesRef={formValuesRef}
             validatePlanFormRef={validatePlanFormRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialStateRef.current}
             quoteDates={options?.quoteDates}
             customer={options?.customer}

--- a/src/pages/quotes/hooks/useUpdateQuote.ts
+++ b/src/pages/quotes/hooks/useUpdateQuote.ts
@@ -13,6 +13,7 @@ gql`
   mutation updateQuoteVersion($input: UpdateQuoteVersionInput!) {
     updateQuoteVersion(input: $input) {
       id
+      currency
     }
   }
 

--- a/translations/base.json
+++ b/translations/base.json
@@ -4584,5 +4584,9 @@
   "text_1786365890845pt4roxdajsk": "Product filter {{productFilterCode}} was updated",
   "text_1786365890845gfq9jteut9u": "Product",
   "text_1786365890846dgl39wcqgik": "Product category",
-  "text_1786365890846v53b5wwzxjh": "Product filter"
+  "text_1786365890846v53b5wwzxjh": "Product filter",
+  "text_1786367738116xtz2r6c9eoz": "Rate card {{rateCardCode}} was created",
+  "text_1786367738117541mevhwa63": "Rate card {{rateCardCode}} was deleted",
+  "text_1786367738117gbjclk29or1": "Rate card {{rateCardCode}} was updated",
+  "text_1786367738117s1n9lpwf97k": "Rate card"
 }


### PR DESCRIPTION
Follow-up to #4110, which shipped Product/ProductCategory/ProductFilter
but skipped RateCard since the backend wasn't ready. lago-api#5707
(open) now adds `RateCard` to the activity log resource union and
`rate_card.created/updated/deleted` activity types.

**Note:** this will fail typecheck until lago-api#5707 merges and
`pnpm codegen` is rerun to regenerate `RateCard`/`ActivityTypeEnum` in
`src/generated/graphql.tsx` — same informational-red state #4087 was
in ahead of the product-catalog merge.

- 3 new activity type labels + 1 resource type label (translation keys)
- Resource fragment member (`id` only, no rate card detail page yet)
- Description parameter keyed on `RateCard.code`