### PR TITLE
fix(members): stop search row from shrinking

### DIFF
--- a/src/pages/settings/teamAndSecurity/members/common/MembersFilters.tsx
+++ b/src/pages/settings/teamAndSecurity/members/common/MembersFilters.tsx
@@ -56,7 +56,7 @@ const MembersFilters = ({ searchQuery, setSearchQuery, type }: MembersFiltersPro
   }
 
   return (
-    <div className="flex h-16 shrink-0 items-center justify-between gap-3 shadow-b">
+    <div className="flex shrink-0 items-center justify-between gap-3 pb-4 shadow-b">
       <Popper
         PopperProps={{ placement: 'bottom-start' }}
         opener={

--- a/src/pages/settings/teamAndSecurity/members/common/MembersFilters.tsx
+++ b/src/pages/settings/teamAndSecurity/members/common/MembersFilters.tsx
@@ -56,7 +56,7 @@ const MembersFilters = ({ searchQuery, setSearchQuery, type }: MembersFiltersPro
   }
 
   return (
-    <div className="flex h-16 items-center justify-between gap-3 shadow-b">
+    <div className="flex h-16 shrink-0 items-center justify-between gap-3 shadow-b">
       <Popper
         PopperProps={{ placement: 'bottom-start' }}
         opener={

--- a/src/pages/settings/teamAndSecurity/members/common/__tests__/__snapshots__/MembersFilters.test.tsx.snap
+++ b/src/pages/settings/teamAndSecurity/members/common/__tests__/__snapshots__/MembersFilters.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MembersFilters Snapshot Tests matches snapshot with default props 1`] = `
 <div>
   <div
-    class="flex h-16 shrink-0 items-center justify-between gap-3 shadow-b"
+    class="flex shrink-0 items-center justify-between gap-3 pb-4 shadow-b"
   >
     <div
       class=""
@@ -86,7 +86,7 @@ exports[`MembersFilters Snapshot Tests matches snapshot with default props 1`] =
 exports[`MembersFilters Snapshot Tests matches snapshot with invitations type 1`] = `
 <div>
   <div
-    class="flex h-16 shrink-0 items-center justify-between gap-3 shadow-b"
+    class="flex shrink-0 items-center justify-between gap-3 pb-4 shadow-b"
   >
     <div
       class=""
@@ -169,7 +169,7 @@ exports[`MembersFilters Snapshot Tests matches snapshot with invitations type 1`
 exports[`MembersFilters Snapshot Tests matches snapshot with members type 1`] = `
 <div>
   <div
-    class="flex h-16 shrink-0 items-center justify-between gap-3 shadow-b"
+    class="flex shrink-0 items-center justify-between gap-3 pb-4 shadow-b"
   >
     <div
       class=""
@@ -252,7 +252,7 @@ exports[`MembersFilters Snapshot Tests matches snapshot with members type 1`] = 
 exports[`MembersFilters Snapshot Tests matches snapshot with search query 1`] = `
 <div>
   <div
-    class="flex h-16 shrink-0 items-center justify-between gap-3 shadow-b"
+    class="flex shrink-0 items-center justify-between gap-3 pb-4 shadow-b"
   >
     <div
       class=""

--- a/src/pages/settings/teamAndSecurity/members/common/__tests__/__snapshots__/MembersFilters.test.tsx.snap
+++ b/src/pages/settings/teamAndSecurity/members/common/__tests__/__snapshots__/MembersFilters.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MembersFilters Snapshot Tests matches snapshot with default props 1`] = `
 <div>
   <div
-    class="flex h-16 items-center justify-between gap-3 shadow-b"
+    class="flex h-16 shrink-0 items-center justify-between gap-3 shadow-b"
   >
     <div
       class=""
@@ -86,7 +86,7 @@ exports[`MembersFilters Snapshot Tests matches snapshot with default props 1`] =
 exports[`MembersFilters Snapshot Tests matches snapshot with invitations type 1`] = `
 <div>
   <div
-    class="flex h-16 items-center justify-between gap-3 shadow-b"
+    class="flex h-16 shrink-0 items-center justify-between gap-3 shadow-b"
   >
     <div
       class=""
@@ -169,7 +169,7 @@ exports[`MembersFilters Snapshot Tests matches snapshot with invitations type 1`
 exports[`MembersFilters Snapshot Tests matches snapshot with members type 1`] = `
 <div>
   <div
-    class="flex h-16 items-center justify-between gap-3 shadow-b"
+    class="flex h-16 shrink-0 items-center justify-between gap-3 shadow-b"
   >
     <div
       class=""
@@ -252,7 +252,7 @@ exports[`MembersFilters Snapshot Tests matches snapshot with members type 1`] = 
 exports[`MembersFilters Snapshot Tests matches snapshot with search query 1`] = `
 <div>
   <div
-    class="flex h-16 items-center justify-between gap-3 shadow-b"
+    class="flex h-16 shrink-0 items-center justify-between gap-3 shadow-b"
   >
     <div
       class=""


### PR DESCRIPTION
Fixes ING-573

## Context

On Team & security → Members (and Invitations), the search field lost its vertical padding: its bottom border sat exactly on the row divider above the table header.

The filters row (`MembersFilters`) is a flex item in a height-constrained column (`MembersList` root `flex min-h-0 flex-1 flex-col`) whose only sibling, the table container, is `shrink-0`. So the row was the single child that could give up space: as soon as the list was taller than the space available, it collapsed from `h-16` (64px) to its min-content height of 48px — exactly the height of the search field (`MuiOutlinedInput.input { height: 48px }`). Field fills the row edge to edge, zero padding, worst at the bottom where its border merges with the row's `shadow-b`.

Threshold at 1440x920: it triggers from ~7 members up, and the page size is 20, so any real organization always saw it. A fresh org with a single member looks fine, which is why it went unnoticed.

The row became compressible in #3808 (numbered pagination), which moved the page to a full-height flex column (`min-h-0 flex-1` on the container, wrapper, list item and tab panel). Before that the row was in block flow and `h-16` always held. The row markup itself has not changed since #3215.

## Description

- `shrink-0` on the filters row, so it can no longer be compressed.
- Fixed height dropped in favour of `pb-4`. `h-16` + `items-center` split the slack evenly inside the row (8px / 8px), but `SettingsListItem` also puts a 16px `gap-4` between the tab bar and the tab panel, which lands above the row: measured from the two dividers a user actually sees, that read as 24px above the field and 8px below. The row is now 48px (field) + 16px, so both gaps are 16px. Total height stays 64px, so the table does not move and the role button stays centred on the field.
- Covers both tabs, since Members and Invitations share `MembersFilters`.
- Snapshots updated for the new classes.

Measured in the browser (real DOM), full page of members, distances between the tab-bar divider and the row divider:

| state | row height | above field | below field |
| --- | --- | --- | --- |
| before | 48px (shrunk) | 16px | 0px |
| `h-16 shrink-0` | 64px | 24px | 8px |
| this PR (`shrink-0 pb-4`) | 64px | 16px | 16px |