### PR TITLE
feat(pricing-units): migrate CreatePricingUnit form from Formik to TanStack Form

### DIFF
--- a/src/pages/settings/Invoices/CreatePricingUnit.tsx
+++ b/src/pages/settings/Invoices/CreatePricingUnit.tsx
@@ -1,28 +1,32 @@
 import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
-import { useState } from 'react'
+import { revalidateLogic, useStore } from '@tanstack/react-form'
+import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { object, string } from 'yup'
 
 import { Alert } from '~/components/designSystem/Alert'
 import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
-import { TextInput, TextInputField } from '~/components/form'
+import NameAndCodeGroup from '~/components/form/NameAndCodeGroup/NameAndCodeGroup'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
+import { scrollToFirstInputError } from '~/core/form/scrollToFirstInputError'
 import { INVOICE_SETTINGS_ROUTE, useNavigate } from '~/core/router'
-import { updateNameAndMaybeCode } from '~/core/utils/updateNameAndMaybeCode'
 import {
-  CreatePricingUnitInput,
   LagoApiError,
   useCreatePricingUnitMutation,
   useGetSinglePricingUnitQuery,
   useUpdatePricingUnitMutation,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useAppForm } from '~/hooks/forms/useAppform'
 import { FormLoadingSkeleton } from '~/styles/mainObjectsForm'
