### PR TITLE
fix(subscriptions): show scheduled start date when pending

### DIFF
--- a/src/components/subscriptions/SubscriptionInformationFields.tsx
+++ b/src/components/subscriptions/SubscriptionInformationFields.tsx
@@ -205,6 +205,10 @@ const getSubscriptionInformationGrid = ({
     .filter(Boolean)
     .join(' ')
 
+  // A pending subscription has no `startedAt` yet, so fall back to the date it is
+  // scheduled to start on. Both being empty should not happen in practice.
+  const startDate = subscription?.startedAt ?? subscription?.subscriptionAt
+
   return [
     {
       label: translate('text_65201c5a175a4b0238abf29a'),
@@ -225,7 +229,7 @@ const getSubscriptionInformationGrid = ({
     },
     {
       label: translate('text_65201c5a175a4b0238abf29e'),
-      value: subscription?.startedAt ? intlFormatDateTimeOrgaTZ(subscription.startedAt).date : '-',
+      value: startDate ? intlFormatDateTimeOrgaTZ(startDate).date : '-',
     },
     {
       label: translate('text_1781859135627z59hpfpa8pt'),

--- a/src/components/subscriptions/__tests__/SubscriptionInformationFields.test.tsx
+++ b/src/components/subscriptions/__tests__/SubscriptionInformationFields.test.tsx
@@ -96,8 +96,32 @@ describe('SubscriptionInformationFields', () => {
     ).toBeInTheDocument()
   })
 
-  it('shows "-" instead of an invalid date when the subscription has no start date', () => {
-    render(<SubscriptionInformationFields subscription={baseSubscription({ startedAt: null })} />)
+  it('falls back to the scheduled start date under "Start date" when the subscription is pending', () => {
+    // Pending scenario: started_at is still empty, subscription_at holds the future start date
+    render(
+      <SubscriptionInformationFields
+        subscription={baseSubscription({
+          status: StatusTypeEnum.Pending,
+          startedAt: null,
+          subscriptionAt: '2026-06-01',
+        })}
+      />,
+    )
+
+    expect(
+      getValueUnderLabel(START_DATE_LABEL).getByText('formatted-2026-06-01'),
+    ).toBeInTheDocument()
+    expect(
+      getValueUnderLabel(BILLING_ANCHOR_LABEL).getByText('formatted-2026-06-01'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows "-" instead of an invalid date when the subscription has neither a start nor a scheduled date', () => {
+    render(
+      <SubscriptionInformationFields
+        subscription={baseSubscription({ startedAt: null, subscriptionAt: null })}
+      />,
+    )
 
     expect(getValueUnderLabel(START_DATE_LABEL).getByText('-')).toBeInTheDocument()
   })

--- a/src/components/subscriptions/details-v2/__tests__/SubscriptionInformationSection.test.tsx
+++ b/src/components/subscriptions/details-v2/__tests__/SubscriptionInformationSection.test.tsx
@@ -42,6 +42,7 @@ const subscription = {
   id: 'sub-1',
   externalId: 'ext-1',
   status: StatusTypeEnum.Active,
+  startedAt: '2026-01-15',
   subscriptionAt: '2026-01-01',
   endingAt: null,
   terminatedAt: null,
@@ -76,6 +77,8 @@ describe('SubscriptionInformationSection', () => {
     expect(screen.getByText('text_6335e8900c69f8ebdfef5312')).toBeInTheDocument() // title
     expect(screen.getByText('ext-1')).toBeInTheDocument()
     expect(screen.getByText('Acme')).toBeInTheDocument()
+    // Start date reads startedAt, the billing anchor keeps subscriptionAt
+    expect(screen.getByText('formatted-2026-01-15')).toBeInTheDocument()
     expect(screen.getByText('formatted-2026-01-01')).toBeInTheDocument()
   })
 


### PR DESCRIPTION
Fixes BIL-540

## Context

Reported by Epicor. On a pending subscription, the details page **Start date** field showed the literal string `Invalid DateTime`, while the very same date rendered correctly under **Billing anchor date**. A pending subscription has no `started_at` yet, and `intlFormatDateTimeOrgaTZ(subscription?.startedAt ?? '')` feeds an empty string to luxon, which prints `Invalid DateTime`.

#4115 already guarded that call so it renders `-` instead of the broken string, but `-` is not what the user expects either: the subscription does have a known start date, it just has not been reached yet.

## Description

`Start date` now resolves to `startedAt ?? subscriptionAt`: the date it actually started on, or the date it is about to start on, falling back to `-` if neither is set (not a reachable state in practice). This matches what the subscription lists already do in `annotateSubscriptions` (`startedAt || subscriptionAt`), so details and lists no longer disagree.

Tests cover the pending fallback and the both-empty case.