### PR TITLE
feat(orders): display API error messages on order execution

### DIFF
--- a/src/pages/quotes/ExecuteOrder.tsx
+++ b/src/pages/quotes/ExecuteOrder.tsx
@@ -25,6 +25,10 @@ import { buildOrderHeader } from './common/buildOrderHeader'
 import { buildQuotePreviewProps } from './common/buildQuotePreviewProps'
 import { getQuoteOrderTypeTranslationKey } from './common/getQuoteOrderTypeTranslationKey'
 import { QuotePreviewCard } from './common/QuotePreviewCard'
+import {
+  getQuoteMutationErrors,
+  QUOTE_MUTATION_SILENT_ERROR_CODES,
+} from './utils/quoteMutationErrors'
 
 export const EXECUTE_ORDER_CLOSE_BUTTON_TEST_ID = 'execute-order-close-button'
 export const EXECUTE_ORDER_CANCEL_BUTTON_TEST_ID = 'execute-order-cancel-button'
@@ -85,7 +89,14 @@ const ExecuteOrder = () => {
   })
 
   const [executeOrderMutation, { loading: executing }] = useExecuteOrderMutation({
+    // The client's default `errorPolicy: 'all'` keeps the mutation from throwing, so this
+    // refetch runs on a failed execution too — which matters because the API can still have
+    // moved the order to `failed`.
     refetchQueries: ['getOrders'],
+    // Handled locally by `getQuoteMutationErrors`, so the global error link must not
+    // also fire its generic toast (nor report these expected failures to Sentry).
+    // Copied: the link pushes its own force-silenced codes onto the array it receives.
+    context: { silentErrorCodes: [...QUOTE_MUTATION_SILENT_ERROR_CODES] },
   })
 
   const order = data?.order
@@ -119,16 +130,22 @@ const ExecuteOrder = () => {
       variables: { input: { id: orderId } },
     })
 
