### PR TITLE
fix(catalog): design-system blue links, unify visited state

### DIFF
--- a/packages/design-system/src/style.css
+++ b/packages/design-system/src/style.css
@@ -14,7 +14,7 @@
   }
 
   a {
-    @apply text-blue no-underline visited:text-purple hover:underline focus:rounded focus:ring;
+    @apply text-blue no-underline hover:underline focus:rounded focus:ring;
   }
 
   b {

--- a/src/components/creditNote/CreditNoteDetailsExternalSync.tsx
+++ b/src/components/creditNote/CreditNoteDetailsExternalSync.tsx
@@ -117,7 +117,7 @@ const OverviewLine: FC<
       )}
       {link && (
         <Link
-          className="w-fit line-break-anywhere visited:text-blue hover:no-underline"
+          className="w-fit line-break-anywhere hover:no-underline"
           target="_blank"
           rel="noopener noreferrer"
           to={link}

--- a/src/components/creditNote/CreditNoteDetailsOverview.tsx
+++ b/src/components/creditNote/CreditNoteDetailsOverview.tsx
@@ -198,7 +198,6 @@ export const CreditNoteDetailsOverview: FC<CreditNoteDetailsOverviewProps> = ({
                       validWrapper={(children) => <>{children}</>}
                       invalidWrapper={(children) => (
                         <Link
-                          className="visited:text-blue"
                           to={generatePath(CUSTOMER_DETAILS_ROUTE, {
                             customerId: creditNote?.customer?.id,
                           })}
@@ -216,7 +215,6 @@ export const CreditNoteDetailsOverview: FC<CreditNoteDetailsOverviewProps> = ({
                     title={translate('text_637655cb50f04bf1c8379d02')}
                     value={
                       <Link
-                        className="visited:text-blue"
                         to={generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
                           customerId: creditNote?.customer?.id,
                           invoiceId: creditNote?.invoice.id,

--- a/src/components/wallets/WalletDetailsDrawer.tsx
+++ b/src/components/wallets/WalletDetailsDrawer.tsx
@@ -635,7 +635,7 @@ export const WalletDetailsDrawer = forwardRef<WalletDetailsDrawerRef, WalletDeta
                                     label={translate('text_64188b3d9735d5007d71226c')}
                                     value={
                                       <Link
-                                        className="visited:text-blue focus:underline focus:ring-0"
+                                        className="focus:underline focus:ring-0"
                                         to={generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
                                           invoiceId: invoice?.id,
                                           customerId: invoice?.customer?.id,
@@ -717,7 +717,7 @@ export const WalletDetailsDrawer = forwardRef<WalletDetailsDrawerRef, WalletDeta
                                               target="_blank"
                                               rel="noopener noreferrer"
                                               to={href}
-                                              className="flex items-center gap-2 visited:text-blue focus:underline focus:ring-0"
+                                              className="flex items-center gap-2 focus:underline focus:ring-0"
                                             >
                                               {payment.providerPaymentId}
                                               <Icon name="outside" />

--- a/src/components/wallets/WalletTransactionItems.tsx
+++ b/src/components/wallets/WalletTransactionItems.tsx
@@ -139,7 +139,7 @@ const WalletTransactionItems = ({
                     })}?walletId=${wallet.id}&transactionId=${transaction.walletTransaction.id}`}
                   >
                     <Button
-                      className="visited:text-blue focus:underline focus:ring-0"
+                      className="focus:underline focus:ring-0"
                       variant="inline"
                       endIcon="outside"
                     >

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -15518,14 +15518,14 @@ export type GetRateCardForDetailsQueryVariables = Exact<{
 
 export type GetRateCardForDetailsQuery = { __typename?: 'Query', rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null } | null };
 
-export type RateCardForDetailsOverviewFragment = { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null };
+export type RateCardForDetailsOverviewFragment = { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null };
 
 export type GetRateCardForDetailsOverviewQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetRateCardForDetailsOverviewQuery = { __typename?: 'Query', rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null } | null };
+export type GetRateCardForDetailsOverviewQuery = { __typename?: 'Query', rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null } | null };
 
 export type RateCardForPreviewProductFragment = { __typename?: 'Product', id: string, name: string };
 
@@ -22283,6 +22283,7 @@ export const RateCardForDetailsOverviewFragmentDoc = gql`
     id
     name
     code
+    invoiceDisplayName
   }
   productFilter {
     id

--- a/src/layouts/MainNavLayout/OrganizationSwitcher.tsx
+++ b/src/layouts/MainNavLayout/OrganizationSwitcher.tsx
@@ -263,7 +263,7 @@ export const OrganizationSwitcher = ({
                 {isVersionLoading && <Skeleton variant="text" className="w-30" />}
                 {!isVersionLoading && !!currentVersion?.githubUrl && !!currentVersion?.number && (
                   <a
-                    className="flex items-center gap-2 text-blue visited:text-blue"
+                    className="flex items-center gap-2 text-blue"
                     href={currentVersion.githubUrl}
                     target="_blank"
                     rel="noreferrer noopener"

--- a/src/main.css
+++ b/src/main.css
@@ -7,7 +7,7 @@
 @tailwind utilities;
 
 a {
-  @apply text-blue no-underline visited:text-purple hover:underline focus:rounded focus:ring;
+  @apply text-blue no-underline hover:underline focus:rounded focus:ring;
 }
 
 .superset-dashboard iframe {

--- a/src/pages/catalog/details/ProductDetailsOverview.tsx
+++ b/src/pages/catalog/details/ProductDetailsOverview.tsx
@@ -111,9 +111,7 @@ export const ProductDetailsOverview = () => {
                     tab: ProductCategoryDetailsTabsOptionsEnum.overview,
                   })}
                 >
-                  <Typography variant="body" color="grey700">
-                    {product.productCategory.name}
-                  </Typography>
+                  {product.productCategory.name}
                 </Link>
               ) : (
                 '-'
@@ -153,9 +151,7 @@ export const ProductDetailsOverview = () => {
                     tab: BillableMetricDetailsTabsOptionsEnum.overview,
                   })}
                 >
-                  <Typography variant="body" color="grey700">
-                    {product.billableMetric.name}
-                  </Typography>
+                  {product.billableMetric.name}
                 </Link>
               ) : (
                 '-'

--- a/src/pages/catalog/details/ProductDetailsOverview.tsx
+++ b/src/pages/catalog/details/ProductDetailsOverview.tsx
@@ -77,6 +77,46 @@ export const ProductDetailsOverview = () => {
     return <DetailsPage.Skeleton />
   }
 
+  const attachedProductCategory = product?.productCategory ? (
+    <Link
+      to={generatePath(PRODUCT_CATEGORY_DETAILS_ROUTE, {
+        productCategoryId: product.productCategory.id,
+        tab: ProductCategoryDetailsTabsOptionsEnum.overview,
+      })}
+    >
+      {product.productCategory.name}
+    </Link>
+  ) : (
+    '-'
+  )
+
+  const productTypeChip = product?.productType ? (
+    <Chip size="small" label={translate(ITEM_TYPE_TRANSLATION_KEY[product.productType])} />
+  ) : (
+    '-'
+  )
+
+  const code = product?.code ? (
+    <TypographyWithCopy variant="body" color="grey700">
+      {product.code}
+    </TypographyWithCopy>
+  ) : (
+    '-'
+  )
+
+  const attachedBillableMetric = product?.billableMetric ? (
+    <Link
+      to={generatePath(BILLABLE_METRIC_DETAILS_ROUTE, {
+        billableMetricId: product.billableMetric.id,
+        tab: BillableMetricDetailsTabsOptionsEnum.overview,
+      })}
+    >
+      {product.billableMetric.name}
+    </Link>
+  ) : (
+    '-'
+  )
+
   return (
     <section>
       <div className="flex h-18 items-center justify-between gap-4">
@@ -104,58 +144,14 @@ export const ProductDetailsOverview = () => {
           grid={[
             {
               label: translate('text_17839807181143h6kt2bdiyi'),
-              value: product?.productCategory ? (
-                <Link
-                  to={generatePath(PRODUCT_CATEGORY_DETAILS_ROUTE, {
-                    productCategoryId: product.productCategory.id,
-                    tab: ProductCategoryDetailsTabsOptionsEnum.overview,
-                  })}
-                >
-                  {product.productCategory.name}
-                </Link>
-              ) : (
-                '-'
-              ),
+              value: attachedProductCategory,
             },
-            {
-              label: translate('text_1783980718113na6t9imp2k0'),
-              value: product?.productType ? (
-                <Chip
-                  size="small"
-                  label={translate(ITEM_TYPE_TRANSLATION_KEY[product.productType])}
-                />
-              ) : (
-                '-'
-              ),
-            },
-            {
-              label: translate('text_17839807181150t4xkvfjefv'),
-              value: product?.name || '-',
-            },
-            {
-              label: translate('text_1783980718114rdgmz1gtpm2'),
-              value: product?.code ? (
-                <TypographyWithCopy variant="body" color="grey700">
-                  {product.code}
-                </TypographyWithCopy>
-              ) : (
-                '-'
-              ),
-            },
+            { label: translate('text_1783980718113na6t9imp2k0'), value: productTypeChip },
+            { label: translate('text_17839807181150t4xkvfjefv'), value: product?.name || '-' },
+            { label: translate('text_1783980718114rdgmz1gtpm2'), value: code },
             product?.productType === ProductTypeEnum.Usage && {
               label: translate('text_178398071811327xropcsqmr'),
-              value: product?.billableMetric ? (
-                <Link
-                  to={generatePath(BILLABLE_METRIC_DETAILS_ROUTE, {
-                    billableMetricId: product.billableMetric.id,
-                    tab: BillableMetricDetailsTabsOptionsEnum.overview,
-                  })}
-                >
-                  {product.billableMetric.name}
-                </Link>
-              ) : (
-                '-'
-              ),
+              value: attachedBillableMetric,
             },
           ]}
         />

--- a/src/pages/catalog/details/ProductFilterDetailsOverview.tsx
+++ b/src/pages/catalog/details/ProductFilterDetailsOverview.tsx
@@ -100,9 +100,7 @@ const ProductFilterDetailsOverview = ({ productFilterId }: { productFilterId: st
         tab: ProductCategoryDetailsTabsOptionsEnum.overview,
       })}
     >
-      <Typography variant="body" color="grey700">
-        {product.productCategory.name}
-      </Typography>
+      {product.productCategory.name}
     </Link>
   ) : (
     <Typography
@@ -121,9 +119,7 @@ const ProductFilterDetailsOverview = ({ productFilterId }: { productFilterId: st
         tab: ProductDetailsTabsOptionsEnum.overview,
       })}
     >
-      <Typography variant="body" color="grey700">
-        {product.invoiceDisplayName || product.name}
-      </Typography>
+      {product.invoiceDisplayName || product.name}
     </Link>
   )
 

--- a/src/pages/catalog/details/ProductFilterDetailsOverview.tsx
+++ b/src/pages/catalog/details/ProductFilterDetailsOverview.tsx
@@ -24,8 +24,8 @@ import { useProductFilterDrawer } from '../drawers/productFilter/useProductFilte
 
 export const PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_EDIT_TEST_ID =
   'product-item-filter-details-overview-edit'
-export const PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_NO_PRODUCT_TEST_ID =
-  'product-item-filter-details-overview-no-productCategory'
+export const PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_NO_PRODUCT_CATEGORY_TEST_ID =
+  'product-item-filter-details-overview-no-product-category'
 
 gql`
   fragment ProductFilterForDetailsOverview on ProductFilter {
@@ -103,13 +103,9 @@ const ProductFilterDetailsOverview = ({ productFilterId }: { productFilterId: st
       {product.productCategory.name}
     </Link>
   ) : (
-    <Typography
-      data-test={PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_NO_PRODUCT_TEST_ID}
-      variant="body"
-      color="grey700"
-    >
+    <span data-test={PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_NO_PRODUCT_CATEGORY_TEST_ID}>
       {translate('text_1784590896872hcbug1hthjl')}
-    </Typography>
+    </span>
   )
 
   const attachedProduct = (

--- a/src/pages/catalog/details/RateCardDetailsOverview.tsx
+++ b/src/pages/catalog/details/RateCardDetailsOverview.tsx
@@ -73,6 +73,7 @@ gql`
       id
       name
       code
+      invoiceDisplayName
     }
     productFilter {
       id
@@ -124,7 +125,7 @@ const RateCardDetailsOverview = ({ rateCardId }: { rateCardId: string }) => {
         tab: ProductDetailsTabsOptionsEnum.overview,
       })}
     >
-      {product.name}
+      {product.invoiceDisplayName || product.name}
     </Link>
   )
 

--- a/src/pages/catalog/details/RateCardDetailsOverview.tsx
+++ b/src/pages/catalog/details/RateCardDetailsOverview.tsx
@@ -124,9 +124,7 @@ const RateCardDetailsOverview = ({ rateCardId }: { rateCardId: string }) => {
         tab: ProductDetailsTabsOptionsEnum.overview,
       })}
     >
-      <Typography variant="body" color="grey700">
-        {product.name}
-      </Typography>
+      {product.name}
     </Link>
   )
 
@@ -137,9 +135,7 @@ const RateCardDetailsOverview = ({ rateCardId }: { rateCardId: string }) => {
         tab: ProductFilterDetailsTabsOptionsEnum.overview,
       })}
     >
-      <Typography variant="body" color="grey700">
-        {productFilter.name}
-      </Typography>
+      {productFilter.name}
     </Link>
   ) : (
     '-'

--- a/src/pages/catalog/details/__tests__/ProductFilterDetailsOverview.test.tsx
+++ b/src/pages/catalog/details/__tests__/ProductFilterDetailsOverview.test.tsx
@@ -9,7 +9,7 @@ import { AllTheProviders, TestMocksType } from '~/test-utils'
 
 import ProductFilterDetailsOverview, {
   PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_EDIT_TEST_ID,
-  PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_NO_PRODUCT_TEST_ID,
+  PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_NO_PRODUCT_CATEGORY_TEST_ID,
 } from '../ProductFilterDetailsOverview'
 
 const mockOpenEditProductFilterDrawer = jest.fn()
@@ -192,7 +192,7 @@ describe('ProductFilterDetailsOverview', () => {
         expect(await screen.findByText('EU pro filter')).toBeInTheDocument()
         expect(screen.queryByRole('link', { name: 'Object storage' })).not.toBeInTheDocument()
         expect(
-          screen.getByTestId(PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_NO_PRODUCT_TEST_ID),
+          screen.getByTestId(PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_NO_PRODUCT_CATEGORY_TEST_ID),
         ).toBeInTheDocument()
       })
     })

--- a/src/pages/catalog/useRateCardTableColumns.tsx
+++ b/src/pages/catalog/useRateCardTableColumns.tsx
@@ -108,7 +108,7 @@ export const useRateCardTableColumns = ({
                 })
 
             return (
-              <Typography color="info600" noWrap>
+              <Typography color="inherit" noWrap>
                 <Link to={to}>{productFilter?.name ?? product.name}</Link>
               </Typography>
             )

--- a/translations/base.json
+++ b/translations/base.json
@@ -4780,7 +4780,7 @@
   "text_1784590896872mnuossjldco": "Filter information",
   "text_17845908968721vd9etj0npq": "How the filter functions.",
   "text_1784590896872igg2htzgnso": "Filter by",
-  "text_1784590896872hcbug1hthjl": "No product",
+  "text_1784590896872hcbug1hthjl": "No category",
   "text_17845928288679yi8tiutrl4": "Logs reflecting this product filter's activity.",
   "text_1784593927667g72f4poh3cq": "Filters added here scope this product to specific billable metric filter values.",
   "text_17845939276671s82cze921q": "View all {{count}} filters",


### PR DESCRIPTION
## Context

Cross-object links in the catalog details pages (product, product filter, rate card) rendered black instead of the design-system blue used everywhere else in the app, for instance the customer link in invoice details.

Chasing that down surfaced a second, app-wide inconsistency: the global `a` rule turned every visited link purple, and seven call sites had already worked around it one by one with a local `visited:text-blue`. This PR unifies that instead of adding an eighth workaround.

## Description

One commit per concern:

- **`fix(catalog): blue design-system links in details`** - the six catalog detail links wrapped their label in `<Typography variant="body" color="grey700">`, and that explicit colour overrode the global `a { @apply text-blue ... }` rule. The wrapper was redundant anyway, since `DetailsPage.InfoGrid` already wraps every value in exactly that Typography, so it is dropped and the anchors inherit the design-system blue.
- **`fix(design-system): keep visited links blue`** - unifies visited-link styling app-wide: drops `visited:text-purple` from the global `a` rule in `src/main.css` and `packages/design-system/src/style.css`, and removes the seven scattered `className="visited:text-blue"` overrides that existed only to undo it.
- **`refactor(catalog): extract product overview grid values`** - pulls the inline multi-line ternaries out of the `InfoGrid` array into consts above the return, matching the two sibling pages and the "Prefer Logic Out of JSX" rule.
- **`fix(catalog): show product display name on rate card`** - the rate card overview rendered `product.name` while the product filter overview renders `invoiceDisplayName || name` for the same Product. Selects the field in the fragment and aligns the two.
- **`fix(catalog): correct product filter empty-state copy`** - the "Attached category" row rendered the copy "No product"; also finishes the half-done `Product` -> `ProductCategory` test-id rename, and replaces a dead `color="info600"` on the rate card table link (it maps to purple and never rendered, the anchor rule always won) with `color="inherit"`.

No Linear ticket for this one.
