### PR TITLE
feat(invoices): use the capped invoice count in the list

### DIFF
--- a/src/components/MainHeader/__tests__/formatCountToMetadata.test.ts
+++ b/src/components/MainHeader/__tests__/formatCountToMetadata.test.ts
@@ -77,4 +77,37 @@ describe('formatCountToMetadata', () => {
       })
     })
   })
+
+  describe('GIVEN the count is capped', () => {
+    // A capped count is a lower bound: it reads as a formatted floor, and its key is single-form
+    // (a floor above the cap is never "1"), so no plural argument is passed.
+    const mockCappedTranslate = jest.fn(
+      (_key: string, params?: Record<string, string | number>) => `${params?.count}+ results`,
+    ) as unknown as TranslateFunc
+
+    describe('WHEN called with capped set', () => {
+      it('THEN should format the count as a floor, without a plural argument', () => {
+        const result = formatCountToMetadata(10000, mockCappedTranslate, true)
+
+        expect(mockCappedTranslate).toHaveBeenCalledWith(expect.any(String), { count: '10,000' })
+        expect(result).toBe('10,000+ results')
+      })
+    })
+
+    describe('WHEN called with capped explicitly false', () => {
+      it('THEN should keep the exact-total behaviour', () => {
+        const result = formatCountToMetadata(10000, mockTranslate, false)
+
+        expect(mockTranslate).toHaveBeenCalledWith(expect.any(String), { count: 10000 }, 10000)
+        expect(result).toBe('10000 results')
+      })
+    })
+
+    describe('WHEN the count is absent', () => {
+      it.each([[undefined], [null]])('THEN should return undefined (count = %s)', (count) => {
+        expect(formatCountToMetadata(count, mockCappedTranslate, true)).toBeUndefined()
+        expect(mockCappedTranslate).not.toHaveBeenCalled()
+      })
+    })
+  })
 })

--- a/src/components/MainHeader/formatCountToMetadata.ts
+++ b/src/components/MainHeader/formatCountToMetadata.ts
@@ -1,14 +1,27 @@
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { TranslateFunc } from '~/hooks/core/useInternationalization'
 
 /**
  * Formats a totalCount into a metadata string (e.g. "42 results").
  * Returns `undefined` if count is absent.
+ *
+ * `capped` is for the lists whose total the API caps (the invoices list): the count is then a
+ * lower bound, so it reads as a pre-formatted floor ("10,000+ results") instead of an exact total.
+ * Its key is single-form on purpose (a floor above the cap is never "1"), which is why no plural
+ * argument is passed — keep it single-form, a piped variant would resolve to its first segment.
  */
 export const formatCountToMetadata = (
   count: number | undefined | null,
   translate: TranslateFunc,
+  capped = false,
 ): string | undefined => {
   if (count === undefined || count === null) return undefined
+
+  if (capped) {
+    return translate('text_1786997491915trapg3o2kee', {
+      count: intlFormatNumber(count, { style: 'decimal', maximumFractionDigits: 0 }),
+    })
+  }
 
   return translate('text_17740184000000_total_results', { count }, count)
 }

--- a/src/components/designSystem/Pagination/PaginatedContent.tsx
+++ b/src/components/designSystem/Pagination/PaginatedContent.tsx
@@ -2,13 +2,26 @@ import { ReactNode, useEffect, useRef } from 'react'
 
 import { Pagination } from '~/components/designSystem/Pagination/Pagination'
 import { getScrollableAncestor } from '~/components/designSystem/Pagination/utils'
-import { CollectionMetadata } from '~/generated/graphql'
+import { CollectionMetadata, InvoiceCollectionMetadata } from '~/generated/graphql'
 import { tw } from '~/styles/utils'
