### PR TITLE
fix(quotes): reorder order actions and fix missing-date display

### DIFF
--- a/src/components/subscriptions/SubscriptionInformationFields.tsx
+++ b/src/components/subscriptions/SubscriptionInformationFields.tsx
@@ -94,7 +94,9 @@ const SubscriptionEndOrTerminatedAt = ({
   const { intlFormatDateTimeOrgaTZ } = useOrganizationInfos()
 
   if (subscription?.status === StatusTypeEnum.Terminated) {
-    return intlFormatDateTimeOrgaTZ(subscription?.terminatedAt ?? '').date
+    if (!subscription.terminatedAt) return '-'
+
+    return intlFormatDateTimeOrgaTZ(subscription.terminatedAt).date
   }
 
   if (subscription?.endingAt) {
@@ -226,11 +228,13 @@ const getSubscriptionInformationGrid = ({
     },
     {
       label: translate('text_65201c5a175a4b0238abf29e'),
-      value: intlFormatDateTimeOrgaTZ(subscription?.startedAt ?? '').date,
+      value: subscription?.startedAt ? intlFormatDateTimeOrgaTZ(subscription.startedAt).date : '-',
     },
     {
       label: translate('text_1781859135627z59hpfpa8pt'),
-      value: intlFormatDateTimeOrgaTZ(subscription?.subscriptionAt ?? '').date,
+      value: subscription?.subscriptionAt
+        ? intlFormatDateTimeOrgaTZ(subscription.subscriptionAt).date
+        : '-',
     },
     {
       label: translate('text_65201c5a175a4b0238abf2a0'),

--- a/src/components/subscriptions/__tests__/SubscriptionInformationFields.test.tsx
+++ b/src/components/subscriptions/__tests__/SubscriptionInformationFields.test.tsx
@@ -96,6 +96,33 @@ describe('SubscriptionInformationFields', () => {
     ).toBeInTheDocument()
   })
 
+  it('shows "-" instead of an invalid date when the subscription has no start date', () => {
+    render(<SubscriptionInformationFields subscription={baseSubscription({ startedAt: null })} />)
+
+    expect(getValueUnderLabel(START_DATE_LABEL).getByText('-')).toBeInTheDocument()
+  })
+
+  it('shows "-" instead of an invalid date when the subscription has no billing anchor date', () => {
+    render(
+      <SubscriptionInformationFields subscription={baseSubscription({ subscriptionAt: null })} />,
+    )
+
+    expect(getValueUnderLabel(BILLING_ANCHOR_LABEL).getByText('-')).toBeInTheDocument()
+  })
+
+  it('shows "-" for the end date when the subscription is terminated without a terminated date', () => {
+    render(
+      <SubscriptionInformationFields
+        subscription={baseSubscription({
+          status: StatusTypeEnum.Terminated,
+          terminatedAt: null,
+        })}
+      />,
+    )
+
+    expect(getValueUnderLabel(END_DATE_LABEL).getByText('-')).toBeInTheDocument()
+  })
+
   it('shows "-" for the end date when the subscription is active without an ending date', () => {
     render(<SubscriptionInformationFields subscription={baseSubscription()} />)
 

--- a/src/pages/quotes/hooks/__tests__/useOrderActions.test.ts
+++ b/src/pages/quotes/hooks/__tests__/useOrderActions.test.ts
@@ -68,9 +68,10 @@ describe('useOrderActions', () => {
       const actions = result.current.getActions(createMockOrder())
 
       expect(actions).toHaveLength(3)
-      expect(actions[0].icon).toBe('pen')
-      expect(actions[1].icon).toBe('download')
-      expect(actions[2].icon).toBe('flash')
+      // Execute manually comes first in the popper
+      expect(actions[0].icon).toBe('flash')
+      expect(actions[1].icon).toBe('pen')
+      expect(actions[2].icon).toBe('download')
     })
   })
 
@@ -102,7 +103,7 @@ describe('useOrderActions', () => {
       const { result } = renderHook(() => useOrderActions())
       const actions = result.current.getActions(createMockOrder({ id: 'order-42' }))
 
-      actions[0].onAction()
+      actions.find((a) => a.icon === 'pen')?.onAction()
 
       expect(testMockNavigateFn).toHaveBeenCalledWith('/order/order-42/edit')
     })

--- a/src/pages/quotes/hooks/useOrderActions.ts
+++ b/src/pages/quotes/hooks/useOrderActions.ts
@@ -24,6 +24,15 @@ export const useOrderActions = () => {
   const getActions = (order: OrderListItemFragment): OrderAction[] => {
     const actions: OrderAction[] = []
 
+    // Execute manually — only for created (not yet executed) orders, requires ordersExecute
+    if (order.status === OrderStatusEnum.Created && hasPermissions(['ordersExecute'])) {
+      actions.push({
+        icon: 'flash',
+        label: translate('text_17836939541574skv5dmaj06'),
+        onAction: () => navigate(generatePath(EXECUTE_ORDER_ROUTE, { orderId: order.id })),
+      })
+    }
+
     // Edit — only for created (not yet executed) orders, requires ordersUpdate permission
     if (order.status === OrderStatusEnum.Created && hasPermissions(['ordersUpdate'])) {
       actions.push({
@@ -53,15 +62,6 @@ export const useOrderActions = () => {
             }),
           ).catch(() => undefined)
         },
-      })
-    }
-
-    // Execute manually — only for created (not yet executed) orders, requires ordersExecute
-    if (order.status === OrderStatusEnum.Created && hasPermissions(['ordersExecute'])) {
-      actions.push({
-        icon: 'flash',
-        label: translate('text_17836939541574skv5dmaj06'),
-        onAction: () => navigate(generatePath(EXECUTE_ORDER_ROUTE, { orderId: order.id })),
       })
     }
 


### PR DESCRIPTION
## Context

Two small fixes on quotes. In the order actions popper, "Execute manually" — the primary action on a created order — was rendered last, below edit and download. Separately, the subscription information block rendered the literal string "Invalid DateTime" whenever a date was null, because `startedAt`, `subscriptionAt` and `terminatedAt` were passed to `intlFormatDateTimeOrgaTZ` with an `?? ''` fallback.

## Description

Moved the "Execute manually" branch to the top of `getActions` in `useOrderActions.ts` so it appears first, and guarded the three date fields in `SubscriptionInformationFields.tsx` to fall back to `-`, matching the existing end-date behaviour. Tests updated accordingly: the edit-action assertion now finds its action by icon instead of index, and three cases cover the null-date fallbacks.

<!-- Linear link -->
Fixes LAGO-1785
Fixes LAGO-1788