### PR TITLE
fix(cache): select id on normalized GraphQL types

### DIFF
--- a/.agents/docs/graphql-fragments.md
+++ b/.agents/docs/graphql-fragments.md
@@ -5,7 +5,7 @@
 **ALWAYS run code generation after modifying ANY GraphQL-related files:**
 
 ```bash
-pnpm code-gen
+pnpm codegen
 ```
 
 **When to run code-gen:**
@@ -16,6 +16,78 @@ pnpm code-gen
 - After modifying inline `gql` template literals
 
 **This is MANDATORY** - GraphQL code generation updates TypeScript types and ensures type safety across the application. Never skip this step or you will cause type errors and runtime issues.
+
+### ⚠️ CRITICAL: Always select `id` on a type that has one
+
+**Every selection set on a type that exposes an `id` must select `id`** - in fragments,
+in queries, in mutation payloads. No exceptions, even when the component renders none
+of it.
+
+Apollo normalizes an object into `TypeName:id` **only** when the selection set contains
+`id`. Without it the object is stored **inline**, and that write **replaces** whatever
+the cache held at that location - including a `{ __ref }` some other query put there.
+
+```graphql
+# query A
+organization { id name slug timezone }     # ROOT_QUERY.organization = { __ref: "CurrentOrganization:abc" }
+
+# query B - no `id`
+organization { name email }                # ROOT_QUERY.organization = { name, email }  ← reference destroyed
+```
+
+After B runs, A's cache read is incomplete, so Apollo refetches A. A rewrites the
+reference, B's read goes incomplete, B refetches. Ping-pong.
+
+**Why it is worse than a wasted request here:** `useOrganizationInfos` sets
+`notifyOnNetworkStatusChange: true` and `MainNavLayout` renders
+`{isLoading && <Spinner/>}` / `{!isLoading && <Outlet/>}`. A background refetch
+therefore **unmounts the whole routed page**, which remounts and re-fires all of its
+own `cache-and-network` queries. This was BIL-550: the customer invoices view visibly
+loading twice, plus a burst of duplicate operations across the app.
+
+**Symptoms that point here:** a view that renders twice, layout-level operations
+(`UserIdentifier`, `getOrganizationInfos`, `SideNavInfos`) firing 2-4× on a single
+navigation, or an Apollo `Cache data may be lost when replacing the <field> field`
+console warning.
+
+```graphql
+# ❌ Bad - fragment on a normalized type with no `id`
+fragment OrganizationForDunningEmail on CurrentOrganization {
+  name
+  logoUrl
+  billingConfiguration {
+    documentLocale
+  }
+}
+
+# ✅ Good - `id` at every level that has one
+fragment OrganizationForDunningEmail on CurrentOrganization {
+  id
+  name
+  logoUrl
+  billingConfiguration {
+    id
+    documentLocale
+  }
+}
+```
+
+Notes:
+
+- **Nested levels count.** Adding `id` to `customer` but not to
+  `customer.billingConfiguration` just moves the clobber one level down.
+- **`id` is a cache concern, not a rendering concern.** Do not let a presentational
+  component's prop type force the `id` out of the fragment - keep `id` in the fragment
+  and narrow the props with `Pick<SomeFragment, 'fieldA' | 'fieldB'>` instead
+  (see `DunningEmail.tsx`).
+- **Value objects are fine.** Types with no `id` in the schema (`CustomerAddress`,
+  `ChargeProperties`, …) are never normalized, so there is nothing to clobber.
+
+**Enforced by** `src/core/apolloClient/__tests__/normalizedIdSelections.test.ts`, which
+fails CI when a field is selected **with** `id` in one document and **without** `id` in
+another. It carries a `KNOWN_UNSAFE_SELECTIONS` baseline of pre-existing violations:
+that list must only ever shrink. Fixing one means adding `id`, running `pnpm codegen`,
+and deleting its entry.
 
 ### Fragment Architecture Principles
 

--- a/.agents/docs/graphql-fragments.md
+++ b/.agents/docs/graphql-fragments.md
@@ -20,8 +20,11 @@ pnpm codegen
 ### ⚠️ CRITICAL: Always select `id` on a type that has one
 
 **Every selection set on a type that exposes an `id` must select `id`** - in fragments,
-in queries, in mutation payloads. No exceptions, even when the component renders none
-of it.
+in queries, in mutation payloads. Write it even when the component renders none of it.
+
+Some pre-existing selections still break this rule. They are listed in the guard's
+`KNOWN_UNSAFE_SELECTIONS` baseline described at the end of this section, and that list
+is shrink-only: treat it as debt to burn down, never as licence to add one more.
 
 Apollo normalizes an object into `TypeName:id` **only** when the selection set contains
 `id`. Without it the object is stored **inline**, and that write **replaces** whatever

