### PR TITLE
feat(subscriptions): Offer cancel on incomplete subscriptions

### DIFF
--- a/cypress/e2e/t10-add-subscription.cy.ts
+++ b/cypress/e2e/t10-add-subscription.cy.ts
@@ -46,7 +46,7 @@ describe('Subscriptions', () => {
 
     cy.get('[data-test="status"]').should('have.text', 'Pending')
     cy.get('[data-test="subscription-details-actions"]').click()
-    cy.get('[data-test="subscription-details-terminate"]').click()
+    cy.get('[data-test="subscription-details-cancel"]').click()
 
     // Pending subscriptions use a CentralizedDialog (not FormDialog)
     cy.get('[data-test="centralized-confirm"]').click({ force: true })

--- a/src/components/customers/subscriptions/TerminateCustomerSubscriptionDialog.tsx
+++ b/src/components/customers/subscriptions/TerminateCustomerSubscriptionDialog.tsx
@@ -239,13 +239,20 @@ export const useTerminateCustomerSubscriptionDialog = () => {
 
     const values = form.state.values
 
-    const payload: TerminateSubscriptionInput = {
-      onTerminationInvoice: values.onTerminationInvoice
-        ? OnTerminationInvoiceEnum.Generate
-        : OnTerminationInvoiceEnum.Skip,
-      onTerminationCreditNote: data?.payInAdvance ? values.onTerminationCreditNote : undefined,
-      id: data?.id as string,
-    }
+    // An incomplete subscription has never been billed, so there is no invoice to generate
+    // and no credit note to issue: only the subscription id is meaningful here.
+    const payload: TerminateSubscriptionInput =
+      data?.status === StatusTypeEnum.Incomplete
+        ? { id: data.id }
+        : {
+            onTerminationInvoice: values.onTerminationInvoice
+              ? OnTerminationInvoiceEnum.Generate
+              : OnTerminationInvoiceEnum.Skip,
+            onTerminationCreditNote: data?.payInAdvance
+              ? values.onTerminationCreditNote
+              : undefined,
+            id: data?.id as string,
+          }
 
     await terminate({ variables: { input: payload } })
 
@@ -267,13 +274,18 @@ export const useTerminateCustomerSubscriptionDialog = () => {
     form.reset()
     loadingRef.current = false
 
-    if (data.status === StatusTypeEnum.Pending) {
-      // Pending subscriptions: simple confirmation, no form fields
+    if (data.status === StatusTypeEnum.Pending || data.status === StatusTypeEnum.Incomplete) {
+      // Subscriptions that never started billing: simple confirmation, no form fields.
+      // An incomplete one still has an activation payment in flight, so it warns that
+      // cancelling that payment depends on the payment provider.
+      const description =
+        data.status === StatusTypeEnum.Incomplete
+          ? translate('text_1786964945244ww7yr3vukeh', { subscriptionName: data.name })
+          : translate('text_64a6d96f84411700a90dbf51', { subscriptionName: data.name })
+
       centralizedDialog.open({
         title: translate('text_64a6d8cb9ed7d9007e7121ca'),
-        description: translate('text_64a6d96f84411700a90dbf51', {
-          subscriptionName: data.name,
-        }),
+        description,
         colorVariant: 'danger',
         actionText: translate('text_64a6d736c23125004817627f'),
         onAction: handleTerminate,

--- a/src/components/customers/subscriptions/TerminateCustomerSubscriptionDialog.tsx
+++ b/src/components/customers/subscriptions/TerminateCustomerSubscriptionDialog.tsx
@@ -240,8 +240,7 @@ export const useTerminateCustomerSubscriptionDialog = () => {
 
     const values = form.state.values
 
-    // An incomplete subscription has never been billed, so there is no invoice to generate
-    // and no credit note to issue: only the subscription id is meaningful here.
+    // An incomplete subscription has never been billed: nothing to invoice or credit.
     const payload: TerminateSubscriptionInput =
       data?.status === StatusTypeEnum.Incomplete
         ? { id: data.id }
@@ -276,9 +275,6 @@ export const useTerminateCustomerSubscriptionDialog = () => {
     loadingRef.current = false
 
     if (isSubscriptionCancellation(data.status)) {
-      // Subscriptions that never started billing: simple confirmation, no form fields.
-      // An incomplete one still has an activation payment in flight, so it warns that
-      // cancelling that payment depends on the payment provider.
       const description =
         data.status === StatusTypeEnum.Incomplete
           ? translate('text_1786964945244ww7yr3vukeh', { subscriptionName: data.name })

--- a/src/components/customers/subscriptions/TerminateCustomerSubscriptionDialog.tsx
+++ b/src/components/customers/subscriptions/TerminateCustomerSubscriptionDialog.tsx
@@ -8,6 +8,7 @@ import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { useFormDialog } from '~/components/dialogs/FormDialog'
 import { DialogResult } from '~/components/dialogs/types'
 import { addToast } from '~/core/apolloClient'
+import { isSubscriptionCancellation } from '~/core/constants/statusSubscriptionMapping'
 import {
   InvoiceTypeEnum,
   OnTerminationCreditNoteEnum,
@@ -274,7 +275,7 @@ export const useTerminateCustomerSubscriptionDialog = () => {
     form.reset()
     loadingRef.current = false
 
-    if (data.status === StatusTypeEnum.Pending || data.status === StatusTypeEnum.Incomplete) {
+    if (isSubscriptionCancellation(data.status)) {
       // Subscriptions that never started billing: simple confirmation, no form fields.
       // An incomplete one still has an activation payment in flight, so it warns that
       // cancelling that payment depends on the payment provider.

--- a/src/components/customers/subscriptions/__tests__/TerminateCustomerSubscriptionDialog.test.tsx
+++ b/src/components/customers/subscriptions/__tests__/TerminateCustomerSubscriptionDialog.test.tsx
@@ -161,6 +161,84 @@ describe('TerminateCustomerSubscriptionDialog', () => {
       })
     })
 
+    describe('WHEN subscription status is Incomplete', () => {
+      it('THEN renders centralized dialog with title', async () => {
+        await act(() =>
+          render(
+            <NiceModalWrapper>
+              <TestWrapper status={StatusTypeEnum.Incomplete} />
+            </NiceModalWrapper>,
+          ),
+        )
+
+        await act(async () => {
+          await userEvent.click(screen.getByTestId('open-dialog-btn'))
+        })
+
+        await waitFor(() => {
+          expect(screen.getByTestId(DIALOG_TITLE_TEST_ID)).toBeInTheDocument()
+          expect(screen.getByTestId(CENTRALIZED_DIALOG_CONFIRM_BUTTON_TEST_ID)).toBeInTheDocument()
+        })
+      })
+
+      it('THEN does NOT render the invoice and credit note form', async () => {
+        await act(() =>
+          render(
+            <NiceModalWrapper>
+              <TestWrapper status={StatusTypeEnum.Incomplete} payInAdvance={true} />
+            </NiceModalWrapper>,
+          ),
+        )
+
+        await act(async () => {
+          await userEvent.click(screen.getByTestId('open-dialog-btn'))
+        })
+
+        await waitFor(() => {
+          expect(screen.queryByTestId(FORM_DIALOG_TEST_ID)).not.toBeInTheDocument()
+        })
+      })
+
+      it('THEN confirming calls terminate with the subscription id only', async () => {
+        mockTerminate.mockImplementation(async () => {
+          capturedMutationOnCompleted?.({
+            terminateSubscription: {
+              id: 'sub-123',
+              status: 'canceled',
+              terminatedAt: null,
+              customer: { id: 'cust-1', deletedAt: null, activeSubscriptionsCount: 0 },
+            },
+          })
+        })
+
+        await act(() =>
+          render(
+            <NiceModalWrapper>
+              <TestWrapper status={StatusTypeEnum.Incomplete} payInAdvance={true} />
+            </NiceModalWrapper>,
+          ),
+        )
+
+        await act(async () => {
+          await userEvent.click(screen.getByTestId('open-dialog-btn'))
+        })
+
+        await waitFor(() => {
+          expect(screen.getByTestId(CENTRALIZED_DIALOG_CONFIRM_BUTTON_TEST_ID)).toBeInTheDocument()
+        })
+
+        await act(async () => {
+          await userEvent.click(screen.getByTestId(CENTRALIZED_DIALOG_CONFIRM_BUTTON_TEST_ID))
+        })
+
+        await waitFor(() => {
+          expect(mockTerminate).toHaveBeenCalledWith({
+            variables: { input: { id: 'sub-123' } },
+          })
+        })
+      })
+    })
+
     describe('WHEN invoice has offsettable amount', () => {
       it('THEN renders Offset radio option', async () => {
         mockUseGetInvoicesForTerminationQuery.mockReturnValue(

--- a/src/components/subscriptions/SubscriptionsList.tsx
+++ b/src/components/subscriptions/SubscriptionsList.tsx
@@ -170,11 +170,41 @@ const generateActionColumn = ({
     },
   }
 
+  // A subscription that never started billing is cancelled rather than terminated
+  const isCancellation =
+    subscription.status === StatusTypeEnum.Pending ||
+    subscription.status === StatusTypeEnum.Incomplete
+
+  const terminateAction: ActionItem<AnnotatedSubscription> = {
+    startIcon: 'trash',
+    title: isCancellation
+      ? translate('text_64a6d736c23125004817627f')
+      : translate('text_62d904b97e690a881f2b867c'),
+    onAction: () => {
+      openTerminateDialog({
+        id: subscription.id,
+        name: subscription.name as string,
+        status: subscription.status as StatusTypeEnum,
+        payInAdvance: subscription.payInAdvance,
+      })
+    },
+  }
+
   if (
     subscription.status === StatusTypeEnum.Terminated ||
-    subscription.status === StatusTypeEnum.Canceled ||
-    subscription.status === StatusTypeEnum.Incomplete
+    subscription.status === StatusTypeEnum.Canceled
   ) {
+    return [copyToClipboardAction]
+  }
+
+  // An incomplete subscription is still waiting on its activation payment. There is no
+  // settled plan to edit, upgrade or downgrade, and no usage to alert on, so the only
+  // action beyond copying the id is cancelling the activation.
+  if (subscription.status === StatusTypeEnum.Incomplete) {
+    if (hasSubscriptionsUpdatePermission) {
+      return [copyToClipboardAction, terminateAction]
+    }
+
     return [copyToClipboardAction]
   }
 
@@ -235,21 +265,7 @@ const generateActionColumn = ({
   })
 
   if (hasSubscriptionsUpdatePermission) {
-    actions = actions.concat({
-      startIcon: 'trash',
-      title:
-        subscription.status === StatusTypeEnum.Pending
-          ? translate('text_64a6d736c23125004817627f')
-          : translate('text_62d904b97e690a881f2b867c'),
-      onAction: () => {
-        openTerminateDialog({
-          id: subscription.id,
-          name: subscription.name as string,
-          status: subscription.status as StatusTypeEnum,
-          payInAdvance: subscription.payInAdvance,
-        })
-      },
-    })
+    actions = actions.concat(terminateAction)
   }
 
   return actions

--- a/src/components/subscriptions/SubscriptionsList.tsx
+++ b/src/components/subscriptions/SubscriptionsList.tsx
@@ -141,6 +141,9 @@ const annotateSubscriptions = (
   }, [])
 }
 
+export const SUBSCRIPTIONS_LIST_TERMINATE_TEST_ID = 'subscriptions-list-terminate'
+export const SUBSCRIPTIONS_LIST_CANCEL_TEST_ID = 'subscriptions-list-cancel'
+
 const generateActionColumn = ({
   subscription,
   hasSubscriptionsUpdatePermission,
@@ -178,6 +181,9 @@ const generateActionColumn = ({
     title: isSubscriptionCancellation(subscription.status)
       ? translate('text_64a6d736c23125004817627f')
       : translate('text_62d904b97e690a881f2b867c'),
+    dataTest: isSubscriptionCancellation(subscription.status)
+      ? SUBSCRIPTIONS_LIST_CANCEL_TEST_ID
+      : SUBSCRIPTIONS_LIST_TERMINATE_TEST_ID,
     onAction: () => {
       openTerminateDialog({
         id: subscription.id,

--- a/src/components/subscriptions/SubscriptionsList.tsx
+++ b/src/components/subscriptions/SubscriptionsList.tsx
@@ -6,7 +6,10 @@ import { StatusProps, StatusType } from '~/components/designSystem/Status'
 import { Table, TableProps } from '~/components/designSystem/Table/Table'
 import { ActionItem } from '~/components/designSystem/Table/types'
 import { addToast } from '~/core/apolloClient'
-import { subscriptionStatusMapping } from '~/core/constants/statusSubscriptionMapping'
+import {
+  isSubscriptionCancellation,
+  subscriptionStatusMapping,
+} from '~/core/constants/statusSubscriptionMapping'
 import { CustomerSubscriptionDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import {
   CUSTOMER_SUBSCRIPTION_DETAILS_ROUTE,
@@ -170,14 +173,9 @@ const generateActionColumn = ({
     },
   }
 
-  // A subscription that never started billing is cancelled rather than terminated
-  const isCancellation =
-    subscription.status === StatusTypeEnum.Pending ||
-    subscription.status === StatusTypeEnum.Incomplete
-
   const terminateAction: ActionItem<AnnotatedSubscription> = {
     startIcon: 'trash',
-    title: isCancellation
+    title: isSubscriptionCancellation(subscription.status)
       ? translate('text_64a6d736c23125004817627f')
       : translate('text_62d904b97e690a881f2b867c'),
     onAction: () => {

--- a/src/components/subscriptions/__tests__/SubscriptionsList.test.tsx
+++ b/src/components/subscriptions/__tests__/SubscriptionsList.test.tsx
@@ -1,18 +1,12 @@
 import { ActionItem } from '~/components/designSystem/Table/types'
 import {
   AnnotatedSubscription,
+  SUBSCRIPTIONS_LIST_CANCEL_TEST_ID,
+  SUBSCRIPTIONS_LIST_TERMINATE_TEST_ID,
   SubscriptionsList,
 } from '~/components/subscriptions/SubscriptionsList'
 import { PlanInterval, StatusTypeEnum, Subscription, TimezoneEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
-
-const COPY_ID_KEY = 'text_62d7f6178ec94cd09370e65b'
-const SUBSCRIPTION_DETAILS_KEY = 'text_62d7f6178ec94cd09370e63c'
-const SUBSCRIPTION_PLAN_KEY = 'text_17810297639135ya0hmsldpi'
-const UPGRADE_DOWNGRADE_KEY = 'text_62d7f6178ec94cd09370e64a'
-const ALERTS_KEY = 'text_1746785137190vu5wwlsmzmz'
-const CANCEL_SUBSCRIPTION_KEY = 'text_64a6d736c23125004817627f'
-const TERMINATE_SUBSCRIPTION_KEY = 'text_62d904b97e690a881f2b867c'
 
 const mockTableProps = jest.fn()
 
@@ -82,8 +76,13 @@ const getActions = (status: StatusTypeEnum): ActionItem<AnnotatedSubscription>[]
   return tableProps.actionColumn(tableProps.data[0])
 }
 
-const getActionTitles = (status: StatusTypeEnum): unknown[] =>
-  getActions(status).map((action) => action.title)
+// The action icons identify each entry without leaning on its wording. Whether the last
+// action cancels or terminates is asserted on its dataTest, since both share the same icon.
+const getActionIcons = (status: StatusTypeEnum): unknown[] =>
+  getActions(status).map((action) => action.startIcon)
+
+const getEndingActionTestId = (status: StatusTypeEnum): unknown =>
+  getActions(status).at(-1)?.dataTest
 
 describe('SubscriptionsList', () => {
   beforeEach(() => {
@@ -94,15 +93,17 @@ describe('SubscriptionsList', () => {
   describe('GIVEN an incomplete subscription', () => {
     describe('WHEN the user has the subscriptionsUpdate permission', () => {
       it('THEN should only offer copying the id and cancelling', () => {
-        expect(getActionTitles(StatusTypeEnum.Incomplete)).toEqual([
-          COPY_ID_KEY,
-          CANCEL_SUBSCRIPTION_KEY,
-        ])
+        expect(getActionIcons(StatusTypeEnum.Incomplete)).toEqual(['duplicate', 'trash'])
+        expect(getEndingActionTestId(StatusTypeEnum.Incomplete)).toBe(
+          SUBSCRIPTIONS_LIST_CANCEL_TEST_ID,
+        )
       })
 
       it('THEN should open the terminate dialog with the incomplete status', () => {
         const actions = getActions(StatusTypeEnum.Incomplete)
-        const cancelAction = actions.find((action) => action.title === CANCEL_SUBSCRIPTION_KEY)
+        const cancelAction = actions.find(
+          (action) => action.dataTest === SUBSCRIPTIONS_LIST_CANCEL_TEST_ID,
+        )
 
         cancelAction?.onAction({} as AnnotatedSubscription)
 
@@ -119,34 +120,38 @@ describe('SubscriptionsList', () => {
       it('THEN should only offer copying the id', () => {
         mockHasPermissions.mockReturnValue(false)
 
-        expect(getActionTitles(StatusTypeEnum.Incomplete)).toEqual([COPY_ID_KEY])
+        expect(getActionIcons(StatusTypeEnum.Incomplete)).toEqual(['duplicate'])
       })
     })
   })
 
   describe('GIVEN an active subscription', () => {
     it('THEN should keep the edit actions and label the last one as terminate', () => {
-      expect(getActionTitles(StatusTypeEnum.Active)).toEqual([
-        SUBSCRIPTION_DETAILS_KEY,
-        SUBSCRIPTION_PLAN_KEY,
-        UPGRADE_DOWNGRADE_KEY,
-        COPY_ID_KEY,
-        ALERTS_KEY,
-        TERMINATE_SUBSCRIPTION_KEY,
+      expect(getActionIcons(StatusTypeEnum.Active)).toEqual([
+        'text',
+        'board',
+        'pen',
+        'duplicate',
+        'bell',
+        'trash',
       ])
+      expect(getEndingActionTestId(StatusTypeEnum.Active)).toBe(
+        SUBSCRIPTIONS_LIST_TERMINATE_TEST_ID,
+      )
     })
   })
 
   describe('GIVEN a pending subscription', () => {
     it('THEN should keep the edit actions and label the last one as cancel', () => {
-      expect(getActionTitles(StatusTypeEnum.Pending)).toEqual([
-        SUBSCRIPTION_DETAILS_KEY,
-        SUBSCRIPTION_PLAN_KEY,
-        UPGRADE_DOWNGRADE_KEY,
-        COPY_ID_KEY,
-        ALERTS_KEY,
-        CANCEL_SUBSCRIPTION_KEY,
+      expect(getActionIcons(StatusTypeEnum.Pending)).toEqual([
+        'text',
+        'board',
+        'pen',
+        'duplicate',
+        'bell',
+        'trash',
       ])
+      expect(getEndingActionTestId(StatusTypeEnum.Pending)).toBe(SUBSCRIPTIONS_LIST_CANCEL_TEST_ID)
     })
   })
 
@@ -154,7 +159,7 @@ describe('SubscriptionsList', () => {
     'GIVEN a %s subscription',
     (status) => {
       it('THEN should only offer copying the id', () => {
-        expect(getActionTitles(status)).toEqual([COPY_ID_KEY])
+        expect(getActionIcons(status)).toEqual(['duplicate'])
       })
     },
   )

--- a/src/components/subscriptions/__tests__/SubscriptionsList.test.tsx
+++ b/src/components/subscriptions/__tests__/SubscriptionsList.test.tsx
@@ -1,0 +1,161 @@
+import { ActionItem } from '~/components/designSystem/Table/types'
+import {
+  AnnotatedSubscription,
+  SubscriptionsList,
+} from '~/components/subscriptions/SubscriptionsList'
+import { PlanInterval, StatusTypeEnum, Subscription, TimezoneEnum } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+const COPY_ID_KEY = 'text_62d7f6178ec94cd09370e65b'
+const SUBSCRIPTION_DETAILS_KEY = 'text_62d7f6178ec94cd09370e63c'
+const SUBSCRIPTION_PLAN_KEY = 'text_17810297639135ya0hmsldpi'
+const UPGRADE_DOWNGRADE_KEY = 'text_62d7f6178ec94cd09370e64a'
+const ALERTS_KEY = 'text_1746785137190vu5wwlsmzmz'
+const CANCEL_SUBSCRIPTION_KEY = 'text_64a6d736c23125004817627f'
+const TERMINATE_SUBSCRIPTION_KEY = 'text_62d904b97e690a881f2b867c'
+
+const mockTableProps = jest.fn()
+
+jest.mock('~/components/designSystem/Table/Table', () => ({
+  Table: (props: Record<string, unknown>) => {
+    mockTableProps(props)
+    return null
+  },
+}))
+
+const mockOpenTerminateDialog = jest.fn()
+
+jest.mock('~/components/customers/subscriptions/TerminateCustomerSubscriptionDialog', () => ({
+  useTerminateCustomerSubscriptionDialog: () => ({
+    openTerminateCustomerSubscriptionDialog: mockOpenTerminateDialog,
+  }),
+}))
+
+const mockHasPermissions = jest.fn().mockReturnValue(true)
+
+jest.mock('~/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasPermissions: mockHasPermissions }),
+}))
+
+jest.mock('~/hooks/useSubscriptionPermissionsActions', () => ({
+  useSubscriptionPermissionsActions: () => ({ isStatusEditable: () => true }),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+const buildSubscription = (status: StatusTypeEnum) =>
+  ({
+    id: 'subscription-1',
+    externalId: 'ext-123',
+    name: 'Test Subscription',
+    status,
+    startedAt: '2024-01-01T00:00:00Z',
+    subscriptionAt: '2024-01-01T00:00:00Z',
+    plan: {
+      id: 'plan-1',
+      name: 'Test Plan',
+      interval: PlanInterval.Monthly,
+      payInAdvance: false,
+    },
+    customer: {
+      id: 'customer-1',
+      applicableTimezone: TimezoneEnum.TzUtc,
+    },
+  }) as unknown as Subscription
+
+const getActions = (status: StatusTypeEnum): ActionItem<AnnotatedSubscription>[] => {
+  render(
+    <SubscriptionsList
+      name="subscriptions-list"
+      columns={[]}
+      subscriptions={[buildSubscription(status)]}
+    />,
+  )
+
+  const tableProps = mockTableProps.mock.calls.at(-1)?.[0] as {
+    data: AnnotatedSubscription[]
+    actionColumn: (item: AnnotatedSubscription) => ActionItem<AnnotatedSubscription>[]
+  }
+
+  return tableProps.actionColumn(tableProps.data[0])
+}
+
+const getActionTitles = (status: StatusTypeEnum): unknown[] =>
+  getActions(status).map((action) => action.title)
+
+describe('SubscriptionsList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockHasPermissions.mockReturnValue(true)
+  })
+
+  describe('GIVEN an incomplete subscription', () => {
+    describe('WHEN the user has the subscriptionsUpdate permission', () => {
+      it('THEN should only offer copying the id and cancelling', () => {
+        expect(getActionTitles(StatusTypeEnum.Incomplete)).toEqual([
+          COPY_ID_KEY,
+          CANCEL_SUBSCRIPTION_KEY,
+        ])
+      })
+
+      it('THEN should open the terminate dialog with the incomplete status', () => {
+        const actions = getActions(StatusTypeEnum.Incomplete)
+        const cancelAction = actions.find((action) => action.title === CANCEL_SUBSCRIPTION_KEY)
+
+        cancelAction?.onAction({} as AnnotatedSubscription)
+
+        expect(mockOpenTerminateDialog).toHaveBeenCalledWith({
+          id: 'subscription-1',
+          name: 'Test Subscription',
+          status: StatusTypeEnum.Incomplete,
+          payInAdvance: false,
+        })
+      })
+    })
+
+    describe('WHEN the user lacks the subscriptionsUpdate permission', () => {
+      it('THEN should only offer copying the id', () => {
+        mockHasPermissions.mockReturnValue(false)
+
+        expect(getActionTitles(StatusTypeEnum.Incomplete)).toEqual([COPY_ID_KEY])
+      })
+    })
+  })
+
+  describe('GIVEN an active subscription', () => {
+    it('THEN should keep the edit actions and label the last one as terminate', () => {
+      expect(getActionTitles(StatusTypeEnum.Active)).toEqual([
+        SUBSCRIPTION_DETAILS_KEY,
+        SUBSCRIPTION_PLAN_KEY,
+        UPGRADE_DOWNGRADE_KEY,
+        COPY_ID_KEY,
+        ALERTS_KEY,
+        TERMINATE_SUBSCRIPTION_KEY,
+      ])
+    })
+  })
+
+  describe('GIVEN a pending subscription', () => {
+    it('THEN should keep the edit actions and label the last one as cancel', () => {
+      expect(getActionTitles(StatusTypeEnum.Pending)).toEqual([
+        SUBSCRIPTION_DETAILS_KEY,
+        SUBSCRIPTION_PLAN_KEY,
+        UPGRADE_DOWNGRADE_KEY,
+        COPY_ID_KEY,
+        ALERTS_KEY,
+        CANCEL_SUBSCRIPTION_KEY,
+      ])
+    })
+  })
+
+  describe.each([StatusTypeEnum.Terminated, StatusTypeEnum.Canceled])(
+    'GIVEN a %s subscription',
+    (status) => {
+      it('THEN should only offer copying the id', () => {
+        expect(getActionTitles(status)).toEqual([COPY_ID_KEY])
+      })
+    },
+  )
+})

--- a/src/core/constants/statusSubscriptionMapping.ts
+++ b/src/core/constants/statusSubscriptionMapping.ts
@@ -1,6 +1,17 @@
 import { StatusProps, StatusType } from '~/components/designSystem/Status'
 import { StatusTypeEnum } from '~/generated/graphql'
 
+/**
+ * Tells whether ending a subscription in this status is a cancellation rather than a
+ * termination. Pending and incomplete subscriptions never started billing, so there is
+ * nothing to invoice or credit when they end.
+ *
+ * Callers use it both to word the action ("Cancel subscription" instead of "Terminate
+ * subscription") and to pick the plain confirmation dialog over the invoice form.
+ */
+export const isSubscriptionCancellation = (status?: StatusTypeEnum | null): boolean =>
+  status === StatusTypeEnum.Pending || status === StatusTypeEnum.Incomplete
+
 export const subscriptionStatusMapping = (status?: StatusTypeEnum | null): StatusProps => {
   switch (status) {
     case StatusTypeEnum.Active:

--- a/src/core/constants/statusSubscriptionMapping.ts
+++ b/src/core/constants/statusSubscriptionMapping.ts
@@ -5,9 +5,6 @@ import { StatusTypeEnum } from '~/generated/graphql'
  * Tells whether ending a subscription in this status is a cancellation rather than a
  * termination. Pending and incomplete subscriptions never started billing, so there is
  * nothing to invoice or credit when they end.
- *
- * Callers use it both to word the action ("Cancel subscription" instead of "Terminate
- * subscription") and to pick the plain confirmation dialog over the invoice form.
  */
 export const isSubscriptionCancellation = (status?: StatusTypeEnum | null): boolean =>
   status === StatusTypeEnum.Pending || status === StatusTypeEnum.Incomplete

--- a/src/hooks/__tests__/useSubscriptionPermissionsActions.test.ts
+++ b/src/hooks/__tests__/useSubscriptionPermissionsActions.test.ts
@@ -89,6 +89,56 @@ describe('useSubscriptionPermissionsActions', () => {
     })
   })
 
+  describe('isStatusTerminable', () => {
+    it('should return true for active subscription', () => {
+      const { result } = prepare()
+
+      expect(result.current.isStatusTerminable(StatusTypeEnum.Active)).toBe(true)
+    })
+
+    it('should return true for pending subscription', () => {
+      const { result } = prepare()
+
+      expect(result.current.isStatusTerminable(StatusTypeEnum.Pending)).toBe(true)
+    })
+
+    it('should return true for incomplete subscription', () => {
+      const { result } = prepare()
+
+      expect(result.current.isStatusTerminable(StatusTypeEnum.Incomplete)).toBe(true)
+    })
+
+    it('should return false for terminated subscription', () => {
+      const { result } = prepare()
+
+      expect(result.current.isStatusTerminable(StatusTypeEnum.Terminated)).toBe(false)
+    })
+
+    it('should return false for canceled subscription', () => {
+      const { result } = prepare()
+
+      expect(result.current.isStatusTerminable(StatusTypeEnum.Canceled)).toBe(false)
+    })
+
+    it('should return false for null status', () => {
+      const { result } = prepare()
+
+      expect(result.current.isStatusTerminable(null)).toBe(false)
+    })
+
+    it('should return false for undefined status', () => {
+      const { result } = prepare()
+
+      expect(result.current.isStatusTerminable(undefined)).toBe(false)
+    })
+
+    it('should not depend on permissions', () => {
+      const { result } = prepare({ subscriptionsUpdate: false })
+
+      expect(result.current.isStatusTerminable(StatusTypeEnum.Incomplete)).toBe(true)
+    })
+  })
+
   describe('canEditSubscription', () => {
     it('should return true when user has permission and status is active', () => {
       const { result } = prepare({ subscriptionsUpdate: true })
@@ -142,6 +192,56 @@ describe('useSubscriptionPermissionsActions', () => {
       const { result } = prepare({ subscriptionsUpdate: true })
 
       expect(result.current.canEditSubscription(undefined)).toBe(false)
+    })
+  })
+
+  describe('canTerminateSubscription', () => {
+    it('should return true when user has permission and status is active', () => {
+      const { result } = prepare({ subscriptionsUpdate: true })
+
+      expect(result.current.canTerminateSubscription(StatusTypeEnum.Active)).toBe(true)
+    })
+
+    it('should return true when user has permission and status is pending', () => {
+      const { result } = prepare({ subscriptionsUpdate: true })
+
+      expect(result.current.canTerminateSubscription(StatusTypeEnum.Pending)).toBe(true)
+    })
+
+    it('should return true when user has permission and status is incomplete', () => {
+      const { result } = prepare({ subscriptionsUpdate: true })
+
+      expect(result.current.canTerminateSubscription(StatusTypeEnum.Incomplete)).toBe(true)
+    })
+
+    it('should return false when user has permission but status is terminated', () => {
+      const { result } = prepare({ subscriptionsUpdate: true })
+
+      expect(result.current.canTerminateSubscription(StatusTypeEnum.Terminated)).toBe(false)
+    })
+
+    it('should return false when user has permission but status is canceled', () => {
+      const { result } = prepare({ subscriptionsUpdate: true })
+
+      expect(result.current.canTerminateSubscription(StatusTypeEnum.Canceled)).toBe(false)
+    })
+
+    it('should return false when user does not have permission even if status is incomplete', () => {
+      const { result } = prepare({ subscriptionsUpdate: false })
+
+      expect(result.current.canTerminateSubscription(StatusTypeEnum.Incomplete)).toBe(false)
+    })
+
+    it('should return false for null status even with permission', () => {
+      const { result } = prepare({ subscriptionsUpdate: true })
+
+      expect(result.current.canTerminateSubscription(null)).toBe(false)
+    })
+
+    it('should return false for undefined status even with permission', () => {
+      const { result } = prepare({ subscriptionsUpdate: true })
+
+      expect(result.current.canTerminateSubscription(undefined)).toBe(false)
     })
   })
 })

--- a/src/hooks/useSubscriptionPermissionsActions.ts
+++ b/src/hooks/useSubscriptionPermissionsActions.ts
@@ -18,14 +18,35 @@ export const useSubscriptionPermissionsActions = () => {
   }
 
   /**
+   * Checks if a subscription status allows ending it (not already terminated or canceled).
+   *
+   * Broader than `isStatusEditable`: an incomplete subscription cannot be edited while its
+   * activation payment is pending, but it can be canceled to stop that activation.
+   */
+  const isStatusTerminable = (status: StatusTypeEnum | null | undefined): boolean => {
+    if (!status) return false
+
+    return status !== StatusTypeEnum.Terminated && status !== StatusTypeEnum.Canceled
+  }
+
+  /**
    * Checks if a subscription can be edited based on both permissions and status.
    */
   const canEditSubscription = (status: StatusTypeEnum | null | undefined): boolean => {
     return hasPermissions(['subscriptionsUpdate']) && isStatusEditable(status)
   }
 
+  /**
+   * Checks if a subscription can be terminated or canceled based on both permissions and status.
+   */
+  const canTerminateSubscription = (status: StatusTypeEnum | null | undefined): boolean => {
+    return hasPermissions(['subscriptionsUpdate']) && isStatusTerminable(status)
+  }
+
   return {
     isStatusEditable,
+    isStatusTerminable,
     canEditSubscription,
+    canTerminateSubscription,
   }
 }

--- a/src/pages/subscriptions/SubscriptionDetails.tsx
+++ b/src/pages/subscriptions/SubscriptionDetails.tsx
@@ -73,6 +73,7 @@ export const SUBSCRIPTION_DETAILS_ACTIONS_TEST_ID = 'subscription-details-action
 export const SUBSCRIPTION_DETAILS_UPGRADE_DOWNGRADE_TEST_ID =
   'subscription-details-upgrade-downgrade'
 export const SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID = 'subscription-details-terminate'
+export const SUBSCRIPTION_DETAILS_CANCEL_TEST_ID = 'subscription-details-cancel'
 
 const SubscriptionDetails = () => {
   const navigate = useNavigate()
@@ -360,7 +361,9 @@ const SubscriptionDetails = () => {
           label: isSubscriptionCancellation(subscription?.status)
             ? translate('text_64a6d736c23125004817627f')
             : translate('text_62d904b97e690a881f2b867c'),
-          dataTest: SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID,
+          dataTest: isSubscriptionCancellation(subscription?.status)
+            ? SUBSCRIPTION_DETAILS_CANCEL_TEST_ID
+            : SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID,
           hidden: !canTerminateSubscription(subscription?.status),
           danger: true,
           onClick: (closePopper) => {

--- a/src/pages/subscriptions/SubscriptionDetails.tsx
+++ b/src/pages/subscriptions/SubscriptionDetails.tsx
@@ -77,7 +77,8 @@ const SubscriptionDetails = () => {
   const navigate = useNavigate()
   const { isPremium } = useCurrentUser()
   const { hasPermissions } = usePermissions()
-  const { canEditSubscription, isStatusEditable } = useSubscriptionPermissionsActions()
+  const { canEditSubscription, canTerminateSubscription, isStatusEditable } =
+    useSubscriptionPermissionsActions()
   const { planId = '', customerId = '', subscriptionId = '' } = useParams()
   const { translate } = useInternationalization()
   const { openTerminateCustomerSubscriptionDialog } = useTerminateCustomerSubscriptionDialog()
@@ -357,7 +358,7 @@ const SubscriptionDetails = () => {
         {
           label: translate('text_62d904b97e690a881f2b867c'),
           dataTest: SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID,
-          hidden: !canEditSubscription(subscription?.status),
+          hidden: !canTerminateSubscription(subscription?.status),
           danger: true,
           onClick: (closePopper) => {
             openTerminateCustomerSubscriptionDialog({

--- a/src/pages/subscriptions/SubscriptionDetails.tsx
+++ b/src/pages/subscriptions/SubscriptionDetails.tsx
@@ -16,6 +16,7 @@ import { SubscriptionEntitlementsTabContent } from '~/components/subscriptions/S
 import { SubscriptionProgressiveBillingTab } from '~/components/subscriptions/SubscriptionProgressiveBillingTab/SubscriptionProgressiveBillingTab'
 import { SubscriptionUsageTabContent } from '~/components/subscriptions/SubscriptionUsageTabContent'
 import { addToast } from '~/core/apolloClient'
+import { isSubscriptionCancellation } from '~/core/constants/statusSubscriptionMapping'
 import { CustomerSubscriptionDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import {
   CREATE_ALERT_CUSTOMER_SUBSCRIPTION_ROUTE,
@@ -356,7 +357,9 @@ const SubscriptionDetails = () => {
           },
         },
         {
-          label: translate('text_62d904b97e690a881f2b867c'),
+          label: isSubscriptionCancellation(subscription?.status)
+            ? translate('text_64a6d736c23125004817627f')
+            : translate('text_62d904b97e690a881f2b867c'),
           dataTest: SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID,
           hidden: !canTerminateSubscription(subscription?.status),
           danger: true,

--- a/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
+++ b/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
@@ -12,12 +12,10 @@ import { StatusTypeEnum } from '~/generated/graphql'
 import { render, testMockNavigateFn } from '~/test-utils'
 
 import SubscriptionDetails, {
+  SUBSCRIPTION_DETAILS_CANCEL_TEST_ID,
   SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID,
   SUBSCRIPTION_DETAILS_UPGRADE_DOWNGRADE_TEST_ID,
 } from '../SubscriptionDetails'
-
-const CANCEL_SUBSCRIPTION_KEY = 'text_64a6d736c23125004817627f'
-const TERMINATE_SUBSCRIPTION_KEY = 'text_62d904b97e690a881f2b867c'
 
 let capturedConfig: MainHeaderConfig | null = null
 
@@ -269,28 +267,28 @@ describe('SubscriptionDetails', () => {
       }
     })
 
-    it('THEN should show the terminate dropdown item', () => {
+    it('THEN should show the cancel dropdown item', () => {
       render(<SubscriptionDetails />)
 
       const dropdownAction = capturedConfig?.actions?.items[0]
 
       if (dropdownAction?.type === 'dropdown') {
         const item = dropdownAction.items.find(
-          (i) => i.dataTest === SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID,
+          (i) => i.dataTest === SUBSCRIPTION_DETAILS_CANCEL_TEST_ID,
         )
 
         expect(item?.hidden).toBe(false)
       }
     })
 
-    it('THEN terminate onClick should open the dialog with the incomplete status', () => {
+    it('THEN cancel onClick should open the dialog with the incomplete status', () => {
       render(<SubscriptionDetails />)
 
       const dropdownAction = capturedConfig?.actions?.items[0]
 
       if (dropdownAction?.type === 'dropdown') {
         const terminateItem = dropdownAction.items.find(
-          (i) => i.dataTest === SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID,
+          (i) => i.dataTest === SUBSCRIPTION_DETAILS_CANCEL_TEST_ID,
         )
 
         terminateItem?.onClick(jest.fn())
@@ -305,8 +303,8 @@ describe('SubscriptionDetails', () => {
     })
   })
 
-  describe('GIVEN the terminate dropdown item', () => {
-    const findTerminateItemForStatus = (status: StatusTypeEnum) => {
+  describe('GIVEN the ending dropdown item', () => {
+    const findEndingItemDataTestForStatus = (status: StatusTypeEnum) => {
       mockUseGetSubscriptionForDetailsQuery.mockReturnValue({
         data: { subscription: { ...mockSubscription, status } },
         loading: false,
@@ -319,22 +317,26 @@ describe('SubscriptionDetails', () => {
 
       if (dropdownAction?.type !== 'dropdown') return undefined
 
-      return dropdownAction.items.find((i) => i.dataTest === SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID)
+      return dropdownAction.items.find(
+        (i) =>
+          i.dataTest === SUBSCRIPTION_DETAILS_CANCEL_TEST_ID ||
+          i.dataTest === SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID,
+      )?.dataTest
     }
 
     describe('WHEN the subscription never started billing', () => {
       it.each([StatusTypeEnum.Pending, StatusTypeEnum.Incomplete])(
-        'THEN should label it as cancel for a %s subscription',
+        'THEN should offer cancel for a %s subscription',
         (status) => {
-          expect(findTerminateItemForStatus(status)?.label).toBe(CANCEL_SUBSCRIPTION_KEY)
+          expect(findEndingItemDataTestForStatus(status)).toBe(SUBSCRIPTION_DETAILS_CANCEL_TEST_ID)
         },
       )
     })
 
     describe('WHEN the subscription is active', () => {
-      it('THEN should label it as terminate', () => {
-        expect(findTerminateItemForStatus(StatusTypeEnum.Active)?.label).toBe(
-          TERMINATE_SUBSCRIPTION_KEY,
+      it('THEN should offer terminate', () => {
+        expect(findEndingItemDataTestForStatus(StatusTypeEnum.Active)).toBe(
+          SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID,
         )
       })
     })

--- a/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
+++ b/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
@@ -107,11 +107,13 @@ jest.mock('~/generated/graphql', () => ({
 }))
 
 const mockCanEditSubscription = jest.fn().mockReturnValue(true)
+const mockCanTerminateSubscription = jest.fn().mockReturnValue(true)
 const mockIsStatusEditable = jest.fn().mockReturnValue(true)
 
 jest.mock('~/hooks/useSubscriptionPermissionsActions', () => ({
   useSubscriptionPermissionsActions: () => ({
     canEditSubscription: mockCanEditSubscription,
+    canTerminateSubscription: mockCanTerminateSubscription,
     isStatusEditable: mockIsStatusEditable,
   }),
 }))
@@ -122,6 +124,7 @@ describe('SubscriptionDetails', () => {
     capturedConfig = null
     mockHasPermissions.mockReturnValue(true)
     mockCanEditSubscription.mockReturnValue(true)
+    mockCanTerminateSubscription.mockReturnValue(true)
     mockIsStatusEditable.mockReturnValue(true)
     mockUseCurrentUser.mockReturnValue({ isPremium: true })
 
@@ -175,6 +178,7 @@ describe('SubscriptionDetails', () => {
   describe('GIVEN user does not have subscriptionsUpdate permission', () => {
     beforeEach(() => {
       mockCanEditSubscription.mockReturnValue(false)
+      mockCanTerminateSubscription.mockReturnValue(false)
     })
 
     it.each([
@@ -209,6 +213,7 @@ describe('SubscriptionDetails', () => {
         error: null,
       })
       mockCanEditSubscription.mockReturnValue(false)
+      mockCanTerminateSubscription.mockReturnValue(false)
     })
 
     it.each([
@@ -229,6 +234,70 @@ describe('SubscriptionDetails', () => {
         const item = dropdownAction.items.find((i) => i.dataTest === buttonTestId)
 
         expect(item?.hidden).toBe(true)
+      }
+    })
+  })
+
+  describe('GIVEN subscription is incomplete', () => {
+    beforeEach(() => {
+      mockUseGetSubscriptionForDetailsQuery.mockReturnValue({
+        data: {
+          subscription: { ...mockSubscription, status: StatusTypeEnum.Incomplete },
+        },
+        loading: false,
+        error: null,
+      })
+      // An incomplete subscription cannot be edited, but its activation can be canceled
+      mockCanEditSubscription.mockReturnValue(false)
+      mockCanTerminateSubscription.mockReturnValue(true)
+    })
+
+    it('THEN should hide the upgrade/downgrade dropdown item', () => {
+      render(<SubscriptionDetails />)
+
+      const dropdownAction = capturedConfig?.actions?.items[0]
+
+      if (dropdownAction?.type === 'dropdown') {
+        const item = dropdownAction.items.find(
+          (i) => i.dataTest === SUBSCRIPTION_DETAILS_UPGRADE_DOWNGRADE_TEST_ID,
+        )
+
+        expect(item?.hidden).toBe(true)
+      }
+    })
+
+    it('THEN should show the terminate dropdown item', () => {
+      render(<SubscriptionDetails />)
+
+      const dropdownAction = capturedConfig?.actions?.items[0]
+
+      if (dropdownAction?.type === 'dropdown') {
+        const item = dropdownAction.items.find(
+          (i) => i.dataTest === SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID,
+        )
+
+        expect(item?.hidden).toBe(false)
+      }
+    })
+
+    it('THEN terminate onClick should open the dialog with the incomplete status', () => {
+      render(<SubscriptionDetails />)
+
+      const dropdownAction = capturedConfig?.actions?.items[0]
+
+      if (dropdownAction?.type === 'dropdown') {
+        const terminateItem = dropdownAction.items.find(
+          (i) => i.dataTest === SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID,
+        )
+
+        terminateItem?.onClick(jest.fn())
+
+        expect(mockOpenTerminateDialog).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'subscription-1',
+            status: StatusTypeEnum.Incomplete,
+          }),
+        )
       }
     })
   })

--- a/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
+++ b/src/pages/subscriptions/__tests__/SubscriptionDetails.test.tsx
@@ -16,6 +16,9 @@ import SubscriptionDetails, {
   SUBSCRIPTION_DETAILS_UPGRADE_DOWNGRADE_TEST_ID,
 } from '../SubscriptionDetails'
 
+const CANCEL_SUBSCRIPTION_KEY = 'text_64a6d736c23125004817627f'
+const TERMINATE_SUBSCRIPTION_KEY = 'text_62d904b97e690a881f2b867c'
+
 let capturedConfig: MainHeaderConfig | null = null
 
 jest.mock('~/components/MainHeader/MainHeader', () => ({
@@ -299,6 +302,41 @@ describe('SubscriptionDetails', () => {
           }),
         )
       }
+    })
+  })
+
+  describe('GIVEN the terminate dropdown item', () => {
+    const findTerminateItemForStatus = (status: StatusTypeEnum) => {
+      mockUseGetSubscriptionForDetailsQuery.mockReturnValue({
+        data: { subscription: { ...mockSubscription, status } },
+        loading: false,
+        error: null,
+      })
+
+      render(<SubscriptionDetails />)
+
+      const dropdownAction = capturedConfig?.actions?.items[0]
+
+      if (dropdownAction?.type !== 'dropdown') return undefined
+
+      return dropdownAction.items.find((i) => i.dataTest === SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID)
+    }
+
+    describe('WHEN the subscription never started billing', () => {
+      it.each([StatusTypeEnum.Pending, StatusTypeEnum.Incomplete])(
+        'THEN should label it as cancel for a %s subscription',
+        (status) => {
+          expect(findTerminateItemForStatus(status)?.label).toBe(CANCEL_SUBSCRIPTION_KEY)
+        },
+      )
+    })
+
+    describe('WHEN the subscription is active', () => {
+      it('THEN should label it as terminate', () => {
+        expect(findTerminateItemForStatus(StatusTypeEnum.Active)?.label).toBe(
+          TERMINATE_SUBSCRIPTION_KEY,
+        )
+      })
     })
   })
 

--- a/translations/base.json
+++ b/translations/base.json
@@ -4691,5 +4691,6 @@
   "text_1787146745141j3ktrzyti2x": "the start date is invalid",
   "text_1787146745141wjbnbx6qx0k": "the end date must be a valid future date",
   "text_17871467451419agn4aantij": "the end date must be after the start date",
-  "text_1787216718467e8ca9iw2atm": "An amendment keeps the currency of the subscription it restates"
+  "text_1787216718467e8ca9iw2atm": "An amendment keeps the currency of the subscription it restates",
+  "text_1786964945244ww7yr3vukeh": "You’re about to cancel {{subscriptionName}} subscription. Its activation will stop and Lago will attempt to cancel the pending payment. Depending on its status, the payment provider may not allow it. Are you sure?"
 }


### PR DESCRIPTION
## Context

A payment-gated subscription stays `incomplete` while its activation payment is pending. The dashboard offered no way to act on one: every action but copying the id was hidden, so a merchant looking at a subscription stuck waiting on a payment had nothing to click.

## Description

Offer cancellation for incomplete subscriptions, in the subscriptions list and on the subscription details page. Nothing else opens up: there is no settled plan to edit, upgrade or downgrade, and no usage to alert on, so cancelling is the only action added.

The confirmation says what cancelling actually does. Unlike a pending subscription, an incomplete one has a payment in flight, so the dialog warns that Lago will attempt to cancel it and that the payment provider may not allow it, rather than promising the customer will not be charged.

Three places had each decided independently that a pending or incomplete subscription ends in a cancellation rather than a termination — and the details page had decided nothing at all, labelling its action "Terminate subscription" while opening a dialog titled "Cancel subscription?". That rule now has one home, which also settles the pre-existing wording mismatch for pending subscriptions.

## Depends on

Cancelling an incomplete subscription is rejected by the API until getlago/lago-api#6164 ships. This should merge after it.

Part of INT-214
