### PR TITLE
feat(order-forms): display API error messages on sign and void

### DIFF
--- a/src/pages/quotes/ApproveQuote.tsx
+++ b/src/pages/quotes/ApproveQuote.tsx
@@ -28,6 +28,7 @@ import { getQuoteOrderTypeTranslationKey } from './common/getQuoteOrderTypeTrans
 import { QuotePreviewCard } from './common/QuotePreviewCard'
 import { useApproveQuote } from './hooks/useApproveQuote'
 import { useQuote } from './hooks/useQuote'
+import { applyFormFieldErrors } from './utils/applyFormFieldErrors'
 import { getQuoteMutationErrors } from './utils/quoteMutationErrors'
 
 export const APPROVE_QUOTE_CLOSE_BUTTON_TEST_ID = 'approve-quote-close-button'
@@ -81,16 +82,7 @@ const ApproveQuote = () => {
         const errors = getQuoteMutationErrors(result.errors, translate)
 
         errors.forEach(({ message }) => addToast({ severity: 'danger', message }))
-
-        const fieldError = errors.find(({ field }) => field === 'expiresAt')
-
-        if (fieldError) {
-          formApi.setErrorMap({
-            onDynamic: {
-              fields: { expiresAt: { message: fieldError.message, path: ['expiresAt'] } },
-            },
-          })
-        }
+        applyFormFieldErrors(formApi, errors)
 
         return
       }

--- a/src/pages/quotes/SignOrderForm.tsx
+++ b/src/pages/quotes/SignOrderForm.tsx
@@ -35,6 +35,11 @@ import {
   signOrderFormDefaultValues,
   signOrderFormValidationSchema,
 } from './signOrderForm/validationSchema'
+import { applyFormFieldErrors } from './utils/applyFormFieldErrors'
+import {
+  getQuoteMutationErrors,
+  QUOTE_MUTATION_SILENT_ERROR_CODES,
+} from './utils/quoteMutationErrors'
 
 export const SIGN_ORDER_FORM_CLOSE_BUTTON_TEST_ID = 'sign-order-form-close-button'
 export const SIGN_ORDER_FORM_CANCEL_BUTTON_TEST_ID = 'sign-order-form-cancel-button'
