### PR TITLE
refactor(customer-portal): migrate wallet top-up form to TanStack Form

### DIFF
--- a/src/components/customerPortal/wallet/WalletPage.tsx
+++ b/src/components/customerPortal/wallet/WalletPage.tsx
@@ -20,7 +20,7 @@ import {
 import { useAppForm } from '~/hooks/forms/useAppform'
 import { topUpAmountError } from '~/pages/wallet/form'
 
-import { walletPageTopUpValidationSchema } from './validationSchema'
+import { walletPageTopUpDefaultValues, walletPageTopUpValidationSchema } from './validationSchema'
 
 gql`
   query customerPortalWallet($id: ID!) {
@@ -73,9 +73,7 @@ const WalletPage = () => {
     })
 
   const form = useAppForm({
-    defaultValues: {
-      amount: '' as number | '',
-    },
+    defaultValues: walletPageTopUpDefaultValues,
     validationLogic: revalidateLogic(),
     validators: {
       onDynamic: walletPageTopUpValidationSchema,

--- a/src/components/customerPortal/wallet/WalletPage.tsx
+++ b/src/components/customerPortal/wallet/WalletPage.tsx
@@ -1,8 +1,7 @@
 import { gql } from '@apollo/client'
 import InputAdornment from '@mui/material/InputAdornment'
-import { useFormik } from 'formik'
+import { revalidateLogic, useStore } from '@tanstack/react-form'
 import { useParams } from 'react-router-dom'
-import { number, object } from 'yup'
 
 import useCustomerPortalNavigation from '~/components/customerPortal/common/hooks/useCustomerPortalNavigation'
 import PageTitle from '~/components/customerPortal/common/PageTitle'
@@ -10,9 +9,7 @@ import SectionError from '~/components/customerPortal/common/SectionError'
 import { LoaderWalletPage } from '~/components/customerPortal/common/SectionLoading'
 import useCustomerPortalTranslate from '~/components/customerPortal/common/useCustomerPortalTranslate'
 import { Alert } from '~/components/designSystem/Alert'
-import { Button } from '~/components/designSystem/Button'
 import { Typography } from '~/components/designSystem/Typography'
-import { AmountInputField } from '~/components/form'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import {
@@ -20,7 +17,10 @@ import {
   useCustomerPortalWalletQuery,
   useTopUpPortalWalletMutation,
 } from '~/generated/graphql'
+import { useAppForm } from '~/hooks/forms/useAppform'
 import { topUpAmountError } from '~/pages/wallet/form'
+
+import { walletPageTopUpValidationSchema } from './validationSchema'
 
 gql`
   query customerPortalWallet($id: ID!) {
@@ -59,39 +59,42 @@ const WalletPage = () => {
     },
   })
 
+  const wallet = customerWalletData?.customerPortalWallet
+
   const [topUpPortalWallet, { loading: loadingTopUpPortalWallet, error: errorTopUpPortalWallet }] =
     useTopUpPortalWalletMutation({
       onCompleted(res) {
         if (res) {
-          formikProps.resetForm()
+          form.reset()
 
           goHome?.()
         }
       },
     })
 
