### PR TITLE
fix(events): key events on their deduplication tuple

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,15 +66,13 @@
   `Outlet`, etc.) are unrestricted.
   ```typescript
   // Correct — slug-aware wrappers
+  import { useNavigate, Link, useLocation } from '~/core/router'
   // Correct — route matching with strippedPathname
   import { matchPath } from 'react-router-dom'
-  // Wrong — useMatch uses raw pathname (includes slug), never matches
-  import { useMatch } from 'react-router-dom'
-
-  import { Link, useLocation, useNavigate } from '~/core/router'
-
   const { strippedPathname } = useLocation()
   const match = matchPath(SOME_ROUTE, strippedPathname)
+  // Wrong — useMatch uses raw pathname (includes slug), never matches
+  import { useMatch } from 'react-router-dom'
   ```
 
 ## Pagination (numbered lists & tables)
@@ -151,11 +149,11 @@ Three generations coexist in the codebase. **Only the hook pattern is allowed in
 code** — the other two are migration debt, and their presence is not permission to copy
 them.
 
-| Generation                                                                                                 | Shape                                       | Status                        |
-| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----------------------------- |
-| `use<Feature>Drawer()` hook returning `{ openDrawer }`, built on `useFormDrawer` / `useDrawer` (NiceModal) | no ref, no rendered element                 | ✅ **canonical**              |
-| `useFormDrawer` wrapped in a `forwardRef` + `useImperativeHandle` component that `return null`             | parent holds a ref                          | ⚠️ legacy, migrate on touch   |
-| `~/components/designSystem/Drawer` + `DrawerRef` (`openDrawer`/`closeDrawer`)                              | parent holds a ref to a rendered `<Drawer>` | ⛔ legacy, never for new code |
+| Generation | Shape | Status |
+| ---------- | ----- | ------ |
+| `use<Feature>Drawer()` hook returning `{ openDrawer }`, built on `useFormDrawer` / `useDrawer` (NiceModal) | no ref, no rendered element | ✅ **canonical** |
+| `useFormDrawer` wrapped in a `forwardRef` + `useImperativeHandle` component that `return null` | parent holds a ref | ⚠️ legacy, migrate on touch |
+| `~/components/designSystem/Drawer` + `DrawerRef` (`openDrawer`/`closeDrawer`) | parent holds a ref to a rendered `<Drawer>` | ⛔ legacy, never for new code |
 
 ### The canonical pattern
 
@@ -271,11 +269,11 @@ All dialogs are hook-based, backed by NiceModal. New code must use one of three 
 depending on the shape of the flow — the legacy imperative `forwardRef` + `Dialog` /
 `WarningDialog` pattern is gone, do not reintroduce it.
 
-| Hook                         | Use for                                                 | Signature                                                          |
-| ---------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------ |
-| `useFormDialog`              | Form + submit button                                    | `open({ title, form: { id, submit }, mainAction, children, ... })` |
-| `useCentralizedDialog`       | Confirmation / warning (no form)                        | `open({ title, description, actionText, colorVariant, onAction })` |
-| `useFormDialogOpeningDialog` | Edit form that can open a secondary destructive confirm | same as `useFormDialog` + a nested `open-other-dialog` return      |
+| Hook | Use for | Signature |
+| ---- | ------- | --------- |
+| `useFormDialog` | Form + submit button | `open({ title, form: { id, submit }, mainAction, children, ... })` |
+| `useCentralizedDialog` | Confirmation / warning (no form) | `open({ title, description, actionText, colorVariant, onAction })` |
+| `useFormDialogOpeningDialog` | Edit form that can open a secondary destructive confirm | same as `useFormDialog` + a nested `open-other-dialog` return |
 
 ### The canonical pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,13 +66,15 @@
   `Outlet`, etc.) are unrestricted.
   ```typescript
   // Correct — slug-aware wrappers
-  import { useNavigate, Link, useLocation } from '~/core/router'
   // Correct — route matching with strippedPathname
   import { matchPath } from 'react-router-dom'
-  const { strippedPathname } = useLocation()
-  const match = matchPath(SOME_ROUTE, strippedPathname)
   // Wrong — useMatch uses raw pathname (includes slug), never matches
   import { useMatch } from 'react-router-dom'
+
+  import { Link, useLocation, useNavigate } from '~/core/router'
+
+  const { strippedPathname } = useLocation()
+  const match = matchPath(SOME_ROUTE, strippedPathname)
   ```
 
 ## Pagination (numbered lists & tables)
@@ -149,11 +151,11 @@ Three generations coexist in the codebase. **Only the hook pattern is allowed in
 code** — the other two are migration debt, and their presence is not permission to copy
 them.
 
-| Generation | Shape | Status |
-| ---------- | ----- | ------ |
-| `use<Feature>Drawer()` hook returning `{ openDrawer }`, built on `useFormDrawer` / `useDrawer` (NiceModal) | no ref, no rendered element | ✅ **canonical** |
-| `useFormDrawer` wrapped in a `forwardRef` + `useImperativeHandle` component that `return null` | parent holds a ref | ⚠️ legacy, migrate on touch |
-| `~/components/designSystem/Drawer` + `DrawerRef` (`openDrawer`/`closeDrawer`) | parent holds a ref to a rendered `<Drawer>` | ⛔ legacy, never for new code |
+| Generation                                                                                                 | Shape                                       | Status                        |
+| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----------------------------- |
+| `use<Feature>Drawer()` hook returning `{ openDrawer }`, built on `useFormDrawer` / `useDrawer` (NiceModal) | no ref, no rendered element                 | ✅ **canonical**              |
+| `useFormDrawer` wrapped in a `forwardRef` + `useImperativeHandle` component that `return null`             | parent holds a ref                          | ⚠️ legacy, migrate on touch   |
+| `~/components/designSystem/Drawer` + `DrawerRef` (`openDrawer`/`closeDrawer`)                              | parent holds a ref to a rendered `<Drawer>` | ⛔ legacy, never for new code |
 
 ### The canonical pattern
 
@@ -269,11 +271,11 @@ All dialogs are hook-based, backed by NiceModal. New code must use one of three 
 depending on the shape of the flow — the legacy imperative `forwardRef` + `Dialog` /
 `WarningDialog` pattern is gone, do not reintroduce it.
 
-| Hook | Use for | Signature |
-| ---- | ------- | --------- |
-| `useFormDialog` | Form + submit button | `open({ title, form: { id, submit }, mainAction, children, ... })` |
-| `useCentralizedDialog` | Confirmation / warning (no form) | `open({ title, description, actionText, colorVariant, onAction })` |
-| `useFormDialogOpeningDialog` | Edit form that can open a secondary destructive confirm | same as `useFormDialog` + a nested `open-other-dialog` return |
+| Hook                         | Use for                                                 | Signature                                                          |
+| ---------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------ |
+| `useFormDialog`              | Form + submit button                                    | `open({ title, form: { id, submit }, mainAction, children, ... })` |
+| `useCentralizedDialog`       | Confirmation / warning (no form)                        | `open({ title, description, actionText, colorVariant, onAction })` |
+| `useFormDialogOpeningDialog` | Edit form that can open a secondary destructive confirm | same as `useFormDialog` + a nested `open-other-dialog` return      |
 
 ### The canonical pattern
 
@@ -419,6 +421,7 @@ Legitimate var reads in the codebase (audit anchor, keep this short). Two permit
 - `src/layouts/OrganizationLayout.tsx` — switch detection on the `currentOrgId !== org.id` mismatch (the single sync point that writes the var from the URL slug).
 - `src/components/UserIdentifier.tsx` — query-gates the `UserIdentifier` query (org-scoped `organization` field) on `!!currentOrganizationId` so it doesn't fire on slug-less surfaces (e.g. `/`).
 - `src/hooks/useOrganizationInfos.ts` — query-gates `getOrganizationInfos` (org-scoped) on `!!currentOrganizationId` for the same reason.
+- `src/components/developers/DevtoolsView.tsx` — query-gates the whole devtools panel (`DevtoolsRouter`) on `!!currentOrganizationId`. The panel lives in a `MemoryRouter` that is a SIBLING of the app's `BrowserRouter`, so it has no access to the URL slug and can mount before `OrganizationLayout` has derived the org — a copied inspector link opens it on first paint. Without the gate every tab fires its org-scoped query header-less and the API answers `Missing organization id`.
 - `src/hooks/useCurrentUser.ts` — slug-first resolution of `currentMembership` with var as a fallback for routes outside `/:organizationSlug` (login, customer portal). The fallback exists so callers in those non-org routes still get a membership; if a future audit shows nobody consumes `currentMembership` from those contexts, the fallback can be dropped.
 
 Anything else reading the var in a feature component is a regression — fix it.

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -32,8 +32,10 @@ const PageWrapper = ({ children, routeConfig }: PageWrapperProps) => {
       const url = new URL(window.location.href)
 
       url.pathname = '/'
-      // URLSearchParams.set() handles encoding automatically, so we don't need encodeURIComponent
-      url.searchParams.set(DEVTOOL_TAB_PARAMS, location.pathname)
+      // The search string is part of the devtools address, not decoration — the events tab
+      // keeps three of the four fields identifying the selected event there.
+      // URLSearchParams.set() handles encoding, so no encodeURIComponent here.
+      url.searchParams.set(DEVTOOL_TAB_PARAMS, `${location.pathname}${location.search}`)
       window.location.replace(url.toString())
     }
   }, [location])

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -32,9 +32,7 @@ const PageWrapper = ({ children, routeConfig }: PageWrapperProps) => {
       const url = new URL(window.location.href)
 
       url.pathname = '/'
-      // The search string is part of the devtools address, not decoration — the events tab
-      // keeps three of the four fields identifying the selected event there.
-      // URLSearchParams.set() handles encoding, so no encodeURIComponent here.
+      // The search string is part of the devtools address, not decoration — see `EventKey`.
       url.searchParams.set(DEVTOOL_TAB_PARAMS, `${location.pathname}${location.search}`)
       window.location.replace(url.toString())
     }

