### PR TITLE
fix(quotes): Send quote plan overrides only for changed fields

### DIFF
--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
@@ -44,6 +44,7 @@ interface SubscriptionPricingContentProps {
   // Filled with a submit-and-report-validity function so the drawer can refuse to
   // persist an incomplete plan.
   validatePlanFormRef?: MutableRefObject<ValidatePlanForm | null>
+  basePlanFormValuesRef: MutableRefObject<PlanFormInput | null>
   initialState?: SubscriptionPricingState | null
   quoteDates?: { startDate?: string; endDate?: string }
   customer?: QuoteCustomer | null
@@ -56,6 +57,7 @@ export function SubscriptionPricingContent({
   stateRef,
   formValuesRef,
   validatePlanFormRef,
+  basePlanFormValuesRef,
   initialState,
   quoteDates,
   customer,
@@ -94,6 +96,7 @@ export function SubscriptionPricingContent({
     plan: planData,
     formReady,
     resolvedPlanId,
+    basePlanFormValues,
     subscriptionSettings: billingItemSubscriptionSettings,
     invoicingSettings: billingItemInvoicingSettings,
   } = usePlanFormSetup({
@@ -185,8 +188,9 @@ export function SubscriptionPricingContent({
   const basePlanName =
     planData?.name ?? billingItemPlan?.payload.name ?? initialState?.basePlanName ?? formName
 
-  // Sync to stateRef + formValuesRef. Overrides are no longer computed here:
-  // toPlanBillingItems() derives them from formValuesRef (see buildPlanOverrides).
+  // Sync to stateRef + formValuesRef + basePlanFormValuesRef. Overrides are no longer
+  // computed here: toPlanBillingItems() derives them from the two form value refs
+  // (see buildPlanOverrides).
   useEffect(() => {
     if (!formReady || !selectedPlanId) {
       stateRef.current = null
@@ -204,6 +208,7 @@ export function SubscriptionPricingContent({
     }
 
     formValuesRef.current = formValues
+    basePlanFormValuesRef.current = basePlanFormValues ?? null
   }, [
     formReady,
     planData,
@@ -215,8 +220,10 @@ export function SubscriptionPricingContent({
     formDescription,
     formCode,
     formValues,
+    basePlanFormValues,
     stateRef,
     formValuesRef,
+    basePlanFormValuesRef,
   ])
 
   // ComboBox data

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
@@ -84,6 +84,7 @@ jest.mock('~/generated/graphql', () => ({
 
 // Mock usePlanFormSetup — returns a mock form + plan when planIdToFetch is set
 let mockFormOverrides: Partial<PlanFormInput> = {}
+let mockBasePlanFormValues: PlanFormInput | undefined
 
 // Mirrors TanStack: handleSubmit only invokes onSubmit once the form-level
 // validators pass, which is what the component uses as its validity signal.
@@ -112,6 +113,7 @@ jest.mock('~/hooks/plans/usePlanFormSetup', () => {
         return {
           form,
           plan: planIdToFetch ? mockPlan : undefined,
+          basePlanFormValues: mockBasePlanFormValues,
           formReady: !!planIdToFetch,
           loading: false,
           resolvedPlanId: planIdToFetch,
@@ -169,6 +171,7 @@ describe('SubscriptionPricingContent', () => {
   beforeEach(() => {
     mockFormOverrides = {}
     mockFormPassesValidation = true
+    mockBasePlanFormValues = undefined
     mockOpenSubscriptionSettings.mockClear()
     mockOpenPlanSettings.mockClear()
   })
@@ -176,9 +179,16 @@ describe('SubscriptionPricingContent', () => {
   it('shows plan selection ComboBox without initial data', async () => {
     const stateRef = { current: null as SubscriptionPricingState | null }
     const formValuesRef = { current: null as PlanFormInput | null }
+    const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
     await act(() =>
-      render(<SubscriptionPricingContent stateRef={stateRef} formValuesRef={formValuesRef} />),
+      render(
+        <SubscriptionPricingContent
+          stateRef={stateRef}
+          formValuesRef={formValuesRef}
+          basePlanFormValuesRef={basePlanFormValuesRef}
+        />,
+      ),
     )
 
     // Should show ComboBox for plan selection
@@ -190,6 +200,7 @@ describe('SubscriptionPricingContent', () => {
   it('shows sections when initial plan is provided', async () => {
     const stateRef = { current: null as SubscriptionPricingState | null }
     const formValuesRef = { current: null as PlanFormInput | null }
+    const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
     const initialState: SubscriptionPricingState = {
       planId: 'plan_1',
@@ -206,6 +217,7 @@ describe('SubscriptionPricingContent', () => {
         <SubscriptionPricingContent
           stateRef={stateRef}
           formValuesRef={formValuesRef}
+          basePlanFormValuesRef={basePlanFormValuesRef}
           initialState={initialState}
         />,
       ),
@@ -222,6 +234,7 @@ describe('SubscriptionPricingContent', () => {
   it('syncs state to stateRef when plan is selected', async () => {
     const stateRef = { current: null as SubscriptionPricingState | null }
     const formValuesRef = { current: null as PlanFormInput | null }
+    const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
     const initialState: SubscriptionPricingState = {
       planId: 'plan_1',
@@ -238,6 +251,7 @@ describe('SubscriptionPricingContent', () => {
         <SubscriptionPricingContent
           stateRef={stateRef}
           formValuesRef={formValuesRef}
+          basePlanFormValuesRef={basePlanFormValuesRef}
           initialState={initialState}
         />,
       ),
@@ -251,9 +265,16 @@ describe('SubscriptionPricingContent', () => {
     it('WHEN rendered without initialState THEN stateRef remains null', async () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       await act(() =>
-        render(<SubscriptionPricingContent stateRef={stateRef} formValuesRef={formValuesRef} />),
+        render(
+          <SubscriptionPricingContent
+            stateRef={stateRef}
+            formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
+          />,
+        ),
       )
 
       // formReady is false and selectedPlanId is empty => stateRef.current = null (line 153-154)
@@ -292,6 +313,7 @@ describe('SubscriptionPricingContent', () => {
 
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       const initialState: SubscriptionPricingState = {
         planId: 'plan_1',
@@ -307,6 +329,7 @@ describe('SubscriptionPricingContent', () => {
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
           />,
         ),
@@ -328,6 +351,7 @@ describe('SubscriptionPricingContent', () => {
 
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       const initialState: SubscriptionPricingState = {
         planId: 'plan_1',
@@ -343,6 +367,7 @@ describe('SubscriptionPricingContent', () => {
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
           />,
         ),
@@ -360,6 +385,7 @@ describe('SubscriptionPricingContent', () => {
 
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       const initialState: SubscriptionPricingState = {
         planId: 'plan_1',
@@ -375,6 +401,7 @@ describe('SubscriptionPricingContent', () => {
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
           />,
         ),
@@ -400,12 +427,14 @@ describe('SubscriptionPricingContent', () => {
     it('WHEN a plan is selected THEN the invoicing & payments component is rendered', async () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       await act(() =>
         render(
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
             customer={mockCustomer}
           />,
@@ -418,12 +447,14 @@ describe('SubscriptionPricingContent', () => {
     it('WHEN no customer is provided THEN the invoicing & payments component is hidden', async () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       await act(() =>
         render(
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
           />,
         ),
@@ -448,12 +479,14 @@ describe('SubscriptionPricingContent', () => {
       const user = userEvent.setup()
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       await act(() =>
         render(
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
           />,
         ),
@@ -497,12 +530,14 @@ describe('SubscriptionPricingContent', () => {
     it('WHEN the user switches to a different plan THEN billingItemPlan is dropped so prices reset', async () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       await act(() =>
         render(
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
             billingItemPlan={billingItemPlan}
           />,
@@ -535,12 +570,14 @@ describe('SubscriptionPricingContent', () => {
     it('WHEN the user re-selects the original plan THEN billingItemPlan is preserved', async () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       await act(() =>
         render(
           <SubscriptionPricingContent
             stateRef={stateRef}
             formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialState}
             billingItemPlan={billingItemPlan}
           />,
@@ -559,6 +596,7 @@ describe('SubscriptionPricingContent', () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
       const formValuesRef = { current: null as PlanFormInput | null }
       const validatePlanFormRef = { current: null as (() => Promise<boolean>) | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
 
       const rendered = await act(() =>
         render(
@@ -566,6 +604,7 @@ describe('SubscriptionPricingContent', () => {
             stateRef={stateRef}
             formValuesRef={formValuesRef}
             validatePlanFormRef={validatePlanFormRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
           />,
         ),
       )
@@ -619,6 +658,75 @@ describe('SubscriptionPricingContent', () => {
 
         expect(validatePlanFormRef.current).toBeNull()
       })
+    })
+  })
+
+  describe('GIVEN the override diff baseline', () => {
+    const initialState: SubscriptionPricingState = {
+      planId: 'plan_1',
+      planCode: 'starter',
+      planName: 'Starter',
+      planDescription: '',
+      subscriptionSettings: DEFAULT_SUBSCRIPTION_SETTINGS,
+      invoicingSettings: DEFAULT_INVOICING_SETTINGS,
+      overrides: {},
+    }
+
+    // Seed the base ref (optionally with a stale leftover) and render, returning the
+    // refs so each test can assert how the sync effect wrote them.
+    const renderWithRefs = async (basePlanFormValuesInit: PlanFormInput | null = null) => {
+      const stateRef = { current: null as SubscriptionPricingState | null }
+      const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: basePlanFormValuesInit }
+
+      await act(() =>
+        render(
+          <SubscriptionPricingContent
+            stateRef={stateRef}
+            formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
+            initialState={initialState}
+          />,
+        ),
+      )
+
+      return { stateRef, basePlanFormValuesRef }
+    }
+
+    it('WHEN the catalog plan values are available THEN basePlanFormValuesRef captures them', async () => {
+      mockBasePlanFormValues = {
+        name: 'Starter',
+        code: 'starter',
+        interval: PlanInterval.Monthly,
+        amountCents: '5000',
+        amountCurrency: CurrencyEnum.Usd,
+        charges: [],
+        fixedCharges: [],
+        entitlements: [],
+      } as unknown as PlanFormInput
+
+      const { basePlanFormValuesRef } = await renderWithRefs()
+
+      expect(basePlanFormValuesRef.current).toEqual(mockBasePlanFormValues)
+    })
+
+    it('WHEN no catalog plan values are available THEN the ref is cleared, not left stale', async () => {
+      // A leftover value from a previous plan: the sync must overwrite it, otherwise a
+      // stale baseline would be diffed against the new plan.
+      const { stateRef, basePlanFormValuesRef } = await renderWithRefs({
+        name: 'Previous plan',
+      } as unknown as PlanFormInput)
+
+      expect(stateRef.current).not.toBeNull()
+      expect(basePlanFormValuesRef.current).toBeNull()
+    })
+
+    it('WHEN the baseline has not arrived yet THEN the pricing sections still render', async () => {
+      await renderWithRefs()
+
+      // The plan query is cache-and-network, so it reports loading on every open —
+      // the drawer must not blank out waiting for the diff baseline.
+      expect(screen.getByTestId('fixed-charges-section')).toBeInTheDocument()
     })
   })
 })

--- a/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
+++ b/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
@@ -411,6 +411,198 @@ describe('buildPlanOverrides', () => {
 })
 
 // ---------------------------------------------------------------------------
+// buildPlanOverrides — diff against the catalog plan baseline (LAGO-1789)
+// ---------------------------------------------------------------------------
+
+describe('buildPlanOverrides with a catalog plan baseline', () => {
+  const fixedCharge = {
+    addOn: { code: 'setup_fee' },
+    chargeModel: FixedChargeChargeModelEnum.Standard,
+    properties: { amount: '100' },
+  } as unknown as PlanFormInput['fixedCharges'][number]
+
+  const usageCharge = {
+    billableMetric: { code: 'api_calls' },
+    chargeModel: ChargeModelEnum.Standard,
+    properties: { amount: '0.01' },
+  } as unknown as PlanFormInput['charges'][number]
+
+  // A plan carrying every overridable field, so an untouched save proves each one
+  // is diffed and not blindly forwarded.
+  const fullyConfiguredPlan: PlanFormInput = {
+    ...baseFormValues,
+    invoiceDisplayName: 'Platform fee',
+    fixedCharges: [fixedCharge],
+    charges: [usageCharge],
+    minimumCommitment: {
+      amountCents: '5000',
+      invoiceDisplayName: 'Annual minimum',
+      commitmentType: CommitmentTypeEnum.MinimumCommitment,
+    },
+    nonRecurringUsageThresholds: [
+      { amountCents: 10000, thresholdDisplayName: 'Tier 1', recurring: false },
+    ] as PlanFormInput['nonRecurringUsageThresholds'],
+    recurringUsageThreshold: {
+      amountCents: 50000,
+      thresholdDisplayName: 'Monthly cap',
+      recurring: true,
+    } as PlanFormInput['recurringUsageThreshold'],
+  }
+
+  it('returns no overrides when the form matches the catalog plan', () => {
+    expect(buildPlanOverrides(baseFormValues, baseFormValues)).toEqual({})
+  })
+
+  it('returns no overrides for an untouched plan that configures every field', () => {
+    expect(buildPlanOverrides(fullyConfiguredPlan, fullyConfiguredPlan)).toEqual({})
+  })
+
+  it('emits only the subscription fee when only the fee changed', () => {
+    const result = buildPlanOverrides(
+      { ...fullyConfiguredPlan, amountCents: '900.00' },
+      fullyConfiguredPlan,
+    )
+
+    expect(result).toEqual({ amountCents: 90000 })
+  })
+
+  it('emits only the invoice display name when only that changed', () => {
+    const result = buildPlanOverrides(
+      { ...fullyConfiguredPlan, invoiceDisplayName: 'Acme platform fee' },
+      fullyConfiguredPlan,
+    )
+
+    expect(result).toEqual({ invoiceDisplayName: 'Acme platform fee' })
+  })
+
+  it('emits the whole charges array when a single charge property changed', () => {
+    const result = buildPlanOverrides(
+      {
+        ...fullyConfiguredPlan,
+        charges: [
+          { ...usageCharge, properties: { amount: '0.02' } } as PlanFormInput['charges'][number],
+        ],
+      },
+      fullyConfiguredPlan,
+    )
+
+    // The backend replaces the whole usage charge set, so a single edit sends them
+    // all. Fixed charges live under overrides.fixedCharges and stay untouched here.
+    expect(Object.keys(result)).toEqual(['charges'])
+    expect(result.charges).toHaveLength(1)
+    expect(result.charges?.[0]).toEqual({
+      billableMetricCode: 'api_calls',
+      chargeModel: ChargeModelEnum.Standard,
+      properties: { amount: '0.02' },
+    })
+  })
+
+  it('emits only the minimum commitment when only that changed', () => {
+    const result = buildPlanOverrides(
+      {
+        ...fullyConfiguredPlan,
+        minimumCommitment: {
+          amountCents: '7000',
+          invoiceDisplayName: 'Annual minimum',
+          commitmentType: CommitmentTypeEnum.MinimumCommitment,
+        },
+      },
+      fullyConfiguredPlan,
+    )
+
+    expect(result).toEqual({
+      minimumCommitment: { amountCents: 700000, invoiceDisplayName: 'Annual minimum' },
+    })
+  })
+
+  it('emits only the usage thresholds when only those changed', () => {
+    const result = buildPlanOverrides(
+      {
+        ...fullyConfiguredPlan,
+        recurringUsageThreshold: {
+          amountCents: 60000,
+          thresholdDisplayName: 'Monthly cap',
+          recurring: true,
+        } as PlanFormInput['recurringUsageThreshold'],
+      },
+      fullyConfiguredPlan,
+    )
+
+    expect(Object.keys(result)).toEqual(['usageThresholds'])
+    expect(result.usageThresholds).toEqual([
+      { amountCents: 1000000, recurring: false, thresholdDisplayName: 'Tier 1' },
+      { amountCents: 6000000, recurring: true, thresholdDisplayName: 'Monthly cap' },
+    ])
+  })
+
+  it('keeps every configured field when no baseline is provided', () => {
+    const result = buildPlanOverrides(fullyConfiguredPlan)
+
+    expect(result.amountCents).toBe(85000)
+    expect(result.invoiceDisplayName).toBe('Platform fee')
+    expect(result.charges).toHaveLength(1)
+    expect(result.fixedCharges).toHaveLength(1)
+    expect(result.minimumCommitment).toBeDefined()
+    expect(result.usageThresholds).toHaveLength(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// toPlanBillingItems — baseline forwarding (LAGO-1789)
+// ---------------------------------------------------------------------------
+
+describe('toPlanBillingItems with a catalog plan baseline', () => {
+  it('produces empty overrides for an unedited plan', () => {
+    const result = toPlanBillingItems(basePricingState, baseFormValues, baseFormValues)
+
+    expect(result.plans[0].overrides).toEqual({})
+  })
+
+  it('keeps the payload snapshot even when nothing is overridden', () => {
+    const result = toPlanBillingItems(basePricingState, baseFormValues, baseFormValues)
+
+    expect(result.plans[0].payload.amountCents).toBe('85000')
+    expect(result.plans[0].payload.interval).toBe(PlanInterval.Monthly)
+  })
+
+  it('still emits the renamed plan alongside an otherwise unedited form', () => {
+    const result = toPlanBillingItems(
+      basePricingState,
+      { ...baseFormValues, name: 'Enterprise Plan - Acme' },
+      baseFormValues,
+    )
+
+    expect(result.plans[0].overrides).toEqual({ name: 'Enterprise Plan - Acme' })
+  })
+
+  // The real edit flow never compares two copies of the same object: the form values
+  // come back from the stored quote payload (a JSON round-trip that dropped every
+  // explicitly-undefined key) while the baseline comes straight from the plan query
+  // (which carries __typename and keeps those keys). Both must still read as unchanged.
+  it('produces empty overrides when the form is a payload round-trip of the baseline', () => {
+    const baselineCharge = {
+      billableMetric: { code: 'api_calls', __typename: 'BillableMetric' },
+      chargeModel: ChargeModelEnum.Graduated,
+      properties: {
+        amount: undefined,
+        graduatedRanges: [
+          { fromValue: 0, toValue: 10, perUnitAmount: '1', flatAmount: '0', __typename: 'Range' },
+        ],
+        __typename: 'Properties',
+      },
+    } as unknown as PlanFormInput['charges'][number]
+
+    const baseline: PlanFormInput = { ...baseFormValues, charges: [baselineCharge] }
+    // What fromPlanBillingItems hands back after the payload was stored as JSON.
+    const roundTripped: PlanFormInput = JSON.parse(JSON.stringify(baseline))
+
+    const result = toPlanBillingItems(basePricingState, roundTripped, baseline)
+
+    expect(result.plans[0].overrides).toEqual({})
+  })
+})
+
+// ---------------------------------------------------------------------------
 // fromPlanBillingItems — existing tests
 // ---------------------------------------------------------------------------
 

--- a/src/core/serializers/serializeQuotePlanBillingItems.ts
+++ b/src/core/serializers/serializeQuotePlanBillingItems.ts
@@ -4,6 +4,7 @@ import type {
   LocalUsageChargeInput,
   PlanFormInput,
 } from '~/components/plans/types'
+import { comparable } from '~/core/utils/comparableValue'
 import { CommitmentTypeEnum, CurrencyEnum } from '~/generated/graphql'
 
 import { buildPlanPreviewData } from './buildPlanPreviewData'
@@ -317,13 +318,14 @@ const serializeFixedCharge = (charge: LocalFixedChargeInput): SerializedFixedCha
 }
 
 /**
- * Builds the camelCase `overrides` payload from the plan form state.
+ * Maps the plan form state to the camelCase `overrides` payload, with no regard
+ * for what the catalog plan holds.
  *
  * This is the single source of truth for the form → override mapping: it is
  * derived from the same `PlanFormInput` that feeds the plan `payload`, so the
  * two can't silently drift when a charge field is added.
  */
-export const buildPlanOverrides = (formValues: PlanFormInput): PlanOverrides => {
+const buildRawPlanOverrides = (formValues: PlanFormInput): PlanOverrides => {
   const overrides: PlanOverrides = {}
 
   // Form amounts are in currency units (e.g. "10" for $10); the backend
@@ -331,9 +333,9 @@ export const buildPlanOverrides = (formValues: PlanFormInput): PlanOverrides => 
   const currency = (formValues.amountCurrency as CurrencyEnum) ?? CurrencyEnum.Usd
 
   // Subscription fee
-  overrides.amountCents = Number(formValues.amountCents)
-    ? serializeAmount(formValues.amountCents, currency)
-    : undefined
+  if (Number(formValues.amountCents)) {
+    overrides.amountCents = serializeAmount(formValues.amountCents, currency)
+  }
   if (formValues.invoiceDisplayName) {
     overrides.invoiceDisplayName = formValues.invoiceDisplayName || undefined
   }
@@ -390,9 +392,52 @@ export const buildPlanOverrides = (formValues: PlanFormInput): PlanOverrides => 
   return overrides
 }
 
+/**
+ * Builds the `overrides` payload the backend uses to decide whether the quote
+ * creates an overridden subscription — so it must contain ONLY the fields the
+ * user actually changed relative to the catalog plan. Without `basePlanFormValues`
+ * every configured field is sent and every quoted subscription ends up
+ * overridden (LAGO-1789).
+ *
+ * Both sides run through `buildRawPlanOverrides` on purpose: the current form
+ * values and the baseline reach this function from different origins (a saved
+ * quote payload vs. a freshly fetched plan), and mapping them identically makes
+ * their representation differences cancel out instead of reading as changes.
+ * `comparable` finishes the job on the differences the mapping can't erase —
+ * `__typename` on the fetched side, keys the stored JSON dropped because their
+ * value was `undefined` on the payload side.
+ *
+ * Fields are dropped from the raw result rather than copied into a fresh object,
+ * so a new override field added to `buildRawPlanOverrides` is diffed without
+ * having to be repeated here. Every field is all-or-nothing (the backend replaces
+ * the whole charge set, so a single edited charge means sending them all).
+ */
+export const buildPlanOverrides = (
+  formValues: PlanFormInput,
+  basePlanFormValues?: PlanFormInput,
+): PlanOverrides => {
+  const overrides = buildRawPlanOverrides(formValues)
+
+  // With a baseline, drop the fields that match the catalog plan. Without one
+  // (catalog not loaded, or a caller that has none) keep the every-field
+  // behavior rather than silently dropping real overrides.
+  if (basePlanFormValues) {
+    const base = buildRawPlanOverrides(basePlanFormValues)
+
+    for (const key of Object.keys(overrides) as Array<keyof PlanOverrides>) {
+      if (comparable(overrides[key]) === comparable(base[key])) {
+        delete overrides[key]
+      }
+    }
+  }
+
+  return overrides
+}
+
 export const toPlanBillingItems = (
   state: SubscriptionPricingState,
   formValues?: PlanFormInput,
+  basePlanFormValues?: PlanFormInput,
 ): { plans: BillingItemPlan[] } => {
   const { planId, planCode, planName, planDescription, subscriptionSettings, invoicingSettings } =
     state
@@ -403,7 +448,9 @@ export const toPlanBillingItems = (
 
   // Derive overrides from the form values (single source of truth). Fall back to
   // any pre-built overrides on the state for callers that serialize without form values.
-  const overrides = formValues ? buildPlanOverrides(formValues) : (state.overrides ?? {})
+  const overrides = formValues
+    ? buildPlanOverrides(formValues, basePlanFormValues)
+    : (state.overrides ?? {})
 
   // The renamed plan goes into `overrides.name` (backend applies plan changes from
   // `overrides`), and only when it actually differs from the base — mirroring the

--- a/src/core/utils/__tests__/comparableValue.test.ts
+++ b/src/core/utils/__tests__/comparableValue.test.ts
@@ -1,0 +1,79 @@
+import { comparable, sortedWithoutTypename } from '../comparableValue'
+
+describe('sortedWithoutTypename', () => {
+  describe('GIVEN an object graph', () => {
+    describe('WHEN it carries __typename keys', () => {
+      it('THEN should drop them at every depth', () => {
+        const result = sortedWithoutTypename({
+          __typename: 'Plan',
+          charges: [{ __typename: 'Charge', properties: { __typename: 'Props', amount: '1' } }],
+        })
+
+        expect(result).toEqual({ charges: [{ properties: { amount: '1' } }] })
+      })
+    })
+
+    describe('WHEN keys are declared in different orders', () => {
+      it('THEN should produce the same sorted shape', () => {
+        expect(sortedWithoutTypename({ b: 1, a: 2 })).toEqual(sortedWithoutTypename({ a: 2, b: 1 }))
+        expect(Object.keys(sortedWithoutTypename({ b: 1, a: 2 }) as object)).toEqual(['a', 'b'])
+      })
+    })
+
+    describe('WHEN it holds primitives and null', () => {
+      it.each([
+        ['a string', 'value'],
+        ['a number', 42],
+        ['a boolean', true],
+        ['null', null],
+        ['undefined', undefined],
+      ])('THEN should return %s unchanged', (_, value) => {
+        expect(sortedWithoutTypename(value)).toBe(value)
+      })
+    })
+
+    describe('WHEN arrays hold objects', () => {
+      it('THEN should preserve array order', () => {
+        const result = sortedWithoutTypename([{ b: 1, a: 2 }, { c: 3 }])
+
+        expect(result).toEqual([{ a: 2, b: 1 }, { c: 3 }])
+      })
+    })
+  })
+})
+
+describe('comparable', () => {
+  describe('GIVEN two values built by different code paths', () => {
+    describe('WHEN they differ only by key order', () => {
+      it('THEN should compare equal', () => {
+        expect(comparable({ a: 1, b: 2 })).toBe(comparable({ b: 2, a: 1 }))
+      })
+    })
+
+    describe('WHEN one side carries __typename', () => {
+      it('THEN should compare equal', () => {
+        expect(comparable({ code: 'api', __typename: 'Metric' })).toBe(comparable({ code: 'api' }))
+      })
+    })
+
+    describe('WHEN one side has an explicitly-undefined key the other dropped', () => {
+      it('THEN should compare equal', () => {
+        // This is the JSON round-trip a stored quote payload goes through.
+        expect(comparable({ amount: '1', rate: undefined })).toBe(comparable({ amount: '1' }))
+      })
+    })
+
+    describe('WHEN a value really differs', () => {
+      it('THEN should compare unequal', () => {
+        expect(comparable({ amount: '1' })).not.toBe(comparable({ amount: '2' }))
+      })
+    })
+
+    describe('WHEN a key is missing on one side with a null value on the other', () => {
+      it('THEN should compare unequal', () => {
+        // null survives JSON, so it stays a real difference — unlike undefined.
+        expect(comparable({ amount: null })).not.toBe(comparable({}))
+      })
+    })
+  })
+})

--- a/src/core/utils/comparableValue.ts
+++ b/src/core/utils/comparableValue.ts
@@ -1,0 +1,29 @@
+/**
+ * Recursively drops `__typename` and sorts object keys so two values produced by
+ * the same serialization compare equal regardless of key order / `__typename`.
+ */
+export const sortedWithoutTypename = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(sortedWithoutTypename)
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => key !== '__typename')
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, entry]) => [key, sortedWithoutTypename(entry)]),
+    )
+  }
+
+  return value
+}
+
+/**
+ * A stable string form of `value`, suitable for equality checks between two
+ * values that describe the same thing but were built by different code paths.
+ *
+ * On top of key order and `__typename`, the `JSON.stringify` also erases
+ * explicitly-`undefined` keys — which is what makes a value rebuilt from a
+ * stored JSON payload (where those keys were dropped on write) compare equal to
+ * a freshly built one (where they are present and `undefined`).
+ */
+export const comparable = (value: unknown): string => JSON.stringify(sortedWithoutTypename(value))

--- a/src/hooks/customer/useAddSubscription.tsx
+++ b/src/hooks/customer/useAddSubscription.tsx
@@ -16,6 +16,7 @@ import {
   useNavigate,
 } from '~/core/router'
 import { serializePlanInput } from '~/core/serializers'
+import { comparable } from '~/core/utils/comparableValue'
 import {
   BillingTimeEnum,
   CreateSubscriptionInput,
@@ -137,25 +138,6 @@ type UseAddSubscription = (args: {
   billingTime?: BillingTimeEnum
   subscriptionAt?: string
 }) => UseAddSubscriptionReturn
-
-// Recursively drops __typename and sorts object keys so two values produced by
-// the same serialization compare equal regardless of key order / __typename.
-const sortedWithoutTypename = (value: unknown): unknown => {
-  if (Array.isArray(value)) return value.map(sortedWithoutTypename)
-
-  if (value !== null && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .filter(([key]) => key !== '__typename')
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([key, entry]) => [key, sortedWithoutTypename(entry)]),
-    )
-  }
-
-  return value
-}
-
-const comparable = (value: unknown): string => JSON.stringify(sortedWithoutTypename(value))
 
 // The override-meaningful content of a (serialized + cleaned) fixed charge,
 // excluding `units` (compared separately) and identity fields. The edit drawer

--- a/src/hooks/plans/__tests__/usePlanFormSetup.test.ts
+++ b/src/hooks/plans/__tests__/usePlanFormSetup.test.ts
@@ -388,6 +388,92 @@ describe('usePlanFormSetup', () => {
     })
   })
 
+  describe('GIVEN the override diff baseline (LAGO-1789)', () => {
+    describe('WHEN a plan id resolves', () => {
+      it('THEN should query the catalog plan even though the form query is skipped', () => {
+        const billingItemPlan = { id: 'plan-from-billing', payload: {}, overrides: {} }
+
+        mockFromPlanBillingItems.mockReturnValue({
+          formValues: { name: 'From Billing' },
+          subscriptionSettings: {},
+          invoicingSettings: {},
+        })
+
+        renderHook(() => usePlanFormSetup({ billingItemPlan: billingItemPlan as never }))
+
+        expect(mockUseGetSinglePlanQuery).toHaveBeenCalledWith(
+          expect.objectContaining({ skip: false, variables: { id: 'plan-from-billing' } }),
+        )
+      })
+
+      it('THEN should build the baseline with the catalog plan own currency', () => {
+        const billingItemPlan = { id: 'plan-from-billing', payload: {}, overrides: {} }
+
+        mockFromPlanBillingItems.mockReturnValue({
+          formValues: { name: 'From Billing' },
+          subscriptionSettings: {},
+          invoicingSettings: {},
+        })
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: { plan: { ...mockPlan, amountCurrency: 'EUR' } },
+          loading: false,
+          error: undefined,
+        })
+
+        renderHook(() => usePlanFormSetup({ billingItemPlan: billingItemPlan as never }))
+
+        // The form side is hydrated from the billing item (no plan, USD default), so an
+        // EUR call can only come from the baseline.
+        expect(mockBuildDefaultValues).toHaveBeenCalledWith(
+          expect.objectContaining({ amountCurrency: 'EUR' }),
+          FORM_TYPE_ENUM.creation,
+          CurrencyEnum.Eur,
+          false,
+        )
+      })
+    })
+
+    describe('WHEN no plan id resolves', () => {
+      it('THEN should skip the baseline query and expose no baseline', () => {
+        const { result } = renderHook(() => usePlanFormSetup({}))
+
+        expect(result.current.basePlanFormValues).toBeUndefined()
+        expect(mockUseGetSinglePlanQuery).toHaveBeenCalledWith(
+          expect.objectContaining({ skip: true }),
+        )
+      })
+    })
+
+    describe('WHEN the form query already fetched the plan (case 4)', () => {
+      it('THEN should not fire a second query for the baseline', () => {
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: { plan: mockPlan },
+          loading: false,
+          error: undefined,
+        })
+
+        renderHook(() => usePlanFormSetup({ planIdToFetch: 'plan-123' }))
+
+        const skipFlags = mockUseGetSinglePlanQuery.mock.calls.map((call) => call[0].skip)
+
+        // One live query (the form's) — the baseline reuses its result.
+        expect(skipFlags.filter((skip) => skip === false)).toHaveLength(1)
+      })
+
+      it('THEN should still expose a baseline built from that plan', () => {
+        mockUseGetSinglePlanQuery.mockReturnValue({
+          data: { plan: mockPlan },
+          loading: false,
+          error: undefined,
+        })
+
+        const { result } = renderHook(() => usePlanFormSetup({ planIdToFetch: 'plan-123' }))
+
+        expect(result.current.basePlanFormValues).toEqual({ name: 'default-plan' })
+      })
+    })
+  })
+
   describe('GIVEN the hook returns error from plan query', () => {
     describe('WHEN the plan query errors', () => {
       it('THEN should expose the error', () => {

--- a/src/hooks/plans/usePlanFormSetup.ts
+++ b/src/hooks/plans/usePlanFormSetup.ts
@@ -119,6 +119,26 @@ export const usePlanFormSetup = ({
   const currency =
     initialCurrency || (effectivePlan?.amountCurrency as CurrencyEnum) || CurrencyEnum.Usd
 
+  // Baseline: the catalog plan untouched by the form, used by the quote serializer
+  // to emit only the fields the user really overrode (LAGO-1789). Case 4 already has
+  // it in `plan`; only cases 2 and 3 — which hydrate the form from a quote payload or
+  // a subscription and skip the query above — need to fetch it.
+  const { data: basePlanData } = useGetSinglePlanQuery({
+    context: { silentError: LagoApiError.NotFound },
+    variables: { id: resolvedPlanId as string },
+    skip: !resolvedPlanId || !skipPlanQuery,
+  })
+  const basePlan = plan ?? basePlanData?.plan
+  const baseCurrency =
+    initialCurrency || (basePlan?.amountCurrency as CurrencyEnum) || CurrencyEnum.Usd
+  const basePlanFormValues = useMemo(
+    () =>
+      basePlan
+        ? buildDefaultValues(basePlan, formType, baseCurrency, hasAnyPricingUnitConfigured)
+        : undefined,
+    [basePlan, formType, baseCurrency, hasAnyPricingUnitConfigured],
+  )
+
   const form = useAppForm({
     defaultValues:
       billingItemData?.formValues ??
@@ -170,6 +190,7 @@ export const usePlanFormSetup = ({
   return {
     form,
     plan: effectivePlan as EditPlanFragment | undefined,
+    basePlanFormValues,
     formReady,
     loading,
     error,

--- a/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
+++ b/src/hooks/plans/useSubscriptionFixedChargeMutations.ts
@@ -3,6 +3,7 @@ import { gql, useApolloClient } from '@apollo/client'
 import { LocalFixedChargeInput } from '~/components/plans/types'
 import { addToast } from '~/core/apolloClient'
 import { serializeFixedChargeProperties } from '~/core/serializers/serializePlanInput'
+import { sortedWithoutTypename } from '~/core/utils/comparableValue'
 import {
   FixedChargeForDetailsV2Fragment,
   UpdateSubscriptionFixedChargeInput,
@@ -42,24 +43,6 @@ type Args = {
   // row showing the stale plan default. When absent, falls back to the
   // name-based refresh.
   refetchOverrides?: () => Promise<unknown>
-}
-
-// Recursively drops __typename and sorts object keys, so cached values
-// (with __typename, selection-set key order) compare equal to drawer values
-// (no __typename, form key order) when nothing changed.
-const sortedWithoutTypename = (value: unknown): unknown => {
-  if (Array.isArray(value)) return value.map(sortedWithoutTypename)
-
-  if (value !== null && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .filter(([key]) => key !== '__typename')
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([key, entry]) => [key, sortedWithoutTypename(entry)]),
-    )
-  }
-
-  return value
 }
 
 const comparableProperties = (

--- a/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
@@ -1,8 +1,10 @@
 import { act, renderHook } from '@testing-library/react'
 
+import type { PlanFormInput } from '~/components/plans/types'
 import { addToast } from '~/core/apolloClient'
 import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBillingItems'
 import type { SubscriptionPricingState } from '~/core/serializers/serializeQuotePlanBillingItems'
+import { CurrencyEnum, PlanInterval } from '~/generated/graphql'
 import { QUOTE_SAVE_FAILED_TOAST_KEY } from '~/pages/quotes/utils/quoteSaveErrorKeys'
 import { render } from '~/test-utils'
 
@@ -21,6 +23,8 @@ const mockDrawerClose = jest.fn()
 // State the mocked content component hydrates into the hook's stateRef on render.
 // `null` keeps the ref empty (exercises the early-return branch in handleSave).
 let mockInjectedState: SubscriptionPricingState | null = null
+let mockInjectedFormValues: PlanFormInput | null = null
+let mockInjectedBasePlanFormValues: PlanFormInput | null = null
 
 // Verdict the mocked content component reports through validatePlanFormRef.
 // `null` leaves the ref unfilled, as when the content component never mounted.
@@ -37,19 +41,30 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 }))
 
 // Mock SubscriptionPricingContent — on render it hydrates the shared stateRef
-// so the drawer's submit handler has a subscription state to serialize.
+// so the drawer's submit handler has a subscription state to serialize, plus the
+// form values and their catalog-plan baseline used to diff the overrides.
 jest.mock(
   '~/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent',
   () => ({
     SubscriptionPricingContent: ({
       stateRef,
+      formValuesRef,
+      basePlanFormValuesRef,
       validatePlanFormRef,
     }: {
       stateRef?: { current: SubscriptionPricingState | null }
+      formValuesRef?: { current: PlanFormInput | null }
+      basePlanFormValuesRef?: { current: PlanFormInput | null }
       validatePlanFormRef?: { current: (() => Promise<boolean>) | null }
     }) => {
       if (stateRef) {
         stateRef.current = mockInjectedState
+      }
+      if (formValuesRef) {
+        formValuesRef.current = mockInjectedFormValues
+      }
+      if (basePlanFormValuesRef) {
+        basePlanFormValuesRef.current = mockInjectedBasePlanFormValues
       }
 
       if (validatePlanFormRef) {
@@ -67,6 +82,8 @@ describe('useSubscriptionPricingDrawer', () => {
     jest.clearAllMocks()
     mockInjectedState = null
     mockPlanFormValid = null
+    mockInjectedFormValues = null
+    mockInjectedBasePlanFormValues = null
   })
 
   it('returns the expected interface', () => {
@@ -536,6 +553,88 @@ describe('useSubscriptionPricingDrawer', () => {
     expect(mockAddToast).toHaveBeenCalledWith({
       severity: 'danger',
       translateKey: QUOTE_SAVE_FAILED_TOAST_KEY,
+    })
+  })
+
+  describe('override diff baseline (LAGO-1789)', () => {
+    const planState: SubscriptionPricingState = {
+      planId: 'plan_123',
+      planCode: 'enterprise',
+      planName: 'Enterprise Plan',
+      basePlanName: 'Enterprise Plan',
+      planDescription: '',
+      subscriptionSettings: {
+        externalId: '',
+        subscriptionName: '',
+        billingTime: 'anniversary',
+        startDate: '2023-07-26',
+        endDate: '',
+      },
+      invoicingSettings: { paymentMethodId: '', invoiceCustomFooter: '' },
+      overrides: {},
+    }
+
+    const catalogFormValues = {
+      name: 'Enterprise Plan',
+      code: 'enterprise',
+      description: '',
+      interval: PlanInterval.Monthly,
+      amountCents: '850.00',
+      amountCurrency: CurrencyEnum.Usd,
+      payInAdvance: false,
+      trialPeriod: 0,
+      charges: [],
+      fixedCharges: [],
+      entitlements: [],
+    } as unknown as PlanFormInput
+
+    const saveAndReadPlan = async (): Promise<{ overrides: Record<string, unknown> }> => {
+      const onSave = jest.fn().mockResolvedValue({ ok: true })
+      const { result } = renderHook(() => useSubscriptionPricingDrawer(undefined))
+
+      act(() => {
+        result.current.onPricingCommand({ onSave })
+      })
+
+      const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+      render(openArgs.children)
+
+      await act(async () => {
+        await openArgs.form.submit()
+      })
+
+      return onSave.mock.calls[0][2].plans[0]
+    }
+
+    it('sends no overrides when the form matches the catalog plan', async () => {
+      mockInjectedState = planState
+      mockInjectedFormValues = catalogFormValues
+      mockInjectedBasePlanFormValues = catalogFormValues
+
+      const plan = await saveAndReadPlan()
+
+      expect(plan.overrides).toEqual({})
+    })
+
+    it('sends only the edited field when the form differs from the catalog plan', async () => {
+      mockInjectedState = planState
+      mockInjectedFormValues = { ...catalogFormValues, amountCents: '900.00' }
+      mockInjectedBasePlanFormValues = catalogFormValues
+
+      const plan = await saveAndReadPlan()
+
+      expect(plan.overrides).toEqual({ amountCents: 90000 })
+    })
+
+    it('falls back to sending every configured field when no baseline is available', async () => {
+      mockInjectedState = planState
+      mockInjectedFormValues = catalogFormValues
+      mockInjectedBasePlanFormValues = null
+
+      const plan = await saveAndReadPlan()
+
+      expect(plan.overrides).toEqual({ amountCents: 85000 })
     })
   })
 })

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -60,6 +60,9 @@ export const useSubscriptionPricingDrawer = (
   const subscriptionStateRef = useRef<SubscriptionPricingState | null>(null)
   const formValuesRef = useRef<PlanFormInput | null>(null)
   const validatePlanFormRef = useRef<ValidatePlanForm | null>(null)
+  // The catalog plan's own form values, used to serialize only the fields the user
+  // really changed instead of overriding the plan wholesale (LAGO-1789).
+  const basePlanFormValuesRef = useRef<PlanFormInput | null>(null)
 
   // Latest saved billingItems, kept in a ref so plan saves/syncs can preserve
   // sibling categories (coupons, addons) instead of overwriting billingItems and
@@ -147,7 +150,11 @@ export const useSubscriptionPricingDrawer = (
           throw new Error('Invalid plan')
         }
 
-        const billingItems = toPlanBillingItems(state, formValues ?? undefined)
+        const billingItems = toPlanBillingItems(
+          state,
+          formValues ?? undefined,
+          basePlanFormValuesRef.current ?? undefined,
+        )
         const entityData: Record<string, EntityData> = {
           [state.planId]: {
             entityId: state.planId,
@@ -199,6 +206,7 @@ export const useSubscriptionPricingDrawer = (
             stateRef={subscriptionStateRef}
             formValuesRef={formValuesRef}
             validatePlanFormRef={validatePlanFormRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
             initialState={initialStateRef.current}
             quoteDates={options?.quoteDates}
             customer={options?.customer}


### PR DESCRIPTION
## Context

Subscriptions created from a quote were always flagged as overridden, even
when the user picked a plan and changed nothing (same currency, same plan
information). The quote serializer emitted the plan `overrides` payload
unconditionally from the current form state — it never compared against the
catalog plan — so every quoted subscription carried a non-empty `overrides`
object and the backend created an override child plan.

## Description

- `buildPlanOverrides` now diffs each override key against a baseline built
  from the untouched catalog plan and keeps only the fields that actually
  differ; when nothing changed, `overrides` is `{}`. The raw mapping is split
  into `buildRawPlanOverrides` and both sides run through it so representation
  differences (payload-derived vs freshly fetched plan) cancel out.
- The baseline catalog plan is threaded through the form: `usePlanFormSetup`
  exposes `basePlanFormValues` (fetching the catalog plan for the quote-edit and
  subscription paths, deduped by Apollo on the fresh-selection path),
  `SubscriptionPricingContent` writes it to a `basePlanFormValuesRef`, and
  `useSubscriptionPricingDrawer` forwards it to `toPlanBillingItems`.
- Added `src/core/utils/comparableValue.ts` (`sortedWithoutTypename` +
  `comparable`) to normalize values before comparing — stripping `__typename`,
  sorting keys, and erasing explicitly-`undefined` keys dropped by a stored
  JSON round-trip. Extracted from `useAddSubscription`, which now reuses it.
- `payload` shape and `fromPlanBillingItems` deserialization are unchanged, so
  the quote preview/PDF keep rendering the effective configuration.

<!-- Linear link -->
Fixes LAGO-1789
