### PR TITLE
fix(quotes): include plan preview payload in drawer save

### DIFF
--- a/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useSubscriptionPricingDrawer.test.tsx
@@ -26,6 +26,20 @@ let mockInjectedState: SubscriptionPricingState | null = null
 let mockInjectedFormValues: PlanFormInput | null = null
 let mockInjectedBasePlanFormValues: PlanFormInput | null = null
 
+const catalogFormValues = {
+  name: 'Enterprise Plan',
+  code: 'enterprise',
+  description: '',
+  interval: PlanInterval.Monthly,
+  amountCents: '850.00',
+  amountCurrency: CurrencyEnum.Usd,
+  payInAdvance: false,
+  trialPeriod: 0,
+  charges: [],
+  fixedCharges: [],
+  entitlements: [],
+} as unknown as PlanFormInput
+
 // Verdict the mocked content component reports through validatePlanFormRef.
 // `null` leaves the ref unfilled, as when the content component never mounted.
 let mockPlanFormValid: boolean | null = null
@@ -292,6 +306,81 @@ describe('useSubscriptionPricingDrawer', () => {
       undefined,
     )
     expect(result.current.entities).toHaveProperty('plan_123')
+  })
+
+  it('commits the plan preview payload built from the form values', async () => {
+    mockInjectedState = {
+      planId: 'plan_123',
+      planCode: 'enterprise',
+      planName: 'Enterprise Plan',
+      planDescription: '',
+      subscriptionSettings: {
+        externalId: '',
+        subscriptionName: '',
+        billingTime: 'anniversary',
+        startDate: '2023-07-26',
+        endDate: '2024-07-26',
+      },
+      invoicingSettings: { paymentMethodId: '', invoiceCustomFooter: '' },
+      overrides: {},
+    }
+    mockInjectedFormValues = catalogFormValues
+
+    const onSave = jest.fn().mockResolvedValue({ ok: true })
+
+    const { result } = renderHook(() => useSubscriptionPricingDrawer(undefined))
+
+    act(() => {
+      result.current.onPricingCommand({ onSave })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(openArgs.children)
+
+    await act(async () => {
+      await openArgs.form.submit()
+    })
+
+    expect(result.current.entities.plan_123.plan).toBeDefined()
+    expect(result.current.entities.plan_123.plan?.rows.length).toBeGreaterThan(0)
+  })
+
+  it('commits an empty preview payload when no form values are available', async () => {
+    mockInjectedState = {
+      planId: 'plan_123',
+      planCode: 'enterprise',
+      planName: 'Enterprise Plan',
+      planDescription: '',
+      subscriptionSettings: {
+        externalId: '',
+        subscriptionName: '',
+        billingTime: 'anniversary',
+        startDate: '2023-07-26',
+        endDate: '2024-07-26',
+      },
+      invoicingSettings: { paymentMethodId: '', invoiceCustomFooter: '' },
+      overrides: {},
+    }
+    mockInjectedFormValues = null
+
+    const onSave = jest.fn().mockResolvedValue({ ok: true })
+
+    const { result } = renderHook(() => useSubscriptionPricingDrawer(undefined))
+
+    act(() => {
+      result.current.onPricingCommand({ onSave })
+    })
+
+    const openArgs = mockDrawerOpen.mock.calls[0][0]
+
+    render(openArgs.children)
+
+    await act(async () => {
+      await openArgs.form.submit()
+    })
+
+    expect(result.current.entities.plan_123.plan).toEqual({ rows: [] })
   })
 
   it('toasts and keeps the drawer open when the save fails', async () => {
@@ -571,20 +660,6 @@ describe('useSubscriptionPricingDrawer', () => {
       invoicingSettings: { paymentMethodId: '', invoiceCustomFooter: '' },
       overrides: {},
     }
-
-    const catalogFormValues = {
-      name: 'Enterprise Plan',
-      code: 'enterprise',
-      description: '',
-      interval: PlanInterval.Monthly,
-      amountCents: '850.00',
-      amountCurrency: CurrencyEnum.Usd,
-      payInAdvance: false,
-      trialPeriod: 0,
-      charges: [],
-      fixedCharges: [],
-      entitlements: [],
-    } as unknown as PlanFormInput
 
     const saveAndReadPlan = async (): Promise<{ overrides: Record<string, unknown> }> => {
       const onSave = jest.fn().mockResolvedValue({ ok: true })

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -172,9 +172,6 @@ export const useSubscriptionPricingDrawer = (
             entityType: 'plan',
             name: state.planName,
             code: state.planCode,
-            // The preview branch of PricingBlockView renders the plan table only when
-            // `plan` is set, and the commit below replaces the whole entity — without
-            // the payload the block goes blank in preview until a refetch re-hydrates it.
             plan: buildPlanPreviewData(formValues ?? null),
           },
         }

--- a/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
+++ b/src/pages/quotes/hooks/useSubscriptionPricingDrawer.tsx
@@ -13,6 +13,7 @@ import {
 import { useFormDrawer } from '~/components/drawers/useDrawer'
 import type { PlanFormInput } from '~/components/plans/types'
 import { addToast } from '~/core/apolloClient'
+import { buildPlanPreviewData } from '~/core/serializers/buildPlanPreviewData'
 import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBillingItems'
 import {
   fromPlanBillingItems,
@@ -171,6 +172,10 @@ export const useSubscriptionPricingDrawer = (
             entityType: 'plan',
             name: state.planName,
             code: state.planCode,
+            // The preview branch of PricingBlockView renders the plan table only when
+            // `plan` is set, and the commit below replaces the whole entity — without
+            // the payload the block goes blank in preview until a refetch re-hydrates it.
+            plan: buildPlanPreviewData(formValues ?? null),
           },
         }
 


### PR DESCRIPTION
## Context

In the quote editor, saving a subscription pricing block wrote a partial plan entity (id, type, name, code) that replaced the hydrated entity wholesale, dropping the `plan` preview payload. The in-editor preview renders the plan table only when that payload is present, so after a save the pricing block went blank in preview until a refetch happened to re-run hydration. QA reported it as order-dependent (credits/discounts placed before pricing), but the ordering is a timing proxy: the preview depended on the post-save refetch racing the drawer's write.

## Description

- `useSubscriptionPricingDrawer.handleSave` now builds the preview payload itself with `buildPlanPreviewData(formValues ?? null)` — the same serializer the hydration path uses — so the committed entity is complete at save time and the preview no longer depends on a refetch. A save with no form values yields `{ rows: [] }` (empty table) instead of a vanishing block.
- Tests: hoisted the `catalogFormValues` fixture to module scope and added two cases — the committed entity carries a non-empty preview payload when form values exist, and an empty `{ rows: [] }` payload when they don't.

<!-- Linear link -->
Fixes LAGO-1862