### PR TITLE
fix(conductor): robust archive teardown hook

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -14,7 +14,15 @@ delete_branch_on_archive = true
 
 [scripts]
 setup = "pnpm install"
-archive = "$CONDUCTOR_WORKSPACE_PATH/scripts/conductor-front-container.sh down"
+# The archive hook resolves the teardown script from the MAIN clone
+# ($CONDUCTOR_ROOT_PATH), not from the workspace being archived. A workspace
+# whose branch predates the commit that added scripts/conductor-front-container.sh
+# has no such file in its checkout, and by archive time its directory may already
+# be gone, so $CONDUCTOR_WORKSPACE_PATH/scripts/... fails with "no such file or
+# directory". Teardown only needs the generated compose file (kept outside the
+# workspace), so the main clone copy is always the right one. Falls back to the
+# workspace copy, then no-ops, so a missing script never fails the archive.
+archive = 'if [ -x "$CONDUCTOR_ROOT_PATH/scripts/conductor-front-container.sh" ]; then "$CONDUCTOR_ROOT_PATH/scripts/conductor-front-container.sh" down; elif [ -x "$CONDUCTOR_WORKSPACE_PATH/scripts/conductor-front-container.sh" ]; then "$CONDUCTOR_WORKSPACE_PATH/scripts/conductor-front-container.sh" down; else echo "archive hook: container teardown script not found, nothing to tear down"; fi'
 run_mode = "concurrent"
 
 # Run the workspace in its own Docker container on the shared lago stack network.

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -30,7 +30,8 @@ CMD="${1:-}"
 NAME="${CONDUCTOR_WORKSPACE_NAME:?CONDUCTOR_WORKSPACE_NAME is required (run via Conductor)}"
 # Optional: `down` works purely off the generated compose file (kept outside the
 # workspace), so archiving still tears the container down after the workspace
-# directory is gone. up/shell/host require it, see require_ws.
+# directory is gone. `shell` only needs the running container. Only up/host read
+# it, see require_ws.
 WS="${CONDUCTOR_WORKSPACE_PATH:-}"
 ROOT="${CONDUCTOR_ROOT_PATH:?CONDUCTOR_ROOT_PATH is required (run via Conductor)}"
 PORT="${CONDUCTOR_PORT:-8080}"
@@ -158,6 +159,8 @@ teardown_san() {
   # referencing $san in the same statement trips `set -u`.
   local san="$1"
   local file="$COMPOSE_DIR/${san}.yml"
+  local project="lago_front_ct_${san}"
+
   if [[ -f "$file" ]] && docker compose -f "$file" down -v; then
     rm -f "$file"
     return
@@ -173,11 +176,32 @@ teardown_san() {
   fi
 
   # No compose file (deleted manually), or it no longer parses (stale format from
-  # an older revision of this script): remove the container and its named volumes
+  # an older revision of this script): remove the container and its volumes
   # directly so nothing is left orphaned.
+  docker rm -f "$project" >/dev/null 2>&1 || true
+
+  # Compose prefixes every declared volume with the project name, so the real
+  # volumes are lago_front_ct_<san>_front_nm_ct_<san>, not front_nm_ct_<san>.
+  # Match on the compose project label, which survives the compose file, and fall
+  # back to the prefixed literals in case the label is missing.
+  local -a vols=()
+  local vol
+  while IFS= read -r vol; do
+    [[ -n "$vol" ]] && vols+=("$vol")
+  done < <(docker volume ls -q --filter "label=com.docker.compose.project=${project}" 2>/dev/null || true)
+  if [[ ${#vols[@]} -gt 0 ]]; then
+    docker volume rm "${vols[@]}" >/dev/null 2>&1 || true
+  fi
+  docker volume rm "${project}_front_nm_ct_${san}" "${project}_front_dist_ct_${san}" >/dev/null 2>&1 || true
+
+  # Only drop the compose file once the container is really gone. Deleting it on a
+  # failed removal would destroy the sole record of the project name and volume
+  # set, leaving both unreclaimable.
+  if docker ps -a --format '{{.Names}}' | grep -qx "$project"; then
+    echo "warn: container ${project} still present, keeping ${file}." >&2
+    return
+  fi
   rm -f "$file"
-  docker rm -f "lago_front_ct_${san}" >/dev/null 2>&1 || true
-  docker volume rm "front_nm_ct_${san}" "front_dist_ct_${san}" >/dev/null 2>&1 || true
 }
 
 cmd_down() {
@@ -256,7 +280,9 @@ cmd_host() {
 case "$CMD" in
   up) require_ws; cmd_up ;;
   down) cmd_down ;;
-  shell) require_ws; cmd_shell ;;
+  # No require_ws: cmd_shell only needs the running container, not the directory,
+  # so it stays usable when the workspace has already been removed.
+  shell) cmd_shell ;;
   host) require_ws; cmd_host ;;
   *)
     echo "Usage: conductor-front-container.sh {up|down|shell|host}" >&2

