### PR TITLE
fix(quotes): allow plan change and lock external id on amendment quotes

### DIFF
--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
@@ -91,14 +91,14 @@ export function SubscriptionPricingContent({
     variables: { limit: 100 },
   })
 
-  // Track the plan this drawer opened with. Once the user picks a *different*
-  // plan, stop forwarding billingItemPlan so usePlanFormSetup falls back to
-  // fetching the newly selected plan and resets prices to its defaults (LAGO-1602).
-  const originalBillingItemPlanId = useRef(billingItemPlan?.id)
+  // Track the plan this drawer opened with — either the saved billing item's plan or,
+  // on an amendment, the plan resolved from the subscription (recorded by the sync effect
+  // below). Once the user picks a *different* plan, stop forwarding both billingItemPlan
+  // and subscriptionId so usePlanFormSetup falls back to fetching the newly selected plan
+  // and resets prices to its defaults (LAGO-1602, LAGO-1822).
+  const originalPlanIdRef = useRef(billingItemPlan?.id)
   const userSwitchedPlan =
-    !!originalBillingItemPlanId.current &&
-    !!selectedPlanId &&
-    selectedPlanId !== originalBillingItemPlanId.current
+    !!originalPlanIdRef.current && !!selectedPlanId && selectedPlanId !== originalPlanIdRef.current
 
   // Set by the form's own onSubmit, which TanStack only calls once the form-level
   // `planFormSchema` passed — so it doubles as the validity signal.
