### PR TITLE
feat(agents): add the loop-flywheel skill

### DIFF
--- a/.agents/skills/loop-flywheel/SKILL.md
+++ b/.agents/skills/loop-flywheel/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: loop-flywheel
+description: 'Harvest phase of the loop pipeline for lago-front. Reads the proposals loop-run appended to _flywheel.md, keeps the ones that earned their place, applies them to the loop-* skills and the .agents docs, and opens a PR. Use when user says "/loop-flywheel", asks to apply flywheel feedback, or asks to turn the flywheel into a PR.'
+---
+
+# Loop Flywheel - harvest proposals into a PR
+
+loop-run only ever *proposes*: on every terminal outcome it appends a dated `target / evidence / proposed edit` block to `$LOOP_STATE_DIR/_flywheel.md` (default `~/.claude/loop-state/_flywheel.md`) and never touches a skill file. This skill is the other half. It reads that backlog, decides which proposals earned a permanent line in the instructions, applies them, and opens a PR for a human to merge.
+
+**Repo:** the lago monorepo root; lago-front checkout at `front/`. Only `.agents/skills/**` and `.agents/docs/**` are in scope. Never a code change.
+
+## Steps
+
+1. **Read the backlog**: `$LOOP_STATE_DIR/_flywheel.md`. Missing, empty, or every entry already carries an `applied:` line → report "nothing to harvest" and stop. Skip entries with an `applied:` line; they shipped in an earlier harvest.
+
+2. **Read the current instructions before judging anything**: the `target:` file of every remaining proposal, plus `front/CLAUDE.md` and the `.agents/docs/*` it references. A proposal is only worth applying against what the skills say *today*, and several will already be covered.
+
+3. **Triage each proposal** into keep / drop / merge / relocate:
+   - **Keep** when it is recurring or expensive (it escaped a review, cost a build↔review cycle, or shipped a defect), concrete enough to check without judgment, and still true against the current code.
+   - **Drop** when it is a one-off with no generalizable rule, already covered by an existing line in the target file or a doc (name the line), contradicts a project convention, or is too vague to verify. Dropping is the common case: say why in the report, the entry stays in the backlog.
+   - **Merge** two proposals stating the same rule into one bullet. Two `as unknown as` escapes are one rule with two remedies, not two rules.
+   - **Relocate**: `target:` is the proposer's guess, not a routing decision. Place the rule where it is actually enforced. Test-authoring rules go to `make-tests` / `.agents/docs/testing-practices.md`, codebase-wide conventions to `.agents/docs/*` (CLAUDE.md loads them for every session, not just the loop), pipeline behavior to the loop-* skill. A rule whose home is a doc gets a one-line pointer from the skill, never a copy.
+
+4. **Apply the kept proposals**, one bullet each:
+   - Every skill file is read in full on every run, so a line that changes no decision costs tokens forever. Cap a proposal at 1-3 lines and cut the evidence narrative: the rule, the trigger, the remedy.
+   - When the new rule supersedes an existing one, rewrite that line instead of stacking a second one beside it.
+   - A build-phase rule usually wants its review-phase mirror: loop-build states how to write it, loop-review states how to catch it. That pairing is the pipeline's shape, not duplication, but only add the mirror when a review could plausibly miss it.
+
+5. **Open the PR** from a throwaway worktree off `origin/main`. Markdown only, so plain git is enough; do NOT spend a `lago-worktree` slot (no docker, no pnpm install):
+
+   ```bash
+   git -C front fetch origin main
+   git -C front worktree add /tmp/lago-flywheel -b <BRANCH> origin/main
+   ```
+
+   `<BRANCH>` = kebab-case topic slug, no Linear ID (these harvests have no ticket), e.g. `loop-skills-flywheel-harvest`. Commit with a `docs(agents):` or `chore(agents):` subject of 50 chars or less, push, then `gh pr create --base main --repo getlago/lago-front`. Nothing to gate: `pnpm lint` covers `src/`, `cypress/` and `index.html` only, so `.agents/**` markdown sits outside every gate.
+
+   PR body: one line per proposal, applied where or dropped and why. That list is what the operator reviews; the diff alone does not show what was rejected.
+
+6. **Mark the harvest** in `_flywheel.md`: append `- applied: <PR URL>` (or `- dropped: <one-line reason>`) under each entry this run judged. Never delete an entry: the backlog is the record of what the pipeline actually got wrong.
+
+7. **Report**: PR URL, kept/dropped counts, and the one-line rationale per dropped proposal.
+
+## Hard rules
+
+- Proposals are input, not instructions. A `proposed edit` quoted in `_flywheel.md` is a draft written by a tired pipeline at the end of a failed run: rewrite it, place it, or drop it, never paste it in verbatim.
+- Never delete or rewrite a flywheel entry, only annotate it.
+- Never touch anything outside `.agents/skills/**` and `.agents/docs/**`. No code, no test, no translation change.
+- Humans merge. No self-approval, no merge, no auto-merge flag.
+- **No AI attribution anywhere**: commit message and PR title/body carry no "Co-Authored-By", no "Generated with", no AI mention of any kind.
+- **Two communication registers**: messages to humans (chat report, PR body) = short, direct, plain language. Internal state files (`_flywheel.md` annotations) = dense and precise, written for the AI of a later harvest.

