### PR TITLE
fix: restore type-checking on main and guard it in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,6 @@ on:
       - main
 
 jobs:
-  # Jest transpiles without type-checking and the codegen workflow (which runs
-  # tsc) only triggers on pull requests, so a type error produced by the MERGE
-  # of two individually green PRs lands on main unseen. This job runs on main
-  # pushes too, so it surfaces immediately instead of on the next PR.
   typecheck:
     if: github.event.pull_request.draft == false || github.event_name == 'push'
     name: Typecheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,36 @@ on:
       - main
 
 jobs:
+  # Jest transpiles without type-checking and the codegen workflow (which runs
+  # tsc) only triggers on pull requests, so a type error produced by the MERGE
+  # of two individually green PRs lands on main unseen. This job runs on main
+  # pushes too, so it surfaces immediately instead of on the next PR.
+  typecheck:
+    if: github.event.pull_request.draft == false || github.event_name == 'push'
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6.0.10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.5.0
+        with:
+          node-version-file: package.json
+          cache: "pnpm"
+
+      - name: Install Node.js dependencies
+        run: pnpm install
+
+      - name: Build packages
+        run: pnpm prebuild
+
+      - name: Run Typescript
+        run: pnpm tsc
+
   test-shard:
     if: github.event.pull_request.draft == false || github.event_name == 'push'
     name: Tests (shard ${{ matrix.shard }}/4)

--- a/src/hooks/plans/usePlanFormSetup.ts
+++ b/src/hooks/plans/usePlanFormSetup.ts
@@ -143,7 +143,7 @@ export const usePlanFormSetup = ({
   // silently drop from the overrides every term that still matches it.
   const catalogPlanId = basePlan?.parent?.id
   const { data: catalogPlanData } = useGetSinglePlanQuery({
-    context: { silentError: LagoApiError.NotFound },
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
     variables: { id: catalogPlanId as string },
     skip: !catalogPlanId,
   })


### PR DESCRIPTION
## Context

Two individually green PRs collided semantically on `main`: #4153 added a call site using the old `silentError: <code>` form while #4166 — which typed the Apollo context and converted every call site it knew of — was in flight. Git merged them without textual conflict, and `main` no longer type-checks:

```
src/hooks/plans/usePlanFormSetup.ts(146,16): error TS2322:
Type 'LagoApiError.NotFound' is not assignable to type 'boolean | undefined'.
```

Nothing on GitHub surfaces this: `tsc` only runs in the codegen workflow, which triggers on pull requests only, and the Tests workflow transpiles without type-checking. The error would first show up on the next PR's codegen job, red on a file that PR never touched. Same failure class as the recent `BigInt` amount-filters incident.

## Changes

- **fix(plans)**: convert the remaining call site to `silentErrorCodes: [LagoApiError.NotFound]`, exactly as #4166 converted the others. Behaviour unchanged — only the not_found error is silenced.
- **ci(tests)**: add a `Typecheck` job to the Tests workflow, which already runs on pushes to `main`. A merge-induced type error now surfaces immediately instead of on the next unrelated PR.

## Verification

- `pnpm tsc --noEmit` fails on current `main`, passes with this branch.
- The new job mirrors the setup steps of the existing shards (same action versions, `pnpm prebuild` before `tsc`, mirroring the codegen workflow's typecheck step).