### PR TITLE
fix(quotes): display correct customer name in pricing block

### DIFF
--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
@@ -336,6 +336,8 @@ export function SubscriptionPricingContent({
     currency: displayCurrency,
   })
 
+  const customerName = customer?.displayName || customer?.externalId || ''
+
   return (
     <CenteredPage.SubsectionWrapper>
       {/* 1. Plan selection */}
@@ -349,7 +351,7 @@ export function SubscriptionPricingContent({
         <CenteredPage.PageSection>
           <CenteredPage.PageSectionTitle
             title={translate('text_65118a52df984447c186940f', {
-              customerName: customer?.name,
+              customerName,
             })}
             description={translate('text_1781099100337s3ou7wd0l4z')}
           />

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/QuoteInvoicingPaymentsSettings.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/QuoteInvoicingPaymentsSettings.test.tsx
@@ -61,7 +61,7 @@ jest.mock('~/components/invoicingSettings/InvoicingSettingsSelector', () => ({
   },
 }))
 
-const customer = { id: 'cust-1', externalId: 'ext-1', name: 'Acme' }
+const customer = { id: 'cust-1', externalId: 'ext-1', displayName: 'Acme' }
 
 const section: InvoiceCustomSectionInput = {
   invoiceCustomSections: [{ id: 'sec-1', name: 'Bank details' }],

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
@@ -1,6 +1,7 @@
 import { act, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import { PAGE_SECTION_TITLE_TEST_ID } from '~/components/layouts/CenteredPage'
 import type { PlanFormInput } from '~/components/plans/types'
 import {
   type BillingItemPlan,
@@ -15,6 +16,7 @@ import {
   PlanInterval,
 } from '~/generated/graphql'
 import { usePlanFormSetup } from '~/hooks/plans/usePlanFormSetup'
+import type { QuoteCustomer } from '~/pages/quotes/hooks/useSubscriptionPricingDrawer'
 import { render } from '~/test-utils'
 
 import { SubscriptionPricingContent } from '../SubscriptionPricingContent'
@@ -442,7 +444,7 @@ describe('SubscriptionPricingContent', () => {
       invoicingSettings: DEFAULT_INVOICING_SETTINGS,
       overrides: {},
     }
-    const mockCustomer = { id: 'cust-1', externalId: 'ext-1', name: 'Acme' }
+    const mockCustomer = { id: 'cust-1', externalId: 'ext-1', displayName: 'Acme' }
 
     it('WHEN a plan is selected THEN the invoicing & payments component is rendered', async () => {
       const stateRef = { current: null as SubscriptionPricingState | null }
@@ -481,6 +483,53 @@ describe('SubscriptionPricingContent', () => {
       )
 
       expect(screen.queryByTestId('quote-invoicing-payments-settings')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('GIVEN the plan-selection section title is rendered', () => {
+    const renderWithCustomer = async (customer?: QuoteCustomer): Promise<HTMLElement> => {
+      const stateRef = { current: null as SubscriptionPricingState | null }
+      const formValuesRef = { current: null as PlanFormInput | null }
+      const basePlanFormValuesRef = { current: null as PlanFormInput | null }
+
+      await act(() =>
+        render(
+          <SubscriptionPricingContent
+            stateRef={stateRef}
+            formValuesRef={formValuesRef}
+            basePlanFormValuesRef={basePlanFormValuesRef}
+            customer={customer}
+          />,
+        ),
+      )
+
+      return screen.getAllByTestId(PAGE_SECTION_TITLE_TEST_ID)[0]
+    }
+
+    it('WHEN the customer has a displayName THEN the title shows it', async () => {
+      const title = await renderWithCustomer({
+        id: 'cust-1',
+        externalId: 'ext-1',
+        displayName: 'Acme',
+      })
+
+      expect(title).toHaveTextContent('Acme')
+    })
+
+    it('WHEN the customer has no displayName THEN the title falls back to the externalId', async () => {
+      const title = await renderWithCustomer({ id: 'cust-1', externalId: 'ext-1' })
+
+      expect(title).toHaveTextContent('ext-1')
+    })
+
+    it.each([
+      ['a customer with a displayName', { id: 'cust-1', externalId: 'ext-1', displayName: 'Acme' }],
+      ['a customer without a displayName', { id: 'cust-1', externalId: 'ext-1' }],
+      ['no customer at all', undefined],
+    ])('WHEN rendered with %s THEN the title never contains "undefined"', async (_, customer) => {
+      const title = await renderWithCustomer(customer)
+
+      expect(title).not.toHaveTextContent('undefined')
     })
   })
 

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -36,7 +36,8 @@ interface UseSubscriptionPricingDrawerReturn {
 export interface QuoteCustomer {
   id: string
   externalId: string
-  name?: string | null
+  /** Resolved customer label — the `QuoteDetailItem` fragment selects `displayName`, never `name`. */
+  displayName?: string | null
 }
 
 export interface SubscriptionPricingDrawerOptions {


### PR DESCRIPTION
## Context

In the pricing block of a subscription amendment quote, the plan-selection section title reads "Assign a plan to undefined" instead of showing the customer name.

The title is rendered from `translate('...', { customerName: customer?.name })`, but `QuoteCustomer` declared a `name` field that the `QuoteDetailItem` GraphQL fragment never selects — it selects `displayName`. `name` was therefore always `undefined`, and `replaceDynamicVarInString` stringifies it to the literal "undefined".

## Description

- `QuoteCustomer` (`useSubscriptionPricingDrawer.tsx`): replace the phantom `name` field with `displayName`, matching what the fragment actually provides.
- `SubscriptionPricingContent.tsx`: derive the title name as `customer?.displayName || customer?.externalId || ''`, the same fallback chain already used in `CreateSubscription.tsx`.
- Update the customer fixtures in the two affected test files and add coverage for the three cases: displayName present, displayName absent (externalId fallback), and no customer at all — asserting the title never renders "undefined".

No GraphQL or translation changes: `displayName` was already selected and the existing key is reused. The same wrong label affected subscription-creation quotes, so fixing the shared component covers both order types.

<!-- Linear link -->
Fixes LAGO-1824