### PR TITLE
feat(quotes): drop startDate on subscription amendment quotes

### DIFF
--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
@@ -58,6 +58,11 @@ interface SubscriptionPricingContentProps {
   hasQuoteCurrency?: boolean
   billingItemPlan?: BillingItemPlan
   subscriptionId?: string
+  /**
+   * Subscription-amendment quote: the start date belongs to the amended subscription, so it
+   * is never displayed nor seeded here (LAGO-1814).
+   */
+  isAmendment?: boolean
 }
 
 export function SubscriptionPricingContent({
@@ -72,6 +77,7 @@ export function SubscriptionPricingContent({
   hasQuoteCurrency,
   billingItemPlan,
   subscriptionId,
+  isAmendment = false,
 }: Readonly<SubscriptionPricingContentProps>) {
   const { translate } = useInternationalization()
 
@@ -144,14 +150,23 @@ export function SubscriptionPricingContent({
 
   // Quote-specific state
   const [subscriptionSettings, setSubscriptionSettings] = useState(() => {
-    if (initialState?.subscriptionSettings) return initialState.subscriptionSettings
-    if (billingItemSubscriptionSettings) return billingItemSubscriptionSettings
+    const getInitialSettings = () => {
+      if (initialState?.subscriptionSettings) return initialState.subscriptionSettings
+      if (billingItemSubscriptionSettings) return billingItemSubscriptionSettings
 
-    return {
-      ...DEFAULT_SUBSCRIPTION_SETTINGS,
-      startDate: quoteDates?.startDate ?? '',
-      endDate: quoteDates?.endDate ?? '',
+      return {
+        ...DEFAULT_SUBSCRIPTION_SETTINGS,
+        startDate: quoteDates?.startDate ?? '',
+        endDate: quoteDates?.endDate ?? '',
+      }
     }
+
+    const settings = getInitialSettings()
+
+    // An amendment quote never carries a start date, whichever source seeded the settings.
+    if (isAmendment) return { ...settings, startDate: '' }
+
+    return settings
   })
   const [invoicingSettings, setInvoicingSettings] = useState(
     initialState?.invoicingSettings ?? billingItemInvoicingSettings ?? DEFAULT_INVOICING_SETTINGS,
@@ -160,7 +175,7 @@ export function SubscriptionPricingContent({
   // Hook-based drawers for settings
   const subscriptionSettingsDrawer = useSubscriptionSettingsDrawer(
     (values) => setSubscriptionSettings(values),
-    !!subscriptionId,
+    isAmendment,
   )
   const showInvoicingSection = Boolean(customer?.externalId || customer?.id)
   const planSettingsDrawer = useQuotePlanSettingsDrawer(planForm, {

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/useSubscriptionSettingsDrawer.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/useSubscriptionSettingsDrawer.test.tsx
@@ -244,12 +244,30 @@ describe('useSubscriptionSettingsDrawer', () => {
 
   describe('GIVEN the drawer is opened in amendment mode', () => {
     describe('WHEN isAmendment is true', () => {
-      it('THEN should disable the start date field', () => {
+      it('THEN should NOT render the start date field', () => {
         openAndRenderDrawer(populatedValues, true)
 
-        const startDateInput = document.querySelector('input[name="startDate"]') as HTMLInputElement
+        expect(document.querySelector('input[name="startDate"]')).not.toBeInTheDocument()
+      })
 
-        expect(startDateInput).toBeDisabled()
+      it('THEN should still render the end date field', () => {
+        openAndRenderDrawer(populatedValues, true)
+
+        expect(document.querySelector('input[name="endDate"]')).toBeInTheDocument()
+      })
+
+      it('THEN should save even though the start date is empty', async () => {
+        const user = userEvent.setup()
+
+        openAndRenderDrawer({ ...populatedValues, startDate: '' }, true)
+
+        await user.click(screen.getByTestId(SUBSCRIPTION_SETTINGS_DRAWER_SAVE_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockOnSave).toHaveBeenCalledTimes(1)
+        })
+
+        expect(mockOnSave).toHaveBeenCalledWith(expect.objectContaining({ startDate: '' }))
       })
     })
   })

--- a/src/components/designSystem/RichTextEditor/PricingBlock/useSubscriptionSettingsDrawer.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/useSubscriptionSettingsDrawer.tsx
@@ -20,23 +20,26 @@ export interface SubscriptionSettingsFormValues {
   endDate: string
 }
 
-const subscriptionSettingsSchema = z
-  .object({
-    externalId: z.string(),
-    subscriptionName: z.string(),
-    billingTime: z.enum(['anniversary', 'calendar']),
-    startDate: z.string().min(1, 'text_624ea7c29103fd010732ab7d'),
-    endDate: z.string(),
-  })
-  .superRefine((data, ctx) => {
-    if (data.endDate && data.startDate && data.endDate < data.startDate) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'End date must be after start date',
-        path: ['endDate'],
-      })
-    }
-  })
+// Amendment quotes don't display a start date (it belongs to the amended subscription), so
+// the hidden, always-empty field must not block the save (LAGO-1814).
+const makeSubscriptionSettingsSchema = (isAmendment: boolean) =>
+  z
+    .object({
+      externalId: z.string(),
+      subscriptionName: z.string(),
+      billingTime: z.enum(['anniversary', 'calendar']),
+      startDate: isAmendment ? z.string() : z.string().min(1, 'text_624ea7c29103fd010732ab7d'),
+      endDate: z.string(),
+    })
+    .superRefine((data, ctx) => {
+      if (data.endDate && data.startDate && data.endDate < data.startDate) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'End date must be after start date',
+          path: ['endDate'],
+        })
+      }
+    })
 
 const DEFAULT_VALUES: SubscriptionSettingsFormValues = {
   externalId: '',
@@ -171,15 +174,16 @@ const SubscriptionSettingsDrawerContent = withForm({
           </form.AppField>
         </div>
         <div className="flex gap-3">
-          <form.AppField name="startDate">
-            {(field) => (
-              <field.DatePickerField
-                disabled={isAmendment}
-                label={translate('text_65201c5a175a4b0238abf29e')}
-                className="flex-1"
-              />
-            )}
-          </form.AppField>
+          {!isAmendment && (
+            <form.AppField name="startDate">
+              {(field) => (
+                <field.DatePickerField
+                  label={translate('text_65201c5a175a4b0238abf29e')}
+                  className="flex-1"
+                />
+              )}
+            </form.AppField>
+          )}
           <form.AppField name="endDate">
             {(field) => (
               <field.DatePickerField
@@ -204,7 +208,7 @@ export const useSubscriptionSettingsDrawer = (
   const form = useAppForm({
     defaultValues: DEFAULT_VALUES,
     validationLogic: revalidateLogic(),
-    validators: { onDynamic: subscriptionSettingsSchema },
+    validators: { onDynamic: makeSubscriptionSettingsSchema(isAmendment) },
     onSubmit: async ({ value }) => {
       onSave(value)
       drawer.close()

--- a/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
+++ b/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
@@ -128,6 +128,21 @@ describe('toPlanBillingItems', () => {
     expect(result.plans[0].payload.endDate).toBe('2024-07-26')
   })
 
+  it('omits the startDate key entirely when omitStartDate is set', () => {
+    const result = toPlanBillingItems(basePricingState, baseFormValues, undefined, {
+      omitStartDate: true,
+    })
+
+    expect(result.plans[0].payload).not.toHaveProperty('startDate')
+    expect(result.plans[0].payload.endDate).toBeNull()
+  })
+
+  it('keeps the startDate key when omitStartDate is not set', () => {
+    const result = toPlanBillingItems(basePricingState, baseFormValues)
+
+    expect(result.plans[0].payload.startDate).toBe('2023-07-26')
+  })
+
   it('includes invoicing settings in the payload', () => {
     const state: SubscriptionPricingState = {
       ...basePricingState,

--- a/src/core/serializers/serializeQuotePlanBillingItems.ts
+++ b/src/core/serializers/serializeQuotePlanBillingItems.ts
@@ -143,7 +143,9 @@ interface PlanPayload {
   subscriptionExternalId: string | null
   subscriptionName: string | null
   billingTime: 'anniversary' | 'calendar'
-  startDate: string | null
+  // Omitted entirely for subscription-amendment quotes: the start date belongs to the
+  // amended subscription, so the quote must not carry one (LAGO-1814).
+  startDate?: string | null
   endDate: string | null
   paymentMethodId: string | null
   invoiceCustomFooter: string | null
@@ -438,6 +440,7 @@ export const toPlanBillingItems = (
   state: SubscriptionPricingState,
   formValues?: PlanFormInput,
   basePlanFormValues?: PlanFormInput,
+  options?: { omitStartDate?: boolean },
 ): { plans: BillingItemPlan[] } => {
   const { planId, planCode, planName, planDescription, subscriptionSettings, invoicingSettings } =
     state
@@ -467,7 +470,9 @@ export const toPlanBillingItems = (
     subscriptionExternalId: normalizeOptional(subscriptionSettings.externalId),
     subscriptionName: normalizeOptional(subscriptionSettings.subscriptionName),
     billingTime: subscriptionSettings.billingTime,
-    startDate: normalizeOptional(subscriptionSettings.startDate),
+    ...(options?.omitStartDate
+      ? {}
+      : { startDate: normalizeOptional(subscriptionSettings.startDate) }),
     endDate: normalizeOptional(subscriptionSettings.endDate),
     paymentMethodId: normalizeOptional(invoicingSettings.paymentMethodId),
     invoiceCustomFooter: normalizeOptional(invoicingSettings.invoiceCustomFooter),
@@ -543,7 +548,7 @@ interface FromPlanBillingItemsResult {
   formValues: PlanFormInput | null
 }
 
-const denormalizeOptional = (value: string | null): string => value ?? ''
+const denormalizeOptional = (value: string | null | undefined): string => value ?? ''
 
 const deserializeTaxes = (
   taxes: SerializedTax[],

--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -99,18 +99,22 @@ const EditQuote = () => {
 
   const isUpdating = isUpdatingQuote || isUpdatingQuoteVersion
 
+  // The amended subscription owns the start date: it is neither displayed nor sent (LAGO-1814).
+  const isAmendment = quote?.orderType === OrderTypeEnum.SubscriptionAmendment
+
   const handleSubscriptionDatesChange = useCallback(
     async (startDate?: string, endDate?: string) => {
       if (!versionId) return
 
-      await updateQuoteVersionRef.current({ id: versionId, startDate, endDate }, false)
+      await updateQuoteVersionRef.current(
+        { id: versionId, endDate, ...(isAmendment ? {} : { startDate }) },
+        false,
+      )
     },
-    [versionId],
+    [versionId, isAmendment],
   )
 
-  const isSubscriptionOrder =
-    quote?.orderType === OrderTypeEnum.SubscriptionCreation ||
-    quote?.orderType === OrderTypeEnum.SubscriptionAmendment
+  const isSubscriptionOrder = quote?.orderType === OrderTypeEnum.SubscriptionCreation || isAmendment
 
   // The quote version currency is the source of truth for every amount shown or
   // serialized in this quote. Until it is set (legacy quotes, or before the
@@ -124,8 +128,9 @@ const EditQuote = () => {
 
   const subscriptionPricing = useSubscriptionPricingDrawer(quote?.currentVersion?.billingItems, {
     quoteDates: {
-      startDate:
-        quote?.subscription?.subscriptionAt ?? quote?.currentVersion?.startDate ?? undefined,
+      startDate: isAmendment
+        ? undefined
+        : (quote?.subscription?.subscriptionAt ?? quote?.currentVersion?.startDate ?? undefined),
       endDate: quote?.currentVersion?.endDate ?? undefined,
     },
     onDatesChange: handleSubscriptionDatesChange,
@@ -133,6 +138,7 @@ const EditQuote = () => {
     subscriptionId: quote?.subscription?.id,
     currency: effectiveQuoteCurrency,
     hasQuoteCurrency: !!quoteVersionCurrency,
+    isAmendment,
   })
   const oneOffPricing = useOneOffPricingDrawer(quote?.currentVersion?.billingItems, {
     currency: effectiveQuoteCurrency,

--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -126,11 +126,15 @@ const EditQuote = () => {
     organization?.defaultCurrency ??
     CurrencyEnum.Usd
 
+  const getStartDate = (): string | undefined => {
+    if (isAmendment) return undefined
+
+    return quote?.subscription?.subscriptionAt ?? quote?.currentVersion?.startDate ?? undefined
+  }
+
   const subscriptionPricing = useSubscriptionPricingDrawer(quote?.currentVersion?.billingItems, {
     quoteDates: {
-      startDate: isAmendment
-        ? undefined
-        : (quote?.subscription?.subscriptionAt ?? quote?.currentVersion?.startDate ?? undefined),
+      startDate: getStartDate(),
       endDate: quote?.currentVersion?.endDate ?? undefined,
     },
     onDatesChange: handleSubscriptionDatesChange,

--- a/src/pages/quotes/__tests__/EditQuote.test.tsx
+++ b/src/pages/quotes/__tests__/EditQuote.test.tsx
@@ -1079,6 +1079,82 @@ describe('EditQuote', () => {
     })
   })
 
+  describe('GIVEN a subscription amendment quote', () => {
+    type PricingDrawerDateOptions = {
+      isAmendment?: boolean
+      quoteDates?: { startDate?: string; endDate?: string }
+      onDatesChange?: (startDate?: string, endDate?: string) => Promise<void>
+    }
+
+    const renderAmendment = (): PricingDrawerDateOptions => {
+      mockUseQuote.mockReturnValue({
+        quote: {
+          ...mockQuote,
+          orderType: 'subscription_amendment',
+          currentVersion: { ...mockQuote.currentVersion, startDate: '2026-01-01T00:00:00Z' },
+        },
+        loading: false,
+        refetch: mockRefetchQuote,
+      })
+
+      render(<EditQuote />)
+
+      return capturedPricingDrawerArgs[1] as PricingDrawerDateOptions
+    }
+
+    describe('WHEN the pricing drawer options are built', () => {
+      it('THEN should flag the amendment and seed no start date', () => {
+        const options = renderAmendment()
+
+        expect(options.isAmendment).toBe(true)
+        expect(options.quoteDates?.startDate).toBeUndefined()
+      })
+    })
+
+    describe('WHEN the pricing drawer reports a date change', () => {
+      it('THEN should update the version without a startDate key', async () => {
+        mockUpdateQuoteVersion.mockResolvedValue({
+          data: { updateQuoteVersion: { id: 'version-1' } },
+        })
+
+        const options = renderAmendment()
+
+        await act(async () => {
+          await options.onDatesChange?.('2026-01-01T00:00:00Z', '2026-06-01T00:00:00Z')
+        })
+
+        const payload = mockUpdateQuoteVersion.mock.calls.at(-1)?.[0]
+
+        expect(payload).not.toHaveProperty('startDate')
+        expect(payload.endDate).toBe('2026-06-01T00:00:00Z')
+      })
+    })
+  })
+
+  describe('GIVEN a subscription creation quote', () => {
+    describe('WHEN the pricing drawer reports a date change', () => {
+      it('THEN should update the version with the startDate', async () => {
+        mockUpdateQuoteVersion.mockResolvedValue({
+          data: { updateQuoteVersion: { id: 'version-1' } },
+        })
+
+        render(<EditQuote />)
+
+        const options = capturedPricingDrawerArgs[1] as {
+          onDatesChange?: (startDate?: string, endDate?: string) => Promise<void>
+        }
+
+        await act(async () => {
+          await options.onDatesChange?.('2026-01-01T00:00:00Z', '2026-06-01T00:00:00Z')
+        })
+
+        const payload = mockUpdateQuoteVersion.mock.calls.at(-1)?.[0]
+
+        expect(payload.startDate).toBe('2026-01-01T00:00:00Z')
+      })
+    })
+  })
+
   describe('GIVEN the discount command integration', () => {
     describe('WHEN the quote is a subscription order', () => {
       it('THEN should pass a defined onDiscountCommand to RichTextEditor', () => {

--- a/src/pages/quotes/editQuote/EditQuoteAside.tsx
+++ b/src/pages/quotes/editQuote/EditQuoteAside.tsx
@@ -109,6 +109,8 @@ const EditQuoteAsideForm = ({
 
   const hasSubscription = !!quote.subscription
   const isOneOff = quote.orderType === OrderTypeEnum.OneOff
+  // The amended subscription owns the start date: it is neither displayed nor sent (LAGO-1814).
+  const isAmendment = quote.orderType === OrderTypeEnum.SubscriptionAmendment
   const versionId = quote.currentVersion.id
 
   const getDefaultValues = (): EditQuoteAsideFormValues => {
@@ -120,7 +122,9 @@ const EditQuoteAsideForm = ({
       subscriptionLabel: quote.subscription
         ? `${quote.subscription.plan?.name ?? ''} - ${quote.subscription.externalId}`
         : undefined,
-      startDate: quote.subscription?.subscriptionAt ?? quote.currentVersion.startDate ?? undefined,
+      startDate: isAmendment
+        ? undefined
+        : (quote.subscription?.subscriptionAt ?? quote.currentVersion.startDate ?? undefined),
       endDate: quote.currentVersion.endDate ?? undefined,
       netPaymentTermLabel: formatNetPaymentTerm(
         quote.customer.netPaymentTerm ?? quote.customer.billingEntity?.netPaymentTerm,
@@ -195,8 +199,8 @@ const EditQuoteAsideForm = ({
 
         const payload: UpdateQuoteVersionInput = {
           id: versionId,
-          startDate,
           endDate,
+          ...(isAmendment ? {} : { startDate }),
         }
 
         try {
@@ -211,7 +215,7 @@ const EditQuoteAsideForm = ({
           onSaveErrorRef.current?.(payload)
         }
       }, AUTO_SAVE_DELAY_MS),
-    [versionId],
+    [versionId, isAmendment],
   )
 
   const startDate = useStore(form.store, (state) => state.values.startDate)
@@ -346,16 +350,22 @@ const EditQuoteAsideForm = ({
 
           {!isOneOff && (
             <>
-              <Typography
-                variant="caption"
-                color="grey600"
-                data-test={EDIT_QUOTE_ASIDE_START_DATE_TEST_ID}
-              >
-                {translate('text_65201c5a175a4b0238abf29e')}
-              </Typography>
-              <form.AppField name="startDate">
-                {(field) => <field.DatePickerField disabled={hasSubscription} placement="auto" />}
-              </form.AppField>
+              {!isAmendment && (
+                <>
+                  <Typography
+                    variant="caption"
+                    color="grey600"
+                    data-test={EDIT_QUOTE_ASIDE_START_DATE_TEST_ID}
+                  >
+                    {translate('text_65201c5a175a4b0238abf29e')}
+                  </Typography>
+                  <form.AppField name="startDate">
+                    {(field) => (
+                      <field.DatePickerField disabled={hasSubscription} placement="auto" />
+                    )}
+                  </form.AppField>
+                </>
+              )}
 
               <Typography
                 variant="caption"

--- a/src/pages/quotes/editQuote/EditQuoteAside.tsx
+++ b/src/pages/quotes/editQuote/EditQuoteAside.tsx
@@ -113,6 +113,12 @@ const EditQuoteAsideForm = ({
   const isAmendment = quote.orderType === OrderTypeEnum.SubscriptionAmendment
   const versionId = quote.currentVersion.id
 
+  const getStartDate = (): string | undefined => {
+    if (isAmendment) return undefined
+
+    return quote.subscription?.subscriptionAt ?? quote.currentVersion.startDate ?? undefined
+  }
+
   const getDefaultValues = (): EditQuoteAsideFormValues => {
     return {
       orderTypeLabel: translate(getQuoteOrderTypeTranslationKey(quote.orderType)),
@@ -122,9 +128,7 @@ const EditQuoteAsideForm = ({
       subscriptionLabel: quote.subscription
         ? `${quote.subscription.plan?.name ?? ''} - ${quote.subscription.externalId}`
         : undefined,
-      startDate: isAmendment
-        ? undefined
-        : (quote.subscription?.subscriptionAt ?? quote.currentVersion.startDate ?? undefined),
+      startDate: getStartDate(),
       endDate: quote.currentVersion.endDate ?? undefined,
       netPaymentTermLabel: formatNetPaymentTerm(
         quote.customer.netPaymentTerm ?? quote.customer.billingEntity?.netPaymentTerm,

--- a/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
+++ b/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
@@ -84,6 +84,9 @@ jest.mock('~/hooks/usePermissions', () => ({
   usePermissions: () => ({ hasPermissions: mockHasPermissions }),
 }))
 
+// The translate mock echoes keys, so the DatePicker's default placeholder is its key
+const DATE_PLACEHOLDER_KEY = 'text_62cd78ea9bff25e3391b243d'
+
 const mockQuote: QuoteDetailItemFragment = {
   __typename: 'Quote',
   id: 'quote-1',
@@ -506,7 +509,7 @@ describe('EditQuoteAside', () => {
 
   describe('GIVEN a subscription amendment quote', () => {
     describe('WHEN the component renders', () => {
-      it('THEN should render the start date field', () => {
+      it('THEN should NOT render the start date field', () => {
         const amendmentQuote = {
           ...mockQuote,
           orderType: OrderTypeEnum.SubscriptionAmendment,
@@ -514,7 +517,7 @@ describe('EditQuoteAside', () => {
 
         render(<EditQuoteAside quote={amendmentQuote} />)
 
-        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_START_DATE_TEST_ID)).toBeInTheDocument()
+        expect(screen.queryByTestId(EDIT_QUOTE_ASIDE_START_DATE_TEST_ID)).not.toBeInTheDocument()
       })
 
       it('THEN should render the end date field', () => {
@@ -526,6 +529,67 @@ describe('EditQuoteAside', () => {
         render(<EditQuoteAside quote={amendmentQuote} />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_END_DATE_TEST_ID)).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the user changes the end date', () => {
+      it('THEN should auto-save without a startDate key', async () => {
+        const amendmentQuote = {
+          ...mockQuote,
+          orderType: OrderTypeEnum.SubscriptionAmendment,
+          currentVersion: { ...mockQuote.currentVersion, startDate: '2026-01-01T00:00:00Z' },
+        }
+
+        render(<EditQuoteAside quote={amendmentQuote} />)
+
+        const dateInputs = screen.getAllByPlaceholderText(DATE_PLACEHOLDER_KEY)
+
+        // Only the end date remains on an amendment quote
+        expect(dateInputs).toHaveLength(1)
+
+        fireEvent.change(dateInputs[0], { target: { value: '06/01/2026' } })
+
+        await waitFor(
+          () => {
+            expect(mockUpdateQuoteVersion).toHaveBeenCalled()
+          },
+          { timeout: 5000 },
+        )
+
+        const payload = mockUpdateQuoteVersion.mock.calls.at(-1)?.[0]
+
+        expect(payload).not.toHaveProperty('startDate')
+        expect(payload.endDate).toBeTruthy()
+      })
+    })
+  })
+
+  describe('GIVEN a subscription creation quote', () => {
+    describe('WHEN the user changes the end date', () => {
+      it('THEN should still auto-save the startDate', async () => {
+        const creationQuote = {
+          ...mockQuote,
+          currentVersion: { ...mockQuote.currentVersion, startDate: '2026-01-01T00:00:00Z' },
+        }
+
+        render(<EditQuoteAside quote={creationQuote} />)
+
+        const dateInputs = screen.getAllByPlaceholderText(DATE_PLACEHOLDER_KEY)
+
+        expect(dateInputs).toHaveLength(2)
+
+        fireEvent.change(dateInputs[1], { target: { value: '06/01/2026' } })
+
+        await waitFor(
+          () => {
+            expect(mockUpdateQuoteVersion).toHaveBeenCalled()
+          },
+          { timeout: 5000 },
+        )
+
+        const payload = mockUpdateQuoteVersion.mock.calls.at(-1)?.[0]
+
+        expect(payload.startDate).toBe('2026-01-01T00:00:00Z')
       })
     })
   })

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -48,6 +48,11 @@ export interface SubscriptionPricingDrawerOptions {
   currency?: CurrencyEnum | null
   /** Whether `currency` is the quote's own currency rather than a fallback. */
   hasQuoteCurrency?: boolean
+  /**
+   * Subscription-amendment quote: the amended subscription owns the start date, so it is
+   * neither displayed nor serialized (LAGO-1814).
+   */
+  isAmendment?: boolean
 }
 
 export const useSubscriptionPricingDrawer = (
@@ -158,6 +163,7 @@ export const useSubscriptionPricingDrawer = (
           state,
           formValues ?? undefined,
           basePlanFormValuesRef.current ?? undefined,
+          { omitStartDate: !!options?.isAmendment },
         )
         const entityData: Record<string, EntityData> = {
           [state.planId]: {
@@ -224,6 +230,7 @@ export const useSubscriptionPricingDrawer = (
             hasQuoteCurrency={options?.hasQuoteCurrency}
             billingItemPlan={billingItemPlan}
             subscriptionId={billingItemPlan ? undefined : options?.subscriptionId}
+            isAmendment={options?.isAmendment}
           />
         ),
       })


### PR DESCRIPTION
## Context

A `subscription_amendment` quote amends an existing subscription, whose start date is already fixed by that subscription — so showing a start-date field is noise, and shipping `startDate` in the payload is a lie.

## Description

For amendment quotes only, the start date is no longer displayed (aside row and pricing-block subscription-settings picker) and the `startDate` key is omitted entirely — not sent as `null` — from both the `updateQuoteVersion` mutation and the plan billing-items payload (`toPlanBillingItems` gained an `omitStartDate` option). This also fixes a related bug: the pricing block detected amendments via `!!subscriptionId`, which went falsy once `billingItems` held a plan and silently re-enabled the start-date picker after the first save; it is replaced by an explicit `isAmendment` flag threaded down from `EditQuote`, and the settings drawer's zod schema is now built per-mode so the hidden, empty field can't block Save. `endDate` and all other order types are untouched.

<!-- Linear link -->
Fixes LAGO-1814

🤖 Generated with [Claude Code](https://claude.com/claude-code)