+
+/**
+ * What a paginated list must select for the footer to work: `currentPage`, `totalPages` and
+ * `totalCount`. `hasNextPage` and `totalCountCapped` are optional because only collections whose
+ * total can be capped server-side expose them (the invoice list); every other list omits them and
+ * keeps the exact-total behaviour.
+ */
+export type PaginationMetadata = Pick<
+  CollectionMetadata,
+  'currentPage' | 'totalPages' | 'totalCount'
+> &
+  Partial<Pick<InvoiceCollectionMetadata, 'hasNextPage' | 'totalCountCapped'>>
 
 interface PaginatedContentProps {
   /** Pagination metadata returned by the list query. The query must select `currentPage`,
-   *  `totalPages` and `totalCount` — the footer always shows "X-Y of N results". */
-  metadata?: Pick<CollectionMetadata, 'currentPage' | 'totalPages' | 'totalCount'> | null
+   *  `totalPages` and `totalCount` — the footer shows "X-Y of N results" (or "of N+ results"
+   *  when the collection reports a capped total). See `PaginationMetadata`. */
+  metadata?: PaginationMetadata | null
   /** Called with the target page when the user navigates */
   onPageChange: (page: number) => void
   /** Rows displayed per page — drives the range label and selected option */
@@ -66,13 +79,25 @@ export const PaginatedContent = ({
   // reads like a "no data" empty state even though data exists. Clamp to the last real page —
   // standard pager behaviour — but only when there IS data (a truly empty list keeps its empty
   // state). `currentPage` echoes the requested page, so this converges after one correction.
+  //
+  // A capped total voids the whole premise: `totalPages` is then a floor, so `currentPage >
+  // totalPages` says nothing about being out of range and every page past the cap — including the
+  // real last one — would be yanked back to the cap. Hence both opt-outs: `hasNextPage` for the
+  // pages that still have a successor, `totalCountCapped` for the collection as a whole (the last
+  // page reports `hasNextPage: false` while sitting past the floored `totalPages`).
+  // Accepted trade-off: a capped list no longer auto-recovers from an absurd stale `?page=999999`
+  // — it shows its empty state until the user pages back. Un-capped lists keep recovering.
   const currentPage = metadata?.currentPage
   const totalPages = metadata?.totalPages
   const totalCount = metadata?.totalCount
+  const hasNextPage = metadata?.hasNextPage
+  const totalCountCapped = metadata?.totalCountCapped
 
   useEffect(() => {
     if (
       !loading &&
+      !hasNextPage &&
+      !totalCountCapped &&
       totalCount &&
       totalCount > 0 &&
       totalPages &&
@@ -82,7 +107,7 @@ export const PaginatedContent = ({
     ) {
       onPageChange(totalPages)
     }
-  }, [loading, currentPage, totalPages, totalCount, onPageChange])
+  }, [loading, hasNextPage, totalCountCapped, currentPage, totalPages, totalCount, onPageChange])
 
   // After a page change, reposition the list so the new page isn't opened scrolled to its end
   // (e.g. paging from the bottom of a 100-row page):
@@ -134,6 +159,8 @@ export const PaginatedContent = ({
       currentPage={metadata?.currentPage ?? 1}
       totalPages={metadata?.totalPages ?? 0}
       totalCount={metadata?.totalCount ?? 0}
+      hasNextPage={hasNextPage}
+      totalCountCapped={totalCountCapped}
       pageSize={pageSize}
       onPageChange={handlePageChange}
       onPageSizeChange={onPageSizeChange}

--- a/src/components/designSystem/Pagination/Pagination.tsx
+++ b/src/components/designSystem/Pagination/Pagination.tsx
@@ -6,6 +6,7 @@ import { getPageRange, shouldRenderFooter } from '~/components/designSystem/Pagi
 import { Popper } from '~/components/designSystem/Popper'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from '~/core/constants/pagination'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { MenuPopper } from '~/styles'
 import { tw } from '~/styles/utils'
@@ -13,8 +14,16 @@ import { tw } from '~/styles/utils'
 interface PaginationProps {
   currentPage: number
   totalPages: number
-  /** Total number of items across all pages — drives the "X-Y of N results" label */
+  /** Total number of items across all pages — drives the "X-Y of N results" label. A lower bound
+   *  rather than an exact total when `totalCountCapped` is set. */
   totalCount: number
+  /** Whether another page follows the current one. Only collections that report it pass it (the
+   *  invoice list, whose total is capped server-side); left undefined it is derived from
+   *  `currentPage < totalPages`, as it always was. */
+  hasNextPage?: boolean
+  /** True when `totalCount` is a lower bound instead of the exact total (capped server-side).
+   *  The range label then reads "1-20 of 10,000+ results". */
+  totalCountCapped?: boolean
   /** Rows displayed per page — drives the range label and the selected option */
   pageSize?: number
   onPageChange: (page: number) => void
@@ -50,6 +59,8 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
       currentPage,
       totalPages,
       totalCount,
+      hasNextPage,
+      totalCountCapped,
       pageSize = DEFAULT_PAGE_SIZE,
       onPageChange,
       onPageSizeChange,
@@ -74,14 +85,38 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
       return null
     }
 
-    const { startNumber, endNumber } = getPageRange({ currentPage, pageSize, totalCount })
-
-    // "{start}-{end} of {total} results"
-    const rangeLabel = translate(
-      'text_1782992964028u0dbq1gbcy4',
-      { startNumber, endNumber, count: totalCount },
+    const { startNumber, endNumber } = getPageRange({
+      currentPage,
+      pageSize,
       totalCount,
-    )
+      hasNextPage,
+      totalCountCapped,
+    })
+
+    // A capped total makes `totalPages` a floor too, so the page arithmetic can only be trusted
+    // when the collection doesn't tell us whether another page follows.
+    const canGoNext = hasNextPage ?? currentPage < totalPages
+
+    // "{start}-{end} of {total} results" — or "of {total}+ results" when the total is a capped
+    // floor. The floor is pre-formatted ("10,000+") because it reads as a round number; exact
+    // totals keep printing raw, and keep their singular/plural form.
+    const getRangeLabel = (): string => {
+      if (totalCountCapped) {
+        return translate('text_1786997491915x333f5g35ff', {
+          startNumber,
+          endNumber,
+          count: intlFormatNumber(totalCount, { style: 'decimal', maximumFractionDigits: 0 }),
+        })
+      }
+
+      return translate(
+        'text_1782992964028u0dbq1gbcy4',
+        { startNumber, endNumber, count: totalCount },
+        totalCount,
+      )
+    }
+
+    const rangeLabel = getRangeLabel()
 
     // 40px tall, 12px horizontal padding, 16px, grey-600, centered
     const labelClassName = 'flex h-10 items-center justify-center px-3 text-base text-grey-600'
@@ -159,7 +194,7 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
           type="button"
           aria-label="next page"
           className={arrowClassName}
-          disabled={loading || currentPage >= totalPages}
+          disabled={loading || !canGoNext}
           onClick={() => onPageChange(currentPage + 1)}
         >
           <Icon name="chevron-right" size="medium" />

--- a/src/components/designSystem/Pagination/__tests__/PaginatedContent.test.tsx
+++ b/src/components/designSystem/Pagination/__tests__/PaginatedContent.test.tsx
@@ -136,6 +136,108 @@ describe('PaginatedContent', () => {
     expect(onPageChange).not.toHaveBeenCalled()
   })
 
+  it('does not clamp a page past the capped total while another page follows', () => {
+    // capped invoice list: totalPages is a 500-page floor, so page 600 is a real page
+    render(
+      <PaginatedContent
+        onPageChange={onPageChange}
+        metadata={{
+          currentPage: 600,
+          totalPages: 500,
+          totalCount: 10000,
+          hasNextPage: true,
+          totalCountCapped: true,
+        }}
+      >
+        <div />
+      </PaginatedContent>,
+    )
+
+    expect(onPageChange).not.toHaveBeenCalled()
+  })
+
+  it('does not clamp the last page of a capped list (no next page, still past the floor)', () => {
+    // 12,050 matches at 20/page: the real last page is 603 while totalPages floors at 500 and the
+    // collection reports no next page. Clamping here made the last page unreachable.
+    render(
+      <PaginatedContent
+        onPageChange={onPageChange}
+        metadata={{
+          currentPage: 603,
+          totalPages: 500,
+          totalCount: 10000,
+          hasNextPage: false,
+          totalCountCapped: true,
+        }}
+      >
+        <div />
+      </PaginatedContent>,
+    )
+
+    expect(onPageChange).not.toHaveBeenCalled()
+  })
+
+  it('still clamps an out-of-range page when no page follows', () => {
+    render(
+      <PaginatedContent
+        onPageChange={onPageChange}
+        metadata={{
+          currentPage: 200000,
+          totalPages: 3,
+          totalCount: 45,
+          hasNextPage: false,
+          totalCountCapped: false,
+        }}
+      >
+        <div />
+      </PaginatedContent>,
+    )
+
+    expect(onPageChange).toHaveBeenCalledWith(3)
+  })
+
+  it('forwards hasNextPage and totalCountCapped to Pagination', () => {
+    render(
+      <PaginatedContent
+        onPageChange={onPageChange}
+        metadata={{
+          currentPage: 600,
+          totalPages: 500,
+          totalCount: 10000,
+          hasNextPage: true,
+          totalCountCapped: true,
+        }}
+      >
+        <div />
+      </PaginatedContent>,
+    )
+
+    expect(mockPaginationSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasNextPage: true,
+        totalCountCapped: true,
+      }),
+    )
+  })
+
+  it('leaves both capped fields undefined for lists that do not select them', () => {
+    render(
+      <PaginatedContent
+        onPageChange={onPageChange}
+        metadata={{ currentPage: 3, totalPages: 7, totalCount: 130 }}
+      >
+        <div />
+      </PaginatedContent>,
+    )
+
+    expect(mockPaginationSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasNextPage: undefined,
+        totalCountCapped: undefined,
+      }),
+    )
+  })
+
   it('forwards pageSize, onPageSizeChange, pageSizeOptions and loading', () => {
     const onPageSizeChange = jest.fn()
 

--- a/src/components/designSystem/Pagination/__tests__/Pagination.test.tsx
+++ b/src/components/designSystem/Pagination/__tests__/Pagination.test.tsx
@@ -8,6 +8,9 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
       if (key === 'text_1782992964028u0dbq1gbcy4') {
         return `${args?.startNumber}-${args?.endNumber} of ${args?.count} results`
       }
+      if (key === 'text_1786997491915x333f5g35ff') {
+        return `${args?.startNumber}-${args?.endNumber} of ${args?.count}+ results`
+      }
       if (key === 'text_1782992964029cazjloaotl0') {
         return `${args?.count} rows per page`
       }
@@ -171,5 +174,83 @@ describe('Pagination', () => {
     )
 
     expect(container).toBeEmptyDOMElement()
+  })
+
+  // Capped total (invoice list): `totalCount` is a 10,000 floor and `totalPages` its 500-page
+  // counterpart, so the collection's own `hasNextPage` decides whether next is reachable.
+  const cappedProps = {
+    ...baseProps,
+    currentPage: 600,
+    totalPages: 500,
+    totalCount: 10000,
+    pageSize: 20,
+    hasNextPage: true,
+    totalCountCapped: true,
+  }
+
+  it('keeps next enabled past the last counted page when hasNextPage is true', () => {
+    const onPageChange = jest.fn()
+
+    render(<Pagination {...cappedProps} onPageChange={onPageChange} />)
+
+    const [, next] = within(screen.getByRole('navigation', { name: 'pagination' })).getAllByRole(
+      'button',
+    )
+
+    expect(next).not.toBeDisabled()
+
+    fireEvent.click(next)
+    expect(onPageChange).toHaveBeenCalledWith(601)
+  })
+
+  it('disables next when hasNextPage is false, even with pages left to count', () => {
+    render(<Pagination {...baseProps} currentPage={1} totalPages={3} hasNextPage={false} />)
+
+    const [, next] = within(screen.getByRole('navigation', { name: 'pagination' })).getAllByRole(
+      'button',
+    )
+
+    expect(next).toBeDisabled()
+  })
+
+  it.each([
+    ['enabled in the middle of the collection', 2, false],
+    ['disabled on the last page', 3, true],
+  ])(
+    'derives next from the page arithmetic when hasNextPage is absent (%s)',
+    (_, currentPage, expectedDisabled) => {
+      render(<Pagination {...baseProps} currentPage={currentPage} />)
+
+      const [, next] = within(screen.getByRole('navigation', { name: 'pagination' })).getAllByRole(
+        'button',
+      )
+
+      expect(next).toHaveProperty('disabled', expectedDisabled)
+    },
+  )
+
+  it('renders the range label with a formatted floor when the total is capped', () => {
+    render(<Pagination {...cappedProps} currentPage={1} />)
+
+    expect(screen.getByText('1-20 of 10,000+ results')).toBeInTheDocument()
+  })
+
+  it('does not clamp the range to the capped total on a page past it', () => {
+    render(<Pagination {...cappedProps} />)
+
+    expect(screen.getByText('11981-12000 of 10,000+ results')).toBeInTheDocument()
+  })
+
+  it('keeps the range readable on the last page of a capped list', () => {
+    // no next page, yet already past the counted range: clamping would invert the range
+    render(<Pagination {...cappedProps} currentPage={603} hasNextPage={false} />)
+
+    expect(screen.getByText('12041-12060 of 10,000+ results')).toBeInTheDocument()
+  })
+
+  it('keeps the exact-total label when the total is not capped', () => {
+    render(<Pagination {...baseProps} currentPage={2} hasNextPage totalCountCapped={false} />)
+
+    expect(screen.getByText('21-40 of 45 results')).toBeInTheDocument()
   })
 })

