### PR TITLE
fix(plans): keep the plan form fields required locally

### DIFF
--- a/src/components/plans/types.ts
+++ b/src/components/plans/types.ts
@@ -9,6 +9,7 @@ import {
   EntitlementInput,
   EntitlementPrivilegeInput,
   FixedChargeInput,
+  PlanInterval,
   PrivilegeValueTypeEnum,
   PropertiesInput,
   TaxForPlanAndChargesInPlanFormFragment,
@@ -81,8 +82,20 @@ export type LocalEntitlementInput = Omit<EntitlementInput, 'privileges'> & {
 
 export type PlanFormInput = Omit<
   CreatePlanInput,
-  'clientMutationId' | 'charges' | 'usageThresholds' | 'entitlements' | 'fixedCharges'
+  | 'clientMutationId'
+  | 'charges'
+  | 'usageThresholds'
+  | 'entitlements'
+  | 'fixedCharges'
+  | 'interval'
+  | 'amountCents'
+  | 'payInAdvance'
 > & {
+  // The API input is optional only for product-catalog plans, which do not
+  // use this form: the legacy plan form always sets these.
+  interval: PlanInterval
+  amountCents: NonNullable<CreatePlanInput['amountCents']>
+  payInAdvance: boolean
   fixedCharges: LocalFixedChargeInput[]
   charges: LocalUsageChargeInput[]
   // NOTE: this is used for display purpose but will be replaced by taxCodes[] on save


### PR DESCRIPTION
## Context

getlago/lago-api#5779 makes `interval`, `amountCents` and `payInAdvance` optional on `CreatePlanInput`/`UpdatePlanInput` — product-catalog plans carry no plan-level pricing, and a catalog organization manages plans through the existing mutations. `PlanFormInput` derives from that input type, so the fields would go optional across the entire legacy plan form flow (13 type errors), even though that form always sets them.

## Description

Re-require the three fields on `PlanFormInput`, at the type boundary rather than at 13 call sites. The legacy plan form always initializes them, and the product-catalog flow does not use this form.

**This can merge before the API change**: the `Omit`-then-re-add shape compiles against both the current schema (fields required) and the upcoming one (fields optional) — verified in both directions, with the plans/serializers/hooks suites green (1197 tests).

Follow-up to #4152, which handled the output-side nullability of the same fields.
