### PR TITLE
fix(localStorage): refuse to persist nullish values

### DIFF
--- a/src/core/apolloClient/reactiveVars/__tests__/authTokenVar.test.ts
+++ b/src/core/apolloClient/reactiveVars/__tests__/authTokenVar.test.ts
@@ -1,0 +1,51 @@
+import {
+  AUTH_TOKEN_LS_KEY,
+  authTokenVar,
+  updateAuthTokenVar,
+} from '~/core/apolloClient/reactiveVars/authTokenVar'
+
+describe('authTokenVar', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('GIVEN updateAuthTokenVar is called with a token', () => {
+    describe('WHEN the token is a string', () => {
+      it('THEN should persist it verbatim', () => {
+        updateAuthTokenVar('a-real-token')
+
+        expect(localStorage.getItem(AUTH_TOKEN_LS_KEY)).toBe('a-real-token')
+      })
+
+      it('THEN should expose it on the var', () => {
+        updateAuthTokenVar('a-real-token')
+
+        expect(authTokenVar()).toBe('a-real-token')
+      })
+    })
+  })
+
+  describe('GIVEN updateAuthTokenVar is called with no argument (log out)', () => {
+    describe('WHEN a token was previously stored', () => {
+      it('THEN should remove the key instead of storing the string "undefined"', () => {
+        updateAuthTokenVar('a-real-token')
+
+        updateAuthTokenVar()
+
+        expect(localStorage.getItem(AUTH_TOKEN_LS_KEY)).toBeNull()
+      })
+
+      it('THEN should clear the var', () => {
+        updateAuthTokenVar('a-real-token')
+
+        updateAuthTokenVar()
+
+        expect(authTokenVar()).toBeUndefined()
+      })
+    })
+  })
+})

