### PR TITLE
fix(filters): order is between bounds independently of input order

### DIFF
--- a/src/components/Filters/graphql/__tests__/utils.test.ts
+++ b/src/components/Filters/graphql/__tests__/utils.test.ts
@@ -25,11 +25,14 @@ import {
   isValidDateRangeValue,
   keyWithPrefix,
   mapRateCardFilterVars,
+  orderIntervalBounds,
   parseFromToValue,
   parseMetadataFilter,
   unescapeFilterLabel,
 } from '~/components/Filters/graphql/utils'
 import {
+  AMOUNT_INTERVALS_TRANSLATION_MAP,
+  AmountFilterInterval,
   AvailableFiltersEnum,
   filterDataInlineSeparator,
   filterWithoutProductCategoryValue,
@@ -481,6 +484,32 @@ describe('Filters utils', () => {
 
       expect(result).toBe('Acme Corp, Beta Inc')
     })
+
+    describe('GIVEN an is between interval', () => {
+      const translate = ((key: string) =>
+        key === AMOUNT_INTERVALS_TRANSLATION_MAP[AmountFilterInterval.isBetween]
+          ? 'Is between'
+          : 'And') as TranslateFunc
+
+      it.each([
+        ['ascending bounds', 'isBetween,10,11'],
+        ['descending bounds', 'isBetween,11,10'],
+      ])('WHEN the amount value has %s THEN should read the interval ascending', (_, value) => {
+        const result = formatActiveFilterValueDisplay(AvailableFiltersEnum.amount, value, translate)
+
+        expect(result).toBe('Is between 10 and 11')
+      })
+
+      it('WHEN the activeSubscriptions bounds are descending THEN should read the interval ascending', () => {
+        const result = formatActiveFilterValueDisplay(
+          AvailableFiltersEnum.activeSubscriptions,
+          'isBetween,8,3',
+          translate,
+        )
+
+        expect(result).toBe('Is between 3 and 8')
+      })
+    })
   })
 
   describe('getFilterValue', () => {
@@ -587,6 +616,42 @@ describe('Filters utils', () => {
       expect(result).toEqual({
         from: 20,
         to: null,
+      })
+    })
+  })
+
+  describe('orderIntervalBounds', () => {
+    describe('GIVEN an is between interval with both bounds', () => {
+      it.each([
+        ['the from is greater than the to', 'isBetween,11,10', 'isBetween,10,11'],
+        ['the bounds are decimals', 'isBetween,10.5,10.05', 'isBetween,10.05,10.5'],
+        ['the from is positive and the to is zero', 'isBetween,3,0', 'isBetween,0,3'],
+      ])('WHEN %s THEN should swap the bounds', (_, value, expected) => {
+        expect(orderIntervalBounds(value)).toBe(expected)
+      })
+
+      it.each([
+        ['the from is lower than the to', 'isBetween,10,11'],
+        ['the bounds are identical', 'isBetween,10,10'],
+        ['both bounds are zero', 'isBetween,0,0'],
+        ['a bound is not a number', 'isBetween,abc,10'],
+      ])('WHEN %s THEN should keep the value untouched', (_, value) => {
+        expect(orderIntervalBounds(value)).toBe(value)
+      })
+    })
+
+    describe('GIVEN a value without two comparable bounds', () => {
+      it.each([
+        ['the interval has a single bound', 'isAtLeast,11'],
+        ['the interval compares to one bound', 'isEqualTo,11,'],
+        ['the upper bound only is set', 'isUpTo,,10'],
+        ['the interval is lower than', 'isLessThan,,10'],
+        ['the interval is greater than', 'isGreaterThan,11,'],
+        ['the is between from is missing', 'isBetween,,10'],
+        ['the is between to is missing', 'isBetween,11,'],
+        ['the value is empty', ''],
+      ])('WHEN %s THEN should keep the value untouched', (_, value) => {
+        expect(orderIntervalBounds(value)).toBe(value)
       })
     })
   })
