### PR TITLE
fix(api-keys): copying a key no longer reveals it

### DIFF
--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -91,6 +91,8 @@ export interface TableProps<T> {
 const ACTION_COLUMN_ID = 'actionColumn'
 const LOADING_ROW_COUNT = DEFAULT_PAGE_SIZE
 
+export const OPEN_ACTION_BUTTON_TEST_ID = 'open-action-button'
+
 const MIN_CONTAINER_PADDING_PX = 4
 
 // The outer columns' padding follows the table's exterior gutter
@@ -570,7 +572,7 @@ export const Table = <T extends DataItem>({
                                   <Button
                                     icon="dots-horizontal"
                                     variant="quaternary"
-                                    data-test="open-action-button"
+                                    data-test={OPEN_ACTION_BUTTON_TEST_ID}
                                   />
                                 </Tooltip>
                               </PopperOpener>

--- a/src/components/developers/apiKeys/ApiKeys.tsx
+++ b/src/components/developers/apiKeys/ApiKeys.tsx
@@ -14,6 +14,7 @@ import { Typography } from '~/components/designSystem/Typography'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import {
   API_KEY_COPY_ACTION_TEST_ID,
+  API_KEY_REVEAL_ACTION_TEST_ID,
   API_KEY_REVEAL_BUTTON_TEST_ID,
 } from '~/components/developers/apiKeys/dataTestConstants'
 import { useDeleteApiKeyDialog } from '~/components/developers/apiKeys/DeleteApiKeyDialog'
@@ -491,6 +492,7 @@ export const ApiKeys = () => {
                         {
                           startIcon: !!apiKeyValue ? 'eye-hidden' : 'eye',
                           disabled: apiKeysLoading,
+                          dataTest: API_KEY_REVEAL_ACTION_TEST_ID,
                           title: !!apiKeyValue
                             ? translate('text_1731085297554jks9n068fpp')
                             : translate('text_1731085297554lu61x8djvcr'),

--- a/src/components/developers/apiKeys/ApiKeys.tsx
+++ b/src/components/developers/apiKeys/ApiKeys.tsx
@@ -12,7 +12,10 @@ import { ActionItem } from '~/components/designSystem/Table/types'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
-import { API_KEY_COPY_ACTION_TEST_ID } from '~/components/developers/apiKeys/dataTestConstants'
+import {
+  API_KEY_COPY_ACTION_TEST_ID,
+  API_KEY_REVEAL_BUTTON_TEST_ID,
+} from '~/components/developers/apiKeys/dataTestConstants'
 import { useDeleteApiKeyDialog } from '~/components/developers/apiKeys/DeleteApiKeyDialog'
 import { useRotateApiKeyDialog } from '~/components/developers/apiKeys/RotateApiKeyDialog'
 import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
@@ -113,8 +116,13 @@ export const ApiKeys = () => {
     variables: { page: 1, limit: pageSize },
     notifyOnNetworkStatusChange: true,
   })
+  // `no-cache`, not `network-only`: the plaintext key must never reach the normalized
+  // cache, which `cachePersistor` serializes to IndexedDB in full. The revealed value
+  // is held in React state instead, so nothing reads it back from the cache.
+  // `nextFetchPolicy` has to be set too, since the client defaults it to `cache-first`.
   const [getApiKeyValue] = useGetApiKeyValueLazyQuery({
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'no-cache',
+    nextFetchPolicy: 'no-cache',
   })
 
   const showPremiumAddApiKeyState = !isPremium && !!apiKeysData?.apiKeys.collection.length
@@ -124,16 +132,22 @@ export const ApiKeys = () => {
   // never unmask it on screen (LAGO-1813).
   const fetchApiKeyValue = useCallback(
     async (id: string): Promise<string | undefined> => {
+      // Apollo's lazy-query execute resolves with `error` set instead of rejecting, so
+      // a failure has to be read off the result; the catch is belt-and-braces.
       try {
         const res = await getApiKeyValue({ variables: { id } })
 
-        return res?.data?.apiKey?.value
+        if (!res.error && !!res.data?.apiKey?.value) {
+          return res.data.apiKey.value
+        }
       } catch {
-        addToast({
-          severity: 'danger',
-          translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-        })
+        // falls through to the toast below
       }
+
+      addToast({
+        severity: 'danger',
+        translateKey: 'text_62b31e1f6a5b8b1b745ece48',
+      })
     },
     [getApiKeyValue],
   )
@@ -439,6 +453,7 @@ export const ApiKeys = () => {
                                   size="small"
                                   loading={isRevealing}
                                   icon={!!apiKeyValue ? 'eye-hidden' : 'eye'}
+                                  data-test={API_KEY_REVEAL_BUTTON_TEST_ID}
                                   onClick={() => toggleApiKeyVisibility(id)}
                                 />
                               </Tooltip>

--- a/src/components/developers/apiKeys/ApiKeys.tsx
+++ b/src/components/developers/apiKeys/ApiKeys.tsx
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 import { Icon } from 'lago-design-system'
 import { DateTime } from 'luxon'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
@@ -12,6 +12,7 @@ import { ActionItem } from '~/components/designSystem/Table/types'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
+import { API_KEY_COPY_ACTION_TEST_ID } from '~/components/developers/apiKeys/dataTestConstants'
 import { useDeleteApiKeyDialog } from '~/components/developers/apiKeys/DeleteApiKeyDialog'
 import { useRotateApiKeyDialog } from '~/components/developers/apiKeys/RotateApiKeyDialog'
 import { usePremiumWarningDialog } from '~/components/dialogs/PremiumWarningDialog'
@@ -118,55 +119,101 @@ export const ApiKeys = () => {
 
   const showPremiumAddApiKeyState = !isPremium && !!apiKeysData?.apiKeys.collection.length
 
+  // The list query only returns sanitized values, so the plaintext has to be fetched
+  // per key. Fetching is deliberately kept separate from revealing: copying a key must
+  // never unmask it on screen (LAGO-1813).
+  const fetchApiKeyValue = useCallback(
+    async (id: string): Promise<string | undefined> => {
+      try {
+        const res = await getApiKeyValue({ variables: { id } })
+
+        return res?.data?.apiKey?.value
+      } catch {
+        addToast({
+          severity: 'danger',
+          translateKey: 'text_62b31e1f6a5b8b1b745ece48',
+        })
+      }
+    },
+    [getApiKeyValue],
+  )
+
   // Reveals a single key's value, tracking the loading state per row id (a Set, so
   // several keys can reveal concurrently) and keeping the rest of the list as-is
   // instead of flashing the whole list to loading.
-  const revealApiKey = async (id: string): Promise<string | undefined> => {
-    setLoadingKeyIds((prev) => new Set(prev).add(id))
+  const revealApiKey = useCallback(
+    async (id: string): Promise<string | undefined> => {
+      setLoadingKeyIds((prev) => new Set(prev).add(id))
 
-    try {
-      const res = await getApiKeyValue({ variables: { id } })
-      const fetchedValue = res?.data?.apiKey?.value
+      try {
+        const fetchedValue = await fetchApiKeyValue(id)
 
-      if (fetchedValue) {
-        setShownApiKeysMap((prev) => new Map(prev.set(id, fetchedValue)))
+        if (fetchedValue) {
+          setShownApiKeysMap((prev) => new Map(prev).set(id, fetchedValue))
+        }
+
+        return fetchedValue
+      } finally {
+        setLoadingKeyIds((prev) => {
+          const next = new Set(prev)
+
+          next.delete(id)
+          return next
+        })
       }
+    },
+    [fetchApiKeyValue],
+  )
 
-      return fetchedValue
-    } catch {
-      addToast({
-        severity: 'danger',
-        translateKey: 'text_62b31e1f6a5b8b1b745ece48',
-      })
-    } finally {
-      setLoadingKeyIds((prev) => {
-        const next = new Set(prev)
+  const hideApiKey = (id: string): void => {
+    setShownApiKeysMap((prev) => {
+      const next = new Map(prev)
 
-        next.delete(id)
-        return next
-      })
+      next.delete(id)
+      return next
+    })
+  }
+
+  const toggleApiKeyVisibility = async (id: string): Promise<void> => {
+    if (shownApiKeysMap.has(id)) {
+      hideApiKey(id)
+      return
     }
+
+    await revealApiKey(id)
+  }
+
+  // Copies the plaintext value without revealing it: already-revealed keys are read
+  // from the map, hidden ones are fetched on demand and never stored.
+  const copyApiKey = async (id: string): Promise<void> => {
+    const value = shownApiKeysMap.get(id) ?? (await fetchApiKeyValue(id))
+
+    if (!value) return
+
+    copyToClipboard(value)
+    addToast({
+      severity: 'info',
+      translateKey: 'text_6227a2e847fcd700e9038952',
+    })
   }
 
   useEffect(() => {
-    const revealGivenKey = async () => {
-      const res = await getApiKeyValue({ variables: { id: state[STATE_KEY_ID_TO_REVEAL] } })
+    const keyIdToReveal = state?.[STATE_KEY_ID_TO_REVEAL]
 
-      if (!!res?.data?.apiKey?.value) {
-        setShownApiKeysMap(
-          (prev) => new Map(prev.set(state[STATE_KEY_ID_TO_REVEAL], res.data?.apiKey.value || '')),
-        )
+    // Incase we're redirected here with a keyIdToReveal, trigger the query
+    if (!keyIdToReveal) return
 
+    const revealGivenKey = async (): Promise<void> => {
+      const fetchedValue = await revealApiKey(keyIdToReveal)
+
+      if (!!fetchedValue) {
         // Remove the keyIdToReveal from the state
         window.history.replaceState({}, '')
       }
     }
 
-    // Incase we're redirected here with a keyIdToReveal, trigger the query
-    if (!!state?.[STATE_KEY_ID_TO_REVEAL]) {
-      revealGivenKey()
-    }
-  }, [getApiKeyValue, state])
+    revealGivenKey()
+  }, [revealApiKey, state])
 
   return (
     <div className="flex h-full flex-col not-last-child:shadow-b">
@@ -373,22 +420,7 @@ export const ApiKeys = () => {
                                   className="ml-0 line-break-auto [text-wrap:auto]"
                                   color="grey700"
                                   variant="captionCode"
-                                  masked={!apiKeyValue}
-                                  onCopy={
-                                    apiKeyValue
-                                      ? undefined
-                                      : async () => {
-                                          const fetchedValue = await revealApiKey(id)
-
-                                          if (fetchedValue) {
-                                            copyToClipboard(fetchedValue)
-                                            addToast({
-                                              severity: 'info',
-                                              translateKey: 'text_6227a2e847fcd700e9038952',
-                                            })
-                                          }
-                                        }
-                                  }
+                                  onCopy={() => copyApiKey(id)}
                                 >
                                   {apiKeyValue || value}
                                 </TypographyWithCopy>
@@ -407,18 +439,7 @@ export const ApiKeys = () => {
                                   size="small"
                                   loading={isRevealing}
                                   icon={!!apiKeyValue ? 'eye-hidden' : 'eye'}
-                                  onClick={async () => {
-                                    if (!!apiKeyValue) {
-                                      setShownApiKeysMap((prev) => {
-                                        const newMap = new Map(prev)
-
-                                        newMap.delete(id)
-                                        return newMap
-                                      })
-                                    } else {
-                                      await revealApiKey(id)
-                                    }
-                                  }}
+                                  onClick={() => toggleApiKeyVisibility(id)}
                                 />
                               </Tooltip>
                             </div>
@@ -458,34 +479,16 @@ export const ApiKeys = () => {
                           title: !!apiKeyValue
                             ? translate('text_1731085297554jks9n068fpp')
                             : translate('text_1731085297554lu61x8djvcr'),
-                          onAction: async () => {
-                            if (!!apiKeyValue) {
-                              setShownApiKeysMap((prev) => {
-                                const newMap = new Map(prev)
-
-                                newMap.delete(id)
-                                return newMap
-                              })
-                            } else {
-                              await revealApiKey(id)
-                            }
-                          },
+                          onAction: () => toggleApiKeyVisibility(id),
                         },
 
-                        apiKeyValue
-                          ? {
-                              startIcon: 'duplicate',
-                              disabled: apiKeysLoading,
-                              title: translate('text_637f813d31381b1ed90ab30a'),
-                              onAction: () => {
-                                copyToClipboard(apiKeyValue)
-                                addToast({
-                                  severity: 'info',
-                                  translateKey: 'text_6227a2e847fcd700e9038952',
-                                })
-                              },
-                            }
-                          : null,
+                        {
+                          startIcon: 'duplicate',
+                          disabled: apiKeysLoading,
+                          dataTest: API_KEY_COPY_ACTION_TEST_ID,
+                          title: translate('text_637f813d31381b1ed90ab30a'),
+                          onAction: () => copyApiKey(id),
+                        },
 
                         {
                           startIcon: 'pivot',
@@ -495,8 +498,8 @@ export const ApiKeys = () => {
                             openRotateApiKeyDialog({
                               apiKey: item,
                               callBack: (itemToReveal) => {
-                                setShownApiKeysMap(
-                                  (prev) => new Map(prev.set(itemToReveal.id, itemToReveal.value)),
+                                setShownApiKeysMap((prev) =>
+                                  new Map(prev).set(itemToReveal.id, itemToReveal.value),
                                 )
                               },
                               openPremiumDialog: () => premiumWarningDialog.open(),

--- a/src/components/developers/apiKeys/__tests__/ApiKeys.test.tsx
+++ b/src/components/developers/apiKeys/__tests__/ApiKeys.test.tsx
@@ -1,10 +1,18 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 
+import { OPEN_ACTION_BUTTON_TEST_ID } from '~/components/designSystem/Table/Table'
+import { TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID } from '~/components/designSystem/TypographyWithCopy'
 import { maskValue } from '~/core/formats/maskValue'
-import { GetApiKeysDocument, GetOrganizationInfosForApiKeyDocument } from '~/generated/graphql'
+import { copyToClipboard } from '~/core/utils/copyToClipboard'
+import {
+  GetApiKeysDocument,
+  GetApiKeyValueDocument,
+  GetOrganizationInfosForApiKeyDocument,
+} from '~/generated/graphql'
 import { AllTheProviders } from '~/test-utils'
 
 import { ApiKeys } from '../ApiKeys'
+import { API_KEY_COPY_ACTION_TEST_ID } from '../dataTestConstants'
 
 // Mock IntersectionObserver (undefined in jsdom, used by some design-system components)
 const mockIntersectionObserver = jest.fn()
@@ -20,6 +28,11 @@ globalThis.IntersectionObserver = mockIntersectionObserver
 const MOCK_ORG_ID = 'org-12345-abcde-67890'
 const MOCK_API_KEY_ID = 'api-key-12345'
 const MOCK_API_KEY_VALUE = '••••••••xyz'
+const MOCK_API_KEY_PLAINTEXT_VALUE = 'secret-api-key-xyz'
+
+jest.mock('~/core/utils/copyToClipboard', () => ({
+  copyToClipboard: jest.fn(),
+}))
 
 // Mock hooks that require providers
 jest.mock('~/hooks/useDeveloperTool', () => ({
@@ -58,10 +71,13 @@ const mockApiKeysData = {
   result: {
     data: {
       apiKeys: {
-        __typename: 'ApiKeyCollection',
+        __typename: 'SanitizedApiKeyCollection',
         collection: [
           {
-            __typename: 'ApiKey',
+            // The list only ever returns sanitized keys, a distinct type from the
+            // `ApiKey` returned by the value query, so the plaintext fetched for a copy
+            // can never overwrite the masked value in the cache.
+            __typename: 'SanitizedApiKey',
             id: MOCK_API_KEY_ID,
             name: 'Test API Key',
             value: MOCK_API_KEY_VALUE,
@@ -81,18 +97,49 @@ const mockApiKeysData = {
   },
 }
 
+const mockApiKeyValueData = {
+  request: {
+    query: GetApiKeyValueDocument,
+    variables: { id: MOCK_API_KEY_ID },
+  },
+  result: {
+    data: {
+      apiKey: {
+        __typename: 'ApiKey',
+        id: MOCK_API_KEY_ID,
+        value: MOCK_API_KEY_PLAINTEXT_VALUE,
+      },
+    },
+  },
+}
+
 const renderComponent = () => {
   return render(<ApiKeys />, {
     wrapper: ({ children }) =>
       AllTheProviders({
         children,
-        mocks: [mockOrganizationData, mockApiKeysData],
+        // The value query is mocked twice: MockedProvider consumes a mock per call, and
+        // some tests fetch the value more than once (copy, then reveal).
+        mocks: [mockOrganizationData, mockApiKeysData, mockApiKeyValueData, mockApiKeyValueData],
         forceTypenames: true,
       }),
   })
 }
 
+const getApiKeyRow = async (): Promise<HTMLElement> => {
+  const valueCell = await screen.findByText(MOCK_API_KEY_VALUE)
+  const row = valueCell.closest('tr')
+
+  if (!row) throw new Error('API key row not found')
+
+  return row
+}
+
 describe('ApiKeys', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('should show masked organization ID by default', async () => {
     renderComponent()
 
@@ -108,6 +155,60 @@ describe('ApiKeys', () => {
 
     await waitFor(() => {
       expect(screen.getByText(MOCK_API_KEY_VALUE)).toBeInTheDocument()
+    })
+  })
+
+  describe('GIVEN a masked API key', () => {
+    describe('WHEN clicking the inline copy button', () => {
+      it('THEN should copy the plaintext value without revealing it', async () => {
+        renderComponent()
+
+        const row = await getApiKeyRow()
+
+        fireEvent.click(within(row).getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(copyToClipboard).toHaveBeenCalledWith(MOCK_API_KEY_PLAINTEXT_VALUE)
+        })
+
+        expect(screen.queryByText(MOCK_API_KEY_PLAINTEXT_VALUE)).not.toBeInTheDocument()
+        expect(screen.getByText(MOCK_API_KEY_VALUE)).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN clicking the copy action in the action menu', () => {
+      it('THEN should copy the plaintext value without revealing it', async () => {
+        renderComponent()
+
+        const row = await getApiKeyRow()
+
+        fireEvent.click(within(row).getByTestId(OPEN_ACTION_BUTTON_TEST_ID))
+        fireEvent.click(await screen.findByTestId(API_KEY_COPY_ACTION_TEST_ID))
+
+        await waitFor(() => {
+          expect(copyToClipboard).toHaveBeenCalledWith(MOCK_API_KEY_PLAINTEXT_VALUE)
+        })
+
+        expect(screen.queryByText(MOCK_API_KEY_PLAINTEXT_VALUE)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN clicking the reveal button', () => {
+      it('THEN should display the plaintext value', async () => {
+        renderComponent()
+
+        const row = await getApiKeyRow()
+        const revealButton = within(row)
+          .getByTestId(/^eye\//)
+          .closest('button')
+
+        expect(revealButton).not.toBeNull()
+
+        fireEvent.click(revealButton as HTMLElement)
+
+        expect(await screen.findByText(MOCK_API_KEY_PLAINTEXT_VALUE)).toBeInTheDocument()
+        expect(copyToClipboard).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/src/components/developers/apiKeys/__tests__/ApiKeys.test.tsx
+++ b/src/components/developers/apiKeys/__tests__/ApiKeys.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 
 import { OPEN_ACTION_BUTTON_TEST_ID } from '~/components/designSystem/Table/Table'
 import { TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID } from '~/components/designSystem/TypographyWithCopy'
+import { addToast } from '~/core/apolloClient'
 import { maskValue } from '~/core/formats/maskValue'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import {
@@ -9,10 +10,10 @@ import {
   GetApiKeyValueDocument,
   GetOrganizationInfosForApiKeyDocument,
 } from '~/generated/graphql'
-import { AllTheProviders } from '~/test-utils'
+import { AllTheProviders, TestMocksType } from '~/test-utils'
 
 import { ApiKeys } from '../ApiKeys'
-import { API_KEY_COPY_ACTION_TEST_ID } from '../dataTestConstants'
+import { API_KEY_COPY_ACTION_TEST_ID, API_KEY_REVEAL_BUTTON_TEST_ID } from '../dataTestConstants'
 
 // Mock IntersectionObserver (undefined in jsdom, used by some design-system components)
 const mockIntersectionObserver = jest.fn()
@@ -32,6 +33,11 @@ const MOCK_API_KEY_PLAINTEXT_VALUE = 'secret-api-key-xyz'
 
 jest.mock('~/core/utils/copyToClipboard', () => ({
   copyToClipboard: jest.fn(),
+}))
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: jest.fn(),
 }))
 
 // Mock hooks that require providers
@@ -113,14 +119,24 @@ const mockApiKeyValueData = {
   },
 }
 
-const renderComponent = () => {
+const mockApiKeyValueError = {
+  request: {
+    query: GetApiKeyValueDocument,
+    variables: { id: MOCK_API_KEY_ID },
+  },
+  error: new Error('Network error'),
+}
+
+// `MockedProvider` consumes one mock per call and the query is `no-cache`, so the value
+// mock is listed twice for the tests that fetch it twice (copy, then reveal).
+const renderComponent = (
+  valueMocks: TestMocksType = [mockApiKeyValueData, mockApiKeyValueData],
+) => {
   return render(<ApiKeys />, {
     wrapper: ({ children }) =>
       AllTheProviders({
         children,
-        // The value query is mocked twice: MockedProvider consumes a mock per call, and
-        // some tests fetch the value more than once (copy, then reveal).
-        mocks: [mockOrganizationData, mockApiKeysData, mockApiKeyValueData, mockApiKeyValueData],
+        mocks: [mockOrganizationData, mockApiKeysData, ...valueMocks],
         forceTypenames: true,
       }),
   })
@@ -198,16 +214,51 @@ describe('ApiKeys', () => {
         renderComponent()
 
         const row = await getApiKeyRow()
-        const revealButton = within(row)
-          .getByTestId(/^eye\//)
-          .closest('button')
 
-        expect(revealButton).not.toBeNull()
-
-        fireEvent.click(revealButton as HTMLElement)
+        fireEvent.click(within(row).getByTestId(API_KEY_REVEAL_BUTTON_TEST_ID))
 
         expect(await screen.findByText(MOCK_API_KEY_PLAINTEXT_VALUE)).toBeInTheDocument()
         expect(copyToClipboard).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN copying the key and then revealing it', () => {
+      it('THEN should reveal the value the copy left masked', async () => {
+        renderComponent()
+
+        const row = await getApiKeyRow()
+
+        fireEvent.click(within(row).getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(copyToClipboard).toHaveBeenCalledWith(MOCK_API_KEY_PLAINTEXT_VALUE)
+        })
+
+        expect(screen.queryByText(MOCK_API_KEY_PLAINTEXT_VALUE)).not.toBeInTheDocument()
+
+        fireEvent.click(within(row).getByTestId(API_KEY_REVEAL_BUTTON_TEST_ID))
+
+        expect(await screen.findByText(MOCK_API_KEY_PLAINTEXT_VALUE)).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the value query fails', () => {
+      it('THEN should show an error toast and copy nothing', async () => {
+        renderComponent([mockApiKeyValueError])
+
+        const row = await getApiKeyRow()
+
+        fireEvent.click(within(row).getByTestId(TYPOGRAPHY_WITH_COPY_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledWith({
+            severity: 'danger',
+            translateKey: 'text_62b31e1f6a5b8b1b745ece48',
+          })
+        })
+
+        expect(copyToClipboard).not.toHaveBeenCalled()
+        expect(screen.getByText(MOCK_API_KEY_VALUE)).toBeInTheDocument()
       })
     })
   })

--- a/src/components/developers/apiKeys/__tests__/ApiKeys.test.tsx
+++ b/src/components/developers/apiKeys/__tests__/ApiKeys.test.tsx
@@ -10,10 +10,15 @@ import {
   GetApiKeyValueDocument,
   GetOrganizationInfosForApiKeyDocument,
 } from '~/generated/graphql'
+import { STATE_KEY_ID_TO_REVEAL } from '~/pages/developers/ApiKeysForm'
 import { AllTheProviders, TestMocksType } from '~/test-utils'
 
 import { ApiKeys } from '../ApiKeys'
-import { API_KEY_COPY_ACTION_TEST_ID, API_KEY_REVEAL_BUTTON_TEST_ID } from '../dataTestConstants'
+import {
+  API_KEY_COPY_ACTION_TEST_ID,
+  API_KEY_REVEAL_ACTION_TEST_ID,
+  API_KEY_REVEAL_BUTTON_TEST_ID,
+} from '../dataTestConstants'
 
 // Mock IntersectionObserver (undefined in jsdom, used by some design-system components)
 const mockIntersectionObserver = jest.fn()
@@ -38,6 +43,14 @@ jest.mock('~/core/utils/copyToClipboard', () => ({
 jest.mock('~/core/apolloClient', () => ({
   ...jest.requireActual('~/core/apolloClient'),
   addToast: jest.fn(),
+}))
+
+// Router state carries the id to auto-reveal after a key is created
+const mockLocation: { state: Record<string, string> | null } = { state: null }
+
+jest.mock('~/core/router', () => ({
+  ...jest.requireActual('~/core/router'),
+  useLocation: () => mockLocation,
 }))
 
 // Mock hooks that require providers
@@ -154,6 +167,7 @@ const getApiKeyRow = async (): Promise<HTMLElement> => {
 describe('ApiKeys', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockLocation.state = null
   })
 
   it('should show masked organization ID by default', async () => {
@@ -237,6 +251,49 @@ describe('ApiKeys', () => {
         expect(screen.queryByText(MOCK_API_KEY_PLAINTEXT_VALUE)).not.toBeInTheDocument()
 
         fireEvent.click(within(row).getByTestId(API_KEY_REVEAL_BUTTON_TEST_ID))
+
+        expect(await screen.findByText(MOCK_API_KEY_PLAINTEXT_VALUE)).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN revealing then clicking the reveal button again', () => {
+      it('THEN should mask the value back', async () => {
+        renderComponent()
+
+        const row = await getApiKeyRow()
+
+        fireEvent.click(within(row).getByTestId(API_KEY_REVEAL_BUTTON_TEST_ID))
+
+        expect(await screen.findByText(MOCK_API_KEY_PLAINTEXT_VALUE)).toBeInTheDocument()
+
+        fireEvent.click(within(row).getByTestId(API_KEY_REVEAL_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(screen.queryByText(MOCK_API_KEY_PLAINTEXT_VALUE)).not.toBeInTheDocument()
+        })
+
+        expect(screen.getByText(MOCK_API_KEY_VALUE)).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN using the reveal action in the action menu', () => {
+      it('THEN should reveal the value', async () => {
+        renderComponent()
+
+        const row = await getApiKeyRow()
+
+        fireEvent.click(within(row).getByTestId(OPEN_ACTION_BUTTON_TEST_ID))
+        fireEvent.click(await screen.findByTestId(API_KEY_REVEAL_ACTION_TEST_ID))
+
+        expect(await screen.findByText(MOCK_API_KEY_PLAINTEXT_VALUE)).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN redirected here with a key id to reveal', () => {
+      it('THEN should reveal that key on mount', async () => {
+        mockLocation.state = { [STATE_KEY_ID_TO_REVEAL]: MOCK_API_KEY_ID }
+
+        renderComponent()
 
         expect(await screen.findByText(MOCK_API_KEY_PLAINTEXT_VALUE)).toBeInTheDocument()
       })

--- a/src/components/developers/apiKeys/dataTestConstants.ts
+++ b/src/components/developers/apiKeys/dataTestConstants.ts
@@ -1,3 +1,4 @@
 export const ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID = 'rotate-api-key-submit-button'
 export const API_KEY_COPY_ACTION_TEST_ID = 'api-key-copy-action'
 export const API_KEY_REVEAL_BUTTON_TEST_ID = 'api-key-reveal-button'
+export const API_KEY_REVEAL_ACTION_TEST_ID = 'api-key-reveal-action'

--- a/src/components/developers/apiKeys/dataTestConstants.ts
+++ b/src/components/developers/apiKeys/dataTestConstants.ts
@@ -1,2 +1,3 @@
 export const ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID = 'rotate-api-key-submit-button'
 export const API_KEY_COPY_ACTION_TEST_ID = 'api-key-copy-action'
+export const API_KEY_REVEAL_BUTTON_TEST_ID = 'api-key-reveal-button'

--- a/src/components/developers/apiKeys/dataTestConstants.ts
+++ b/src/components/developers/apiKeys/dataTestConstants.ts
@@ -1,1 +1,2 @@
 export const ROTATE_API_KEY_DIALOG_SUBMIT_BUTTON_TEST_ID = 'rotate-api-key-submit-button'
+export const API_KEY_COPY_ACTION_TEST_ID = 'api-key-copy-action'


### PR DESCRIPTION
Fixes LAGO-1813

## Context

In Settings → Developers → API keys, clicking a masked API key copied it to the
clipboard **and** unmasked it on screen, without the user ever clicking "Reveal".
Revealing a secret as a side effect of copying exposes it during a screen share, a
demo or a recorded call.

`revealApiKey` did two things at once: it fetched the plaintext value (the list query
only returns `SanitizedApiKey`, so the real value needs a per-key fetch) and it wrote
that value into `shownApiKeysMap`, the state that drives the row display. The copy
handler reused it, so every copy revealed.

Regression from #3681, which hoisted the copy path's inline fetch into the new shared
`revealApiKey` to reuse its per-row loading `Set`, and inherited the map write.

## Description

Fetching is now separate from revealing:

- `fetchApiKeyValue(id)` — network call only, no state write
- `revealApiKey(id)` — fetch + map write + per-row loading state (unchanged behaviour)
- `copyApiKey(id)` — reads the map when the key is already revealed, otherwise fetches
  on demand, and never stores the value

Copying no longer sets the per-row loading flag either, so the masked value stays in
place instead of flashing a skeleton; the "copied" toast is the feedback.

### The value query no longer touches the cache

`getApiKeyValue` was `fetchPolicy: 'network-only'`, which skips the cache *read* but
still *writes* the result. `ApiKey` has no `typePolicies` entry, so the plaintext
normalized to `ApiKey:<id>`, and `cachePersistor` serializes the whole cache into
IndexedDB with no denylist — so copying a key the user never revealed still left the
secret at rest on disk until the next logout or org switch. Masking it on screen while
persisting it to disk is not much of a fix.

Now `no-cache`, plus `nextFetchPolicy: 'no-cache'` since the client defaults that to
`cache-first`. Same policy the sibling `getApiKeyToEdit` query already uses in
`ApiKeysForm.tsx`. Nothing reads the value back through the cache — revealed values
live in React state.

### The error path actually runs now

The `catch` around the lazy-query execute was dead code. In Apollo Client 3.14,
`executeQuery` is a `new Promise(resolve)` with no reject path and resolves from its
`error` subscriber, so a failed fetch never threw: no toast, and copy silently did
nothing at all. Confirmed by running the new error test against the previous code —
`addToast` calls: 0. It now branches on `res.error`.

### Also

- The copy action is always present in the row action menu, hidden or not. It
  previously only appeared once the key had been revealed, which was inconsistent with
  the inline copy button.
- Dropped the `masked` prop on the key row: it was passed without `maskOptions`, so
  `TypographyWithCopy` ignored it. The masking there comes from the backend-sanitized
  value. `TypographyWithCopy` itself is untouched.
- `toggleApiKeyVisibility` / `hideApiKey` replace the reveal/hide branch that was
  duplicated in the eye button and the action menu.
- The `keyIdToReveal` effect (post-creation redirect) reuses `revealApiKey` instead of
  re-implementing the fetch and the map write.
- `new Map(prev.set(...))` mutated the previous state object before copying it; now
  `new Map(prev).set(...)`.
- Test IDs as exported constants: `OPEN_ACTION_BUTTON_TEST_ID` from `Table`,
  `API_KEY_COPY_ACTION_TEST_ID` and `API_KEY_REVEAL_BUTTON_TEST_ID` from
  `dataTestConstants`.

## Tests

Five cases: inline copy leaves the row masked, action-menu copy leaves it masked,
reveal shows the plaintext, copy-then-reveal still reveals, and a failed value query
toasts instead of failing silently.

Two notes for reviewers:

- The existing `getApiKeys` mock declared `__typename: 'ApiKey'` / `'ApiKeyCollection'`
  where the schema says `SanitizedApiKey` / `SanitizedApiKeyCollection`. With the wrong
  typename both queries normalize onto the same cache entity, so the plaintext fetched
  for a copy overwrote the masked list value and the row unmasked anyway, making the fix
  look broken. Corrected.
- The tests use `fireEvent` rather than `userEvent`: hovering mounts a MUI Tooltip
  Popper, and jsdom then throws
  `SyntaxError: 'div#:ro:.MuiPopper-root [data-id="actionColumn"] button:hover' is not a valid selector`
  on Table's `sx` `:has()` rule. Environment limitation, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)