--- a/src/components/activityLogs/ActivityLogsTable.tsx
+++ b/src/components/activityLogs/ActivityLogsTable.tsx
@@ -28,7 +28,7 @@ gql`
 
 interface ActivityLogsTableProps extends Pick<
   TableProps<ActivityLogsTableDataFragment>,
-  'data' | 'isLoading' | 'containerSize' | 'onRowActionLink' | 'loadingRowCount'
+  'data' | 'isLoading' | 'containerSize' | 'onRowActionLink' | 'loadingRowCount' | 'activeRowId'
 > {
   refetch: QueryResult['refetch']
   error: ApolloError | undefined
@@ -41,6 +41,7 @@ export const ActivityLogsTable: FC<ActivityLogsTableProps> = ({
   containerSize = 16,
   onRowActionLink,
   loadingRowCount,
+  activeRowId,
   refetch,
 }) => {
   const { translate } = useInternationalization()
@@ -123,6 +124,7 @@ export const ActivityLogsTable: FC<ActivityLogsTableProps> = ({
       containerSize={containerSize}
       rowSize={48}
       data={logs}
+      activeRowId={activeRowId}
       hasError={!!error}
       isLoading={isLoading}
       loadingRowCount={loadingRowCount}

--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -77,12 +77,6 @@ export interface TableProps<T> {
   hasError?: boolean
   loadingRowCount?: number
   placeholder?: TablePlaceholder
-  /**
-   * `id` of the row to mark as selected. Rendered as `data-state="selected"`, which the
-   * row styling above already keys on. Declarative on purpose: the master-detail lists
-   * used to set that attribute imperatively after mount, and any later re-render of the
-   * rows silently threw it away.
-   */
   activeRowId?: string
   onRowActionLink?: (item: T) => string
   onRowActionClick?: (item: T) => void

--- a/src/components/designSystem/Table/Table.tsx
+++ b/src/components/designSystem/Table/Table.tsx
@@ -77,6 +77,13 @@ export interface TableProps<T> {
   hasError?: boolean
   loadingRowCount?: number
   placeholder?: TablePlaceholder
+  /**
+   * `id` of the row to mark as selected. Rendered as `data-state="selected"`, which the
+   * row styling above already keys on. Declarative on purpose: the master-detail lists
+   * used to set that attribute imperatively after mount, and any later re-render of the
+   * rows silently threw it away.
+   */
+  activeRowId?: string
   onRowActionLink?: (item: T) => string
   onRowActionClick?: (item: T) => void
   actionColumn?: ActionColumn<T>
@@ -284,6 +291,7 @@ export const Table = <T extends DataItem>({
   placeholder,
   tableInDialog,
   containerClassName,
+  activeRowId,
   onRowActionLink,
   onRowActionClick,
   actionColumn,
@@ -528,6 +536,7 @@ export const Table = <T extends DataItem>({
                   key={`${TABLE_ID}-row-${i}`}
                   id={`${TABLE_ID}-row-${i}`}
                   data-id={item.id}
+                  data-state={!!activeRowId && item.id === activeRowId ? 'selected' : undefined}
                   isClickable={isClickable}
                   tabIndex={isClickable ? 0 : undefined}
                   onKeyDown={isClickable ? onKeyDown : undefined}

--- a/src/components/developers/DevtoolsView.tsx
+++ b/src/components/developers/DevtoolsView.tsx
@@ -37,9 +37,8 @@ export const DevtoolsView: FC = () => {
   const copyInspectorLink = () => {
     const windowUrl = new URL(window.location.href)
 
-    // The panel's own search string is part of the address: the events tab carries three of
-    // the four fields identifying the selected event there, so a pathname alone reopens the
-    // wrong row. URLSearchParams.set() handles encoding, so no encodeURIComponent here.
+    // The panel's own search string is part of the address — see `EventKey`. A pathname alone
+    // reopens the events tab on the wrong row.
     windowUrl.searchParams.set(DEVTOOL_TAB_PARAMS, `${pathname}${search}`)
     copyToClipboard(windowUrl.toString())
     addToast({

--- a/src/components/developers/DevtoolsView.tsx
+++ b/src/components/developers/DevtoolsView.tsx
@@ -1,11 +1,14 @@
+import { useReactiveVar } from '@apollo/client'
 import { FC, useEffect } from 'react'
 import { Panel, PanelResizeHandle } from 'react-resizable-panels'
 
 import { Button } from '~/components/designSystem/Button'
 import { NavigationTab, TabManagedBy } from '~/components/designSystem/NavigationTab'
+import { Spinner } from '~/components/designSystem/Spinner'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { devToolsNavigationMapping, DevtoolsRouter } from '~/components/developers/DevtoolsRouter'
 import { addToast } from '~/core/apolloClient'
+import { currentOrganizationVar } from '~/core/apolloClient/reactiveVars/currentOrganizationVar'
 import { useLocation, useNavigate } from '~/core/router'
 import { copyToClipboard } from '~/core/utils/copyToClipboard'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -28,6 +31,14 @@ export const DevtoolsView: FC = () => {
 
   const { translate } = useInternationalization()
   const { pathname, search } = useLocation()
+  // Query-gate: every devtools tab reads org-scoped data, and the `x-lago-organization`
+  // header is built from this var. The panel lives in a MemoryRouter that is a SIBLING of
+  // the app's BrowserRouter, so it can mount before `OrganizationLayout` has derived the org
+  // from the URL slug — which is exactly what happens when a copied inspector link opens the
+  // panel on first paint. Rendering the tabs then fires their queries header-less and the API
+  // rejects them with "Missing organization id", leaving the tab stuck on its error state
+  // until the user hits refresh.
+  const currentOrganizationId = useReactiveVar(currentOrganizationVar)
 
   const { hasPermissions } = usePermissions()
   const { isPremium } = useCurrentUser()
@@ -125,7 +136,13 @@ export const DevtoolsView: FC = () => {
             </Tooltip>
           </NavigationTab>
           <div className="flex min-h-0 flex-1 flex-col overflow-auto">
-            <DevtoolsRouter />
+            {currentOrganizationId ? (
+              <DevtoolsRouter />
+            ) : (
+              <div className="flex flex-1 items-center justify-center">
+                <Spinner />
+              </div>
+            )}
           </div>
         </div>
       </Panel>

--- a/src/components/developers/DevtoolsView.tsx
+++ b/src/components/developers/DevtoolsView.tsx
@@ -20,12 +20,14 @@ import {
 } from '~/hooks/useDeveloperTool'
 import { usePermissions } from '~/hooks/usePermissions'
 
+export const DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID = 'devtools-copy-inspector-link'
+
 export const DevtoolsView: FC = () => {
   const { panelRef, panelOpen, isFullscreen, expandPanel, resizePanel, closePanel, url, setUrl } =
     useDeveloperTool()
 
   const { translate } = useInternationalization()
-  const { pathname } = useLocation()
+  const { pathname, search } = useLocation()
 
   const { hasPermissions } = usePermissions()
   const { isPremium } = useCurrentUser()
@@ -35,8 +37,10 @@ export const DevtoolsView: FC = () => {
   const copyInspectorLink = () => {
     const windowUrl = new URL(window.location.href)
 
-    // URLSearchParams.set() handles encoding automatically, so we don't need encodeURIComponent
-    windowUrl.searchParams.set(DEVTOOL_TAB_PARAMS, pathname)
+    // The panel's own search string is part of the address: the events tab carries three of
+    // the four fields identifying the selected event there, so a pathname alone reopens the
+    // wrong row. URLSearchParams.set() handles encoding, so no encodeURIComponent here.
+    windowUrl.searchParams.set(DEVTOOL_TAB_PARAMS, `${pathname}${search}`)
     copyToClipboard(windowUrl.toString())
     addToast({
       severity: 'info',
@@ -92,6 +96,7 @@ export const DevtoolsView: FC = () => {
               startIcon="link"
               size="small"
               variant="quaternary"
+              data-test={DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID}
               onClick={() => copyInspectorLink()}
             >
               {translate('text_17460208605597iyd249v26z')}

--- a/src/components/developers/LogsLayout.tsx
+++ b/src/components/developers/LogsLayout.tsx
@@ -16,7 +16,6 @@ const CTASection = ({ children, className }: { children: ReactNode; className?: 
 
 export type ListSectionRef = {
   updateView: (direction: 'forward' | 'backward') => void
-  setActiveRow: (id: string) => void
 }
 
 type ListSectionProps = {
@@ -36,24 +35,9 @@ const ListSection = forwardRef<ListSectionRef, ListSectionProps>(
       }
     }
 
-    const setActiveRow = (id: string) => {
-      if (logListRef.current) {
-        const selectedRows = logListRef.current.querySelectorAll('tr[data-state="selected"]')
-
-        selectedRows.forEach((row) => {
-          row.removeAttribute('data-state')
-        })
-
-        const element = logListRef.current.querySelector(`tr[data-id="${id}"]`) as HTMLElement
-
-        element?.setAttribute('data-state', 'selected')
-      }
-    }
-
     useImperativeHandle(ref, () => {
       return {
         updateView,
-        setActiveRow,
       }
     })
 

--- a/src/components/developers/__tests__/DevtoolsView.test.tsx
+++ b/src/components/developers/__tests__/DevtoolsView.test.tsx
@@ -6,6 +6,7 @@ import {
   DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID,
   DevtoolsView,
 } from '~/components/developers/DevtoolsView'
+import { currentOrganizationVar } from '~/core/apolloClient/reactiveVars/currentOrganizationVar'
 
 configure({ testIdAttribute: 'data-test' })
 
@@ -68,7 +69,7 @@ jest.mock('~/components/designSystem/NavigationTab', () => ({
 }))
 
 jest.mock('~/components/developers/DevtoolsRouter', () => ({
-  DevtoolsRouter: () => <div />,
+  DevtoolsRouter: () => <div data-test="devtools-router-mock" />,
   devToolsNavigationMapping: () => [],
 }))
 
@@ -86,6 +87,11 @@ describe('DevtoolsView', () => {
     jest.clearAllMocks()
     window.history.replaceState({}, '', '/customers')
     mockLocation.search = ''
+    currentOrganizationVar('organization-1')
+  })
+
+  afterEach(() => {
+    currentOrganizationVar(null)
   })
 
   describe('GIVEN the events tab has an event selected', () => {
@@ -117,6 +123,39 @@ describe('DevtoolsView', () => {
         const link = await copiedInspectorLink()
 
         expect(link.searchParams.get('devtool-tab')).toBe('/devtool/events/transaction-1')
+      })
+    })
+  })
+
+  describe('GIVEN the current organization is not known yet', () => {
+    describe('WHEN the panel renders', () => {
+      it('THEN it should not render the devtools routes', () => {
+        currentOrganizationVar(null)
+
+        render(<DevtoolsView />)
+
+        // Every devtools tab queries org-scoped data. The `x-lago-organization` header is
+        // built from this var, so rendering the routes before it is set fires the queries
+        // without it and the API rejects them with "Missing organization id".
+        expect(screen.queryByTestId('devtools-router-mock')).not.toBeInTheDocument()
+      })
+
+      it('THEN it should still render the panel chrome', () => {
+        currentOrganizationVar(null)
+
+        render(<DevtoolsView />)
+
+        expect(screen.getByTestId(DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN the current organization is known', () => {
+    describe('WHEN the panel renders', () => {
+      it('THEN it should render the devtools routes', () => {
+        render(<DevtoolsView />)
+
+        expect(screen.getByTestId('devtools-router-mock')).toBeInTheDocument()
       })
     })
   })

--- a/src/components/developers/__tests__/DevtoolsView.test.tsx
+++ b/src/components/developers/__tests__/DevtoolsView.test.tsx
@@ -1,0 +1,121 @@
+import { configure, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ReactNode } from 'react'
+
+import {
+  DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID,
+  DevtoolsView,
+} from '~/components/developers/DevtoolsView'
+
+configure({ testIdAttribute: 'data-test' })
+
+const mockCopyToClipboard = jest.fn()
+const mockLocation = { pathname: '/devtool/events/transaction-1', search: '' }
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('~/core/utils/copyToClipboard', () => ({
+  copyToClipboard: (value: string) => mockCopyToClipboard(value),
+}))
+
+jest.mock('~/core/apolloClient', () => ({
+  addToast: jest.fn(),
+}))
+
+jest.mock('~/core/router', () => ({
+  useLocation: () => mockLocation,
+  useNavigate: () => jest.fn(),
+}))
+
+jest.mock('~/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasPermissions: () => true }),
+}))
+
+jest.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ isPremium: true }),
+}))
+
+jest.mock('~/hooks/useDeveloperTool', () => ({
+  DEVTOOL_TAB_PARAMS: 'devtool-tab',
+  DEFAULT_RESIZABLE_HEIGHT: 40,
+  MIN_RESIZABLE_HEIGHT: 20,
+  MAX_RESIZABLE_HEIGHT: 90,
+  FULLSCREEN: 100,
+  useDeveloperTool: () => ({
+    panelRef: { current: null },
+    panelOpen: true,
+    isFullscreen: false,
+    expandPanel: jest.fn(),
+    resizePanel: jest.fn(),
+    closePanel: jest.fn(),
+    url: '',
+    setUrl: jest.fn(),
+  }),
+}))
+
+jest.mock('react-resizable-panels', () => ({
+  Panel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PanelResizeHandle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('~/components/designSystem/NavigationTab', () => ({
+  NavigationTab: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabManagedBy: { URL: 'url' },
+}))
+
+jest.mock('~/components/developers/DevtoolsRouter', () => ({
+  DevtoolsRouter: () => <div />,
+  devToolsNavigationMapping: () => [],
+}))
+
+const copiedInspectorLink = async (): Promise<URL> => {
+  const user = userEvent.setup()
+
+  render(<DevtoolsView />)
+  await user.click(screen.getByTestId(DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID))
+
+  return new URL(mockCopyToClipboard.mock.calls[0][0])
+}
+
+describe('DevtoolsView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    window.history.replaceState({}, '', '/customers')
+    mockLocation.search = ''
+  })
+
+  describe('GIVEN the events tab has an event selected', () => {
+    describe('WHEN copying the inspector link', () => {
+      it('THEN it should carry the panel search params, which hold three of the four key fields', async () => {
+        mockLocation.search =
+          '?externalSubscriptionId=subscription-1&timestampMs=1740000000123&code=api_calls'
+
+        const link = await copiedInspectorLink()
+
+        expect(link.searchParams.get('devtool-tab')).toBe(
+          '/devtool/events/transaction-1?externalSubscriptionId=subscription-1&timestampMs=1740000000123&code=api_calls',
+        )
+      })
+
+      it('THEN it should keep the page the user is on', async () => {
+        const link = await copiedInspectorLink()
+
+        expect(link.pathname).toBe('/customers')
+      })
+    })
+  })
+
+  describe('GIVEN a devtools tab without search params', () => {
+    describe('WHEN copying the inspector link', () => {
+      it('THEN it should carry the pathname alone, with no trailing question mark', async () => {
+        const link = await copiedInspectorLink()
+
+        expect(link.searchParams.get('devtool-tab')).toBe('/devtool/events/transaction-1')
+      })
+    })
+  })
+})

--- a/src/components/developers/__tests__/DevtoolsView.test.tsx
+++ b/src/components/developers/__tests__/DevtoolsView.test.tsx
@@ -102,6 +102,8 @@ describe('DevtoolsView', () => {
       })
 
       it('THEN it should keep the page the user is on', async () => {
+        mockLocation.search = '?code=api_calls'
+
         const link = await copiedInspectorLink()
 
         expect(link.pathname).toBe('/customers')

--- a/src/components/developers/activityLogs/ActivityLogTable.tsx
+++ b/src/components/developers/activityLogs/ActivityLogTable.tsx
@@ -11,6 +11,7 @@ import { ActivityLogsQueryResult } from '~/generated/graphql'
 interface ActivityLogTableProps {
   getActivityLogsResult: ActivityLogsQueryResult
   logListRef: RefObject<ListSectionRef>
+  activeRowId?: string
   pageSize?: number
   onPageSizeChange?: (pageSize: number) => void
 }
@@ -18,6 +19,7 @@ interface ActivityLogTableProps {
 export const ActivityLogTable: FC<ActivityLogTableProps> = ({
   getActivityLogsResult,
   logListRef,
+  activeRowId,
   pageSize,
   onPageSizeChange,
 }) => {
@@ -34,6 +36,7 @@ export const ActivityLogTable: FC<ActivityLogTableProps> = ({
     >
       <Table
         data={data?.activityLogs?.collection ?? []}
+        activeRowId={activeRowId}
         isLoading={loading}
         loadingRowCount={pageSize}
         error={error}

--- a/src/components/developers/activityLogs/ActivityLogs.tsx
+++ b/src/components/developers/activityLogs/ActivityLogs.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { generatePath, useParams, useSearchParams } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
@@ -127,13 +127,6 @@ export const ActivityLogs = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data?.activityLogs?.collection, logId, searchParams])
 
-  // The table should highlight the selected row when the logId is provided in params
-  useLayoutEffect(() => {
-    if (logId) {
-      logListRef.current?.setActiveRow(logId)
-    }
-  }, [logId])
-
   const shouldDisplayLogDetails = !!logId && !!data?.activityLogs?.collection.length
 
   return (
@@ -178,6 +171,7 @@ export const ActivityLogs = () => {
           <ActivityLogTable
             getActivityLogsResult={getActivityLogsResult}
             logListRef={logListRef}
+            activeRowId={logId}
             pageSize={pageSize}
             onPageSizeChange={setPageSize}
           />

--- a/src/components/developers/apiLogs/ApiLogs.tsx
+++ b/src/components/developers/apiLogs/ApiLogs.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { generatePath, useParams, useSearchParams } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
@@ -117,13 +117,6 @@ export const ApiLogs = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data?.apiLogs?.collection, logId, searchParams])
 
-  // The table should highlight the selected row when the logId is provided in params
-  useLayoutEffect(() => {
-    if (!!logId) {
-      logListRef.current?.setActiveRow(logId)
-    }
-  }, [logId])
-
   const shouldDisplayLogDetails = !!logId && !!data?.apiLogs?.collection.length
 
   return (
@@ -169,6 +162,7 @@ export const ApiLogs = () => {
           <ApiLogsTable
             getApiLogsResult={getApiLogsResult}
             logListRef={logListRef}
+            activeRowId={logId}
             pageSize={pageSize}
             onPageSizeChange={setPageSize}
           />

--- a/src/components/developers/apiLogs/ApiLogsTable.tsx
+++ b/src/components/developers/apiLogs/ApiLogsTable.tsx
@@ -16,6 +16,7 @@ import { useFormatterDateHelper } from '~/hooks/helpers/useFormatterDateHelper'
 interface ApiLogsTableProps {
   getApiLogsResult: GetApiLogsQueryResult
   logListRef: RefObject<ListSectionRef>
+  activeRowId?: string
   pageSize?: number
   onPageSizeChange?: (pageSize: number) => void
 }
@@ -23,6 +24,7 @@ interface ApiLogsTableProps {
 export const ApiLogsTable: FC<ApiLogsTableProps> = ({
   getApiLogsResult,
   logListRef,
+  activeRowId,
   pageSize,
   onPageSizeChange,
 }) => {
@@ -55,6 +57,7 @@ export const ApiLogsTable: FC<ApiLogsTableProps> = ({
         containerSize={16}
         rowSize={48}
         data={apiLogs}
+        activeRowId={activeRowId}
         loadingRowCount={pageSize}
         hasError={!!error}
         isLoading={loading}

--- a/src/components/developers/events/EventDetails.tsx
+++ b/src/components/developers/events/EventDetails.tsx
@@ -1,12 +1,13 @@
 import { gql } from '@apollo/client'
 import { Fragment } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useSearchParams } from 'react-router-dom'
 
 import { CodeSnippet } from '~/components/CodeSnippet'
 import { Alert } from '~/components/designSystem/Alert'
 import { Button } from '~/components/designSystem/Button'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Typography } from '~/components/designSystem/Typography'
+import { parseEventKeyFromUrl } from '~/components/developers/events/eventKey'
 import { TimezoneDate } from '~/components/TimezoneDate'
 import { DateFormat, TimeFormat } from '~/core/timezone/utils'
 import { useGetSingleEventQuery } from '~/generated/graphql'
@@ -18,6 +19,7 @@ gql`
     code
     transactionId
     timestamp
