### PR TITLE
feat(taxes): update schema for product integrations mapping

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -2375,6 +2375,7 @@ export type CreateRateCardInput = {
   proration?: InputMaybe<Scalars['Boolean']['input']>;
   rates?: InputMaybe<Array<RateCardRateInput>>;
   regroupPaidFees?: InputMaybe<RateCardRegroupPaidFeesEnum>;
+  taxCodes?: InputMaybe<Array<Scalars['String']['input']>>;
   walletTargetable?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
@@ -5472,7 +5473,8 @@ export type LoseInvoiceDisputeInput = {
 
 export enum MappableTypeEnum {
   AddOn = 'AddOn',
-  BillableMetric = 'BillableMetric'
+  BillableMetric = 'BillableMetric',
+  Product = 'Product'
 }
 
 export type Mapping = {
@@ -8106,12 +8108,19 @@ export type Product = {
   description?: Maybe<Scalars['String']['output']>;
   filtersCount: Scalars['Int']['output'];
   id: Scalars['ID']['output'];
+  integrationMappings?: Maybe<Array<Mapping>>;
   invoiceDisplayName?: Maybe<Scalars['String']['output']>;
   name: Scalars['String']['output'];
   organization?: Maybe<Organization>;
   productCategory?: Maybe<ProductCategory>;
   productType: ProductTypeEnum;
   updatedAt: Scalars['ISO8601DateTime']['output'];
+};
+
+
+/** Base product */
+export type ProductIntegrationMappingsArgs = {
+  integrationId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** Base product_category */
@@ -9683,6 +9692,7 @@ export type RateCard = {
   proration: Scalars['Boolean']['output'];
   ratesCount: Scalars['Int']['output'];
   regroupPaidFees: RateCardRegroupPaidFeesEnum;
+  taxes: Array<Tax>;
   updatedAt: Scalars['ISO8601DateTime']['output'];
   walletTargetable?: Maybe<Scalars['Boolean']['output']>;
 };
@@ -11484,6 +11494,7 @@ export type UpdateRateCardInput = {
   name?: InputMaybe<Scalars['String']['input']>;
   proration?: InputMaybe<Scalars['Boolean']['input']>;
   regroupPaidFees?: InputMaybe<RateCardRegroupPaidFeesEnum>;
+  taxCodes?: InputMaybe<Array<Scalars['String']['input']>>;
   walletTargetable?: InputMaybe<Scalars['Boolean']['input']>;
 };
 

--- a/src/pages/settings/integrations/FetchableIntegrationItemList/types.ts
+++ b/src/pages/settings/integrations/FetchableIntegrationItemList/types.ts
@@ -16,6 +16,8 @@ import {
   MappableIntegrationProvider,
 } from '~/pages/settings/integrations/common'
 
+type SupportedMappableType = MappableTypeEnum.AddOn | MappableTypeEnum.BillableMetric
+
 export type FetchMoreFunction = ReturnType<
   | typeof useGetAddOnsForNetsuiteItemsListLazyQuery
   | typeof useGetBillableMetricsForNetsuiteItemsListLazyQuery
@@ -36,7 +38,7 @@ export type FetchIntegrationItemsListProps = {
   isLoading: boolean
   integrationMapItemDrawerRef: MappableIntegrationMapItemDrawerRef
   createRoute: string
-  mappableType: MappableTypeEnum
+  mappableType: SupportedMappableType
   provider: MappableIntegrationProvider
   firstColumnName?: string
 }
@@ -47,6 +49,6 @@ export type FetchableIntegrationItemErrorProps = {
 
 export type FetchableIntegrationItemEmptyProps = {
   hasSearchTerm: boolean
-  type: MappableTypeEnum
+  type: SupportedMappableType
   createRoute: string
 }


### PR DESCRIPTION
## Context

_Part of the products and plans project._

Backend PR https://github.com/getlago/lago-api/pull/6210 adds `Product` to `MappableTypeEnum` and exposes integration mappings on Products.

This PR should be merged immediately after the backend PR

## Description

- Regenerate the GraphQL types.
- Restrict the existing integration item list to Add-ons and Billable Metrics.

The actual support for Products in integration mapping UI will be added in a future PR.
