### PR TITLE
fix(rich-text-editor): resolve drag handle position at event time and wrap dividers

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "@tiptap/extension-color": "3.30.1",
     "@tiptap/extension-heading": "3.30.1",
     "@tiptap/extension-highlight": "3.30.1",
+    "@tiptap/extension-horizontal-rule": "3.30.1",
     "@tiptap/extension-image": "3.30.1",
     "@tiptap/extension-link": "3.30.1",
     "@tiptap/extension-mention": "3.30.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@tiptap/extension-highlight':
         specifier: 3.30.1
         version: 3.30.1(@tiptap/core@3.30.1(@tiptap/pm@3.30.1))
+      '@tiptap/extension-horizontal-rule':
+        specifier: 3.30.1
+        version: 3.30.1(@tiptap/core@3.30.1(@tiptap/pm@3.30.1))(@tiptap/pm@3.30.1)
       '@tiptap/extension-image':
         specifier: 3.30.1
         version: 3.30.1(@tiptap/core@3.30.1(@tiptap/pm@3.30.1))

--- a/src/components/designSystem/RichTextEditor/BlockControls/BlockToolbar.tsx
+++ b/src/components/designSystem/RichTextEditor/BlockControls/BlockToolbar.tsx
@@ -104,8 +104,8 @@ const BlockToolbar = ({ editor }: BlockToolbarProps) => {
     const blockRect = dom.getBoundingClientRect()
 
     setPosition({
-      top: blockRect.top - containerRect.top,
-      left: blockRect.left - containerRect.left,
+      top: blockRect.top - containerRect.top + editorContainer.scrollTop,
+      left: blockRect.left - containerRect.left + editorContainer.scrollLeft,
     })
   }, [editor, blockSelection])
 

--- a/src/components/designSystem/RichTextEditor/BlockControls/__tests__/BlockToolbar.test.tsx
+++ b/src/components/designSystem/RichTextEditor/BlockControls/__tests__/BlockToolbar.test.tsx
@@ -186,6 +186,26 @@ describe('BlockToolbar', () => {
       })
     })
 