+    timestampMs
     receivedAt
     payload
     billableMetricName
@@ -29,8 +31,18 @@ gql`
     customerTimezone
   }
 
-  query getSingleEvent($transactionId: ID!) {
-    event(transactionId: $transactionId) {
+  query getSingleEvent(
+    $transactionId: ID!
+    $externalSubscriptionId: ID
+    $timestampMs: BigInt
+    $code: String
+  ) {
+    event(
+      transactionId: $transactionId
+      externalSubscriptionId: $externalSubscriptionId
+      timestampMs: $timestampMs
+      code: $code
+    ) {
       id
       ...EventDetails
     }
@@ -43,12 +55,22 @@ const dateFormatOptions = {
 }
 
 export const EventDetails = ({ goBack }: { goBack: () => void }) => {
-  const { '*': eventId } = useParams<{ '*': string }>()
+  const { '*': transactionIdParam } = useParams<{ '*': string }>()
+  const [searchParams] = useSearchParams()
   const { translate } = useInternationalization()
 
+  // The transactionId alone cannot address one event — see `EventKey`. Sending the whole tuple
+  // is what gives each duplicate its own Apollo field key instead of replaying the first match.
+  const eventKey = parseEventKeyFromUrl(transactionIdParam, searchParams)
+
   const { data, loading } = useGetSingleEventQuery({
-    variables: { transactionId: eventId || '' },
-    skip: !eventId,
+    variables: {
+      transactionId: eventKey.transactionId || '',
+      externalSubscriptionId: eventKey.externalSubscriptionId,
+      timestampMs: eventKey.timestampMs,
+      code: eventKey.code,
+    },
+    skip: !eventKey.transactionId,
   })
 
   const {

--- a/src/components/developers/events/EventTable.tsx
+++ b/src/components/developers/events/EventTable.tsx
@@ -15,6 +15,7 @@ import { useFormatterDateHelper } from '~/hooks/helpers/useFormatterDateHelper'
 type EventTableProps = {
   getEventsResult: EventsQueryResult
   logListRef: RefObject<ListSectionRef>
+  activeRowId?: string
   pageSize?: number
   onPageSizeChange?: (pageSize: number) => void
 }
@@ -22,6 +23,7 @@ type EventTableProps = {
 export const EventTable: FC<EventTableProps> = ({
   getEventsResult,
   logListRef,
+  activeRowId,
   pageSize,
   onPageSizeChange,
 }) => {
@@ -63,6 +65,7 @@ export const EventTable: FC<EventTableProps> = ({
         containerSize={16}
         rowSize={48}
         data={events}
+        activeRowId={activeRowId}
         hasError={!!error}
         isLoading={loading}
         loadingRowCount={pageSize}

--- a/src/components/developers/events/EventTable.tsx
+++ b/src/components/developers/events/EventTable.tsx
@@ -1,10 +1,11 @@
+import { uniqBy } from 'lodash'
 import { FC, RefObject, useMemo } from 'react'
-import { generatePath } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 
 import { PaginatedContent } from '~/components/designSystem/Pagination'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
-import { EVENT_LOG_ROUTE } from '~/components/developers/devtoolsRoutes'
+import { buildEventLink, serializeEventKey } from '~/components/developers/events/eventKey'
 import { ListSectionRef } from '~/components/developers/LogsLayout'
 import { getCurrentBreakpoint } from '~/core/utils/getCurrentBreakpoint'
 import { EventsQueryResult } from '~/generated/graphql'
@@ -26,16 +27,25 @@ export const EventTable: FC<EventTableProps> = ({
 }) => {
   const { translate } = useInternationalization()
   const { formattedDateTimeWithSecondsOrgaTZ } = useFormatterDateHelper()
+  const [searchParams] = useSearchParams()
 
   const { data, error, loading, fetchMore, refetch } = getEventsResult
 
+  // Rows are keyed on the whole dedup tuple (see `EventKey`), so `Event.id` collisions no
+  // longer merge distinct events. Rows matching the full tuple ARE the same event and are
+  // collapsed here: the API deliberately does not deduplicate the list (measured on 3M rows,
+  // count 18ms -> 1699ms, page 45ms -> 2445ms, reverted in lago-api 2a31919c1). Consequence:
+  // `metadata.totalCount` keeps counting raw rows, so the pager can report one more event
+  // than the list shows.
   const events = useMemo(
     () =>
-      data?.events?.collection.map((event) => ({
-        ...event,
-        // We need to use the transactionId as the id because the eventId is not always available (for Clickhouse events)
-        id: event.transactionId as string,
-      })) || [],
+      uniqBy(
+        data?.events?.collection.map((event) => ({
+          ...event,
+          id: serializeEventKey(event),
+        })) || [],
+        'id',
+      ),
     [data?.events?.collection],
   )
 
@@ -56,14 +66,12 @@ export const EventTable: FC<EventTableProps> = ({
         hasError={!!error}
         isLoading={loading}
         loadingRowCount={pageSize}
-        onRowActionLink={({ transactionId }) => {
+        onRowActionLink={(event) => {
           if (getCurrentBreakpoint() === 'sm') {
             logListRef.current?.updateView('forward')
           }
 
-          return generatePath(EVENT_LOG_ROUTE, {
-            '*': transactionId as string,
-          })
+          return buildEventLink(event, searchParams)
         }}
         columns={[
           {

--- a/src/components/developers/events/Events.tsx
+++ b/src/components/developers/events/Events.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useParams, useSearchParams } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
@@ -84,15 +84,6 @@ export const Events = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data?.events?.collection, transactionId, searchParams])
 
-  // `setActiveRow` writes a raw `data-state` attribute React does not manage, and the table
-  // keys its rows by index, so a new page reuses the same <tr> elements. The highlight has to
-  // be reapplied whenever the rows change, not only when the selected event does.
-  useLayoutEffect(() => {
-    if (transactionId) {
-      logListRef.current?.setActiveRow(selectedEventKey)
-    }
-  }, [transactionId, selectedEventKey, data?.events?.collection])
-
   const shouldDisplayLogDetails = !!transactionId && !!data?.events?.collection.length
 
   return (
@@ -123,6 +114,7 @@ export const Events = () => {
           <EventTable
             getEventsResult={getEventsResult}
             logListRef={logListRef}
+            activeRowId={transactionId ? selectedEventKey : undefined}
             pageSize={pageSize}
             onPageSizeChange={setPageSize}
           />

--- a/src/components/developers/events/Events.tsx
+++ b/src/components/developers/events/Events.tsx
@@ -1,11 +1,15 @@
 import { gql } from '@apollo/client'
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { generatePath, useParams } from 'react-router-dom'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useParams, useSearchParams } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
-import { EVENT_LOG_ROUTE } from '~/components/developers/devtoolsRoutes'
 import { EventDetails } from '~/components/developers/events/EventDetails'
+import {
+  buildEventLink,
+  parseEventKeyFromUrl,
+  serializeEventKey,
+} from '~/components/developers/events/eventKey'
 import { EventTable } from '~/components/developers/events/EventTable'
 import { ListSectionRef, LogsLayout } from '~/components/developers/LogsLayout'
 import { DEFAULT_PAGE_SIZE } from '~/core/constants/pagination'
@@ -18,6 +22,8 @@ gql`
   fragment EventItem on Event {
     id
     transactionId
+    externalSubscriptionId
+    timestampMs
     code
     receivedAt
   }
