### PR TITLE
fix(invoices): handle a stale draft-invoice fee with an actionable error

### DIFF
--- a/src/components/invoices/details/EditFeeDrawer.tsx
+++ b/src/components/invoices/details/EditFeeDrawer.tsx
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql, useApolloClient } from '@apollo/client'
 import InputAdornment from '@mui/material/InputAdornment'
 import { useFormik } from 'formik'
 import { tw } from 'lago-design-system'
@@ -12,6 +12,7 @@ import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Typography } from '~/components/designSystem/Typography'
 import { AmountInputField, ComboBox, ComboBoxField, TextInputField } from '~/components/form'
 import { DrawerLayout } from '~/components/layouts/Drawer'
+import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { ALL_CHARGE_MODELS, ALL_FILTER_VALUES } from '~/core/constants/form'
 import { TExtendedRemainingFee } from '~/core/formats/formatInvoiceItemsMap'
 import { getCurrencySymbol, intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -24,6 +25,7 @@ import {
   FeeForCreateFeeDrawerFragment,
   FixedCharge,
   FixedChargeChargeModelEnum,
+  LagoApiError,
   useCreateAdjustedFeeMutation,
   useGetInvoiceDetailsForCreateFeeDrawerQuery,
 } from '~/generated/graphql'
@@ -32,6 +34,7 @@ import { OnRegeneratedFeeAdd } from '~/pages/CustomerInvoiceRegenerate'
 
 import { InvoiceTableSection } from './InvoiceDetailsTable'
 import { InvoiceDetailsTableBodyLine } from './InvoiceDetailsTableBodyLine'
+import { EDIT_FEE_DRAWER_SUBMIT_BUTTON_TEST_ID } from './invoiceDetailsTestIds'
 import {
   getChargesComboboxDataFromInvoiceSubscription,
   getChargesFiltersComboboxDataFromInvoiceSubscription,
@@ -206,6 +209,7 @@ type formikValues = Omit<Partial<CreateAdjustedFeeInput>, 'feeId'> & {
 
 export const EditFeeDrawer = forwardRef<EditFeeDrawerRef>((_, ref) => {
   const { translate } = useInternationalization()
+  const client = useApolloClient()
   const drawerRef = useRef<DrawerRef>(null)
   const [localData, setLocalData] = useState<EditFeeDrawerProps | undefined>(undefined)
   const isRegenerateMode = localData?.mode === 'regenerate'
@@ -248,6 +252,21 @@ export const EditFeeDrawer = forwardRef<EditFeeDrawerRef>((_, ref) => {
   )
 
   const [createFee] = useCreateAdjustedFeeMutation({
+    // Draft fees are destroyed and recreated when the draft is refreshed server-side, so a
+    // row rendered before that refresh submits a `feeId` the API can no longer resolve.
+    context: { silentErrorCodes: [LagoApiError.NotFound] },
+    onError(error) {
+      if (!isEditMode || !hasDefinedGQLError('NotFound', error, 'fee')) {
+        addToast({ severity: 'danger', translateKey: 'text_622f7a3dc32ce100c46a5154' })
+
+        return
+      }
+
+      addToast({ severity: 'danger', translateKey: 'text_1788330185449ifi9d6haua6' })
+      drawerRef.current?.closeDrawer()
+      resetForm()
+      client.refetchQueries({ include: ['getInvoiceDetails', 'getInvoiceFees'] })
+    },
     onCompleted({ createAdjustedFee }) {
       if (createAdjustedFee?.id) {
         // Close drawer
@@ -767,6 +786,7 @@ export const EditFeeDrawer = forwardRef<EditFeeDrawerRef>((_, ref) => {
             </Button>
 
             <Button
+              data-test={EDIT_FEE_DRAWER_SUBMIT_BUTTON_TEST_ID}
               disabled={!formikProps.isValid || !formikProps.dirty || !isChargeFilterIdValid}
               loading={formikProps.isSubmitting}
               onClick={formikProps.submitForm}

--- a/src/components/invoices/details/EditFeeDrawer.tsx
+++ b/src/components/invoices/details/EditFeeDrawer.tsx
@@ -256,16 +256,20 @@ export const EditFeeDrawer = forwardRef<EditFeeDrawerRef>((_, ref) => {
     // row rendered before that refresh submits a `feeId` the API can no longer resolve.
     context: { silentErrorCodes: [LagoApiError.NotFound] },
     onError(error) {
-      if (!isEditMode || !hasDefinedGQLError('NotFound', error, 'fee')) {
-        addToast({ severity: 'danger', translateKey: 'text_622f7a3dc32ce100c46a5154' })
+      // Only `not_found` is silenced, so every other code is still the global error link's to
+      // toast and report — re-toasting it here would only be saved by addToast's dedupe.
+      if (!hasDefinedGQLError('NotFound', error)) return
+
+      if (isEditMode && hasDefinedGQLError('NotFound', error, 'fee')) {
+        addToast({ severity: 'danger', translateKey: 'text_1788330185449ifi9d6haua6' })
+        drawerRef.current?.closeDrawer()
+        resetForm()
+        client.refetchQueries({ include: ['getInvoiceDetails', 'getInvoiceFees'] })
 
         return
       }
 
-      addToast({ severity: 'danger', translateKey: 'text_1788330185449ifi9d6haua6' })
-      drawerRef.current?.closeDrawer()
-      resetForm()
-      client.refetchQueries({ include: ['getInvoiceDetails', 'getInvoiceFees'] })
+      addToast({ severity: 'danger', translateKey: 'text_622f7a3dc32ce100c46a5154' })
     },
     onCompleted({ createAdjustedFee }) {
       if (createAdjustedFee?.id) {

--- a/src/components/invoices/details/__tests__/EditFeeDrawer.test.tsx
+++ b/src/components/invoices/details/__tests__/EditFeeDrawer.test.tsx
@@ -82,15 +82,22 @@ const settleDrawerTransition = async (): Promise<void> => {
   })
 }
 
-const renderEditDrawer = (): void => {
+const renderAndOpenDrawer = (data: Parameters<EditFeeDrawerRef['openDrawer']>[0]): void => {
   const ref = createRef<EditFeeDrawerRef>()
 
   render(<EditFeeDrawer ref={ref} />)
 
   act(() => {
-    ref.current?.openDrawer({ mode: 'edit', invoiceId: 'invoice-1', fee: buildFee() })
+    ref.current?.openDrawer(data)
   })
+
+  // Guard the precondition: the close assertions below are negative, so a drawer that silently
+  // failed to open would let them pass without proving anything.
+  expect(screen.getByTestId(EDIT_FEE_DRAWER_SUBMIT_BUTTON_TEST_ID)).toBeInTheDocument()
 }
+
+const renderEditDrawer = (): void =>
+  renderAndOpenDrawer({ mode: 'edit', invoiceId: 'invoice-1', fee: buildFee() })
 
 describe('EditFeeDrawer', () => {
   beforeEach(() => {
@@ -99,6 +106,14 @@ describe('EditFeeDrawer', () => {
   })
 
   describe('GIVEN the drawer is open in edit mode', () => {
+    describe('WHEN openDrawer is called with a fee', () => {
+      it('THEN should render the drawer body', () => {
+        renderEditDrawer()
+
+        expect(screen.getByTestId(EDIT_FEE_DRAWER_SUBMIT_BUTTON_TEST_ID)).toBeInTheDocument()
+      })
+    })
+
     describe('WHEN the createAdjustedFee mutation is configured', () => {
       it('THEN should silence not_found so the global error link stops toasting it generically', () => {
         renderEditDrawer()
@@ -220,16 +235,10 @@ describe('EditFeeDrawer', () => {
       // No feeId is submitted in add mode, so a not_found can never be the stale-fee case —
       // claiming "this fee no longer exists" there would be plainly wrong.
       it('THEN should fall back to the generic toast', () => {
-        const ref = createRef<EditFeeDrawerRef>()
-
-        render(<EditFeeDrawer ref={ref} />)
-
-        act(() => {
-          ref.current?.openDrawer({
-            mode: 'add',
-            invoiceId: 'invoice-1',
-            invoiceSubscriptionId: 'sub-1',
-          })
+        renderAndOpenDrawer({
+          mode: 'add',
+          invoiceId: 'invoice-1',
+          invoiceSubscriptionId: 'sub-1',
         })
 
         act(() => {

--- a/src/components/invoices/details/__tests__/EditFeeDrawer.test.tsx
+++ b/src/components/invoices/details/__tests__/EditFeeDrawer.test.tsx
@@ -1,0 +1,225 @@
+import { ApolloError } from '@apollo/client'
+import { act, screen } from '@testing-library/react'
+import { createRef } from 'react'
+
+import { TExtendedRemainingFee } from '~/core/formats/formatInvoiceItemsMap'
+import { CurrencyEnum, LagoApiError } from '~/generated/graphql'
+import { render } from '~/test-utils'
+
+import { EditFeeDrawer, EditFeeDrawerRef } from '../EditFeeDrawer'
+import { EDIT_FEE_DRAWER_SUBMIT_BUTTON_TEST_ID } from '../invoiceDetailsTestIds'
+
+const GENERIC_ERROR_KEY = 'text_622f7a3dc32ce100c46a5154'
+const STALE_FEE_ERROR_KEY = 'text_1788330185449ifi9d6haua6'
+
+type MutationConfig = {
+  context?: { silentErrorCodes?: unknown[] }
+  onError?: (error: ApolloError) => void
+}
+
+// EditFeeDrawer reaches `~/components/drawers/useDrawer` through the invoice table it renders,
+// and jest cannot parse the `import.meta` in its drawerStack module.
+jest.mock('~/components/drawers/useDrawer', () => ({
+  useDrawer: () => ({ open: jest.fn(), close: jest.fn() }),
+  useFormDrawer: () => ({ open: jest.fn(), close: jest.fn() }),
+}))
+
+const mockCreateFee = jest.fn()
+let mockMutationConfig: MutationConfig | undefined
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useCreateAdjustedFeeMutation: (config: MutationConfig) => {
+    mockMutationConfig = config
+    return [mockCreateFee]
+  },
+  useGetInvoiceDetailsForCreateFeeDrawerQuery: () => ({
+    loading: false,
+    data: undefined,
+    refetch: jest.fn(),
+  }),
+}))
+
+const mockAddToast = jest.fn()
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: (...args: unknown[]) => mockAddToast(...args),
+}))
+
+const mockRefetchQueries = jest.fn()
+
+jest.mock('@apollo/client', () => ({
+  ...jest.requireActual('@apollo/client'),
+  useApolloClient: () => ({ refetchQueries: mockRefetchQueries }),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+const buildFee = (overrides: Partial<TExtendedRemainingFee> = {}): TExtendedRemainingFee =>
+  ({
+    id: 'fee-1',
+    currency: CurrencyEnum.Usd,
+    itemName: 'Premium plan',
+    units: 1,
+    ...overrides,
+  }) as TExtendedRemainingFee
+
+const buildError = (code: LagoApiError, details?: Record<string, string[]>): ApolloError =>
+  ({
+    graphQLErrors: [{ message: 'error', extensions: details ? { code, details } : { code } }],
+  }) as unknown as ApolloError
+
+// The MUI Drawer keeps its children mounted for the length of its close transition, so both
+// the "closed" and the "still open" assertions have to look after that window, not before it.
+const settleDrawerTransition = async (): Promise<void> => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 400))
+  })
+}
+
+const renderEditDrawer = (): void => {
+  const ref = createRef<EditFeeDrawerRef>()
+
+  render(<EditFeeDrawer ref={ref} />)
+
+  act(() => {
+    ref.current?.openDrawer({ mode: 'edit', invoiceId: 'invoice-1', fee: buildFee() })
+  })
+}
+
+describe('EditFeeDrawer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockMutationConfig = undefined
+  })
+
+  describe('GIVEN the drawer is open in edit mode', () => {
+    describe('WHEN the createAdjustedFee mutation is configured', () => {
+      it('THEN should silence not_found so the global error link stops toasting it generically', () => {
+        renderEditDrawer()
+
+        expect(mockMutationConfig?.context?.silentErrorCodes).toContain(LagoApiError.NotFound)
+      })
+    })
+
+    describe('WHEN the mutation fails because the fee no longer exists', () => {
+      // Draft fees are recreated with new ids when the draft is refreshed server-side, so a row
+      // rendered before that refresh submits a feeId the API 404s on. Before this was handled the
+      // user got the generic "an error occurred" toast and a drawer stuck on the stale id.
+      const failWithStaleFee = (): void => {
+        renderEditDrawer()
+
+        act(() => {
+          mockMutationConfig?.onError?.(buildError(LagoApiError.NotFound, { fee: ['not_found'] }))
+        })
+      }
+
+      it('THEN should show the dedicated stale-fee toast rather than the generic one', () => {
+        failWithStaleFee()
+
+        expect(mockAddToast).toHaveBeenCalledWith({
+          severity: 'danger',
+          translateKey: STALE_FEE_ERROR_KEY,
+        })
+      })
+
+      it('THEN should close the drawer instead of leaving it on the stale fee', async () => {
+        failWithStaleFee()
+
+        await settleDrawerTransition()
+
+        expect(screen.queryByTestId(EDIT_FEE_DRAWER_SUBMIT_BUTTON_TEST_ID)).not.toBeInTheDocument()
+      })
+
+      it('THEN should refetch the invoice so the rows carry the new fee ids', () => {
+        failWithStaleFee()
+
+        expect(mockRefetchQueries).toHaveBeenCalledWith({
+          include: ['getInvoiceDetails', 'getInvoiceFees'],
+        })
+      })
+    })
+
+    describe('WHEN the mutation fails for a reason unrelated to the fee', () => {
+      it.each([
+        [
+          'a not_found pointing at another resource',
+          LagoApiError.NotFound,
+          { charge: ['not_found'] },
+        ],
+        ['a validation error', LagoApiError.UnprocessableEntity, undefined],
+      ])('THEN should fall back to the generic toast on %s', (_, code, details) => {
+        renderEditDrawer()
+
+        act(() => {
+          mockMutationConfig?.onError?.(buildError(code, details))
+        })
+
+        expect(mockAddToast).toHaveBeenCalledWith({
+          severity: 'danger',
+          translateKey: GENERIC_ERROR_KEY,
+        })
+      })
+
+      it('THEN should keep the drawer open so the user can retry', async () => {
+        renderEditDrawer()
+
+        act(() => {
+          mockMutationConfig?.onError?.(
+            buildError(LagoApiError.NotFound, { charge: ['not_found'] }),
+          )
+        })
+
+        await settleDrawerTransition()
+
+        expect(screen.getByTestId(EDIT_FEE_DRAWER_SUBMIT_BUTTON_TEST_ID)).toBeInTheDocument()
+      })
+
+      it('THEN should not refetch the invoice', () => {
+        renderEditDrawer()
+
+        act(() => {
+          mockMutationConfig?.onError?.(
+            buildError(LagoApiError.NotFound, { charge: ['not_found'] }),
+          )
+        })
+
+        expect(mockRefetchQueries).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN the drawer is open in add mode', () => {
+    describe('WHEN the mutation fails with a bare not_found', () => {
+      // No feeId is submitted in add mode, so a not_found can never be the stale-fee case —
+      // claiming "this fee no longer exists" there would be plainly wrong.
+      it('THEN should fall back to the generic toast', () => {
+        const ref = createRef<EditFeeDrawerRef>()
+
+        render(<EditFeeDrawer ref={ref} />)
+
+        act(() => {
+          ref.current?.openDrawer({
+            mode: 'add',
+            invoiceId: 'invoice-1',
+            invoiceSubscriptionId: 'sub-1',
+          })
+        })
+
+        act(() => {
+          mockMutationConfig?.onError?.(buildError(LagoApiError.NotFound))
+        })
+
+        expect(mockAddToast).toHaveBeenCalledWith({
+          severity: 'danger',
+          translateKey: GENERIC_ERROR_KEY,
+        })
+      })
+    })
+  })
+})

--- a/src/components/invoices/details/__tests__/EditFeeDrawer.test.tsx
+++ b/src/components/invoices/details/__tests__/EditFeeDrawer.test.tsx
@@ -145,20 +145,19 @@ describe('EditFeeDrawer', () => {
       })
     })
 
-    describe('WHEN the mutation fails for a reason unrelated to the fee', () => {
-      it.each([
-        [
-          'a not_found pointing at another resource',
-          LagoApiError.NotFound,
-          { charge: ['not_found'] },
-        ],
-        ['a validation error', LagoApiError.UnprocessableEntity, undefined],
-      ])('THEN should fall back to the generic toast on %s', (_, code, details) => {
+    describe('WHEN the mutation fails with a not_found pointing at another resource', () => {
+      const failWithOtherNotFound = (): void => {
         renderEditDrawer()
 
         act(() => {
-          mockMutationConfig?.onError?.(buildError(code, details))
+          mockMutationConfig?.onError?.(
+            buildError(LagoApiError.NotFound, { charge: ['not_found'] }),
+          )
         })
+      }
+
+      it('THEN should fall back to the generic toast, since not_found is silenced here', () => {
+        failWithOtherNotFound()
 
         expect(mockAddToast).toHaveBeenCalledWith({
           severity: 'danger',
@@ -167,13 +166,7 @@ describe('EditFeeDrawer', () => {
       })
 
       it('THEN should keep the drawer open so the user can retry', async () => {
-        renderEditDrawer()
-
-        act(() => {
-          mockMutationConfig?.onError?.(
-            buildError(LagoApiError.NotFound, { charge: ['not_found'] }),
-          )
-        })
+        failWithOtherNotFound()
 
         await settleDrawerTransition()
 
@@ -181,14 +174,42 @@ describe('EditFeeDrawer', () => {
       })
 
       it('THEN should not refetch the invoice', () => {
+        failWithOtherNotFound()
+
+        expect(mockRefetchQueries).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the mutation fails with a code the global error link still handles', () => {
+      // Only not_found is silenced, so the link still toasts and reports these itself. Toasting
+      // here too would queue a second identical toast and lean on addToast's translateKey dedupe.
+      it.each([
+        ['a validation error', LagoApiError.UnprocessableEntity, undefined],
+        [
+          'a validation error carrying details',
+          LagoApiError.UnprocessableEntity,
+          { units: ['value_is_out_of_range'] },
+        ],
+      ])('THEN should leave the toast to the error link on %s', (_, code, details) => {
         renderEditDrawer()
 
         act(() => {
-          mockMutationConfig?.onError?.(
-            buildError(LagoApiError.NotFound, { charge: ['not_found'] }),
-          )
+          mockMutationConfig?.onError?.(buildError(code, details))
         })
 
+        expect(mockAddToast).not.toHaveBeenCalled()
+      })
+
+      it('THEN should keep the drawer open and not refetch', async () => {
+        renderEditDrawer()
+
+        act(() => {
+          mockMutationConfig?.onError?.(buildError(LagoApiError.UnprocessableEntity))
+        })
+
+        await settleDrawerTransition()
+
+        expect(screen.getByTestId(EDIT_FEE_DRAWER_SUBMIT_BUTTON_TEST_ID)).toBeInTheDocument()
         expect(mockRefetchQueries).not.toHaveBeenCalled()
       })
     })

--- a/src/components/invoices/details/invoiceDetailsTestIds.ts
+++ b/src/components/invoices/details/invoiceDetailsTestIds.ts
@@ -19,5 +19,8 @@ export const VIEW_FEE_DETAILS_OVERVIEW_TEST_ID = 'view-fee-details-overview'
 export const VIEW_FEE_DETAILS_SOURCE_ITEM_TEST_ID = 'view-fee-details-source-item'
 export const VIEW_FEE_DETAILS_PGK_TABLE_TEST_ID = 'view-fee-details-pgk-table'
 
+// EditFeeDrawer — the add/edit/regenerate fee drawer
+export const EDIT_FEE_DRAWER_SUBMIT_BUTTON_TEST_ID = 'edit-fee-drawer-submit-button'
+
 // InvoiceDetailsTableBodyLine — clickable fee row (dynamic id appended)
 export const FEE_ROW_TEST_ID_PREFIX = 'fee-row'

--- a/translations/base.json
+++ b/translations/base.json
@@ -4891,5 +4891,6 @@
   "text_1788165722542bcdlld0bbxg": "Logs reflecting this rate card's activity.",
   "text_1788272700125nn7h1cyxjvf": "Add a pricing block with a plan to the quote content before approving it.",
   "text_1788272700125mb3btrwjl5b": "Add a pricing block with at least one add-on to the quote content before approving it.",
-  "text_1788272907430gswzvnbqi2z": "Add a pricing block to the quote content before approving it."
+  "text_1788272907430gswzvnbqi2z": "Add a pricing block to the quote content before approving it.",
+  "text_1788330185449ifi9d6haua6": "This fee no longer exists, the invoice has been refreshed. Please review the updated fees and try again."
 }


### PR DESCRIPTION
## Context

Sentry reported `createAdjustedFee` returning a 404 with `{"fee":["not_found"]}` while a user was editing a fee on a draft invoice.

Draft invoice fees are destroyed and recreated server-side when the draft is refreshed, which changes their ids. A row rendered before such a refresh still holds the old id, so opening it and submitting sends a fee id that no longer exists — the backend 404 is correct, the front-end is acting on stale data.

The error was not silenced, so the global Apollo error link fired the generic "an error occurred" toast, reported to Sentry, and left the drawer open with the stale `feeId` still in the form. Every retry failed the same way.

## Description

`EditFeeDrawer` now handles the not-found case itself:

- `context.silentErrorCodes` lists `NotFound`, so the global error link stops toasting it generically and stops reporting it to Sentry.
- `onError` tells the stale-fee case apart with `hasDefinedGQLError('NotFound', error, 'fee')`, guarded on edit mode since no `feeId` is submitted otherwise. It shows a dedicated message, closes the drawer, resets the form so the stale id is dropped, and refetches `getInvoiceDetails` / `getInvoiceFees` so the rows come back with the new ids.
- Any other error on the mutation keeps the generic toast, so nothing else changes behaviour.

Adds a test id on the drawer's submit button and a test file covering the toast, the drawer close, the refetch, and the fallback for unrelated errors.

<!-- Linear link -->
Fixes LAGO-1868

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4xZj5kLpJAPxecsH5qHHT)_