--- a/src/components/designSystem/Pagination/__tests__/utils.test.ts
+++ b/src/components/designSystem/Pagination/__tests__/utils.test.ts
@@ -58,6 +58,83 @@ describe('Pagination/utils', () => {
         })
       })
     })
+
+    describe('GIVEN a capped total with another page to come', () => {
+      describe('WHEN the range runs past the capped count', () => {
+        it('THEN the end is not clamped (the page is necessarily full)', () => {
+          // page 600 of a 12,000-match list whose total is capped at 10,000
+          expect(
+            getPageRange({ currentPage: 600, pageSize: 20, totalCount: 10000, hasNextPage: true }),
+          ).toEqual({
+            startNumber: 11981,
+            endNumber: 12000,
+          })
+        })
+      })
+
+      describe('WHEN the range sits inside the counted range', () => {
+        it('THEN the end is the full page, as it already was', () => {
+          expect(
+            getPageRange({ currentPage: 2, pageSize: 20, totalCount: 10000, hasNextPage: true }),
+          ).toEqual({
+            startNumber: 21,
+            endNumber: 40,
+          })
+        })
+      })
+    })
+
+    describe('GIVEN no page follows the current one', () => {
+      describe('WHEN hasNextPage is false or absent', () => {
+        it.each([[false], [undefined]])(
+          'THEN the end is still clamped to totalCount (hasNextPage = %s)',
+          (hasNextPage) => {
+            expect(
+              getPageRange({ currentPage: 3, pageSize: 20, totalCount: 45, hasNextPage }),
+            ).toEqual({
+              startNumber: 41,
+              endNumber: 45,
+            })
+          },
+        )
+      })
+
+      describe('WHEN the total is capped', () => {
+        it('THEN the end is a whole page rather than an inverted range', () => {
+          // last page of a capped list: without the opt-out this returned end 10000 < start 12041
+          expect(
+            getPageRange({
+              currentPage: 603,
+              pageSize: 20,
+              totalCount: 10000,
+              hasNextPage: false,
+              totalCountCapped: true,
+            }),
+          ).toEqual({
+            startNumber: 12041,
+            endNumber: 12060,
+          })
+        })
+
+        // A page well inside the counted range lands on the same numbers with or without the
+        // opt-out (the clamp only ever bites once the range reaches totalCount), so this pins that
+        // the capped flag does not disturb the ordinary case rather than exercising the branch.
+        it('THEN a page inside the counted range keeps the plain full-page range', () => {
+          expect(
+            getPageRange({
+              currentPage: 2,
+              pageSize: 20,
+              totalCount: 10000,
+              hasNextPage: false,
+              totalCountCapped: true,
+            }),
+          ).toEqual({
+            startNumber: 21,
+            endNumber: 40,
+          })
+        })
+      })
+    })
   })
 
   describe('shouldRenderFooter', () => {

--- a/src/components/designSystem/Pagination/utils.ts
+++ b/src/components/designSystem/Pagination/utils.ts
@@ -3,18 +3,35 @@
 /**
  * The 1-based item range shown on the current page — e.g. page 2 at 20 rows over 45 items
  * → `{ startNumber: 21, endNumber: 40 }`. The end is clamped to `totalCount` on the last page.
+ *
+ * Both flags opt out of that clamp, because clamping to a `totalCount` that is only a floor
+ * renders nonsense like "11981-10000":
+ *  - `hasNextPage`: another page follows, so the current one is necessarily full.
+ *  - `totalCountCapped`: the total is a floor, which also covers the last page of a capped
+ *    collection (no next page, yet already past the counted range). The end is then a whole page
+ *    even if the last one is partial — an overstatement of at most `pageSize - 1`, and the only
+ *    approximation available without a row count.
+ *
+ * Left undefined, both keep the original clamp.
  */
 export const getPageRange = ({
   currentPage,
   pageSize,
   totalCount,
+  hasNextPage,
+  totalCountCapped,
 }: {
   currentPage: number
   pageSize: number
   totalCount: number
+  hasNextPage?: boolean
+  totalCountCapped?: boolean
 }): { startNumber: number; endNumber: number } => ({
   startNumber: (currentPage - 1) * pageSize + 1,
-  endNumber: Math.min(currentPage * pageSize, totalCount),
+  endNumber:
+    hasNextPage || totalCountCapped
+      ? currentPage * pageSize
+      : Math.min(currentPage * pageSize, totalCount),
 })
 
 /**

--- a/src/components/invoices/__tests__/InvoicesList.test.tsx
+++ b/src/components/invoices/__tests__/InvoicesList.test.tsx
@@ -240,13 +240,20 @@ const createMockInvoices = (count: number): InvoiceItem[] => {
 
 const createMockMetadata = (
   overrides: Partial<GetInvoicesListQuery['invoices']['metadata']> = {},
-): GetInvoicesListQuery['invoices']['metadata'] => ({
-  __typename: 'CollectionMetadata',
-  currentPage: 1,
-  totalPages: 1,
-  totalCount: 1,
-  ...overrides,
-})
+): GetInvoicesListQuery['invoices']['metadata'] => {
+  const { currentPage = 1, totalPages = 1, totalCount = 1 } = overrides
+
+  return {
+    __typename: 'InvoiceCollectionMetadata',
+    currentPage,
+    totalPages,
+    totalCount,
+    totalCountCapped: false,
+    // What the API reports for an uncapped total; override it to exercise the capped list
+    hasNextPage: currentPage < totalPages,
+    ...overrides,
+  }
+}
 
 // Default props type
 type TInvoiceListProps = {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -5067,7 +5067,24 @@ export type InvoiceCollection = {
   /** A collection of paginated InvoiceCollection */
   collection: Array<Invoice>;
   /** Pagination Metadata for navigating the Pagination */
-  metadata: CollectionMetadata;
+  metadata: InvoiceCollectionMetadata;
+};
+
+/** Pagination metadata for a collection of invoices */
+export type InvoiceCollectionMetadata = {
+  __typename?: 'InvoiceCollectionMetadata';
+  /** Current Page of loaded data */
+  currentPage: Scalars['Int']['output'];
+  /** True when another page follows, even when `totalCount` is capped */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** The number of items per page */
+  limitValue: Scalars['Int']['output'];
+  /** The total number of items to be paginated */
+  totalCount: Scalars['Int']['output'];
+  /** True when `totalCount` hit the counting limit and is a lower bound, not the exact total */
+  totalCountCapped: Scalars['Boolean']['output'];
+  /** The total number of pages in the pagination */
+  totalPages: Scalars['Int']['output'];
 };
 
 export type InvoiceCustomSection = {
@@ -11834,7 +11851,7 @@ export type GetInvoiceNumbersForFilterItemInvoiceNumbersQueryVariables = Exact<{
 }>;
 
 
-export type GetInvoiceNumbersForFilterItemInvoiceNumbersQuery = { __typename?: 'Query', invoices: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Invoice', id: string, number: string }> } };
+export type GetInvoiceNumbersForFilterItemInvoiceNumbersQuery = { __typename?: 'Query', invoices: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'InvoiceCollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Invoice', id: string, number: string }> } };
 
 export type GetCustomersForFilterItemMultipleCustomersQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -12227,7 +12244,7 @@ export type CustomerPortalInvoicesQueryVariables = Exact<{
 }>;
 
 
-export type CustomerPortalInvoicesQuery = { __typename?: 'Query', customerPortalInvoices: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Invoice', id: string, paymentStatus: InvoicePaymentStatusTypeEnum, paymentOverdue: boolean, paymentDisputeLostAt?: any | null, number: string, issuingDate: any, totalAmountCents: any, totalDueAmountCents: any, currency?: CurrencyEnum | null, invoiceType: InvoiceTypeEnum }> } };
+export type CustomerPortalInvoicesQuery = { __typename?: 'Query', customerPortalInvoices: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'InvoiceCollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Invoice', id: string, paymentStatus: InvoicePaymentStatusTypeEnum, paymentOverdue: boolean, paymentDisputeLostAt?: any | null, number: string, issuingDate: any, totalAmountCents: any, totalDueAmountCents: any, currency?: CurrencyEnum | null, invoiceType: InvoiceTypeEnum }> } };
 
 export type DownloadCustomerPortalInvoiceMutationVariables = Exact<{
   input: DownloadCustomerPortalInvoiceInput;
@@ -12386,7 +12403,7 @@ export type IntegrationsListForCustomerMainInfosQuery = { __typename?: 'Query', 
 
 export type InvoiceListItemFragment = { __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, taxStatus?: InvoiceTaxStatusTypeEnum | null, paymentStatus: InvoicePaymentStatusTypeEnum, paymentOverdue: boolean, number: string, issuingDate: any, totalAmountCents: any, totalDueAmountCents: any, totalPaidAmountCents: any, currency?: CurrencyEnum | null, voidable: boolean, paymentDisputeLostAt?: any | null, taxProviderVoidable: boolean, invoiceType: InvoiceTypeEnum, associatedActiveWalletPresent: boolean, voidedInvoiceId?: string | null, regeneratedInvoiceId?: string | null, customer: { __typename?: 'Customer', id: string, externalId: string, name?: string | null, displayName: string, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, hasActiveWallet: boolean, email?: string | null, deletedAt?: any | null }, errorDetails?: Array<{ __typename?: 'ErrorDetail', errorCode: ErrorCodesEnum, errorDetails?: string | null }> | null, billingEntity: { __typename?: 'BillingEntity', id: string, name: string, code: string, email?: string | null, einvoicing: boolean }, payments?: Array<{ __typename?: 'Payment', createdAt: any, paymentMethodId?: string | null }> | null };
 
-export type InvoiceForInvoiceListFragment = { __typename?: 'InvoiceCollection', collection: Array<{ __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, taxStatus?: InvoiceTaxStatusTypeEnum | null, paymentStatus: InvoicePaymentStatusTypeEnum, paymentOverdue: boolean, number: string, issuingDate: any, totalAmountCents: any, totalDueAmountCents: any, totalPaidAmountCents: any, currency?: CurrencyEnum | null, voidable: boolean, paymentDisputeLostAt?: any | null, taxProviderVoidable: boolean, invoiceType: InvoiceTypeEnum, associatedActiveWalletPresent: boolean, voidedInvoiceId?: string | null, regeneratedInvoiceId?: string | null, customer: { __typename?: 'Customer', id: string, externalId: string, name?: string | null, displayName: string, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, hasActiveWallet: boolean, email?: string | null, deletedAt?: any | null }, errorDetails?: Array<{ __typename?: 'ErrorDetail', errorCode: ErrorCodesEnum, errorDetails?: string | null }> | null, billingEntity: { __typename?: 'BillingEntity', id: string, name: string, code: string, email?: string | null, einvoicing: boolean }, payments?: Array<{ __typename?: 'Payment', createdAt: any, paymentMethodId?: string | null }> | null }>, metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalCount: number, totalPages: number } };
+export type InvoiceForInvoiceListFragment = { __typename?: 'InvoiceCollection', collection: Array<{ __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, taxStatus?: InvoiceTaxStatusTypeEnum | null, paymentStatus: InvoicePaymentStatusTypeEnum, paymentOverdue: boolean, number: string, issuingDate: any, totalAmountCents: any, totalDueAmountCents: any, totalPaidAmountCents: any, currency?: CurrencyEnum | null, voidable: boolean, paymentDisputeLostAt?: any | null, taxProviderVoidable: boolean, invoiceType: InvoiceTypeEnum, associatedActiveWalletPresent: boolean, voidedInvoiceId?: string | null, regeneratedInvoiceId?: string | null, customer: { __typename?: 'Customer', id: string, externalId: string, name?: string | null, displayName: string, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, hasActiveWallet: boolean, email?: string | null, deletedAt?: any | null }, errorDetails?: Array<{ __typename?: 'ErrorDetail', errorCode: ErrorCodesEnum, errorDetails?: string | null }> | null, billingEntity: { __typename?: 'BillingEntity', id: string, name: string, code: string, email?: string | null, einvoicing: boolean }, payments?: Array<{ __typename?: 'Payment', createdAt: any, paymentMethodId?: string | null }> | null }>, metadata: { __typename?: 'InvoiceCollectionMetadata', currentPage: number, totalCount: number, totalPages: number } };
 
 export type DownloadInvoiceItemMutationVariables = Exact<{
   input: DownloadInvoiceInput;
@@ -12420,7 +12437,7 @@ export type GetCustomerInvoicesQueryVariables = Exact<{
 }>;
 
 
-export type GetCustomerInvoicesQuery = { __typename?: 'Query', customerInvoices: { __typename?: 'InvoiceCollection', collection: Array<{ __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, taxStatus?: InvoiceTaxStatusTypeEnum | null, paymentStatus: InvoicePaymentStatusTypeEnum, paymentOverdue: boolean, number: string, issuingDate: any, totalAmountCents: any, totalDueAmountCents: any, totalPaidAmountCents: any, currency?: CurrencyEnum | null, voidable: boolean, paymentDisputeLostAt?: any | null, taxProviderVoidable: boolean, invoiceType: InvoiceTypeEnum, associatedActiveWalletPresent: boolean, voidedInvoiceId?: string | null, regeneratedInvoiceId?: string | null, customer: { __typename?: 'Customer', id: string, externalId: string, name?: string | null, displayName: string, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, hasActiveWallet: boolean, email?: string | null, deletedAt?: any | null }, errorDetails?: Array<{ __typename?: 'ErrorDetail', errorCode: ErrorCodesEnum, errorDetails?: string | null }> | null, billingEntity: { __typename?: 'BillingEntity', id: string, name: string, code: string, email?: string | null, einvoicing: boolean }, payments?: Array<{ __typename?: 'Payment', createdAt: any, paymentMethodId?: string | null }> | null }>, metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalCount: number, totalPages: number } } };
+export type GetCustomerInvoicesQuery = { __typename?: 'Query', customerInvoices: { __typename?: 'InvoiceCollection', collection: Array<{ __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, taxStatus?: InvoiceTaxStatusTypeEnum | null, paymentStatus: InvoicePaymentStatusTypeEnum, paymentOverdue: boolean, number: string, issuingDate: any, totalAmountCents: any, totalDueAmountCents: any, totalPaidAmountCents: any, currency?: CurrencyEnum | null, voidable: boolean, paymentDisputeLostAt?: any | null, taxProviderVoidable: boolean, invoiceType: InvoiceTypeEnum, associatedActiveWalletPresent: boolean, voidedInvoiceId?: string | null, regeneratedInvoiceId?: string | null, customer: { __typename?: 'Customer', id: string, externalId: string, name?: string | null, displayName: string, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, hasActiveWallet: boolean, email?: string | null, deletedAt?: any | null }, errorDetails?: Array<{ __typename?: 'ErrorDetail', errorCode: ErrorCodesEnum, errorDetails?: string | null }> | null, billingEntity: { __typename?: 'BillingEntity', id: string, name: string, code: string, email?: string | null, einvoicing: boolean }, payments?: Array<{ __typename?: 'Payment', createdAt: any, paymentMethodId?: string | null }> | null }>, metadata: { __typename?: 'InvoiceCollectionMetadata', currentPage: number, totalCount: number, totalPages: number } } };
 
 export type CustomerMainInfosFragment = { __typename?: 'Customer', id: string, customerType?: CustomerTypeEnum | null, name?: string | null, firstname?: string | null, lastname?: string | null, externalId: string, externalSalesforceId?: string | null, legalName?: string | null, legalNumber?: string | null, taxIdentificationNumber?: string | null, phone?: string | null, email?: string | null, currency?: CurrencyEnum | null, addressLine1?: string | null, addressLine2?: string | null, state?: string | null, country?: CountryCode | null, city?: string | null, url?: string | null, zipcode?: string | null, paymentProvider?: ProviderTypeEnum | null, timezone?: TimezoneEnum | null, paymentProviderCode?: string | null, shippingAddress?: { __typename?: 'CustomerAddress', addressLine1?: string | null, addressLine2?: string | null, city?: string | null, country?: CountryCode | null, state?: string | null, zipcode?: string | null } | null, anrokCustomer?: { __typename?: 'AnrokCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null } | null, avalaraCustomer?: { __typename?: 'AvalaraCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null } | null, netsuiteCustomer?: { __typename?: 'NetsuiteCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null } | null, providerCustomer?: { __typename?: 'ProviderCustomer', id: string, providerCustomerId?: string | null, providerPaymentMethods?: Array<ProviderPaymentMethodsEnum> | null } | null, xeroCustomer?: { __typename?: 'XeroCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null } | null, hubspotCustomer?: { __typename?: 'HubspotCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null, targetedObject?: HubspotTargetedObjectsEnum | null } | null, salesforceCustomer?: { __typename?: 'SalesforceCustomer', id: string, integrationId?: string | null, externalCustomerId?: string | null } | null, metadata?: Array<{ __typename?: 'CustomerMetadata', id: string, key: string, value: string }> | null, billingEntity: { __typename?: 'BillingEntity', id: string, name: string, code: string } };
 
@@ -13634,7 +13651,7 @@ export type RetryAllInvoicesMutationVariables = Exact<{
 }>;
 
 
-export type RetryAllInvoicesMutation = { __typename?: 'Mutation', retryAllInvoices?: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'CollectionMetadata', totalCount: number } } | null };
+export type RetryAllInvoicesMutation = { __typename?: 'Mutation', retryAllInvoices?: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'InvoiceCollectionMetadata', totalCount: number } } | null };
 
 export type AvalaraIntegrationItemsFragment = { __typename?: 'AvalaraIntegration', id: string };
 
