### PR TITLE
feat(quotes): make the pricing block discoverable in the quote editor

### DIFF
--- a/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/designSystem/RichTextEditor/RichTextEditor.tsx
@@ -49,7 +49,7 @@ import { PricingBlock } from './extensions/PricingBlock'
 import { type PricingBlockAttributes } from './extensions/PricingBlock.schema'
 import { QuoteImageSchema } from './extensions/QuoteImage'
 import { QuoteImageNodeView } from './extensions/QuoteImageNodeView'
-import { SlashCommands } from './extensions/SlashCommands'
+import { insertPricingBlock, SlashCommands } from './extensions/SlashCommands'
 import { TableCommands } from './extensions/TableCommands'
 import { TemplateSelectorExtension } from './extensions/TemplateSelectorExtension'
 import { type MentionItem, MentionList, type MentionListRef } from './Mentions/MentionList'
@@ -69,6 +69,7 @@ interface RichTextEditorProps {
   templates?: EditorTemplate[]
   getMarkdownRef?: React.MutableRefObject<(() => string) | null>
   removeBlockRef?: React.MutableRefObject<((localId: string) => void) | null>
+  insertPricingBlockRef?: React.MutableRefObject<(() => void) | null>
   onChange?: () => void
   onPricingCommand?: OnPricingCommand
   isPricingDisabled?: () => boolean
@@ -274,6 +275,7 @@ const RichTextEditor = ({
   templates,
   getMarkdownRef,
   removeBlockRef,
+  insertPricingBlockRef,
   onPricingCommand,
   isPricingDisabled,
   onPricingBlocksChange,
@@ -454,6 +456,24 @@ const RichTextEditor = ({
       }
     }
   }, [getMarkdownRef, getMarkdown])
+
+  useEffect(() => {
+    if (!insertPricingBlockRef) return
+
+    insertPricingBlockRef.current = () => {
+      const handler = onPricingCommandRef.current
+
+      if (!editor || !handler) return
+
+      insertPricingBlock(editor, handler, { at: 'end' })
+    }
+
+    return () => {
+      if (insertPricingBlockRef) {
+        insertPricingBlockRef.current = null
+      }
+    }
+  }, [insertPricingBlockRef, editor])
 
   useEffect(() => {
     if (!removeBlockRef) return

--- a/src/components/designSystem/RichTextEditor/__tests__/RichTextEditor.test.tsx
+++ b/src/components/designSystem/RichTextEditor/__tests__/RichTextEditor.test.tsx
@@ -35,6 +35,8 @@ jest.mock('../extensions/CreditsBlock', () => ({
   },
 }))
 
+const mockInsertPricingBlock = jest.fn()
+
 jest.mock('../extensions/SlashCommands', () => ({
   SlashCommands: {
     configure: jest.fn((config: Record<string, unknown>) => {
@@ -44,6 +46,7 @@ jest.mock('../extensions/SlashCommands', () => ({
     }),
   },
   slashCommandDefinitions: [],
+  insertPricingBlock: (...args: unknown[]) => mockInsertPricingBlock(...args),
 }))
 
 const mockGetMarkdown = jest.fn().mockReturnValue('# Hello World')
@@ -1117,6 +1120,96 @@ describe('RichTextEditor', () => {
         removeBlockRef.current?.('plan-2')
 
         expect(mockDeleteRange).not.toHaveBeenCalled()
+      })
+    })
+  })
+})
+
+describe('RichTextEditor insertPricingBlockRef', () => {
+  beforeEach(() => {
+    mockInsertPricingBlock.mockClear()
+  })
+
+  describe('GIVEN the insertPricingBlockRef prop is provided', () => {
+    describe('WHEN the editor mounts with a pricing handler', () => {
+      it('THEN should assign a function to insertPricingBlockRef.current', async () => {
+        const insertPricingBlockRef = { current: null } as React.MutableRefObject<
+          (() => void) | null
+        >
+
+        await act(() =>
+          render(
+            <RichTextEditor
+              insertPricingBlockRef={insertPricingBlockRef}
+              onPricingCommand={jest.fn()}
+            />,
+          ),
+        )
+
+        expect(typeof insertPricingBlockRef.current).toBe('function')
+      })
+
+      // The out-of-editor CTAs run on a document the user never clicked into, where the
+      // selection is still at the very start.
+      it('THEN should insert at the end of the document when called', async () => {
+        const insertPricingBlockRef = { current: null } as React.MutableRefObject<
+          (() => void) | null
+        >
+        const onPricingCommand = jest.fn()
+
+        await act(() =>
+          render(
+            <RichTextEditor
+              insertPricingBlockRef={insertPricingBlockRef}
+              onPricingCommand={onPricingCommand}
+            />,
+          ),
+        )
+
+        act(() => {
+          insertPricingBlockRef.current?.()
+        })
+
+        expect(mockInsertPricingBlock).toHaveBeenCalledWith(expect.anything(), onPricingCommand, {
+          at: 'end',
+        })
+      })
+    })
+
+    describe('WHEN no pricing handler is provided', () => {
+      it('THEN should not insert anything', async () => {
+        const insertPricingBlockRef = { current: null } as React.MutableRefObject<
+          (() => void) | null
+        >
+
+        await act(() => render(<RichTextEditor insertPricingBlockRef={insertPricingBlockRef} />))
+
+        act(() => {
+          insertPricingBlockRef.current?.()
+        })
+
+        expect(mockInsertPricingBlock).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the editor unmounts', () => {
+      it('THEN should clear insertPricingBlockRef.current', async () => {
+        const insertPricingBlockRef = { current: null } as React.MutableRefObject<
+          (() => void) | null
+        >
+
+        await act(() =>
+          render(
+            <RichTextEditor
+              insertPricingBlockRef={insertPricingBlockRef}
+              onPricingCommand={jest.fn()}
+            />,
+          ),
+        )
+
+        cleanup()
+
+        expect(insertPricingBlockRef.current).toBeNull()
       })
     })
   })

--- a/src/components/designSystem/RichTextEditor/extensions/SlashCommands.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/SlashCommands.ts
@@ -12,6 +12,34 @@ import type {
 } from '../common/RichTextEditorContext'
 import { SlashMenu, type SlashMenuRef } from '../SlashMenu/SlashMenu'
 
+// `at: 'end'` must resolve to a numeric position, never `focus('end')`: on a document ending
+// in a selectable atom that yields a NodeSelection, and insertContent would replace the node.
+export const insertPricingBlock = (
+  editor: Editor,
+  onPricingCommand: OnPricingCommand,
+  { at }: { at?: 'end' } = {},
+): void => {
+  onPricingCommand({
+    onSave: (attrs) => {
+      const content = { type: 'pricingBlock', attrs }
+
+      if (at === 'end') {
+        editor.chain().focus().insertContentAt(editor.state.doc.content.size, content).run()
+      } else {
+        editor.chain().focus().insertContent(content).run()
+      }
+
+      // After inserting an atom node, ProseMirror may create a NodeSelection
+      // which triggers the BlockToolbar overlay. Move to a text selection.
+      const { selection } = editor.state
+
+      if (selection instanceof NodeSelection) {
+        editor.commands.setTextSelection(selection.from + selection.node.nodeSize)
+      }
+    },
+  })
+}
+
 export interface SlashCommandItem {
   title: string
   description: string
@@ -168,21 +196,7 @@ export const SlashCommands = Extension.create({
         title: translate('text_1779802343219a1cl5ckvtrn'),
         description: translate('text_1779802343219rul1jvs7170'),
         icon: 'board',
-        command: (editor) => {
-          onPricingCommand({
-            onSave: (attrs) => {
-              editor.chain().focus().insertContent({ type: 'pricingBlock', attrs }).run()
-
-              // After inserting an atom node, ProseMirror may create a NodeSelection
-              // which triggers the BlockToolbar overlay. Move to a text selection.
-              const { selection } = editor.state
-
-              if (selection instanceof NodeSelection) {
-                editor.commands.setTextSelection(selection.from + selection.node.nodeSize)
-              }
-            },
-          })
-        },
+        command: (editor) => insertPricingBlock(editor, onPricingCommand),
       }
       resolvedItems.push(pricingItem)
     }

--- a/src/components/designSystem/RichTextEditor/extensions/__tests__/SlashCommands.test.ts
+++ b/src/components/designSystem/RichTextEditor/extensions/__tests__/SlashCommands.test.ts
@@ -1,7 +1,9 @@
 import { Editor } from '@tiptap/core'
+import { NodeSelection } from '@tiptap/pm/state'
 import StarterKit from '@tiptap/starter-kit'
 
-import { slashCommandDefinitions, SlashCommands } from '../SlashCommands'
+import { PricingBlockSchema } from '../PricingBlock.schema'
+import { insertPricingBlock, slashCommandDefinitions, SlashCommands } from '../SlashCommands'
 
 const mockDestroyPopup = jest.fn()
 const mockHidePopup = jest.fn()
@@ -790,10 +792,6 @@ describe('SlashCommands', () => {
           },
         }
 
-        // Create a fake NodeSelection-like object using the actual NodeSelection class
-        const { NodeSelection } = jest.requireActual('@tiptap/pm/state') as {
-          NodeSelection: { prototype: object }
-        }
         const fakeNodeSelection = Object.create(NodeSelection.prototype, {
           from: { value: 5 },
           node: { value: { nodeSize: 3 } },
@@ -1654,6 +1652,143 @@ describe('SlashCommands', () => {
         expect(creditsItem?.disabled).toBe(false)
 
         document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+        editor.destroy()
+      })
+    })
+  })
+})
+
+describe('insertPricingBlock', () => {
+  const buildMockEditor = (selection: unknown) => {
+    const runMock = jest.fn()
+    const chainMethods: Record<string, jest.Mock> = {}
+    const handler: ProxyHandler<Record<string, jest.Mock>> = {
+      get: (_target, prop: string) => {
+        if (prop === 'run') return runMock
+
+        if (!chainMethods[prop]) {
+          chainMethods[prop] = jest.fn().mockReturnValue(new Proxy({}, handler))
+        }
+
+        return chainMethods[prop]
+      },
+    }
+
+    const editor = {
+      chain: jest.fn().mockReturnValue(new Proxy({}, handler)),
+      commands: { setTextSelection: jest.fn() },
+      state: { selection, doc: { content: { size: 42 } } },
+    } as unknown as Editor
+
+    return { editor, chainMethods, runMock }
+  }
+
+  describe('GIVEN the helper is called from outside the editor', () => {
+    describe('WHEN it runs', () => {
+      it('THEN should open the pricing drawer with an onSave callback', () => {
+        const onPricingCommand = jest.fn()
+        const { editor } = buildMockEditor({})
+
+        insertPricingBlock(editor, onPricingCommand)
+
+        expect(onPricingCommand).toHaveBeenCalledWith({ onSave: expect.any(Function) })
+      })
+    })
+
+    describe('WHEN onSave is invoked', () => {
+      it('THEN should insert the pricingBlock node with the given attrs', () => {
+        const onPricingCommand = jest.fn()
+        const { editor, chainMethods, runMock } = buildMockEditor({})
+        const attrs = { pricingType: 'plan' as const, entityIds: ['plan-1'] }
+
+        insertPricingBlock(editor, onPricingCommand)
+        onPricingCommand.mock.calls[0][0].onSave(attrs, {})
+
+        expect(chainMethods['insertContent']).toHaveBeenCalledWith({
+          type: 'pricingBlock',
+          attrs,
+        })
+        expect(runMock).toHaveBeenCalled()
+      })
+
+      it('THEN should insert at the caret by default', () => {
+        const onPricingCommand = jest.fn()
+        const { editor, chainMethods } = buildMockEditor({})
+
+        insertPricingBlock(editor, onPricingCommand)
+        onPricingCommand.mock.calls[0][0].onSave({ pricingType: 'plan', entityIds: [] }, {})
+
+        expect(chainMethods['insertContentAt']).toBeUndefined()
+      })
+
+      it('THEN should append at the document size when asked for the end', () => {
+        const onPricingCommand = jest.fn()
+        const { editor, chainMethods } = buildMockEditor({})
+        const attrs = { pricingType: 'plan' as const, entityIds: [] }
+
+        insertPricingBlock(editor, onPricingCommand, { at: 'end' })
+        onPricingCommand.mock.calls[0][0].onSave(attrs, {})
+
+        expect(chainMethods['insertContentAt']).toHaveBeenCalledWith(42, {
+          type: 'pricingBlock',
+          attrs,
+        })
+      })
+    })
+
+    describe('WHEN the insert leaves a NodeSelection', () => {
+      // Without this the BlockToolbar overlay pops open on the freshly inserted block.
+      it('THEN should move the cursor past the inserted node', () => {
+        const onPricingCommand = jest.fn()
+        const nodeSelection = Object.create(NodeSelection.prototype, {
+          from: { value: 4 },
+          node: { value: { nodeSize: 1 } },
+        })
+        const { editor } = buildMockEditor(nodeSelection)
+
+        insertPricingBlock(editor, onPricingCommand)
+        onPricingCommand.mock.calls[0][0].onSave({ pricingType: 'plan', entityIds: [] }, {})
+
+        expect(editor.commands.setTextSelection).toHaveBeenCalledWith(5)
+      })
+    })
+
+    describe('WHEN the insert leaves a plain text selection', () => {
+      it('THEN should leave the selection untouched', () => {
+        const onPricingCommand = jest.fn()
+        const { editor } = buildMockEditor({ from: 4 })
+
+        insertPricingBlock(editor, onPricingCommand)
+        onPricingCommand.mock.calls[0][0].onSave({ pricingType: 'plan', entityIds: [] }, {})
+
+        expect(editor.commands.setTextSelection).not.toHaveBeenCalled()
+      })
+    })
+  })
+})
+
+describe('insertPricingBlock on a real editor', () => {
+  describe('GIVEN a document ending in a selectable atom', () => {
+    describe('WHEN the block is appended at the end', () => {
+      // `focus('end')` resolves to a NodeSelection over that trailing atom, and insertContent
+      // would replace it — the divider would be silently deleted and autosaved away.
+      it('THEN should keep the trailing node and insert after it', () => {
+        const editor = new Editor({
+          extensions: [StarterKit, PricingBlockSchema],
+          content: '<p>Intro</p><hr>',
+        })
+        const onPricingCommand = jest.fn()
+
+        insertPricingBlock(editor, onPricingCommand, { at: 'end' })
+        onPricingCommand.mock.calls[0][0].onSave({ pricingType: 'plan', entityIds: ['plan-1'] }, {})
+
+        expect(editor.getJSON().content?.map((node) => node.type)).toEqual([
+          'paragraph',
+          'horizontalRule',
+          'pricingBlock',
+          'paragraph',
+        ])
+
         editor.destroy()
       })
     })

--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -4,6 +4,7 @@ import { debounce } from 'lodash'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
+import { Alert } from '~/components/designSystem/Alert'
 import { Button } from '~/components/designSystem/Button'
 import type {
   OnCreditsCommand,
@@ -39,6 +40,8 @@ import { useSubscriptionPricingDrawer } from './hooks/useSubscriptionPricingDraw
 import { useUpdateQuote } from './hooks/useUpdateQuote'
 
 const AUTO_SAVE_DELAY_MS = 2000
+
+export const EDIT_QUOTE_PRICING_CTA_TEST_ID = 'edit-quote-pricing-cta'
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
 
@@ -165,10 +168,40 @@ const EditQuote = () => {
     [entities, discount.entities, credits.entities],
   )
 
+  // `isPricingDisabled()` reads a ref, so it cannot drive a render. Until the editor has
+  // reported its blocks the saved billingItems stand in, so a priced quote never paints the CTA.
+  const savedBillingItems = quote?.currentVersion?.billingItems as BillingItemsPayload | undefined
+  const hasSavedPricing = !!(savedBillingItems?.plans?.length || savedBillingItems?.addOns?.length)
+  const [hasPricingBlockInDocument, setHasPricingBlockInDocument] = useState<boolean | null>(null)
+  const hasPricingBlock = hasPricingBlockInDocument ?? hasSavedPricing
+
+  const pricingSummary = useMemo(() => {
+    // The pricing hooks index each add-on twice — by localId and by catalog id, for
+    // backward compat with older documents — so the names must be deduped by entityId.
+    const seen = new Set<string>()
+    const names: string[] = []
+
+    for (const entity of Object.values(entities)) {
+      if (!entity || seen.has(entity.entityId)) continue
+
+      seen.add(entity.entityId)
+      names.push(entity.invoiceDisplayName || entity.name)
+    }
+
+    return names.join(', ')
+  }, [entities])
+
   const customerLocale = (quote?.customer?.billingConfiguration?.documentLocale ?? 'en') as Locale
 
   const getMarkdownRef = useRef<(() => string) | null>(null)
   const removeBlockRef = useRef<((localId: string) => void) | null>(null)
+  const insertPricingBlockRef = useRef<(() => void) | null>(null)
+
+  // Runs the very command the slash menu's "Pricing" item runs, so the save, the rollback
+  // and the selection fix-up stay in one place.
+  const handleAddPricingBlock = useCallback(() => {
+    insertPricingBlockRef.current?.()
+  }, [])
   const isRollingBackRef = useRef(false)
   const lastSavedContentRef = useRef('')
   const isReadyForChangesRef = useRef(false)
@@ -395,6 +428,10 @@ const EditQuote = () => {
 
   const handlePricingBlocksChange = useCallback(
     (blocks: PricingBlockAttributes[]) => {
+      // Before the rollback guard below: a rolled-back insert must still clear the flag,
+      // only the corrective save is skipped.
+      setHasPricingBlockInDocument(blocks.length > 0)
+
       // A rollback tears the block back out after a failed save. Skip
       // reconciliation entirely — not just the corrective save: otherwise
       // `syncEntitiesWithBlocks` prunes the just-failed add-on's cached catalog
@@ -536,6 +573,9 @@ const EditQuote = () => {
           <EditQuoteAside
             quote={quote}
             isSaving={saveStatus === 'saving'}
+            hasPricingBlock={hasPricingBlock}
+            pricingSummary={pricingSummary}
+            onAddPricingBlock={handleAddPricingBlock}
             onSaveStart={() => setSaveStatus('saving')}
             onSaveFinished={onUpdateFinished}
             onSaveError={(payload) => {
@@ -552,25 +592,44 @@ const EditQuote = () => {
             <Skeleton variant="text" className="w-5/6" />
           </div>
         ) : (
-          <RichTextEditor
-            content={quote?.currentVersion?.content ?? ''}
-            getMarkdownRef={getMarkdownRef}
-            removeBlockRef={removeBlockRef}
-            onChange={handleChange}
-            mode={editorMode}
-            onPricingCommand={handlePricingCommand}
-            isPricingDisabled={isPricingDisabled}
-            entities={mergedEntities}
-            onPricingBlocksChange={handlePricingBlocksChange}
-            onDiscountBlocksChange={handleDiscountBlocksChange}
-            {...subscriptionEditorProps}
-            customerLocale={customerLocale}
-            documentCurrency={effectiveQuoteCurrency}
-            variableItems={mentionItems}
-            mentionValues={mentionValues}
-            images={images}
-            onImageUpload={onImageUpload}
-          />
+          <div className="flex h-full flex-col">
+            <div className="min-h-0 flex-1">
+              <RichTextEditor
+                content={quote?.currentVersion?.content ?? ''}
+                getMarkdownRef={getMarkdownRef}
+                removeBlockRef={removeBlockRef}
+                insertPricingBlockRef={insertPricingBlockRef}
+                onChange={handleChange}
+                mode={editorMode}
+                onPricingCommand={handlePricingCommand}
+                isPricingDisabled={isPricingDisabled}
+                entities={mergedEntities}
+                onPricingBlocksChange={handlePricingBlocksChange}
+                onDiscountBlocksChange={handleDiscountBlocksChange}
+                {...subscriptionEditorProps}
+                customerLocale={customerLocale}
+                documentCurrency={effectiveQuoteCurrency}
+                variableItems={mentionItems}
+                mentionValues={mentionValues}
+                images={images}
+                onImageUpload={onImageUpload}
+              />
+            </div>
+            {!hasPricingBlock && (
+              <div className="mx-auto w-full max-w-4xl shrink-0 px-10 pb-4">
+                <Alert
+                  type="warning"
+                  data-test={EDIT_QUOTE_PRICING_CTA_TEST_ID}
+                  ButtonProps={{
+                    label: translate('text_1788277738981ng58j3nfudd'),
+                    onClick: handleAddPricingBlock,
+                  }}
+                >
+                  {translate('text_1788277738980lq42krzk56z')}
+                </Alert>
+              </div>
+            )}
+          </div>
         )}
       </RightAsidePage.Content>
     </RightAsidePage.Wrapper>

--- a/src/pages/quotes/__tests__/EditQuote.test.tsx
+++ b/src/pages/quotes/__tests__/EditQuote.test.tsx
@@ -7,7 +7,7 @@ import { makeEmptyWalletItem, toWallets } from '~/core/serializers/serializeQuot
 import { CurrencyEnum } from '~/generated/graphql'
 import { render, testMockNavigateFn } from '~/test-utils'
 
-import EditQuote from '../EditQuote'
+import EditQuote, { EDIT_QUOTE_PRICING_CTA_TEST_ID } from '../EditQuote'
 
 // --- Shared state for mocks ---
 
@@ -21,6 +21,14 @@ type AsideCallbacks = {
 }
 
 let capturedAsideCallbacks: AsideCallbacks = {}
+
+type AsidePricingProps = {
+  hasPricingBlock?: boolean
+  pricingSummary?: string
+  onAddPricingBlock?: () => void
+}
+
+let capturedAsidePricingProps: AsidePricingProps = {}
 
 type PricingCommandParams = {
   onSave: (...args: unknown[]) => void
@@ -36,6 +44,7 @@ let capturedOnCreditsBlocksChange: ((blocks: unknown[]) => void) | undefined
 let capturedEditorCustomerLocale: string | undefined
 let capturedEditorDocumentCurrency: string | undefined
 let capturedRemoveBlockRef: { current: ((localId: string) => void) | null } | undefined
+const mockInsertPricingBlock = jest.fn()
 
 // --- Mocks ---
 
@@ -58,6 +67,7 @@ jest.mock('~/components/designSystem/RichTextEditor/RichTextEditor', () => {
   const MockRichTextEditor = ({
     getMarkdownRef,
     removeBlockRef,
+    insertPricingBlockRef,
     onChange,
     onPricingCommand,
     onPricingBlocksChange,
@@ -70,6 +80,7 @@ jest.mock('~/components/designSystem/RichTextEditor/RichTextEditor', () => {
   }: {
     getMarkdownRef?: React.MutableRefObject<(() => string) | null>
     removeBlockRef?: React.MutableRefObject<((localId: string) => void) | null>
+    insertPricingBlockRef?: React.MutableRefObject<(() => void) | null>
     onChange?: () => void
     onPricingCommand?: (params: PricingCommandParams) => void
     onPricingBlocksChange?: (blocks: unknown[]) => void
@@ -95,14 +106,22 @@ jest.mock('~/components/designSystem/RichTextEditor/RichTextEditor', () => {
       capturedEditorDocumentCurrency = documentCurrency
       capturedRemoveBlockRef = removeBlockRef
 
+      if (insertPricingBlockRef) {
+        insertPricingBlockRef.current = mockInsertPricingBlock
+      }
+
       return () => {
         if (getMarkdownRef) {
           getMarkdownRef.current = null
+        }
+        if (insertPricingBlockRef) {
+          insertPricingBlockRef.current = null
         }
       }
     }, [
       getMarkdownRef,
       removeBlockRef,
+      insertPricingBlockRef,
       onChange,
       onPricingCommand,
       onPricingBlocksChange,
@@ -128,6 +147,9 @@ jest.mock('../editQuote/EditQuoteAside', () => {
     __esModule: true,
     default: (props: {
       isSaving?: boolean
+      hasPricingBlock?: boolean
+      pricingSummary?: string
+      onAddPricingBlock?: () => void
       onSaveStart?: () => void
       onSaveFinished?: () => void
       onSaveError?: (payload: unknown) => void
@@ -136,6 +158,11 @@ jest.mock('../editQuote/EditQuoteAside', () => {
         onSaveStart: props.onSaveStart,
         onSaveFinished: props.onSaveFinished,
         onSaveError: props.onSaveError,
+      }
+      capturedAsidePricingProps = {
+        hasPricingBlock: props.hasPricingBlock,
+        pricingSummary: props.pricingSummary,
+        onAddPricingBlock: props.onAddPricingBlock,
       }
 
       return <div data-test="mock-edit-quote-aside" data-is-saving={String(!!props.isSaving)} />
@@ -221,6 +248,8 @@ jest.mock('../hooks/useQuote', () => ({
   useQuote: (...args: unknown[]) => mockUseQuote(...args),
 }))
 
+let mockPricingEntities: Record<string, { entityId: string; name: string }> = {}
+
 const mockDrawerOnPricingCommand = jest.fn()
 const mockSyncEntitiesWithBlocks = jest.fn().mockReturnValue(null)
 let capturedPricingDrawerArgs: unknown[] = []
@@ -233,7 +262,7 @@ jest.mock('../hooks/useSubscriptionPricingDrawer', () => ({
     return {
       onPricingCommand: mockDrawerOnPricingCommand,
       isPricingDisabled: () => false,
-      entities: {},
+      entities: mockPricingEntities,
       syncEntitiesWithBlocks: mockSyncEntitiesWithBlocks,
     }
   },
@@ -311,6 +340,8 @@ describe('EditQuote', () => {
     capturedPricingDrawerArgs = []
     capturedOneOffDrawerArgs = []
     capturedDiscountDrawerOptions = undefined
+    capturedAsidePricingProps = {}
+    mockPricingEntities = {}
     mockSyncEntitiesWithBlocks.mockReturnValue(null)
     mockSyncDiscountBlocks.mockReturnValue(null)
 
@@ -1705,6 +1736,127 @@ describe('EditQuote', () => {
           expect(mockUpdateQuoteVersion).toHaveBeenCalled()
         })
         expect(mockUpdateQuoteVersion.mock.calls[0][0]).not.toHaveProperty('currency')
+      })
+    })
+  })
+  describe('GIVEN the quote has no pricing block', () => {
+    describe('WHEN rendered', () => {
+      it('THEN should display the empty-state CTA below the editor', () => {
+        render(<EditQuote />)
+
+        const cta = screen.getByTestId(EDIT_QUOTE_PRICING_CTA_TEST_ID)
+        const editor = screen.getByTestId('mock-rich-text-editor')
+
+        expect(cta).toBeInTheDocument()
+        expect(editor.compareDocumentPosition(cta) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+      })
+
+      it('THEN should tell the aside there is no pricing block', () => {
+        render(<EditQuote />)
+
+        expect(capturedAsidePricingProps.hasPricingBlock).toBe(false)
+      })
+    })
+
+    describe('WHEN the CTA button is clicked', () => {
+      it('THEN should run the editor insert command', async () => {
+        const user = userEvent.setup()
+
+        render(<EditQuote />)
+
+        const cta = screen.getByTestId(EDIT_QUOTE_PRICING_CTA_TEST_ID)
+
+        await user.click(cta.querySelector('button') as HTMLButtonElement)
+
+        expect(mockInsertPricingBlock).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('WHEN the aside asks to add a pricing block', () => {
+      it('THEN should run the same editor insert command', () => {
+        render(<EditQuote />)
+
+        act(() => {
+          capturedAsidePricingProps.onAddPricingBlock?.()
+        })
+
+        expect(mockInsertPricingBlock).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('WHEN a pricing block is inserted in the editor', () => {
+      it('THEN should hide the CTA and tell the aside', () => {
+        render(<EditQuote />)
+
+        act(() => {
+          capturedOnPricingBlocksChange?.([{ pricingType: 'plan', entityIds: ['plan-1'] }])
+        })
+
+        expect(screen.queryByTestId(EDIT_QUOTE_PRICING_CTA_TEST_ID)).not.toBeInTheDocument()
+        expect(capturedAsidePricingProps.hasPricingBlock).toBe(true)
+      })
+    })
+  })
+
+  describe('GIVEN the quote already has saved pricing', () => {
+    describe.each([
+      ['a subscription plan', { plans: [{ id: 'plan-1' }] }],
+      ['one-off add-ons', { addOns: [{ id: 'addon-1' }] }],
+    ])('WHEN the saved billingItems hold %s', (_label, billingItems) => {
+      // The CTA must not flash on the first paint of a quote that is already priced.
+      it('THEN should never render the CTA', () => {
+        mockUseQuote.mockReturnValue({
+          quote: {
+            ...mockQuote,
+            currentVersion: { ...mockQuote.currentVersion, billingItems },
+          },
+          loading: false,
+          refetch: mockRefetchQuote,
+        })
+
+        render(<EditQuote />)
+
+        expect(screen.queryByTestId(EDIT_QUOTE_PRICING_CTA_TEST_ID)).not.toBeInTheDocument()
+        expect(capturedAsidePricingProps.hasPricingBlock).toBe(true)
+      })
+    })
+
+    describe('WHEN the last pricing block is removed from the editor', () => {
+      it('THEN should bring the CTA back', () => {
+        mockUseQuote.mockReturnValue({
+          quote: {
+            ...mockQuote,
+            currentVersion: { ...mockQuote.currentVersion, billingItems: { plans: [{ id: 'p' }] } },
+          },
+          loading: false,
+          refetch: mockRefetchQuote,
+        })
+
+        render(<EditQuote />)
+
+        act(() => {
+          capturedOnPricingBlocksChange?.([])
+        })
+
+        expect(screen.getByTestId(EDIT_QUOTE_PRICING_CTA_TEST_ID)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN priced entities are cached by the pricing drawer', () => {
+    describe('WHEN the aside receives the pricing summary', () => {
+      // The drawer indexes each add-on twice — by localId and by catalog id — so an
+      // undeduped summary would repeat every name.
+      it('THEN should list each entity name once', () => {
+        mockPricingEntities = {
+          'local-1': { entityId: 'addon-1', name: 'Setup fee' },
+          'addon-1': { entityId: 'addon-1', name: 'Setup fee' },
+          'local-2': { entityId: 'addon-2', name: 'Support pack' },
+        }
+
+        render(<EditQuote />)
+
+        expect(capturedAsidePricingProps.pricingSummary).toBe('Setup fee, Support pack')
       })
     })
   })

--- a/src/pages/quotes/editQuote/EditQuoteAside.tsx
+++ b/src/pages/quotes/editQuote/EditQuoteAside.tsx
@@ -4,6 +4,7 @@ import { generatePath } from 'react-router-dom'
 
 import { BillingEntityFormPicker } from '~/components/billingEntity/BillingEntityFormPicker'
 import { Button } from '~/components/designSystem/Button'
+import { Tooltip } from '~/components/designSystem/Tooltip'
 import { Typography } from '~/components/designSystem/Typography'
 import { CURRENCY_DATA } from '~/components/form/CurrencyPicker'
 import { addToast } from '~/core/apolloClient'
@@ -40,10 +41,17 @@ export const EDIT_QUOTE_ASIDE_CURRENCY_INPUT_TEST_ID = 'edit-quote-aside-currenc
 export const EDIT_QUOTE_ASIDE_CURRENCY_COMBOBOX_TEST_ID = 'edit-quote-aside-currency-combobox'
 export const EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID = 'edit-quote-aside-download-pdf'
 export const EDIT_QUOTE_ASIDE_APPROVE_TEST_ID = 'edit-quote-aside-approve'
+export const EDIT_QUOTE_ASIDE_PRICING_LABEL_TEST_ID = 'edit-quote-aside-pricing'
+export const EDIT_QUOTE_ASIDE_PRICING_SUMMARY_TEST_ID = 'edit-quote-aside-pricing-summary'
+export const EDIT_QUOTE_ASIDE_PRICING_EMPTY_TEST_ID = 'edit-quote-aside-pricing-empty'
+export const EDIT_QUOTE_ASIDE_ADD_PRICING_TEST_ID = 'edit-quote-aside-add-pricing'
 
 interface EditQuoteAsideProps {
   quote: QuoteDetailItemFragment | null | undefined
   isSaving?: boolean
+  hasPricingBlock: boolean
+  pricingSummary: string
+  onAddPricingBlock: () => void
   onSaveStart?: () => void
   onSaveFinished?: () => void
   onSaveError?: (payload: UpdateQuoteVersionInput) => void
@@ -52,6 +60,9 @@ interface EditQuoteAsideProps {
 const EditQuoteAside = ({
   quote,
   isSaving,
+  hasPricingBlock,
+  pricingSummary,
+  onAddPricingBlock,
   onSaveStart,
   onSaveFinished,
   onSaveError,
@@ -62,6 +73,9 @@ const EditQuoteAside = ({
     <EditQuoteAsideForm
       quote={quote}
       isSaving={isSaving}
+      hasPricingBlock={hasPricingBlock}
+      pricingSummary={pricingSummary}
+      onAddPricingBlock={onAddPricingBlock}
       onSaveStart={onSaveStart}
       onSaveFinished={onSaveFinished}
       onSaveError={onSaveError}
@@ -72,12 +86,18 @@ const EditQuoteAside = ({
 const EditQuoteAsideForm = ({
   quote,
   isSaving,
+  hasPricingBlock,
+  pricingSummary,
+  onAddPricingBlock,
   onSaveStart,
   onSaveFinished,
   onSaveError,
 }: {
   quote: QuoteDetailItemFragment
   isSaving?: boolean
+  hasPricingBlock: boolean
+  pricingSummary: string
+  onAddPricingBlock: () => void
   onSaveStart?: () => void
   onSaveFinished?: () => void
   onSaveError?: (payload: UpdateQuoteVersionInput) => void
@@ -206,6 +226,42 @@ const EditQuoteAsideForm = ({
 
   const gridClassName = 'grid grid-cols-[7.5rem_1fr] items-center gap-0 gap-y-2'
 
+  const renderPricingValue = () => {
+    if (hasPricingBlock) {
+      return (
+        <Typography
+          variant="body"
+          color="grey700"
+          noWrap
+          data-test={EDIT_QUOTE_ASIDE_PRICING_SUMMARY_TEST_ID}
+        >
+          {pricingSummary}
+        </Typography>
+      )
+    }
+
+    return (
+      <div className="flex items-center gap-2">
+        <Typography
+          variant="body"
+          color="grey500"
+          data-test={EDIT_QUOTE_ASIDE_PRICING_EMPTY_TEST_ID}
+        >
+          {translate('text_17882777389811he711tg7yj')}
+        </Typography>
+        <Button
+          variant="quaternary"
+          size="small"
+          startIcon="plus"
+          data-test={EDIT_QUOTE_ASIDE_ADD_PRICING_TEST_ID}
+          onClick={onAddPricingBlock}
+        >
+          {translate('text_1788277738981ng58j3nfudd')}
+        </Button>
+      </div>
+    )
+  }
+
   const handleDownloadPdf = () => {
     download(
       buildQuotePreviewProps({
@@ -326,6 +382,15 @@ const EditQuoteAsideForm = ({
               </form.AppField>
             </>
           )}
+
+          <Typography
+            variant="caption"
+            color="grey600"
+            data-test={EDIT_QUOTE_ASIDE_PRICING_LABEL_TEST_ID}
+          >
+            {translate('text_1779802343219a1cl5ckvtrn')}
+          </Typography>
+          {renderPricingValue()}
         </div>
       </div>
       <div className="sticky bottom-0 mt-auto flex justify-end gap-3 border-t border-grey-200 bg-white p-4">
@@ -339,15 +404,23 @@ const EditQuoteAsideForm = ({
           {translate('text_17797156485850t8yms6hf7z')}
         </Button>
         {canApprove && (
-          <Button
-            variant="primary"
-            data-test={EDIT_QUOTE_ASIDE_APPROVE_TEST_ID}
-            loading={isSaving}
-            disabled={!!isSaving}
-            onClick={() => goToApproveQuote(quote.id, quote.currentVersion.id)}
+          // Tooltip only: the server stays the authority on approvability, so a
+          // client-side false negative must never disable the button.
+          <Tooltip
+            placement="top-end"
+            title={translate('text_1788272907430gswzvnbqi2z')}
+            disableHoverListener={hasPricingBlock}
           >
-            {translate('text_1776848720529vv5zmyyq94k')}
-          </Button>
+            <Button
+              variant="primary"
+              data-test={EDIT_QUOTE_ASIDE_APPROVE_TEST_ID}
+              loading={isSaving}
+              disabled={!!isSaving}
+              onClick={() => goToApproveQuote(quote.id, quote.currentVersion.id)}
+            >
+              {translate('text_1776848720529vv5zmyyq94k')}
+            </Button>
+          </Tooltip>
         )}
       </div>
     </div>

--- a/src/pages/quotes/editQuote/EditQuoteAside.tsx
+++ b/src/pages/quotes/editQuote/EditQuoteAside.tsx
@@ -43,7 +43,6 @@ export const EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID = 'edit-quote-aside-download-
 export const EDIT_QUOTE_ASIDE_APPROVE_TEST_ID = 'edit-quote-aside-approve'
 export const EDIT_QUOTE_ASIDE_PRICING_LABEL_TEST_ID = 'edit-quote-aside-pricing'
 export const EDIT_QUOTE_ASIDE_PRICING_SUMMARY_TEST_ID = 'edit-quote-aside-pricing-summary'
-export const EDIT_QUOTE_ASIDE_PRICING_EMPTY_TEST_ID = 'edit-quote-aside-pricing-empty'
 export const EDIT_QUOTE_ASIDE_ADD_PRICING_TEST_ID = 'edit-quote-aside-add-pricing'
 
 interface EditQuoteAsideProps {
@@ -241,24 +240,16 @@ const EditQuoteAsideForm = ({
     }
 
     return (
-      <div className="flex items-center gap-2">
-        <Typography
-          variant="body"
-          color="grey500"
-          data-test={EDIT_QUOTE_ASIDE_PRICING_EMPTY_TEST_ID}
-        >
-          {translate('text_17882777389811he711tg7yj')}
-        </Typography>
-        <Button
-          variant="quaternary"
-          size="small"
-          startIcon="plus"
-          data-test={EDIT_QUOTE_ASIDE_ADD_PRICING_TEST_ID}
-          onClick={onAddPricingBlock}
-        >
-          {translate('text_1788277738981ng58j3nfudd')}
-        </Button>
-      </div>
+      <Button
+        className="w-fit"
+        variant="quaternary"
+        size="small"
+        startIcon="plus"
+        data-test={EDIT_QUOTE_ASIDE_ADD_PRICING_TEST_ID}
+        onClick={onAddPricingBlock}
+      >
+        {translate('text_1788277738981ng58j3nfudd')}
+      </Button>
     )
   }
 

--- a/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
+++ b/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
@@ -22,7 +22,6 @@ import EditQuoteAside, {
   EDIT_QUOTE_ASIDE_CUSTOMER_INPUT_TEST_ID,
   EDIT_QUOTE_ASIDE_CUSTOMER_LINK_TEST_ID,
   EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID,
-  EDIT_QUOTE_ASIDE_PRICING_EMPTY_TEST_ID,
   EDIT_QUOTE_ASIDE_PRICING_LABEL_TEST_ID,
   EDIT_QUOTE_ASIDE_PRICING_SUMMARY_TEST_ID,
   EDIT_QUOTE_ASIDE_QUOTE_TYPE_COMBOBOX_TEST_ID,
@@ -1080,7 +1079,6 @@ describe('EditQuoteAside', () => {
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_PRICING_SUMMARY_TEST_ID)).toHaveTextContent(
           'Premium plan',
         )
-        expect(screen.queryByTestId(EDIT_QUOTE_ASIDE_PRICING_EMPTY_TEST_ID)).not.toBeInTheDocument()
         expect(screen.queryByTestId(EDIT_QUOTE_ASIDE_ADD_PRICING_TEST_ID)).not.toBeInTheDocument()
       })
 
@@ -1100,12 +1098,12 @@ describe('EditQuoteAside', () => {
     })
 
     describe('WHEN the quote has no pricing block', () => {
-      it('THEN should display the empty label and the add button', () => {
+      it('THEN should display the add button in place of a summary', () => {
         render(
           <EditQuoteAside {...defaultPricingProps} quote={mockQuote} hasPricingBlock={false} />,
         )
 
-        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_PRICING_EMPTY_TEST_ID)).toBeInTheDocument()
+        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_PRICING_LABEL_TEST_ID)).toBeInTheDocument()
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_ADD_PRICING_TEST_ID)).toBeInTheDocument()
         expect(
           screen.queryByTestId(EDIT_QUOTE_ASIDE_PRICING_SUMMARY_TEST_ID),

--- a/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
+++ b/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
@@ -14,6 +14,7 @@ import { BILLING_ENTITY_INHERIT_CODE } from '~/hooks/useBillingEntitiesOptions'
 import { render } from '~/test-utils'
 
 import EditQuoteAside, {
+  EDIT_QUOTE_ASIDE_ADD_PRICING_TEST_ID,
   EDIT_QUOTE_ASIDE_APPROVE_TEST_ID,
   EDIT_QUOTE_ASIDE_BILLING_ENTITY_INPUT_TEST_ID,
   EDIT_QUOTE_ASIDE_CURRENCY_COMBOBOX_TEST_ID,
@@ -21,6 +22,9 @@ import EditQuoteAside, {
   EDIT_QUOTE_ASIDE_CUSTOMER_INPUT_TEST_ID,
   EDIT_QUOTE_ASIDE_CUSTOMER_LINK_TEST_ID,
   EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID,
+  EDIT_QUOTE_ASIDE_PRICING_EMPTY_TEST_ID,
+  EDIT_QUOTE_ASIDE_PRICING_LABEL_TEST_ID,
+  EDIT_QUOTE_ASIDE_PRICING_SUMMARY_TEST_ID,
   EDIT_QUOTE_ASIDE_QUOTE_TYPE_COMBOBOX_TEST_ID,
   EDIT_QUOTE_ASIDE_SUBSCRIPTION_INPUT_TEST_ID,
 } from '../EditQuoteAside'
@@ -166,6 +170,14 @@ const mockQuote: QuoteDetailItemFragment = {
   },
 }
 
+const mockAddPricingBlock = jest.fn()
+
+const defaultPricingProps = {
+  hasPricingBlock: true,
+  pricingSummary: 'Premium plan',
+  onAddPricingBlock: mockAddPricingBlock,
+}
+
 describe('EditQuoteAside', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -182,19 +194,19 @@ describe('EditQuoteAside', () => {
   describe('GIVEN a quote is provided', () => {
     describe('WHEN the component renders', () => {
       it('THEN should render the quote type field', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_QUOTE_TYPE_COMBOBOX_TEST_ID)).toBeInTheDocument()
       })
 
       it('THEN should render the customer field', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_CUSTOMER_INPUT_TEST_ID)).toBeInTheDocument()
       })
 
       it('THEN should render the billing entity field', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(
           screen.getByTestId(EDIT_QUOTE_ASIDE_BILLING_ENTITY_INPUT_TEST_ID),
@@ -206,7 +218,9 @@ describe('EditQuoteAside', () => {
   describe('GIVEN a quote with no subscription', () => {
     describe('WHEN the component renders', () => {
       it('THEN should NOT render the subscription field', () => {
-        render(<EditQuoteAside quote={{ ...mockQuote, subscription: null }} />)
+        render(
+          <EditQuoteAside {...defaultPricingProps} quote={{ ...mockQuote, subscription: null }} />,
+        )
 
         expect(
           screen.queryByTestId(EDIT_QUOTE_ASIDE_SUBSCRIPTION_INPUT_TEST_ID),
@@ -234,7 +248,7 @@ describe('EditQuoteAside', () => {
           },
         }
 
-        render(<EditQuoteAside quote={quoteWithSubscription} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={quoteWithSubscription} />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_SUBSCRIPTION_INPUT_TEST_ID)).toBeInTheDocument()
       })
@@ -244,7 +258,7 @@ describe('EditQuoteAside', () => {
   describe('GIVEN no quote is provided', () => {
     describe('WHEN the component renders', () => {
       it('THEN should not render any fields', () => {
-        render(<EditQuoteAside quote={undefined} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={undefined} />)
 
         expect(
           screen.queryByTestId(EDIT_QUOTE_ASIDE_QUOTE_TYPE_COMBOBOX_TEST_ID),
@@ -268,7 +282,7 @@ describe('EditQuoteAside', () => {
   describe('GIVEN a quote with customer currency', () => {
     describe('WHEN the component renders', () => {
       it('THEN should render the currency field', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_CURRENCY_INPUT_TEST_ID)).toBeInTheDocument()
       })
@@ -279,6 +293,7 @@ describe('EditQuoteAside', () => {
     const renderWithCurrency = (currency: CurrencyEnum | null) =>
       render(
         <EditQuoteAside
+          {...defaultPricingProps}
           quote={{
             ...mockQuote,
             // The customer currency no longer feeds this field — only the version's does.
@@ -324,6 +339,7 @@ describe('EditQuoteAside', () => {
 
         render(
           <EditQuoteAside
+            {...defaultPricingProps}
             quote={{
               ...mockQuote,
               currentVersion: { ...mockQuote.currentVersion, currency: CurrencyEnum.Eur },
@@ -364,6 +380,7 @@ describe('EditQuoteAside', () => {
 
         rerender(
           <EditQuoteAside
+            {...defaultPricingProps}
             quote={{
               ...mockQuote,
               customer: { ...mockQuote.customer, currency: CurrencyEnum.Gbp },
@@ -404,7 +421,7 @@ describe('EditQuoteAside', () => {
           },
         }
 
-        render(<EditQuoteAside quote={quoteWithSubscription} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={quoteWithSubscription} />)
 
         expect(screen.getByDisplayValue('Premium Plan - ext-sub-1')).toBeInTheDocument()
       })
@@ -414,28 +431,28 @@ describe('EditQuoteAside', () => {
   describe('GIVEN the footer actions', () => {
     describe('WHEN the component renders', () => {
       it('THEN should render the Download PDF button', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID)).toBeInTheDocument()
       })
 
       it('THEN should still render the Download PDF button without the quotesApprove permission', () => {
         mockHasPermissions.mockReturnValue(false)
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID)).toBeInTheDocument()
       })
 
       it('THEN should render the Approve button when the user has the quotesApprove permission', () => {
         mockHasPermissions.mockReturnValue(true)
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID)).toBeInTheDocument()
       })
 
       it('THEN should NOT render the Approve button without the quotesApprove permission', () => {
         mockHasPermissions.mockReturnValue(false)
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(screen.queryByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID)).not.toBeInTheDocument()
       })
@@ -443,7 +460,7 @@ describe('EditQuoteAside', () => {
 
     describe('WHEN the Download PDF button is clicked', () => {
       it('THEN should trigger a PDF download', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID))
 
@@ -451,7 +468,7 @@ describe('EditQuoteAside', () => {
       })
 
       it('THEN should build the PDF header from the quote number and version', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID))
 
@@ -468,7 +485,7 @@ describe('EditQuoteAside', () => {
 
     describe('WHEN the Approve button is clicked', () => {
       it('THEN should navigate to the approve quote page', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID))
 
@@ -478,7 +495,7 @@ describe('EditQuoteAside', () => {
 
     describe('WHEN the quote is saving', () => {
       it('THEN should disable both action buttons and show loading spinners', () => {
-        render(<EditQuoteAside quote={mockQuote} isSaving />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} isSaving />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID)).toBeDisabled()
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID)).toBeDisabled()
@@ -486,7 +503,7 @@ describe('EditQuoteAside', () => {
       })
 
       it('THEN should not trigger a PDF download while saving', () => {
-        render(<EditQuoteAside quote={mockQuote} isSaving />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} isSaving />)
 
         fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID))
 
@@ -494,7 +511,7 @@ describe('EditQuoteAside', () => {
       })
 
       it('THEN should not navigate to approve while saving', () => {
-        render(<EditQuoteAside quote={mockQuote} isSaving />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} isSaving />)
 
         fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID))
 
@@ -504,7 +521,7 @@ describe('EditQuoteAside', () => {
 
     describe('WHEN the quote is NOT saving', () => {
       it('THEN should not show any loading spinners', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(screen.queryAllByTestId(/processing/)).toHaveLength(0)
       })
@@ -513,7 +530,7 @@ describe('EditQuoteAside', () => {
   describe('GIVEN the customer row', () => {
     describe('WHEN the component renders', () => {
       it('THEN should link to the customer detail page', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_CUSTOMER_LINK_TEST_ID)).toHaveAttribute(
           'href',
@@ -522,7 +539,7 @@ describe('EditQuoteAside', () => {
       })
 
       it('THEN should display the customer name inside the link', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(screen.getByTestId(EDIT_QUOTE_ASIDE_CUSTOMER_LINK_TEST_ID)).toHaveTextContent(
           'Acme Corp',
@@ -534,13 +551,13 @@ describe('EditQuoteAside', () => {
   describe('GIVEN the billing entity row', () => {
     describe('WHEN the organization has several entities on a non-amendment quote', () => {
       it('THEN should render the picker', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(screen.getByTestId(BILLING_ENTITY_FORM_PICKER_DATA_TEST)).toBeInTheDocument()
       })
 
       it('THEN should request the inherit option', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(mockBillingEntitiesOptions).toHaveBeenCalledWith({ includeInheritOption: true })
       })
@@ -555,7 +572,7 @@ describe('EditQuoteAside', () => {
           hasMultipleEntities: false,
         })
 
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         expect(
           screen.queryByTestId(EDIT_QUOTE_ASIDE_BILLING_ENTITY_INPUT_TEST_ID),
@@ -568,6 +585,7 @@ describe('EditQuoteAside', () => {
       it('THEN should hide the row, because the backend rejects an entity there', () => {
         render(
           <EditQuoteAside
+            {...defaultPricingProps}
             quote={{ ...mockQuote, orderType: OrderTypeEnum.SubscriptionAmendment }}
           />,
         )
@@ -582,6 +600,7 @@ describe('EditQuoteAside', () => {
       it('THEN should preselect it', () => {
         render(
           <EditQuoteAside
+            {...defaultPricingProps}
             quote={{
               ...mockQuote,
               currentVersion: { ...mockQuote.currentVersion, billingEntityId: 'be-2' },
@@ -599,7 +618,7 @@ describe('EditQuoteAside', () => {
 
     describe('WHEN the version pins no entity', () => {
       it('THEN should preselect the inherit option rather than the customer entity', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         const input = screen
           .getByTestId(BILLING_ENTITY_FORM_PICKER_DATA_TEST)
@@ -612,7 +631,7 @@ describe('EditQuoteAside', () => {
       it('THEN should keep the inherit option displayed after the field loses focus', async () => {
         const user = userEvent.setup({ delay: null })
 
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         const input = screen
           .getByTestId(BILLING_ENTITY_FORM_PICKER_DATA_TEST)
@@ -631,7 +650,9 @@ describe('EditQuoteAside', () => {
         const user = userEvent.setup({ delay: null })
         const onSaveStart = jest.fn()
 
-        render(<EditQuoteAside quote={mockQuote} onSaveStart={onSaveStart} />)
+        render(
+          <EditQuoteAside {...defaultPricingProps} quote={mockQuote} onSaveStart={onSaveStart} />,
+        )
 
         const input = screen
           .getByTestId(BILLING_ENTITY_FORM_PICKER_DATA_TEST)
@@ -660,6 +681,7 @@ describe('EditQuoteAside', () => {
       const renderWithPinnedEntity = () =>
         render(
           <EditQuoteAside
+            {...defaultPricingProps}
             quote={{
               ...mockQuote,
               currentVersion: { ...mockQuote.currentVersion, billingEntityId: 'be-2' },
@@ -734,10 +756,11 @@ describe('EditQuoteAside', () => {
 
     describe('WHEN the version entity changes outside the form', () => {
       it('THEN should sync the field without issuing another save', async () => {
-        const { rerender } = render(<EditQuoteAside quote={mockQuote} />)
+        const { rerender } = render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         rerender(
           <EditQuoteAside
+            {...defaultPricingProps}
             quote={{
               ...mockQuote,
               currentVersion: { ...mockQuote.currentVersion, billingEntityId: 'be-2' },
@@ -763,7 +786,7 @@ describe('EditQuoteAside', () => {
 
     describe('WHEN the aside renders', () => {
       it('THEN should still show the currency, read-only', () => {
-        render(<EditQuoteAside quote={amendmentQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={amendmentQuote} />)
 
         const input = screen
           .getByTestId(EDIT_QUOTE_ASIDE_CURRENCY_COMBOBOX_TEST_ID)
@@ -774,7 +797,7 @@ describe('EditQuoteAside', () => {
       })
 
       it('THEN should leave it editable on every other order type', () => {
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         const input = screen
           .getByTestId(EDIT_QUOTE_ASIDE_CURRENCY_COMBOBOX_TEST_ID)
@@ -786,10 +809,13 @@ describe('EditQuoteAside', () => {
 
     describe('WHEN the field is driven programmatically', () => {
       it('THEN should still refuse to persist a currency', async () => {
-        const { rerender } = render(<EditQuoteAside quote={amendmentQuote} />)
+        const { rerender } = render(
+          <EditQuoteAside {...defaultPricingProps} quote={amendmentQuote} />,
+        )
 
         rerender(
           <EditQuoteAside
+            {...defaultPricingProps}
             quote={{
               ...amendmentQuote,
               currentVersion: { ...amendmentQuote.currentVersion, currency: CurrencyEnum.Jpy },
@@ -825,7 +851,7 @@ describe('EditQuoteAside', () => {
 
       respondWith({ billing_entity_name: 'Second Entity' })
 
-      render(<EditQuoteAside quote={mockQuote} />)
+      render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
       const input = screen
         .getByTestId(BILLING_ENTITY_FORM_PICKER_DATA_TEST)
@@ -858,6 +884,7 @@ describe('EditQuoteAside', () => {
 
       render(
         <EditQuoteAside
+          {...defaultPricingProps}
           quote={{
             ...mockQuote,
             currentVersion: { ...mockQuote.currentVersion, currency: CurrencyEnum.Eur },
@@ -910,7 +937,9 @@ describe('EditQuoteAside', () => {
           ],
         })
 
-        render(<EditQuoteAside quote={mockQuote} onSaveError={onSaveError} />)
+        render(
+          <EditQuoteAside {...defaultPricingProps} quote={mockQuote} onSaveError={onSaveError} />,
+        )
 
         const input = screen
           .getByTestId(BILLING_ENTITY_FORM_PICKER_DATA_TEST)
@@ -952,7 +981,7 @@ describe('EditQuoteAside', () => {
           ],
         })
 
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         const input = screen
           .getByTestId(BILLING_ENTITY_FORM_PICKER_DATA_TEST)
@@ -1001,7 +1030,7 @@ describe('EditQuoteAside', () => {
           ],
         })
 
-        render(<EditQuoteAside quote={mockQuote} />)
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
 
         const pickSecondEntity = async (): Promise<void> => {
           const input = screen
@@ -1033,6 +1062,116 @@ describe('EditQuoteAside', () => {
           { id: 'version-1', billingEntityId: 'be-2' },
           false,
         )
+      })
+    })
+  })
+  describe('GIVEN the pricing row', () => {
+    describe('WHEN the quote has a pricing block', () => {
+      it('THEN should display the priced entities and no add button', () => {
+        render(
+          <EditQuoteAside
+            {...defaultPricingProps}
+            quote={mockQuote}
+            pricingSummary="Premium plan"
+          />,
+        )
+
+        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_PRICING_LABEL_TEST_ID)).toBeInTheDocument()
+        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_PRICING_SUMMARY_TEST_ID)).toHaveTextContent(
+          'Premium plan',
+        )
+        expect(screen.queryByTestId(EDIT_QUOTE_ASIDE_PRICING_EMPTY_TEST_ID)).not.toBeInTheDocument()
+        expect(screen.queryByTestId(EDIT_QUOTE_ASIDE_ADD_PRICING_TEST_ID)).not.toBeInTheDocument()
+      })
+
+      it('THEN should list every add-on of a one-off quote', () => {
+        render(
+          <EditQuoteAside
+            {...defaultPricingProps}
+            quote={{ ...mockQuote, orderType: OrderTypeEnum.OneOff }}
+            pricingSummary="Setup fee, Support pack"
+          />,
+        )
+
+        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_PRICING_SUMMARY_TEST_ID)).toHaveTextContent(
+          'Setup fee, Support pack',
+        )
+      })
+    })
+
+    describe('WHEN the quote has no pricing block', () => {
+      it('THEN should display the empty label and the add button', () => {
+        render(
+          <EditQuoteAside {...defaultPricingProps} quote={mockQuote} hasPricingBlock={false} />,
+        )
+
+        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_PRICING_EMPTY_TEST_ID)).toBeInTheDocument()
+        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_ADD_PRICING_TEST_ID)).toBeInTheDocument()
+        expect(
+          screen.queryByTestId(EDIT_QUOTE_ASIDE_PRICING_SUMMARY_TEST_ID),
+        ).not.toBeInTheDocument()
+      })
+
+      it('THEN should open the pricing drawer when the add button is clicked', async () => {
+        const user = userEvent.setup()
+
+        render(
+          <EditQuoteAside {...defaultPricingProps} quote={mockQuote} hasPricingBlock={false} />,
+        )
+
+        await user.click(screen.getByTestId(EDIT_QUOTE_ASIDE_ADD_PRICING_TEST_ID))
+
+        expect(mockAddPricingBlock).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('GIVEN the approve button', () => {
+    describe('WHEN the quote has no pricing block', () => {
+      // The server stays the authority on approvability: a client-side false negative
+      // must never lock a user out of a legitimately approvable quote.
+      it('THEN should keep the approve button enabled', () => {
+        render(
+          <EditQuoteAside {...defaultPricingProps} quote={mockQuote} hasPricingBlock={false} />,
+        )
+
+        expect(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID)).not.toBeDisabled()
+      })
+
+      it('THEN should still navigate to the approval page when clicked', () => {
+        render(
+          <EditQuoteAside {...defaultPricingProps} quote={mockQuote} hasPricingBlock={false} />,
+        )
+
+        fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID))
+
+        expect(mockGoToApproveQuote).toHaveBeenCalledWith('quote-1', 'version-1')
+      })
+
+      it('THEN should explain the pricing requirement on hover', async () => {
+        const user = userEvent.setup()
+
+        render(
+          <EditQuoteAside {...defaultPricingProps} quote={mockQuote} hasPricingBlock={false} />,
+        )
+
+        await user.hover(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID))
+
+        expect(await screen.findByRole('tooltip')).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the quote has a pricing block', () => {
+      it('THEN should not explain the pricing requirement on hover', async () => {
+        const user = userEvent.setup()
+
+        render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
+
+        await user.hover(screen.getByTestId(EDIT_QUOTE_ASIDE_APPROVE_TEST_ID))
+
+        await waitFor(() => {
+          expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+        })
       })
     })
   })

--- a/translations/base.json
+++ b/translations/base.json
@@ -4894,6 +4894,5 @@
   "text_1788272907430gswzvnbqi2z": "Add a pricing block to the quote content before approving it.",
   "text_1788277738980lq42krzk56z": "This quote has no pricing block yet. Add one to define what the customer is billed for.",
   "text_1788277738981ng58j3nfudd": "Add pricing block",
-  "text_17882777389811he711tg7yj": "No pricing block",
   "text_1788330185449ifi9d6haua6": "This fee no longer exists, the invoice has been refreshed. Please review the updated fees and try again."
 }

--- a/translations/base.json
+++ b/translations/base.json
@@ -4891,5 +4891,8 @@
   "text_1788165722542bcdlld0bbxg": "Logs reflecting this rate card's activity.",
   "text_1788272700125nn7h1cyxjvf": "Add a pricing block with a plan to the quote content before approving it.",
   "text_1788272700125mb3btrwjl5b": "Add a pricing block with at least one add-on to the quote content before approving it.",
-  "text_1788272907430gswzvnbqi2z": "Add a pricing block to the quote content before approving it."
+  "text_1788272907430gswzvnbqi2z": "Add a pricing block to the quote content before approving it.",
+  "text_1788277738980lq42krzk56z": "This quote has no pricing block yet. Add one to define what the customer is billed for.",
+  "text_1788277738981ng58j3nfudd": "Add pricing block",
+  "text_17882777389811he711tg7yj": "No pricing block"
 }


### PR DESCRIPTION
## Context

LAGO-1869 made the approval failure legible: approving a quote with no pricing
block now explains what is missing instead of saying "Something went wrong".
That fixed the message, not the cause.

A pricing block could still only be inserted two ways, both of which require
already knowing they exist: typing `/` in the editor body and picking "Pricing"
from the slash menu, or the `+` on the block drag handle, which only appears on
hover. The Approve button was gated on permission alone, so nothing told a user
a pricing block was mandatory until the approval came back rejected.

## Description

Two affordances, both driven by the pricing blocks the editor already reports
through `onPricingBlocksChange`, seeded from the quote's saved `billingItems` so
an already-priced quote never paints the empty state.

- **Empty-state CTA under the editor** — a warning `Alert` with an "Add pricing
  block" button, rendered as a sibling of the `RichTextEditor` (never a TipTap
  node: a document node would be serialized into the quote content and the PDF).
  It disappears as soon as a block exists.
- **Pricing row in the aside** — the priced entity names when a block exists,
  otherwise "No pricing block" plus its own "Add pricing block" button. Names are
  deduped by entity id, since the pricing hooks index each add-on twice.
- **Approve tooltip** — while no pricing block exists, hovering Approve explains
  the requirement. The button stays enabled on purpose: the server remains the
  authority on approvability, and a client-side false negative must not lock a
  user out of a legitimately approvable quote.

Both buttons run the very command the slash menu runs: the three steps of the
"Pricing" item are extracted into an exported `insertPricingBlock` helper, exposed
to the page through `insertPricingBlockRef` on `RichTextEditor` and routed through
`handlePricingCommand`, so the unified content+billingItems save and the rollback
of a failed insert still own the write path. The out-of-editor callers append at
an explicit numeric position: an editor the user never clicked into still sits on
`Selection.atStart`, and `focus('end')` would resolve to a NodeSelection that
`insertContent` replaces — silently deleting a trailing divider, image or block.

Works for all three order types; the one-off path prices add-ons, so no copy
assumes a plan.

## Needs product sign-off

Three new translation keys ship with placeholder copy: the CTA body, the "Add
pricing block" button label, and the empty Pricing row value. The Approve tooltip
reuses the existing `text_1788272907430gswzvnbqi2z` shipped with LAGO-1869.

<!-- Linear link -->
Fixes LAGO-1870