--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -10,11 +10,15 @@ set -euo pipefail
 # owner of worktree create/destroy. Wired from the committed team config
 # .conductor/settings.toml:
 #   [scripts.run.container] command = "$CONDUCTOR_WORKSPACE_PATH/scripts/conductor-front-container.sh up"
-#   scripts.archive        = "$CONDUCTOR_WORKSPACE_PATH/scripts/conductor-front-container.sh down"
+#   scripts.archive        = "$CONDUCTOR_ROOT_PATH/scripts/conductor-front-container.sh down"
 #
-# The script is located via $CONDUCTOR_WORKSPACE_PATH (set by Conductor for every
-# script, including the headless archive hook) rather than a user shell var like
-# $LAGO_PATH, which is not present in Conductor's non-interactive script env.
+# The run scripts are located via $CONDUCTOR_WORKSPACE_PATH so a branch-local edit
+# to this file is what actually runs. The archive hook instead resolves it from
+# $CONDUCTOR_ROOT_PATH (the main clone): a workspace whose branch predates the
+# commit that added this file has no copy in its checkout, and by archive time the
+# workspace directory may already be gone. Either way $CONDUCTOR_ROOT_PATH is a
+# Conductor-provided var, not a user shell var like $LAGO_PATH, which is not
+# present in Conductor's non-interactive script env.
 #
 # Prerequisites:
 #   - the main Lago Docker stack is running (`lago up -d`)
@@ -24,7 +28,10 @@ set -euo pipefail
 CMD="${1:-}"
 
 NAME="${CONDUCTOR_WORKSPACE_NAME:?CONDUCTOR_WORKSPACE_NAME is required (run via Conductor)}"
-WS="${CONDUCTOR_WORKSPACE_PATH:?CONDUCTOR_WORKSPACE_PATH is required (run via Conductor)}"
+# Optional: `down` works purely off the generated compose file (kept outside the
+# workspace), so archiving still tears the container down after the workspace
+# directory is gone. up/shell/host require it, see require_ws.
+WS="${CONDUCTOR_WORKSPACE_PATH:-}"
 ROOT="${CONDUCTOR_ROOT_PATH:?CONDUCTOR_ROOT_PATH is required (run via Conductor)}"
 PORT="${CONDUCTOR_PORT:-8080}"
 
@@ -32,6 +39,13 @@ LAGO_PATH="$(cd "$ROOT/.." && pwd)"
 COMPOSE_DIR="$LAGO_PATH/.conductor-front-containers"
 SAN="$(echo "$NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g')"
 COMPOSE_FILE="$COMPOSE_DIR/${SAN}.yml"