@@ -39,7 +45,8 @@ gql`
 export const Events = () => {
   const { translate } = useInternationalization()
   const navigate = useNavigate()
-  const { '*': eventId } = useParams<{ '*': string }>()
+  const { '*': transactionId } = useParams<{ '*': string }>()
+  const [searchParams] = useSearchParams()
   const logListRef = useRef<ListSectionRef>(null)
 
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE)
@@ -51,43 +58,42 @@ export const Events = () => {
 
   const { data, loading, refetch } = getEventsResult
 
-  const navigateToFirstEvent = useCallback(
-    (eventCollection?: EventItemFragment[]) => {
-      if (eventCollection?.length) {
-        const firstEvent = eventCollection[0]
+  // Two events can share a transactionId, so the selected row is identified by the whole
+  // dedup tuple: the path carries the transactionId, the search params carry the rest.
+  const selectedEventKey = useMemo(
+    () => serializeEventKey(parseEventKeyFromUrl(transactionId, searchParams)),
+    [transactionId, searchParams],
+  )
 
-        if (firstEvent && getCurrentBreakpoint() !== 'sm') {
-          // We need to use the transactionId as the id because the eventId is not always available (for Clickhouse events)
-          navigate(
-            generatePath(EVENT_LOG_ROUTE, {
-              '*': firstEvent.transactionId as string,
-            }),
-            {
-              replace: true,
-            },
-          )
-        }
-      }
+  const navigateToFirstEvent = useCallback(
+    (eventCollection?: EventItemFragment[], currentSearchParams?: URLSearchParams) => {
+      const firstEvent = eventCollection?.[0]
+
+      if (!firstEvent || getCurrentBreakpoint() === 'sm') return
+
+      navigate(buildEventLink(firstEvent, currentSearchParams), { replace: true })
     },
     [navigate],
   )
 
-  // If no eventId is provided in params, navigate to the first event
+  // If no event is provided in params, navigate to the first event
   useEffect(() => {
-    if (!eventId) {
-      navigateToFirstEvent(data?.events?.collection)
+    if (!transactionId) {
+      navigateToFirstEvent(data?.events?.collection, searchParams)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data?.events?.collection, eventId])
+  }, [data?.events?.collection, transactionId, searchParams])
 
-  // The table should highlight the selected row when the eventId is provided in params
+  // `setActiveRow` writes a raw `data-state` attribute React does not manage, and the table
+  // keys its rows by index, so a new page reuses the same <tr> elements. The highlight has to
+  // be reapplied whenever the rows change, not only when the selected event does.
   useLayoutEffect(() => {
-    if (eventId) {
-      logListRef.current?.setActiveRow(eventId)
+    if (transactionId) {
+      logListRef.current?.setActiveRow(selectedEventKey)
     }
-  }, [eventId])
+  }, [transactionId, selectedEventKey, data?.events?.collection])
 
-  const shouldDisplayLogDetails = !!eventId && !!data?.events?.collection.length
+  const shouldDisplayLogDetails = !!transactionId && !!data?.events?.collection.length
 
   return (
     <div className="flex h-full flex-col not-last-child:shadow-b">
@@ -104,7 +110,7 @@ export const Events = () => {
           onClick={async () => {
             const result = await refetch()
 
-            navigateToFirstEvent(result.data?.events?.collection)
+            navigateToFirstEvent(result.data?.events?.collection, searchParams)
           }}
         >
           {translate('text_1738748043939zqoqzz350yj')}

--- a/src/components/developers/events/__tests__/EventDetails.test.tsx
+++ b/src/components/developers/events/__tests__/EventDetails.test.tsx
@@ -1,0 +1,102 @@
+import { render } from '~/test-utils'
+
+import { EventDetails } from '../EventDetails'
+import {
+  EVENT_CODE_PARAM,
+  EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM,
+  EVENT_TIMESTAMP_MS_PARAM,
+} from '../eventKey'
+
+const mockUseGetSingleEventQuery = jest.fn()
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useGetSingleEventQuery: (options: unknown) => mockUseGetSingleEventQuery(options),
+}))
+
+const setUrl = (search = ''): void => {
+  window.history.pushState({}, '', `/devtool/events${search}`)
+}
+
+describe('EventDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    setUrl()
+    mockUseGetSingleEventQuery.mockReturnValue({ data: undefined, loading: true })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('GIVEN an event selected by its whole dedup tuple', () => {
+    describe('WHEN the details are fetched', () => {
+      it('THEN should query with every key field', () => {
+        setUrl(
+          `?${EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM}=subscription-1&${EVENT_TIMESTAMP_MS_PARAM}=1740000000123&${EVENT_CODE_PARAM}=api_calls`,
+        )
+
+        render(<EventDetails goBack={jest.fn()} />, { useParams: { '*': 'transaction-1' } })
+
+        expect(mockUseGetSingleEventQuery).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: {
+              transactionId: 'transaction-1',
+              externalSubscriptionId: 'subscription-1',
+              timestampMs: '1740000000123',
+              code: 'api_calls',
+            },
+            skip: false,
+          }),
+        )
+      })
+
+      it('THEN should pass timestampMs back untouched, as a string', () => {
+        setUrl(`?${EVENT_TIMESTAMP_MS_PARAM}=1740000000123`)
+
+        render(<EventDetails goBack={jest.fn()} />, { useParams: { '*': 'transaction-1' } })
+
+        const { variables } = mockUseGetSingleEventQuery.mock.calls[0][0]
+
+        expect(variables.timestampMs).toBe('1740000000123')
+      })
+    })
+  })
+
+  describe('GIVEN a url carrying only a transactionId', () => {
+    describe('WHEN the details are fetched', () => {
+      it('THEN should send the missing key fields as null', () => {
+        render(<EventDetails goBack={jest.fn()} />, { useParams: { '*': 'transaction-1' } })
+
+        expect(mockUseGetSingleEventQuery).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: {
+              transactionId: 'transaction-1',
+              externalSubscriptionId: null,
+              timestampMs: null,
+              code: null,
+            },
+          }),
+        )
+      })
+    })
+  })
+
+  describe('GIVEN no event in the url', () => {
+    describe('WHEN the component renders', () => {
+      it('THEN should skip the query', () => {
+        render(<EventDetails goBack={jest.fn()} />, { useParams: {} })
+
+        expect(mockUseGetSingleEventQuery).toHaveBeenCalledWith(
+          expect.objectContaining({ skip: true }),
+        )
+      })
+    })
+  })
+})

--- a/src/components/developers/events/__tests__/EventTable.test.tsx
+++ b/src/components/developers/events/__tests__/EventTable.test.tsx
@@ -51,11 +51,17 @@ const buildResult = (collection: ReturnType<typeof anEvent>[]) =>
   }) as unknown as EventsQueryResult
 
 const logListRef = {
-  current: { updateView: jest.fn(), setActiveRow: jest.fn() },
+  current: { updateView: jest.fn() },
 } as unknown as RefObject<ListSectionRef>
 
-const renderTable = (collection: ReturnType<typeof anEvent>[]) =>
-  render(<EventTable getEventsResult={buildResult(collection)} logListRef={logListRef} />)
+const renderTable = (collection: ReturnType<typeof anEvent>[], activeRowId?: string) =>
+  render(
+    <EventTable
+      getEventsResult={buildResult(collection)}
+      logListRef={logListRef}
+      activeRowId={activeRowId}
+    />,
+  )
 
 describe('EventTable', () => {
   beforeEach(() => {
@@ -139,6 +145,48 @@ describe('EventTable', () => {
         await user.click(screen.getByTestId('table-row-1'))
 
         expect(testMockNavigateFn).toHaveBeenCalledWith(buildEventLink(second))
+      })
+    })
+  })
+  describe('GIVEN one of the duplicate rows is selected', () => {
+    describe('WHEN the table renders', () => {
+      it('THEN should mark only that row as selected', () => {
+        const first = anEvent()
+        const second = anEvent({ code: 'storage' })
+
+        renderTable([first, second], serializeEventKey(second))
+
+        expect(screen.getByTestId('table-row-0')).not.toHaveAttribute('data-state')
+        expect(screen.getByTestId('table-row-1')).toHaveAttribute('data-state', 'selected')
+      })
+
+      it('THEN should keep the selection through a re-render of the rows', () => {
+        const event = anEvent()
+
+        const { rerender } = renderTable([event], serializeEventKey(event))
+
+        // The highlight used to be written straight into the DOM after mount, so any later
+        // re-render of the rows dropped it. Rendering it from the data is what keeps it.
+        rerender(
+          <EventTable
+            getEventsResult={buildResult([event])}
+            logListRef={logListRef}
+            activeRowId={serializeEventKey(event)}
+          />,
+        )
+
+        expect(screen.getByTestId('table-row-0')).toHaveAttribute('data-state', 'selected')
+      })
+    })
+  })
+
+  describe('GIVEN no row is selected', () => {
+    describe('WHEN the table renders', () => {
+      it('THEN should mark no row as selected', () => {
+        renderTable([anEvent(), anEvent({ code: 'storage' })])
+
+        expect(screen.getByTestId('table-row-0')).not.toHaveAttribute('data-state')
+        expect(screen.getByTestId('table-row-1')).not.toHaveAttribute('data-state')
       })
     })
   })

--- a/src/components/developers/events/__tests__/EventTable.test.tsx
+++ b/src/components/developers/events/__tests__/EventTable.test.tsx
@@ -1,0 +1,145 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RefObject } from 'react'
+
+import { ListSectionRef } from '~/components/developers/LogsLayout'
+import { EventsQueryResult } from '~/generated/graphql'
+import { render, testMockNavigateFn } from '~/test-utils'
+
+import { buildEventLink, serializeEventKey } from '../eventKey'
+import { EventTable } from '../EventTable'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('~/hooks/helpers/useFormatterDateHelper', () => ({
+  useFormatterDateHelper: () => ({
+    formattedDateTimeWithSecondsOrgaTZ: (date: string) => date,
+  }),
+}))
+
+jest.mock('~/core/utils/getCurrentBreakpoint', () => ({
+  getCurrentBreakpoint: () => 'md',
+}))
+
+const anEvent = (overrides: Record<string, unknown> = {}) => ({
+  __typename: 'Event' as const,
+  id: 'organization-1-subscription-1-transaction-1-1740000000',
+  transactionId: 'transaction-1',
+  externalSubscriptionId: 'subscription-1',
+  timestampMs: '1740000000123',
+  code: 'api_calls',
+  receivedAt: '2026-02-19T00:00:00Z',
+  ...overrides,
+})
+
+const buildResult = (collection: ReturnType<typeof anEvent>[]) =>
+  ({
+    data: {
+      events: {
+        collection,
+        metadata: { currentPage: 1, totalPages: 1, totalCount: collection.length },
+      },
+    },
+    error: undefined,
+    loading: false,
+    fetchMore: jest.fn(),
+    refetch: jest.fn(),
+  }) as unknown as EventsQueryResult
+
+const logListRef = {
+  current: { updateView: jest.fn(), setActiveRow: jest.fn() },
+} as unknown as RefObject<ListSectionRef>
+
+const renderTable = (collection: ReturnType<typeof anEvent>[]) =>
+  render(<EventTable getEventsResult={buildResult(collection)} logListRef={logListRef} />)
+
+describe('EventTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN two events sharing the same transactionId', () => {
+    describe('WHEN they match the whole dedup tuple', () => {
+      it('THEN should collapse them into a single row', () => {
+        renderTable([anEvent(), anEvent()])
+
+        expect(screen.getAllByRole('row', { name: /api_calls/ })).toHaveLength(1)
+      })
+    })
+
+    describe('WHEN they differ only by code', () => {
+      it('THEN should keep both rows', () => {
+        renderTable([anEvent(), anEvent({ code: 'storage' })])
+
+        expect(screen.getByTestId('table-row-0')).toBeInTheDocument()
+        expect(screen.getByTestId('table-row-1')).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN they differ only by timestampMs', () => {
+      it('THEN should keep both rows', () => {
+        renderTable([anEvent(), anEvent({ timestampMs: '1740000000456' })])
+
+        expect(screen.getByTestId('table-row-1')).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN they differ only by externalSubscriptionId', () => {
+      it('THEN should keep both rows', () => {
+        renderTable([anEvent(), anEvent({ externalSubscriptionId: 'subscription-2' })])
+
+        expect(screen.getByTestId('table-row-1')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN two distinct events sharing the synthesized Clickhouse id', () => {
+    describe('WHEN the table renders', () => {
+      it('THEN should give each row the dedup tuple as data-id', () => {
+        const first = anEvent()
+        const second = anEvent({ code: 'storage' })
+
+        renderTable([first, second])
+
+        expect(screen.getByTestId('table-row-0')).toHaveAttribute(
+          'data-id',
+          serializeEventKey(first),
+        )
+        expect(screen.getByTestId('table-row-1')).toHaveAttribute(
+          'data-id',
+          serializeEventKey(second),
+        )
+      })
+    })
+  })
+
+  describe('GIVEN a rendered row', () => {
+    describe('WHEN it is clicked', () => {
+      it('THEN should navigate to the link carrying the whole dedup tuple', async () => {
+        const user = userEvent.setup()
+        const event = anEvent()
+
+        renderTable([event])
+
+        await user.click(screen.getByTestId('table-row-0'))
+
+        expect(testMockNavigateFn).toHaveBeenCalledWith(buildEventLink(event))
+      })
+
+      it('THEN should navigate to a different link for the duplicate transactionId', async () => {
+        const user = userEvent.setup()
+        const second = anEvent({ code: 'storage' })
+
+        renderTable([anEvent(), second])
+
+        await user.click(screen.getByTestId('table-row-1'))
+
+        expect(testMockNavigateFn).toHaveBeenCalledWith(buildEventLink(second))
+      })
+    })
+  })
+})

--- a/src/components/developers/events/__tests__/Events.test.tsx
+++ b/src/components/developers/events/__tests__/Events.test.tsx
@@ -1,0 +1,171 @@
+import { ReactNode } from 'react'
+
+import { render, testMockNavigateFn } from '~/test-utils'
+
+import {
+  buildEventLink,
+  EVENT_CODE_PARAM,
+  EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM,
+  EVENT_TIMESTAMP_MS_PARAM,
+  serializeEventKey,
+} from '../eventKey'
+import { Events } from '../Events'
+
+const mockSetActiveRow = jest.fn()
+const mockUpdateView = jest.fn()
+const mockUseEventsQuery = jest.fn()
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('~/core/utils/getCurrentBreakpoint', () => ({
+  getCurrentBreakpoint: () => 'md',
+}))
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useEventsQuery: () => mockUseEventsQuery(),
+}))
+
+jest.mock('~/components/developers/events/EventTable', () => ({
+  EventTable: () => <div data-test="event-table-mock" />,
+}))
+
+jest.mock('~/components/developers/events/EventDetails', () => ({
+  EventDetails: () => <div data-test="event-details-mock" />,
+}))
+
+jest.mock('~/components/developers/LogsLayout', () => {
+  const { forwardRef, useImperativeHandle } = jest.requireActual('react')
+
+  return {
+    LogsLayout: {
+      CTASection: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+      ListSection: forwardRef(
+        (
+          { leftSide, rightSide }: { leftSide: ReactNode; rightSide: ReactNode },
+          ref: React.Ref<unknown>,
+        ) => {
+          useImperativeHandle(ref, () => ({
+            setActiveRow: mockSetActiveRow,
+            updateView: mockUpdateView,
+          }))
+
+          return (
+            <div>
+              {leftSide}
+              {rightSide}
+            </div>
+          )
+        },
+      ),
+    },
+  }
+})
+
+const firstEvent = {
+  __typename: 'Event' as const,
+  id: 'organization-1-subscription-1-transaction-1-1740000000',
+  transactionId: 'transaction-1',
+  externalSubscriptionId: 'subscription-1',
+  timestampMs: '1740000000123',
+  code: 'api_calls',
+  receivedAt: '2026-02-19T00:00:00Z',
+}
+
+const duplicateEvent = { ...firstEvent, code: 'storage' }
+
+const setUrl = (search = ''): void => {
+  window.history.pushState({}, '', `/devtool/events${search}`)
+}
+
+describe('Events', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    setUrl()
+    mockUseEventsQuery.mockReturnValue({
+      data: {
+        events: {
+          collection: [firstEvent, duplicateEvent],
+          metadata: { currentPage: 1, totalPages: 1, totalCount: 2 },
+        },
+      },
+      loading: false,
+      refetch: jest.fn(),
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('GIVEN no event is selected in the url', () => {
+    describe('WHEN the list has loaded', () => {
+      it('THEN should redirect to the first event with its whole dedup tuple', () => {
+        render(<Events />)
+
+        expect(testMockNavigateFn).toHaveBeenCalledWith(buildEventLink(firstEvent), {
+          replace: true,
+        })
+      })
+
+      it('THEN should not highlight any row', () => {
+        render(<Events />)
+
+        expect(mockSetActiveRow).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the list is empty', () => {
+      it('THEN should not redirect', () => {
+        mockUseEventsQuery.mockReturnValue({
+          data: { events: { collection: [], metadata: {} } },
+          loading: false,
+          refetch: jest.fn(),
+        })
+
+        render(<Events />)
+
+        expect(testMockNavigateFn).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN two events sharing a transactionId', () => {
+    describe('WHEN the url selects the first one', () => {
+      it('THEN should highlight the row matching its dedup tuple', () => {
+        setUrl(
+          `?${EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM}=subscription-1&${EVENT_TIMESTAMP_MS_PARAM}=1740000000123&${EVENT_CODE_PARAM}=api_calls`,
+        )
+
+        render(<Events />, { useParams: { '*': 'transaction-1' } })
+
+        expect(mockSetActiveRow).toHaveBeenCalledWith(serializeEventKey(firstEvent))
+      })
+    })
+
+    describe('WHEN the url selects the duplicate', () => {
+      it('THEN should highlight the other row, not the first one', () => {
+        setUrl(
+          `?${EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM}=subscription-1&${EVENT_TIMESTAMP_MS_PARAM}=1740000000123&${EVENT_CODE_PARAM}=storage`,
+        )
+
+        render(<Events />, { useParams: { '*': 'transaction-1' } })
+
+        expect(mockSetActiveRow).toHaveBeenCalledWith(serializeEventKey(duplicateEvent))
+        expect(mockSetActiveRow).not.toHaveBeenCalledWith(serializeEventKey(firstEvent))
+      })
+    })
+
+    describe('WHEN an event is already selected', () => {
+      it('THEN should not redirect to the first event', () => {
+        render(<Events />, { useParams: { '*': 'transaction-1' } })
+
+        expect(testMockNavigateFn).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/components/developers/events/__tests__/Events.test.tsx
+++ b/src/components/developers/events/__tests__/Events.test.tsx
@@ -11,9 +11,9 @@ import {
 } from '../eventKey'
 import { Events } from '../Events'
 
-const mockSetActiveRow = jest.fn()
 const mockUpdateView = jest.fn()
 const mockUseEventsQuery = jest.fn()
+const capturedEventTableProps: { activeRowId?: string } = {}
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({
@@ -31,7 +31,11 @@ jest.mock('~/generated/graphql', () => ({
 }))
 
 jest.mock('~/components/developers/events/EventTable', () => ({
-  EventTable: () => <div data-test="event-table-mock" />,
+  EventTable: ({ activeRowId }: { activeRowId?: string }) => {
+    capturedEventTableProps.activeRowId = activeRowId
+
+    return <div data-test="event-table-mock" />
+  },
 }))
 
 jest.mock('~/components/developers/events/EventDetails', () => ({
@@ -50,7 +54,6 @@ jest.mock('~/components/developers/LogsLayout', () => {
           ref: React.Ref<unknown>,
         ) => {
           useImperativeHandle(ref, () => ({
-            setActiveRow: mockSetActiveRow,
             updateView: mockUpdateView,
           }))
 
@@ -85,6 +88,7 @@ const setUrl = (search = ''): void => {
 describe('Events', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    capturedEventTableProps.activeRowId = undefined
     setUrl()
     mockUseEventsQuery.mockReturnValue({
       data: {
@@ -112,10 +116,10 @@ describe('Events', () => {
         })
       })
 
-      it('THEN should not highlight any row', () => {
+      it('THEN should not mark any row as selected', () => {
         render(<Events />)
 
-        expect(mockSetActiveRow).not.toHaveBeenCalled()
+        expect(capturedEventTableProps.activeRowId).toBeUndefined()
       })
     })
 
@@ -136,27 +140,27 @@ describe('Events', () => {
 
   describe('GIVEN two events sharing a transactionId', () => {
     describe('WHEN the url selects the first one', () => {
-      it('THEN should highlight the row matching its dedup tuple', () => {
+      it('THEN should select the row matching its dedup tuple', () => {
         setUrl(
           `?${EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM}=subscription-1&${EVENT_TIMESTAMP_MS_PARAM}=1740000000123&${EVENT_CODE_PARAM}=api_calls`,
         )
 
         render(<Events />, { useParams: { '*': 'transaction-1' } })
 
-        expect(mockSetActiveRow).toHaveBeenCalledWith(serializeEventKey(firstEvent))
+        expect(capturedEventTableProps.activeRowId).toBe(serializeEventKey(firstEvent))
       })
     })
 
     describe('WHEN the url selects the duplicate', () => {
-      it('THEN should highlight the other row, not the first one', () => {
+      it('THEN should select the other row, not the first one', () => {
         setUrl(
           `?${EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM}=subscription-1&${EVENT_TIMESTAMP_MS_PARAM}=1740000000123&${EVENT_CODE_PARAM}=storage`,
         )
 
         render(<Events />, { useParams: { '*': 'transaction-1' } })
 
-        expect(mockSetActiveRow).toHaveBeenCalledWith(serializeEventKey(duplicateEvent))
-        expect(mockSetActiveRow).not.toHaveBeenCalledWith(serializeEventKey(firstEvent))
+        expect(capturedEventTableProps.activeRowId).toBe(serializeEventKey(duplicateEvent))
+        expect(capturedEventTableProps.activeRowId).not.toBe(serializeEventKey(firstEvent))
       })
     })
 

--- a/src/components/developers/events/__tests__/eventKey.test.ts
+++ b/src/components/developers/events/__tests__/eventKey.test.ts
@@ -1,0 +1,195 @@
+import {
+  buildEventLink,
+  EVENT_CODE_PARAM,
+  EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM,
+  EVENT_TIMESTAMP_MS_PARAM,
+  EventKey,
+  parseEventKeyFromUrl,
+  serializeEventKey,
+} from '../eventKey'
+
+const EVENTS_PATH = '/devtool/events/'
+
+const baseKey: EventKey = {
+  transactionId: 'transaction-1',
+  externalSubscriptionId: 'subscription-1',
+  timestampMs: '1740000000123',
+  code: 'api_calls',
+}
+
+// Mirrors the two steps React Router applies on the way out: `decodePath` decodes each
+// pathname segment and re-escapes literal slashes, then `matchPath` substitutes those back
+// into the splat param.
+const parseLink = (link: string): EventKey => {
+  const [pathname, search] = link.split('?')
+  const decodedPathname = pathname
+    .split('/')
+    .map((segment) => decodeURIComponent(segment).replace(/\//g, '%2F'))
+    .join('/')
+  const splat = decodedPathname.replace(EVENTS_PATH, '').replace(/%2F/g, '/')
+
+  return parseEventKeyFromUrl(splat, new URLSearchParams(search))
+}
+
+describe('eventKey', () => {
+  describe('GIVEN two event keys', () => {
+    describe('WHEN the four fields are equal', () => {
+      it('THEN should produce the same serialization', () => {
+        expect(serializeEventKey({ ...baseKey })).toBe(serializeEventKey({ ...baseKey }))
+      })
+
+      it('THEN should treat null and undefined as the same absent value', () => {
+        const withNulls: EventKey = {
+          transactionId: 'transaction-1',
+          externalSubscriptionId: null,
+          timestampMs: null,
+          code: null,
+        }
+        const withUndefined: EventKey = { transactionId: 'transaction-1' }
+
+        expect(serializeEventKey(withNulls)).toBe(serializeEventKey(withUndefined))
+      })
+    })
+
+    describe('WHEN a single field differs', () => {
+      it.each([
+        ['transactionId', { transactionId: 'transaction-2' }],
+        ['externalSubscriptionId', { externalSubscriptionId: 'subscription-2' }],
+        ['timestampMs', { timestampMs: '1740000000124' }],
+        ['code', { code: 'storage' }],
+      ])('THEN should produce a different serialization for %s', (_, override) => {
+        expect(serializeEventKey({ ...baseKey, ...override })).not.toBe(serializeEventKey(baseKey))
+      })
+
+      it('THEN should distinguish an absent field from an empty string', () => {
+        expect(serializeEventKey({ ...baseKey, externalSubscriptionId: null })).not.toBe(
+          serializeEventKey({ ...baseKey, externalSubscriptionId: '' }),
+        )
+      })
+    })
+
+    describe('WHEN the values contain the characters used by the serialization', () => {
+      it.each([
+        ['a slash', 'transaction/1'],
+        ['a lone dash, the marker used for an absent field', '-'],
+        ['a colon', 'transaction:1'],
+        ['a double quote', 'transaction"1'],
+        ['a separator', 'transaction|1'],
+        ['a percent sign', '50%off'],
+      ])('THEN should still serialize %s distinctly', (_, value) => {
+        expect(serializeEventKey({ ...baseKey, transactionId: value })).not.toBe(
+          serializeEventKey(baseKey),
+        )
+      })
+
+      it('THEN should not alias two tuples whose values are shifted across fields', () => {
+        const shiftedLeft = serializeEventKey({
+          ...baseKey,
+          transactionId: 'a|b',
+          externalSubscriptionId: 'c',
+        })
+        const shiftedRight = serializeEventKey({
+          ...baseKey,
+          transactionId: 'a',
+          externalSubscriptionId: 'b|c',
+        })
+
+        expect(shiftedLeft).not.toBe(shiftedRight)
+      })
+
+      it('THEN should escape the characters that would break a data-id selector', () => {
+        const serialized = serializeEventKey({ ...baseKey, transactionId: 'transaction"\\1' })
+
+        expect(serialized).not.toContain('"')
+        expect(serialized).not.toContain('\\')
+      })
+    })
+  })
+
+  describe('GIVEN an event key to link to', () => {
+    describe('WHEN building the link', () => {
+      it('THEN should keep the transactionId in the path', () => {
+        const link = buildEventLink(baseKey)
+
+        expect(link.split('?')[0]).toBe(`${EVENTS_PATH}transaction-1`)
+      })
+
+      it('THEN should percent-encode a transactionId containing a slash', () => {
+        const link = buildEventLink({ ...baseKey, transactionId: 'transaction/1' })
+
+        expect(link.split('?')[0]).toBe(`${EVENTS_PATH}transaction%2F1`)
+      })
+
+      it('THEN should percent-encode a transactionId containing a question mark', () => {
+        const link = buildEventLink({ ...baseKey, transactionId: 'transaction?1' })
+
+        expect(link.split('?')[0]).toBe(`${EVENTS_PATH}transaction%3F1`)
+      })
+
+      it('THEN should carry the three remaining key fields as search params', () => {
+        const searchParams = new URLSearchParams(buildEventLink(baseKey).split('?')[1])
+
+        expect(searchParams.get(EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM)).toBe('subscription-1')
+        expect(searchParams.get(EVENT_TIMESTAMP_MS_PARAM)).toBe('1740000000123')
+        expect(searchParams.get(EVENT_CODE_PARAM)).toBe('api_calls')
+      })
+
+      it('THEN should preserve search params that were already there', () => {
+        const link = buildEventLink(baseKey, new URLSearchParams({ unrelated: 'kept' }))
+        const searchParams = new URLSearchParams(link.split('?')[1])
+
+        expect(searchParams.get('unrelated')).toBe('kept')
+      })
+
+      it('THEN should drop the params of the previously selected event when a field is absent', () => {
+        const link = buildEventLink(
+          { transactionId: 'transaction-1' },
+          new URLSearchParams({
+            [EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM]: 'stale-subscription',
+            [EVENT_TIMESTAMP_MS_PARAM]: '1',
+            [EVENT_CODE_PARAM]: 'stale_code',
+          }),
+        )
+        const searchParams = new URLSearchParams(link.split('?')[1])
+
+        expect(searchParams.get(EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM)).toBeNull()
+        expect(searchParams.get(EVENT_TIMESTAMP_MS_PARAM)).toBeNull()
+        expect(searchParams.get(EVENT_CODE_PARAM)).toBeNull()
+      })
+
+      it('THEN should return a bare path when no key field is set', () => {
+        expect(buildEventLink({})).toBe('/devtool/events')
+      })
+    })
+  })
+
+  describe('GIVEN a link built from an event key', () => {
+    describe('WHEN parsing it back', () => {
+      it.each([
+        ['a complete key', baseKey],
+        ['a key with only a transactionId', { transactionId: 'transaction-1' }],
+        [
+          'a key whose values contain special characters',
+          { ...baseKey, transactionId: 'transaction/1?x', externalSubscriptionId: 'sub&1=2' },
+        ],
+      ])('THEN should round-trip %s', (_, key) => {
+        expect(serializeEventKey(parseLink(buildEventLink(key)))).toBe(serializeEventKey(key))
+      })
+
+      it('THEN should read every field back', () => {
+        expect(parseLink(buildEventLink(baseKey))).toEqual(baseKey)
+      })
+    })
+
+    describe('WHEN the url carries no key at all', () => {
+      it('THEN should return an empty key', () => {
+        expect(parseEventKeyFromUrl(undefined, new URLSearchParams())).toEqual({
+          transactionId: null,
+          externalSubscriptionId: null,
+          timestampMs: null,
+          code: null,
+        })
+      })
+    })
+  })
+})

--- a/src/components/developers/events/eventKey.ts
+++ b/src/components/developers/events/eventKey.ts
@@ -1,0 +1,109 @@
+import { generatePath } from 'react-router-dom'
+
+import { EVENT_LOG_ROUTE } from '~/components/developers/devtoolsRoutes'
+
+export const EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM = 'externalSubscriptionId'
+export const EVENT_TIMESTAMP_MS_PARAM = 'timestampMs'
+export const EVENT_CODE_PARAM = 'code'
+
+/**
+ * The four fields that identify one event.
+ *
+ * `transactionId` alone is not an identity: it is unique only within a subscription on
+ * Postgres and not constrained at all on Clickhouse, where `events_raw` is a plain
+ * MergeTree. `Event.id` is no better — Clickhouse synthesizes it as
+ * `"#{organization_id}-#{external_subscription_id}-#{transaction_id}-#{ingested_at.to_i}"`,
+ * so it truncates to whole seconds and carries no `code`. `code` matters because the
+ * aggregation stores run once per billable metric and bill those rows separately.
+ *
+ * All four are nullable here because that is what the callers hold: three come from
+ * `URLSearchParams.get`, which returns `string | null`, and `transactionId` and
+ * `externalSubscriptionId` are nullable in the schema too. (`code` is not — it is nullable here
+ * only because of the URL round trip.)
+ */
+export type EventKey = {
+  transactionId?: string | null
+  externalSubscriptionId?: string | null
+  /**
+   * `timestampMs` is a GraphQL `BigInt`: it arrives as a string and must be passed back
+   * untouched. Parsing it into a JS number is what loses the millisecond precision that
+   * makes the key an identity in the first place.
+   */
+  timestampMs?: string | null
+  code?: string | null
+}
+
+const SEGMENT_SEPARATOR = '|'
+const NULLISH_SEGMENT = '-'
+const VALUE_SEGMENT_PREFIX = '.'
+
+/**
+ * Encodes one field so that no two distinct tuples can produce the same serialization:
+ * the leading marker separates "absent" from "present", `encodeURIComponent` escapes the
+ * separator (`|` -> `%7C`) so splitting stays unambiguous, and it also escapes `"` and
+ * `\`, which matters because the result ends up in a `data-id` attribute read back with
+ * `querySelector('tr[data-id="…"]')`.
+ */
+const serializeSegment = (value?: string | null): string => {
+  if (value === null || value === undefined) return NULLISH_SEGMENT
+
+  return `${VALUE_SEGMENT_PREFIX}${encodeURIComponent(value)}`
+}
+
+export const serializeEventKey = (key: EventKey): string =>
+  [key.transactionId, key.externalSubscriptionId, key.timestampMs, key.code]
+    .map(serializeSegment)
+    .join(SEGMENT_SEPARATOR)
+
+const setOrDeleteParam = (
+  searchParams: URLSearchParams,
+  name: string,
+  value?: string | null,
+): void => {
+  if (value === null || value === undefined) {
+    // Dropping the param is what makes switching from an event that has the field to one
+    // that does not produce the right key instead of inheriting the previous selection's.
+    searchParams.delete(name)
+
+    return
+  }
+
+  searchParams.set(name, value)
+}
+
+/**
+ * Builds the link to one event: `transactionId` stays in the `*` catchall of
+ * `EVENT_LOG_ROUTE`, the three remaining key fields ride along as search params.
+ *
+ * The catchall can only absorb one value, and every field may contain a `/`. The
+ * `transactionId` is percent-encoded because `generatePath` interpolates the splat raw:
+ * an unencoded `?` or `#` would otherwise truncate the path and swallow the key params.
+ * React Router decodes it back on the way out, so `useParams()['*']` reads the original —
+ * verified for `/ ? # % space | " \`. Known limitation: the router substitutes `%2F` back to
+ * `/` after decoding, so a `transactionId` containing that literal sequence arrives as a
+ * slash. No known ingestion produces one.
+ */
+export const buildEventLink = (key: EventKey, currentSearchParams?: URLSearchParams): string => {
+  const searchParams = new URLSearchParams(currentSearchParams)
+
+  setOrDeleteParam(searchParams, EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM, key.externalSubscriptionId)
+  setOrDeleteParam(searchParams, EVENT_TIMESTAMP_MS_PARAM, key.timestampMs)
+  setOrDeleteParam(searchParams, EVENT_CODE_PARAM, key.code)
+
+  const pathname = generatePath(EVENT_LOG_ROUTE, {
+    '*': key.transactionId ? encodeURIComponent(key.transactionId) : '',
+  })
+  const search = searchParams.toString()
+
+  return search ? `${pathname}?${search}` : pathname
+}
+
+export const parseEventKeyFromUrl = (
+  transactionId: string | undefined,
+  searchParams: URLSearchParams,
+): EventKey => ({
+  transactionId: transactionId || null,
+  externalSubscriptionId: searchParams.get(EVENT_EXTERNAL_SUBSCRIPTION_ID_PARAM),
+  timestampMs: searchParams.get(EVENT_TIMESTAMP_MS_PARAM),
+  code: searchParams.get(EVENT_CODE_PARAM),
+})

--- a/src/components/developers/webhooks/WebhookLogTable.tsx
+++ b/src/components/developers/webhooks/WebhookLogTable.tsx
@@ -16,6 +16,7 @@ import { useFormatterDateHelper } from '~/hooks/helpers/useFormatterDateHelper'
 type WebhookLogTableProps = {
   getWebhookLogsResult: GetWebhookLogQueryResult
   logListRef: React.RefObject<ListSectionRef>
+  activeRowId?: string
   isLoading: boolean
   pageSize?: number
   onPageSizeChange?: (pageSize: number) => void
@@ -24,6 +25,7 @@ type WebhookLogTableProps = {
 export const WebhookLogTable: FC<WebhookLogTableProps> = ({
   getWebhookLogsResult,
   logListRef,
+  activeRowId,
   isLoading,
   pageSize,
   onPageSizeChange,
@@ -49,6 +51,7 @@ export const WebhookLogTable: FC<WebhookLogTableProps> = ({
         containerSize={16}
         rowSize={48}
         data={data?.webhooks.collection ?? []}
+        activeRowId={activeRowId}
         hasError={!!error}
         isLoading={isLoading}
         loadingRowCount={pageSize}

--- a/src/components/developers/webhooks/WebhookLogs.tsx
+++ b/src/components/developers/webhooks/WebhookLogs.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { generatePath, useParams, useSearchParams } from 'react-router-dom'
 
 import { Button } from '~/components/designSystem/Button'
@@ -167,14 +167,6 @@ export const WebhookLogs = ({ webhookId }: WebhookLogsProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data?.webhooks.collection, logId])
 
-  // The table should highlight the selected row when the logId is provided in params
-  useLayoutEffect(() => {
-    if (logId && logListRef.current) {
-      logListRef.current.setActiveRow(logId)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [logId, logListRef.current])
-
   const shouldDisplayLogDetails = !!logId && !!data?.webhooks.collection.length
 
   return (
@@ -221,6 +213,7 @@ export const WebhookLogs = ({ webhookId }: WebhookLogsProps) => {
           <WebhookLogTable
             getWebhookLogsResult={getWebhookLogsResult}
             logListRef={logListRef}
+            activeRowId={logId}
             isLoading={isSearchLoading}
             pageSize={pageSize}
             onPageSizeChange={setPageSize}

--- a/src/core/apolloClient/__tests__/cache.test.ts
+++ b/src/core/apolloClient/__tests__/cache.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import { DocumentNode, FieldNode, OperationDefinitionNode, parse, SelectionNode } from 'graphql'
 import path from 'path'
 
-import { queryFieldPolicies } from '../cache'
+import { cache, EVENT_KEY_FIELDS, queryFieldPolicies } from '../cache'
 
 const SRC_DIR = path.resolve(__dirname, '../../..')
 
@@ -175,5 +175,51 @@ describe('cache typePolicies', () => {
     for (const fieldName of FIELDS_WITHOUT_FETCH_MORE) {
       expect(Array.from(paginatedFields.keys())).toContain(fieldName)
     }
+  })
+})
+
+// `Event.id` is synthesized by Clickhouse at whole-second precision and without the
+// billable metric code, so two genuinely distinct events can share it and collapse into a
+// single normalized entity — which is what made the events list render the wrong rows.
+// Shortening this tuple silently reintroduces that bug, hence the exact-match assertion.
+describe('Event typePolicy', () => {
+  it('normalizes Event on the full dedup tuple', () => {
+    expect(EVENT_KEY_FIELDS).toEqual([
+      'transactionId',
+      'externalSubscriptionId',
+      'timestampMs',
+      'code',
+    ])
+  })
+
+  it('gives two events differing only by code distinct cache entries', () => {
+    const identify = (code: string): string | undefined =>
+      cache.identify({
+        __typename: 'Event',
+        id: 'organization-1-subscription-1-transaction-1-1740000000',
+        transactionId: 'transaction-1',
+        externalSubscriptionId: 'subscription-1',
+        timestampMs: '1740000000123',
+        code,
+      })
+
+    expect(identify('api_calls')).not.toEqual(identify('storage'))
+  })
+
+  it('gives two events matching the whole tuple the same cache entry', () => {
+    const event = {
+      __typename: 'Event',
+      transactionId: 'transaction-1',
+      externalSubscriptionId: 'subscription-1',
+      timestampMs: '1740000000123',
+      code: 'api_calls',
+    }
+
+    const identified = cache.identify({ ...event, id: 'synthesized-id-1' })
+
+    // `identify` returns undefined for a key field missing from the object, so without this
+    // the equality below would also hold for two failed lookups.
+    expect(identified).toBeDefined()
+    expect(identified).toEqual(cache.identify({ ...event, id: 'synthesized-id-2' }))
   })
 })

--- a/src/core/apolloClient/cache.ts
+++ b/src/core/apolloClient/cache.ts
@@ -1,5 +1,7 @@
 import { FieldPolicy, InMemoryCache } from '@apollo/client'
 
+import { Event } from '~/generated/graphql'
+
 import { createPaginatedFieldPolicy, createSinglePageFieldPolicy } from './cacheHelpers'
 
 // Every root query field consumed via fetchMore needs a merge policy here, otherwise
@@ -87,10 +89,27 @@ export const queryFieldPolicies: Record<string, FieldPolicy> = {
   },
 }
 
+// `Event.id` is not an identity — the rationale lives on `EventKey` in
+// `~/components/developers/events/eventKey`. Dropping any of the four fields re-merges events
+// the API bills separately, which is the bug this policy exists to prevent.
+//
+// Every query returning an `Event` MUST select all four fields. A selection missing one makes
+// Apollo throw (InvariantError 5, raised by the key extractor) and discard the whole write —
+// it does not merely warn. Both `EventItem` and `EventDetails` cover the tuple.
+export const EVENT_KEY_FIELDS = [
+  'transactionId',
+  'externalSubscriptionId',
+  'timestampMs',
+  'code',
+] satisfies (keyof Event)[]
+
 export const cache = new InMemoryCache({
   typePolicies: {
     Query: {
       fields: queryFieldPolicies,
+    },
+    Event: {
+      keyFields: EVENT_KEY_FIELDS,
     },
   },
 })

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -4145,6 +4145,7 @@ export type Event = {
   payload: Scalars['JSON']['output'];
   receivedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   timestamp?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  timestampMs?: Maybe<Scalars['BigInt']['output']>;
   transactionId?: Maybe<Scalars['String']['output']>;
 };
 
@@ -8795,7 +8796,10 @@ export type QueryDunningCampaignsArgs = {
 
 
 export type QueryEventArgs = {
-  transactionId: Scalars['ID']['input'];
+  code?: InputMaybe<Scalars['String']['input']>;
+  externalSubscriptionId?: InputMaybe<Scalars['ID']['input']>;
+  timestampMs?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 
@@ -12683,16 +12687,19 @@ export type GetApiLogsQueryVariables = Exact<{
 
 export type GetApiLogsQuery = { __typename?: 'Query', apiLogs?: { __typename?: 'ApiLogCollection', collection: Array<{ __typename?: 'ApiLog', requestId: string, httpMethod: HttpMethodEnum, httpStatus: number, requestPath?: string | null, loggedAt: any }>, metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number } } | null };
 
-export type EventDetailsFragment = { __typename?: 'Event', id: string, code: string, transactionId?: string | null, timestamp?: any | null, receivedAt?: any | null, payload: any, billableMetricName?: string | null, matchBillableMetric?: boolean | null, matchCustomField?: boolean | null, apiClient?: string | null, ipAddress?: string | null, externalSubscriptionId?: string | null, customerTimezone: TimezoneEnum };
+export type EventDetailsFragment = { __typename?: 'Event', id: string, code: string, transactionId?: string | null, timestamp?: any | null, timestampMs?: any | null, receivedAt?: any | null, payload: any, billableMetricName?: string | null, matchBillableMetric?: boolean | null, matchCustomField?: boolean | null, apiClient?: string | null, ipAddress?: string | null, externalSubscriptionId?: string | null, customerTimezone: TimezoneEnum };
 
 export type GetSingleEventQueryVariables = Exact<{
   transactionId: Scalars['ID']['input'];
+  externalSubscriptionId?: InputMaybe<Scalars['ID']['input']>;
+  timestampMs?: InputMaybe<Scalars['BigInt']['input']>;
+  code?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type GetSingleEventQuery = { __typename?: 'Query', event?: { __typename?: 'Event', id: string, code: string, transactionId?: string | null, timestamp?: any | null, receivedAt?: any | null, payload: any, billableMetricName?: string | null, matchBillableMetric?: boolean | null, matchCustomField?: boolean | null, apiClient?: string | null, ipAddress?: string | null, externalSubscriptionId?: string | null, customerTimezone: TimezoneEnum } | null };
+export type GetSingleEventQuery = { __typename?: 'Query', event?: { __typename?: 'Event', id: string, code: string, transactionId?: string | null, timestamp?: any | null, timestampMs?: any | null, receivedAt?: any | null, payload: any, billableMetricName?: string | null, matchBillableMetric?: boolean | null, matchCustomField?: boolean | null, apiClient?: string | null, ipAddress?: string | null, externalSubscriptionId?: string | null, customerTimezone: TimezoneEnum } | null };
 
-export type EventItemFragment = { __typename?: 'Event', id: string, transactionId?: string | null, code: string, receivedAt?: any | null };
+export type EventItemFragment = { __typename?: 'Event', id: string, transactionId?: string | null, externalSubscriptionId?: string | null, timestampMs?: any | null, code: string, receivedAt?: any | null };
 
 export type EventsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -12700,7 +12707,7 @@ export type EventsQueryVariables = Exact<{
 }>;
 
 
-export type EventsQuery = { __typename?: 'Query', events?: { __typename?: 'EventCollection', collection: Array<{ __typename?: 'Event', id: string, transactionId?: string | null, code: string, receivedAt?: any | null }>, metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number } } | null };
+export type EventsQuery = { __typename?: 'Query', events?: { __typename?: 'EventCollection', collection: Array<{ __typename?: 'Event', id: string, transactionId?: string | null, externalSubscriptionId?: string | null, timestampMs?: any | null, code: string, receivedAt?: any | null }>, metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number } } | null };
 
 export type WebhookLogDetailsFragment = { __typename?: 'Webhook', id: string, webhookType: string, status: WebhookStatusEnum, payload?: string | null, response?: string | null, httpStatus?: number | null, endpoint: string, retries: number, updatedAt: any };
 
@@ -18102,6 +18109,7 @@ export const EventDetailsFragmentDoc = gql`
   code
   transactionId
   timestamp