@@ -13704,7 +13721,7 @@ export type RetryAllAvalaraInvoicesMutationVariables = Exact<{
 }>;
 
 
-export type RetryAllAvalaraInvoicesMutation = { __typename?: 'Mutation', retryAllInvoices?: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'CollectionMetadata', totalCount: number } } | null };
+export type RetryAllAvalaraInvoicesMutation = { __typename?: 'Mutation', retryAllInvoices?: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'InvoiceCollectionMetadata', totalCount: number } } | null };
 
 export type DeleteAnrokIntegrationDialogFragment = { __typename?: 'AnrokIntegration', id: string, name: string };
 
@@ -15240,14 +15257,14 @@ export type GetInvoicesListQueryVariables = Exact<{
 }>;
 
 
-export type GetInvoicesListQuery = { __typename?: 'Query', invoices: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number }, collection: Array<{ __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, taxStatus?: InvoiceTaxStatusTypeEnum | null, paymentStatus: InvoicePaymentStatusTypeEnum, paymentOverdue: boolean, number: string, issuingDate: any, totalAmountCents: any, totalDueAmountCents: any, totalPaidAmountCents: any, currency?: CurrencyEnum | null, voidable: boolean, paymentDisputeLostAt?: any | null, taxProviderVoidable: boolean, invoiceType: InvoiceTypeEnum, associatedActiveWalletPresent: boolean, voidedInvoiceId?: string | null, regeneratedInvoiceId?: string | null, customer: { __typename?: 'Customer', id: string, externalId: string, name?: string | null, displayName: string, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, hasActiveWallet: boolean, email?: string | null, deletedAt?: any | null }, errorDetails?: Array<{ __typename?: 'ErrorDetail', errorCode: ErrorCodesEnum, errorDetails?: string | null }> | null, billingEntity: { __typename?: 'BillingEntity', id: string, name: string, code: string, email?: string | null, einvoicing: boolean }, payments?: Array<{ __typename?: 'Payment', createdAt: any, paymentMethodId?: string | null }> | null }> } };
+export type GetInvoicesListQuery = { __typename?: 'Query', invoices: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'InvoiceCollectionMetadata', currentPage: number, totalPages: number, totalCount: number, totalCountCapped: boolean, hasNextPage: boolean }, collection: Array<{ __typename?: 'Invoice', id: string, status: InvoiceStatusTypeEnum, taxStatus?: InvoiceTaxStatusTypeEnum | null, paymentStatus: InvoicePaymentStatusTypeEnum, paymentOverdue: boolean, number: string, issuingDate: any, totalAmountCents: any, totalDueAmountCents: any, totalPaidAmountCents: any, currency?: CurrencyEnum | null, voidable: boolean, paymentDisputeLostAt?: any | null, taxProviderVoidable: boolean, invoiceType: InvoiceTypeEnum, associatedActiveWalletPresent: boolean, voidedInvoiceId?: string | null, regeneratedInvoiceId?: string | null, customer: { __typename?: 'Customer', id: string, externalId: string, name?: string | null, displayName: string, applicableTimezone: TimezoneEnum, paymentProvider?: ProviderTypeEnum | null, hasActiveWallet: boolean, email?: string | null, deletedAt?: any | null }, errorDetails?: Array<{ __typename?: 'ErrorDetail', errorCode: ErrorCodesEnum, errorDetails?: string | null }> | null, billingEntity: { __typename?: 'BillingEntity', id: string, name: string, code: string, email?: string | null, einvoicing: boolean }, payments?: Array<{ __typename?: 'Payment', createdAt: any, paymentMethodId?: string | null }> | null }> } };
 
 export type RetryAllInvoicePaymentsMutationVariables = Exact<{
   input: RetryAllInvoicePaymentsInput;
 }>;
 
 