+
+require_ws() {
+  [[ -d "$WS" ]] || {
+    echo "CONDUCTOR_WORKSPACE_PATH must point at an existing directory (got: ${WS:-<unset>})" >&2
+    exit 1
+  }
+}
 
 gen_compose() {
   mkdir -p "$COMPOSE_DIR"
@@ -138,16 +152,54 @@ cmd_up() {
   docker compose -f "$COMPOSE_FILE" logs -f
 }
 
-cmd_down() {
-  if [[ -f "$COMPOSE_FILE" ]]; then
-    docker compose -f "$COMPOSE_FILE" down -v
-    rm -f "$COMPOSE_FILE"
-  else
-    # No compose file (e.g. deleted manually) — still remove the container and
-    # its named volumes directly so nothing is left orphaned.
-    docker rm -f "lago_front_ct_${SAN}" >/dev/null 2>&1 || true
-    docker volume rm "front_nm_ct_${SAN}" "front_dist_ct_${SAN}" >/dev/null 2>&1 || true
+# Tear down one compose project by its sanitised name, compose file or not.
+teardown_san() {
+  # Two statements: bash expands the whole `local` line before assigning, so
+  # referencing $san in the same statement trips `set -u`.
+  local san="$1"
+  local file="$COMPOSE_DIR/${san}.yml"
+  if [[ -f "$file" ]] && docker compose -f "$file" down -v; then
+    rm -f "$file"
+    return
   fi
+
+  # Docker itself unreachable (daemon down, CLI missing): there is nothing to
+  # remove right now and dropping the compose file would lose the only record of
+  # what to clean up, so warn and leave it. Never fail: this runs from the archive
+  # hook, where a teardown error would surface as a failed archive.
+  if ! docker info >/dev/null 2>&1; then
+    echo "warn: docker unreachable, leaving '${san}' teardown for later." >&2
+    return
+  fi
+
+  # No compose file (deleted manually), or it no longer parses (stale format from
+  # an older revision of this script): remove the container and its named volumes
+  # directly so nothing is left orphaned.
+  rm -f "$file"
+  docker rm -f "lago_front_ct_${san}" >/dev/null 2>&1 || true
+  docker volume rm "front_nm_ct_${san}" "front_dist_ct_${san}" >/dev/null 2>&1 || true
+}
+
+cmd_down() {
+  teardown_san "$SAN"
+
+  # The compose project is named after CONDUCTOR_WORKSPACE_NAME at `up` time, so
+  # renaming the workspace afterwards makes $SAN miss the project that is actually
+  # running and orphans its node_modules volume (~600MB each). Also tear down any
+  # other compose project whose /app mount is this workspace, so a rename between
+  # `up` and archive still cleans up.
+  if [[ -n "$WS" && -d "$COMPOSE_DIR" ]]; then
+    local file other
+    for file in "$COMPOSE_DIR"/*.yml; do
+      [[ -f "$file" ]] || continue
+      grep -qF -- "${WS}:/app:cached" "$file" || continue
+      other="$(basename "$file" .yml)"
+      if [[ "$other" == "$SAN" ]]; then continue; fi
+      echo "Also tearing down stale project '$other' for this workspace (renamed since 'up')."
+      teardown_san "$other"
+    done
+  fi
+
   echo "Removed front container for '$NAME'."
 }
 
@@ -202,10 +254,10 @@ cmd_host() {
 }
 
 case "$CMD" in
-  up) cmd_up ;;
+  up) require_ws; cmd_up ;;
   down) cmd_down ;;
-  shell) cmd_shell ;;
-  host) cmd_host ;;
+  shell) require_ws; cmd_shell ;;
+  host) require_ws; cmd_host ;;
   *)
     echo "Usage: conductor-front-container.sh {up|down|shell|host}" >&2
     exit 1


### PR DESCRIPTION
The archive hook resolved its teardown script from `$CONDUCTOR_WORKSPACE_PATH`, which is asymmetric: Conductor reads `.conductor/settings.toml` from the remote default branch, but resolves the path against the workspace checkout. Any workspace whose branch predates `b148efab9` (the commit that added `scripts/conductor-front-container.sh`) has no copy of the file, so archiving it failed with:

```
zsh: no such file or directory: .../front/davao/scripts/conductor-front-container.sh
```

By archive time the workspace directory can also already be gone, so a re-run never succeeds either (the failed hook for a workspace archived on 2026-07-23 fired again a month later at app startup).

## Changes

`.conductor/settings.toml`
- resolve the script from `$CONDUCTOR_ROOT_PATH` (the main clone, same branch as the settings file), fall back to the workspace copy, then no-op instead of failing.
- `[scripts.run.*]` deliberately keep `$CONDUCTOR_WORKSPACE_PATH` so a branch-local edit to the script is what actually runs.

`scripts/conductor-front-container.sh`
- `down` no longer requires the workspace directory: it works off the generated compose file, which lives outside the workspace. `up`/`shell`/`host` assert the directory exists instead (`require_ws`).
- the compose project is named after `CONDUCTOR_WORKSPACE_NAME` at `up` time, so renaming a workspace made `down` miss the live project and orphan its ~600MB node_modules volume. `down` now also tears down any compose project whose `/app` mount is this workspace. This had leaked 5 orphaned projects / 10 volumes / ~2.5GB locally, since cleaned up.
- a stale or unparseable compose file falls back to removing the container and volumes directly, and docker being unreachable warns rather than failing the archive.

## Notes

- Verified in an isolated fake superproject: rename sweep removes container + volume + compose file (exit 0), unrelated projects untouched, archive with a missing workspace directory exits 0, `up` with a missing directory fails loudly.
- The settings change only takes effect once merged, since the Mac app reads the shared settings file from the remote default branch.
