### PR TITLE
fix(activity-logs): select id on catalog resource types

### DIFF
--- a/src/components/developers/activityLogs/ActivityLogDetails.tsx
+++ b/src/components/developers/activityLogs/ActivityLogDetails.tsx
@@ -111,6 +111,9 @@ gql`
       ... on PaymentReceipt {
         id
       }
+      ... on RateCard {
+        id
+      }
     }
     loggedAt
     userEmail

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -12333,6 +12333,7 @@ export type ActivityLogDetailsFragment = { __typename?: 'ActivityLog', activityT
     | { __typename?: 'Product', id: string }
     | { __typename?: 'ProductCategory', id: string }
     | { __typename?: 'ProductFilter', id: string }
+    | { __typename?: 'RateCard', id: string }
     | { __typename?: 'Subscription', id: string }
     | { __typename?: 'Wallet', id: string, walletCustomer?: { __typename?: 'Customer', id: string } | null }
    | null };
@@ -12356,6 +12357,7 @@ export type GetSingleActivityLogQuery = { __typename?: 'Query', activityLog?: { 
       | { __typename?: 'Product', id: string }
       | { __typename?: 'ProductCategory', id: string }
       | { __typename?: 'ProductFilter', id: string }
+      | { __typename?: 'RateCard', id: string }
       | { __typename?: 'Subscription', id: string }
       | { __typename?: 'Wallet', id: string, walletCustomer?: { __typename?: 'Customer', id: string } | null }
      | null } | null };
@@ -17786,6 +17788,9 @@ export const ActivityLogDetailsFragmentDoc = gql`
       }
     }
     ... on PaymentReceipt {
+      id
+    }
+    ... on RateCard {
       id
     }
   }


### PR DESCRIPTION
## Context

The `ActivityLogResourceObject` GraphQL union recently gained catalog members (`Product`, `ProductCategory`, `ProductFilter`, `RateCard`). The `ActivityLogDetails` fragment did not select any field on `RateCard`, so codegen emitted it as a bare `{ __typename }` member with no `id`. That removed `id` as a common property of the union, and `tsc` failed everywhere the activity-log resource `id` is read (`activityLogs/utils.ts`, `ActivityLogDetails.tsx`).

## Description

Select `id` on `RateCard` in the `ActivityLogDetails` fragment, alongside the other catalog resource types already covered. Every union member now exposes `id`, so the resource `id` accesses type-check again.

Generated types are intentionally left out of this PR: CI regenerates them from the API schema before typechecking, and a full regen locally pulls in unrelated schema drift that belongs in its own sync.

## Tests

Ran `pnpm codegen` against the current API schema followed by `pnpm tsc --noEmit`: the `Property 'id' does not exist` errors are gone and the typecheck passes.
