### PR TITLE
fix(app-env): fail closed when appEnv is undefined

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -5,7 +5,7 @@ interface Window {
 
 declare type AppEnvEnum = import('./src/core/constants/globalTypes').AppEnvEnum
 
-declare var APP_ENV: AppEnvEnum
+declare var APP_ENV: AppEnvEnum | undefined
 declare var API_URL: string
 declare var LAGO_DOMAIN: string
 declare var APP_VERSION: string

--- a/src/components/creditNote/CreditNoteDetailsExternalSync.tsx
+++ b/src/components/creditNote/CreditNoteDetailsExternalSync.tsx
@@ -12,8 +12,8 @@ import {
   buildNetsuiteCreditNoteUrl,
   buildXeroCreditNoteUrl,
 } from '~/core/constants/externalUrls'
-import { AppEnvEnum } from '~/core/constants/globalTypes'
 import { Link } from '~/core/router'
+import { isProductionAppEnv } from '~/core/utils/appEnv'
 import { getConnectedIntegration } from '~/core/utils/integrations'
 import {
   AnrokIntegration,
@@ -258,7 +258,7 @@ export const CreditNoteDetailsExternalSync: FC<CreditNoteDetailsExternalSyncProp
                 accountId: connectedAvalaraIntegration?.accountId,
                 companyId: connectedAvalaraIntegration?.companyId || '',
                 objectId: creditNote?.taxProviderId,
-                isSandbox: appEnv !== AppEnvEnum.production,
+                isSandbox: !isProductionAppEnv(appEnv),
               })}
               id={creditNote?.taxProviderId}
             />

