### PR TITLE
fix(invoices): scope tax-provider re-sync rows to the connected provider

### DIFF
--- a/src/pages/InvoiceOverview.tsx
+++ b/src/pages/InvoiceOverview.tsx
@@ -60,6 +60,11 @@ import { tw } from '~/styles/utils'
 
 const { appEnv } = envGlobalVar()
 
+export const ANROK_SECTION_TEST_ID = 'invoice-overview-anrok-section'
+export const AVALARA_SECTION_TEST_ID = 'invoice-overview-avalara-section'
+export const ANROK_RESYNC_CTA_TEST_ID = 'invoice-overview-anrok-resync-cta'
+export const AVALARA_RESYNC_CTA_TEST_ID = 'invoice-overview-avalara-resync-cta'
+
 gql`
   fragment InvoiceDetailsForInvoiceOverview on Invoice {
     id
@@ -230,9 +235,18 @@ const InlineLink = ({ children, ...props }: LinkProps) => {
   )
 }
 
-const InfoLine = ({ children }: { children: React.ReactNode }) => {
+const InfoLine = ({
+  children,
+  dataTest,
+}: {
+  children: React.ReactNode
+  dataTest?: string
+}): JSX.Element => {
   return (
-    <div className="mb-3 flex items-start first-child:mr-3 first-child:min-w-58 first-child:leading-7 last-child:w-full last-child:line-break-anywhere">
+    <div
+      data-test={dataTest}
+      className="mb-3 flex items-start first-child:mr-3 first-child:min-w-58 first-child:leading-7 last-child:w-full last-child:line-break-anywhere"
+    >
       {children}
     </div>
   )
@@ -410,9 +424,14 @@ const InvoiceOverview = memo(
     const showNetsuiteSection =
       !!connectedNetsuiteIntegration?.accountId && !!invoice?.externalIntegrationId
 
+    // `taxProviderVoidable` is tax-provider-agnostic, so each re-sync row must be scoped to the
+    // tax provider the customer is actually connected to.
     const showTaxProviderReSyncButton = invoice?.taxProviderVoidable
+    const showAnrokReSyncButton = !!showTaxProviderReSyncButton && !!customer?.anrokCustomer
+    const showAvalaraReSyncButton = !!showTaxProviderReSyncButton && !!customer?.avalaraCustomer
+
     const showAnrokLink = isInvoiceFinalizedOrVoided && !!customer?.anrokCustomer?.externalAccountId
-    const showAnrokSection = (showTaxProviderReSyncButton || showAnrokLink) && !!fees?.length
+    const showAnrokSection = (showAnrokReSyncButton || showAnrokLink) && !!fees?.length
 
     const showAvalaraLink =
       isInvoiceFinalizedOrVoided &&
@@ -421,7 +440,7 @@ const InvoiceOverview = memo(
       !!connectedAvalaraIntegration?.accountId &&
       !!invoice?.taxProviderId
 
-    const showAvalaraSection = (showAvalaraLink || showTaxProviderReSyncButton) && !!fees?.length
+    const showAvalaraSection = (showAvalaraLink || showAvalaraReSyncButton) && !!fees?.length
 
     const showHubspotReSyncButton = invoice?.integrationHubspotSyncable
     const showHubspotLink =
@@ -565,7 +584,7 @@ const InvoiceOverview = memo(
                   </SectionHeader>
 
                   {showAnrokSection && (
-                    <InfoLine>
+                    <InfoLine dataTest={ANROK_SECTION_TEST_ID}>
                       <Typography variant="caption" color="grey600" noWrap>
                         {translate('text_1724772240299r3u9nouqflf')}
                       </Typography>
@@ -594,6 +613,7 @@ const InvoiceOverview = memo(
                           </Typography>
                           <span>•</span>
                           <InlineLink
+                            data-test={ANROK_RESYNC_CTA_TEST_ID}
                             to={'#'}
                             onClick={(e) => {
                               e.preventDefault()
@@ -613,7 +633,7 @@ const InvoiceOverview = memo(
                   )}
 
                   {showAvalaraSection && (
-                    <InfoLine>
+                    <InfoLine dataTest={AVALARA_SECTION_TEST_ID}>
                       <Typography variant="caption" color="grey600" noWrap>
                         {translate('text_1747408519913t2tehiclc5m')}
                       </Typography>
@@ -645,6 +665,7 @@ const InvoiceOverview = memo(
                           </Typography>
                           <span>•</span>
                           <InlineLink
+                            data-test={AVALARA_RESYNC_CTA_TEST_ID}
                             to={'#'}
                             onClick={(e) => {
                               e.preventDefault()

--- a/src/pages/__tests__/InvoiceOverview.test.tsx
+++ b/src/pages/__tests__/InvoiceOverview.test.tsx
@@ -1,0 +1,204 @@
+import { RenderResult, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import {
+  AllInvoiceDetailsForCustomerInvoiceDetailsFragment,
+  CustomerForInvoiceOverviewFragment,
+  FeeDetailsForInvoiceOverviewFragment,
+  InvoiceStatusTypeEnum,
+  TimezoneEnum,
+} from '~/generated/graphql'
+import InvoiceOverview, {
+  ANROK_RESYNC_CTA_TEST_ID,
+  ANROK_SECTION_TEST_ID,
+  AVALARA_RESYNC_CTA_TEST_ID,
+  AVALARA_SECTION_TEST_ID,
+} from '~/pages/InvoiceOverview'
+import { render } from '~/test-utils'
+
+// Stub the heavy children of the overview: they pull drawer/dialog stacks relying on the
+// Vite-only `import.meta`, which jest cannot parse. The tax-provider rows under test live
+// in InvoiceOverview itself.
+jest.mock('~/components/invoices/details/ViewFeeDetailsDrawer', () => ({
+  ViewFeeDetailsDrawerProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useViewFeeDetailsDrawer: () => ({ open: jest.fn(), close: jest.fn() }),
+}))
+
+jest.mock('~/components/invoices/details/EditFeeDrawer', () => ({
+  EditFeeDrawer: () => null,
+}))
+
+jest.mock('~/components/invoices/details/InvoiceDetailsTable', () => ({
+  InvoiceDetailsTable: () => null,
+  InvoiceTableSection: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('~/components/invoices/InvoiceOverviewHeaderButtons', () => ({
+  InvoiceOverviewHeaderButtons: () => null,
+}))
+
+jest.mock('~/components/invoices/InvoiceCustomerInfos', () => ({
+  InvoiceCustomerInfos: () => null,
+}))
+
+jest.mock('~/components/invoices/Metadatas', () => ({
+  Metadatas: () => null,
+}))
+
+const ANROK_CUSTOMER = { id: 'anrok-customer-1', externalAccountId: null }
+const AVALARA_CUSTOMER = { id: 'avalara-customer-1', externalCustomerId: null }
+
+const buildCustomer = (
+  overrides: Partial<CustomerForInvoiceOverviewFragment>,
+): CustomerForInvoiceOverviewFragment =>
+  ({
+    id: 'customer-1',
+    applicableTimezone: TimezoneEnum.TzUtc,
+    anrokCustomer: null,
+    avalaraCustomer: null,
+    xeroCustomer: null,
+    hubspotCustomer: null,
+    salesforceCustomer: null,
+    ...overrides,
+  }) as CustomerForInvoiceOverviewFragment
+
+const buildVoidedInvoice = (): AllInvoiceDetailsForCustomerInvoiceDetailsFragment =>
+  ({
+    id: 'invoice-1',
+    status: InvoiceStatusTypeEnum.Voided,
+    taxProviderVoidable: true,
+    taxProviderId: null,
+    externalIntegrationId: null,
+  }) as AllInvoiceDetailsForCustomerInvoiceDetailsFragment
+
+const FEES = [{ id: 'fee-1' }] as FeeDetailsForInvoiceOverviewFragment[]
+
+const noop = jest.fn()
+
+const renderOverview = ({
+  customer,
+  retryTaxProviderVoiding = noop,
+}: {
+  customer: CustomerForInvoiceOverviewFragment
+  retryTaxProviderVoiding?: jest.Mock
+}): RenderResult =>
+  render(
+    <InvoiceOverview
+      customer={customer}
+      invoice={buildVoidedInvoice()}
+      fees={FEES}
+      hasError={false}
+      hasTaxProviderError={false}
+      loading={false}
+      loadingInvoiceDownload={false}
+      loadingInvoiceXmlDownload={false}
+      loadingRefreshInvoice={false}
+      loadingRetryInvoice={false}
+      loadingRetryTaxProviderVoiding={false}
+      loadingSyncHubspotIntegrationInvoice={false}
+      loadingSyncSalesforceIntegrationInvoice={false}
+      downloadInvoice={noop}
+      downloadInvoiceXml={noop}
+      refreshInvoice={noop}
+      retryInvoice={noop}
+      retryTaxProviderVoiding={retryTaxProviderVoiding}
+      syncHubspotIntegrationInvoice={noop}
+      syncSalesforceIntegrationInvoice={noop}
+      connectedNetsuiteIntegration={undefined}
+      connectedHubspotIntegration={undefined}
+      connectedSalesforceIntegration={undefined}
+      connectedAvalaraIntegration={undefined}
+    />,
+    { useParams: { invoiceId: 'invoice-1' } },
+  )
+
+describe('InvoiceOverview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN a voided invoice with an outstanding tax-provider voiding error', () => {
+    describe('WHEN the customer is connected to Anrok only', () => {
+      it.each([
+        ['Anrok row', ANROK_SECTION_TEST_ID],
+        ['Anrok re-sync call to action', ANROK_RESYNC_CTA_TEST_ID],
+      ])('THEN should display the %s', (_, testId) => {
+        renderOverview({ customer: buildCustomer({ anrokCustomer: ANROK_CUSTOMER }) })
+
+        expect(screen.getByTestId(testId)).toBeInTheDocument()
+      })
+
+      it.each([
+        ['Avalara row', AVALARA_SECTION_TEST_ID],
+        ['Avalara re-sync call to action', AVALARA_RESYNC_CTA_TEST_ID],
+      ])('THEN should not display the %s', (_, testId) => {
+        renderOverview({ customer: buildCustomer({ anrokCustomer: ANROK_CUSTOMER }) })
+
+        expect(screen.queryByTestId(testId)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the customer is connected to Avalara only', () => {
+      it.each([
+        ['Avalara row', AVALARA_SECTION_TEST_ID],
+        ['Avalara re-sync call to action', AVALARA_RESYNC_CTA_TEST_ID],
+      ])('THEN should display the %s', (_, testId) => {
+        renderOverview({ customer: buildCustomer({ avalaraCustomer: AVALARA_CUSTOMER }) })
+
+        expect(screen.getByTestId(testId)).toBeInTheDocument()
+      })
+
+      it.each([
+        ['Anrok row', ANROK_SECTION_TEST_ID],
+        ['Anrok re-sync call to action', ANROK_RESYNC_CTA_TEST_ID],
+      ])('THEN should not display the %s', (_, testId) => {
+        renderOverview({ customer: buildCustomer({ avalaraCustomer: AVALARA_CUSTOMER }) })
+
+        expect(screen.queryByTestId(testId)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the customer is connected to both tax providers', () => {
+      it.each([
+        ['Anrok re-sync call to action', ANROK_RESYNC_CTA_TEST_ID],
+        ['Avalara re-sync call to action', AVALARA_RESYNC_CTA_TEST_ID],
+      ])('THEN should display the %s', (_, testId) => {
+        renderOverview({
+          customer: buildCustomer({
+            anrokCustomer: ANROK_CUSTOMER,
+            avalaraCustomer: AVALARA_CUSTOMER,
+          }),
+        })
+
+        expect(screen.getByTestId(testId)).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the customer is connected to no tax provider', () => {
+      it.each([
+        ['Anrok row', ANROK_SECTION_TEST_ID],
+        ['Avalara row', AVALARA_SECTION_TEST_ID],
+      ])('THEN should not display the %s', (_, testId) => {
+        renderOverview({ customer: buildCustomer({}) })
+
+        expect(screen.queryByTestId(testId)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN clicking the re-sync call to action of the connected tax provider', () => {
+      it('THEN should trigger the tax-provider voiding retry', async () => {
+        const user = userEvent.setup()
+        const retryTaxProviderVoiding = jest.fn()
+
+        renderOverview({
+          customer: buildCustomer({ anrokCustomer: ANROK_CUSTOMER }),
+          retryTaxProviderVoiding,
+        })
+
+        await user.click(screen.getByTestId(ANROK_RESYNC_CTA_TEST_ID))
+
+        expect(retryTaxProviderVoiding).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Context

On the invoice overview page's "Connected to external apps" section, a customer
using a single tax provider could see a sync line for a provider they are not
connected to. A voided invoice for an Anrok-only customer displayed an Avalara
line reading "Invoice not synced to Avalara • Sync voided invoice to Avalara"
next to its correct Anrok line, and the reverse happened for Avalara-only
customers.

The cause is that `Invoice.taxProviderVoidable` — the flag that drives the
re-sync call to action — is tax-provider-agnostic, yet it was OR-ed into both
`showAnrokSection` and `showAvalaraSection`, so any outstanding tax-voiding
error rendered both provider rows regardless of the customer's integrations.

## Description

- Derive two per-provider flags in `InvoiceOverview`, `showAnrokReSyncButton`
  and `showAvalaraReSyncButton`, each requiring both `taxProviderVoidable` and
  the matching tax-provider customer object (`customer.anrokCustomer` /
  `customer.avalaraCustomer`), and feed those into `showAnrokSection` /
  `showAvalaraSection` instead of the provider-agnostic flag. This mirrors the
  existing per-provider gating in `CreditNoteDetailsExternalSync`.
- The success-link branches are untouched: `showAnrokLink` and
  `showAvalaraLink` already imply the corresponding customer object, so every
  row that rendered before still renders.
- Add exported `data-test` constants for the two provider rows and their
  re-sync call to action, plus an optional `dataTest` prop on the local
  `InfoLine`, so the tests target the re-sync branch by identity.
- New test suite `src/pages/__tests__/InvoiceOverview.test.tsx` covering the
  four provider combinations (Anrok only, Avalara only, both, neither) and the
  re-sync click.

No GraphQL change — the customer fragment already selects both tax-provider
objects — and no new translation keys.

<!-- Linear link -->
Fixes INT-238