-    if (result.data?.executeOrder) {
-      addToast({ severity: 'success', translateKey: 'text_1783693954158zdvy0q96esu' })
-
-      navigate(
-        generatePath(QUOTE_DETAILS_ROUTE, {
-          quoteId,
-          tab: QuoteDetailsTabsOptionsEnum.orders,
-        }),
+    if (!result.data?.executeOrder) {
+      getQuoteMutationErrors(result.errors, translate, 'order').forEach(({ message }) =>
+        addToast({ severity: 'danger', message }),
       )
+
+      return
     }
+
+    addToast({ severity: 'success', translateKey: 'text_1783693954158zdvy0q96esu' })
+
+    navigate(
+      generatePath(QUOTE_DETAILS_ROUTE, {
+        quoteId,
+        tab: QuoteDetailsTabsOptionsEnum.orders,
+      }),
+    )
   }
 
   if (error) {

--- a/src/pages/quotes/__tests__/ExecuteOrder.test.tsx
+++ b/src/pages/quotes/__tests__/ExecuteOrder.test.tsx
@@ -1,3 +1,4 @@
+import { ApolloError } from '@apollo/client'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
@@ -12,6 +13,7 @@ import ExecuteOrder, {
   EXECUTE_ORDER_PREVIEW_TEST_ID,
   EXECUTE_ORDER_SUBMIT_BUTTON_TEST_ID,
 } from '../ExecuteOrder'
+import { QUOTE_MUTATION_SILENT_ERROR_CODES } from '../utils/quoteMutationErrors'
 
 jest.mock('~/components/designSystem/RichTextEditor/RichTextEditor', () => ({
   __esModule: true,
@@ -60,17 +62,35 @@ jest.mock('~/hooks/core/useLocationHistory', () => ({
 
 const mockExecuteOrder = jest.fn()
 const mockUseGetOrderForExecuteQuery = jest.fn()
+const mockUseExecuteOrderMutation = jest.fn()
 
 jest.mock('~/generated/graphql', () => ({
   ...jest.requireActual('~/generated/graphql'),
   useGetOrderForExecuteQuery: (...args: unknown[]) => mockUseGetOrderForExecuteQuery(...args),
-  useExecuteOrderMutation: () => [mockExecuteOrder, { loading: false }],
+  useExecuteOrderMutation: (...args: unknown[]) => {
+    mockUseExecuteOrderMutation(...args)
+
+    return [mockExecuteOrder, { loading: false }]
+  },
 }))
 
 jest.mock('~/core/apolloClient', () => ({
   ...jest.requireActual('~/core/apolloClient'),
   addToast: jest.fn(),
 }))
+
+// Mirrors what `ExecutionErrorResponder` puts on a failed `executeOrder`: a top-level code
+// plus a camelized `field -> [errorCode]` detail map.
+const makeGraphQLErrors = (
+  code: string,
+  details?: Record<string, string[]>,
+): ApolloError['graphQLErrors'] =>
+  [
+    {
+      message: 'error',
+      extensions: details ? { code, details } : { code },
+    },
+  ] as never
 
 const mockOrder = {
   id: 'order-123',
@@ -161,6 +181,124 @@ describe('ExecuteOrder', () => {
       expect(mockExecuteOrder).toHaveBeenCalled()
     })
     expect(testMockNavigateFn).not.toHaveBeenCalled()
+  })
+
+  describe('API error handling', () => {
+    it('silences the error codes it handles locally', () => {
+      render(<ExecuteOrder />)
+
+      expect(mockUseExecuteOrderMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: { silentErrorCodes: [...QUOTE_MUTATION_SILENT_ERROR_CODES] },
+        }),
+      )
+
+      // The link pushes its own force-silenced codes onto the array it receives, so passing
+      // the shared constant itself would mutate it for every other caller.
+      const { context } = mockUseExecuteOrderMutation.mock.calls[0][0]
+
+      expect(context.silentErrorCodes).not.toBe(QUOTE_MUTATION_SILENT_ERROR_CODES)
+    })
+
+    it('toasts the mapped message and stays on the page when execution fails', async () => {
+      mockExecuteOrder.mockResolvedValueOnce({
+        data: { executeOrder: null },
+        errors: makeGraphQLErrors('unprocessable_entity', {
+          executionMode: ['value_is_mandatory'],
+        }),
+      })
+
+      const user = userEvent.setup()
+
+      render(<ExecuteOrder />)
+
+      await user.click(screen.getByTestId(EXECUTE_ORDER_SUBMIT_BUTTON_TEST_ID))
+
+      // Pins the order-scoped copy: the order-form scope would resolve
+      // `text_17866108946411ovi8xqry3n` here, and the quote scope the generic message.
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith({
+          severity: 'danger',
+          message: 'text_1786630268015x89z5erp5gc',
+        })
+      })
+      expect(addToast).toHaveBeenCalledTimes(1)
+      expect(addToast).not.toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+      expect(testMockNavigateFn).not.toHaveBeenCalled()
+    })
+
+    // The error link force-silences `forbidden`, so without the local branch this failure
+    // produced no feedback at all.
+    it('toasts a permission failure the link would otherwise swallow', async () => {
+      mockExecuteOrder.mockResolvedValueOnce({
+        data: { executeOrder: null },
+        errors: makeGraphQLErrors('forbidden'),
+      })
+
+      const user = userEvent.setup()
+
+      render(<ExecuteOrder />)
+
+      await user.click(screen.getByTestId(EXECUTE_ORDER_SUBMIT_BUTTON_TEST_ID))
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith({
+          severity: 'danger',
+          message: 'text_17865407897429mqm1fco12j',
+        })
+      })
+      expect(testMockNavigateFn).not.toHaveBeenCalled()
+    })
+
+    it('toasts one message per key of a multi-key failure', async () => {
+      mockExecuteOrder.mockResolvedValueOnce({
+        data: { executeOrder: null },
+        errors: makeGraphQLErrors('not_found', {
+          plan: ['not_found'],
+          coupon: ['not_found'],
+        }),
+      })
+
+      const user = userEvent.setup()
+
+      render(<ExecuteOrder />)
+
+      await user.click(screen.getByTestId(EXECUTE_ORDER_SUBMIT_BUTTON_TEST_ID))
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledTimes(2)
+      })
+
+      expect(addToast).toHaveBeenCalledWith({
+        severity: 'danger',
+        message: 'text_1786630268016ukk6fi5u778',
+      })
+      expect(addToast).toHaveBeenCalledWith({
+        severity: 'danger',
+        message: 'text_1786630268016171ivs0g1kv',
+      })
+    })
+
+    it('does not leave a failure silent when the API sends no details', async () => {
+      mockExecuteOrder.mockResolvedValueOnce({
+        data: { executeOrder: null },
+        errors: makeGraphQLErrors('unprocessable_entity'),
+      })
+
+      const user = userEvent.setup()
+
+      render(<ExecuteOrder />)
+
+      await user.click(screen.getByTestId(EXECUTE_ORDER_SUBMIT_BUTTON_TEST_ID))
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith({
+          severity: 'danger',
+          message: 'text_622f7a3dc32ce100c46a5154',
+        })
+      })
+      expect(addToast).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('navigates back (goBack) via cancel and close buttons', async () => {

--- a/src/pages/quotes/utils/__tests__/quoteMutationErrors.test.ts
+++ b/src/pages/quotes/utils/__tests__/quoteMutationErrors.test.ts
@@ -6,6 +6,7 @@ import {
   BILLING_ITEM_CODE_KEYS,
   BILLING_ITEM_FIELD_ERROR_KEYS,
   getQuoteMutationErrors,
+  ORDER_ERROR_KEYS,
   ORDER_FORM_ERROR_KEYS,
   QUOTE_MUTATION_SILENT_ERROR_CODES,
   TOP_LEVEL_ERROR_KEYS,
@@ -315,6 +316,136 @@ describe('getQuoteMutationErrors', () => {
     })
   })
 
+  describe('order scope', () => {
+    // `executeOrder` reports the order itself and every catalog entity its billing snapshot
+    // points at, so these arrive as top-level `<resource>.<code>` details.
+    it.each([
+      ['not_found', 'order', 'not_found', 'text_1786630268015utxlmxzyv6k'],
+      [
+        'unprocessable_entity',
+        'orderType',
+        'unsupported_order_type',
+        'text_17866302680156sw8ubyaf72',
+      ],
+      ['unprocessable_entity', 'base', 'concurrency_conflict', 'text_178663026801526jdrqexzy1'],
+      ['not_found', 'plan', 'not_found', 'text_1786630268016ukk6fi5u778'],
+      ['not_found', 'coupon', 'not_found', 'text_1786630268016171ivs0g1kv'],
+      ['not_found', 'addOn', 'not_found', 'text_1786630268016o1hi9xo2obe'],
+      ['not_found', 'charge', 'not_found', 'text_1786630268016h9odzv5jjs5'],
+      ['not_found', 'fixedCharge', 'not_found', 'text_1786630268016t366gcvcago'],
+      ['not_found', 'billableMetric', 'not_found', 'text_1786630268016qtainhwsys3'],
+      [
+        'unprocessable_entity',
+        'chargeModel',
+        'charge_model_changed',
+        'text_1786630268016w264kj4y86j',
+      ],
+      [
+        'unprocessable_entity',
+        'fixedChargeModel',
+        'fixed_charge_model_changed',
+        'text_1786630268016meyak1nxn9g',
+      ],
+      ['not_found', 'customer', 'not_found', 'text_1786630268016i9hcrwrzkcc'],
+      ['not_found', 'fees', 'not_found', 'text_1786630268016vpwqdibatsd'],
+    ])('maps %s / %s.%s to its own message', (code, field, detailCode, expectedKey) => {
+      const errors = getQuoteMutationErrors(
+        makeError(code, { [field]: [detailCode] }),
+        translate,
+        'order',
+      )
+
+      expect(errors).toEqual([{ message: expectedKey, field: undefined }])
+    })
+
+    it('names the order, not the order form, on the shared executionMode key', () => {
+      const details = { executionMode: ['value_is_mandatory'] }
+
+      expect(
+        getQuoteMutationErrors(makeError('unprocessable_entity', details), translate, 'order'),
+      ).toEqual([
+        {
+          message: 'text_1786630268015x89z5erp5gc',
+          field: 'executionMode',
+          messageKey: 'text_1786630268015x89z5erp5gc',
+        },
+      ])
+      expect(
+        getQuoteMutationErrors(makeError('unprocessable_entity', details), translate, 'orderForm'),
+      ).toEqual([
+        {
+          message: 'text_17866108946411ovi8xqry3n',
+          field: 'executionMode',
+          messageKey: 'text_17866108946411ovi8xqry3n',
+        },
+      ])
+      // The quote scope never sees this detail, so it stays on the generic copy — and with no
+      // key to show inline, it is not flagged as a field error either.
+      expect(getQuoteMutationErrors(makeError('unprocessable_entity', details), translate)).toEqual(
+        [{ message: GENERIC_ERROR_KEY }],
+      )
+    })
+
+    it('keeps the quote messages for details the scope does not override', () => {
+      const errors = getQuoteMutationErrors(
+        makeError('not_found', { quoteVersion: ['not_found'] }),
+        translate,
+        'order',
+      )
+
+      expect(errors).toEqual([{ message: 'text_178654078974209u9bigc6ta', field: undefined }])
+    })
+
+    it('does not borrow the order-form copy', () => {
+      const errors = getQuoteMutationErrors(
+        makeError('not_found', { orderForm: ['not_found'] }),
+        translate,
+        'order',
+      )
+
+      expect(errors).toEqual([{ message: GENERIC_ERROR_KEY }])
+    })
+
+    it('reports permission and premium failures the same way as the quote scope', () => {
+      expect(getQuoteMutationErrors(makeError('forbidden'), translate, 'order')).toEqual([
+        { message: 'text_17865407897429mqm1fco12j' },
+      ])
+      expect(getQuoteMutationErrors(makeError('feature_unavailable'), translate, 'order')).toEqual([
+        { message: 'text_1786540789742kokuwxcy86s' },
+      ])
+    })
+
+    it('leaves an unknown detail on the generic message, and an unhandled code to the link', () => {
+      expect(
+        getQuoteMutationErrors(
+          makeError('unprocessable_entity', { order: ['who_knows'] }),
+          translate,
+          'order',
+        ),
+      ).toEqual([{ message: GENERIC_ERROR_KEY }])
+      expect(getQuoteMutationErrors(makeError('internal_error'), translate, 'order')).toEqual([])
+    })
+
+    it('caps a multi-key execution failure at three messages', () => {
+      const errors = getQuoteMutationErrors(
+        makeError('not_found', {
+          plan: ['not_found'],
+          coupon: ['not_found'],
+          addOn: ['not_found'],
+          billableMetric: ['not_found'],
+        }),
+        translate,
+        'order',
+      )
+
+      expect(errors).toEqual([
+        { message: 'text_1786630268016ukk6fi5u778', field: undefined },
+        { message: 'text_1786630268016171ivs0g1kv', field: undefined },
+        { message: 'text_1786630268016o1hi9xo2obe', field: undefined },
+      ])
+    })
+  })
+
   it('silences exactly the codes it handles locally', () => {
     expect(QUOTE_MUTATION_SILENT_ERROR_CODES).toEqual([
       'unprocessable_entity',
@@ -327,6 +458,7 @@ describe('getQuoteMutationErrors', () => {
     const allKeys = [
       ...Object.values(TOP_LEVEL_ERROR_KEYS),
       ...Object.values(ORDER_FORM_ERROR_KEYS),
+      ...Object.values(ORDER_ERROR_KEYS),
       ...Object.values(BILLING_ITEM_FIELD_ERROR_KEYS),
       ...Object.values(BILLING_ITEM_CODE_KEYS),
     ]

--- a/src/pages/quotes/utils/quoteMutationErrors.ts
+++ b/src/pages/quotes/utils/quoteMutationErrors.ts
@@ -90,10 +90,43 @@ export const ORDER_FORM_ERROR_KEYS: Record<string, string> = {
 }
 
 /**
- * Which entity the failing mutation targets. Only `status.not_voidable` actually overlaps
- * today, but the scope keeps the two key sets from silently borrowing each other's copy.
+ * Order execution failures, keyed the same way. `executeOrder` reports on the order itself and on
+ * every catalog entity its billing snapshot points at, so a quoted plan/coupon/add-on that has
+ * since disappeared surfaces here as a top-level `<resource>.not_found` — unlike the billing-item
+ * keys below, which the approve mutation reports positionally.
  */
-export type QuoteMutationErrorScope = 'quote' | 'orderForm'
+export const ORDER_ERROR_KEYS: Record<string, string> = {
+  'order.not_found': 'text_1786630268015utxlmxzyv6k',
+  'orderType.unsupported_order_type': 'text_17866302680156sw8ubyaf72',
+  'executionMode.value_is_mandatory': 'text_1786630268015x89z5erp5gc',
+  'base.concurrency_conflict': 'text_178663026801526jdrqexzy1',
+  'plan.not_found': 'text_1786630268016ukk6fi5u778',
+  'coupon.not_found': 'text_1786630268016171ivs0g1kv',
+  'addOn.not_found': 'text_1786630268016o1hi9xo2obe',
+  'charge.not_found': 'text_1786630268016h9odzv5jjs5',
+  'fixedCharge.not_found': 'text_1786630268016t366gcvcago',
+  'billableMetric.not_found': 'text_1786630268016qtainhwsys3',
+  'chargeModel.charge_model_changed': 'text_1786630268016w264kj4y86j',
+  'fixedChargeModel.fixed_charge_model_changed': 'text_1786630268016meyak1nxn9g',
+  'customer.not_found': 'text_1786630268016i9hcrwrzkcc',
+  'fees.not_found': 'text_1786630268016vpwqdibatsd',
+}
+
+/**
+ * Which entity the failing mutation targets. `status.not_voidable` and
+ * `executionMode.value_is_mandatory` are each reported on two entities, so the scope is what keeps
+ * the key sets from silently borrowing each other's copy.
+ */
+export type QuoteMutationErrorScope = 'quote' | 'orderForm' | 'order'
+
+/**
+ * Scope-specific overrides, consulted before `TOP_LEVEL_ERROR_KEYS`. `quote` has no entry: it is
+ * the base scope, so it reads `TOP_LEVEL_ERROR_KEYS` directly.
+ */
+const SCOPED_ERROR_KEYS: Partial<Record<QuoteMutationErrorScope, Record<string, string>>> = {
+  orderForm: ORDER_FORM_ERROR_KEYS,
+  order: ORDER_ERROR_KEYS,
+}
 
 /** Detail keys that map onto a form field, so the error can also be shown inline. */
 const FORM_FIELD_BY_DETAIL_KEY: Record<string, string> = {
@@ -242,8 +275,7 @@ const getDetailError = (
   scope: QuoteMutationErrorScope,
 ): QuoteMutationError => {
   const detailKey = `${rawKey}.${code}`
-  const scopedKey = scope === 'orderForm' ? ORDER_FORM_ERROR_KEYS[detailKey] : undefined
-  const topLevelKey = scopedKey ?? TOP_LEVEL_ERROR_KEYS[detailKey]
+  const topLevelKey = SCOPED_ERROR_KEYS[scope]?.[detailKey] ?? TOP_LEVEL_ERROR_KEYS[detailKey]
 
   if (topLevelKey) {
     const field = FORM_FIELD_BY_DETAIL_KEY[rawKey]
@@ -263,7 +295,7 @@ const getDetailError = (
 }
 
 /**
- * Turns a failed quote or order-form mutation into user-facing messages.
+ * Turns a failed quote, order-form or order mutation into user-facing messages.
  *
  * The API answers through `ExecutionErrorResponder`, which exposes
  * `extensions.code` plus a camelized `extensions.details` map of

--- a/translations/base.json
+++ b/translations/base.json
@@ -4640,5 +4640,19 @@
   "text_1786610894641m8ffsiodyjw": "The selected execution type is invalid",
   "text_1786610894641sjyf79n6nny": "The execution date must be in the future",
   "text_1786610894641nv1aitlslgu": "The signed document could not be read. Please upload a valid PDF, JPEG or PNG file",
-  "text_17866108946418951e8uxdcl": "An order has already been created for this order form"
+  "text_17866108946418951e8uxdcl": "An order has already been created for this order form",
+  "text_1786630268015utxlmxzyv6k": "This order could not be found",
+  "text_17866302680156sw8ubyaf72": "This type of order cannot be executed yet",
+  "text_1786630268015x89z5erp5gc": "This order has no execution type, please edit it before executing it",
+  "text_178663026801526jdrqexzy1": "This order is already being executed, please try again in a moment",
+  "text_1786630268016ukk6fi5u778": "A plan of this order no longer exists",
+  "text_1786630268016171ivs0g1kv": "A coupon of this order no longer exists",
+  "text_1786630268016o1hi9xo2obe": "An add-on of this order no longer exists",
+  "text_1786630268016h9odzv5jjs5": "A charge of this order no longer exists on its plan",
+  "text_1786630268016t366gcvcago": "A fixed charge of this order no longer exists on its plan",
+  "text_1786630268016qtainhwsys3": "A billable metric of this order no longer exists",
+  "text_1786630268016w264kj4y86j": "The charge model of a plan has changed since the quote was approved",
+  "text_1786630268016meyak1nxn9g": "The fixed charge model of a plan has changed since the quote was approved",
+  "text_1786630268016i9hcrwrzkcc": "The customer of this order could not be found",
+  "text_1786630268016vpwqdibatsd": "This order has nothing to bill"
 }


### PR DESCRIPTION
## Context

Executing an order had no client-side error branch: `onExecute` only
handled the success case, so every failure fell through to the global
Apollo error link and produced a single generic "Something went wrong"
toast — and nothing at all for permission errors, since the link
force-silences `forbidden`. The API returns rich `extensions.code` +
camelized `extensions.details` that we were discarding, exactly as quote
approve/void did before #4119 and order-form sign/void before #4122.

## Description

Extends the existing shared mapper with a third scope rather than adding
another one: `QuoteMutationErrorScope` gains `order`, and the
`scope === 'orderForm' ? … : undefined` ternary is replaced by a
`SCOPED_ERROR_KEYS` map so a third scope resolves at the same single
lookup point instead of nesting a second branch.

The new `ORDER_ERROR_KEYS` covers the 14 detail keys `executeOrder` can
actually produce, each traced to the service that raises it: `order`,
`orderType` and `executionMode` plus `base.concurrency_conflict` from the
mutation and `Orders::BaseExecuteService`, and the catalog entities the
billing snapshot points at — `plan`, `coupon`, `addOn`, `charge`,
`fixedCharge`, `billableMetric`, `chargeModel`, `fixedChargeModel`,
`customer` and `fees` — which surface as top-level `<resource>.not_found`
rather than through the positional billing-item keys. `forbidden` and
`feature_unavailable` already had copy. ActiveRecord failures bubbling up
from the nested subscription/wallet/coupon/invoice services stay on the
generic message on purpose.

The mutation now passes `silentErrorCodes` for the codes it handles
locally so the generic toast no longer double-fires and Sentry stops
recording expected validation failures, and `onExecute` gains the
early-return failure branch that toasts one danger message per mapped
error. No inline field errors: the Execute page renders read-only fields
and has no form.

One spec item dissolved on inspection and needed no code — a failed
execution can move the order to `failed` server-side, but the client sets
`errorPolicy: 'all'` as a mutation default, so Apollo still runs
`markMutationResult` and the existing `refetchQueries: ['getOrders']`
already refreshes the list after a failure. A comment records that.

Covered by 29 new tests (60 suites / 673 tests green in
`src/pages/quotes`); the copy for the 14 new translation keys is a first
draft and may want a product pass.

<!-- Linear link -->
Fixes LAGO-1809