@@ -92,6 +97,10 @@ const SignOrderForm = () => {
 
   const [markOrderFormAsSignedMutation] = useMarkOrderFormAsSignedMutation({
     refetchQueries: ['getOrderForms'],
+    // Handled locally by `getQuoteMutationErrors`, so the global error link must not
+    // also fire its generic toast (nor report these expected failures to Sentry).
+    // Copied: the link pushes its own force-silenced codes onto the array it receives.
+    context: { silentErrorCodes: [...QUOTE_MUTATION_SILENT_ERROR_CODES] },
   })
 
   // Single source of truth for preview inputs (shared with the PDF renderer).
@@ -117,7 +126,7 @@ const SignOrderForm = () => {
     defaultValues: signOrderFormDefaultValues,
     validationLogic: revalidateLogic(),
     validators: { onDynamic: signOrderFormValidationSchema },
-    onSubmit: async ({ value }) => {
+    onSubmit: async ({ value, formApi }) => {
       const quoteId = orderForm?.quote?.id
 
       if (!orderFormId || !quoteId) return
@@ -126,16 +135,23 @@ const SignOrderForm = () => {
         variables: { input: buildSignOrderFormInput(orderFormId, value) },
       })
 
-      if (result.data?.markOrderFormAsSigned) {
-        addToast({ severity: 'success', translateKey: 'text_1781686594125pop15l3s7yw' })
+      if (!result.data?.markOrderFormAsSigned) {
+        const errors = getQuoteMutationErrors(result.errors, translate, 'orderForm')
 
-        navigate(
-          generatePath(QUOTE_DETAILS_ROUTE, {
-            quoteId,
-            tab: QuoteDetailsTabsOptionsEnum.orders,
-          }),
-        )
+        errors.forEach(({ message }) => addToast({ severity: 'danger', message }))
+        applyFormFieldErrors(formApi, errors)
+
+        return
       }
+
+      addToast({ severity: 'success', translateKey: 'text_1781686594125pop15l3s7yw' })
+
+      navigate(
+        generatePath(QUOTE_DETAILS_ROUTE, {
+          quoteId,
+          tab: QuoteDetailsTabsOptionsEnum.orders,
+        }),
+      )
     },
   })
 

--- a/src/pages/quotes/VoidOrderForm.tsx
+++ b/src/pages/quotes/VoidOrderForm.tsx
@@ -21,6 +21,10 @@ import { FormLoadingSkeleton, Main, Side } from '~/styles/mainObjectsForm'
 import { buildQuotePreviewProps } from './common/buildQuotePreviewProps'
 import { getOrderFormStatusMapping } from './common/getOrderFormStatusMapping'
 import { QuotePreviewCard } from './common/QuotePreviewCard'
+import {
+  getQuoteMutationErrors,
+  QUOTE_MUTATION_SILENT_ERROR_CODES,
+} from './utils/quoteMutationErrors'
 
 export const VOID_ORDER_FORM_CLOSE_BUTTON_TEST_ID = 'void-order-form-close-button'
 export const VOID_ORDER_FORM_VOID_BUTTON_TEST_ID = 'void-order-form-void-button'
@@ -95,6 +99,10 @@ const VoidOrderForm = () => {
 
   const [voidOrderFormMutation] = useVoidOrderFormMutation({
     refetchQueries: ['getOrderForms'],
+    // Handled locally by `getQuoteMutationErrors`, so the global error link must not
+    // also fire its generic toast (nor report these expected failures to Sentry).
+    // Copied: the link pushes its own force-silenced codes onto the array it receives.
+    context: { silentErrorCodes: [...QUOTE_MUTATION_SILENT_ERROR_CODES] },
   })
 
   const onSubmit = async () => {
@@ -110,19 +118,25 @@ const VoidOrderForm = () => {
       },
     })
 
-    if (result.data?.voidOrderForm) {
-      addToast({
-        severity: 'success',
-        translateKey: 'text_1781625672232ia473jidiy8',
-      })
-
-      navigate(
-        generatePath(QUOTE_DETAILS_ROUTE, {
-          quoteId,
-          tab: QuoteDetailsTabsOptionsEnum.orderForms,
-        }),
+    if (!result.data?.voidOrderForm) {
+      getQuoteMutationErrors(result.errors, translate, 'orderForm').forEach(({ message }) =>
+        addToast({ severity: 'danger', message }),
       )
+
+      return
     }
+
+    addToast({
+      severity: 'success',
+      translateKey: 'text_1781625672232ia473jidiy8',
+    })
+
+    navigate(
+      generatePath(QUOTE_DETAILS_ROUTE, {
+        quoteId,
+        tab: QuoteDetailsTabsOptionsEnum.orderForms,
+      }),
+    )
   }
 
   const onClose = () => {

--- a/src/pages/quotes/__tests__/SignOrderForm.test.tsx
+++ b/src/pages/quotes/__tests__/SignOrderForm.test.tsx
@@ -220,6 +220,149 @@ describe('SignOrderForm', () => {
     })
   })
 
+  describe('API errors', () => {
+    const submitWithExecutionMode = async (user: ReturnType<typeof userEvent.setup>) => {
+      const comboboxContainer = screen.getByTestId(SIGN_ORDER_FORM_EXECUTION_TYPE_TEST_ID)
+      const comboboxInputBase = comboboxContainer.querySelector('.MuiInputBase-root') as HTMLElement
+
+      await user.click(comboboxInputBase)
+
+      const optionWrapper = await screen.findByTestId('combobox-item-text_1781686594125wc395bj9cul')
+      const option = optionWrapper.querySelector('.MuiAutocomplete-option') as HTMLElement
+
+      await user.click(option)
+      await user.click(screen.getByTestId(SIGN_ORDER_FORM_SUBMIT_BUTTON_TEST_ID))
+    }
+
+    it('toasts the API message and stays on the page when the status changed', async () => {
+      mockMarkSigned.mockResolvedValueOnce({
+        data: null,
+        errors: [
+          {
+            message: 'Unprocessable Entity',
+            extensions: { code: 'unprocessable_entity', details: { status: ['not_signable'] } },
+          },
+        ],
+      })
+
+      const user = userEvent.setup()
+
+      renderPage()
+
+      await submitWithExecutionMode(user)
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith({
+          severity: 'danger',
+          message: 'text_1786610894641lt5jhzuiulg',
+        })
+      })
+      expect(addToast).not.toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+      expect(testMockNavigateFn).not.toHaveBeenCalled()
+    })
+
+    it('toasts the permission message on forbidden, which the error link silences', async () => {
+      mockMarkSigned.mockResolvedValueOnce({
+        data: null,
+        errors: [{ message: 'Missing permissions', extensions: { code: 'forbidden' } }],
+      })
+
+      const user = userEvent.setup()
+
+      renderPage()
+
+      await submitWithExecutionMode(user)
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith({
+          severity: 'danger',
+          message: 'text_17865407897429mqm1fco12j',
+        })
+      })
+      expect(testMockNavigateFn).not.toHaveBeenCalled()
+    })
+
+    it('shows the executeAt failure inline on top of its toast', async () => {
+      mockMarkSigned.mockResolvedValueOnce({
+        data: null,
+        errors: [
+          {
+            message: 'Unprocessable Entity',
+            extensions: { code: 'unprocessable_entity', details: { executeAt: ['invalid_date'] } },
+          },
+        ],
+      })
+
+      const user = userEvent.setup()
+
+      renderPage()
+
+      await submitWithExecutionMode(user)
+
+      await waitFor(() => {
+        expect(screen.getByText('text_1786610894641sjyf79n6nny')).toBeInTheDocument()
+      })
+      expect(addToast).toHaveBeenCalledWith({
+        severity: 'danger',
+        message: 'text_1786610894641sjyf79n6nny',
+      })
+    })
+
+    it('shows the executionMode failure inline on top of its toast', async () => {
+      mockMarkSigned.mockResolvedValueOnce({
+        data: null,
+        errors: [
+          {
+            message: 'Unprocessable Entity',
+            extensions: {
+              code: 'unprocessable_entity',
+              details: { executionMode: ['value_is_invalid'] },
+            },
+          },
+        ],
+      })
+
+      const user = userEvent.setup()
+
+      renderPage()
+
+      await submitWithExecutionMode(user)
+
+      await waitFor(() => {
+        expect(screen.getByText('text_1786610894641m8ffsiodyjw')).toBeInTheDocument()
+      })
+      expect(addToast).toHaveBeenCalledWith({
+        severity: 'danger',
+        message: 'text_1786610894641m8ffsiodyjw',
+      })
+    })
+
+    it('falls back to the generic message when the payload carries no known detail', async () => {
+      mockMarkSigned.mockResolvedValueOnce({
+        data: null,
+        errors: [
+          {
+            message: 'Unprocessable Entity',
+            extensions: { code: 'unprocessable_entity', details: { base: ['who_knows'] } },
+          },
+        ],
+      })
+
+      const user = userEvent.setup()
+
+      renderPage()
+
+      await submitWithExecutionMode(user)
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith({
+          severity: 'danger',
+          message: 'text_622f7a3dc32ce100c46a5154',
+        })
+      })
+    })
+  })
+
   describe('unsaved-changes guard', () => {
     const selectExecutionMode = async (user: ReturnType<typeof userEvent.setup>) => {
       const comboboxContainer = screen.getByTestId(SIGN_ORDER_FORM_EXECUTION_TYPE_TEST_ID)

--- a/src/pages/quotes/__tests__/VoidOrderForm.test.tsx
+++ b/src/pages/quotes/__tests__/VoidOrderForm.test.tsx
@@ -231,6 +231,81 @@ describe('VoidOrderForm', () => {
         expect(testMockNavigateFn).toHaveBeenCalledWith('/quote/quote-456/order-forms')
       })
     })
+
+    describe('WHEN the API rejects the void', () => {
+      it('THEN should toast the order-form status message and stay on the page', async () => {
+        mockVoidOrderForm.mockResolvedValueOnce({
+          data: null,
+          errors: [
+            {
+              message: 'Unprocessable Entity',
+              extensions: { code: 'unprocessable_entity', details: { status: ['not_voidable'] } },
+            },
+          ],
+        })
+
+        const user = userEvent.setup()
+
+        render(<VoidOrderForm />)
+
+        await user.click(screen.getByTestId(VOID_ORDER_FORM_VOID_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledWith({
+            severity: 'danger',
+            message: 'text_1786610894641usymql0rk8r',
+          })
+        })
+
+        expect(addToast).not.toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+        expect(testMockNavigateFn).not.toHaveBeenCalled()
+      })
+
+      it('THEN should toast the not-found message when the order form is gone', async () => {
+        mockVoidOrderForm.mockResolvedValueOnce({
+          data: null,
+          errors: [
+            {
+              message: 'Resource not found',
+              extensions: { code: 'not_found', details: { orderForm: ['not_found'] } },
+            },
+          ],
+        })
+
+        const user = userEvent.setup()
+
+        render(<VoidOrderForm />)
+
+        await user.click(screen.getByTestId(VOID_ORDER_FORM_VOID_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledWith({
+            severity: 'danger',
+            message: 'text_1786610894641duk7n532hdi',
+          })
+        })
+      })
+
+      it('THEN should toast the permission message on forbidden', async () => {
+        mockVoidOrderForm.mockResolvedValueOnce({
+          data: null,
+          errors: [{ message: 'Missing permissions', extensions: { code: 'forbidden' } }],
+        })
+
+        const user = userEvent.setup()
+
+        render(<VoidOrderForm />)
+
+        await user.click(screen.getByTestId(VOID_ORDER_FORM_VOID_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledWith({
+            severity: 'danger',
+            message: 'text_17865407897429mqm1fco12j',
+          })
+        })
+      })
+    })
   })
 
   describe('GIVEN an order form whose quote has content', () => {

--- a/src/pages/quotes/utils/__tests__/quoteMutationErrors.test.ts
+++ b/src/pages/quotes/utils/__tests__/quoteMutationErrors.test.ts
@@ -6,6 +6,7 @@ import {
   BILLING_ITEM_CODE_KEYS,
   BILLING_ITEM_FIELD_ERROR_KEYS,
   getQuoteMutationErrors,
+  ORDER_FORM_ERROR_KEYS,
   QUOTE_MUTATION_SILENT_ERROR_CODES,
   TOP_LEVEL_ERROR_KEYS,
 } from '../quoteMutationErrors'
@@ -95,7 +96,13 @@ describe('getQuoteMutationErrors', () => {
         translate,
       )
 
-      expect(errors).toEqual([{ message: 'text_1786540789742b4ym3200cp6', field: 'expiresAt' }])
+      expect(errors).toEqual([
+        {
+          message: 'text_1786540789742b4ym3200cp6',
+          field: 'expiresAt',
+          messageKey: 'text_1786540789742b4ym3200cp6',
+        },
+      ])
     })
 
     it('maps the not_found payload the API sends for an unknown version', () => {
@@ -233,6 +240,81 @@ describe('getQuoteMutationErrors', () => {
     })
   })
 
+  describe('order-form scope', () => {
+    it.each([
+      ['orderForm', 'not_found', 'text_1786610894641duk7n532hdi'],
+      ['status', 'not_signable', 'text_1786610894641lt5jhzuiulg'],
+      ['status', 'not_voidable', 'text_1786610894641usymql0rk8r'],
+      ['signedDocument', 'invalid_format', 'text_1786610894641nv1aitlslgu'],
+      ['orderFormId', 'value_already_exist', 'text_17866108946418951e8uxdcl'],
+    ])('maps %s.%s to its own message', (field, code, expectedKey) => {
+      const errors = getQuoteMutationErrors(
+        makeError('unprocessable_entity', { [field]: [code] }),
+        translate,
+        'orderForm',
+      )
+
+      expect(errors).toEqual([{ message: expectedKey, field: undefined }])
+    })
+
+    it.each([
+      ['executionMode', 'value_is_mandatory', 'text_17866108946411ovi8xqry3n'],
+      ['executionMode', 'value_is_invalid', 'text_1786610894641m8ffsiodyjw'],
+      ['executeAt', 'invalid_date', 'text_1786610894641sjyf79n6nny'],
+    ])('flags %s.%s as a form field error', (field, code, expectedKey) => {
+      const errors = getQuoteMutationErrors(
+        makeError('unprocessable_entity', { [field]: [code] }),
+        translate,
+        'orderForm',
+      )
+
+      expect(errors).toEqual([{ message: expectedKey, field, messageKey: expectedKey }])
+    })
+
+    it('names the order form, not the quote version, on the shared not_voidable key', () => {
+      const details = { status: ['not_voidable'] }
+
+      expect(getQuoteMutationErrors(makeError('unprocessable_entity', details), translate)).toEqual(
+        [{ message: 'text_1786540789742nso5acvqa28', field: undefined }],
+      )
+      expect(
+        getQuoteMutationErrors(makeError('unprocessable_entity', details), translate, 'orderForm'),
+      ).toEqual([{ message: 'text_1786610894641usymql0rk8r', field: undefined }])
+    })
+
+    it('keeps the quote messages for details the scope does not override', () => {
+      const errors = getQuoteMutationErrors(
+        makeError('not_found', { quoteVersion: ['not_found'] }),
+        translate,
+        'orderForm',
+      )
+
+      expect(errors).toEqual([{ message: 'text_178654078974209u9bigc6ta', field: undefined }])
+    })
+
+    it('reports permission and premium failures the same way as the quote scope', () => {
+      expect(getQuoteMutationErrors(makeError('forbidden'), translate, 'orderForm')).toEqual([
+        { message: 'text_17865407897429mqm1fco12j' },
+      ])
+      expect(
+        getQuoteMutationErrors(makeError('feature_unavailable'), translate, 'orderForm'),
+      ).toEqual([{ message: 'text_1786540789742kokuwxcy86s' }])
+    })
+
+    it('leaves an unknown detail on the generic message, and an unhandled code to the link', () => {
+      expect(
+        getQuoteMutationErrors(
+          makeError('unprocessable_entity', { status: ['who_knows'] }),
+          translate,
+          'orderForm',
+        ),
+      ).toEqual([{ message: GENERIC_ERROR_KEY }])
+      expect(getQuoteMutationErrors(makeError('internal_error'), translate, 'orderForm')).toEqual(
+        [],
+      )
+    })
+  })
+
   it('silences exactly the codes it handles locally', () => {
     expect(QUOTE_MUTATION_SILENT_ERROR_CODES).toEqual([
       'unprocessable_entity',
@@ -244,6 +326,7 @@ describe('getQuoteMutationErrors', () => {
   it('declares no duplicate translation keys across its maps', () => {
     const allKeys = [
       ...Object.values(TOP_LEVEL_ERROR_KEYS),
+      ...Object.values(ORDER_FORM_ERROR_KEYS),
       ...Object.values(BILLING_ITEM_FIELD_ERROR_KEYS),
       ...Object.values(BILLING_ITEM_CODE_KEYS),
     ]

--- a/src/pages/quotes/utils/applyFormFieldErrors.ts
+++ b/src/pages/quotes/utils/applyFormFieldErrors.ts
@@ -1,0 +1,28 @@
+import { AnyFormApi } from '@tanstack/react-form'
+
+import { QuoteMutationError } from './quoteMutationErrors'
+
+/**
+ * Pushes the field-targeted messages of a failed quote/order-form mutation into the form, so
+ * the error shows inline next to the offending input on top of its toast.
+ *
+ * Fields are handed the translation key, not the translated sentence: the inputs translate
+ * whatever error they receive, exactly like the zod messages the same forms already emit.
+ *
+ * Errors without a `field` are toast-only and ignored here. `AnyFormApi` keeps the helper
+ * usable from any of the quote forms — the field names come from the API payload, so they
+ * cannot be tied to a single form's shape.
+ */
+export const applyFormFieldErrors = (formApi: AnyFormApi, errors: QuoteMutationError[]): void => {
+  const fields: Record<string, { message: string; path: string[] }> = {}
+
+  for (const { field, message, messageKey } of errors) {
+    if (!field) continue
+
+    fields[field] = { message: messageKey ?? message, path: [field] }
+  }
+
+  if (!Object.keys(fields).length) return
+
+  formApi.setErrorMap({ onDynamic: { fields } })
+}

--- a/src/pages/quotes/utils/quoteMutationErrors.ts
+++ b/src/pages/quotes/utils/quoteMutationErrors.ts
@@ -11,6 +11,14 @@ export interface QuoteMutationError {
   message: string
   /** Form field path, set only for field-targeted errors. */
   field?: string
+  /**
+   * Untranslated key behind `message`, set alongside `field`. Form fields translate the error
+   * they are given (`TextInput` runs it through `translate`, `DatePickerField` asks
+   * `useFieldError` for `translateErrors`), so an inline error has to be handed the key —
+   * feeding it a translated sentence only works through the missing-key fallback and logs a
+   * warning per render.
+   */
+  messageKey?: string
 }
 
 /**
@@ -65,9 +73,33 @@ export const TOP_LEVEL_ERROR_KEYS: Record<string, string> = {
   'startDate.invalid_date_range': 'text_1786540789742hb3p2cjocck',
 }
 
-/** Detail keys that map onto an approve-form field, so the error can also be shown inline. */
+/**
+ * Order-form failures, keyed the same way. Consulted before `TOP_LEVEL_ERROR_KEYS` when the
+ * caller passes the `orderForm` scope, because `status.not_voidable` is reported on both
+ * entities and the copy has to name the right one.
+ */
+export const ORDER_FORM_ERROR_KEYS: Record<string, string> = {
+  'orderForm.not_found': 'text_1786610894641duk7n532hdi',
+  'status.not_signable': 'text_1786610894641lt5jhzuiulg',
+  'status.not_voidable': 'text_1786610894641usymql0rk8r',
+  'executionMode.value_is_mandatory': 'text_17866108946411ovi8xqry3n',
+  'executionMode.value_is_invalid': 'text_1786610894641m8ffsiodyjw',
+  'executeAt.invalid_date': 'text_1786610894641sjyf79n6nny',
+  'signedDocument.invalid_format': 'text_1786610894641nv1aitlslgu',
+  'orderFormId.value_already_exist': 'text_17866108946418951e8uxdcl',
+}
+
+/**
+ * Which entity the failing mutation targets. Only `status.not_voidable` actually overlaps
+ * today, but the scope keeps the two key sets from silently borrowing each other's copy.
+ */
+export type QuoteMutationErrorScope = 'quote' | 'orderForm'
+
+/** Detail keys that map onto a form field, so the error can also be shown inline. */
 const FORM_FIELD_BY_DETAIL_KEY: Record<string, string> = {
   expiresAt: 'expiresAt',
+  executionMode: 'executionMode',
+  executeAt: 'executeAt',
 }
 
 /** `billingItems.<entity>` prefixes, interpolated with the 1-based item position. */
@@ -207,11 +239,20 @@ const getDetailError = (
   rawKey: string,
   code: string,
   translate: TranslateFunc,
+  scope: QuoteMutationErrorScope,
 ): QuoteMutationError => {
-  const topLevelKey = TOP_LEVEL_ERROR_KEYS[`${rawKey}.${code}`]
+  const detailKey = `${rawKey}.${code}`
+  const scopedKey = scope === 'orderForm' ? ORDER_FORM_ERROR_KEYS[detailKey] : undefined
+  const topLevelKey = scopedKey ?? TOP_LEVEL_ERROR_KEYS[detailKey]
 
   if (topLevelKey) {
-    return { message: translate(topLevelKey), field: FORM_FIELD_BY_DETAIL_KEY[rawKey] }
+    const field = FORM_FIELD_BY_DETAIL_KEY[rawKey]
+
+    return {
+      message: translate(topLevelKey),
+      field,
+      messageKey: field ? topLevelKey : undefined,
+    }
   }
 
   const billingItemMessage = getBillingItemMessage(rawKey, code, translate)
@@ -222,7 +263,7 @@ const getDetailError = (
 }
 
 /**
- * Turns a failed quote mutation into user-facing messages.
+ * Turns a failed quote or order-form mutation into user-facing messages.
  *
  * The API answers through `ExecutionErrorResponder`, which exposes
  * `extensions.code` plus a camelized `extensions.details` map of
@@ -233,6 +274,7 @@ const getDetailError = (
 export const getQuoteMutationErrors = (
   errorObject: ApolloError | readonly GraphQLFormattedError[] | undefined,
   translate: TranslateFunc,
+  scope: QuoteMutationErrorScope = 'quote',
 ): QuoteMutationError[] => {
   const genericError: QuoteMutationError[] = [{ message: translate(GENERIC_ERROR_KEY) }]
   const extensions = extractGraphQLErrors(errorObject)[0]?.extensions
@@ -254,7 +296,7 @@ export const getQuoteMutationErrors = (
 
   for (const [rawKey, codes] of Object.entries(details)) {
     const detailCode = Array.isArray(codes) ? codes[0] : String(codes)
-    const error = getDetailError(rawKey, detailCode, translate)
+    const error = getDetailError(rawKey, detailCode, translate, scope)
 
     if (seenMessages.has(error.message)) continue
 

--- a/translations/base.json
+++ b/translations/base.json
@@ -4632,5 +4632,13 @@
   "text_1786367738116xtz2r6c9eoz": "Rate card {{rateCardCode}} was created",
   "text_1786367738117541mevhwa63": "Rate card {{rateCardCode}} was deleted",
   "text_1786367738117gbjclk29or1": "Rate card {{rateCardCode}} was updated",
-  "text_1786367738117s1n9lpwf97k": "Rate card"
+  "text_1786367738117s1n9lpwf97k": "Rate card",
+  "text_1786610894641duk7n532hdi": "This order form could not be found",
+  "text_1786610894641lt5jhzuiulg": "This order form can no longer be signed because its status has changed",
+  "text_1786610894641usymql0rk8r": "This order form can no longer be voided because its status has changed",
+  "text_17866108946411ovi8xqry3n": "Please select an execution type",
+  "text_1786610894641m8ffsiodyjw": "The selected execution type is invalid",
+  "text_1786610894641sjyf79n6nny": "The execution date must be in the future",
+  "text_1786610894641nv1aitlslgu": "The signed document could not be read. Please upload a valid PDF, JPEG or PNG file",
+  "text_17866108946418951e8uxdcl": "An order has already been created for this order form"
 }


### PR DESCRIPTION
## Context

Signing or voiding an order form had no client-side error branch, so every failure fell through to the global Apollo error link and produced a single generic "Something went wrong" toast — and nothing at all for permission errors, since the link force-silences `forbidden`. The API returns rich `extensions.code` + camelized `extensions.details` that we were discarding, exactly as quote approve/void did before #4119.

## Description

Extends the existing quote mapper with an order-form scope rather than adding a second one: `getQuoteMutationErrors` takes an optional `scope` and consults a new `ORDER_FORM_ERROR_KEYS` map first when it is `orderForm`, which is what lets the shared `status.not_voidable` detail key name the order form instead of the quote version — the other seven keys cover `orderForm.not_found`, `status.not_signable`, both `executionMode` failures, `executeAt.invalid_date`, `signedDocument.invalid_format` and `orderFormId.value_already_exist`, while `forbidden` and `feature_unavailable` already had copy. Both mutations now pass `silentErrorCodes` for the codes they handle locally so the generic toast no longer double-fires and Sentry stops recording expected validation failures, and the sign page additionally sets inline errors on the execution-mode and execution-date fields via a new `applyFormFieldErrors` helper that also replaces the hand-rolled block in `ApproveQuote`. That helper hands fields the translation key rather than the translated sentence, since the inputs translate whatever error they receive — the previous behaviour only rendered through the missing-key fallback and logged a warning (plus a Sentry `captureMessage` on non-English production locales) on every render. Covered by 21 new tests (60 suites / 644 tests green in `src/pages/quotes`); the copy for the 8 new translation keys is a first draft and may want a product pass.

<!-- Linear link -->
Fixes LAGO-1808

🤖 Generated with [Claude Code](https://claude.com/claude-code)