### PR TITLE
fix(forms): publish rejected dates and validate the 1970 floor in schemas

### DIFF
--- a/src/components/Filters/graphql/filtersElements/DateRangeFilterFields.tsx
+++ b/src/components/Filters/graphql/filtersElements/DateRangeFilterFields.tsx
@@ -36,6 +36,9 @@ const parseBound = (isoDate?: string | null, zone?: string): DateTime | undefine
  * Keeps the range ordered: picking a "from" after the current "to" (or a "to" before the
  * current "from") clamps the opposite bound to the same day instead of persisting an
  * inverted range the API would silently answer with no results.
+ *
+ * A bound the API cannot store (before `MIN_SUPPORTED_DATE`) is accepted rather than guarded:
+ * a filter writes nothing, so the worst case is the empty result set the user asked for.
  */
 export const DateRangeFilterFields = ({
   value = ',',

--- a/src/components/designSystem/RichTextEditor/PricingBlock/AddOnSelectionContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/AddOnSelectionContent.tsx
@@ -14,6 +14,7 @@ import { ComboboxItem } from '~/components/form'
 import { ComboBox } from '~/components/form/ComboBox/ComboBox'
 import { MUI_INPUT_BASE_ROOT_CLASSNAME } from '~/core/constants/form'
 import { getCurrencySymbol, intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { addUnsupportedDateIssue } from '~/formValidation/zodCustoms'
 import {
   type AddOnForPricingSectionFragment,
   CurrencyEnum,
@@ -102,6 +103,33 @@ function TotalAmountCell({
 }
 
 type TranslateFn = ReturnType<typeof useInternationalization>['translate']
+
+export const buildEditAddOnSchema = (translate: TranslateFn) =>
+  z
+    .object({
+      invoiceDisplayName: z.string(),
+      description: z.string(),
+      fromDatetime: z.string().min(1, { message: translate('text_1780327356834f5f3nndfg80') }),
+      toDatetime: z.string().min(1, { message: translate('text_17803273568346wguor4j5u5') }),
+    })
+    .superRefine((data, ctx) => {
+      addUnsupportedDateIssue(ctx, data.fromDatetime, ['fromDatetime'])
+
+      if (addUnsupportedDateIssue(ctx, data.toDatetime, ['toDatetime'])) return
+
+      if (data.fromDatetime && data.toDatetime) {
+        const from = DateTime.fromISO(data.fromDatetime)
+        const to = DateTime.fromISO(data.toDatetime)
+
+        if (to < from) {
+          ctx.addIssue({
+            code: 'custom',
+            message: translate('text_64ef55a730b88e3d2117b3d4'),
+            path: ['toDatetime'],
+          })
+        }
+      }
+    })
 
 function PendingAddOnRow({
   index,
@@ -314,33 +342,7 @@ const AddOnSelectionContent = withForm({
     const editDrawer = useFormDrawer()
     const editingIndexRef = useRef<number | null>(null)
 
-    const editAddOnSchema = useMemo(
-      () =>
-        z
-          .object({
-            invoiceDisplayName: z.string(),
-            description: z.string(),
-            fromDatetime: z
-              .string()
-              .min(1, { message: translate('text_1780327356834f5f3nndfg80') }),
-            toDatetime: z.string().min(1, { message: translate('text_17803273568346wguor4j5u5') }),
-          })
-          .superRefine((data, ctx) => {
-            if (data.fromDatetime && data.toDatetime) {
-              const from = DateTime.fromISO(data.fromDatetime)
-              const to = DateTime.fromISO(data.toDatetime)
-
-              if (to < from) {
-                ctx.addIssue({
-                  code: 'custom',
-                  message: translate('text_64ef55a730b88e3d2117b3d4'),
-                  path: ['toDatetime'],
-                })
-              }
-            }
-          }),
-      [translate],
-    )
+    const editAddOnSchema = useMemo(() => buildEditAddOnSchema(translate), [translate])
 
     const editForm = useAppForm({
       defaultValues: editAddOnDrawerDefaultValues,

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/AddOnSelectionContent.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/AddOnSelectionContent.test.tsx
@@ -749,7 +749,7 @@ describe('editAddOnSchema date validation (LAGO-1502)', () => {
     })
   })
 
-  // Regression (ING-634): only the ordering was checked, and it cannot fail on a start date
+  // Regression: only the ordering was checked, and it cannot fail on a start date
   // that is earlier than a modern end date, so a typed pre-1970 start date went through.
   describe('GIVEN fromDatetime is before the minimum supported date', () => {
     describe('WHEN the schema validates', () => {

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/AddOnSelectionContent.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/AddOnSelectionContent.test.tsx
@@ -1,12 +1,11 @@
 import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { DateTime } from 'luxon'
-import { z } from 'zod'
 
+import { UNSUPPORTED_DATE_ERROR } from '~/core/constants/form'
 import { CurrencyEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
-import AddOnSelectionContent from '../AddOnSelectionContent'
+import AddOnSelectionContent, { buildEditAddOnSchema } from '../AddOnSelectionContent'
 import { type AddOnItem, pricingDrawerDefaultValues } from '../constants'
 
 const mockUseGetAddOnsForPricingSectionQuery = jest.fn()
@@ -693,29 +692,7 @@ describe('AddOnSelectionContent', () => {
   })
 })
 
-// --- editAddOnSchema validation tests (mirrors the schema defined in AddOnSelectionContent) ---
-
-const editAddOnSchema = z
-  .object({
-    invoiceDisplayName: z.string(),
-    description: z.string(),
-    fromDatetime: z.string().min(1, { message: 'Start date is required' }),
-    toDatetime: z.string().min(1, { message: 'End date is required' }),
-  })
-  .superRefine((data, ctx) => {
-    if (data.fromDatetime && data.toDatetime) {
-      const from = DateTime.fromISO(data.fromDatetime)
-      const to = DateTime.fromISO(data.toDatetime)
-
-      if (to < from) {
-        ctx.addIssue({
-          code: 'custom',
-          message: 'End date must not be before start date',
-          path: ['toDatetime'],
-        })
-      }
-    }
-  })
+const editAddOnSchema = buildEditAddOnSchema((key: string) => key)
 
 describe('editAddOnSchema date validation (LAGO-1502)', () => {
   const validData = {
@@ -768,6 +745,27 @@ describe('editAddOnSchema date validation (LAGO-1502)', () => {
         })
 
         expect(result.success).toBe(true)
+      })
+    })
+  })
+
+  // Regression (ING-634): only the ordering was checked, and it cannot fail on a start date
+  // that is earlier than a modern end date, so a typed pre-1970 start date went through.
+  describe('GIVEN fromDatetime is before the minimum supported date', () => {
+    describe('WHEN the schema validates', () => {
+      it('THEN should fail with the unsupported-date error on fromDatetime', () => {
+        const result = editAddOnSchema.safeParse({
+          ...validData,
+          fromDatetime: '0026-08-31T00:00:00.000+00:00',
+        })
+
+        expect(result.success).toBe(false)
+
+        if (!result.success) {
+          expect(result.error.issues).toEqual([
+            expect.objectContaining({ path: ['fromDatetime'], message: UNSUPPORTED_DATE_ERROR }),
+          ])
+        }
       })
     })
   })

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/useSubscriptionSettingsDrawer.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/useSubscriptionSettingsDrawer.test.tsx
@@ -393,6 +393,31 @@ describe('useSubscriptionSettingsDrawer', () => {
     })
   })
 
+  // Regression (ING-634): the schema only ordered the two dates, so a typed pre-1970 date
+  // saved once the picker stopped withholding it. Each case is picked so the ordering rule
+  // cannot fire in its place — the start date carries the only modern bound, and the end
+  // date case runs in amendment mode where the start date is empty and unrequired.
+  describe.each([
+    ['the start date', { startDate: '0026-08-31', endDate: '2025-01-01' }, false],
+    ['the end date', { startDate: '', endDate: '0026-08-31' }, true],
+  ])('GIVEN %s is before the minimum supported date', (_, dates, isAmendment) => {
+    describe('WHEN the save button is clicked', () => {
+      it('THEN should not call onSave', async () => {
+        const user = userEvent.setup()
+
+        openAndRenderDrawer({ ...populatedValues, ...dates }, isAmendment)
+
+        await user.click(screen.getByTestId(SUBSCRIPTION_SETTINGS_DRAWER_SAVE_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockDrawerClose).not.toHaveBeenCalled()
+        })
+
+        expect(mockOnSave).not.toHaveBeenCalled()
+      })
+    })
+  })
+
   describe('GIVEN the form is re-opened after being previously opened', () => {
     describe('WHEN openDrawer is called with new values', () => {
       it('THEN should reset the form to the new values', () => {

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/useSubscriptionSettingsDrawer.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/useSubscriptionSettingsDrawer.test.tsx
@@ -393,10 +393,6 @@ describe('useSubscriptionSettingsDrawer', () => {
     })
   })
 
-  // Regression (ING-634): the schema only ordered the two dates, so a typed pre-1970 date
-  // saved once the picker stopped withholding it. Each case is picked so the ordering rule
-  // cannot fire in its place — the start date carries the only modern bound, and the end
-  // date case runs in amendment mode where the start date is empty and unrequired.
   describe.each([
     ['the start date', { startDate: '0026-08-31', endDate: '2025-01-01' }, false],
     ['the end date', { startDate: '', endDate: '0026-08-31' }, true],

--- a/src/components/designSystem/RichTextEditor/PricingBlock/useSubscriptionSettingsDrawer.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/useSubscriptionSettingsDrawer.tsx
@@ -7,6 +7,7 @@ import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { useDrawer } from '~/components/drawers/useDrawer'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
+import { addUnsupportedDateIssue } from '~/formValidation/zodCustoms'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm, withForm } from '~/hooks/forms/useAppform'
 
@@ -34,6 +35,10 @@ const makeSubscriptionSettingsSchema = (isAmendment: boolean) =>
       endDate: z.string(),
     })
     .superRefine((data, ctx) => {
+      addUnsupportedDateIssue(ctx, data.startDate, ['startDate'])
+
+      if (addUnsupportedDateIssue(ctx, data.endDate, ['endDate'])) return
+
       if (data.endDate && data.startDate && data.endDate < data.startDate) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,

--- a/src/components/form/DatePicker/DatePicker.tsx
+++ b/src/components/form/DatePicker/DatePicker.tsx
@@ -169,9 +169,6 @@ export const DatePicker = ({
                 return
               }
 
-              // Nothing to publish: an unparseable date has no ISO representation. Any date
-              // that has one is published as typed — whether it is acceptable is the
-              // consuming schema's rule, see `addUnsupportedDateIssue`.
               if (!nextDate.isValid) {
                 onError?.(DATE_PICKER_ERROR_ENUM.invalid)
                 return

--- a/src/components/form/DatePicker/DatePicker.tsx
+++ b/src/components/form/DatePicker/DatePicker.tsx
@@ -13,7 +13,7 @@ import { Button } from '~/components/designSystem/Button'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { TextInputProps } from '~/components/form'
-import { MIN_SUPPORTED_DATE, MIN_SUPPORTED_DATE_YEAR } from '~/core/constants/form'
+import { MIN_SUPPORTED_DATE } from '~/core/constants/form'
 import { getTimezoneConfig } from '~/core/timezone'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
@@ -30,9 +30,6 @@ gql`
 enum DATE_PICKER_ERROR_ENUM {
   invalid = 'invalid',
 }
-
-const isBelowMinSupportedDate = (date: DateTime): boolean =>
-  date.toUTC().year < MIN_SUPPORTED_DATE_YEAR
 
 export interface DatePickerProps extends Omit<
   TextInputProps,
@@ -91,7 +88,7 @@ export const DatePicker = ({
 
   const [localDate, setLocalDate] = useState<DateTime | null>(getValueFormatted())
 
-  const isInvalid = !!localDate && (!localDate.isValid || isBelowMinSupportedDate(localDate))
+  const isInvalid = !!localDate && !localDate.isValid
 
   const getHelperText = useCallback(() => {
     if (!!error || isInvalid) {
@@ -172,7 +169,10 @@ export const DatePicker = ({
                 return
               }
 
-              if (!nextDate.isValid || isBelowMinSupportedDate(nextDate)) {
+              // Nothing to publish: an unparseable date has no ISO representation. Any date
+              // that has one is published as typed — whether it is acceptable is the
+              // consuming schema's rule, see `addUnsupportedDateIssue`.
+              if (!nextDate.isValid) {
                 onError?.(DATE_PICKER_ERROR_ENUM.invalid)
                 return
               }

--- a/src/components/form/DatePicker/DatePickerField.tsx
+++ b/src/components/form/DatePicker/DatePickerField.tsx
@@ -25,11 +25,7 @@ export const DatePickerField = memo(
         name={name}
         onBlur={handleBlur}
         value={_get(values, name)}
-        // Not gated on `touched`: DatePicker drops `onBlur`, so it would never turn true
-        // and the field would render no error at all.
         error={error ? translate(error) : undefined}
-        // A key rather than the picker's own code: whatever lands in `errors` is rendered
-        // as the message, so it has to be one.
         onError={(err) => setFieldError(name, err && UNSUPPORTED_DATE_ERROR)}
         onChange={(value: string | null | undefined) => {
           setFieldValue(name, value)

--- a/src/components/form/DatePicker/DatePickerField.tsx
+++ b/src/components/form/DatePicker/DatePickerField.tsx
@@ -3,6 +3,9 @@ import _get from 'lodash/get'
 import _isEqual from 'lodash/isEqual'
 import { memo } from 'react'
 
+import { UNSUPPORTED_DATE_ERROR } from '~/core/constants/form'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
 import { DatePicker, DatePickerProps } from './DatePicker'
 
 interface DatePickerFieldFormProps extends Omit<DatePickerProps, 'name' | 'onChange' | 'onError'> {
@@ -13,15 +16,21 @@ interface DatePickerFieldFormProps extends Omit<DatePickerProps, 'name' | 'onCha
 
 export const DatePickerField = memo(
   ({ name, formikProps, ...props }: DatePickerFieldFormProps) => {
-    const { values, errors, touched, handleBlur, setFieldValue, setFieldError } = formikProps
+    const { translate } = useInternationalization()
+    const { values, errors, handleBlur, setFieldValue, setFieldError } = formikProps
+    const error = errors[name] as string | undefined
 
     return (
       <DatePicker
         name={name}
         onBlur={handleBlur}
         value={_get(values, name)}
-        error={touched[name] ? (errors[name] as string) : undefined}
-        onError={(err) => setFieldError(name, err)}
+        // Not gated on `touched`: DatePicker drops `onBlur`, so it would never turn true
+        // and the field would render no error at all.
+        error={error ? translate(error) : undefined}
+        // A key rather than the picker's own code: whatever lands in `errors` is rendered
+        // as the message, so it has to be one.
+        onError={(err) => setFieldError(name, err && UNSUPPORTED_DATE_ERROR)}
         onChange={(value: string | null | undefined) => {
           setFieldValue(name, value)
         }}
@@ -37,8 +46,7 @@ export const DatePickerField = memo(
       _isEqual(prev, next) &&
       prevName === nextName &&
       prevFormikProps.values[prevName] === nextformikProps.values[nextName] &&
-      prevFormikProps.errors[prevName] === nextformikProps.errors[nextName] &&
-      prevFormikProps.touched[prevName] === nextformikProps.touched[nextName]
+      prevFormikProps.errors[prevName] === nextformikProps.errors[nextName]
     )
   },
 )

--- a/src/components/form/DatePicker/__tests__/DatePicker.test.tsx
+++ b/src/components/form/DatePicker/__tests__/DatePicker.test.tsx
@@ -79,7 +79,7 @@ describe('DatePicker', () => {
     })
   })
 
-  // Regression (ING-634): withholding these left the form on the previously accepted value
+  // Regression: withholding these left the form on the previously accepted value
   // while the input showed the rejected one. The floor is the consuming schema's rule now.
   describe.each([
     [

--- a/src/components/form/DatePicker/__tests__/DatePicker.test.tsx
+++ b/src/components/form/DatePicker/__tests__/DatePicker.test.tsx
@@ -79,37 +79,24 @@ describe('DatePicker', () => {
     })
   })
 
+  // Regression (ING-634): withholding these left the form on the previously accepted value
+  // while the input showed the rejected one. The floor is the consuming schema's rule now.
   describe.each([
-    ['a year with fewer than four digits', DateTime.fromObject({ year: 26, month: 2, day: 9 })],
+    [
+      'a year with fewer than four digits',
+      DateTime.fromObject({ year: 26, month: 2, day: 9 }),
+      '0026-02-09T00:00:00.000Z',
+    ],
     [
       'an instant before the minimum supported year',
       DateTime.fromObject({ year: 1969, month: 12, day: 31 }, { zone: 'utc' }),
+      '1969-12-31T00:00:00.000Z',
     ],
     [
       'a supported calendar date whose instant is before the minimum',
       DateTime.fromObject({ year: 1970, month: 1, day: 1 }, { zone: 'Asia/Tokyo' }),
+      '1969-12-31T15:00:00.000Z',
     ],
-  ])('GIVEN %s', (_, date) => {
-    describe('WHEN the date changes', () => {
-      it('THEN should show an invalid error without publishing the date', () => {
-        const onChange = jest.fn()
-        const onError = jest.fn()
-
-        render(<DatePicker onChange={onChange} onError={onError} />)
-        changeDate(date)
-
-        expect(onChange).not.toHaveBeenCalled()
-        expect(onError).toHaveBeenCalledTimes(1)
-        expect(onError).toHaveBeenCalledWith('invalid')
-        expect(getPickerProps().slotProps?.textField).toMatchObject({
-          error: true,
-          helperText: 'translated_text_62cd78ea9bff25e3391b2459',
-        })
-      })
-    })
-  })
-
-  describe.each([
     [
       'the minimum supported instant',
       DateTime.fromObject({ year: 1970, month: 1, day: 1 }, { zone: 'utc' }),
@@ -132,6 +119,33 @@ describe('DatePicker', () => {
         expect(onChange).toHaveBeenCalledTimes(1)
         expect(onChange).toHaveBeenCalledWith(expectedIso)
         expect(onError).toHaveBeenCalledWith(undefined)
+      })
+
+      it('THEN should not render an error', () => {
+        render(<DatePicker onChange={jest.fn()} />)
+        changeDate(date)
+
+        expect(getPickerProps().slotProps?.textField).toMatchObject({ error: false })
+      })
+    })
+  })
+
+  describe('GIVEN a date that has no ISO representation', () => {
+    describe('WHEN the date changes', () => {
+      it('THEN should show an invalid error without publishing the date', () => {
+        const onChange = jest.fn()
+        const onError = jest.fn()
+
+        render(<DatePicker onChange={onChange} onError={onError} />)
+        changeDate(DateTime.fromISO('not-a-date'))
+
+        expect(onChange).not.toHaveBeenCalled()
+        expect(onError).toHaveBeenCalledTimes(1)
+        expect(onError).toHaveBeenCalledWith('invalid')
+        expect(getPickerProps().slotProps?.textField).toMatchObject({
+          error: true,
+          helperText: 'translated_text_62cd78ea9bff25e3391b2459',
+        })
       })
     })
   })

--- a/src/components/form/DatePicker/__tests__/DatePickerField.test.tsx
+++ b/src/components/form/DatePicker/__tests__/DatePickerField.test.tsx
@@ -1,0 +1,78 @@
+import { screen, waitFor } from '@testing-library/react'
+import { useFormik } from 'formik'
+import { date, object } from 'yup'
+
+import { MIN_SUPPORTED_DATE, UNSUPPORTED_DATE_ERROR } from '~/core/constants/form'
+import { render } from '~/test-utils'
+
+import { DatePickerField } from '../DatePickerField'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => `translated_${key}`,
+  }),
+}))
+
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  useOrganizationInfos: () => ({
+    organization: { id: 'org-1', timezone: 'UTC' },
+  }),
+}))
+
+const FIELD_NAME = 'createdAt'
+
+// Mirrors CreatePayment, the last yup form holding a date field.
+const Harness = ({ createdAt }: { createdAt: string }) => {
+  const formikProps = useFormik({
+    initialValues: { [FIELD_NAME]: createdAt },
+    validateOnMount: true,
+    validationSchema: object().shape({
+      [FIELD_NAME]: date().required('').min(MIN_SUPPORTED_DATE.toJSDate(), UNSUPPORTED_DATE_ERROR),
+    }),
+    onSubmit: jest.fn(),
+  })
+
+  return (
+    <>
+      <DatePickerField name={FIELD_NAME} formikProps={formikProps} />
+      <span data-test="is-valid">{String(formikProps.isValid)}</span>
+    </>
+  )
+}
+
+describe('DatePickerField', () => {
+  describe('GIVEN a date the schema accepts', () => {
+    describe('WHEN the field renders', () => {
+      it('THEN should keep the form valid and render no error', async () => {
+        render(<Harness createdAt="2026-09-02T00:00:00.000Z" />)
+
+        await waitFor(() => {
+          expect(screen.getByTestId('is-valid')).toHaveTextContent('true')
+        })
+
+        expect(screen.queryByText(`translated_${UNSUPPORTED_DATE_ERROR}`)).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  // Regression (ING-634): the error was gated on Formik's `touched`, which DatePicker never
+  // turns true because it drops `onBlur` — so the rejection was invisible and only showed up
+  // as a disabled submit button.
+  describe('GIVEN a date the schema rejects', () => {
+    describe('WHEN the field renders', () => {
+      it('THEN should render the translated schema error', async () => {
+        render(<Harness createdAt="0026-08-31T00:00:00.000Z" />)
+
+        expect(await screen.findByText(`translated_${UNSUPPORTED_DATE_ERROR}`)).toBeInTheDocument()
+      })
+
+      it('THEN should keep the form invalid', async () => {
+        render(<Harness createdAt="0026-08-31T00:00:00.000Z" />)
+
+        await waitFor(() => {
+          expect(screen.getByTestId('is-valid')).toHaveTextContent('false')
+        })
+      })
+    })
+  })
+})

--- a/src/components/form/DatePicker/__tests__/DatePickerField.test.tsx
+++ b/src/components/form/DatePicker/__tests__/DatePickerField.test.tsx
@@ -55,7 +55,7 @@ describe('DatePickerField', () => {
     })
   })
 
-  // Regression (ING-634): the error was gated on Formik's `touched`, which DatePicker never
+  // Regression: the error was gated on Formik's `touched`, which DatePicker never
   // turns true because it drops `onBlur` — so the rejection was invisible and only showed up
   // as a disabled submit button.
   describe('GIVEN a date the schema rejects', () => {

--- a/src/components/invoices/EditFeeBillingPeriod.tsx
+++ b/src/components/invoices/EditFeeBillingPeriod.tsx
@@ -8,6 +8,7 @@ import { useFormDialog } from '~/components/dialogs/FormDialog'
 import { DatePicker } from '~/components/form'
 import { dateErrorCodes } from '~/core/constants/form'
 import { getTimezoneConfig } from '~/core/timezone'
+import { addUnsupportedDateIssue } from '~/formValidation/zodCustoms'
 import { TimezoneEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm } from '~/hooks/forms/useAppform'
@@ -24,6 +25,9 @@ const editFeeBillingPeriodValidationSchema = z
   .object({
     fromDatetime: z.string().min(1, { message: '' }),
     toDatetime: z.string(),
+  })
+  .superRefine((data, ctx) => {
+    addUnsupportedDateIssue(ctx, data.fromDatetime, ['fromDatetime'])
   })
   .refine((data) => !data.toDatetime || DateTime.fromISO(data.toDatetime).isValid, {
     message: dateErrorCodes.wrongFormat,

--- a/src/components/invoices/__tests__/EditFeeBillingPeriod.test.tsx
+++ b/src/components/invoices/__tests__/EditFeeBillingPeriod.test.tsx
@@ -178,6 +178,37 @@ describe('useEditFeeBillingPeriodDialog', () => {
       })
     })
 
+    // Regression (ING-634): only toDatetime was checked, so a typed pre-1970 from datetime
+    // reached the callback once the picker stopped withholding it.
+    describe('WHEN the from datetime is before the minimum supported date', () => {
+      it('THEN should not invoke the callback and should report the submit as unsuccessful', async () => {
+        const callback = jest.fn()
+        let didSubmitSucceed: boolean | undefined
+
+        mockFormDialogOpen.mockImplementation(async (config) => {
+          await config.form.submit()
+          didSubmitSucceed = config.form.didSubmitSucceed?.()
+
+          return { reason: 'close' }
+        })
+
+        const { result } = renderHook(() => useEditFeeBillingPeriodDialog(), {
+          wrapper: customWrapper,
+        })
+
+        await act(async () => {
+          result.current.openEditFeeBillingPeriodDialog({
+            fromDatetime: '0026-08-31T00:00:00.000Z',
+            toDatetime: TO_DATETIME,
+            callback,
+          })
+        })
+
+        expect(callback).not.toHaveBeenCalled()
+        expect(didSubmitSucceed).toBe(false)
+      })
+    })
+
     describe('WHEN the to datetime is before the from datetime', () => {
       it('THEN should not invoke the callback and should report the submit as unsuccessful', async () => {
         const callback = jest.fn()

--- a/src/components/invoices/__tests__/EditFeeBillingPeriod.test.tsx
+++ b/src/components/invoices/__tests__/EditFeeBillingPeriod.test.tsx
@@ -178,7 +178,7 @@ describe('useEditFeeBillingPeriodDialog', () => {
       })
     })
 
-    // Regression (ING-634): only toDatetime was checked, so a typed pre-1970 from datetime
+    // Regression: only toDatetime was checked, so a typed pre-1970 from datetime
     // reached the callback once the picker stopped withholding it.
     describe('WHEN the from datetime is before the minimum supported date', () => {
       it('THEN should not invoke the callback and should report the submit as unsuccessful', async () => {

--- a/src/core/constants/form.ts
+++ b/src/core/constants/form.ts
@@ -23,8 +23,8 @@ export const dateErrorCodes = {
   shouldBeFutureAndBiggerThanSubscriptionAt: 'shouldBeFutureAndBiggerThanSubscriptionAt',
   shouldBeFutureAndBiggerThanFromDatetime: 'shouldBeFutureAndBiggerThanFromDatetime',
 } as const
-export const MIN_SUPPORTED_DATE_YEAR = 1970
 export const MIN_SUPPORTED_DATE = DateTime.fromISO('1970-01-01T00:00:00.000Z', { zone: 'utc' })
+export const UNSUPPORTED_DATE_ERROR = 'text_62cd78ea9bff25e3391b2459'
 export const MIN_AMOUNT_SHOULD_BE_LOWER_THAN_MAX_ERROR = 'minAmountShouldBeLowerThanMax'
 
 /**** Selectors ****/

--- a/src/formValidation/__tests__/subscriptionFormSchema.test.ts
+++ b/src/formValidation/__tests__/subscriptionFormSchema.test.ts
@@ -85,7 +85,7 @@ describe('subscriptionFormSchema', () => {
       })
     })
 
-    // Regression (ING-634): the picker publishes a typed pre-1970 date now, and nothing
+    // Regression: the picker publishes a typed pre-1970 date now, and nothing
     // else in this schema rejects a start date.
     describe.each([
       ['a year with fewer than four digits', '0026-08-31T00:00:00.000Z'],
@@ -132,7 +132,7 @@ describe('subscriptionFormSchema', () => {
       })
     })
 
-    // Regression (ING-634): the picker used to clear the field instead, and an absent
+    // Regression: the picker used to clear the field instead, and an absent
     // endingAt skipped every rule below through `if (!data.endingAt) return`.
     describe('WHEN endingAt is before 1970', () => {
       it('THEN should fail with an unsupported-date error on endingAt', () => {

--- a/src/formValidation/__tests__/subscriptionFormSchema.test.ts
+++ b/src/formValidation/__tests__/subscriptionFormSchema.test.ts
@@ -1,5 +1,6 @@
 import { Settings } from 'luxon'
 
+import { UNSUPPORTED_DATE_ERROR } from '~/core/constants/form'
 import { ActivationRuleFormTypeEnum } from '~/core/constants/subscriptionActivationRules'
 import { BillingTimeEnum } from '~/generated/graphql'
 
@@ -83,6 +84,27 @@ describe('subscriptionFormSchema', () => {
         }
       })
     })
+
+    // Regression (ING-634): the picker publishes a typed pre-1970 date now, and nothing
+    // else in this schema rejects a start date.
+    describe.each([
+      ['a year with fewer than four digits', '0026-08-31T00:00:00.000Z'],
+      ['the last instant before 1970', '1969-12-31T23:59:59.999Z'],
+    ])('WHEN subscriptionAt is %s', (_, subscriptionAt) => {
+      it('THEN should fail with an error on subscriptionAt', () => {
+        const result = subscriptionFormSchema.safeParse(buildValidValues({ subscriptionAt }))
+
+        expect(result.success).toBe(false)
+
+        if (!result.success) {
+          const error = result.error.issues.find((i) => i.path.includes('subscriptionAt'))
+
+          expect(error).toEqual(
+            expect.objectContaining({ message: UNSUPPORTED_DATE_ERROR, path: ['subscriptionAt'] }),
+          )
+        }
+      })
+    })
   })
 
   describe('GIVEN endingAt validation', () => {
@@ -106,6 +128,24 @@ describe('subscriptionFormSchema', () => {
           const error = result.error.issues.find((i) => i.path.includes('endingAt'))
 
           expect(error).toBeDefined()
+        }
+      })
+    })
+
+    // Regression (ING-634): the picker used to clear the field instead, and an absent
+    // endingAt skipped every rule below through `if (!data.endingAt) return`.
+    describe('WHEN endingAt is before 1970', () => {
+      it('THEN should fail with an unsupported-date error on endingAt', () => {
+        const result = subscriptionFormSchema.safeParse(
+          buildValidValues({ endingAt: '0026-08-31T00:00:00.000Z' }),
+        )
+
+        expect(result.success).toBe(false)
+
+        if (!result.success) {
+          expect(result.error.issues).toEqual([
+            expect.objectContaining({ message: UNSUPPORTED_DATE_ERROR, path: ['endingAt'] }),
+          ])
         }
       })
     })

--- a/src/formValidation/__tests__/zodCustoms.test.ts
+++ b/src/formValidation/__tests__/zodCustoms.test.ts
@@ -1,4 +1,9 @@
+import { DateTime } from 'luxon'
+import { z } from 'zod'
+
+import { UNSUPPORTED_DATE_ERROR } from '~/core/constants/form'
 import {
+  addUnsupportedDateIssue,
   PASSWORD_VALIDATION_ERRORS,
   validatePassword,
   zodDomain,
@@ -452,6 +457,116 @@ describe('zodCustoms', () => {
         expect(messages).toContain(PASSWORD_VALIDATION_ERRORS.NUMBER)
         expect(messages).toContain(PASSWORD_VALIDATION_ERRORS.SPECIAL)
       }
+    })
+  })
+  describe('addUnsupportedDateIssue', () => {
+    const parse = (value: string | null | undefined, floor?: DateTime) =>
+      z
+        .custom<{ date: string | null | undefined }>()
+        .superRefine((data, ctx) => {
+          addUnsupportedDateIssue(ctx, data.date, ['date'], floor)
+        })
+        .safeParse({ date: value })
+
+    describe.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['an empty string', ''],
+    ])('GIVEN %s', (_, value) => {
+      describe('WHEN the schema runs', () => {
+        it('THEN should add no issue', () => {
+          expect(parse(value).success).toBe(true)
+        })
+      })
+    })
+
+    describe.each([
+      ['the minimum supported instant', '1970-01-01T00:00:00.000Z'],
+      ['an instant after the minimum', '2026-09-02T00:00:00.000Z'],
+    ])('GIVEN %s', (_, value) => {
+      describe('WHEN the schema runs', () => {
+        it('THEN should add no issue', () => {
+          expect(parse(value).success).toBe(true)
+        })
+      })
+    })
+
+    describe.each([
+      ['a year with fewer than four digits', '0026-02-09T00:00:00.000Z'],
+      ['the last instant before the minimum', '1969-12-31T23:59:59.999Z'],
+      ['a value that is not a date at all', 'not-a-date'],
+    ])('GIVEN %s', (_, value) => {
+      describe('WHEN the schema runs', () => {
+        it('THEN should add an issue on the given path', () => {
+          const result = parse(value)
+
+          expect(result.success).toBe(false)
+
+          if (!result.success) {
+            expect(result.error.issues).toEqual([
+              expect.objectContaining({ path: ['date'], message: UNSUPPORTED_DATE_ERROR }),
+            ])
+          }
+        })
+      })
+    })
+
+    describe('GIVEN a stricter floor', () => {
+      describe('WHEN the date is above 1970 but below that floor', () => {
+        it('THEN should add an issue', () => {
+          const result = parse(
+            '2020-01-01T00:00:00.000Z',
+            DateTime.fromISO('2026-01-01', {
+              zone: 'utc',
+            }),
+          )
+
+          expect(result.success).toBe(false)
+        })
+      })
+
+      describe('WHEN the date is above that floor', () => {
+        it('THEN should add no issue', () => {
+          const result = parse(
+            '2026-06-01T00:00:00.000Z',
+            DateTime.fromISO('2026-01-01', {
+              zone: 'utc',
+            }),
+          )
+
+          expect(result.success).toBe(true)
+        })
+      })
+    })
+
+    describe('GIVEN a caller that branches on the return value', () => {
+      describe('WHEN the date is unsupported', () => {
+        it('THEN should report that an issue was added', () => {
+          const added: boolean[] = []
+
+          z.custom<string>()
+            .superRefine((value, ctx) => {
+              added.push(addUnsupportedDateIssue(ctx, value, ['date']))
+            })
+            .safeParse('0026-02-09T00:00:00.000Z')
+
+          expect(added).toEqual([true])
+        })
+      })
+
+      describe('WHEN the date is supported', () => {
+        it('THEN should report that no issue was added', () => {
+          const added: boolean[] = []
+
+          z.custom<string>()
+            .superRefine((value, ctx) => {
+              added.push(addUnsupportedDateIssue(ctx, value, ['date']))
+            })
+            .safeParse('2026-09-02T00:00:00.000Z')
+
+          expect(added).toEqual([false])
+        })
+      })
     })
   })
 })

--- a/src/formValidation/subscriptionFormSchema.ts
+++ b/src/formValidation/subscriptionFormSchema.ts
@@ -5,6 +5,7 @@ import { InvoiceCustomSectionInput } from '~/components/invoceCustomFooter/types
 import { SelectedPaymentMethod } from '~/components/paymentMethodSelection/types'
 import { addPurchaseOrderNumberMaxLengthIssue } from '~/components/purchaseOrder/validation'
 import { ActivationRuleFormTypeEnum } from '~/core/constants/subscriptionActivationRules'
+import { addUnsupportedDateIssue } from '~/formValidation/zodCustoms'
 import { BillingTimeEnum } from '~/generated/graphql'
 
 export interface SubscriptionFormValues {
@@ -40,6 +41,8 @@ export const subscriptionFormSchema = z
         message: 'text_624ea7c29103fd010732ab7d',
         path: ['subscriptionAt'],
       })
+    } else {
+      addUnsupportedDateIssue(ctx, data.subscriptionAt, ['subscriptionAt'])
     }
 
     addPurchaseOrderNumberMaxLengthIssue(ctx, data.purchaseOrderNumber, ['purchaseOrderNumber'])
@@ -65,14 +68,7 @@ export const subscriptionFormSchema = z
 
     if (!data.endingAt) return
 
-    if (!DateTime.fromISO(data.endingAt).isValid) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'text_64ef55a730b88e3d2117b3d4',
-        path: ['endingAt'],
-      })
-      return
-    }
+    if (addUnsupportedDateIssue(ctx, data.endingAt, ['endingAt'])) return
 
     if (data.subscriptionAt) {
       const subscriptionAt = DateTime.fromISO(data.subscriptionAt)

--- a/src/formValidation/zodCustoms.ts
+++ b/src/formValidation/zodCustoms.ts
@@ -1,8 +1,33 @@
+import { DateTime } from 'luxon'
 import { z } from 'zod'
 
+import { MIN_SUPPORTED_DATE, UNSUPPORTED_DATE_ERROR } from '~/core/constants/form'
 import { validateHostWithoutProtocol } from '~/core/utils/validateHostWithoutProtocol'
 import { allPermissions } from '~/pages/settings/teamAndSecurity/roles/common/permissionsConst'
 import { PermissionName } from '~/pages/settings/teamAndSecurity/roles/common/permissionsTypes'
+
+/**
+ * `DatePicker` publishes whatever the user typed, so a date the API cannot store reaches
+ * the form and the floor is the schema's rule — never the input's. Pass a stricter `floor`
+ * to keep the 1970 guarantee while adding your own bound. Returns whether an issue was
+ * added, so a caller can skip the rules that would only restate it.
+ */
+export const addUnsupportedDateIssue = (
+  ctx: z.RefinementCtx,
+  value: string | null | undefined,
+  path: (string | number)[],
+  floor: DateTime = MIN_SUPPORTED_DATE,
+): boolean => {
+  if (!value) return false
+
+  const date = DateTime.fromISO(value)
+
+  if (date.isValid && date.toUTC() >= floor) return false
+
+  ctx.addIssue({ code: 'custom', message: UNSUPPORTED_DATE_ERROR, path })
+
+  return true
+}
 
 export const EMAIL_REGEX: RegExp =
   // eslint-disable-next-line no-control-regex

--- a/src/pages/CreatePayment.tsx
+++ b/src/pages/CreatePayment.tsx
@@ -106,8 +106,6 @@ const CreatePayment = () => {
         .required('')
         .test((value) => maxAmount(value)),
       reference: string().max(40).required(''),
-      // The last yup form holding a date field, so the shared zod
-      // `addUnsupportedDateIssue` cannot be reused here.
       createdAt: date().required('').min(MIN_SUPPORTED_DATE.toJSDate(), UNSUPPORTED_DATE_ERROR),
     }),
     enableReinitialize: true,

--- a/src/pages/CreatePayment.tsx
+++ b/src/pages/CreatePayment.tsx
@@ -15,6 +15,7 @@ import { useCentralizedDialog } from '~/components/dialogs/CentralizedDialog'
 import { AmountInputField, ComboBox, DatePickerField, TextInputField } from '~/components/form'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { addToast } from '~/core/apolloClient'
+import { MIN_SUPPORTED_DATE, UNSUPPORTED_DATE_ERROR } from '~/core/constants/form'
 import { paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
 import { getCurrencySymbol, intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import { PAYMENT_DETAILS_ROUTE, PAYMENTS_ROUTE, useNavigate } from '~/core/router'
@@ -105,7 +106,9 @@ const CreatePayment = () => {
         .required('')
         .test((value) => maxAmount(value)),
       reference: string().max(40).required(''),
-      createdAt: date().required(''),
+      // The last yup form holding a date field, so the shared zod
+      // `addUnsupportedDateIssue` cannot be reused here.
+      createdAt: date().required('').min(MIN_SUPPORTED_DATE.toJSDate(), UNSUPPORTED_DATE_ERROR),
     }),
     enableReinitialize: true,
     validateOnMount: true,

--- a/src/pages/catalog/drawers/rateCardRate/__tests__/schema.test.ts
+++ b/src/pages/catalog/drawers/rateCardRate/__tests__/schema.test.ts
@@ -1,3 +1,4 @@
+import { UNSUPPORTED_DATE_ERROR } from '~/core/constants/form'
 import { RateCardRateBillingIntervalUnitEnum, RateCardRateModelEnum } from '~/generated/graphql'
 
 import {
@@ -61,6 +62,18 @@ describe('buildRateCardRateSchema', () => {
           'billingIntervalCount',
           VALUE_REQUIRED_KEY,
         ])
+      })
+    })
+  })
+
+  // Regression (ING-634): the picker publishes a typed pre-1970 date now, and a card with no
+  // active rate yet has no boundary for the appendable check to fail against.
+  describe('GIVEN the effective date is before the minimum supported date', () => {
+    describe('WHEN it is parsed with no active-rate boundary', () => {
+      it('THEN reports the unsupported-date issue on effectiveFrom', () => {
+        const result = parse({ ...validValues, effectiveFrom: '0026-08-31T00:00:00.000Z' })
+
+        expect(issuePathsAndMessages(result)).toEqual([['effectiveFrom', UNSUPPORTED_DATE_ERROR]])
       })
     })
   })

--- a/src/pages/catalog/drawers/rateCardRate/__tests__/schema.test.ts
+++ b/src/pages/catalog/drawers/rateCardRate/__tests__/schema.test.ts
@@ -66,7 +66,7 @@ describe('buildRateCardRateSchema', () => {
     })
   })
 
-  // Regression (ING-634): the picker publishes a typed pre-1970 date now, and a card with no
+  // Regression: the picker publishes a typed pre-1970 date now, and a card with no
   // active rate yet has no boundary for the appendable check to fail against.
   describe('GIVEN the effective date is before the minimum supported date', () => {
     describe('WHEN it is parsed with no active-rate boundary', () => {

--- a/src/pages/catalog/drawers/rateCardRate/schema.ts
+++ b/src/pages/catalog/drawers/rateCardRate/schema.ts
@@ -4,6 +4,7 @@ import {
   PropertiesZodInput,
   validateChargeProperties,
 } from '~/formValidation/chargePropertiesSchema'
+import { addUnsupportedDateIssue } from '~/formValidation/zodCustoms'
 
 import {
   RATE_CARD_RATE_EFFECTIVE_DATE_AFTER_ACTIVE_KEY,
@@ -18,6 +19,34 @@ export type RateCardRateSchemaContext = {
   effectiveFromBoundary: string | null
 }
 
+const addEffectiveFromIssues = (
+  effectiveFrom: string,
+  boundary: string | null,
+  ctx: z.RefinementCtx,
+): void => {
+  const path = ['effectiveFrom']
+
+  if (!effectiveFrom) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path, message: VALUE_REQUIRED_KEY })
+
+    return
+  }
+
+  // A card with no active rate has no boundary, so the check below cannot catch a date the
+  // API refuses.
+  if (addUnsupportedDateIssue(ctx, effectiveFrom, path)) return
+
+  if (!isEffectiveFromAppendable(effectiveFrom, boundary)) {
+    // Only blocks the submit: the copy interpolates the boundary date, so the drawer body
+    // renders it through `errorOverride` instead.
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path,
+      message: RATE_CARD_RATE_EFFECTIVE_DATE_AFTER_ACTIVE_KEY,
+    })
+  }
+}
+
 // A getter, not a value: the schema is built once for the form's lifetime while the card being
 // edited changes on every `openDrawer`.
 export const buildRateCardRateSchema = (getContext: () => RateCardRateSchemaContext) =>
@@ -26,21 +55,7 @@ export const buildRateCardRateSchema = (getContext: () => RateCardRateSchemaCont
   z.custom<RateCardRateFormValues>().superRefine((values, ctx) => {
     const { requiresConversionRate, effectiveFromBoundary } = getContext()
 
-    if (!values.effectiveFrom) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['effectiveFrom'],
-        message: VALUE_REQUIRED_KEY,
-      })
-    } else if (!isEffectiveFromAppendable(values.effectiveFrom, effectiveFromBoundary)) {
-      // Only blocks the submit: the copy interpolates the boundary date, so the drawer body
-      // renders it through `errorOverride` instead.
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['effectiveFrom'],
-        message: RATE_CARD_RATE_EFFECTIVE_DATE_AFTER_ACTIVE_KEY,
-      })
-    }
+    addEffectiveFromIssues(values.effectiveFrom, effectiveFromBoundary, ctx)
 
     if (!values.code) {
       ctx.addIssue({

--- a/src/pages/quotes/approveQuote/__tests__/validationSchema.test.ts
+++ b/src/pages/quotes/approveQuote/__tests__/validationSchema.test.ts
@@ -15,7 +15,7 @@ describe('approveQuoteValidationSchema', () => {
     })
   })
 
-  // Regression (ING-634): this schema had no date rule at all, so a typed pre-1970 expiry
+  // Regression: this schema had no date rule at all, so a typed pre-1970 expiry
   // reached the API once the picker stopped withholding it.
   describe.each([
     ['a year with fewer than four digits', '0026-08-31T00:00:00.000Z'],

--- a/src/pages/quotes/approveQuote/__tests__/validationSchema.test.ts
+++ b/src/pages/quotes/approveQuote/__tests__/validationSchema.test.ts
@@ -1,0 +1,61 @@
+import { UNSUPPORTED_DATE_ERROR } from '~/core/constants/form'
+
+import { approveQuoteValidationSchema, buildApproveQuoteVersionInput } from '../validationSchema'
+
+describe('approveQuoteValidationSchema', () => {
+  describe.each([
+    ['expiresAt is omitted', undefined],
+    ['expiresAt is the minimum supported instant', '1970-01-01T00:00:00.000Z'],
+    ['expiresAt is well after the minimum', '2026-09-02T00:00:00.000Z'],
+  ])('GIVEN %s', (_, expiresAt) => {
+    describe('WHEN it is parsed', () => {
+      it('THEN should report no issue', () => {
+        expect(approveQuoteValidationSchema.safeParse({ expiresAt }).success).toBe(true)
+      })
+    })
+  })
+
+  // Regression (ING-634): this schema had no date rule at all, so a typed pre-1970 expiry
+  // reached the API once the picker stopped withholding it.
+  describe.each([
+    ['a year with fewer than four digits', '0026-08-31T00:00:00.000Z'],
+    ['the last instant before 1970', '1969-12-31T23:59:59.999Z'],
+  ])('GIVEN expiresAt is %s', (_, expiresAt) => {
+    describe('WHEN it is parsed', () => {
+      it('THEN should report the unsupported-date issue on expiresAt', () => {
+        const result = approveQuoteValidationSchema.safeParse({ expiresAt })
+
+        expect(result.success).toBe(false)
+
+        if (!result.success) {
+          expect(result.error.issues).toEqual([
+            expect.objectContaining({ path: ['expiresAt'], message: UNSUPPORTED_DATE_ERROR }),
+          ])
+        }
+      })
+    })
+  })
+})
+
+describe('buildApproveQuoteVersionInput', () => {
+  describe('GIVEN an expiry date', () => {
+    describe('WHEN the input is built', () => {
+      it('THEN should carry the version id and the end of that UTC day', () => {
+        expect(
+          buildApproveQuoteVersionInput('version-1', { expiresAt: '2026-09-02T10:00:00.000Z' }),
+        ).toEqual({ id: 'version-1', expiresAt: '2026-09-02T23:59:59.999Z' })
+      })
+    })
+  })
+
+  describe('GIVEN no expiry date', () => {
+    describe('WHEN the input is built', () => {
+      it('THEN should leave expiresAt undefined', () => {
+        expect(buildApproveQuoteVersionInput('version-1', { expiresAt: undefined })).toEqual({
+          id: 'version-1',
+          expiresAt: undefined,
+        })
+      })
+    })
+  })
+})

--- a/src/pages/quotes/approveQuote/validationSchema.ts
+++ b/src/pages/quotes/approveQuote/validationSchema.ts
@@ -1,11 +1,16 @@
 import { DateTime } from 'luxon'
 import { z } from 'zod'
 
+import { addUnsupportedDateIssue } from '~/formValidation/zodCustoms'
 import { ApproveQuoteVersionInput } from '~/generated/graphql'
 
-export const approveQuoteValidationSchema = z.object({
-  expiresAt: z.string().optional(),
-})
+export const approveQuoteValidationSchema = z
+  .object({
+    expiresAt: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    addUnsupportedDateIssue(ctx, data.expiresAt, ['expiresAt'])
+  })
 
 export type ApproveQuoteFormValues = z.infer<typeof approveQuoteValidationSchema>
 

--- a/src/pages/wallet/formInitialization/__tests__/validationSchema.test.ts
+++ b/src/pages/wallet/formInitialization/__tests__/validationSchema.test.ts
@@ -1,4 +1,4 @@
-import { dateErrorCodes } from '~/core/constants/form'
+import { dateErrorCodes, UNSUPPORTED_DATE_ERROR } from '~/core/constants/form'
 import { DEFAULT_ZOD_ERROR_MESSAGE } from '~/formValidation/initializeZod'
 import { MetadataErrorsEnum } from '~/formValidation/metadataSchema'
 import {
@@ -424,6 +424,18 @@ describe('walletFormValidationSchema', () => {
 
       expect(issueFor(invalid, 'recurringTransactionRules.0.startedAt')?.message).toBe(
         dateErrorCodes.wrongFormat,
+      )
+    })
+
+    // Regression (ING-634): startedAt has no future rule, so a typed pre-1970 date now
+    // reaching the form would otherwise pass the format-only check.
+    it('rejects a startedAt before the minimum supported date', () => {
+      const result = walletFormValidationSchema.safeParse(
+        baseForm({ recurringTransactionRules: [baseRule({ startedAt: '0026-08-31T00:00:00Z' })] }),
+      )
+
+      expect(issueFor(result, 'recurringTransactionRules.0.startedAt')?.message).toBe(
+        UNSUPPORTED_DATE_ERROR,
       )
     })
 

--- a/src/pages/wallet/formInitialization/__tests__/validationSchema.test.ts
+++ b/src/pages/wallet/formInitialization/__tests__/validationSchema.test.ts
@@ -427,7 +427,7 @@ describe('walletFormValidationSchema', () => {
       )
     })
 
-    // Regression (ING-634): startedAt has no future rule, so a typed pre-1970 date now
+    // Regression: startedAt has no future rule, so a typed pre-1970 date now
     // reaching the form would otherwise pass the format-only check.
     it('rejects a startedAt before the minimum supported date', () => {
       const result = walletFormValidationSchema.safeParse(

--- a/src/pages/wallet/formInitialization/validationSchema.ts
+++ b/src/pages/wallet/formInitialization/validationSchema.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { addPurchaseOrderNumberMaxLengthIssue } from '~/components/purchaseOrder/validation'
 import { dateErrorCodes } from '~/core/constants/form'
 import { zodMetadataSchema } from '~/formValidation/metadataSchema'
+import { addUnsupportedDateIssue } from '~/formValidation/zodCustoms'
 import {
   RecurringTransactionMethodEnum,
   RecurringTransactionTriggerEnum,
@@ -252,17 +253,20 @@ const addTargetOngoingBalanceIssue = ({ rule, ctx, rulePath }: RuleIssueArgs): v
 const addStartedAtIssue = ({ rule, ctx, rulePath }: RuleIssueArgs): void => {
   const { trigger, startedAt } = rule
 
-  if (
-    (!trigger || trigger === RecurringTransactionTriggerEnum.Interval) &&
-    !!startedAt &&
-    !DateTime.fromISO(startedAt).isValid
-  ) {
+  if (trigger && trigger !== RecurringTransactionTriggerEnum.Interval) return
+
+  if (!!startedAt && !DateTime.fromISO(startedAt).isValid) {
     ctx.addIssue({
       code: 'custom',
       message: dateErrorCodes.wrongFormat,
       path: rulePath('startedAt'),
     })
+
+    return
   }
+
+  // Unlike expirationAt below, startedAt has no future rule to reject a pre-1970 date.
+  addUnsupportedDateIssue(ctx, startedAt, rulePath('startedAt'))
 }
 
 /** transactionMetadata — key unique & <= 20 chars, value <= 100 chars. */


### PR DESCRIPTION
## Context

Follow-up to ING-626. `DatePicker` withheld any date below 1970 from the form, so the input showed one value while the form held another — the previously accepted date, or nothing at all. Four symptoms came out of that single disagreement: a subscription created on the previously accepted date, an optional end date submitted empty, cross-field rules guarded on the value silently skipped, and captions rendering "Invalid DateTime".

## Description

`DatePicker` no longer gatekeeps the floor. It publishes any date it can represent as ISO, and "is this date acceptable?" becomes a validation rule like any other. `minDate` stays a free prop and `MIN_SUPPORTED_DATE` remains only the default calendar bound. An unparseable date is still withheld — it has no ISO representation to publish — and keeps the component's own format error.

Adds `addUnsupportedDateIssue` in `formValidation/zodCustoms`, a shared zod refinement taking the floor as a parameter and defaulting to 1970. It returns whether an issue was added so callers can skip rules that would only restate it. Adopted where nothing already rejects a pre-1970 value:

- `subscriptionFormSchema` — `subscriptionAt`, and `endingAt` in place of its ISO-format check
- wallet `startedAt` (both the wallet form and the recurring-rule drawer share `addRecurringRuleIssues`)
- `approveQuoteValidationSchema`, which had no date rule at all
- `editFeeBillingPeriodValidationSchema` — `fromDatetime`
- `makeSubscriptionSettingsSchema` — `startDate` and `endDate`
- the rate card rate `effectiveFrom`, ahead of the active-rate boundary a card without an active rate does not have
- the add-on drawer `fromDatetime` / `toDatetime`

Left alone, with an existing rule that already rejects the floor and carries better copy: the quote `executeAt` fields (must be a future day), the coupon `expirationAt` (must be later than yesterday, and nulled unless the expiration is time-limited), and both wallet `expirationAt` fields (must be in the future). Adding the shared rule on top would stack a second, vaguer message under the same input.

`CreatePayment` is the last yup form holding a date field and gets its own `date().min()` rule. Its error was invisible because the Formik `DatePickerField` gated display on Formik's `touched`, which `DatePicker` never turns true since it drops `onBlur`; the wrapper now renders the field error directly and maps the picker's own code to a message key.

The date-range filters keep no schema on purpose: a filter writes nothing, so an unsupported bound only returns the empty result set the user asked for. Noted in the component.

Also extracts the add-on drawer schema as `buildEditAddOnSchema` so its test exercises the real schema instead of a mirrored copy that had already drifted from it.

### Tests

`DatePicker`'s existing floor tests are inverted — representable dates now publish, only an unparseable one withholds — and each schema gets the pre-1970 case, picked so no pre-existing rule can fail in the new rule's place. Both new pricing-block cases were verified to fail with the schema change reverted. New files: `DatePickerField.test.tsx` (the Formik wrapper's error display) and `approveQuote/__tests__/validationSchema.test.ts`.

`pnpm run code:style`: 0 errors. Warnings 57 vs. 56 on `main` — the one addition is the `formik` deprecation warning from the new `DatePickerField` test, which must import `useFormik` to exercise the wrapper it covers.

<!-- Linear link -->
Fixes ING-634
