### PR TITLE
fix(feature-flags): survive corrupted value, allow flags on prod

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,6 +1,6 @@
 interface Window {
   Cypress: any
-  Lago: any
+  Lago: import('./src/core/utils/featureFlagsConsole').LagoWindowApi
 }
 
 declare type AppEnvEnum = import('./src/core/constants/globalTypes').AppEnvEnum

--- a/src/core/utils/__tests__/featureFlags.test.ts
+++ b/src/core/utils/__tests__/featureFlags.test.ts
@@ -1,0 +1,131 @@
+import {
+  FeatureFlags,
+  getEnableFeatureFlags,
+  isFeatureFlagActive,
+  listFeatureFlags,
+  setFeatureFlags,
+} from '~/core/utils/featureFlags'
+
+const FF_KEY = 'featureFlags'
+
+describe('featureFlags', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('listFeatureFlags', () => {
+    it('returns every declared flag', () => {
+      expect(listFeatureFlags()).toEqual([
+        FeatureFlags.SUPERSET_PERSISTENT_FILTERS,
+        FeatureFlags.REVENUE_RECOGNITION,
+      ])
+    })
+  })
+
+  describe('getEnableFeatureFlags', () => {
+    it('returns an empty array when nothing is stored', () => {
+      expect(getEnableFeatureFlags()).toEqual([])
+    })
+
+    it('returns the stored flags', () => {
+      localStorage.setItem(FF_KEY, JSON.stringify([FeatureFlags.REVENUE_RECOGNITION]))
+
+      expect(getEnableFeatureFlags()).toEqual([FeatureFlags.REVENUE_RECOGNITION])
+    })
+
+    it('drops values that are not declared flags', () => {
+      localStorage.setItem(
+        FF_KEY,
+        JSON.stringify(['revenue_recognition_typo', FeatureFlags.REVENUE_RECOGNITION, 42, null]),
+      )
+
+      expect(getEnableFeatureFlags()).toEqual([FeatureFlags.REVENUE_RECOGNITION])
+    })
+
+    // The stored value is hand-editable in devtools, so every malformed shape has
+    // to resolve to an empty array instead of throwing — see Sentry FRONT-17H.
+    describe.each([
+      ['the literal string undefined', 'undefined'],
+      ['a JSON null', 'null'],
+      ['a JSON number', '42'],
+      ['a JSON object', '{}'],
+      ['a JSON string holding a flag name', '"revenue_recognition"'],
+      ['an unquoted flag name', 'revenue_recognition'],
+      ['an unquoted array of flag names', '[revenue_recognition]'],
+      ['a coerced object', '[object Object]'],
+      ['a comma-joined array', 'superset_persistent_filters,revenue_recognition'],
+    ])('when the stored value is %s', (_label, stored) => {
+      beforeEach(() => {
+        localStorage.setItem(FF_KEY, stored)
+      })
+
+      it('returns an empty array', () => {
+        expect(getEnableFeatureFlags()).toEqual([])
+      })
+
+      it('clears the corrupted value so the next read is clean', () => {
+        getEnableFeatureFlags()
+
+        expect(localStorage.getItem(FF_KEY)).toBeNull()
+      })
+
+      it('does not report any flag as active', () => {
+        expect(isFeatureFlagActive(FeatureFlags.REVENUE_RECOGNITION)).toBe(false)
+      })
+    })
+
+    it('keeps an empty stored value untouched', () => {
+      localStorage.setItem(FF_KEY, '')
+
+      expect(getEnableFeatureFlags()).toEqual([])
+      expect(localStorage.getItem(FF_KEY)).toBe('')
+    })
+  })
+
+  describe('isFeatureFlagActive', () => {
+    it('is true for a stored flag', () => {
+      setFeatureFlags(FeatureFlags.REVENUE_RECOGNITION)
+
+      expect(isFeatureFlagActive(FeatureFlags.REVENUE_RECOGNITION)).toBe(true)
+    })
+
+    it('is false for a flag that is not stored', () => {
+      setFeatureFlags(FeatureFlags.REVENUE_RECOGNITION)
+
+      expect(isFeatureFlagActive(FeatureFlags.SUPERSET_PERSISTENT_FILTERS)).toBe(false)
+    })
+  })
+
+  describe('setFeatureFlags', () => {
+    it('stores a single flag', () => {
+      expect(setFeatureFlags(FeatureFlags.REVENUE_RECOGNITION)).toEqual([
+        FeatureFlags.REVENUE_RECOGNITION,
+      ])
+      expect(localStorage.getItem(FF_KEY)).toBe(JSON.stringify([FeatureFlags.REVENUE_RECOGNITION]))
+    })
+
+    it('stores a list of flags', () => {
+      expect(
+        setFeatureFlags([
+          FeatureFlags.REVENUE_RECOGNITION,
+          FeatureFlags.SUPERSET_PERSISTENT_FILTERS,
+        ]),
+      ).toEqual([FeatureFlags.REVENUE_RECOGNITION, FeatureFlags.SUPERSET_PERSISTENT_FILTERS])
+    })
+
+    it('stores every flag when asked for all', () => {
+      expect(setFeatureFlags('all')).toEqual(listFeatureFlags())
+    })
+
+    it('clears the flags when given an empty list', () => {
+      setFeatureFlags('all')
+
+      expect(setFeatureFlags([])).toEqual([])
+    })
+
+    it('drops names that are not declared flags', () => {
+      expect(setFeatureFlags(['revenue_recognition_typo' as FeatureFlags])).toEqual([])
+      expect(getEnableFeatureFlags()).toEqual([])
+    })
+  })
+})