@@ -120,7 +120,7 @@ export function SubscriptionPricingContent({
     // its own currency and seeds the quote's on save.
     initialCurrency: hasQuoteCurrency ? (currency ?? undefined) : undefined,
     billingItemPlan: userSwitchedPlan ? undefined : billingItemPlan,
-    subscriptionId,
+    subscriptionId: userSwitchedPlan ? undefined : subscriptionId,
     onSubmit: () => {
       planFormValidRef.current = true
     },
@@ -141,9 +141,12 @@ export function SubscriptionPricingContent({
     }
   }, [planForm, validatePlanFormRef])
 
-  // Sync selectedPlanId from resolvedPlanId when billing items or subscription data arrives
+  // Sync selectedPlanId from resolvedPlanId when billing items or subscription data arrives.
+  // That first resolution is also the plan the drawer opened with, so record it as the
+  // baseline for userSwitchedPlan (the subscription path has no billingItemPlan to seed it).
   useEffect(() => {
     if (resolvedPlanId && !selectedPlanId) {
+      originalPlanIdRef.current = resolvedPlanId
       setSelectedPlanId(resolvedPlanId)
     }
   }, [resolvedPlanId, selectedPlanId])
@@ -172,11 +175,30 @@ export function SubscriptionPricingContent({
     initialState?.invoicingSettings ?? billingItemInvoicingSettings ?? DEFAULT_INVOICING_SETTINGS,
   )
 
-  // Hook-based drawers for settings
-  const subscriptionSettingsDrawer = useSubscriptionSettingsDrawer(
-    (values) => setSubscriptionSettings(values),
-    isAmendment,
+  // On an amendment the settings come from the subscription query, which resolves *after*
+  // mount — the lazy initializer above has already run with the defaults by then, so seed
+  // them once when they land. Skipped when a saved quote state or the user already owns them.
+  const subscriptionSettingsSeededRef = useRef(
+    !!initialState?.subscriptionSettings || !!billingItemSubscriptionSettings,
   )
+
+  useEffect(() => {
+    if (subscriptionSettingsSeededRef.current || !billingItemSubscriptionSettings) return
+
+    subscriptionSettingsSeededRef.current = true
+    setSubscriptionSettings(
+      // An amendment quote never carries a start date (it belongs to the subscription).
+      isAmendment
+        ? { ...billingItemSubscriptionSettings, startDate: '' }
+        : billingItemSubscriptionSettings,
+    )
+  }, [billingItemSubscriptionSettings, isAmendment])
+
+  // Hook-based drawers for settings
+  const subscriptionSettingsDrawer = useSubscriptionSettingsDrawer((values) => {
+    subscriptionSettingsSeededRef.current = true
+    setSubscriptionSettings(values)
+  }, isAmendment)
   const showInvoicingSection = Boolean(customer?.externalId || customer?.id)
   const planSettingsDrawer = useQuotePlanSettingsDrawer(planForm, {
     disableCurrencyInput: hasQuoteCurrency,
@@ -335,7 +357,7 @@ export function SubscriptionPricingContent({
             data={comboBoxData}
             loading={plansLoading}
             searchQuery={getPlans}
-            disabled={!!subscriptionId}
+            disabled={!!subscriptionId && !isAmendment}
             label={translate('text_17810991003371jgudmuzk6a')}
             placeholder={translate('text_1781099100337xeyy7omuzp8')}
             value={selectedPlanId}

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
@@ -90,6 +90,12 @@ let mockBasePlanFormValues: PlanFormInput | undefined
 // validators pass, which is what the component uses as its validity signal.
 let mockFormPassesValidation = true
 
+// Amendment path: while the quote still amends a subscription, the hook resolves the plan
+// (and the subscription settings) from that subscription instead of planIdToFetch, and both
+// only land once the query resolves — after mount.
+let mockSubscriptionPlanId: string | undefined
+let mockSubscriptionSettings: SubscriptionPricingState['subscriptionSettings'] | undefined
+
 jest.mock('~/hooks/plans/usePlanFormSetup', () => {
   const { createMockPlanForm } = jest.requireActual('~/test-utils/createMockPlanForm')
 
@@ -97,9 +103,11 @@ jest.mock('~/hooks/plans/usePlanFormSetup', () => {
     usePlanFormSetup: jest.fn(
       ({
         planIdToFetch,
+        subscriptionId,
         onSubmit,
       }: {
         planIdToFetch?: string
+        subscriptionId?: string
         onSubmit?: (value: PlanFormInput) => void
       }) => {
         const form = createMockPlanForm(mockFormOverrides)
@@ -110,14 +118,18 @@ jest.mock('~/hooks/plans/usePlanFormSetup', () => {
           }
         })
 
+        // The subscription's own plan wins over planIdToFetch as long as the
+        // subscription is still forwarded.
+        const resolvedPlanId = (subscriptionId && mockSubscriptionPlanId) || planIdToFetch
+
         return {
           form,
-          plan: planIdToFetch ? mockPlan : undefined,
+          plan: resolvedPlanId ? mockPlan : undefined,
           basePlanFormValues: mockBasePlanFormValues,
-          formReady: !!planIdToFetch,
+          formReady: !!resolvedPlanId,
           loading: false,
-          resolvedPlanId: planIdToFetch,
-          subscriptionSettings: undefined,
+          resolvedPlanId,
+          subscriptionSettings: subscriptionId ? mockSubscriptionSettings : undefined,
           invoicingSettings: undefined,
         }
       },
@@ -178,6 +190,8 @@ describe('SubscriptionPricingContent', () => {
     mockFormOverrides = {}
     mockFormPassesValidation = true
     mockBasePlanFormValues = undefined
+    mockSubscriptionPlanId = undefined
+    mockSubscriptionSettings = undefined
     mockOpenSubscriptionSettings.mockClear()
     mockOpenPlanSettings.mockClear()
   })
@@ -775,6 +789,136 @@ describe('SubscriptionPricingContent', () => {
       // The plan query is cache-and-network, so it reports loading on every open —
       // the drawer must not blank out waiting for the diff baseline.
       expect(screen.getByTestId('fixed-charges-section')).toBeInTheDocument()
+    })
+  })
+
+  describe('GIVEN a quote attached to a subscription', () => {
+    const subscriptionSettings = {
+      externalId: 'sub_ext_1',
+      subscriptionName: 'Acme monthly',
+      billingTime: 'calendar' as const,
+      startDate: '2026-01-01',
+      endDate: '2026-12-31',
+    }
+
+    const renderWithSubscription = async (isAmendment: boolean) => {
+      const stateRef = { current: null as SubscriptionPricingState | null }
+      const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
+
+      // A fresh element every time: React bails out of a re-render given the very same
+      // element reference, and the mocked hook would never be called again.
+      const buildElement = () => (
+        <SubscriptionPricingContent
+          stateRef={stateRef}
+          formValuesRef={formValuesRef}
+          basePlanFormValuesRef={basePlanFormValuesRef}
+          subscriptionId="sub_1"
+          isAmendment={isAmendment}
+        />
+      )
+
+      const rendered = await act(() => render(buildElement()))
+
+      return {
+        stateRef,
+        // Replays the render so the mocked hook returns its newly-set values, the way the
+        // subscription query resolving after mount would.
+        rerender: async () => {
+          await act(async () => {
+            rendered.rerender(buildElement())
+          })
+        },
+      }
+    }
+
+    const selectPlan = async (label: string) => {
+      const combobox = screen.getByRole('combobox') as HTMLInputElement
+
+      await userEvent.click(combobox)
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('listbox').length).toBeGreaterThan(0)
+      })
+
+      const listboxId = combobox.getAttribute('aria-controls') as string
+      const listbox = document.getElementById(listboxId) as HTMLElement
+
+      await userEvent.click(within(listbox).getByText(label))
+    }
+
+    it('WHEN it is an amendment THEN the plan can still be changed', async () => {
+      mockSubscriptionPlanId = 'plan_1'
+
+      await renderWithSubscription(true)
+
+      expect(screen.getByRole('combobox')).not.toBeDisabled()
+    })
+
+    it('WHEN it is not an amendment THEN the plan stays locked to the subscription', async () => {
+      mockSubscriptionPlanId = 'plan_1'
+
+      await renderWithSubscription(false)
+
+      expect(screen.getByRole('combobox')).toBeDisabled()
+    })
+
+    it('WHEN the user switches plan on an amendment THEN the subscription is dropped so prices reset', async () => {
+      mockSubscriptionPlanId = 'plan_1'
+
+      await renderWithSubscription(true)
+
+      // While the original plan is selected, the subscription still drives the form
+      expect(usePlanFormSetup).toHaveBeenLastCalledWith(
+        expect.objectContaining({ subscriptionId: 'sub_1', planIdToFetch: 'plan_1' }),
+      )
+
+      await selectPlan('Pro (pro)')
+
+      // Both sources are dropped, so the hook fetches plan_2 and resets to its defaults
+      expect(usePlanFormSetup).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          subscriptionId: undefined,
+          billingItemPlan: undefined,
+          planIdToFetch: 'plan_2',
+        }),
+      )
+    })
+
+    it('WHEN the subscription settings resolve after mount THEN they seed the quote state', async () => {
+      mockSubscriptionPlanId = 'plan_1'
+
+      const { stateRef, rerender } = await renderWithSubscription(true)
+
+      expect(stateRef.current?.subscriptionSettings.externalId).toBe('')
+
+      mockSubscriptionSettings = subscriptionSettings
+      await rerender()
+
+      expect(stateRef.current?.subscriptionSettings).toEqual({
+        ...subscriptionSettings,
+        // An amendment quote never carries a start date
+        startDate: '',
+      })
+    })
+
+    it('WHEN the user switches plan THEN the seeded subscription settings are preserved', async () => {
+      mockSubscriptionPlanId = 'plan_1'
+      mockSubscriptionSettings = subscriptionSettings
+
+      const { stateRef, rerender } = await renderWithSubscription(true)
+
+      await rerender()
+      await selectPlan('Pro (pro)')
+
+      // The subscription query is no longer forwarded, but its settings must survive
+      expect(usePlanFormSetup).toHaveBeenLastCalledWith(
+        expect.objectContaining({ subscriptionId: undefined, planIdToFetch: 'plan_2' }),
+      )
+      expect(stateRef.current?.subscriptionSettings).toEqual({
+        ...subscriptionSettings,
+        startDate: '',
+      })
     })
   })
 })

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/useSubscriptionSettingsDrawer.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/useSubscriptionSettingsDrawer.test.tsx
@@ -269,6 +269,59 @@ describe('useSubscriptionSettingsDrawer', () => {
 
         expect(mockOnSave).toHaveBeenCalledWith(expect.objectContaining({ startDate: '' }))
       })
+
+      it('THEN should lock the pre-filled external ID', () => {
+        openAndRenderDrawer(populatedValues, true)
+
+        const externalIdInput = document.querySelector(
+          'input[name="externalId"]',
+        ) as HTMLInputElement
+
+        // The external id identifies the amended subscription: neither editable...
+        expect(externalIdInput).toBeDisabled()
+        // ...nor removable
+        const fieldRow = externalIdInput.closest('.flex.flex-row')
+
+        expect(within(fieldRow as HTMLElement).queryByTestId('button')).not.toBeInTheDocument()
+      })
+
+      it('THEN should leave the subscription name editable', () => {
+        openAndRenderDrawer(populatedValues, true)
+
+        const subscriptionNameInput = document.querySelector(
+          'input[name="subscriptionName"]',
+        ) as HTMLInputElement
+
+        expect(subscriptionNameInput).not.toBeDisabled()
+      })
+
+      it('THEN should keep the "add external ID" flow when there is none to lock', async () => {
+        const user = userEvent.setup()
+
+        openAndRenderDrawer(defaultValues, true)
+
+        await user.click(screen.getByTestId('show-external-id'))
+
+        expect(document.querySelector('input[name="externalId"]')).not.toBeDisabled()
+      })
+    })
+  })
+
+  describe('GIVEN a subscription-creation quote with a pre-filled external ID', () => {
+    describe('WHEN isAmendment is false', () => {
+      it('THEN should keep the external ID editable and removable', () => {
+        openAndRenderDrawer(populatedValues, false)
+
+        const externalIdInput = document.querySelector(
+          'input[name="externalId"]',
+        ) as HTMLInputElement
+
+        expect(externalIdInput).not.toBeDisabled()
+
+        const fieldRow = externalIdInput.closest('.flex.flex-row')
+
+        expect(within(fieldRow as HTMLElement).getByTestId('button')).toBeInTheDocument()
+      })
     })
   })
 

