### PR TITLE
fix(deps): bump react-router-dom to 6.30.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "react-dom": "18.3.1",
     "react-markdown": "10.1.0",
     "react-resizable-panels": "3.0.6",
-    "react-router-dom": "6.30.4",
+    "react-router-dom": "6.30.6",
     "recharts": "2.15.4",
     "remark-gfm": "4.0.1",
     "sanitize-html": "2.17.5",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -30,7 +30,7 @@
     "@mui/x-date-pickers": "6.20.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router-dom": "6.30.4"
+    "react-router-dom": "6.30.6"
   },
   "devDependencies": {
     "@svgr/core": "8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,8 +199,8 @@ importers:
         specifier: 3.0.6
         version: 3.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
-        specifier: 6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 6.30.6
+        version: 6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
         specifier: 2.15.4
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -494,8 +494,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-router-dom:
-        specifier: 6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 6.30.6
+        version: 6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@svgr/core':
         specifier: 8.1.0
@@ -2832,8 +2832,8 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
-  '@remix-run/router@1.23.3':
-    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
+  '@remix-run/router@1.23.4':
+    resolution: {integrity: sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==}
     engines: {node: '>=14.0.0'}
 
   '@repeaterjs/repeater@3.0.6':
@@ -7707,15 +7707,15 @@ packages:
       react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
-  react-router-dom@6.30.4:
-    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
+  react-router-dom@6.30.6:
+    resolution: {integrity: sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router@6.30.4:
-    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
+  react-router@6.30.6:
+    resolution: {integrity: sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
@@ -11500,7 +11500,7 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@remix-run/router@1.23.3': {}
+  '@remix-run/router@1.23.4': {}
 
   '@repeaterjs/repeater@3.0.6': {}
 
@@ -16979,16 +16979,16 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-router-dom@6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.3
+      '@remix-run/router': 1.23.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.4(react@18.3.1)
+      react-router: 6.30.6(react@18.3.1)
 
-  react-router@6.30.4(react@18.3.1):
+  react-router@6.30.6(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.3
+      '@remix-run/router': 1.23.4
       react: 18.3.1
 
   react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):


### PR DESCRIPTION
Related: LAGO-1859 (React Router v6 -> v7 upgrade)

Patches **CVE-2026-53668** / GHSA-jjmj-jmhj-qwj2 (open redirect leading to XSS), Dependabot alerts #250 and #252. `6.30.6` is the last v6 release ever published, and this is the only one of the three open react-router advisories that has a v6 fix.

The real change is `@remix-run/router` `1.23.3` -> `1.23.4`, which drops the `isAbsoluteUrl` early-return in `resolvePath`. Verified against the installed tree:

| input | 6.30.4 | 6.30.6 |
| --- | --- | --- |
| `javascript:alert(1)//` | passed through verbatim | `/acme/customers/javascript:alert(1)/` |
| `//evil.com` | `//evil.com` | `/evil.com` |

`react-router` and `react-router-dom` themselves only get a version-banner bump between 6.30.4 and 6.30.6 - the `.d.ts` surface is byte-identical, so there is no API risk. Resolved graph stays on a single version: `react-router-dom@6.30.6` -> `react-router@6.30.6` -> `@remix-run/router@1.23.4`.

Both manifests are bumped because both pin the version exactly (root `package.json` and `packages/design-system/package.json`).

The 6.30.6 changelog flags one possible breaking bug fix, "if you are using `navigate` for external navigations". We have zero external `navigate()` calls, and the only external `<Link to="https://...">` is in `src/pages/__devOnly/DesignSystem.tsx`, which goes through the `ABSOLUTE_URL_REGEX` path in `react-router-dom` that did not change.

### What this does not fix

CVE-2026-53669 (alert #253) and CVE-2026-53666 (alert #251) have **no v6 patch and never will** - React Router v6 has been EOL since 2026-06-18 and upstream has stated it will not backport further CVE fixes to the 6.x line. Both advisories use a `< 7.18.0` range, so they stay open on any v6 version. Neither is reachable in this app today (no SSR, and `ensureSlugPrefix` neutralises the only untrusted-input-to-navigate path). They are intentionally left open rather than dismissed, and the v7 upgrade is tracked in LAGO-1859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)