### PR TITLE
fix(orders): send an explicit null when clearing the execution date

### DIFF
--- a/src/pages/quotes/EditOrder.tsx
+++ b/src/pages/quotes/EditOrder.tsx
@@ -33,6 +33,11 @@ import {
   EditOrderFormValues,
   editOrderValidationSchema,
 } from './editOrder/validationSchema'
+import { applyFormFieldErrors } from './utils/applyFormFieldErrors'
+import {
+  getQuoteMutationErrors,
+  QUOTE_MUTATION_SILENT_ERROR_CODES,
+} from './utils/quoteMutationErrors'
 
 export const EDIT_ORDER_CLOSE_BUTTON_TEST_ID = 'edit-order-close-button'
 export const EDIT_ORDER_CANCEL_BUTTON_TEST_ID = 'edit-order-cancel-button'
@@ -96,6 +101,7 @@ const EditOrderFormContent = ({ order, loading }: EditOrderFormContentProps) => 
 
   const [updateOrderMutation] = useUpdateOrderMutation({
     refetchQueries: ['getOrders'],
+    context: { silentErrorCodes: [...QUOTE_MUTATION_SILENT_ERROR_CODES] },
   })
 
   const previewProps = useMemo(
@@ -129,18 +135,25 @@ const EditOrderFormContent = ({ order, loading }: EditOrderFormContentProps) => 
     defaultValues,
     validationLogic: revalidateLogic(),
     validators: { onDynamic: editOrderValidationSchema },
-    onSubmit: async ({ value }) => {
+    onSubmit: async ({ value, formApi }) => {
       if (!orderId) return
 
       const result = await updateOrderMutation({
         variables: { input: buildUpdateOrderInput(orderId, value) },
       })
 
-      if (result.data?.updateOrder) {
-        addToast({ severity: 'success', translateKey: 'text_1782723591984c30uudt9ma9' })
+      if (!result.data?.updateOrder) {
+        const errors = getQuoteMutationErrors(result.errors, translate, 'order')
 
-        closeRedirection()
+        errors.forEach(({ message }) => addToast({ severity: 'danger', message }))
+        applyFormFieldErrors(formApi, errors)
+
+        return
       }
+
+      addToast({ severity: 'success', translateKey: 'text_1782723591984c30uudt9ma9' })
+
+      closeRedirection()
     },
   })
 

--- a/src/pages/quotes/__tests__/EditOrder.test.tsx
+++ b/src/pages/quotes/__tests__/EditOrder.test.tsx
@@ -1,6 +1,7 @@
 import NiceModal from '@ebay/nice-modal-react'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { DateTime } from 'luxon'
 
 import CentralizedDialog from '~/components/dialogs/CentralizedDialog'
 import {
@@ -109,6 +110,15 @@ const mockOrder = {
   },
 }
 
+// Noon UTC keeps the same calendar date across all realistic test timezones
+const mockOrderWithExecuteAt = {
+  ...mockOrder,
+  executionMode: OrderExecutionModeEnum.ExecuteInLago,
+  executeAt: '2030-12-25T12:00:00.000Z',
+}
+
+const executeAtInput = () => screen.getByPlaceholderText('text_17816865941253r8yqeoibh1')
+
 describe('EditOrder', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -151,6 +161,7 @@ describe('EditOrder', () => {
           input: expect.objectContaining({
             id: 'order-123',
             executionMode: OrderExecutionModeEnum.ExecuteInLago,
+            executeAt: null,
           }),
         },
       })
@@ -250,11 +261,109 @@ describe('EditOrder', () => {
           input: expect.objectContaining({
             id: 'order-123',
             executionMode: OrderExecutionModeEnum.OrderOnly,
+            executeAt: null,
           }),
         },
       })
     })
     expect(mockGoBack).toHaveBeenCalled()