+    describe('WHEN the editor container is scrolled', () => {
+      it('THEN should offset the toolbar by the container scroll position', () => {
+        mockSelectorReturn = blockSelection
+
+        const editorContainer = createMockEditorContainer()
+
+        Object.defineProperty(editorContainer, 'scrollTop', { value: 240, writable: true })
+        Object.defineProperty(editorContainer, 'scrollLeft', { value: 30, writable: true })
+
+        render(<BlockToolbar editor={createMockEditor({ editorContainer })} />)
+
+        const toolbar = screen.getByTestId(BLOCK_TOOLBAR_TEST_ID)
+
+        // block.top(100) - container.top(20) + scrollTop(240) = 320
+        expect(toolbar.style.top).toBe('320px')
+        // block.left(50) - container.left(10) + scrollLeft(30) = 70
+        expect(toolbar.style.left).toBe('70px')
+      })
+    })
+
     describe('WHEN the delete button is clicked', () => {
       it('THEN should delete the block via deleteRange', async () => {
         const user = userEvent.setup()

--- a/src/components/designSystem/RichTextEditor/extensions/DragHandle.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/DragHandle.ts
@@ -238,9 +238,6 @@ export const DragHandle = Extension.create({
 
       doc.forEach((node, pos) => {
         decorations.push(
-          // The widget's position moves with document edits (oldSet.map below),
-          // so the handle must resolve it at event time through getPos — a
-          // captured `pos` goes stale after any same-childCount edit.
           Decoration.widget(pos, (_view, getPos): HTMLElement => createHandleElement(getPos), {
             side: -1,
             key: `drag-handle-${pos}`,

--- a/src/components/designSystem/RichTextEditor/extensions/DragHandle.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/DragHandle.ts
@@ -145,7 +145,7 @@ export const DragHandle = Extension.create({
       editor.view.focus()
     }
 
-    function createHandleElement(pos: number): HTMLElement {
+    function createHandleElement(getPos: () => number | undefined): HTMLElement {
       const group = document.createElement('div')
 
       group.className = 'block-handle-group'
@@ -184,6 +184,14 @@ export const DragHandle = Extension.create({
       renderIcon(gripIconContainer, 'double-dots-vertical')
 
       gripButton.addEventListener('dragstart', (e) => {
+        const pos = getPos()
+
+        if (pos === undefined) {
+          e.preventDefault()
+
+          return
+        }
+
         selectBlock(pos)
 
         editor.view.dragging = {
@@ -211,6 +219,11 @@ export const DragHandle = Extension.create({
       gripButton.addEventListener('click', (e) => {
         e.preventDefault()
         e.stopPropagation()
+
+        const pos = getPos()
+
+        if (pos === undefined) return
+
         selectBlock(pos)
       })
 
@@ -225,7 +238,10 @@ export const DragHandle = Extension.create({
 
       doc.forEach((node, pos) => {
         decorations.push(
-          Decoration.widget(pos, () => createHandleElement(pos), {
+          // The widget's position moves with document edits (oldSet.map below),
+          // so the handle must resolve it at event time through getPos — a
+          // captured `pos` goes stale after any same-childCount edit.
+          Decoration.widget(pos, (_view, getPos): HTMLElement => createHandleElement(getPos), {
             side: -1,
             key: `drag-handle-${pos}`,
             ignoreSelection: true,

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/DragHandle.test.ts
@@ -7,6 +7,7 @@ import { NodeSelection } from '@tiptap/pm/state'
 import StarterKit from '@tiptap/starter-kit'
 import { act } from 'react'
 
+import { getBaseExtensions } from '../baseExtensions'
 import { BlockColors } from '../BlockColors'
 import { DragHandle, type DragHandleStorage, resolveSelectedTable } from '../DragHandle'
 
@@ -1114,6 +1115,182 @@ describe('DragHandle', () => {
         expect(removeSpy).toHaveBeenCalledWith('mousedown', expect.any(Function))
 
         removeSpy.mockRestore()
+      })
+    })
+  })
+
+  describe('GIVEN the document has been edited without a structural change', () => {
+    /**
+     * jsdom does not propagate exceptions thrown inside DOM listeners to the
+     * caller of element.click() — it dispatches a window `error` event instead.
+     * Capture those so a throwing click handler fails the test rather than
+     * silently leaving the previous selection in place.
+     */
+    const clickCapturingWindowErrors = (element: HTMLElement): ErrorEvent[] => {
+      const errors: ErrorEvent[] = []
+      const onError = (event: ErrorEvent): void => {
+        event.preventDefault()
+        errors.push(event)
+      }
+
+      window.addEventListener('error', onError)
+      element.click()
+      window.removeEventListener('error', onError)
+
+      return errors
+    }
+
+    describe('WHEN text is inserted into an earlier block and a later grip is clicked', () => {
+      it('THEN should select the block at its current position', () => {
+        const editor = createEditor('<p>Alpha</p><p>Beta</p><p>Gamma</p>')
+
+        editor.commands.insertContentAt(6, 'XXXXXXXXXX')
+
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const errors = clickCapturingWindowErrors(grips[1] as HTMLElement)
+
+        const { selection } = editor.state
+        const isNodeSelection = selection instanceof NodeSelection
+        const selectedFrom = selection.from
+        const selectedText = isNodeSelection ? selection.node.textContent : null
+
+        editor.destroy()
+
+        expect(errors).toHaveLength(0)
+        expect(isNodeSelection).toBe(true)
+        expect(selectedFrom).toBe(17)
+        expect(selectedText).toBe('Beta')
+      })
+
+      it('THEN should select the last block at its current position', () => {
+        const editor = createEditor('<p>Alpha</p><p>Beta</p><p>Gamma</p>')
+
+        editor.commands.insertContentAt(6, 'XXXXXXXXXX')
+
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const errors = clickCapturingWindowErrors(grips[2] as HTMLElement)
+
+        const { selection } = editor.state
+        const isNodeSelection = selection instanceof NodeSelection
+        const selectedFrom = selection.from
+        const selectedText = isNodeSelection ? selection.node.textContent : null
+
+        editor.destroy()
+
+        expect(errors).toHaveLength(0)
+        expect(isNodeSelection).toBe(true)
+        expect(selectedFrom).toBe(23)
+        expect(selectedText).toBe('Gamma')
+      })
+
+      it('THEN should point the selection at a block whose DOM node is resolvable', () => {
+        const editor = createEditor('<p>Alpha</p><p>Beta</p><p>Gamma</p>')
+
+        editor.commands.insertContentAt(6, 'XXXXXXXXXX')
+
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+
+        clickCapturingWindowErrors(grips[1] as HTMLElement)
+
+        // BlockToolbar only renders the menu when nodeDOM resolves to an element.
+        const blockDom = editor.view.nodeDOM(editor.state.selection.from)
+
+        editor.destroy()
+
+        expect(blockDom).toBeInstanceOf(HTMLElement)
+      })
+    })
+
+    describe('WHEN a single character is inserted and a later grip is clicked', () => {
+      it('THEN should select the block without throwing in the click listener', () => {
+        const editor = createEditor('<p>Alpha</p><p>Beta</p>')
+
+        editor.commands.insertContentAt(6, 'X')
+
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const errors = clickCapturingWindowErrors(grips[1] as HTMLElement)
+
+        const { selection } = editor.state
+        const isNodeSelection = selection instanceof NodeSelection
+        const selectedFrom = selection.from
+        const selectedText = isNodeSelection ? selection.node.textContent : null
+
+        editor.destroy()
+
+        expect(errors).toHaveLength(0)
+        expect(isNodeSelection).toBe(true)
+        expect(selectedFrom).toBe(8)
+        expect(selectedText).toBe('Beta')
+      })
+    })
+
+    describe('WHEN markdown is pasted into an earlier block and a later grip is clicked', () => {
+      it('THEN should select the block at its current position', () => {
+        let editor!: Editor
+
+        act(() => {
+          editor = new Editor({
+            extensions: [...getBaseExtensions(), DragHandle],
+            content: '<p></p><p>Outro</p>',
+          })
+        })
+
+        // jsdom has no ClipboardEvent — build the slice the way ProseMirror's
+        // paste path does, through the Markdown extension's clipboardTextParser.
+        editor.commands.setTextSelection(1)
+
+        const slice = editor.view.someProp('clipboardTextParser', (parser) =>
+          parser(
+            'Hello **world** this is markdown',
+            editor.state.selection.$from,
+            false,
+            editor.view,
+          ),
+        )
+
+        if (!slice) throw new Error('clipboardTextParser did not produce a slice')
+
+        editor.view.dispatch(editor.state.tr.replaceSelection(slice))
+
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const errors = clickCapturingWindowErrors(grips[1] as HTMLElement)
+
+        const { selection } = editor.state
+        const isNodeSelection = selection instanceof NodeSelection
+        const selectedFrom = selection.from
+        const selectedText = isNodeSelection ? selection.node.textContent : null
+
+        editor.destroy()
+
+        expect(errors).toHaveLength(0)
+        expect(isNodeSelection).toBe(true)
+        expect(selectedFrom).toBe(30)
+        expect(selectedText).toBe('Outro')
+      })
+    })
+
+    describe('WHEN text is inserted before a table and the table grip is clicked', () => {
+      it('THEN should store the table at its current position', () => {
+        const editor = createEditor(
+          '<p>Before</p><table><tbody><tr><td>A1</td><td>B1</td></tr></tbody></table><p>After</p>',
+        )
+        const storage = getDragHandleStorage(editor)
+
+        editor.commands.insertContentAt(4, 'YYYY')
+
+        const tablePos = findTablePos(editor)
+        const grips = editor.view.dom.querySelectorAll('.block-handle-grip')
+        const errors = clickCapturingWindowErrors(grips[1] as HTMLElement)
+
+        const selectedBlock = storage.selectedBlock
+        const resolved = resolveSelectedTable(editor.state, selectedBlock)
+        const resolvedNodeName = resolved?.node.type.name
+
+        editor.destroy()
+
+        expect(errors).toHaveLength(0)
+        expect(selectedBlock).toEqual({ pos: tablePos })
+        expect(resolvedNodeName).toBe('table')
       })
     })
   })

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/baseExtensions.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/baseExtensions.test.ts
@@ -288,4 +288,28 @@ describe('getBaseExtensions', () => {
       expect(markdown?.options.html).toBe(true)
     })
   })
+
+  describe('GIVEN the WrappedHorizontalRule extension', () => {
+    describe('WHEN a document contains a horizontal rule', () => {
+      it('THEN should render the hr inside the spacer block wrapper', () => {
+        const editor = createEditor('<p>Title</p><hr><p>Body</p>')
+        const html = editor.getHTML()
+
+        editor.destroy()
+
+        expect(html).toContain(
+          '<div class="spacer" data-type="horizontalRule"><div class="block-wrapper"><hr></div></div>',
+        )
+      })
+
+      it('THEN should keep the markdown round-trip identical', () => {
+        const editor = createEditor('<p>Title</p><hr><p>Body</p>')
+        const markdown = getMarkdown(editor)
+
+        editor.destroy()
+
+        expect(markdown).toBe('Title\n\n---\n\nBody')
+      })
+    })
+  })
 })

--- a/src/components/designSystem/RichTextEditor/extensions/baseExtensions.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/baseExtensions.ts
@@ -5,6 +5,7 @@ import CodeBlock from '@tiptap/extension-code-block'
 import Color from '@tiptap/extension-color'
 import Heading from '@tiptap/extension-heading'
 import Highlight from '@tiptap/extension-highlight'
+import HorizontalRule from '@tiptap/extension-horizontal-rule'
 import Link from '@tiptap/extension-link'
 import OrderedList from '@tiptap/extension-ordered-list'
 import Paragraph from '@tiptap/extension-paragraph'
@@ -193,6 +194,16 @@ const WrappedCodeBlock = CodeBlock.extend({
   },
 })
 
+// Without the wrapper a bare <hr> has no .spacer sibling, so the drag handle's
+// hover reveal rules never match and the divider can't be selected or deleted.
+const WrappedHorizontalRule = HorizontalRule.extend({
+  renderHTML(props) {
+    const inner = this.parent ? this.parent(props) : (['hr'] satisfies DOMOutputSpec)
+
+    return wrapInBlockWrapper('horizontalRule', inner)
+  },
+})
+
 // -- Extension list -----------------------------------------------------------
 
 interface BaseExtensionsOptions {
@@ -217,6 +228,7 @@ export const getBaseExtensions = (options?: BaseExtensionsOptions): Extensions =
     orderedList: false,
     blockquote: false,
     codeBlock: false,
+    horizontalRule: false,
   }),
   WrappedParagraph,
   WrappedHeading,
@@ -224,6 +236,7 @@ export const getBaseExtensions = (options?: BaseExtensionsOptions): Extensions =
   WrappedOrderedList,
   WrappedBlockquote,
   WrappedCodeBlock,
+  WrappedHorizontalRule,
   Link.configure({ openOnClick: false }),
   Underline,
   Superscript,

--- a/src/components/designSystem/RichTextEditor/richTextEditor.css
+++ b/src/components/designSystem/RichTextEditor/richTextEditor.css
@@ -415,6 +415,12 @@
   margin-top: 20px;
 }
 
+/* A divider's <hr> is a 1px line at the top of its block-wrapper, not a text
+   line — pull the group up so the buttons center on the line itself. */
+.block-handle-group:has(+ .spacer[data-type='horizontalRule']) {
+  margin-top: -4px;
+}
+
 .tableWrapper {
   @apply relative rounded-md p-2 pb-8;
 }

--- a/src/components/designSystem/RichTextEditor/richTextEditor.css
+++ b/src/components/designSystem/RichTextEditor/richTextEditor.css
@@ -415,8 +415,6 @@
   margin-top: 20px;
 }
 
-/* A divider's <hr> is a 1px line at the top of its block-wrapper, not a text
-   line — pull the group up so the buttons center on the line itself. */
 .block-handle-group:has(+ .spacer[data-type='horizontalRule']) {
   margin-top: -4px;
 }


### PR DESCRIPTION
## Context

QA return LAGO-1863: after pasting markdown into the editor, the block menu never opens, so lines can't be deleted or recolored. Two independent causes: the drag handle widget captured its block position at creation time and kept using it after any non-structural document edit (a markdown paste, a single keystroke), so clicks selected the wrong node or threw; and `---` dividers rendered as a bare `<hr>` without the `.spacer` wrapper, so the hover rule that reveals the handle never matched and dividers couldn't be selected, moved, or deleted at all.

## Description

- `DragHandle.ts`: the widget constructor now receives ProseMirror's live `getPos` resolver instead of a captured number. The grip's `click` and `dragstart` listeners resolve the position at event time and bail out when the widget has left the document (`dragstart` also cancels the native drag). The table branch of `selectBlock` becomes reachable again with a correct position.
- `baseExtensions.ts`: `horizontalRule` is now wrapped in the standard `.spacer`/`.block-wrapper` structure (new `WrappedHorizontalRule`, StarterKit's own node disabled), so the existing `:has(+ .spacer:hover)` reveal rule matches. Markdown round-trip stays byte identical. New dependency `@tiptap/extension-horizontal-rule@3.30.1`.
- Tests: new `GIVEN the document has been edited without a structural change` block in `DragHandle.test.ts` covering stale-position clicks after inserts, single-character edits, markdown paste, and the table grip; `baseExtensions.test.ts` asserts the wrapped `<hr>` render shape and the markdown round-trip.

Known visual follow-up: dividers gain the standard block spacing (~16px vertical) in editor, preview, and PDF — intended, it is what makes them hoverable. Coloring a divider stays a no-op (not in BLOCK_TYPES); separate ticket.

<!-- Linear link -->
Fixes LAGO-1863
