### PR TITLE
ci: bump sonarqube-scan-action to v8.2.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,7 +133,7 @@ jobs:
       - name: SonarQube Scan (Pull Request)
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: SonarSource/sonarqube-scan-action@40f5b61913e891f9d316696628698051136015be
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -146,7 +146,7 @@ jobs:
       - name: SonarQube Scan (Main Branch)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         continue-on-error: true
-        uses: SonarSource/sonarqube-scan-action@40f5b61913e891f9d316696628698051136015be
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- SonarQube scan action was pinned to a commit whose action.yml declares `using: node20`, deprecated by GitHub Actions runners
- Bumped both PR-scan and main-branch-scan steps to v8.2.1, which declares `using: node24`