--- a/src/components/designSystem/RichTextEditor/PricingBlock/useSubscriptionSettingsDrawer.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/useSubscriptionSettingsDrawer.tsx
@@ -58,6 +58,9 @@ const SubscriptionSettingsDrawerContent = withForm({
   render: function Render({ form, initialValues, isAmendment }) {
     const { translate } = useInternationalization()
     const [showExternalId, setShowExternalId] = useState(!!initialValues.externalId)
+    // On an amendment the external id identifies the subscription being amended, so once it
+    // is prefilled it can neither be edited nor removed (LAGO-1822).
+    const isExternalIdLocked = isAmendment && !!initialValues.externalId
     const [showSubscriptionName, setShowSubscriptionName] = useState(
       !!initialValues.subscriptionName,
     )
@@ -76,23 +79,26 @@ const SubscriptionSettingsDrawerContent = withForm({
                   label={translate('text_642a94e522316cd9e1875224')}
                   placeholder={translate('text_642ac1d1407baafb9e4390ee')}
                   helperText={translate('text_642ac28c65c2180085afe31a')}
+                  disabled={isExternalIdLocked}
                 />
               )}
             </form.AppField>
-            <Tooltip
-              className="mt-7 h-fit"
-              placement="top-end"
-              title={translate('text_63aa085d28b8510cd46443ff')}
-            >
-              <Button
-                icon="trash"
-                variant="quaternary"
-                onClick={() => {
-                  form.setFieldValue('externalId', '')
-                  setShowExternalId(false)
-                }}
-              />
-            </Tooltip>
+            {!isExternalIdLocked && (
+              <Tooltip
+                className="mt-7 h-fit"
+                placement="top-end"
+                title={translate('text_63aa085d28b8510cd46443ff')}
+              >
+                <Button
+                  icon="trash"
+                  variant="quaternary"
+                  onClick={() => {
+                    form.setFieldValue('externalId', '')
+                    setShowExternalId(false)
+                  }}
+                />
+              </Tooltip>
+            )}
           </div>
         )}
         {showSubscriptionName && (


### PR DESCRIPTION
## Context

On a `subscription_amendment` quote the plan could not be changed — the plan ComboBox was `disabled={!!subscriptionId}`, and even unlocked it would have had no effect since `usePlanFormSetup` resolves the plan from the subscription (`billingItemPlan?.id ?? parentPlanId ?? planIdToFetch` + `skipPlanQuery`). Meanwhile the amended subscription's external id was freely editable, and in fact never even reached the component state: the `subscriptionSettings` lazy initializer runs at mount while the subscription query is still in flight, so nothing was displayed or preserved.

## Description

Selecting a different plan on an amendment now drops both `subscriptionId` and `billingItemPlan` on the way into `usePlanFormSetup`, so it fetches the new plan and the existing reset wipes charges, fees, commitments and thresholds to its defaults (subscription and invoicing settings are kept). A one-shot effect seeds `subscriptionSettings` when the subscription query resolves, and the external id is rendered disabled without its trash button whenever it is prefilled on an amendment — the add/remove flow is untouched for subscription-creation quotes. Covered by new cases in `SubscriptionPricingContent.test.tsx` and `useSubscriptionSettingsDrawer.test.tsx`.

<!-- Linear link -->
Fixes LAGO-1822

🤖 Generated with [Claude Code](https://claude.com/claude-code)