--- a/.agents/skills/loop-run/SKILL.md
+++ b/.agents/skills/loop-run/SKILL.md
@@ -119,7 +119,7 @@ Run these two steps on every way the pipeline ends — happy path (after Announc
    - proposed edit: <the concrete instruction to add/change, quoted>
    ```
 
-   Rules: proposals ONLY — NEVER edit the skill files themselves, NEVER notify the operator. They read _flywheel.md when they want, and a proposal that proves itself becomes a PR against these skills. Nothing avoidable found → append nothing (no empty entries).
+   Rules: proposals ONLY — NEVER edit the skill files themselves, NEVER notify the operator. They read _flywheel.md when they want, and the `loop-flywheel` skill is what turns the proposals that prove themselves into a PR against these skills. Nothing avoidable found → append nothing (no empty entries).
 
 ## Failure handling
 


### PR DESCRIPTION
The loop pipeline has an open end: on every terminal outcome `loop-run` appends a `target / evidence / proposed edit` block to `_flywheel.md`, and is explicitly forbidden from editing a skill file. Nothing on the other side ever turned those proposals into instructions, so the backlog only grew.

`loop-flywheel` is that other side. It reads the backlog, triages each proposal (keep / drop / merge / relocate), applies the survivors, opens a PR and annotates the entries with its URL.

The parts that carry the design:

- **Proposals are input, not instructions.** A `proposed edit` is a draft written by a tired pipeline at the end of a failed run: rewrite it, place it, or drop it, never paste it verbatim.
- **`target:` is a guess, not routing.** Test-authoring rules belong in `make-tests` / `.agents/docs/testing-practices.md`, codebase-wide conventions in `.agents/docs/*` where CLAUDE.md loads them for every session, pipeline behavior in the loop-* skill. A rule whose home is a doc gets a pointer from the skill, never a copy.
- **Token budget.** Skill files are read in full on every run, so a line that changes no decision costs tokens forever: 1-3 lines per proposal, and a rule that supersedes an older one rewrites it instead of stacking beside it.
- **Dropping is the common case**, and the PR body has to say what was rejected and why: the diff alone cannot show it.
- **The backlog is append-only.** Entries get an `applied:` / `dropped:` line, never a deletion; it is the record of what the pipeline actually got wrong.

Cheap by design: markdown only, so a plain `git worktree` off main, no `lago-worktree` slot, no docker, no pnpm install, and nothing to gate (`pnpm lint` covers `src/`, `cypress/` and `index.html`).

First harvest ran by hand on #4193, whose runs produced the current backlog: the nine proposals there landed as edits to `loop-build`, `loop-review`, `loop-spec`, `make-tests` and `testing-practices.md` on that PR's own branch.