-export type RetryAllInvoicePaymentsMutation = { __typename?: 'Mutation', retryAllInvoicePayments?: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'CollectionMetadata', totalCount: number } } | null };
+export type RetryAllInvoicePaymentsMutation = { __typename?: 'Mutation', retryAllInvoicePayments?: { __typename?: 'InvoiceCollection', metadata: { __typename?: 'InvoiceCollectionMetadata', totalCount: number } } | null };
 
 export type CreateInvoicesDataExportMutationVariables = Exact<{
   input: CreateDataExportsInvoicesInput;
@@ -39272,6 +39289,8 @@ export const GetInvoicesListDocument = gql`
       currentPage
       totalPages
       totalCount
+      totalCountCapped
+      hasNextPage
     }
     collection {
       id

--- a/src/pages/InvoicesPage.tsx
+++ b/src/pages/InvoicesPage.tsx
@@ -19,6 +19,7 @@ import { SearchInput } from '~/components/SearchInput'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { INVOICE_LIST_FILTER_PREFIX } from '~/core/constants/filters'
 import { DEFAULT_PAGE_SIZE } from '~/core/constants/pagination'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { serializeAmount } from '~/core/serializers/serializeAmount'
 import {
   CurrencyEnum,
@@ -84,6 +85,8 @@ gql`
         currentPage
         totalPages
         totalCount
+        totalCountCapped
+        hasNextPage
       }
       collection {
         id
@@ -218,13 +221,30 @@ const InvoicesPage = () => {
   })
 
   const invoicesTotalCount = data?.invoices?.metadata?.totalCount