--- a/src/core/utils/__tests__/localStorage.test.ts
+++ b/src/core/utils/__tests__/localStorage.test.ts
@@ -1,0 +1,147 @@
+import { getItemFromLS, removeItemFromLS, setItemFromLS } from '~/core/utils/localStorage'
+
+const KEY = 'lago-test-key'
+
+describe('localStorage utils', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  describe('GIVEN setItemFromLS is called with a nullish value', () => {
+    describe('WHEN the value is undefined', () => {
+      it('THEN should not persist the string "undefined"', () => {
+        setItemFromLS(KEY, undefined)
+
+        expect(localStorage.getItem(KEY)).toBeNull()
+      })
+    })
+
+    describe('WHEN the value is null', () => {
+      it('THEN should not persist the string "null"', () => {
+        setItemFromLS(KEY, null)
+
+        expect(localStorage.getItem(KEY)).toBeNull()
+      })
+    })
+
+    describe('WHEN the key already holds a value', () => {
+      it.each([
+        ['undefined', undefined],
+        ['null', null],
+      ])('THEN should remove the previous value for %s', (_, value) => {
+        setItemFromLS(KEY, 'a-real-token')
+
+        setItemFromLS(KEY, value)
+
+        expect(localStorage.getItem(KEY)).toBeNull()
+      })
+    })
+  })
+
+  describe('GIVEN setItemFromLS is called with a non-nullish value', () => {
+    describe('WHEN the value is a string', () => {
+      it('THEN should store it verbatim without JSON quoting', () => {
+        setItemFromLS(KEY, 'a-real-token')
+
+        expect(localStorage.getItem(KEY)).toBe('a-real-token')
+      })
+    })
+
+    describe('WHEN the value is not a string', () => {
+      it.each([
+        ['an object', { locale: 'fr' }],
+        ['an array', [1, 2, 3]],
+        ['a number', 42],
+        ['a boolean', false],
+      ])('THEN should JSON stringify %s', (_, value) => {
+        setItemFromLS(KEY, value)
+
+        expect(localStorage.getItem(KEY)).toBe(JSON.stringify(value))
+      })
+
+      it('THEN should round-trip through getItemFromLS', () => {
+        const value = { locale: 'fr', translations: { key: 'label' } }
+
+        setItemFromLS(KEY, value)
+
+        expect(getItemFromLS(KEY)).toEqual(value)
+      })
+    })
+  })
+
+  describe('GIVEN a key was poisoned by an older version', () => {
+    describe('WHEN the raw stored value is the string "undefined"', () => {
+      it('THEN getItemFromLS should return undefined instead of throwing', () => {
+        localStorage.setItem(KEY, 'undefined')
+
+        expect(getItemFromLS(KEY)).toBeUndefined()
+      })
+    })
+  })
+
+  describe('GIVEN a key holds a value getItemFromLS cannot parse', () => {
+    describe('WHEN the raw stored value is not valid JSON', () => {
+      it('THEN should return the raw string', () => {
+        localStorage.setItem(KEY, 'not-json{')
+
+        expect(getItemFromLS(KEY)).toBe('not-json{')
+      })
+    })
+  })
+
+  describe('GIVEN a key was never written', () => {
+    describe('WHEN reading it', () => {
+      it('THEN should return null', () => {
+        expect(getItemFromLS(KEY)).toBeNull()
+      })
+    })
+  })
+
+  describe('GIVEN the underlying storage access throws', () => {
+    describe('WHEN reading a key', () => {
+      it('THEN getItemFromLS should return undefined instead of throwing', () => {
+        jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+          throw new Error('The operation is insecure.')
+        })
+
+        expect(() => getItemFromLS(KEY)).not.toThrow()
+        expect(getItemFromLS(KEY)).toBeUndefined()
+      })
+    })
+
+    describe('WHEN writing a key', () => {
+      it('THEN setItemFromLS should not throw', () => {
+        jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+          throw new Error('QuotaExceededError')
+        })
+
+        expect(() => setItemFromLS(KEY, 'a-real-token')).not.toThrow()
+      })
+    })
+
+    describe('WHEN removing a key', () => {
+      it('THEN removeItemFromLS should not throw', () => {
+        jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+          throw new Error('The operation is insecure.')
+        })
+
+        expect(() => removeItemFromLS(KEY)).not.toThrow()
+      })
+    })
+
+    describe('WHEN persisting a nullish value', () => {
+      it('THEN setItemFromLS should not throw', () => {
+        jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+          throw new Error('The operation is insecure.')
+        })
+
+        expect(() => setItemFromLS(KEY, undefined)).not.toThrow()
+      })
+    })
+  })
+})

--- a/src/core/utils/localStorage.ts
+++ b/src/core/utils/localStorage.ts
@@ -7,27 +7,54 @@
  * This file MUST NOT import from `@apollo/client`, `~/core/apolloClient`,
  * or anything that transitively pulls them in. That invariant is what makes
  * it safe to import from any reactive var.
+ *
+ * Every storage access is wrapped: `localStorage` itself throws in Safari
+ * private mode, with "block all cookies" enabled, and in sandboxed iframes.
+ * The module-init callers (`authTokenVar`, `customerPortalTokenVar`,
+ * `duplicatePlanVar`, `internationalizationVar`) run during import evaluation,
+ * before React mounts — an escaping error there is a blank page with no error
+ * boundary and no Sentry event, so these helpers degrade silently instead.
  */
 export const getItemFromLS = (key: string) => {
-  const data = typeof window !== 'undefined' ? localStorage.getItem(key) : ''
+  if (typeof window === 'undefined') return ''
+
+  let data: string | null
 
   try {
-    if (data === 'undefined') {
-      return undefined
-    }
+    data = localStorage.getItem(key)
+  } catch {
+    return undefined
+  }
 
+  // Keys poisoned by an older version that persisted the string "undefined"
+  // still exist in users' browsers and must keep reading back as `undefined`.
+  if (data === 'undefined') return undefined
+
+  try {
     return !!data ? JSON.parse(data) : data
   } catch {
     return data
   }
 }
 