-  const wallet = customerWalletData?.customerPortalWallet
-
-  const formikProps = useFormik({
-    initialValues: {
-      amount: undefined,
+  const form = useAppForm({
+    defaultValues: {
+      amount: '' as number | '',
     },
-    validationSchema: object().shape({
-      amount: number().required(''),
-    }),
-    onSubmit: async ({ amount }) => {
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: walletPageTopUpValidationSchema,
+    },
+    onSubmit: async ({ value }) => {
       if (!wallet?.id) return
 
-      topUpPortalWallet({
+      await topUpPortalWallet({
         variables: {
           input: {
             walletId: wallet?.id,
-            paidCredits: String(amount),
+            paidCredits: String(value.amount),
           },
         },
       })
     },
   })
+
+  const amount = useStore(form.store, (state) => state.values.amount)
 
   const isError = !customerWalletLoading && customerWalletError
 
@@ -105,18 +108,17 @@ const WalletPage = () => {
 
   const paidCreditsError = topUpAmountError({
     rateAmount: wallet?.rateAmount?.toString(),
-    paidCredits: formikProps?.values?.amount,
+    paidCredits: amount === '' ? undefined : String(amount),
     paidTopUpMinAmountCents,
     paidTopUpMaxAmountCents,
     currency: wallet?.currency,
     translate,
   })
 
-  const submitButtonDisabled =
-    !formikProps?.values?.amount ||
-    loadingTopUpPortalWallet ||
-    formikProps?.values?.amount <= 0 ||
-    paidCreditsError?.error
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    form.handleSubmit()
+  }
 
   if (isError) {
     return (
@@ -135,37 +137,39 @@ const WalletPage = () => {
       {customerWalletLoading && <LoaderWalletPage />}
 
       {!customerWalletLoading && (
-        <div>
-          <AmountInputField
-            name="amount"
-            displayErrorText={false}
-            beforeChangeFormatter={['positiveNumber']}
-            helperText={
-              <Typography variant="body" color="grey600" className="mt-1">
-                {translate('text_17279456600803f8on7ku8jo', {
-                  credits: intlFormatNumber(
-                    Number(formikProps?.values?.amount || 0) * Number(wallet?.rateAmount || 0),
-                    {
-                      currencyDisplay: 'narrowSymbol',
-                      currency: wallet?.currency,
-                      locale: documentLocale,
-                    },
+        <form onSubmit={handleSubmit}>
+          <form.AppField name="amount">
+            {(field) => (
+              <field.AmountInputField
+                displayErrorText={false}
+                beforeChangeFormatter={['positiveNumber']}
+                helperText={
+                  <Typography variant="body" color="grey600" className="mt-1">
+                    {translate('text_17279456600803f8on7ku8jo', {
+                      credits: intlFormatNumber(
+                        Number(amount || 0) * Number(wallet?.rateAmount || 0),
+                        {
+                          currencyDisplay: 'narrowSymbol',
+                          currency: wallet?.currency,
+                          locale: documentLocale,
+                        },
+                      ),
+                    })}
+                  </Typography>
+                }
+                label={translate('text_1728377307160d96z1skvnw3')}
+                currency={wallet?.currency || CurrencyEnum.Usd}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      {translate('text_1728377307160iloscj20uc1')}
+                    </InputAdornment>
                   ),
-                })}
-              </Typography>
-            }
-            label={translate('text_1728377307160d96z1skvnw3')}
-            currency={wallet?.currency || CurrencyEnum.Usd}
-            formikProps={formikProps}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  {translate('text_1728377307160iloscj20uc1')}
-                </InputAdornment>
-              ),
-            }}
-            error={paidCreditsError?.label}
-          />
+                }}
+                errorOverride={paidCreditsError?.label}
+              />
+            )}
+          </form.AppField>
 
           {errorTopUpPortalWallet && (
             <Alert className="mt-8" type="danger" data-test="error-alert">
@@ -174,16 +178,16 @@ const WalletPage = () => {
           )}
 
           <div className="mt-8 flex justify-end">
-            <Button
-              disabled={submitButtonDisabled}
-              loading={loadingTopUpPortalWallet}
-              size="medium"
-              onClick={formikProps.submitForm}
-            >
-              {translate('text_1728377307160e831fr4ydtn')}
-            </Button>
+            <form.AppForm>
+              <form.SubmitButton
+                disabled={loadingTopUpPortalWallet || !!paidCreditsError?.error}
+                size="medium"
+              >
+                {translate('text_1728377307160e831fr4ydtn')}
+              </form.SubmitButton>
+            </form.AppForm>
           </div>
-        </div>
+        </form>
       )}
     </div>
   )

--- a/src/components/customerPortal/wallet/__tests__/WalletPage.test.tsx
+++ b/src/components/customerPortal/wallet/__tests__/WalletPage.test.tsx
@@ -1,0 +1,221 @@
+import { screen } from '@testing-library/react'
+
+import { CurrencyEnum } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import WalletPage from '../WalletPage'
+
+const mockUseCustomerPortalWalletQuery = jest.fn()
+const mockTopUpPortalWallet = jest.fn()
+const mockUseCustomerPortalNavigation = jest.fn()
+const mockUseCustomerPortalTranslate = jest.fn()
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ walletId: 'wallet-1' }),
+}))
+
+jest.mock('~/components/customerPortal/common/hooks/useCustomerPortalNavigation', () => ({
+  __esModule: true,
+  default: () => mockUseCustomerPortalNavigation(),
+}))
+
+jest.mock('~/components/customerPortal/common/useCustomerPortalTranslate', () => ({
+  __esModule: true,
+  default: () => mockUseCustomerPortalTranslate(),
+}))
+
+jest.mock('~/components/customerPortal/common/PageTitle', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-test="page-title">{title}</div>,
+}))
+
+jest.mock('~/components/customerPortal/common/SectionError', () => ({
+  __esModule: true,
+  default: () => <div data-test="section-error">Error</div>,
+}))
+
+jest.mock('~/components/customerPortal/common/SectionLoading', () => ({
+  LoaderWalletPage: () => <div data-test="loading-skeleton">Loading</div>,
+}))
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useCustomerPortalWalletQuery: (...args: unknown[]) => mockUseCustomerPortalWalletQuery(...args),
+  useTopUpPortalWalletMutation: (...args: unknown[]) => [
+    mockTopUpPortalWallet,
+    { loading: false, error: undefined },
+    args,
+  ],
+}))
+
+let mockFormAmountValue: number | '' = ''
+
+jest.mock('~/hooks/forms/useAppform', () => ({
+  useAppForm: ({ onSubmit }: { onSubmit: (arg: { value: { amount: number | '' } }) => void }) => ({
+    store: {
+      subscribe: jest.fn(() => jest.fn()),
+      state: { values: { amount: mockFormAmountValue } },
+      getState: () => ({ values: { amount: mockFormAmountValue }, canSubmit: true }),
+    },
+    reset: jest.fn(),
+    handleSubmit: () => onSubmit({ value: { amount: mockFormAmountValue } }),
+    AppField: ({
+      name,
+      children,
+    }: {
+      name: string
+      children: (field: unknown) => React.ReactNode
+    }) => {
+      const fieldProps = {
+        AmountInputField: ({
+          label,
+          errorOverride,
+        }: {
+          label?: string
+          errorOverride?: string | boolean
+        }) => (
+          <div data-test={`field-${name}`}>
+            {label && <label>{label}</label>}
+            <input data-test={`input-${name}`} readOnly value={mockFormAmountValue} />
+            {errorOverride && <span data-test="bounds-error">{errorOverride}</span>}
+          </div>
+        ),
+      }
+
+      return <>{children(fieldProps)}</>
+    },
+    AppForm: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SubmitButton: ({ children, disabled }: { children: React.ReactNode; disabled?: boolean }) => (
+      <button type="submit" data-test="submit" disabled={disabled}>
+        {children}
+      </button>
+    ),
+  }),
+}))
+
+jest.mock('@tanstack/react-form', () => ({
+  revalidateLogic: jest.fn(() => ({})),
+  useStore: (
+    store: { getState: () => { values: { amount: number | '' } } },
+    selector: (state: { values: { amount: number | '' } }) => unknown,
+  ) => selector(store.getState()),
+}))
+
+const wallet = {
+  id: 'wallet-1',
+  currency: CurrencyEnum.Usd,
+  name: 'Test wallet',
+  rateAmount: '1',
+  paidTopUpMinAmountCents: null,
+  paidTopUpMaxAmountCents: null,
+}
+
+const setupDefaultMocks = () => {
+  mockFormAmountValue = ''
+
+  mockUseCustomerPortalTranslate.mockReturnValue({
+    translate: (key: string) => key,
+    documentLocale: 'en',
+  })
+
+  mockUseCustomerPortalNavigation.mockReturnValue({
+    goHome: jest.fn(),
+  })
+
+  mockUseCustomerPortalWalletQuery.mockReturnValue({
+    data: { customerPortalWallet: wallet },
+    loading: false,
+    error: undefined,
+    refetch: jest.fn(),
+  })
+}
+
+describe('WalletPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    setupDefaultMocks()
+  })
+
+  describe('GIVEN the wallet is loading', () => {
+    it('THEN should render the loading skeleton', () => {
+      mockUseCustomerPortalWalletQuery.mockReturnValue({
+        data: undefined,
+        loading: true,
+        error: undefined,
+        refetch: jest.fn(),
+      })
+
+      render(<WalletPage />)
+
+      expect(screen.getByTestId('loading-skeleton')).toBeInTheDocument()
+      expect(screen.queryByTestId('field-amount')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('GIVEN there is an error', () => {
+    it('THEN should render the error state', () => {
+      mockUseCustomerPortalWalletQuery.mockReturnValue({
+        data: undefined,
+        loading: false,
+        error: new Error('Network error'),
+        refetch: jest.fn(),
+      })
+
+      render(<WalletPage />)
+
+      expect(screen.getByTestId('section-error')).toBeInTheDocument()
+      expect(screen.queryByTestId('field-amount')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('GIVEN the wallet is loaded', () => {
+    it('THEN should render the page title, amount field and submit button', () => {
+      render(<WalletPage />)
+
+      expect(screen.getByTestId('page-title')).toBeInTheDocument()
+      expect(screen.getByTestId('field-amount')).toBeInTheDocument()
+      expect(screen.getByTestId('submit')).toBeInTheDocument()
+    })
+
+    it('THEN should submit the top-up amount', () => {
+      mockFormAmountValue = 10
+
+      render(<WalletPage />)
+
+      screen.getByTestId('submit').click()
+
+      expect(mockTopUpPortalWallet).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            walletId: wallet.id,
+            paidCredits: '10',
+          },
+        },
+      })
+    })
+  })
+
+  describe('GIVEN the entered amount is above the wallet paid top-up max', () => {
+    it('THEN should render the bounds error and disable the submit button', () => {
+      mockFormAmountValue = 10
+
+      mockUseCustomerPortalWalletQuery.mockReturnValue({
+        data: {
+          customerPortalWallet: {
+            ...wallet,
+            paidTopUpMaxAmountCents: '100',
+          },
+        },
+        loading: false,
+        error: undefined,
+        refetch: jest.fn(),
+      })
+
+      render(<WalletPage />)
+
+      expect(screen.getByTestId('bounds-error')).toBeInTheDocument()
+      expect(screen.getByTestId('submit')).toBeDisabled()
+    })
+  })
+})

--- a/src/components/customerPortal/wallet/__tests__/validationSchema.test.ts
+++ b/src/components/customerPortal/wallet/__tests__/validationSchema.test.ts
@@ -1,0 +1,24 @@
+import { formatValue, ValueFormatterType } from '~/components/form/TextInput'
+
+import { walletPageTopUpValidationSchema } from '../validationSchema'
+
+describe('walletPageTopUpValidationSchema', () => {
+  describe('GIVEN a positive amount formatted by AmountInputField', () => {
+    it.each<[string, ValueFormatterType[], string]>([
+      ['a zero-decimal currency', ['positiveNumber', 'int'], '10'],
+      ['a two-decimal currency', ['positiveNumber', 'decimal'], '10.25'],
+      ['a three-decimal currency', ['positiveNumber', 'triDecimal'], '10.251'],
+      ['a four-decimal currency', ['positiveNumber', 'quadDecimal'], '10.2514'],
+    ])('THEN should accept the runtime value for %s', (_, formatters, input) => {
+      const amount = formatValue(input, formatters)
+
+      expect(walletPageTopUpValidationSchema.safeParse({ amount }).success).toBe(true)
+    })
+  })
+
+  describe('GIVEN an amount that is not positive', () => {
+    it.each(['', '0', 0])('THEN should reject %p', (amount) => {
+      expect(walletPageTopUpValidationSchema.safeParse({ amount }).success).toBe(false)
+    })
+  })
+})

--- a/src/components/customerPortal/wallet/validationSchema.ts
+++ b/src/components/customerPortal/wallet/validationSchema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+// The amount field is invisible-error by design (rendered with displayErrorText={false} —
+// the visible label comes from topUpAmountError instead), so only the message KEY matters.
+export const walletPageTopUpErrorLabels = {
+  required: 'text_1771342994699klxu2paz7g8',
+} as const
+
+// `AmountInputField`'s `beforeChangeFormatter={['positiveNumber']}` stores `number | ''` at
+// runtime (parseFloat result, or '' when emptied) — see migrate-formik-to-tanstack Pattern 11.
+// The original Yup schema was only `number().required('')`; combined with the Formik-era
+// `amount <= 0` check baked into the submit-button disabled logic, the actual gate was
+// "a positive number", so both collapse into one refine here.
+export const walletPageTopUpValidationSchema = z.object({
+  amount: z
+    .union([z.number(), z.literal('')])
+    .refine((value) => typeof value === 'number' && value > 0, {
+      message: walletPageTopUpErrorLabels.required,
+    }),
+})
+
+export type WalletPageTopUpFormValues = z.infer<typeof walletPageTopUpValidationSchema>

--- a/src/components/customerPortal/wallet/validationSchema.ts
+++ b/src/components/customerPortal/wallet/validationSchema.ts
@@ -1,22 +1,17 @@
 import { z } from 'zod'
 
-// The amount field is invisible-error by design (rendered with displayErrorText={false} —
-// the visible label comes from topUpAmountError instead), so only the message KEY matters.
-export const walletPageTopUpErrorLabels = {
-  required: 'text_1771342994699klxu2paz7g8',
-} as const
+const REQUIRED_FIELD_MESSAGE = 'text_1771342994699klxu2paz7g8'
 
-// `AmountInputField`'s `beforeChangeFormatter={['positiveNumber']}` stores `number | ''` at
-// runtime (parseFloat result, or '' when emptied) — see migrate-formik-to-tanstack Pattern 11.
-// The original Yup schema was only `number().required('')`; combined with the Formik-era
-// `amount <= 0` check baked into the submit-button disabled logic, the actual gate was
-// "a positive number", so both collapse into one refine here.
+// AmountInputField stores a number for zero-decimal currencies and a string
+// for currencies with decimal precision. An empty field is stored as ''.
 export const walletPageTopUpValidationSchema = z.object({
-  amount: z
-    .union([z.number(), z.literal('')])
-    .refine((value) => typeof value === 'number' && value > 0, {
-      message: walletPageTopUpErrorLabels.required,
-    }),
+  amount: z.union([z.string(), z.number()]).refine((value) => Number(value) > 0, {
+    message: REQUIRED_FIELD_MESSAGE,
+  }),
 })
 
 export type WalletPageTopUpFormValues = z.infer<typeof walletPageTopUpValidationSchema>
+
+export const walletPageTopUpDefaultValues: WalletPageTopUpFormValues = {
+  amount: '',
+}


### PR DESCRIPTION
## Context

Part of the ongoing Formik -> TanStack Form migration (LAGO-1148). The customer-portal wallet top-up page was one of the remaining Formik + Yup forms in the app.

## Description

Migrated `src/components/customerPortal/wallet/WalletPage.tsx` from `useFormik` + Yup to `useAppForm` + Zod, following the established migration conventions:

- New `validationSchema.ts` ports the Yup `amount: number().required('')` rule to Zod. The Formik-era `amount <= 0` check (previously only enforced by the submit-button's external disabled logic) is folded into the same Zod refine, so the observable gating behavior is unchanged.
- `amount` uses `field.AmountInputField` under `form.AppField`; the business-rule bounds error from `topUpAmountError` is still wired through `errorOverride` / the submit button's `disabled` prop, exactly as before.
- `onCompleted` now calls `form.reset()` instead of `formikProps.resetForm()`.
- The mutation call inside `onSubmit` is now awaited, so the submit spinner (driven by `form.SubmitButton`'s `isSubmitting`) correctly covers the network request.
- Added a `<form onSubmit>` wrapper (this page didn't have one), which also means pressing Enter while focused in the amount field now submits the form, consistent with the rest of the app's TanStack forms.
- Added `src/components/customerPortal/wallet/__tests__/WalletPage.test.tsx` covering the loading/error states, rendering, submit, and the bounds-error disabled state.

No visual or UX changes intended beyond the Enter-to-submit addition.

<!-- Linear link -->
Fixes LAGO-1221