+  // Above the API's counting limit the total is a lower bound, so every place printing it says
+  // "10,000+" rather than pretending the floor is exact.
+  const invoicesTotalCountCapped = data?.invoices?.metadata?.totalCountCapped
+
+  // The export runs server-side over every match, so the capped floor is the honest label here too.
+  const getExportTotalCountLabel = (): string => {
+    if (invoicesTotalCountCapped && invoicesTotalCount !== undefined) {
+      return translate('text_1786997491915ihtx5q0emhp', {
+        invoicesTotalCount: intlFormatNumber(invoicesTotalCount, {
+          style: 'decimal',
+          maximumFractionDigits: 0,
+        }),
+      })
+    }
+
+    return translate('text_66b21236c939426d07ff9937', { invoicesTotalCount }, invoicesTotalCount)
+  }
 
   return (
     <>
       <MainHeader.Configure
         entity={{
           viewName: translate('text_63ac86d797f728a87b2f9f85'),
-          metadata: formatCountToMetadata(invoicesTotalCount, translate),
+          metadata: formatCountToMetadata(invoicesTotalCount, translate, invoicesTotalCountCapped),
           metadataLoading: invoiceIsLoading && invoicesTotalCount === undefined,
         }}
         actions={{
@@ -237,11 +257,7 @@ const InvoicesPage = () => {
               disabled: !invoicesTotalCount,
               onClick: () => {
                 openExportDialog({
-                  totalCountLabel: translate(
-                    'text_66b21236c939426d07ff9937',
-                    { invoicesTotalCount },
-                    invoicesTotalCount,
-                  ),
+                  totalCountLabel: getExportTotalCountLabel(),
                   onExport: onInvoicesExport,
                   disableExport: invoicesTotalCount === 0,
                   resourceTypeOptions: [

--- a/src/pages/__tests__/InvoicesPage.test.tsx
+++ b/src/pages/__tests__/InvoicesPage.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react'
 
 import { MainHeaderConfig } from '~/components/MainHeader/types'
 import { GetInvoicesListDocument, GetInvoicesListQueryVariables } from '~/generated/graphql'
+import { TranslateFunc } from '~/hooks/core/useInternationalization'
 import { render } from '~/test-utils'
 import { getOperationVariableTypeName } from '~/test-utils/graphqlDocument'
 
@@ -30,7 +31,9 @@ jest.mock('~/components/MainHeader/MainHeader', () => ({
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({
-    translate: (key: string) => key,
+    // Interpolated values are appended so tests can assert on them without matching keys
+    translate: (key: string, args?: Record<string, unknown>) =>
+      args ? [key, ...Object.values(args)].join(' ') : key,
   }),
 }))
 
@@ -65,6 +68,16 @@ jest.mock('~/core/apolloClient', () => ({
 const mockRetryAll = jest.fn().mockResolvedValue({ errors: undefined })
 const mockCreateExport = jest.fn()
 
+const UNCAPPED_METADATA = {
+  currentPage: 1,
+  totalPages: 1,
+  totalCount: 5,
+  totalCountCapped: false,
+  hasNextPage: false,
+}
+
+let mockInvoicesMetadata: typeof UNCAPPED_METADATA = UNCAPPED_METADATA
+
 jest.mock('~/generated/graphql', () => ({
   ...jest.requireActual('~/generated/graphql'),
   useGetInvoicesListLazyQuery: (options?: { variables?: GetInvoicesListQueryVariables }) => {
@@ -75,7 +88,7 @@ jest.mock('~/generated/graphql', () => ({
       {
         data: {
           invoices: {
-            metadata: { currentPage: 1, totalPages: 1, totalCount: 5 },
+            metadata: mockInvoicesMetadata,
             collection: [],
           },
         },
@@ -103,15 +116,36 @@ jest.mock('~/components/invoices/FinalizeInvoiceDialog', () => ({
   useFinalizeInvoiceDialog: () => ({ openFinalizeInvoiceDialog: jest.fn() }),
 }))
 
+const mockOpenExportDialog = jest.fn()
+
 jest.mock('~/components/exports/ExportDialog', () => ({
-  useExportDialog: () => ({ openExportDialog: jest.fn() }),
+  useExportDialog: () => ({ openExportDialog: mockOpenExportDialog }),
 }))
+
+const mockFormatCountToMetadata = jest.fn()
+
+jest.mock('~/components/MainHeader/formatCountToMetadata', () => ({
+  formatCountToMetadata: (
+    count: number | undefined | null,
+    translate: TranslateFunc,
+    capped?: boolean,
+  ) => mockFormatCountToMetadata(count, translate, capped),
+}))
+
+const openExportDialogFromHeader = (): void => {
+  const exportAction = capturedConfig?.actions?.items[0]
+
+  if (exportAction?.type === 'action') {
+    exportAction.onClick?.()
+  }
+}
 
 describe('InvoicesPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     capturedConfig = null
     capturedListVariables = null
+    mockInvoicesMetadata = UNCAPPED_METADATA
   })
 
   describe('GIVEN the page is rendered', () => {
@@ -175,6 +209,72 @@ describe('InvoicesPage', () => {
       it('THEN should declare the amount variables as BigInt', () => {
         expect(getOperationVariableTypeName(GetInvoicesListDocument, 'amountFrom')).toBe('BigInt')
         expect(getOperationVariableTypeName(GetInvoicesListDocument, 'amountTo')).toBe('BigInt')
+      })
+    })
+  })
+
+  describe('GIVEN the total is exact', () => {
+    describe('WHEN the header count is built', () => {
+      it('THEN should format it as an exact total', () => {
+        render(<InvoicesPage />)
+
+        expect(mockFormatCountToMetadata).toHaveBeenCalledWith(5, expect.any(Function), false)
+      })
+    })
+
+    describe('WHEN the export dialog is opened', () => {
+      it('THEN should label it with the raw count', () => {
+        render(<InvoicesPage />)
+
+        openExportDialogFromHeader()
+
+        expect(mockOpenExportDialog).toHaveBeenCalledWith(
+          expect.objectContaining({ totalCountLabel: expect.stringContaining('5') }),
+        )
+      })
+    })
+  })
+
+  describe('GIVEN the total is capped', () => {
+    const CAPPED_METADATA = {
+      currentPage: 1,
+      totalPages: 500,
+      totalCount: 10000,
+      totalCountCapped: true,
+      hasNextPage: true,
+    }
+
+    beforeEach(() => {
+      mockInvoicesMetadata = CAPPED_METADATA
+    })
+
+    describe('WHEN the header count is built', () => {
+      it('THEN should flag it as capped', () => {
+        render(<InvoicesPage />)
+
+        expect(mockFormatCountToMetadata).toHaveBeenCalledWith(10000, expect.any(Function), true)
+      })
+    })
+
+    describe('WHEN the export dialog is opened', () => {
+      it('THEN should label it with the formatted floor', () => {
+        render(<InvoicesPage />)
+
+        openExportDialogFromHeader()
+
+        expect(mockOpenExportDialog).toHaveBeenCalledWith(
+          expect.objectContaining({ totalCountLabel: expect.stringContaining('10,000') }),
+        )
+      })
+    })
+
+    describe('WHEN the export action is configured', () => {
+      it('THEN should stay enabled (a capped total is a real count)', () => {
+        render(<InvoicesPage />)
+
+        const exportAction = capturedConfig?.actions?.items[0]
+
+        expect(exportAction?.type === 'action' && exportAction.disabled).toBeFalsy()
       })
     })
   })

--- a/translations/base.json
+++ b/translations/base.json
@@ -4846,5 +4846,8 @@
   "text_1785001812444mgdhh9wr0jj": "View all {{count}} rate cards",
   "text_1786374750349h8y80oq55h9": "Product category",
   "text_17863750835491khy0ht8740": "From {{min}} to {{max}}",
-  "text_1786375083549cfjzje75ere": "Price defined in event"
+  "text_1786375083549cfjzje75ere": "Price defined in event",
+  "text_1786997491915x333f5g35ff": "{{startNumber}}-{{endNumber}} of {{count}}+ results",
+  "text_1786997491915trapg3o2kee": "{{count}}+ results",
+  "text_1786997491915ihtx5q0emhp": "{{invoicesTotalCount}}+ invoices"
 }


### PR DESCRIPTION
Frontend counterpart to https://github.com/getlago/lago-api/pull/6165

## Context

The API caps the GraphQL invoice list total at 10,000 behind the per-organization
`invoice_search_terms` flag, because counting every match on a large organization means finding
every match: 14s of CPU and 10GB of buffer reads per distinct search. It adds `totalCountCapped`
and `hasNextPage` to the invoice collection metadata, so `totalCount` and `totalPages` become
lower bounds above the cap.

Until the frontend consumes those fields, enabling the flag on a large organization does not just
show a wrong number, it breaks navigation: next is hard-disabled at page 500
(`currentPage >= totalPages`), the out-of-range effect in `PaginatedContent` pulls a user who
reaches page 501 back to 500 on the next render, and `getPageRange` clamps the range end to the
floored total, rendering "11981-10000".

The frontend cannot ship before the API: it selects fields the deployed schema does not have, and
`getInvoicesList` would fail validation, taking the list with it. `docker-compose.yml` pins
`getlago/api` and `getlago/front` to the same tag, so both land in one release, API first. Until
then, do not enable `invoice_search_terms` on an organization with more than 10,000 invoices.

## Description

`getInvoicesList` selects `totalCountCapped` and `hasNextPage`; the customer-detail invoice tab and
the customer portal are not capped by the API and select nothing new, so they keep exact totals.
Regenerated types follow the API's switch to the `InvoiceCollectionMetadata` type — the other
invoice-shaped operations only change their `__typename`, no field added.

Both fields travel as optional props, so the ~25 other lists using the pagination components keep
today's behaviour byte-for-byte:

- `PaginatedContent` exports a shared `PaginationMetadata` type (the existing `Pick<CollectionMetadata,
  …>` plus the two new fields as `Partial`), forwards them to `Pagination`, and skips its
  out-of-range clamp while either is set. Both signals are needed: `hasNextPage` is page-local and
  false on the last page, which on a capped collection sits past the floored `totalPages`, so
  gating on it alone left the real last page unreachable.
- `Pagination` derives next from `hasNextPage ?? currentPage < totalPages`, and renders the capped
  copy when the total is a floor.
- `getPageRange` stops clamping the range end when another page follows or the total is capped —
  without the second condition the newly reachable last page rendered an inverted "12041-10000".
- `formatCountToMetadata` gains an optional `capped` argument (the nine other call sites are
  untouched), and the export dialog uses the capped copy: the export is server-side and covers
  every match, so a floor is the honest label.

Three new single-form keys print the floor pre-formatted with `intlFormatNumber` ("10,000+"):
pager label, page header, export dialog. Uncapped totals keep printing raw.

Tests cover next past `totalPages`, the last page of a capped list in both the clamp and the range,
the capped labels, and the capped/uncapped header and export paths.

Known trade-off, deliberate: a capped list no longer auto-corrects a stale `?page=999999` — it
shows its empty state until the user pages back. Recovering that, and making the last page's range
exact rather than a whole page, both need the rendered row count threaded into `PaginatedContent`,
which is left for a follow-up.

<!-- Linear link -->
Fixes ING-580