--- a/src/components/emails/DunningEmail.tsx
+++ b/src/components/emails/DunningEmail.tsx
@@ -20,20 +20,24 @@ import { tw } from '~/styles/utils'
 
 gql`
   fragment CustomerForDunningEmail on Customer {
+    id
     displayName
     paymentProvider
     netPaymentTerm
     billingConfiguration {
+      id
       documentLocale
     }
   }
 
   fragment OrganizationForDunningEmail on CurrentOrganization {
+    id
     name
     logoUrl
     email
     netPaymentTerm
     billingConfiguration {
+      id
       documentLocale
     }
   }
@@ -46,12 +50,20 @@ gql`
   }
 `
 
+// Only the rendered fields are picked from the fragments. The fragments also
+// carry `id` (required so Apollo normalizes the entity instead of replacing the
+// cached reference with an inline object) and `billingConfiguration`, which the
+// parent reads — neither is rendered here, and the dunning-campaign preview
+// passes `{{customer_name}}`-style placeholders that have no entity behind them.
 export interface DunningEmailProps {
   locale: LocaleEnum
   invoices: InvoicesForDunningEmailFragment[]
-  customer?: CustomerForDunningEmailFragment
+  customer?: Pick<
+    CustomerForDunningEmailFragment,
+    'displayName' | 'paymentProvider' | 'netPaymentTerm'
+  >
   // Omit the netPaymentTerm from the organization and add it possible string
-  organization?: Omit<OrganizationForDunningEmailFragment, 'netPaymentTerm'> & {
+  organization?: Pick<OrganizationForDunningEmailFragment, 'name' | 'logoUrl' | 'email'> & {
     netPaymentTerm: OrganizationForDunningEmailFragment['netPaymentTerm'] | string
   }
   currency: CurrencyEnum

--- a/src/components/settings/dunnings/PreviewCampaignEmailDrawer.tsx
+++ b/src/components/settings/dunnings/PreviewCampaignEmailDrawer.tsx
@@ -19,6 +19,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 gql`
   fragment OrganizationInfoForPreviewDunningCampaign on CurrentOrganization {
+    id
     name
     email
     logoUrl

--- a/src/components/settings/invoices/PreviewCustomSectionDrawer.tsx
+++ b/src/components/settings/invoices/PreviewCustomSectionDrawer.tsx
@@ -16,7 +16,9 @@ import Logo from '~/public/images/logo/lago-logo-grey.svg'
 gql`
   query GetOrganizationCustomFooterForInvoice {
     organization {
+      id
       billingConfiguration {
+        id
         invoiceFooter
       }
     }

--- a/src/components/subscriptions/SubscriptionUsageTabContent.tsx
+++ b/src/components/subscriptions/SubscriptionUsageTabContent.tsx
@@ -9,6 +9,7 @@ import SubscriptionUsageLifetimeGraph from './SubscriptionUsageLifetimeGraph'
 gql`
   query getCustomerFromSubscription($subscriptionId: ID!) {
     subscription(id: $subscriptionId) {
+      id
       customer {
         id
       }

--- a/src/core/apolloClient/__tests__/normalizedIdSelections.test.ts
+++ b/src/core/apolloClient/__tests__/normalizedIdSelections.test.ts
@@ -1,0 +1,269 @@
+/* eslint-disable import/order -- prettier's sort-imports groups node builtins with externals, conflicting with import/order's builtin-first grouping */
+import fs from 'fs'
+import { FieldNode, Kind, parse, SelectionSetNode } from 'graphql'
+import path from 'path'
+
+const GENERATED_GRAPHQL_PATH = path.resolve(__dirname, '../../../generated/graphql.tsx')
+
+/**
+ * Apollo normalizes an object only when the selection set contains `id`. A
+ * selection WITHOUT `id` is stored inline, and that write REPLACES whatever the
+ * cache held at that location — including a `{ __ref }` written by another
+ * query. Every other query reading that field then diffs as incomplete and
+ * refetches, which in this app cascades: `useOrganizationInfos` has
+ * `notifyOnNetworkStatusChange: true` and `MainNavLayout` swaps `<Outlet />` for
+ * a spinner while it loads, so the whole routed page unmounts, remounts and
+ * re-fires its own queries. That was BIL-550 (the customer invoices view
+ * visibly loading twice after submitting a payment request).
+ *
+ * The failure needs TWO writers of the same field disagreeing about `id`, so
+ * that is exactly what this guard detects: a field selected WITH `id` in one
+ * document and WITHOUT `id` in another. A field nobody ever selects with `id`
+ * is simply never normalized — consistent, and not a clobber.
+ */
+
+type FieldName = string
+type TypeName = string
+
+// `Type.field` -> operations that select it without `id`
+type Conflicts = Record<string, string[]>
+
+/**
+ * Pre-existing violations, each a latent instance of the same defect. This list
+ * must only ever shrink.
+ *
+ * - Adding an entry means a NEW clobber was introduced: add `id` to the
+ *   selection instead.
+ * - Fixing one means removing its entry here (add `id`, run `pnpm codegen`).
+ */
+const KNOWN_UNSAFE_SELECTIONS: Conflicts = {
+  'BillableMetric.filters': ['GetSingleBillableMetric'],
+  'BillingEntity.billingConfiguration': ['UpdateBillingEntityInvoiceIssuingDatePolicy'],
+  'Charge.appliedPricingUnit': [
+    'CreateCharge',
+    'GetPlanForDetailsV2',
+    'GetSinglePlan',
+    'GetSubscriptionForDetailsV2Plan',
+    'GetSubscriptionForQuotePricing',
+    'UpdateCharge',
+    'UpdatePlan',
+    'UpdateSubscriptionCharge',
+  ],
+  'Charge.filters': ['GetSinglePlan', 'GetSubscriptionForQuotePricing'],
+  'CreditNote.customer': ['GetCreditNoteForDetailsExternalSync'],
+  'Customer.billingConfiguration': [
+    'GetOrderForEdit',
+    'GetOrderForExecute',
+    'GetOrderFormDetails',
+    'GetOrderFormForSign',
+    'GetOrderFormForVoid',
+    'GetOrderForms',
+    'GetOrders',
+    'GetQuote',
+    'GetQuotePreview',
+    'UpdateCustomerIssuingDatePolicy',
+  ],
+  'FeatureObject.privileges': ['GetSubscriptionDataForEntitlementForm'],
+  'FeatureObjectCollection.collection': ['GetSubscriptionDataForEntitlementForm'],
+  'Invoice.payments': [
+    'GetCustomerInvoices',
+    'GetInvoicesList',
+    'RetryInvoicePayment',
+    'UpdateInvoicePaymentStatus',
+    'VoidInvoice',
+  ],
+  'InvoiceCollection.collection': ['GetCustomerOverdueInvoicesReadyForPaymentProcessing'],
+  'Quote.currentVersion': ['GetOrderFormForVoid'],
+  'Subscription.usageThresholds': ['ResetSubscriptionProgressiveBilling'],
+}
+
+/**
+ * The generated file is the only complete description of the schema available
+ * to the test suite (codegen fetches the schema over the network, nothing is
+ * checked in). Its emitted types are flat and regular, so `Customer` ->
+ * { id -> null, billingConfiguration -> 'CustomerBillingConfiguration', ... }
+ * can be recovered by reading them line by line.
+ */
+const buildSchemaFieldTypes = (source: string): Map<TypeName, Map<FieldName, TypeName>> => {
+  const types = new Map<TypeName, Map<FieldName, TypeName>>()
+  const typeBlock = /export type (\w+) = \{\n([\s\S]*?)\n\};/g
+
+  let block = typeBlock.exec(source)
+
+  while (block) {
+    const [, typeName, body] = block
+    const fields = new Map<FieldName, TypeName>()
+
+    for (const line of body.split('\n')) {
+      const field = /^ {2}(\w+)\??: (.+);$/.exec(line)
+
+      if (field) {
+        const [, fieldName, rawType] = field
+        // `Maybe<Array<Invoice>>` -> `Invoice`, `Scalars['ID']['output']` -> ''
+        const namedType = rawType
+          .replace(/Maybe<|Array<|Scalars\['[^']+'\]\['[^']+'\]|>/g, '')
+          .trim()
+
+        fields.set(fieldName, namedType)
+      }
+    }
+
+    if (fields.size) types.set(typeName, fields)
+
+    block = typeBlock.exec(source)
+  }
+
+  return types
+}
+
+const buildDocuments = (source: string): Map<string, string> => {
+  const documents = new Map<string, string>()
+  const documentBlock = /export const (\w+) = gql`([\s\S]*?)`;/g
+
+  let block = documentBlock.exec(source)
+
+  while (block) {
+    documents.set(block[1], block[2])
+    block = documentBlock.exec(source)
+  }
+
+  return documents
+}
+
+// Codegen emits `${SomeFragmentDoc}` interpolations rather than inlining them.
+const inlineFragments = (
+  documents: Map<string, string>,
+  name: string,
+  seen: Set<string> = new Set(),
+): string => {
+  if (seen.has(name)) return ''
+
+  seen.add(name)
+
+  return (documents.get(name) ?? '').replace(/\$\{(\w+)\}/g, (_, dependency: string) =>
+    inlineFragments(documents, dependency, seen),
+  )
+}
+
+type MergedField = { name: FieldName; children: FieldNode[] }
+
+const collectConflicts = (source: string): Conflicts => {
+  const schema = buildSchemaFieldTypes(source)
+  const documents = buildDocuments(source)
+  const hasIdField = (typeName: TypeName): boolean => !!schema.get(typeName)?.has('id')
+
+  const usage = new Map<string, { withId: Set<string>; withoutId: Set<string> }>()
+
+  for (const documentName of documents.keys()) {
+    if (!documentName.endsWith('Document')) continue
+
+    const operationName = documentName.replace(/Document$/, '')
+
+    let ast
+
+    try {
+      ast = parse(inlineFragments(documents, documentName))
+    } catch {
+      // A document that does not parse standalone cannot be analysed; the
+      // codegen build already fails on genuinely invalid documents.
+      continue
+    }
+
+    const fragments = new Map(
+      ast.definitions
+        .filter((definition) => definition.kind === Kind.FRAGMENT_DEFINITION)
+        .map((definition) => [definition.name.value, definition]),
+    )
+
+    const flatten = (selectionSet: SelectionSetNode): FieldNode[] =>
+      selectionSet.selections.flatMap((selection) => {
+        if (selection.kind === Kind.FIELD) return [selection]
+        if (selection.kind === Kind.INLINE_FRAGMENT) return flatten(selection.selectionSet)
+
+        const fragment = fragments.get(selection.name.value)
+
+        return fragment ? flatten(fragment.selectionSet) : []
+      })
+
+    // GraphQL merges fields sharing a response key, so two fragments each
+    // selecting `billingConfiguration` on the same parent produce ONE selection
+    // set at write time. Merge before judging, or every split fragment reads as
+    // a false positive.
+    const mergeByResponseKey = (selectionSet: SelectionSetNode): MergedField[] => {
+      const merged = new Map<string, MergedField>()
+
+      for (const field of flatten(selectionSet)) {
+        const responseKey = field.alias?.value ?? field.name.value
+        const entry = merged.get(responseKey) ?? { name: field.name.value, children: [] }
+
+        if (field.selectionSet) entry.children.push(...flatten(field.selectionSet))
+
+        merged.set(responseKey, entry)
+      }
+
+      return [...merged.values()]
+    }
+
+    const walk = (selectionSet: SelectionSetNode, parentType: TypeName): void => {
+      for (const field of mergeByResponseKey(selectionSet)) {
+        if (!field.children.length) continue
+
+        const fieldType = schema.get(parentType)?.get(field.name)
+
+        if (!fieldType) continue
+
+        if (hasIdField(fieldType)) {
+          const key = `${parentType}.${field.name}`
+          const entry = usage.get(key) ?? { withId: new Set(), withoutId: new Set() }
+
+          const selectsId = field.children.some((child) => child.name.value === 'id')
+
+          ;(selectsId ? entry.withId : entry.withoutId).add(operationName)
+          usage.set(key, entry)
+        }
+
+        walk({ kind: Kind.SELECTION_SET, selections: field.children }, fieldType)
+      }
+    }
+
+    for (const definition of ast.definitions) {
+      if (definition.kind !== Kind.OPERATION_DEFINITION) continue
+
+      walk(definition.selectionSet, definition.operation === 'query' ? 'Query' : 'Mutation')
+    }
+  }
+
+  const conflicts: Conflicts = {}
+
+  for (const [key, entry] of [...usage.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    if (entry.withId.size && entry.withoutId.size) {
+      conflicts[key] = [...entry.withoutId].sort()
+    }
+  }
+
+  return conflicts
+}
+
+describe('GraphQL selections on normalized types', () => {
+  const source = fs.readFileSync(GENERATED_GRAPHQL_PATH, 'utf8')
+  const conflicts = collectConflicts(source)
+
+  it('sanity-checks that the generated file could be analysed', () => {
+    expect(buildSchemaFieldTypes(source).get('Customer')?.has('id')).toBe(true)
+    expect(buildDocuments(source).size).toBeGreaterThan(100)
+  })
+
+  it('does not introduce a field selected both with and without `id`', () => {
+    // A mismatch here means some document selects a normalizable type without
+    // `id`, so its write replaces the cached `{ __ref }` with an inline object
+    // and every other reader of that field refetches. Add `id` to the offending
+    // selection and run `pnpm codegen`.
+    expect(conflicts).toEqual(KNOWN_UNSAFE_SELECTIONS)
+  })
+
+  it('keeps the root fields behind BIL-550 normalized everywhere', () => {
+    expect(conflicts['Query.organization']).toBeUndefined()
+    expect(conflicts['Query.customer']).toBeUndefined()
+    expect(conflicts['Query.subscription']).toBeUndefined()
+  })
+})

--- a/src/core/apolloClient/__tests__/normalizedIdSelections.test.ts
+++ b/src/core/apolloClient/__tests__/normalizedIdSelections.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/order -- prettier's sort-imports groups node builtins with externals, conflicting with import/order's builtin-first grouping */
 import fs from 'fs'
-import { FieldNode, Kind, parse, SelectionSetNode } from 'graphql'
+import { DocumentNode, FieldNode, Kind, parse, SelectionSetNode } from 'graphql'
 import path from 'path'
 
 const GENERATED_GRAPHQL_PATH = path.resolve(__dirname, '../../../generated/graphql.tsx')
@@ -20,6 +20,14 @@ const GENERATED_GRAPHQL_PATH = path.resolve(__dirname, '../../../generated/graph
  * that is exactly what this guard detects: a field selected WITH `id` in one
  * document and WITHOUT `id` in another. A field nobody ever selects with `id`
  * is simply never normalized — consistent, and not a clobber.
+ *
+ * KNOWN GAP: codegen emits union and interface types as `export type X = A | B`
+ * rather than an object literal, so `buildSchemaFieldTypes` does not pick them
+ * up and `walk` stops at any field typed as one (`ActivityLogResourceObject`,
+ * …). Selections under a union are therefore never checked. This under-reports;
+ * it never produces a false positive. Resolving members would mean splitting the
+ * selection set per inline fragment, which is worth doing only if a clobber is
+ * ever traced back to a union field.
  */
 
 type FieldName = string
@@ -72,7 +80,6 @@ const KNOWN_UNSAFE_SELECTIONS: Conflicts = {
     'UpdateInvoicePaymentStatus',
     'VoidInvoice',
   ],
-  'InvoiceCollection.collection': ['GetCustomerOverdueInvoicesReadyForPaymentProcessing'],
   'Quote.currentVersion': ['GetOrderFormForVoid'],
   'Subscription.usageThresholds': ['ResetSubscriptionProgressiveBilling'],
 }
@@ -159,7 +166,7 @@ const collectConflicts = (source: string): Conflicts => {
 
     const operationName = documentName.replace(/Document$/, '')
 
-    let ast
+    let ast: DocumentNode
 
     try {
       ast = parse(inlineFragments(documents, documentName))

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -14371,7 +14371,7 @@ export type GetCustomerOverdueInvoicesReadyForPaymentProcessingQueryVariables = 
 }>;
 
 
-export type GetCustomerOverdueInvoicesReadyForPaymentProcessingQuery = { __typename?: 'Query', invoices: { __typename?: 'InvoiceCollection', collection: Array<{ __typename?: 'Invoice', readyForPaymentProcessing: boolean }> } };
+export type GetCustomerOverdueInvoicesReadyForPaymentProcessingQuery = { __typename?: 'Query', invoices: { __typename?: 'InvoiceCollection', collection: Array<{ __typename?: 'Invoice', id: string, readyForPaymentProcessing: boolean }> } };
 
 export type MainOrganizationInfosFragment = { __typename?: 'CurrentOrganization', id: string, name: string, slug: string, logoUrl?: string | null, timezone?: TimezoneEnum | null, defaultCurrency: CurrencyEnum, featureFlags: Array<FeatureFlagEnum>, premiumIntegrations: Array<PremiumIntegrationTypeEnum>, canCreateBillingEntity: boolean, authenticationMethods: Array<AuthenticationMethodsEnum>, authenticatedMethod: AuthenticationMethodsEnum };
 
@@ -35427,6 +35427,7 @@ export const GetCustomerOverdueInvoicesReadyForPaymentProcessingDocument = gql`
     query getCustomerOverdueInvoicesReadyForPaymentProcessing($id: ID!) {
   invoices(paymentOverdue: true, customerId: $id) {
     collection {
+      id
       readyForPaymentProcessing
     }
   }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -12532,9 +12532,9 @@ export type DeleteWebhookMutationVariables = Exact<{
 
 export type DeleteWebhookMutation = { __typename?: 'Mutation', destroyWebhookEndpoint?: { __typename?: 'DestroyWebhookEndpointPayload', id?: string | null } | null };
 
-export type CustomerForDunningEmailFragment = { __typename?: 'Customer', displayName: string, paymentProvider?: ProviderTypeEnum | null, netPaymentTerm?: number | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null };
+export type CustomerForDunningEmailFragment = { __typename?: 'Customer', id: string, displayName: string, paymentProvider?: ProviderTypeEnum | null, netPaymentTerm?: number | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', id: string, documentLocale?: string | null } | null };
 
-export type OrganizationForDunningEmailFragment = { __typename?: 'CurrentOrganization', name: string, logoUrl?: string | null, email?: string | null, netPaymentTerm: number, billingConfiguration?: { __typename?: 'OrganizationBillingConfiguration', documentLocale?: string | null } | null };
+export type OrganizationForDunningEmailFragment = { __typename?: 'CurrentOrganization', id: string, name: string, logoUrl?: string | null, email?: string | null, netPaymentTerm: number, billingConfiguration?: { __typename?: 'OrganizationBillingConfiguration', id: string, documentLocale?: string | null } | null };
 
 export type InvoicesForDunningEmailFragment = { __typename?: 'Invoice', id: string, number: string, totalDueAmountCents: any, currency?: CurrencyEnum | null };
 
@@ -12930,12 +12930,12 @@ export type UsageChargeForDrawerFragment = { __typename?: 'Charge', id: string, 
 
 export type FixedChargesOnPlanFormFragment = { __typename?: 'Plan', id: string, billFixedChargesMonthly?: boolean | null, fixedCharges?: Array<{ __typename?: 'FixedCharge', id: string, prorated: boolean, units: string, chargeModel: FixedChargeChargeModelEnum, invoiceDisplayName?: string | null, payInAdvance: boolean, addOn: { __typename?: 'AddOn', id: string, name: string, code: string }, properties?: { __typename?: 'FixedChargeProperties', amount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: number, perUnitAmount: string, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null }> | null };
 
-export type OrganizationInfoForPreviewDunningCampaignFragment = { __typename?: 'CurrentOrganization', name: string, email?: string | null, logoUrl?: string | null };
+export type OrganizationInfoForPreviewDunningCampaignFragment = { __typename?: 'CurrentOrganization', id: string, name: string, email?: string | null, logoUrl?: string | null };
 
 export type GetOrganizationInfoForPreviewDunningCampaignQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetOrganizationInfoForPreviewDunningCampaignQuery = { __typename?: 'Query', organization?: { __typename?: 'CurrentOrganization', name: string, email?: string | null, logoUrl?: string | null } | null };
+export type GetOrganizationInfoForPreviewDunningCampaignQuery = { __typename?: 'Query', organization?: { __typename?: 'CurrentOrganization', id: string, name: string, email?: string | null, logoUrl?: string | null } | null };
 
 export type UpdateBillingEntityLogoMutationVariables = Exact<{
   input: UpdateBillingEntityInput;
@@ -13711,7 +13711,7 @@ export type UpdateBillingEntityNetPaymentTermMutation = { __typename?: 'Mutation
 export type GetOrganizationCustomFooterForInvoiceQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetOrganizationCustomFooterForInvoiceQuery = { __typename?: 'Query', organization?: { __typename?: 'CurrentOrganization', billingConfiguration?: { __typename?: 'OrganizationBillingConfiguration', invoiceFooter?: string | null } | null } | null };
+export type GetOrganizationCustomFooterForInvoiceQuery = { __typename?: 'Query', organization?: { __typename?: 'CurrentOrganization', id: string, billingConfiguration?: { __typename?: 'OrganizationBillingConfiguration', id: string, invoiceFooter?: string | null } | null } | null };
 
 export type RemoveSubscriptionEntitlementMutationVariables = Exact<{
   input: RemoveSubscriptionEntitlementInput;
@@ -13823,7 +13823,7 @@ export type GetCustomerFromSubscriptionQueryVariables = Exact<{
 }>;
 
 
-export type GetCustomerFromSubscriptionQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', customer: { __typename?: 'Customer', id: string } } | null };
+export type GetCustomerFromSubscriptionQuery = { __typename?: 'Query', subscription?: { __typename?: 'Subscription', id: string, customer: { __typename?: 'Customer', id: string } } | null };
 
 export type DestroySubscriptionAlertMutationVariables = Exact<{
   input: DestroySubscriptionAlertInput;
@@ -14775,7 +14775,7 @@ export type GetRequestOverduePaymentInfosQueryVariables = Exact<{
 }>;
 
 
-export type GetRequestOverduePaymentInfosQuery = { __typename?: 'Query', organization?: { __typename?: 'CurrentOrganization', defaultCurrency: CurrencyEnum, name: string, logoUrl?: string | null, email?: string | null, netPaymentTerm: number, billingConfiguration?: { __typename?: 'OrganizationBillingConfiguration', documentLocale?: string | null } | null } | null, customer?: { __typename?: 'Customer', externalId: string, currency?: CurrencyEnum | null, email?: string | null, displayName: string, paymentProvider?: ProviderTypeEnum | null, netPaymentTerm?: number | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', documentLocale?: string | null } | null } | null, paymentRequests: { __typename?: 'PaymentRequestCollection', collection: Array<{ __typename?: 'PaymentRequest', createdAt: any }> }, invoices: { __typename?: 'InvoiceCollection', collection: Array<{ __typename?: 'Invoice', id: string, number: string, totalDueAmountCents: any, currency?: CurrencyEnum | null, issuingDate: any }> } };
+export type GetRequestOverduePaymentInfosQuery = { __typename?: 'Query', organization?: { __typename?: 'CurrentOrganization', id: string, defaultCurrency: CurrencyEnum, name: string, logoUrl?: string | null, email?: string | null, netPaymentTerm: number, billingConfiguration?: { __typename?: 'OrganizationBillingConfiguration', id: string, documentLocale?: string | null } | null } | null, customer?: { __typename?: 'Customer', id: string, externalId: string, currency?: CurrencyEnum | null, email?: string | null, displayName: string, paymentProvider?: ProviderTypeEnum | null, netPaymentTerm?: number | null, billingConfiguration?: { __typename?: 'CustomerBillingConfiguration', id: string, documentLocale?: string | null } | null } | null, paymentRequests: { __typename?: 'PaymentRequestCollection', collection: Array<{ __typename?: 'PaymentRequest', createdAt: any }> }, invoices: { __typename?: 'InvoiceCollection', collection: Array<{ __typename?: 'Invoice', id: string, number: string, totalDueAmountCents: any, currency?: CurrencyEnum | null, issuingDate: any }> } };
 
 export type CreatePaymentRequestMutationVariables = Exact<{
   input: PaymentRequestCreateInput;
@@ -17906,21 +17906,25 @@ export const WebhookLogFragmentDoc = gql`
     `;
 export const CustomerForDunningEmailFragmentDoc = gql`
     fragment CustomerForDunningEmail on Customer {
+  id
   displayName
   paymentProvider
   netPaymentTerm
   billingConfiguration {
+    id
     documentLocale
   }
 }
     `;
 export const OrganizationForDunningEmailFragmentDoc = gql`
     fragment OrganizationForDunningEmail on CurrentOrganization {
+  id
   name
   logoUrl
   email
   netPaymentTerm
   billingConfiguration {
+    id
     documentLocale
   }
 }
@@ -18974,6 +18978,7 @@ export const BillableMetricForUsageChargeSectionFragmentDoc = gql`
     `;
 export const OrganizationInfoForPreviewDunningCampaignFragmentDoc = gql`
     fragment OrganizationInfoForPreviewDunningCampaign on CurrentOrganization {
+  id
   name
   email
   logoUrl
@@ -32127,7 +32132,9 @@ export type UpdateBillingEntityNetPaymentTermMutationOptions = Apollo.BaseMutati
 export const GetOrganizationCustomFooterForInvoiceDocument = gql`
     query GetOrganizationCustomFooterForInvoice {
   organization {
+    id
     billingConfiguration {
+      id
       invoiceFooter
     }
   }
@@ -32679,6 +32686,7 @@ export type GetSubscriptionForSubscriptionUsageLifetimeGraphQueryResult = Apollo
 export const GetCustomerFromSubscriptionDocument = gql`
     query getCustomerFromSubscription($subscriptionId: ID!) {
   subscription(id: $subscriptionId) {
+    id
     customer {
       id
     }
@@ -37541,10 +37549,12 @@ export type VoidInvoiceMutationOptions = Apollo.BaseMutationOptions<VoidInvoiceM
 export const GetRequestOverduePaymentInfosDocument = gql`
     query getRequestOverduePaymentInfos($id: ID!, $currency: CurrencyEnum, $billingEntityIds: [ID!]) {
   organization {
+    id
     defaultCurrency
     ...OrganizationForDunningEmail
   }
   customer(id: $id) {
+    id
     externalId
     currency
     ...CustomerForRequestOverduePaymentForm

--- a/src/hooks/useIsCustomerReadyForOverduePayment.ts
+++ b/src/hooks/useIsCustomerReadyForOverduePayment.ts
@@ -7,6 +7,7 @@ gql`
   query getCustomerOverdueInvoicesReadyForPaymentProcessing($id: ID!) {
     invoices(paymentOverdue: true, customerId: $id) {
       collection {
+        id
         readyForPaymentProcessing
       }
     }

--- a/src/pages/CustomerRequestOverduePayment/index.tsx
+++ b/src/pages/CustomerRequestOverduePayment/index.tsx
@@ -52,11 +52,13 @@ gql`
     $billingEntityIds: [ID!]
   ) {
     organization {
+      id
       defaultCurrency
       ...OrganizationForDunningEmail
     }
 
     customer(id: $id) {
+      id
       externalId
       currency
       ...CustomerForRequestOverduePaymentForm


### PR DESCRIPTION
## Context

Submitting a payment request redirects back to the customer's **Invoices** tab, and that view visibly loads twice. The redirect itself is correct: a single `pushState`, no bounce. The duplication is in the GraphQL traffic, and it reaches the layout-level operations (`UserIdentifier`, `getOrganizationInfos`), not just the page's own queries.

Root cause is cache normalization. `getRequestOverduePaymentInfos` selected `organization` and `customer(id:)` **without `id`**. Apollo normalizes an object only when the selection set contains `id`; without it the object is stored inline, and that write **replaces** the `{ __ref }` other queries had put at `ROOT_QUERY.organization` and `ROOT_QUERY.customer(...)`.

Every other reader of those fields then diffs as incomplete and refetches. `useOrganizationInfos` sets `notifyOnNetworkStatusChange: true` and `MainNavLayout` renders `{isLoading && <Spinner/>}` / `{!isLoading && <Outlet/>}`, so a background refetch **unmounts the whole routed page**, which remounts and re-fires its own `cache-and-network` queries. Hence the second render pass, and each row of the operation counts on the ticket:

| operation | why it repeats |
| -- | -- |
| `getOrganizationInfos` | cache read incomplete after each clobber |
| `getCustomer` | `ROOT_QUERY.customer(...)` reference destroyed; `CustomerDetails` needs `id` |
| `UserIdentifier` | also selects `organization`; read goes incomplete, `if (!data) refetch()` fires, capped at 3 |
| page queries | re-fire on each `<Outlet />` remount |

Consistent with what the ticket ruled out: a hard load and a plain tab switch are clean because neither runs a query that writes an id-less `organization`.

## Description

- `id` added at every normalized level in `getRequestOverduePaymentInfos` (`organization`, `customer`, and both `billingConfiguration` blocks via the dunning-email fragments).
- Same defect fixed in the three other queries that had it: `getOrganizationInfoForPreviewDunningCampaign`, `GetOrganizationCustomFooterForInvoice`, `getCustomerFromSubscription`.
- `DunningEmailProps` now `Pick`s only the six fields the component renders. Requiring `id` on the props would have forced meaningless ids into the dunning-campaign preview, which passes `{{customer_name}}`-style placeholders with no entity behind them. `id` stays a cache concern, not a rendering one.
- **New guard** `src/core/apolloClient/__tests__/normalizedIdSelections.test.ts`. It recovers the schema from the emitted types in `src/generated/graphql.tsx`, inlines `${...FragmentDoc}` interpolations, merges same-response-key fields, then fails when a field is selected **with** `id` in one document and **without** `id` in another. That inconsistency is the precise clobber condition, so a type nobody ever normalizes stays quiet (105 raw id-less selections narrow to 12 real conflicts). `KNOWN_UNSAFE_SELECTIONS` baselines those 12 pre-existing violations and is documented as shrink-only.
- Rule written up in `.agents/docs/graphql-fragments.md`, with the mechanism, the symptoms to recognise it by, and the nested-level and value-object caveats.

Verified the guard actually catches regressions rather than just passing: removing the `id` added to `GetCustomerFromSubscriptionDocument` turns it red and names the offending operation.

The `src/generated/graphql.tsx` diff is only the 10 hunks caused by these document edits. `pnpm codegen` against a local API also pulled in unrelated schema drift (RateCard, Superset), which was reverted.

Still open, deliberately out of scope: `MainNavLayout` unmounting `<Outlet />` on a *background* refetch is what turns any cache blip into a full page remount, and is worth hardening on its own.

<!-- Linear link -->
Fixes BIL-550