+
+import {
+  createPricingUnitValidationSchema,
+  CreatePricingUnitValues,
+} from './createPricingUnit/validationSchema'
 
 gql`
   fragment PricingUnit on PricingUnit {
@@ -54,6 +58,12 @@ gql`
     }
   }
 `
+
+export const CREATE_PRICING_UNIT_FORM_ID = 'create-pricing-unit-form'
+export const CREATE_PRICING_UNIT_CLOSE_BUTTON_TEST_ID = 'create-pricing-unit-close-button'
+export const CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID = 'create-pricing-unit-submit-button'
+export const CREATE_PRICING_UNIT_DESCRIPTION_DELETE_TEST_ID =
+  'create-pricing-unit-description-delete-button'
 
 const CreatePricingUnit = () => {
   const navigate = useNavigate()
@@ -104,22 +114,21 @@ const CreatePricingUnit = () => {
     },
   })
 
-  const formikProps = useFormik<CreatePricingUnitInput>({
-    initialValues: {
-      name: pricingUnitData?.pricingUnit?.name || '',
-      code: pricingUnitData?.pricingUnit?.code || '',
-      description: pricingUnitData?.pricingUnit?.description || '',
-      shortName: pricingUnitData?.pricingUnit?.shortName || '',
+  const defaultValues: CreatePricingUnitValues = {
+    name: pricingUnitData?.pricingUnit?.name || '',
+    code: pricingUnitData?.pricingUnit?.code || '',
+    description: pricingUnitData?.pricingUnit?.description || '',
+    shortName: pricingUnitData?.pricingUnit?.shortName || '',
+  }
+
+  const form = useAppForm({
+    defaultValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: createPricingUnitValidationSchema,
     },
-    validationSchema: object().shape({
-      name: string().required(''),
-      code: string().required(''),
-      description: string(),
-      shortName: string().required('').max(3, 'text_1750424999815o2wik8216ht'),
-    }),
-    enableReinitialize: true,
-    validateOnMount: true,
-    onSubmit: async ({ code, ...values }) => {
+    onSubmit: async ({ value, formApi }) => {
+      const { code, ...values } = value
       let res
 
       if (!!pricingUnitId) {
@@ -145,152 +154,191 @@ const CreatePricingUnit = () => {
       const { errors } = res
 
       if (!!errors && hasDefinedGQLError('ValueAlreadyExist', errors)) {
-        formikProps.setErrors({
-          code: translate('text_632a2d437e341dcc76817556'),
+        formApi.setErrorMap({
+          onDynamic: {
+            fields: {
+              code: {
+                message: translate('text_632a2d437e341dcc76817556'),
+                path: ['code'],
+              },
+            },
+          },
         })
       }
     },
+    onSubmitInvalid({ formApi }) {
+      scrollToFirstInputError(CREATE_PRICING_UNIT_FORM_ID, formApi.state.errorMap.onDynamic || {})
+    },
   })
 
+  useEffect(() => {
+    if (pricingUnitData?.pricingUnit) {
+      form.reset({
+        name: pricingUnitData.pricingUnit.name || '',
+        code: pricingUnitData.pricingUnit.code || '',
+        description: pricingUnitData.pricingUnit.description || '',
+        shortName: pricingUnitData.pricingUnit.shortName || '',
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pricingUnitData])
+
+  const isDirty = useStore(form.store, (state) => state.isDirty)
+
   const [shouldDisplayDescription, setShouldDisplayDescription] = useState(
-    !!formikProps.initialValues.description,
+    !!pricingUnitData?.pricingUnit?.description,
   )
+
+  useEffect(() => {
+    setShouldDisplayDescription(!!pricingUnitData?.pricingUnit?.description)
+  }, [pricingUnitData?.pricingUnit?.description])
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    form.handleSubmit()
+  }
 
   return (
     <CenteredPage.Wrapper>
-      <CenteredPage.Header>
-        <Typography variant="bodyHl" color="textSecondary" noWrap>
-          {isEdition
-            ? translate('text_17502574817266iopiux8fb8')
-            : translate('text_1750257481726l1npjihgs20')}
-        </Typography>
-        <Button
-          variant="quaternary"
-          icon="close"
-          onClick={() =>
-            formikProps.dirty ? openDirtyAttributesWarning() : navigate(INVOICE_SETTINGS_ROUTE)
-          }
-        />
-      </CenteredPage.Header>
+      <form
+        id={CREATE_PRICING_UNIT_FORM_ID}
+        className="flex min-h-full flex-col"
+        onSubmit={handleSubmit}
+      >
+        <CenteredPage.Header>
+          <Typography variant="bodyHl" color="textSecondary" noWrap>
+            {isEdition
+              ? translate('text_17502574817266iopiux8fb8')
+              : translate('text_1750257481726l1npjihgs20')}
+          </Typography>
+          <Button
+            variant="quaternary"
+            icon="close"
+            data-test={CREATE_PRICING_UNIT_CLOSE_BUTTON_TEST_ID}
+            onClick={() =>
+              isDirty ? openDirtyAttributesWarning() : navigate(INVOICE_SETTINGS_ROUTE)
+            }
+          />
+        </CenteredPage.Header>
 
-      <CenteredPage.Container>
-        {pricingUnitLoading && <FormLoadingSkeleton id="create-pricing-unit" />}
+        <CenteredPage.Container>
+          {pricingUnitLoading && <FormLoadingSkeleton id="create-pricing-unit" />}
 
-        {!pricingUnitLoading && (
-          <>
-            <Alert type="info">{translate('text_1750424999814th7cu8hbg7u')}</Alert>
+          {!pricingUnitLoading && (
+            <>
+              <Alert type="info">{translate('text_1750424999814th7cu8hbg7u')}</Alert>
 
-            <div className="not-last-child:mb-1">
-              <Typography variant="headline" color="textSecondary">
-                {translate('text_17502505476284yyq70yy6mx')}
-              </Typography>
-              <Typography variant="body">{translate('text_1750257831368z0azd7znlhf')}</Typography>
-            </div>
-
-            <div className="flex flex-col gap-12">
-              <div className="not-last-child:mb-2">
-                <Typography variant="subhead1">
-                  {translate('text_17502574817266uy9bvk3i8u')}
+              <div className="not-last-child:mb-1">
+                <Typography variant="headline" color="textSecondary">
+                  {translate('text_17502505476284yyq70yy6mx')}
                 </Typography>
-                <Typography variant="caption">
-                  {translate('text_17502578313682gsr5pls9a3')}
-                </Typography>
+                <Typography variant="body">{translate('text_1750257831368z0azd7znlhf')}</Typography>
               </div>
-              <div className="flex flex-col gap-6">
-                <div className="flex items-start gap-6 *:flex-1">
-                  <TextInput
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
-                    autoFocus
-                    name="name"
-                    value={formikProps.values.name}
-                    onChange={(name) => {
-                      updateNameAndMaybeCode({ name, formikProps })
-                    }}
-                    label={translate('text_6419c64eace749372fc72b0f')}
-                    placeholder={translate('text_6584550dc4cec7adf861504f')}
-                  />
-                  <TextInputField
-                    name="code"
-                    beforeChangeFormatter="code"
-                    formikProps={formikProps}
-                    disabled={isEdition}
-                    label={translate('text_62876e85e32e0300e1803127')}
-                    placeholder={translate('text_6584550dc4cec7adf8615053')}
-                  />
+
+              <div className="flex flex-col gap-12">
+                <div className="not-last-child:mb-2">
+                  <Typography variant="subhead1">
+                    {translate('text_17502574817266uy9bvk3i8u')}
+                  </Typography>
+                  <Typography variant="caption">
+                    {translate('text_17502578313682gsr5pls9a3')}
+                  </Typography>
                 </div>
+                <div className="flex flex-col gap-6">
+                  <NameAndCodeGroup
+                    form={form}
+                    fields={{ name: 'name', code: 'code' }}
+                    disableCodeInput={isEdition}
+                    disableAutoGenerateCode={isEdition}
+                    nameProps={{
+                      autoFocus: true,
+                      label: translate('text_6419c64eace749372fc72b0f'),
+                      placeholder: translate('text_6584550dc4cec7adf861504f'),
+                    }}
+                    codeProps={{
+                      label: translate('text_62876e85e32e0300e1803127'),
+                      placeholder: translate('text_6584550dc4cec7adf8615053'),
+                    }}
+                  />
 
-                <TextInputField
-                  name="shortName"
-                  formikProps={formikProps}
-                  error={formikProps.errors.shortName}
-                  label={translate('text_175025054762801ioe61wdye')}
-                  placeholder={translate('text_1750250547628xh8057w5j8p')}
-                  helperText={translate('text_1750257831368e6n6ys36s6u')}
-                />
-
-                {shouldDisplayDescription ? (
-                  <div className="flex items-center gap-2">
-                    <TextInputField
-                      className="flex-1"
-                      name="description"
-                      label={translate('text_623b42ff8ee4e000ba87d0c8')}
-                      placeholder={translate('text_1750257831368ae3rtaclhjy')}
-                      rows="3"
-                      multiline
-                      formikProps={formikProps}
-                    />
-
-                    <Tooltip
-                      className="mt-7"
-                      placement="top-end"
-                      title={translate('text_63aa085d28b8510cd46443ff')}
-                    >
-                      <Button
-                        icon="trash"
-                        variant="quaternary"
-                        onClick={() => {
-                          formikProps.setFieldValue('description', '')
-                          setShouldDisplayDescription(false)
-                        }}
+                  <form.AppField name="shortName">
+                    {(field) => (
+                      <field.TextInputField
+                        label={translate('text_175025054762801ioe61wdye')}
+                        placeholder={translate('text_1750250547628xh8057w5j8p')}
+                        helperText={translate('text_1750257831368e6n6ys36s6u')}
                       />
-                    </Tooltip>
-                  </div>
-                ) : (
-                  <Button
-                    startIcon="plus"
-                    variant="inline"
-                    align="left"
-                    onClick={() => setShouldDisplayDescription(true)}
-                    data-test="show-description"
-                  >
-                    {translate('text_642d5eb2783a2ad10d670324')}
-                  </Button>
-                )}
-              </div>
-            </div>
-          </>
-        )}
-      </CenteredPage.Container>
+                    )}
+                  </form.AppField>
 
-      <CenteredPage.StickyFooter>
-        <Button
-          variant="quaternary"
-          onClick={() =>
-            formikProps.dirty ? openDirtyAttributesWarning() : navigate(INVOICE_SETTINGS_ROUTE)
-          }
-        >
-          {translate('text_6411e6b530cb47007488b027')}
-        </Button>
-        <Button
-          variant="primary"
-          disabled={!formikProps.isValid || !formikProps.dirty}
-          onClick={formikProps.submitForm}
-        >
-          {isEdition
-            ? translate('text_17295436903260tlyb1gp1i7')
-            : translate('text_1750319326160woun10ws3h1')}
-        </Button>
-      </CenteredPage.StickyFooter>
+                  {shouldDisplayDescription ? (
+                    <div className="flex items-center gap-2">
+                      <form.AppField name="description">
+                        {(field) => (
+                          <field.TextInputField
+                            className="flex-1"
+                            label={translate('text_623b42ff8ee4e000ba87d0c8')}
+                            placeholder={translate('text_1750257831368ae3rtaclhjy')}
+                            rows="3"
+                            multiline
+                          />
+                        )}
+                      </form.AppField>
+
+                      <Tooltip
+                        className="mt-7"
+                        placement="top-end"
+                        title={translate('text_63aa085d28b8510cd46443ff')}
+                      >
+                        <Button
+                          icon="trash"
+                          variant="quaternary"
+                          data-test={CREATE_PRICING_UNIT_DESCRIPTION_DELETE_TEST_ID}
+                          onClick={() => {
+                            form.setFieldValue('description', '')
+                            setShouldDisplayDescription(false)
+                          }}
+                        />
+                      </Tooltip>
+                    </div>
+                  ) : (
+                    <Button
+                      startIcon="plus"
+                      variant="inline"
+                      align="left"
+                      onClick={() => setShouldDisplayDescription(true)}
+                      data-test="show-description"
+                    >
+                      {translate('text_642d5eb2783a2ad10d670324')}
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </CenteredPage.Container>
+
+        <CenteredPage.StickyFooter>
+          <Button
+            variant="quaternary"
+            onClick={() =>
+              isDirty ? openDirtyAttributesWarning() : navigate(INVOICE_SETTINGS_ROUTE)
+            }
+          >
+            {translate('text_6411e6b530cb47007488b027')}
+          </Button>
+          <form.AppForm>
+            <form.SubmitButton
+              dataTest={CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID}
+              disabled={isEdition && !isDirty}
+            >
+              {isEdition
+                ? translate('text_17295436903260tlyb1gp1i7')
+                : translate('text_1750319326160woun10ws3h1')}
+            </form.SubmitButton>
+          </form.AppForm>
+        </CenteredPage.StickyFooter>
+      </form>
     </CenteredPage.Wrapper>
   )
 }

--- a/src/pages/settings/Invoices/CreatePricingUnit.tsx
+++ b/src/pages/settings/Invoices/CreatePricingUnit.tsx
@@ -64,6 +64,7 @@ export const CREATE_PRICING_UNIT_CLOSE_BUTTON_TEST_ID = 'create-pricing-unit-clo
 export const CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID = 'create-pricing-unit-submit-button'
 export const CREATE_PRICING_UNIT_DESCRIPTION_DELETE_TEST_ID =
   'create-pricing-unit-description-delete-button'
+export const CREATE_PRICING_UNIT_SHOW_DESCRIPTION_TEST_ID = 'show-description'
 
 const CreatePricingUnit = () => {
   const navigate = useNavigate()
@@ -173,12 +174,7 @@ const CreatePricingUnit = () => {
 
   useEffect(() => {
     if (pricingUnitData?.pricingUnit) {
-      form.reset({
-        name: pricingUnitData.pricingUnit.name || '',
-        code: pricingUnitData.pricingUnit.code || '',
-        description: pricingUnitData.pricingUnit.description || '',
-        shortName: pricingUnitData.pricingUnit.shortName || '',
-      })
+      form.reset(defaultValues)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pricingUnitData])
@@ -305,9 +301,9 @@ const CreatePricingUnit = () => {
                     <Button
                       startIcon="plus"
                       variant="inline"
-                      align="left"
+                      fitContent
                       onClick={() => setShouldDisplayDescription(true)}
-                      data-test="show-description"
+                      data-test={CREATE_PRICING_UNIT_SHOW_DESCRIPTION_TEST_ID}
                     >
                       {translate('text_642d5eb2783a2ad10d670324')}
                     </Button>

--- a/src/pages/settings/Invoices/__tests__/CreatePricingUnit.test.tsx
+++ b/src/pages/settings/Invoices/__tests__/CreatePricingUnit.test.tsx
@@ -1,0 +1,439 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
+import { render, testMockNavigateFn } from '~/test-utils'
+
+import CreatePricingUnit, {
+  CREATE_PRICING_UNIT_CLOSE_BUTTON_TEST_ID,
+  CREATE_PRICING_UNIT_DESCRIPTION_DELETE_TEST_ID,
+  CREATE_PRICING_UNIT_FORM_ID,
+  CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID,
+} from '../CreatePricingUnit'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+const mockDialogOpen = jest.fn()
+
+jest.mock('~/components/dialogs/CentralizedDialog', () => ({
+  useCentralizedDialog: () => ({ open: mockDialogOpen }),
+}))
+
+jest.mock('~/styles/mainObjectsForm', () => ({
+  FormLoadingSkeleton: ({ id }: { id: string }) => (
+    <div data-test={`form-loading-skeleton-${id}`} />
+  ),
+}))
+
+const mockUseGetSinglePricingUnitQuery = jest.fn()
+const mockCreatePricingUnit = jest.fn()
+const mockUpdatePricingUnit = jest.fn()
+
+type MutationOptions = { onCompleted?: (data: Record<string, unknown>) => void }
+
+// Apollo calls `onCompleted` with the mutation's `data` once it resolves — reproduce that
+// here since the mutation hooks are fully mocked and Apollo never actually runs.
+const withOnCompleted =
+  (mock: jest.Mock) =>
+  (options?: MutationOptions): [(...args: unknown[]) => Promise<unknown>] => [
+    async (...args: unknown[]) => {
+      const result = (await mock(...args)) as { data?: Record<string, unknown> }
+
+      if (result?.data) {
+        options?.onCompleted?.(result.data)
+      }
+
+      return result
+    },
+  ]
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useGetSinglePricingUnitQuery: (...args: unknown[]) => mockUseGetSinglePricingUnitQuery(...args),
+  useCreatePricingUnitMutation: (options?: MutationOptions) =>
+    withOnCompleted(mockCreatePricingUnit)(options),
+  useUpdatePricingUnitMutation: (options?: MutationOptions) =>
+    withOnCompleted(mockUpdatePricingUnit)(options),
+}))
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: jest.fn(),
+  hasDefinedGQLError: jest.fn(() => false),
+}))
+
+const existingPricingUnit = {
+  id: 'pricing-unit-1',
+  name: 'Existing Unit',
+  code: 'existing_unit',
+  description: 'Existing description',
+  shortName: 'EXU',
+}
+
+const mockLoadedQuery = (pricingUnit?: typeof existingPricingUnit) => {
+  mockUseGetSinglePricingUnitQuery.mockReturnValue({
+    data: pricingUnit ? { pricingUnit } : undefined,
+    loading: false,
+  })
+}
+
+const getInput = (name: string) =>
+  document.querySelector(`input[name="${name}"]`) as HTMLInputElement
+
+const getDescriptionTextarea = () =>
+  document.querySelector('textarea[name="description"]') as HTMLTextAreaElement
+
+// The test-utils `useParams` spy leaks its last value across tests (it is never reset),
+// so every render must pass an explicit value instead of relying on the unmocked default.
+const renderInCreateMode = () => render(<CreatePricingUnit />, { useParams: {} })
+
+const renderInEditionMode = () =>
+  render(<CreatePricingUnit />, { useParams: { pricingUnitId: 'pricing-unit-1' } })
+
+describe('CreatePricingUnit', () => {
+  beforeAll(() => {
+    // jsdom does not implement scrollIntoView (used by scrollToFirstInputError on invalid submit)
+    Element.prototype.scrollIntoView = jest.fn()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCreatePricingUnit.mockResolvedValue({
+      data: { createPricingUnit: { id: 'pricing-unit-1' } },
+      errors: undefined,
+    })
+    mockUpdatePricingUnit.mockResolvedValue({
+      data: { updatePricingUnit: { id: 'pricing-unit-1' } },
+      errors: undefined,
+    })
+  })
+
+  describe('GIVEN loading state', () => {
+    it('THEN should display the loading skeleton', () => {
+      mockUseGetSinglePricingUnitQuery.mockReturnValue({ data: undefined, loading: true })
+
+      renderInEditionMode()
+
+      expect(screen.getByTestId('form-loading-skeleton-create-pricing-unit')).toBeInTheDocument()
+    })
+  })
+
+  describe('GIVEN create mode', () => {
+    beforeEach(() => {
+      mockLoadedQuery()
+    })
+
+    describe('WHEN the page loads', () => {
+      it('THEN should display the form', () => {
+        renderInCreateMode()
+
+        expect(document.getElementById(CREATE_PRICING_UNIT_FORM_ID)).toBeInTheDocument()
+      })
+
+      it.each([['name'], ['code'], ['shortName']])(
+        'THEN should display an empty %s input',
+        (name) => {
+          renderInCreateMode()
+
+          expect(getInput(name)).toHaveValue('')
+        },
+      )
+
+      it('THEN should not display the description textarea by default', () => {
+        renderInCreateMode()
+
+        expect(getDescriptionTextarea()).not.toBeInTheDocument()
+      })
+
+      it('THEN should enable the code input', () => {
+        renderInCreateMode()
+
+        expect(getInput('code')).not.toBeDisabled()
+      })
+    })
+
+    describe('WHEN typing a name', () => {
+      it('THEN should derive the code from it', async () => {
+        const user = userEvent.setup()
+
+        renderInCreateMode()
+
+        await user.type(getInput('name'), 'My Unit')
+
+        expect(getInput('code')).toHaveValue('my_unit')
+      })
+
+      it('THEN should stop deriving it once the code has been edited', async () => {
+        const user = userEvent.setup()
+
+        renderInCreateMode()
+
+        await user.type(getInput('code'), 'custom-code')
+        await user.tab()
+        await user.type(getInput('name'), 'My Unit')
+
+        expect(getInput('code')).toHaveValue('custom-code')
+      })
+    })
+
+    describe('WHEN toggling the description', () => {
+      it('THEN should display then hide the description textarea', async () => {
+        const user = userEvent.setup()
+
+        renderInCreateMode()
+
+        await user.click(screen.getByTestId('show-description'))
+        expect(getDescriptionTextarea()).toBeInTheDocument()
+
+        await user.click(screen.getByTestId(CREATE_PRICING_UNIT_DESCRIPTION_DELETE_TEST_ID))
+        expect(getDescriptionTextarea()).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN submitting without required fields', () => {
+      it('THEN should not call the create mutation', async () => {
+        const user = userEvent.setup()
+
+        renderInCreateMode()
+
+        await user.click(screen.getByTestId(CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(screen.getByTestId(CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID)).toBeDisabled()
+        })
+        expect(mockCreatePricingUnit).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the short name is too long', () => {
+      it('THEN should show a validation error and not call the mutation', async () => {
+        const user = userEvent.setup()
+
+        renderInCreateMode()
+
+        await user.type(getInput('name'), 'My Unit')
+        await user.type(getInput('shortName'), 'TOOLONG')
+        await user.click(screen.getByTestId(CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(screen.getByTestId('text-field-error')).toBeInTheDocument()
+        })
+        expect(mockCreatePricingUnit).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN submitting a valid form', () => {
+      it('THEN should call the create mutation with the code and values', async () => {
+        const user = userEvent.setup()
+
+        renderInCreateMode()
+
+        await user.type(getInput('name'), 'My Unit')
+        await user.type(getInput('shortName'), 'MYU')
+        await user.click(screen.getByTestId(CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockCreatePricingUnit).toHaveBeenCalledWith({
+            variables: {
+              input: {
+                code: 'my_unit',
+                name: 'My Unit',
+                description: '',
+                shortName: 'MYU',
+              },
+            },
+          })
+        })
+      })
+
+      it('THEN should show a success toast and navigate away', async () => {
+        const user = userEvent.setup()
+
+        renderInCreateMode()
+
+        await user.type(getInput('name'), 'My Unit')
+        await user.type(getInput('shortName'), 'MYU')
+        await user.click(screen.getByTestId(CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+        })
+        expect(testMockNavigateFn).toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN pressing Enter while an input is focused', () => {
+      it('THEN should submit the form', async () => {
+        const user = userEvent.setup()
+
+        renderInCreateMode()
+
+        await user.type(getInput('name'), 'My Unit')
+        await user.type(getInput('shortName'), 'MYU')
+
+        getInput('shortName').focus()
+        await user.keyboard('{Enter}')
+
+        await waitFor(() => {
+          expect(mockCreatePricingUnit).toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('WHEN the code already exists', () => {
+      it('THEN should keep the user on the form without a toast', async () => {
+        const user = userEvent.setup()
+
+        mockCreatePricingUnit.mockResolvedValue({
+          data: undefined,
+          errors: [{ message: 'ValueAlreadyExist' }],
+        })
+        ;(hasDefinedGQLError as jest.Mock).mockImplementation(
+          (code: string) => code === 'ValueAlreadyExist',
+        )
+
+        renderInCreateMode()
+
+        await user.type(getInput('name'), 'My Unit')
+        await user.type(getInput('shortName'), 'MYU')
+        await user.click(screen.getByTestId(CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockCreatePricingUnit).toHaveBeenCalled()
+        })
+        expect(testMockNavigateFn).not.toHaveBeenCalled()
+        expect(addToast).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN a dirty form', () => {
+    describe('WHEN closing it', () => {
+      it('THEN should ask the user to confirm', async () => {
+        const user = userEvent.setup()
+
+        mockLoadedQuery()
+        renderInCreateMode()
+
+        await user.type(getInput('name'), 'My Unit')
+        await user.click(screen.getByTestId(CREATE_PRICING_UNIT_CLOSE_BUTTON_TEST_ID))
+
+        expect(mockDialogOpen).toHaveBeenCalledWith(
+          expect.objectContaining({ colorVariant: 'danger' }),
+        )
+        expect(testMockNavigateFn).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN a pristine form', () => {
+    describe('WHEN closing it', () => {
+      it('THEN should leave without confirmation', async () => {
+        const user = userEvent.setup()
+
+        mockLoadedQuery()
+        renderInCreateMode()
+
+        await user.click(screen.getByTestId(CREATE_PRICING_UNIT_CLOSE_BUTTON_TEST_ID))
+
+        expect(mockDialogOpen).not.toHaveBeenCalled()
+        expect(testMockNavigateFn).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN edition mode', () => {
+    beforeEach(() => {
+      mockLoadedQuery(existingPricingUnit)
+    })
+
+    describe('WHEN the form is loaded', () => {
+      it.each([
+        ['name', 'Existing Unit'],
+        ['code', 'existing_unit'],
+        ['shortName', 'EXU'],
+      ])('THEN should prefill the %s input', async (name, expected) => {
+        renderInEditionMode()
+
+        await waitFor(() => {
+          expect(getInput(name)).toHaveValue(expected)
+        })
+      })
+
+      it('THEN should display the existing description', async () => {
+        renderInEditionMode()
+
+        await waitFor(() => {
+          expect(getDescriptionTextarea()).toBeInTheDocument()
+        })
+      })
+
+      it('THEN should disable the code input', async () => {
+        renderInEditionMode()
+
+        await waitFor(() => {
+          expect(getInput('code')).toBeDisabled()
+        })
+      })
+
+      it('THEN should disable the submit button while pristine', async () => {
+        renderInEditionMode()
+
+        await waitFor(() => {
+          expect(getInput('name')).toHaveValue('Existing Unit')
+        })
+        expect(screen.getByTestId(CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID)).toBeDisabled()
+      })
+    })
+
+    describe('WHEN typing a new name', () => {
+      it('THEN should not auto-generate the code', async () => {
+        const user = userEvent.setup()
+
+        renderInEditionMode()
+
+        await waitFor(() => {
+          expect(getInput('name')).toHaveValue('Existing Unit')
+        })
+
+        await user.clear(getInput('name'))
+        await user.type(getInput('name'), 'Renamed Unit')
+
+        expect(getInput('code')).toHaveValue('existing_unit')
+      })
+    })
+
+    describe('WHEN submitting an update', () => {
+      it('THEN should call the update mutation without the code', async () => {
+        const user = userEvent.setup()
+
+        renderInEditionMode()
+
+        await waitFor(() => {
+          expect(getInput('name')).toHaveValue('Existing Unit')
+        })
+
+        await user.clear(getInput('name'))
+        await user.type(getInput('name'), 'Renamed Unit')
+        await user.click(screen.getByTestId(CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockUpdatePricingUnit).toHaveBeenCalledWith({
+            variables: {
+              input: {
+                id: 'pricing-unit-1',
+                name: 'Renamed Unit',
+                description: 'Existing description',
+                shortName: 'EXU',
+              },
+            },
+          })
+        })
+      })
+    })
+  })
+})

--- a/src/pages/settings/Invoices/__tests__/CreatePricingUnit.test.tsx
+++ b/src/pages/settings/Invoices/__tests__/CreatePricingUnit.test.tsx
@@ -8,8 +8,11 @@ import CreatePricingUnit, {
   CREATE_PRICING_UNIT_CLOSE_BUTTON_TEST_ID,
   CREATE_PRICING_UNIT_DESCRIPTION_DELETE_TEST_ID,
   CREATE_PRICING_UNIT_FORM_ID,
+  CREATE_PRICING_UNIT_SHOW_DESCRIPTION_TEST_ID,
   CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID,
 } from '../CreatePricingUnit'
+
+const EXISTING_CODE_ERROR_KEY = 'text_632a2d437e341dcc76817556'
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({
@@ -186,7 +189,7 @@ describe('CreatePricingUnit', () => {
 
         renderInCreateMode()
 
-        await user.click(screen.getByTestId('show-description'))
+        await user.click(screen.getByTestId(CREATE_PRICING_UNIT_SHOW_DESCRIPTION_TEST_ID))
         expect(getDescriptionTextarea()).toBeInTheDocument()
 
         await user.click(screen.getByTestId(CREATE_PRICING_UNIT_DESCRIPTION_DELETE_TEST_ID))
@@ -206,6 +209,21 @@ describe('CreatePricingUnit', () => {
           expect(screen.getByTestId(CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID)).toBeDisabled()
         })
         expect(mockCreatePricingUnit).not.toHaveBeenCalled()
+      })
+
+      it('THEN should scroll to the first input in error', async () => {
+        const user = userEvent.setup()
+
+        renderInCreateMode()
+
+        // `name` is the first input of the form, so it is the one `onSubmitInvalid` must reach.
+        const scrollIntoView = jest.spyOn(getInput('name'), 'scrollIntoView')
+
+        await user.click(screen.getByTestId(CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
+        })
       })
     })
 
@@ -307,6 +325,30 @@ describe('CreatePricingUnit', () => {
         })
         expect(testMockNavigateFn).not.toHaveBeenCalled()
         expect(addToast).not.toHaveBeenCalled()
+      })
+
+      it('THEN should surface the error on the code field', async () => {
+        const user = userEvent.setup()
+
+        mockCreatePricingUnit.mockResolvedValue({
+          data: undefined,
+          errors: [{ message: 'ValueAlreadyExist' }],
+        })
+        ;(hasDefinedGQLError as jest.Mock).mockImplementation(
+          (code: string) => code === 'ValueAlreadyExist',
+        )
+
+        renderInCreateMode()
+
+        await user.type(getInput('name'), 'My Unit')
+        await user.type(getInput('shortName'), 'MYU')
+        await user.click(screen.getByTestId(CREATE_PRICING_UNIT_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(getInput('code')).toHaveAttribute('aria-invalid', 'true')
+        })
+        // `code` is the only field in error here, so the lone `text-field-error` is its own.
+        expect(screen.getByTestId('text-field-error')).toHaveTextContent(EXISTING_CODE_ERROR_KEY)
       })
     })
   })

--- a/src/pages/settings/Invoices/createPricingUnit/__tests__/validationSchema.test.ts
+++ b/src/pages/settings/Invoices/createPricingUnit/__tests__/validationSchema.test.ts
@@ -1,0 +1,69 @@
+import { createPricingUnitValidationSchema } from '../validationSchema'
+
+describe('createPricingUnitValidationSchema', () => {
+  describe('GIVEN valid form values', () => {
+    it.each([
+      [{ name: 'Unit', code: 'UNIT', shortName: 'UNI', description: '' }],
+      [{ name: 'Unit', code: 'UNIT', shortName: 'U', description: 'Optional description' }],
+      [{ name: 'Unit', code: 'UNIT', shortName: 'UNI' }],
+    ])('THEN validation passes for valid values', (values) => {
+      const result = createPricingUnitValidationSchema.safeParse(values)
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('GIVEN name is invalid', () => {
+    describe('WHEN name is empty', () => {
+      it('THEN validation fails', () => {
+        const result = createPricingUnitValidationSchema.safeParse({
+          name: '',
+          code: 'UNIT',
+          shortName: 'UNI',
+        })
+
+        expect(result.success).toBe(false)
+      })
+    })
+  })
+
+  describe('GIVEN code is invalid', () => {
+    describe('WHEN code is empty', () => {
+      it('THEN validation fails', () => {
+        const result = createPricingUnitValidationSchema.safeParse({
+          name: 'Unit',
+          code: '',
+          shortName: 'UNI',
+        })
+
+        expect(result.success).toBe(false)
+      })
+    })
+  })
+
+  describe('GIVEN shortName is invalid', () => {
+    describe('WHEN shortName is empty', () => {
+      it('THEN validation fails', () => {
+        const result = createPricingUnitValidationSchema.safeParse({
+          name: 'Unit',
+          code: 'UNIT',
+          shortName: '',
+        })
+
+        expect(result.success).toBe(false)
+      })
+    })
+
+    describe('WHEN shortName exceeds 3 characters', () => {
+      it('THEN validation fails', () => {
+        const result = createPricingUnitValidationSchema.safeParse({
+          name: 'Unit',
+          code: 'UNIT',
+          shortName: 'UNIT',
+        })
+
+        expect(result.success).toBe(false)
+      })
+    })
+  })
+})

--- a/src/pages/settings/Invoices/createPricingUnit/validationSchema.ts
+++ b/src/pages/settings/Invoices/createPricingUnit/validationSchema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+const REQUIRED_FIELD_MESSAGE = 'text_1771342994699klxu2paz7g8'
+
+export const createPricingUnitValidationSchema = z.object({
+  name: z.string().min(1, REQUIRED_FIELD_MESSAGE),
+  code: z.string().min(1, REQUIRED_FIELD_MESSAGE),
+  description: z.string().optional(),
+  shortName: z.string().min(1, REQUIRED_FIELD_MESSAGE).max(3, 'text_1750424999815o2wik8216ht'),
+})
+
+export type CreatePricingUnitValues = z.infer<typeof createPricingUnitValidationSchema>


### PR DESCRIPTION
## Context

Part of the ongoing Formik → TanStack Form migration initiative. `CreatePricingUnit` was one of the remaining pages still relying on Formik and Yup.

## Description

- Migrated `src/pages/settings/Invoices/CreatePricingUnit.tsx` from `useFormik` to `useAppForm`, following the established codebase conventions (`NameAndCodeGroup` for the name/code pair, `form.SubmitButton`, `formApi.setErrorMap` for server errors).
- Added `src/pages/settings/Invoices/createPricingUnit/validationSchema.ts` with an equivalent Zod schema (name/code/shortName required, shortName max length 3, description optional).
- Preserved existing behaviour: code auto-generated from name until manually edited or in edition mode, code field locked in edition mode, submit disabled while the edition form is pristine, "code already exists" server error surfaced on the code field.
- Added a `<form>` wrapper so pressing Enter in a focused input now submits the form, and wired `scrollToFirstInputError` on invalid submit.
- Added unit tests for the form and the validation schema.

Fixes LAGO-1164

---
_Generated by [Claude Code](https://claude.ai/code/session_01LghFViT6iyAosmsMRLpM1P)_