### PR TITLE
chore(cleanup): remove unused type exports

### DIFF
--- a/src/components/designSystem/Pagination/PaginatedContent.tsx
+++ b/src/components/designSystem/Pagination/PaginatedContent.tsx
@@ -11,10 +11,7 @@ import { tw } from '~/styles/utils'
  * total can be capped server-side expose them (the invoice list); every other list omits them and
  * keeps the exact-total behaviour.
  */
-export type PaginationMetadata = Pick<
-  CollectionMetadata,
-  'currentPage' | 'totalPages' | 'totalCount'
-> &
+type PaginationMetadata = Pick<CollectionMetadata, 'currentPage' | 'totalPages' | 'totalCount'> &
   Partial<Pick<InvoiceCollectionMetadata, 'hasNextPage' | 'totalCountCapped'>>
 
 interface PaginatedContentProps {

--- a/src/components/designSystem/RichTextEditor/common/RichTextEditorContext.tsx
+++ b/src/components/designSystem/RichTextEditor/common/RichTextEditorContext.tsx
@@ -51,14 +51,14 @@ interface PricingCommandParams {
 
 export type OnPricingCommand = (params: PricingCommandParams) => void
 
-export interface DiscountCommandParams {
+interface DiscountCommandParams {
   onSave: (attrs: DiscountBlockAttributes) => void
   editData?: { couponId: string; localId: string }
 }
 
 export type OnDiscountCommand = (params: DiscountCommandParams) => void
 
-export interface CreditsCommandParams {
+interface CreditsCommandParams {
   onSave: (attrs: CreditsBlockAttributes) => void
   editData?: { localId: string }
 }

--- a/src/components/settings/integrations/SuccessRedirectUrlDialogs.tsx
+++ b/src/components/settings/integrations/SuccessRedirectUrlDialogs.tsx
@@ -117,7 +117,7 @@ export const SuccessRedirectUrlProviderType = {
   Moneyhash: 'Moneyhash',
 } as const
 
-export type SuccessRedirectUrlProviderTypeKey = keyof typeof SuccessRedirectUrlProviderType
+type SuccessRedirectUrlProviderTypeKey = keyof typeof SuccessRedirectUrlProviderType
 
 type SuccessRedirectUrlProviderFragment =
   | AdyenForCreateAndEditSuccessRedirectUrlFragment

--- a/src/core/router/index.tsx
+++ b/src/core/router/index.tsx
@@ -178,5 +178,4 @@ export * from './types'
 // Enforced by the ESLint `no-restricted-imports` in  packages/configs/eslint.config.mjs
 export { Link } from './Link'
 export { useLocation } from './useLocation'
-export type { SlugAwareLocation } from './useLocation'
 export { useNavigate } from './useNavigate'

--- a/src/core/serializers/serializeQuoteCoupons.ts
+++ b/src/core/serializers/serializeQuoteCoupons.ts
@@ -25,7 +25,7 @@ export interface CouponPayload {
   resolvedPayload: unknown
 }
 
-export type CouponOverrides = Pick<
+type CouponOverrides = Pick<
   CouponPayload,
   'amountCents' | 'percentageRate' | 'frequency' | 'frequencyDuration'
 > & {

--- a/src/core/serializers/serializeQuoteWallets.ts
+++ b/src/core/serializers/serializeQuoteWallets.ts
@@ -50,7 +50,7 @@ export interface WalletFormItem {
 }
 
 // --- Wire shape (camelCase), sent under `payload` ---
-export interface RecurringTransactionRulePayload {
+interface RecurringTransactionRulePayload {
   trigger: string
   method: string
   interval: string | null

--- a/src/hooks/useInvoiceCustomSections.ts
+++ b/src/hooks/useInvoiceCustomSections.ts
@@ -18,7 +18,7 @@ gql`
   }
 `
 
-export type InvoiceCustomSection = NonNullable<
+type InvoiceCustomSection = NonNullable<
   GetInvoiceCustomSectionsQuery['invoiceCustomSections']
 >['collection'][number]
 

--- a/src/pages/catalog/drawers/productFilter/ProductFilterValuesEditor.tsx
+++ b/src/pages/catalog/drawers/productFilter/ProductFilterValuesEditor.tsx
@@ -16,7 +16,7 @@ export type ProductFilterValueEntry = {
   value?: string
 }
 
-export type ProductFilterValuesEditorProps = {
+type ProductFilterValuesEditorProps = {
   billableMetricFilters: Array<Pick<BillableMetricFilter, 'id' | 'key' | 'values'>>
   values: ProductFilterValueEntry[]
   onChange: (values: ProductFilterValueEntry[]) => void


### PR DESCRIPTION
## Context

Routine dead-code sweep of the frontend codebase.

## Description

Drops the `export` keyword from types/interfaces that have no consumer outside the file where they're declared:

- `PaginationMetadata`, `DiscountCommandParams`, `CreditsCommandParams`, `SuccessRedirectUrlProviderTypeKey`, `CouponOverrides`, `RecurringTransactionRulePayload`, `InvoiceCustomSection`, `ProductFilterValuesEditorProps`.
- `~/core/router`'s barrel re-export of `SlugAwareLocation` is also removed — nothing imports it from there; the type stays exported from `useLocation.ts` itself, where `useLocation()` still returns it.

Each symbol was verified with a full-repo `grep` to have zero external importers before being unexported. No behavior changes. `pnpm run code:style` and the full Jest suite pass unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JBTXtmLJn7Ve2Ufa8H62YW)_