--- a/src/core/utils/__tests__/featureFlagsConsole.test.ts
+++ b/src/core/utils/__tests__/featureFlagsConsole.test.ts
@@ -1,0 +1,84 @@
+import { AppEnvEnum } from '~/core/constants/globalTypes'
+import { FeatureFlags } from '~/core/utils/featureFlags'
+import { installLagoWindowApi, printFeatureFlagsHelp } from '~/core/utils/featureFlagsConsole'
+
+const NON_PRODUCTION_ENVS = [AppEnvEnum.development, AppEnvEnum.qa, AppEnvEnum.staging]
+
+describe('featureFlagsConsole', () => {
+  let groupCollapsedSpy: jest.SpyInstance
+  let infoSpy: jest.SpyInstance
+  let groupEndSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    localStorage.clear()
+    groupCollapsedSpy = jest.spyOn(console, 'groupCollapsed').mockImplementation()
+    infoSpy = jest.spyOn(console, 'info').mockImplementation()
+    groupEndSpy = jest.spyOn(console, 'groupEnd').mockImplementation()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('installLagoWindowApi', () => {
+    it('exposes the api on production', () => {
+      installLagoWindowApi(AppEnvEnum.production)
+
+      expect(window.Lago.getEnableFeatureFlags).toBeInstanceOf(Function)
+      expect(window.Lago.setFeatureFlags).toBeInstanceOf(Function)
+      expect(window.Lago.listFeatureFlags).toBeInstanceOf(Function)
+      expect(window.Lago.help).toBeInstanceOf(Function)
+    })
+
+    it('stays silent on production', () => {
+      installLagoWindowApi(AppEnvEnum.production)
+
+      expect(groupCollapsedSpy).not.toHaveBeenCalled()
+      expect(infoSpy).not.toHaveBeenCalled()
+      expect(groupEndSpy).not.toHaveBeenCalled()
+    })
+
+    it('lets a flag be enabled through the api on production', () => {
+      installLagoWindowApi(AppEnvEnum.production)
+
+      expect(window.Lago.setFeatureFlags(FeatureFlags.REVENUE_RECOGNITION)).toEqual([
+        FeatureFlags.REVENUE_RECOGNITION,
+      ])
+      expect(window.Lago.getEnableFeatureFlags()).toEqual([FeatureFlags.REVENUE_RECOGNITION])
+    })
+
+    it.each(NON_PRODUCTION_ENVS)('prints the help on %s', (appEnv) => {
+      installLagoWindowApi(appEnv)
+
+      expect(groupCollapsedSpy).toHaveBeenCalledTimes(1)
+      expect(groupEndSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('prints the help on demand once installed on production', () => {
+      installLagoWindowApi(AppEnvEnum.production)
+
+      window.Lago.help()
+
+      expect(groupCollapsedSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('printFeatureFlagsHelp', () => {
+    const getLoggedLines = (): string => infoSpy.mock.calls.map(([line]) => line).join('\n')
+
+    it('documents every declared flag name', () => {
+      printFeatureFlagsHelp()
+
+      const logged = getLoggedLines()
+
+      expect(logged).toContain(FeatureFlags.SUPERSET_PERSISTENT_FILTERS)
+      expect(logged).toContain(FeatureFlags.REVENUE_RECOGNITION)
+    })
+
+    it('does not document flag names that do not exist', () => {
+      printFeatureFlagsHelp()
+
+      expect(getLoggedLines()).not.toContain('ftr_')
+    })
+  })
+})

--- a/src/core/utils/featureFlags.ts
+++ b/src/core/utils/featureFlags.ts
@@ -20,6 +20,12 @@ const isKnownFeatureFlag = (value: unknown): value is FeatureFlags => {
  * nav and locked the whole app on the error fallback, which a refresh could not
  * recover from (Sentry FRONT-17H).
  */
+const discardStoredFeatureFlags = (): FeatureFlags[] => {
+  localStorage.removeItem(FF_KEY)
+
+  return []
+}
+
 export const getEnableFeatureFlags = (): FeatureFlags[] => {
   const stored = localStorage.getItem(FF_KEY)
 
@@ -27,19 +33,19 @@ export const getEnableFeatureFlags = (): FeatureFlags[] => {
     return []
   }
 
+  let parsed: unknown
+
   try {
-    const parsed: unknown = JSON.parse(stored)
-
-    if (!Array.isArray(parsed)) {
-      throw new Error('Stored feature flags are not an array')
-    }
-
-    return parsed.filter(isKnownFeatureFlag)
+    parsed = JSON.parse(stored)
   } catch {
-    localStorage.removeItem(FF_KEY)
-
-    return []
+    return discardStoredFeatureFlags()
   }
+
+  if (!Array.isArray(parsed)) {
+    return discardStoredFeatureFlags()
+  }
+
+  return parsed.filter(isKnownFeatureFlag)
 }
 
 export const isFeatureFlagActive = (flag: FeatureFlags): boolean => {

--- a/src/core/utils/featureFlags.ts
+++ b/src/core/utils/featureFlags.ts
@@ -5,14 +5,41 @@ export enum FeatureFlags {
 
 const FF_KEY = 'featureFlags'
 
-export const getEnableFeatureFlags = (): FeatureFlags[] => {
-  const flags = localStorage.getItem(FF_KEY)
-
-  return flags ? JSON.parse(flags) : []
-}
-
 export const listFeatureFlags = (): FeatureFlags[] => {
   return Object.values(FeatureFlags)
+}
+
+const isKnownFeatureFlag = (value: unknown): value is FeatureFlags => {
+  return listFeatureFlags().includes(value as FeatureFlags)
+}
+
+/**
+ * The stored value is hand-editable in devtools, so it cannot be trusted:
+ * anything that is not a JSON array of declared flags is discarded and the key
+ * is cleared. Without this, a malformed value threw from the render of the main
+ * nav and locked the whole app on the error fallback, which a refresh could not
+ * recover from (Sentry FRONT-17H).
+ */
+export const getEnableFeatureFlags = (): FeatureFlags[] => {
+  const stored = localStorage.getItem(FF_KEY)
+
+  if (!stored) {
+    return []
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(stored)
+
+    if (!Array.isArray(parsed)) {
+      throw new Error('Stored feature flags are not an array')
+    }
+
+    return parsed.filter(isKnownFeatureFlag)
+  } catch {
+    localStorage.removeItem(FF_KEY)
+
+    return []
+  }
 }
 
 export const isFeatureFlagActive = (flag: FeatureFlags): boolean => {
@@ -21,20 +48,26 @@ export const isFeatureFlagActive = (flag: FeatureFlags): boolean => {
   return flags.includes(flag)
 }
 
-export const setFeatureFlags = (flags: FeatureFlags[] | FeatureFlags | 'all') => {
+const resolveFeatureFlags = (flags: FeatureFlags[] | FeatureFlags | 'all'): FeatureFlags[] => {
   if (!flags) {
-    flags = []
+    return []
   }
 
   if (flags === 'all') {
-    flags = listFeatureFlags()
+    return listFeatureFlags()
   }
 
   if (!Array.isArray(flags)) {
-    flags = [flags]
+    return [flags]
   }
 
-  localStorage.setItem(FF_KEY, JSON.stringify(flags))
+  return flags
+}
+
+export const setFeatureFlags = (flags: FeatureFlags[] | FeatureFlags | 'all'): FeatureFlags[] => {
+  const known = resolveFeatureFlags(flags).filter(isKnownFeatureFlag)
+
+  localStorage.setItem(FF_KEY, JSON.stringify(known))
 
   return getEnableFeatureFlags()
 }

--- a/src/core/utils/featureFlagsConsole.ts
+++ b/src/core/utils/featureFlagsConsole.ts
@@ -1,0 +1,52 @@
+import { AppEnvEnum } from '~/core/constants/globalTypes'
+import { getEnableFeatureFlags, listFeatureFlags, setFeatureFlags } from '~/core/utils/featureFlags'
+
+/**
+ * Devtools console surface for the local feature flags. It is installed in every
+ * environment so a flag can be enabled on production too, but only
+ * non-production advertises it on load: on production it stays silent and is
+ * reachable on demand through `window.Lago.help()`.
+ */
+export type LagoWindowApi = {
+  getEnableFeatureFlags: typeof getEnableFeatureFlags
+  setFeatureFlags: typeof setFeatureFlags
+  listFeatureFlags: typeof listFeatureFlags
+  help: () => void
+}
+
+export const printFeatureFlagsHelp = (): void => {
+  const style = 'background: #eee; color: #fe3d3d'
+  const flags = listFeatureFlags()
+  const flagsSample = flags
+    .slice(0, 2)
+    .map((flag) => `'${flag}'`)
+    .join(', ')
+
+  const logs = [
+    'List available flags: %c window.Lago.listFeatureFlags() ',
+    `Set single flag: %c window.Lago.setFeatureFlags('${flags[0]}') `,
+    `Set multiple flags: %c window.Lago.setFeatureFlags([${flagsSample}]) `,
+    "Set all flags: %c window.Lago.setFeatureFlags('all') ",
+    'Get enable flags: %c window.Lago.getEnableFeatureFlags() ',
+    'Print this help again: %c window.Lago.help() ',
+  ]
+
+  /* eslint-disable no-console */
+  console.groupCollapsed('%c window.Lago is available', style)
+  logs.forEach((log) => console.info(log, style))
+  console.groupEnd()
+  /* eslint-enable no-console */
+}
+
+export const installLagoWindowApi = (appEnv: AppEnvEnum): void => {
+  window.Lago = {
+    getEnableFeatureFlags,
+    setFeatureFlags,
+    listFeatureFlags,
+    help: printFeatureFlagsHelp,
+  }
+
+  if (appEnv !== AppEnvEnum.production) {
+    printFeatureFlagsHelp()
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,12 +5,7 @@ import { createRoot } from 'react-dom/client'
 import App from '~/App'
 import { envGlobalVar } from '~/core/apolloClient'
 import { AppEnvEnum } from '~/core/constants/globalTypes'
-import {
-  FeatureFlags,
-  getEnableFeatureFlags,
-  listFeatureFlags,
-  setFeatureFlags,
-} from '~/core/utils/featureFlags'
+import { installLagoWindowApi } from '~/core/utils/featureFlagsConsole'
 
 import './main.css'
 
@@ -91,52 +86,7 @@ window.addEventListener('vite:preloadError', (event) => {
   })
 })
 
-type LagoWindowApi = {
-  getEnableFeatureFlags: () => FeatureFlags[]
-  setFeatureFlags: (flags: FeatureFlags[] | FeatureFlags | 'all') => FeatureFlags[]
-  listFeatureFlags: () => FeatureFlags[]
-  help: () => void
-}
-
-const printFeatureFlagsHelp = (): void => {
-  const style = 'background: #eee; color: #fe3d3d'
-  const flags = listFeatureFlags()
-  const flagsSample = flags
-    .slice(0, 2)
-    .map((flag) => `'${flag}'`)
-    .join(', ')
-
-  const logs = [
-    'List available flags: %c window.Lago.listFeatureFlags() ',
-    `Set single flag: %c window.Lago.setFeatureFlags('${flags[0]}') `,
-    `Set multiple flags: %c window.Lago.setFeatureFlags([${flagsSample}]) `,
-    "Set all flags: %c window.Lago.setFeatureFlags('all') ",
-    'Get enable flags: %c window.Lago.getEnableFeatureFlags() ',
-    'Print this help again: %c window.Lago.help() ',
-  ]
-
-  /* eslint-disable no-console */
-  console.groupCollapsed('%c window.Lago is available', style)
-  logs.forEach((log) => console.info(log, style))
-  console.groupEnd()
-  /* eslint-enable no-console */
-}
-
-const lagoWindowApi: LagoWindowApi = {
-  getEnableFeatureFlags,
-  setFeatureFlags,
-  listFeatureFlags,
-  help: printFeatureFlagsHelp,
-}
-
-// The API is exposed in every environment so feature flags can be enabled on
-// production too. Only non-production advertises it on load: on production it
-// stays silent and is reachable on demand through `window.Lago.help()`.
-window.Lago = lagoWindowApi
-
-if (appEnv !== AppEnvEnum.production) {
-  printFeatureFlagsHelp()
-}
+installLagoWindowApi(appEnv)
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const container = document.getElementById('root')!

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,12 @@ import { createRoot } from 'react-dom/client'
 import App from '~/App'
 import { envGlobalVar } from '~/core/apolloClient'
 import { AppEnvEnum } from '~/core/constants/globalTypes'
-import { getEnableFeatureFlags, listFeatureFlags, setFeatureFlags } from '~/core/utils/featureFlags'
+import {
+  FeatureFlags,
+  getEnableFeatureFlags,
+  listFeatureFlags,
+  setFeatureFlags,
+} from '~/core/utils/featureFlags'
 
 import './main.css'
 
@@ -86,20 +91,28 @@ window.addEventListener('vite:preloadError', (event) => {
   })
 })
 
-if (appEnv !== AppEnvEnum.production) {
-  window.Lago = {
-    getEnableFeatureFlags: getEnableFeatureFlags,
-    setFeatureFlags: setFeatureFlags,
-    listFeatureFlags: listFeatureFlags,
-  }
+type LagoWindowApi = {
+  getEnableFeatureFlags: () => FeatureFlags[]
+  setFeatureFlags: (flags: FeatureFlags[] | FeatureFlags | 'all') => FeatureFlags[]
+  listFeatureFlags: () => FeatureFlags[]
+  help: () => void
+}
 
+const printFeatureFlagsHelp = (): void => {
   const style = 'background: #eee; color: #fe3d3d'
+  const flags = listFeatureFlags()
+  const flagsSample = flags
+    .slice(0, 2)
+    .map((flag) => `'${flag}'`)
+    .join(', ')
+
   const logs = [
     'List available flags: %c window.Lago.listFeatureFlags() ',
-    "Set single flag: %c window.Lago.setFeatureFlags('ftr_xxx_enabled') ",
-    "Set multiple flags: %c window.Lago.setFeatureFlags(['ftr_xxx_enabled', 'ftr_yyy_enabled']) ",
+    `Set single flag: %c window.Lago.setFeatureFlags('${flags[0]}') `,
+    `Set multiple flags: %c window.Lago.setFeatureFlags([${flagsSample}]) `,
     "Set all flags: %c window.Lago.setFeatureFlags('all') ",
     'Get enable flags: %c window.Lago.getEnableFeatureFlags() ',
+    'Print this help again: %c window.Lago.help() ',
   ]
 
   /* eslint-disable no-console */
@@ -107,6 +120,22 @@ if (appEnv !== AppEnvEnum.production) {
   logs.forEach((log) => console.info(log, style))
   console.groupEnd()
   /* eslint-enable no-console */
+}
+
+const lagoWindowApi: LagoWindowApi = {
+  getEnableFeatureFlags,
+  setFeatureFlags,
+  listFeatureFlags,
+  help: printFeatureFlagsHelp,
+}
+
+// The API is exposed in every environment so feature flags can be enabled on
+// production too. Only non-production advertises it on load: on production it
+// stays silent and is reachable on demand through `window.Lago.help()`.
+window.Lago = lagoWindowApi
+
+if (appEnv !== AppEnvEnum.production) {
+  printFeatureFlagsHelp()
 }
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
## Context

Sentry [FRONT-17H](https://lago.sentry.io/issues/7676137574/) — `SyntaxError: "undefined" is not valid JSON`, production. Reported in #tech-production-errors by a teammate trying to enable revenue recognition.

`getEnableFeatureFlags` parsed `localStorage['featureFlags']` with a bare `JSON.parse`. The stored value was the literal string `undefined`, so the read threw during the render of `MainNavMenuSections` (`isFeatureFlagActive` at line 89). The nearest boundary is the route-level `ErrorBoundary` wrapping the `SideNavLayout` layout route, so the org switcher, the whole nav, the header and the page `Outlet` were all replaced by the full-screen `ErrorFallback` — whose only action is `window.location.reload()`, which re-reads the same key and re-throws. A permanent lockout, escapable only by clearing storage by hand.

The app cannot write that value: `setFeatureFlags` guards `if (!flags) flags = []` and always stringifies an array, and the `JSON.parse` line is unchanged since 2024. It came from a hand-edit in devtools, which is currently the only way to enable a flag on production, since `window.Lago` is gated off there.

## Description

**Harden the read** (`src/core/utils/featureFlags.ts`) — discard anything that is not a JSON array of declared flags, clear the corrupted key, and return `[]`. Writes go through the same predicate, so a typo'd flag name is no longer stored silently.

Four failure modes were reachable, not one: invalid JSON threw `SyntaxError`; `null` / `42` / `{}` parsed fine and then threw from `.includes`; and `'"revenue_recognition"'` parsed to a *string*, where `String.prototype.includes` exists, so the flag silently read as **enabled** and matched substrings. Enum filtering is what closes that last one, so it is not cosmetic.

**Allow flags on production** (`src/main.tsx`) — `window.Lago` is now assigned in every environment, so a flag can be enabled on production. Only non-production advertises it on load; production stays silent and is reachable on demand via `window.Lago.help()`. The help text is generated from `listFeatureFlags()`, replacing hardcoded `ftr_xxx_enabled` names that never existed and pushed people toward hand-editing storage in the first place.

**Tests** — new `src/core/utils/__tests__/featureFlags.test.ts`, 39 cases. There was no coverage for this module before, and all three consumer suites mock it out. Nine corruption shapes each assert an empty result, the key cleared, and no flag reported active.

Two adjacent bugs found during the investigation are filed rather than fixed here: LAGO-1829 (`appEnv` can be `undefined` at runtime, opening every non-production gate) and LAGO-1830 (`logOut` persists the literal string `undefined` as the auth token).

<!-- Linear link -->
Fixes LAGO-XXX