-export const setItemFromLS = (key: string, value: unknown) => {
-  const stringify = typeof value !== 'string' ? JSON.stringify(value) : value
-
-  return localStorage.setItem(key, stringify)
+export const removeItemFromLS = (key: string): void => {
+  try {
+    localStorage.removeItem(key)
+  } catch {
+    // Storage unavailable — nothing to remove, nothing to report.
+  }
 }
 
-export const removeItemFromLS = (key: string) => {
-  return localStorage.removeItem(key)
+export const setItemFromLS = (key: string, value: unknown): void => {
+  // `JSON.stringify(undefined)` returns the *value* `undefined`, which
+  // `Storage.setItem` coerces to the string "undefined" through its WebIDL
+  // `DOMString` argument. Removing the key is the only correct persistence of
+  // a nullish value.
+  if (value === undefined || value === null) return removeItemFromLS(key)
+
+  try {
+    localStorage.setItem(key, typeof value === 'string' ? value : JSON.stringify(value))
+  } catch {
+    // Storage unavailable or quota exceeded — the value stays in memory only.
+  }
 }

--- a/src/core/utils/localStorage.ts
+++ b/src/core/utils/localStorage.ts
@@ -53,7 +53,9 @@ export const setItemFromLS = (key: string, value: unknown): void => {
   if (value === undefined || value === null) return removeItemFromLS(key)
 
   try {
-    localStorage.setItem(key, typeof value === 'string' ? value : JSON.stringify(value))
+    const stringify = typeof value !== 'string' ? JSON.stringify(value) : value
+
+    localStorage.setItem(key, stringify)
   } catch {
     // Storage unavailable or quota exceeded — the value stays in memory only.
   }


### PR DESCRIPTION
## Context

Every logout persisted the 9-character string `undefined` as the stored auth
token. `logOut` calls `updateAuthTokenVar()` with no argument, which reaches
`setItemFromLS(AUTH_TOKEN_LS_KEY, undefined)`. There, the
`typeof value !== 'string' ? JSON.stringify(value) : value` branch yields the
*value* `undefined` (`JSON.stringify(undefined)` is not a string), and
`Storage.setItem` coerces it to `"undefined"` through its WebIDL `DOMString`
argument.

In-app this stayed inert only because of a read-side workaround in
`getItemFromLS`, which special-cases `data === 'undefined'`. That guard is
load-bearing and had no test coverage — there was no test file for
`localStorage.ts` at all. Any consumer reading the key without going through
`getItemFromLS` breaks: `cypress/support/e2e.ts` guards with `if (!token)`, and
the string `"undefined"` is truthy, so the suite proceeded and sent
`Authorization: Bearer undefined`.

Separately, `localStorage` itself throws in Safari private mode, with "block all
cookies" enabled, and in sandboxed iframes. `getItemFromLS` performed its
`localStorage.getItem` outside its own `try` block, and the two mutators had no
`try/catch` at all. The four module-init callers — `authTokenVar`,
`customerPortalTokenVar`, `duplicatePlanVar`, `internationalizationVar` — run
during import evaluation, before React mounts, so an escaping error there is a
blank page with no error boundary and no Sentry event.

## Description

`setItemFromLS` now removes the key when the value is `undefined` or `null`
instead of persisting a string. This fixes the whole class rather than the auth
token alone: the same shape existed latently for the customer portal token via
`onAccessCustomerPortal()`. `logOut` needs no change — `updateAuthTokenVar()`
now clears both the localStorage key and the reactive var in one call.

All three helpers wrap their storage access in `try/catch`. `getItemFromLS`
returns `undefined` when the read throws; the two mutators become no-ops. The
legacy `data === 'undefined'` read guard stays: keys poisoned by earlier
versions still exist in users' browsers and must keep reading back as
`undefined`.

Adds the missing test file for `src/core/utils/localStorage.ts`, pinning that
read guard along with the nullish-removal, verbatim string storage, JSON
round-trip, malformed-JSON fallback, and throwing-storage paths. Adds a test
for `authTokenVar` covering the logout path end to end.

<!-- Linear link -->
Fixes LAGO-1830