@@ -1052,6 +1117,21 @@ describe('Filters utils', () => {
   })
 
   describe('FILTER_VALUE_MAP', () => {
+    describe('GIVEN an is between interval with reversed bounds', () => {
+      it('WHEN parsing the amount filter THEN should query the same interval as ordered bounds', () => {
+        const result = FILTER_VALUE_MAP[AvailableFiltersEnum.amount]('isBetween,11,10')
+
+        expect(result).toEqual(FILTER_VALUE_MAP[AvailableFiltersEnum.amount]('isBetween,10,11'))
+        expect(result).toEqual({ amountFrom: 10, amountTo: 11 })
+      })
+
+      it('WHEN parsing the activeSubscriptions filter THEN should query the same interval as ordered bounds', () => {
+        const result = FILTER_VALUE_MAP[AvailableFiltersEnum.activeSubscriptions]('isBetween,8,3')
+
+        expect(result).toEqual({ activeSubscriptionsFrom: 3, activeSubscriptionsTo: 8 })
+      })
+    })
+
     it('should parse creditNoteType filter correctly', () => {
       const result = FILTER_VALUE_MAP[AvailableFiltersEnum.creditNoteType]('credit,refund,offset')
 

--- a/src/components/Filters/graphql/utils.ts
+++ b/src/components/Filters/graphql/utils.ts
@@ -105,6 +105,34 @@ import { TranslateFunc } from '~/hooks/core/useInternationalization'
 
 export const keyWithPrefix = (key: string, prefix?: string) => (prefix ? `${prefix}_${key}` : key)
 
+/**
+ * `is between` bounds describe an interval, so `11,10` designates the same interval as
+ * `10,11`. Rewriting the raw `interval,from,to` value with its bounds in ascending order
+ * makes the resulting query — and the chip summarising it — independent from the order
+ * the user typed the bounds in.
+ *
+ * Only applied where the value is consumed (query variables, active filter chip), so the
+ * filter inputs keep displaying the bounds as they were typed.
+ */
+export const orderIntervalBounds = (value: string): string => {
+  const [interval, from, to] = value.split(',')
+
+  // `isBetween` holds the same value in AmountFilterInterval and
+  // ActiveSubscriptionsFilterInterval, the two intervals with a lower and an upper bound.
+  if (interval !== AmountFilterInterval.isBetween || !from || !to) {
+    return value
+  }
+
+  const fromNumber = Number(from)
+  const toNumber = Number(to)
+
+  if (Number.isNaN(fromNumber) || Number.isNaN(toNumber) || fromNumber <= toNumber) {
+    return value
+  }
+
+  return `${interval},${to},${from}`
+}
+
 export const parseFromToValue = (value: string, keys: { from: string; to: string }) => {
   const [interval, from, to] = value.split(',')
 
@@ -209,9 +237,12 @@ export const FILTER_VALUE_MAP: Record<AvailableFiltersEnum, Function> = {
   [AvailableFiltersEnum.activitySources]: (value: string) => (value as string).split(','),
   [AvailableFiltersEnum.activityTypes]: (value: string) => (value as string).split(','),
   [AvailableFiltersEnum.activeSubscriptions]: (value: string) =>
-    parseFromToValue(value, { from: 'activeSubscriptionsFrom', to: 'activeSubscriptionsTo' }),
+    parseFromToValue(orderIntervalBounds(value), {
+      from: 'activeSubscriptionsFrom',
+      to: 'activeSubscriptionsTo',
+    }),
   [AvailableFiltersEnum.amount]: (value: string) =>
-    parseFromToValue(value, { from: 'amountFrom', to: 'amountTo' }),
+    parseFromToValue(orderIntervalBounds(value), { from: 'amountFrom', to: 'amountTo' }),
   [AvailableFiltersEnum.apiKeyIds]: (value: string) =>
     value.split(',').map((v) => v.split(filterDataInlineSeparator)[0]),
   [AvailableFiltersEnum.billingEntityIds]: (value: string) =>
@@ -1092,7 +1123,7 @@ export const formatActiveFilterValueDisplay = (
   translate?: TranslateFunc,
 ): string => {
   if (key === AvailableFiltersEnum.amount) {
-    const [interval, from, to] = value.split(',')
+    const [interval, from, to] = orderIntervalBounds(value).split(',')
 
     const intervalLabel = translate?.(
       AMOUNT_INTERVALS_TRANSLATION_MAP[interval as AmountFilterInterval],
@@ -1109,7 +1140,7 @@ export const formatActiveFilterValueDisplay = (
   }
 
   if (key === AvailableFiltersEnum.activeSubscriptions) {
-    const [interval, from, to] = value.split(',')
+    const [interval, from, to] = orderIntervalBounds(value).split(',')
 
     const intervalLabel = translate?.(
       ACTIVE_SUBSCRIPTIONS_INTERVALS_TRANSLATION_MAP[interval as ActiveSubscriptionsFilterInterval],


### PR DESCRIPTION
## Context

On the Invoices page, the `Amount → is between` filter only returned results when the first value entered was lower than the second: `10` and `11` returned the expected invoices, while `11` and `10` returned none, although both describe the same numeric interval.

The raw filter value (`interval,from,to`) was handed to the query untouched, so a reversed pair produced `amountFrom: 11, amountTo: 10` — an empty interval the API answers with no results.

## Description

- Add `orderIntervalBounds` to the filters utils: for the `isBetween` interval, when both bounds are numbers and the lower one comes second, it rewrites the raw value with the bounds in ascending order. Every other interval, a missing bound or a non-numeric bound is returned untouched.
- Apply it where the filter value is consumed:
  - `FILTER_VALUE_MAP` for `amount` and `activeSubscriptions`, so the query variables describe the same interval whichever order was typed;
  - `formatActiveFilterValueDisplay`, so the active filter chip reads the interval the same way the results were fetched.
- The filter inputs are left untouched and keep displaying the bounds as typed.
- `activeSubscriptions` shares the same helper and the same `isBetween` interval, so it is covered by the same fix rather than left with an identical latent bug.
- Cover the helper, both `FILTER_VALUE_MAP` entries and the chip formatting with unit tests.

<!-- Linear link -->
Fixes LAGO-1860

---
_Generated by [Claude Code](https://claude.ai/code/session_01336bP63ba6dZnK2zYabtUh)_