+  timestampMs
   receivedAt
   payload
   billableMetricName
@@ -18117,6 +18125,8 @@ export const EventItemFragmentDoc = gql`
     fragment EventItem on Event {
   id
   transactionId
+  externalSubscriptionId
+  timestampMs
   code
   receivedAt
 }
@@ -27561,8 +27571,13 @@ export type GetApiLogsLazyQueryHookResult = ReturnType<typeof useGetApiLogsLazyQ
 export type GetApiLogsSuspenseQueryHookResult = ReturnType<typeof useGetApiLogsSuspenseQuery>;
 export type GetApiLogsQueryResult = Apollo.QueryResult<GetApiLogsQuery, GetApiLogsQueryVariables>;
 export const GetSingleEventDocument = gql`
-    query getSingleEvent($transactionId: ID!) {
-  event(transactionId: $transactionId) {
+    query getSingleEvent($transactionId: ID!, $externalSubscriptionId: ID, $timestampMs: BigInt, $code: String) {
+  event(
+    transactionId: $transactionId
+    externalSubscriptionId: $externalSubscriptionId
+    timestampMs: $timestampMs
+    code: $code
+  ) {
     id
     ...EventDetails
   }
@@ -27582,6 +27597,9 @@ export const GetSingleEventDocument = gql`
  * const { data, loading, error } = useGetSingleEventQuery({
  *   variables: {
  *      transactionId: // value for 'transactionId'
+ *      externalSubscriptionId: // value for 'externalSubscriptionId'
+ *      timestampMs: // value for 'timestampMs'
+ *      code: // value for 'code'
  *   },
  * });
  */

--- a/src/hooks/__tests__/useDeveloperTool.test.tsx
+++ b/src/hooks/__tests__/useDeveloperTool.test.tsx
@@ -166,6 +166,52 @@ describe('useDeveloperTool', () => {
     })
   })
 
+  describe('checkParamsFromUrl (devtool-tab bridge)', () => {
+    const openWith = (devtoolTab: string) => {
+      const params = new URLSearchParams({ 'devtool-tab': devtoolTab })
+
+      window.history.replaceState({}, '', `/?${params.toString()}`)
+
+      return renderHook(() => useDeveloperTool(), { wrapper })
+    }
+
+    describe('GIVEN a copied link whose devtools address carries search params', () => {
+      describe('WHEN the hook mounts', () => {
+        it('THEN it should reopen the panel on the full address, search string included', () => {
+          const address =
+            '/devtool/events/transaction-1?externalSubscriptionId=subscription-1&timestampMs=1740000000123&code=api_calls'
+
+          const { result } = openWith(address)
+
+          expect(result.current.url).toBe(address)
+          expect(mockOpenPanel).toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('GIVEN a devtools address containing a percent-encoded character', () => {
+      describe('WHEN the hook mounts', () => {
+        it('THEN it should not decode it a second time', () => {
+          const address = '/devtool/events/transaction%3F1?code=api_calls'
+
+          const { result } = openWith(address)
+
+          expect(result.current.url).toBe(address)
+        })
+      })
+    })
+
+    describe('GIVEN no devtool-tab param', () => {
+      describe('WHEN the hook mounts', () => {
+        it('THEN it should not open the panel', () => {
+          renderHook(() => useDeveloperTool(), { wrapper })
+
+          expect(mockOpenPanel).not.toHaveBeenCalled()
+        })
+      })
+    })
+  })
+
   describe('resetDevtoolsNavigation', () => {
     describe('GIVEN the devtools has navigated to a specific tab', () => {
       describe('WHEN resetDevtoolsNavigation is called', () => {

--- a/src/hooks/__tests__/useDeveloperTool.test.tsx
+++ b/src/hooks/__tests__/useDeveloperTool.test.tsx
@@ -8,10 +8,14 @@ import {
   useDeveloperTool,
 } from '~/hooks/useDeveloperTool'
 
-// Mock useCurrentUser
+// Mock useCurrentUser — mutable so a cold cache (user still loading) can be simulated
+let mockCurrentUser: { id: string } | undefined = { id: 'test-user' }
+
 jest.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({
-    currentUser: { id: 'test-user' },
+    get currentUser() {
+      return mockCurrentUser
+    },
   }),
 }))
 
@@ -39,6 +43,7 @@ describe('useDeveloperTool', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     window.history.replaceState({}, '', '/')
+    mockCurrentUser = { id: 'test-user' }
   })
 
   describe('DeveloperToolProvider', () => {
@@ -197,6 +202,33 @@ describe('useDeveloperTool', () => {
           const { result } = openWith(address)
 
           expect(result.current.url).toBe(address)
+        })
+      })
+    })
+
+    describe('GIVEN a cold cache, with the user still loading', () => {
+      describe('WHEN the hook mounts', () => {
+        it('THEN it should not open the panel yet', () => {
+          mockCurrentUser = undefined
+
+          const { result } = openWith('/devtool/events')
+
+          expect(mockOpenPanel).not.toHaveBeenCalled()
+          expect(result.current.url).toBe('')
+        })
+
+        it('THEN it should still open the panel once the user lands', () => {
+          mockCurrentUser = undefined
+
+          const { result, rerender } = openWith('/devtool/events')
+
+          // The param used to be consumed on that first render, so the link was thrown away
+          // before it could open anything.
+          mockCurrentUser = { id: 'test-user' }
+          rerender()
+
+          expect(mockOpenPanel).toHaveBeenCalled()
+          expect(result.current.url).toBe('/devtool/events')
         })
       })
     })

--- a/src/hooks/useDeveloperTool.tsx
+++ b/src/hooks/useDeveloperTool.tsx
@@ -91,15 +91,16 @@ export function useDeveloperTool(): DeveloperToolContextType {
   // We can copy/paste the URL of the devtools in the browser and it will open the devtools with the correct tab
   const checkParamsFromUrl = () => {
     const params = new URLSearchParams(window.location.search)
+    // `params.get` already percent-decodes; decoding twice corrupts any value that legitimately
+    // contains an escape, such as the percent-encoded transaction id of an event.
     const devtoolTab = params.get(DEVTOOL_TAB_PARAMS) ?? ''
-    const decodedDevtoolTab = decodeURIComponent(devtoolTab)
 
     const isValidUser = !!currentUser
 
-    if (decodedDevtoolTab && isValidUser) {
+    if (devtoolTab && isValidUser) {
       // Use setUrl to navigate in the MemoryRouter (devtools panel), not navigate() which would
       // navigate in the BrowserRouter
-      context?.setUrl(decodedDevtoolTab)
+      context?.setUrl(devtoolTab)
       context?.openPanel()
     }
 

--- a/src/hooks/useDeveloperTool.tsx
+++ b/src/hooks/useDeveloperTool.tsx
@@ -95,35 +95,33 @@ export function useDeveloperTool(): DeveloperToolContextType {
     // contains an escape, such as the percent-encoded transaction id of an event.
     const devtoolTab = params.get(DEVTOOL_TAB_PARAMS) ?? ''
 
-    const isValidUser = !!currentUser
+    // On a cold cache the user is still loading on the first render. Consuming the param
+    // then would drop it before it could open anything, so it is left in the URL and the
+    // effect below runs again once the user lands.
+    if (!currentUser || !devtoolTab) return
 
-    if (devtoolTab && isValidUser) {
-      // Use setUrl to navigate in the MemoryRouter (devtools panel), not navigate() which would
-      // navigate in the BrowserRouter
-      context?.setUrl(devtoolTab)
-      context?.openPanel()
-    }
+    // Use setUrl to navigate in the MemoryRouter (devtools panel), not navigate() which would
+    // navigate in the BrowserRouter
+    context?.setUrl(devtoolTab)
+    context?.openPanel()
 
     // Remove the devtool-tab param from the URL using React Router's navigate with replace.
     // This ensures the location object is updated (not just the browser URL), so the location
     // history won't contain the devtool-tab param when goBack() is called later.
-    if (devtoolTab) {
-      params.delete(DEVTOOL_TAB_PARAMS)
-      const search = params.toString()
+    params.delete(DEVTOOL_TAB_PARAMS)
+    const search = params.toString()
 
-      navigate(
-        { pathname: window.location.pathname, search: search ? `?${search}` : '' },
-        { replace: true },
-      )
-    }
+    navigate(
+      { pathname: window.location.pathname, search: search ? `?${search}` : '' },
+      { replace: true },
+    )
   }
 
   useEffect(() => {
-    // On mounted, check the params from the URL
     checkParamsFromUrl()
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [currentUser?.id])
 
   // Throw an error if the hook is used outside of the provider
   if (!context) {


### PR DESCRIPTION
## Context

The developer Events tab could not switch between two events sharing a
transaction ID: clicking the second one left the detail pane on the first, and
the row highlight always landed on the first duplicate.

Two independent defects were behind it.

Selection state lived entirely in the URL, keyed on `transactionId` alone
(`EVENT_LOG_ROUTE` is `/devtool/events/*`). Two events sharing a transaction ID
produced an identical pathname, so `useParams()['*']` never changed, the
`getSingleEvent` variables never changed, and Apollo replayed the cached result.

Separately, the table overwrote each row's `id` with the transaction ID, so the
`data-id` attribute the highlight resolves against collided. Underneath that,
Clickhouse synthesizes `Event.id` as
`"#{organization_id}-#{external_subscription_id}-#{transaction_id}-#{ingested_at.to_i}"`
— whole seconds, and no `code`. Two genuinely distinct, separately billed events
can therefore share a byte-identical `id`, collapse into one normalized Apollo
entity, and make the list itself render the wrong rows, not just the detail pane.

Widening the synthesized id on the backend was rejected: it would change
`lago_id` as exposed by `V1::EventSerializer`, a public REST contract.

## Description

Everything that identifies an event — the URL, the row `data-id` and the Apollo
cache key — now keys on the full deduplication tuple
`transactionId + externalSubscriptionId + timestampMs + code`, which is the
identity the API resolver accepts. All four are required: `code` is not padding,
since the aggregation stores run once per billable metric and bill those rows
separately.

- Both `Event` fragments (`EventItem`, `EventDetails`) select the complete tuple,
  and `getSingleEvent` passes all four to `Query.event`. `timestampMs` is a
  `BigInt`, arrives as a string and is passed back untouched — parsing it into a
  number loses the millisecond precision the key depends on.
- New `eventKey` module owns the addressing: `transactionId` stays in the `*`
  catchall (percent-encoded, since `generatePath` interpolates the splat raw and
  an unencoded `?` would swallow the rest), the other three ride as search
  params. The route shape is unchanged.
- Rows carry the serialized tuple as `id`, so `data-id` is unique per event and
  the highlight follows the clicked row. The highlight is now also reapplied when
  the rows change, since `data-state` is a raw attribute React does not manage
  and the table keys rows by index.
- An `Event` type policy keys normalization on the same four fields. Every query
  returning an `Event` must select all four: a selection missing one makes Apollo
  throw and discard the whole write.
- Duplicate rows are collapsed client-side over the page already fetched. The
  type policy alone is not enough — two identical rows become two references to
  the same entity, so both still render. Server-side deduplication was built,
  measured and reverted: on 3M `events_raw` rows the count went 18ms to 1699ms
  and a page 45ms to 2445ms, and without a memory ceiling it restarted the
  Clickhouse container. Accepted consequence: `metadata.totalCount` keeps
  counting raw rows, so the pager can report one more event than the list shows.
- Fixed the devtools address bridge, which this change would otherwise have
  broken: the `devtool-tab` param captured only the panel's pathname, so a copied
  inspector link or a typed `/devtool/...` URL dropped three of the four key
  fields and reopened the wrong row. It now carries the search string too, and no
  longer decodes the value twice — the second decode corrupted any
  percent-encoded transaction ID.
- Removed two stale comments claiming the event id is "not always available (for
  Clickhouse events)". False since lago-api `cc2fa597e`, where
  `Types::Events::Object` declares `field :id, ID, null: false`.

Depends on the API half: this selects `Event.timestampMs` and the new
`Query.event` arguments, so it cannot merge before getlago/lago-api#6209.

<!-- Linear link -->
Fixes ING-595