+  })
+
+  it('sends an explicit null when the execution date is cleared', async () => {
+    mockUseGetOrderForEditQuery.mockReturnValue({
+      data: { order: mockOrderWithExecuteAt },
+      loading: false,
+      error: undefined,
+    })
+    mockUpdateOrder.mockResolvedValueOnce({
+      data: { updateOrder: { id: 'order-123' } },
+    })
+
+    const user = userEvent.setup()
+
+    renderPage()
+
+    await user.clear(executeAtInput())
+
+    await user.click(screen.getByTestId(EDIT_ORDER_SUBMIT_BUTTON_TEST_ID))
+
+    await waitFor(() => {
+      expect(mockUpdateOrder).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            id: 'order-123',
+            executionMode: OrderExecutionModeEnum.ExecuteInLago,
+            executeAt: null,
+          },
+        },
+      })
+    })
+    expect(mockGoBack).toHaveBeenCalled()
+  })
+
+  it('submits the new execution date when it is changed', async () => {
+    mockUseGetOrderForEditQuery.mockReturnValue({
+      data: { order: mockOrderWithExecuteAt },
+      loading: false,
+      error: undefined,
+    })
+    mockUpdateOrder.mockResolvedValueOnce({
+      data: { updateOrder: { id: 'order-123' } },
+    })
+
+    const user = userEvent.setup()
+
+    renderPage()
+
+    await user.clear(executeAtInput())
+    await user.type(executeAtInput(), '12/31/2030')
+
+    await user.click(screen.getByTestId(EDIT_ORDER_SUBMIT_BUTTON_TEST_ID))
+
+    await waitFor(() => {
+      expect(mockUpdateOrder).toHaveBeenCalled()
+    })
+
+    // Asserted as a calendar date rather than an instant: the picker emits UTC, so the exact
+    // string depends on the runner's timezone.
+    const { executeAt } = mockUpdateOrder.mock.calls[0][0].variables.input
+
+    expect(DateTime.fromISO(executeAt).toFormat('MM/dd/yyyy')).toBe('12/31/2030')
+  })
+
+  it('shows the API failure inline instead of navigating away', async () => {
+    mockUseGetOrderForEditQuery.mockReturnValue({
+      data: { order: mockOrderWithExecuteAt },
+      loading: false,
+      error: undefined,
+    })
+    mockUpdateOrder.mockResolvedValueOnce({
+      data: null,
+      errors: [
+        {
+          message: 'Unprocessable Entity',
+          extensions: {
+            code: 'unprocessable_entity',
+            details: { executeAt: ['after_deal_expiration'] },
+          },
+        },
+      ],
+    })
+
+    const user = userEvent.setup()
+
+    renderPage()
+
+    await user.click(screen.getByTestId(EDIT_ORDER_SUBMIT_BUTTON_TEST_ID))
+
+    await waitFor(() => {
+      expect(screen.getByText('text_1787137341763nutdwcniihz')).toBeInTheDocument()
+    })
+    expect(addToast).toHaveBeenCalledWith({
+      severity: 'danger',
+      message: 'text_1787137341763nutdwcniihz',
+    })
+    expect(mockGoBack).not.toHaveBeenCalled()
   })
 
   describe('unsaved-changes guard', () => {

--- a/src/pages/quotes/editOrder/__tests__/validationSchema.test.ts
+++ b/src/pages/quotes/editOrder/__tests__/validationSchema.test.ts
@@ -53,4 +53,15 @@ describe('buildUpdateOrderInput', () => {
       executeAt: '2030-01-01T00:00:00.000Z',
     })
   })
+
+  // The mutation reads an omitted key as "leave unchanged", and JSON.stringify drops undefined
+  // values, so a cleared date only reaches the API as an explicit null.
+  it('maps a cleared date to an explicit null', () => {
+    const input = buildUpdateOrderInput('order-1', {
+      executionMode: OrderExecutionModeEnum.OrderOnly,
+      executeAt: undefined,
+    })
+
+    expect(input.executeAt).toBeNull()
+  })
 })

--- a/src/pages/quotes/editOrder/validationSchema.ts
+++ b/src/pages/quotes/editOrder/validationSchema.ts
@@ -33,5 +33,5 @@ export const buildUpdateOrderInput = (
 ): UpdateOrderInput => ({
   id: orderId,
   executionMode: values.executionMode,
-  executeAt: values.executeAt,
+  executeAt: values.executeAt ?? null,
 })


### PR DESCRIPTION
## Context

Removing the execution date on an order had no effect: the save reported success and the date
was still there.

Clearing the date picker yields `undefined`, and `JSON.stringify` drops undefined-valued keys
from the request body, so `updateOrder` arrived with no `executeAt` key at all. The API reads an
absent key as "leave unchanged" and an explicit `null` as "clear", so the old value survived.

## Description

`buildUpdateOrderInput` now maps a cleared date to `null`.

`EditOrder` also handled no API failure at all, unlike the sign and execute pages: a rejection
resolves with `data: null` rather than throwing, and the handler had no `else`, so the user got
no inline error and no explanation. It now runs `getQuoteMutationErrors` and
`applyFormFieldErrors` and silences the codes it owns, matching `ExecuteOrder`.

Tests cover clearing, changing and rejecting the date. Reverting the one-line fix turns four of
them red.