--- a/src/components/creditNote/__tests__/CreditNoteDetailsExternalSync.test.tsx
+++ b/src/components/creditNote/__tests__/CreditNoteDetailsExternalSync.test.tsx
@@ -1,0 +1,99 @@
+import { screen } from '@testing-library/react'
+
+import { render } from '~/test-utils'
+
+import { CreditNoteDetailsExternalSync } from '../CreditNoteDetailsExternalSync'
+
+// A deployment that never exported APP_ENV resolves `appEnv` to `undefined`. The external
+// links must then point at the LIVE Avalara dashboard, never at the sandbox one.
+jest.mock('~/core/apolloClient', () => {
+  const actual = jest.requireActual('~/core/apolloClient')
+
+  return {
+    ...actual,
+    envGlobalVar: () => ({ appEnv: undefined }),
+  }
+})
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+    locale: 'en',
+  }),
+}))
+
+const mockCreditNoteQuery = jest.fn()
+const mockIntegrationsQuery = jest.fn()
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useGetCreditNoteForDetailsExternalSyncQuery: () => mockCreditNoteQuery(),
+  useGetIntegrationsListForCreditNoteDetailsExternalSyncQuery: () => mockIntegrationsQuery(),
+}))
+
+const AVALARA_INTEGRATION_ID = 'avalara-integration-1'
+
+describe('CreditNoteDetailsExternalSync', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockCreditNoteQuery.mockReturnValue({
+      data: {
+        creditNote: {
+          id: 'credit-note-1',
+          taxProviderId: 'tax-provider-object-1',
+          taxProviderSyncable: false,
+          externalIntegrationId: null,
+          customer: {
+            anrokCustomer: null,
+            avalaraCustomer: { id: 'avalara-customer-1', integrationId: AVALARA_INTEGRATION_ID },
+            netsuiteCustomer: null,
+            xeroCustomer: null,
+          },
+        },
+      },
+    })
+
+    mockIntegrationsQuery.mockReturnValue({
+      data: {
+        integrations: {
+          collection: [
+            {
+              __typename: 'AvalaraIntegration',
+              id: AVALARA_INTEGRATION_ID,
+              accountId: 'account-1',
+              companyId: 'company-1',
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  describe('GIVEN a credit note synced with Avalara', () => {
+    describe('WHEN appEnv is undefined because the deployment did not set APP_ENV', () => {
+      it('THEN should link to the live Avalara dashboard', () => {
+        render(<CreditNoteDetailsExternalSync retryTaxSync={jest.fn()} />, {
+          useParams: { customerId: 'customer-1', creditNoteId: 'credit-note-1' },
+        })
+
+        const link = screen.getByText('tax-provider-object-1').closest('a')
+
+        expect(link).toHaveAttribute(
+          'href',
+          'https://admin.avalara.com/cup/a/account-1/c/company-1/transactions/tax-provider-object-1',
+        )
+      })
+
+      it('THEN should not link to the sandbox Avalara dashboard', () => {
+        render(<CreditNoteDetailsExternalSync retryTaxSync={jest.fn()} />, {
+          useParams: { customerId: 'customer-1', creditNoteId: 'credit-note-1' },
+        })
+
+        const link = screen.getByText('tax-provider-object-1').closest('a')
+
+        expect(link?.getAttribute('href')).not.toContain('sandbox.')
+      })
+    })
+  })
+})

--- a/src/core/apolloClient/reactiveVars/envGlobalVar.ts
+++ b/src/core/apolloClient/reactiveVars/envGlobalVar.ts
@@ -3,7 +3,7 @@ import { makeVar } from '@apollo/client'
 import { AppEnvEnum } from '~/core/constants/globalTypes'
 
 interface EnvGlobal {
-  appEnv: AppEnvEnum
+  appEnv: AppEnvEnum | undefined
   apiUrl: string
   lagoOauthProxyUrl: string
   disableSignUp: boolean

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -1,5 +1,5 @@
 import { envGlobalVar } from '~/core/apolloClient'
-import { AppEnvEnum } from '~/core/constants/globalTypes'
+import { isDevOrQaAppEnv } from '~/core/utils/appEnv'
 
 import { authRoutes } from './AuthRoutes'
 import { customerPortalRoutes } from './CustomerPortalRoutes'
@@ -93,9 +93,7 @@ const analyticsInlineRoutes: CustomRouteObject[] = [
   },
 ]
 
-const devOnlyInlineRoutes: CustomRouteObject[] = [AppEnvEnum.qa, AppEnvEnum.development].includes(
-  appEnv,
-)
+const devOnlyInlineRoutes: CustomRouteObject[] = isDevOrQaAppEnv(appEnv)
   ? [
       {
         path: [ONLY_DEV_DESIGN_SYSTEM_ROUTE, ONLY_DEV_DESIGN_SYSTEM_TAB_ROUTE],

--- a/src/core/translations/__tests__/utils.test.ts
+++ b/src/core/translations/__tests__/utils.test.ts
@@ -1,3 +1,5 @@
+import { captureMessage } from '@sentry/react'
+
 import { AppEnvEnum } from '~/core/constants/globalTypes'
 import { LocaleEnum } from '~/core/translations/types'
 import {
@@ -5,6 +7,10 @@ import {
   replaceDynamicVarInString,
   translateKey,
 } from '~/core/translations/utils'
+
+jest.mock('@sentry/react', () => ({
+  captureMessage: jest.fn(),
+}))
 
 describe('utils', () => {
   describe('translateKey', () => {
@@ -49,10 +55,52 @@ describe('utils', () => {
     })
 
     describe('when the key is missing', () => {
+      beforeEach(() => {
+        jest.clearAllMocks()
+      })
+
       it('returns the key itself', () => {
         expect(
           translateKey({ ...baseContext, translations: { greeting: 'Hello' } }, 'missing_key'),
         ).toEqual('missing_key')
+      })
+
+      it('reports it to Sentry on production for a non-english locale', () => {
+        translateKey(
+          {
+            translations: { greeting: 'Hello' },
+            locale: LocaleEnum.fr,
+            appEnv: AppEnvEnum.production,
+          },
+          'missing_key',
+        )
+
+        expect(captureMessage).toHaveBeenCalledTimes(1)
+      })
+
+      it('reports it to Sentry when appEnv is undefined for a non-english locale', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+        translateKey(
+          { translations: { greeting: 'Hello' }, locale: LocaleEnum.fr, appEnv: undefined },
+          'missing_key',
+        )
+
+        expect(captureMessage).toHaveBeenCalledTimes(1)
+        expect(warnSpy).not.toHaveBeenCalled()
+
+        warnSpy.mockRestore()
+      })
+
+      it('warns in the console on development instead of reporting to Sentry', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+        translateKey({ ...baseContext, translations: { greeting: 'Hello' } }, 'missing_key')
+
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        expect(captureMessage).not.toHaveBeenCalled()
+
+        warnSpy.mockRestore()
       })
     })
   })

--- a/src/core/translations/utils.ts
+++ b/src/core/translations/utils.ts
@@ -1,6 +1,7 @@
 import { captureMessage } from '@sentry/react'
 
 import { AppEnvEnum } from '~/core/constants/globalTypes'
+import { isDevOrQaAppEnv, isProductionAppEnv } from '~/core/utils/appEnv'
 
 import { Locale, LocaleEnum, TranslateData, Translation, Translations } from './types'
 
@@ -41,7 +42,7 @@ export const translateKey: (
   context: {
     translations: Translations
     locale: Locale
-    appEnv: AppEnvEnum
+    appEnv: AppEnvEnum | undefined
   },
   key: string,
   data?: TranslateData,
@@ -60,7 +61,7 @@ export const translateKey: (
     const translationErrorMessage = `Translation '${key}' for locale '${locale}' not found.`
 
     // We decide to capture the error in production only for non english locale
-    if (appEnv === AppEnvEnum.production && locale !== LocaleEnum.en) {
+    if (isProductionAppEnv(appEnv) && locale !== LocaleEnum.en) {
       const customStack = new Error().stack
 
       captureMessage(translationErrorMessage, {
@@ -69,7 +70,7 @@ export const translateKey: (
           customStack,
         },
       })
-    } else if ([AppEnvEnum.qa, AppEnvEnum.development].includes(appEnv)) {
+    } else if (isDevOrQaAppEnv(appEnv)) {
       // eslint-disable-next-line no-console
       console.warn(translationErrorMessage)
     }

--- a/src/core/utils/__tests__/appEnv.test.ts
+++ b/src/core/utils/__tests__/appEnv.test.ts
@@ -1,7 +1,45 @@
+import { captureMessage } from '@sentry/react'
+
 import { AppEnvEnum } from '~/core/constants/globalTypes'
-import { isDevOrQaAppEnv, isProductionAppEnv } from '~/core/utils/appEnv'
+import { isDevOrQaAppEnv, isProductionAppEnv, reportMissingAppEnv } from '~/core/utils/appEnv'
+
+jest.mock('@sentry/react', () => ({
+  captureMessage: jest.fn(),
+}))
+
+// Single source of truth for what each environment is allowed to do. The `Record` makes a new
+// `AppEnvEnum` member a compile error here, and the membership test below catches a removed one,
+// so neither helper can silently keep classifying an environment it no longer knows about.
+const CLASSIFIED: Record<AppEnvEnum, { production: boolean; devTools: boolean }> = {
+  [AppEnvEnum.production]: { production: true, devTools: false },
+  [AppEnvEnum.staging]: { production: false, devTools: false },
+  [AppEnvEnum.development]: { production: false, devTools: true },
+  [AppEnvEnum.qa]: { production: false, devTools: true },
+}
 
 describe('appEnv', () => {
+  describe('CLASSIFIED', () => {
+    describe('GIVEN the AppEnvEnum members', () => {
+      describe('WHEN a member is added to or removed from the enum', () => {
+        it('THEN should classify exactly the declared members', () => {
+          expect(Object.keys(CLASSIFIED).sort()).toEqual(Object.values(AppEnvEnum).sort())
+        })
+      })
+    })
+
+    describe('GIVEN the classification table', () => {
+      describe('WHEN each declared environment is checked', () => {
+        it.each(Object.entries(CLASSIFIED))(
+          'THEN should report %s as classified',
+          (appEnv, { production, devTools }) => {
+            expect(isProductionAppEnv(appEnv as AppEnvEnum)).toBe(production)
+            expect(isDevOrQaAppEnv(appEnv as AppEnvEnum)).toBe(devTools)
+          },
+        )
+      })
+    })
+  })
+
   describe('isProductionAppEnv', () => {
     describe('GIVEN a known non-production environment', () => {
       describe('WHEN the value is staging, development or qa', () => {
@@ -59,6 +97,48 @@ describe('appEnv', () => {
       describe('WHEN APP_ENV was never set on the deployment', () => {
         it('THEN should fail closed and return false for undefined', () => {
           expect(isDevOrQaAppEnv(undefined)).toBe(false)
+        })
+      })
+    })
+  })
+
+  describe('reportMissingAppEnv', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    describe('GIVEN a deployment that never set APP_ENV', () => {
+      describe('WHEN the app boots', () => {
+        it('THEN should report the misconfiguration to Sentry as a warning', () => {
+          reportMissingAppEnv(undefined)
+
+          expect(captureMessage).toHaveBeenCalledTimes(1)
+          expect(captureMessage).toHaveBeenCalledWith(expect.any(String), { level: 'warning' })
+        })
+
+        it('THEN should warn in the console for deployments without a Sentry DSN', () => {
+          const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+          reportMissingAppEnv(undefined)
+
+          expect(warnSpy).toHaveBeenCalledTimes(1)
+
+          warnSpy.mockRestore()
+        })
+      })
+    })
+
+    describe('GIVEN a deployment with APP_ENV set', () => {
+      describe('WHEN the app boots', () => {
+        it.each(Object.keys(CLASSIFIED))('THEN should stay silent on %s', (appEnv) => {
+          const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+          reportMissingAppEnv(appEnv as AppEnvEnum)
+
+          expect(captureMessage).not.toHaveBeenCalled()
+          expect(warnSpy).not.toHaveBeenCalled()
+
+          warnSpy.mockRestore()
         })
       })
     })

--- a/src/core/utils/__tests__/appEnv.test.ts
+++ b/src/core/utils/__tests__/appEnv.test.ts
@@ -1,0 +1,66 @@
+import { AppEnvEnum } from '~/core/constants/globalTypes'
+import { isDevOrQaAppEnv, isProductionAppEnv } from '~/core/utils/appEnv'
+
+describe('appEnv', () => {
+  describe('isProductionAppEnv', () => {
+    describe('GIVEN a known non-production environment', () => {
+      describe('WHEN the value is staging, development or qa', () => {
+        it.each([
+          ['staging', AppEnvEnum.staging],
+          ['development', AppEnvEnum.development],
+          ['qa', AppEnvEnum.qa],
+        ])('THEN should return false for %s', (_, appEnv) => {
+          expect(isProductionAppEnv(appEnv)).toBe(false)
+        })
+      })
+    })
+
+    describe('GIVEN the production environment', () => {
+      describe('WHEN the value is production', () => {
+        it('THEN should return true', () => {
+          expect(isProductionAppEnv(AppEnvEnum.production)).toBe(true)
+        })
+      })
+    })
+
+    describe('GIVEN no environment at all', () => {
+      describe('WHEN APP_ENV was never set on the deployment', () => {
+        it('THEN should fail closed and return true for undefined', () => {
+          expect(isProductionAppEnv(undefined)).toBe(true)
+        })
+      })
+    })
+  })
+
+  describe('isDevOrQaAppEnv', () => {
+    describe('GIVEN a developer environment', () => {
+      describe('WHEN the value is development or qa', () => {
+        it.each([
+          ['development', AppEnvEnum.development],
+          ['qa', AppEnvEnum.qa],
+        ])('THEN should return true for %s', (_, appEnv) => {
+          expect(isDevOrQaAppEnv(appEnv)).toBe(true)
+        })
+      })
+    })
+
+    describe('GIVEN a deployed environment', () => {
+      describe('WHEN the value is production or staging', () => {
+        it.each([
+          ['production', AppEnvEnum.production],
+          ['staging', AppEnvEnum.staging],
+        ])('THEN should return false for %s', (_, appEnv) => {
+          expect(isDevOrQaAppEnv(appEnv)).toBe(false)
+        })
+      })
+    })
+
+    describe('GIVEN no environment at all', () => {
+      describe('WHEN APP_ENV was never set on the deployment', () => {
+        it('THEN should fail closed and return false for undefined', () => {
+          expect(isDevOrQaAppEnv(undefined)).toBe(false)
+        })
+      })
+    })
+  })
+})

--- a/src/core/utils/__tests__/featureFlagsConsole.test.ts
+++ b/src/core/utils/__tests__/featureFlagsConsole.test.ts
@@ -54,6 +54,23 @@ describe('featureFlagsConsole', () => {
       expect(groupEndSpy).toHaveBeenCalledTimes(1)
     })
 
+    it('exposes the api when appEnv is undefined', () => {
+      installLagoWindowApi(undefined)
+
+      expect(window.Lago.getEnableFeatureFlags).toBeInstanceOf(Function)
+      expect(window.Lago.setFeatureFlags).toBeInstanceOf(Function)
+      expect(window.Lago.listFeatureFlags).toBeInstanceOf(Function)
+      expect(window.Lago.help).toBeInstanceOf(Function)
+    })
+
+    it('stays silent when appEnv is undefined', () => {
+      installLagoWindowApi(undefined)
+
+      expect(groupCollapsedSpy).not.toHaveBeenCalled()
+      expect(infoSpy).not.toHaveBeenCalled()
+      expect(groupEndSpy).not.toHaveBeenCalled()
+    })
+
     it('prints the help on demand once installed on production', () => {
       installLagoWindowApi(AppEnvEnum.production)
 

--- a/src/core/utils/appEnv.ts
+++ b/src/core/utils/appEnv.ts
@@ -1,3 +1,5 @@
+import { captureMessage } from '@sentry/react'
+
 import { AppEnvEnum } from '~/core/constants/globalTypes'
 
 // `appEnv` comes from `window.APP_ENV || APP_ENV` and both sources can be empty: the Vite
@@ -11,3 +13,18 @@ export const isProductionAppEnv = (appEnv: AppEnvEnum | undefined): boolean =>
 
 export const isDevOrQaAppEnv = (appEnv: AppEnvEnum | undefined): boolean =>
   appEnv === AppEnvEnum.development || appEnv === AppEnvEnum.qa
+
+// The fail-closed default above keeps a misconfigured deployment safe, but also silent:
+// @sentry/core reports a missing `environment` as the string 'production', so events from a
+// deployment that never set APP_ENV are indistinguishable from real production ones. Report it
+// once at startup instead. `console.warn` covers deployments without a Sentry DSN, where
+// `captureMessage` is a no-op.
+export const reportMissingAppEnv = (appEnv: AppEnvEnum | undefined): void => {
+  if (appEnv) return
+
+  const message = 'APP_ENV is not set, the app defaults to production behavior'
+
+  captureMessage(message, { level: 'warning' })
+  // eslint-disable-next-line no-console
+  console.warn(message)
+}

--- a/src/core/utils/appEnv.ts
+++ b/src/core/utils/appEnv.ts
@@ -1,0 +1,13 @@
+import { AppEnvEnum } from '~/core/constants/globalTypes'
+
+// `appEnv` comes from `window.APP_ENV || APP_ENV` and both sources can be empty: the Vite
+// `define` is `void 0` when the build has no `APP_ENV`, and `.env.sh` writes an empty string
+// when the deployment does not export it. Both helpers therefore fail closed on an unknown
+// value: production behavior, nothing developer-facing opened by accident. Comparisons are
+// written member by member (no `Array.includes`) so a new `AppEnvEnum` member also lands on
+// the closed branch until it is handled explicitly.
+export const isProductionAppEnv = (appEnv: AppEnvEnum | undefined): boolean =>
+  appEnv !== AppEnvEnum.staging && appEnv !== AppEnvEnum.development && appEnv !== AppEnvEnum.qa
+
+export const isDevOrQaAppEnv = (appEnv: AppEnvEnum | undefined): boolean =>
+  appEnv === AppEnvEnum.development || appEnv === AppEnvEnum.qa

--- a/src/core/utils/featureFlagsConsole.ts
+++ b/src/core/utils/featureFlagsConsole.ts
@@ -1,4 +1,5 @@
 import { AppEnvEnum } from '~/core/constants/globalTypes'
+import { isProductionAppEnv } from '~/core/utils/appEnv'
 import { getEnableFeatureFlags, listFeatureFlags, setFeatureFlags } from '~/core/utils/featureFlags'
 
 /**
@@ -38,7 +39,7 @@ export const printFeatureFlagsHelp = (): void => {
   /* eslint-enable no-console */
 }
 
-export const installLagoWindowApi = (appEnv: AppEnvEnum): void => {
+export const installLagoWindowApi = (appEnv: AppEnvEnum | undefined): void => {
   window.Lago = {
     getEnableFeatureFlags,
     setFeatureFlags,
@@ -46,7 +47,7 @@ export const installLagoWindowApi = (appEnv: AppEnvEnum): void => {
     help: printFeatureFlagsHelp,
   }
 
-  if (appEnv !== AppEnvEnum.production) {
+  if (!isProductionAppEnv(appEnv)) {
     printFeatureFlagsHelp()
   }
 }

--- a/src/layouts/MainNavLayout/BottomNavSection.tsx
+++ b/src/layouts/MainNavLayout/BottomNavSection.tsx
@@ -3,12 +3,12 @@ import Stack from '@mui/material/Stack'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { VerticalMenu } from '~/components/designSystem/VerticalMenu'
 import { envGlobalVar } from '~/core/apolloClient'
-import { AppEnvEnum } from '~/core/constants/globalTypes'
 import {
   ONLY_DEV_DESIGN_SYSTEM_ROUTE,
   ONLY_DEV_DESIGN_SYSTEM_TAB_ROUTE,
   SETTINGS_ROUTE,
 } from '~/core/router'
+import { isDevOrQaAppEnv } from '~/core/utils/appEnv'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useDeveloperTool } from '~/hooks/useDeveloperTool'
 import { usePermissions } from '~/hooks/usePermissions'
@@ -36,7 +36,7 @@ export const BottomNavSection = ({ isLoading, onItemClick }: BottomNavSectionPro
       icon: 'rocket',
       link: ONLY_DEV_DESIGN_SYSTEM_ROUTE,
       match: [ONLY_DEV_DESIGN_SYSTEM_TAB_ROUTE, ONLY_DEV_DESIGN_SYSTEM_ROUTE],
-      hidden: ![AppEnvEnum.qa, AppEnvEnum.development].includes(appEnv),
+      hidden: !isDevOrQaAppEnv(appEnv),
     },
     {
       title: translate('text_62728ff857d47b013204c726'),

--- a/src/layouts/MainNavLayout/__tests__/BottomNavSection.test.tsx
+++ b/src/layouts/MainNavLayout/__tests__/BottomNavSection.test.tsx
@@ -130,6 +130,20 @@ describe('BottomNavSection', () => {
       expect(screen.getByTestId(BOTTOM_NAV_SECTION_TEST_ID)).toBeInTheDocument()
     })
 
+    it('does not render section when appEnv is undefined with no permissions', () => {
+      // A deployment without APP_ENV must behave like production: the design system tab
+      // stays hidden instead of leaking a developer surface.
+      envGlobalVar.mockReturnValue({ appEnv: undefined })
+
+      mockHasPermissions.mockReturnValue(false)
+      mockHasPermissionsOr.mockReturnValue(false)
+
+      const { container } = render(<BottomNavSection {...defaultProps} />)
+
+      expect(screen.queryByTestId(BOTTOM_NAV_SECTION_TEST_ID)).not.toBeInTheDocument()
+      expect(container.firstChild).toBeNull()
+    })
+
     it('renders section when at least one tab is visible (design system in QA)', () => {
       // QA environment where design system tab is visible
       envGlobalVar.mockReturnValue({ appEnv: 'qa' })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client'
 import App from '~/App'
 import { envGlobalVar } from '~/core/apolloClient'
 import { AppEnvEnum } from '~/core/constants/globalTypes'
+import { reportMissingAppEnv } from '~/core/utils/appEnv'
 import { installLagoWindowApi } from '~/core/utils/featureFlagsConsole'
 
 import './main.css'
@@ -85,6 +86,8 @@ window.addEventListener('vite:preloadError', (event) => {
     },
   })
 })
+
+reportMissingAppEnv(appEnv)
 
 installLagoWindowApi(appEnv)
 

--- a/src/pages/InvoiceOverview.tsx
+++ b/src/pages/InvoiceOverview.tsx
@@ -26,9 +26,9 @@ import {
   buildSalesforceUrl,
   buildXeroInvoiceUrl,
 } from '~/core/constants/externalUrls'
-import { AppEnvEnum } from '~/core/constants/globalTypes'
 import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { CUSTOMER_INVOICE_DETAILS_ROUTE, Link } from '~/core/router'
+import { isProductionAppEnv } from '~/core/utils/appEnv'
 import {
   AllInvoiceDetailsForCustomerInvoiceDetailsFragment,
   AvalaraIntegrationInfosForInvoiceOverviewFragment,
@@ -626,7 +626,7 @@ const InvoiceOverview = memo(
                             companyId: connectedAvalaraIntegration?.companyId || '',
                             accountId: connectedAvalaraIntegration?.accountId,
                             objectId: String(invoice?.taxProviderId || ''),
-                            isSandbox: appEnv !== AppEnvEnum.production,
+                            isSandbox: !isProductionAppEnv(appEnv),
                           })}
                         >
                           <Typography


### PR DESCRIPTION
## Context

`appEnv` is resolved as `window.APP_ENV || APP_ENV` and both sources can be
empty: the Vite `define` is `void 0` when the build has no `APP_ENV`, and
`.env.sh` writes an empty string when the deployment does not export it. The
types claimed the value always exists, so nothing flagged the inline
`appEnv !== AppEnvEnum.production` gates — on a deployment without `APP_ENV`
they all evaluate to `true`, opening every non-production path in production.

Two of those gates are user-facing: the Avalara links on invoices and credit
notes point at the sandbox dashboard instead of the live one. The
production-only missing-translation reporting and the `window.Lago`
feature-flag console are affected too.

## Description

- Type the value honestly: `declare var APP_ENV: AppEnvEnum | undefined`
  (`globals.d.ts`) and `EnvGlobal.appEnv: AppEnvEnum | undefined`.
- Add `src/core/utils/appEnv.ts` with two fail-closed helpers,
  `isProductionAppEnv` (unknown ⇒ production) and `isDevOrQaAppEnv`
  (unknown ⇒ not a developer environment). Both compare enum members
  explicitly, so a new `AppEnvEnum` member also lands on the closed branch.
- Route every environment gate through them: the two Avalara `isSandbox`
  computations (`InvoiceOverview`, `CreditNoteDetailsExternalSync`), the
  feature-flag console help print, the missing-translation Sentry/console
  branches, the dev-only routes and the design-system nav entry.
- Tests: full coverage of both helpers including the `undefined` cases, an
  `undefined` case in the feature-flag console and nav suites, missing-key
  reporting cases in the translations suite, and a new
  `CreditNoteDetailsExternalSync` test asserting the live Avalara URL when
  `appEnv` is undefined.

No infrastructure change: adding `APP_ENV` to the image build args belongs to
the deployment repository.

<!-- Linear link -->
Fixes LAGO-1829