### PR TITLE
fix(details): Wrap and truncate long descriptions on details overviews

### DIFF
--- a/src/components/billableMetrics/BillableMetricDetailsOverview.tsx
+++ b/src/components/billableMetrics/BillableMetricDetailsOverview.tsx
@@ -4,6 +4,10 @@ import { useParams } from 'react-router-dom'
 import { CodeSnippet } from '~/components/CodeSnippet'
 import { Accordion } from '~/components/designSystem/Accordion'
 import { Chip } from '~/components/designSystem/Chip'
+import {
+  MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT,
+  ShowMoreText,
+} from '~/components/designSystem/ShowMoreText'
 import { Typography } from '~/components/designSystem/Typography'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
@@ -84,7 +88,14 @@ export const BillableMetricDetailsOverview = () => {
             <DetailsPage.InfoGridItem
               className="col-span-2"
               label={translate('text_6388b923e514213fed58331c')}
-              value={billableMetric?.description}
+              value={
+                <ShowMoreText
+                  variant="body"
+                  color="grey700"
+                  text={billableMetric.description}
+                  limit={MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT}
+                />
+              }
             />
           )}
         </div>

--- a/src/components/billableMetrics/__tests__/BillableMetricDetailsOverview.test.tsx
+++ b/src/components/billableMetrics/__tests__/BillableMetricDetailsOverview.test.tsx
@@ -1,0 +1,108 @@
+import { act, render as rtlRender, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { SHOW_MORE_TEXT_BUTTON_TEST_ID } from '~/components/designSystem/ShowMoreText'
+import {
+  AggregationTypeEnum,
+  GetBillableMetricForDetailsOverviewDocument,
+} from '~/generated/graphql'
+import { AllTheProviders } from '~/test-utils'
+
+import { BillableMetricDetailsOverview } from '../BillableMetricDetailsOverview'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+const billableMetricFixture = {
+  __typename: 'BillableMetric',
+  id: 'bm-1',
+  name: 'API calls',
+  code: 'api_calls',
+  description: 'Counts every API call',
+  aggregationType: AggregationTypeEnum.CountAgg,
+  fieldName: null,
+  recurring: false,
+  expression: null,
+  weightedInterval: null,
+  roundingFunction: null,
+  roundingPrecision: null,
+  filters: [],
+}
+
+const UNBREAKABLE_DESCRIPTION = 'a'.repeat(500)
+
+const overviewQueryMockFactory = (billableMetric: Record<string, unknown>) => ({
+  request: { query: GetBillableMetricForDetailsOverviewDocument, variables: { id: 'bm-1' } },
+  result: { data: { billableMetric } },
+})
+
+// forceTypenames + __typename in the fixture: the query spreads fragments, and
+// the cache only writes fragment fields when it can match the typename.
+const renderOverview = (billableMetric: Record<string, unknown> = billableMetricFixture) =>
+  rtlRender(<BillableMetricDetailsOverview />, {
+    wrapper: ({ children }) => (
+      <AllTheProviders
+        forceTypenames
+        mocks={[overviewQueryMockFactory(billableMetric)]}
+        useParams={{ billableMetricId: 'bm-1' }}
+      >
+        {children}
+      </AllTheProviders>
+    ),
+  })
+
+describe('BillableMetricDetailsOverview', () => {
+  describe('GIVEN a billable metric with a short description', () => {
+    describe('WHEN the overview loads', () => {
+      it('THEN displays the name, code and description', async () => {
+        await act(() => renderOverview())
+
+        expect(await screen.findByText('API calls')).toBeInTheDocument()
+        expect(screen.getByText('api_calls')).toBeInTheDocument()
+        expect(screen.getByText('Counts every API call')).toBeInTheDocument()
+        expect(screen.queryByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a billable metric without a description', () => {
+    describe('WHEN the overview loads', () => {
+      it('THEN omits the description row', async () => {
+        await act(() => renderOverview({ ...billableMetricFixture, description: null }))
+
+        await screen.findByText('API calls')
+
+        expect(screen.queryByText('text_6388b923e514213fed58331c')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a description longer than the display limit', () => {
+    describe('WHEN the overview loads', () => {
+      it('THEN truncates it behind a "See more" button', async () => {
+        await act(() =>
+          renderOverview({ ...billableMetricFixture, description: UNBREAKABLE_DESCRIPTION }),
+        )
+
+        await screen.findByText('API calls')
+
+        expect(screen.queryByText(UNBREAKABLE_DESCRIPTION)).not.toBeInTheDocument()
+        expect(screen.getByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID)).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN "See more" is clicked', () => {
+      it('THEN reveals the whole description, wrapping mid-word', async () => {
+        await act(() =>
+          renderOverview({ ...billableMetricFixture, description: UNBREAKABLE_DESCRIPTION }),
+        )
+
+        await screen.findByText('API calls')
+        await userEvent.click(screen.getByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID))
+
+        expect(screen.getByText(UNBREAKABLE_DESCRIPTION)).toHaveClass('line-break-anywhere')
+      })
+    })
+  })
+})

--- a/src/components/designSystem/ShowMoreText.tsx
+++ b/src/components/designSystem/ShowMoreText.tsx
@@ -10,6 +10,7 @@ interface ShowMoreTextProps extends TypographyProps {
 }
 
 export const MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT = 250
+export const SHOW_MORE_TEXT_BUTTON_TEST_ID = 'show-more-text-button'
 
 export const ShowMoreText = ({ text, limit, showMore, ...props }: ShowMoreTextProps) => {
   const { translate } = useInternationalization()
@@ -29,6 +30,7 @@ export const ShowMoreText = ({ text, limit, showMore, ...props }: ShowMoreTextPr
         {!showMore || typeof showMore === 'string' ? (
           <button
             className="h-auto rounded-none p-0 focus:ring"
+            data-test={SHOW_MORE_TEXT_BUTTON_TEST_ID}
             onClick={() => setIsTextTruncated(false)}
           >
             {showMore ? showMore : translate('text_62bdbf07117c3d1f178d6517')}

--- a/src/components/designSystem/__tests__/ShowMoreText.test.tsx
+++ b/src/components/designSystem/__tests__/ShowMoreText.test.tsx
@@ -1,0 +1,91 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { render } from '~/test-utils'
+
+import {
+  MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT,
+  SHOW_MORE_TEXT_BUTTON_TEST_ID,
+  ShowMoreText,
+} from '../ShowMoreText'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+const UNBREAKABLE_TEXT = 'a'.repeat(500)
+
+describe('ShowMoreText', () => {
+  describe('GIVEN a text shorter than the limit', () => {
+    describe('WHEN the component renders', () => {
+      it('THEN displays the whole text without a "See more" button', () => {
+        render(<ShowMoreText text="A short description" limit={20} />)
+
+        expect(screen.getByText('A short description')).toBeInTheDocument()
+        expect(screen.queryByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID)).not.toBeInTheDocument()
+      })
+
+      it('THEN lets an unbreakable word wrap mid-word', () => {
+        render(<ShowMoreText text={UNBREAKABLE_TEXT} limit={UNBREAKABLE_TEXT.length} />)
+
+        expect(screen.getByText(UNBREAKABLE_TEXT)).toHaveClass('line-break-anywhere')
+      })
+    })
+  })
+
+  describe('GIVEN a text longer than the limit', () => {
+    describe('WHEN the component renders', () => {
+      it('THEN truncates it behind a "See more" button', () => {
+        render(
+          <ShowMoreText text={UNBREAKABLE_TEXT} limit={MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT} />,
+        )
+
+        expect(screen.queryByText(UNBREAKABLE_TEXT)).not.toBeInTheDocument()
+        expect(screen.getByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID)).toBeInTheDocument()
+      })
+
+      it('THEN lets the truncated part wrap mid-word', () => {
+        render(
+          <ShowMoreText text={UNBREAKABLE_TEXT} limit={MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT} />,
+        )
+
+        expect(
+          screen.getByText(
+            `${UNBREAKABLE_TEXT.substring(0, MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT)}...`,
+          ),
+        ).toHaveClass('line-break-anywhere')
+      })
+    })
+
+    describe('WHEN the "See more" button is clicked', () => {
+      it('THEN reveals the whole text and drops the button', async () => {
+        render(
+          <ShowMoreText text={UNBREAKABLE_TEXT} limit={MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT} />,
+        )
+
+        await userEvent.click(screen.getByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID))
+
+        expect(screen.getByText(UNBREAKABLE_TEXT)).toHaveClass('line-break-anywhere')
+        expect(screen.queryByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a custom showMore element', () => {
+    describe('WHEN it is clicked', () => {
+      it('THEN reveals the whole text', async () => {
+        render(
+          <ShowMoreText
+            text={UNBREAKABLE_TEXT}
+            limit={MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT}
+            showMore={<button>Read it all</button>}
+          />,
+        )
+
+        await userEvent.click(screen.getByRole('button', { name: 'Read it all' }))
+
+        expect(screen.getByText(UNBREAKABLE_TEXT)).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/components/features/FeatureDetailsOverview.tsx
+++ b/src/components/features/FeatureDetailsOverview.tsx
@@ -2,6 +2,10 @@ import { gql } from '@apollo/client'
 import { useParams } from 'react-router-dom'
 
 import { Accordion } from '~/components/designSystem/Accordion'
+import {
+  MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT,
+  ShowMoreText,
+} from '~/components/designSystem/ShowMoreText'
 import { Typography } from '~/components/designSystem/Typography'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
@@ -80,7 +84,14 @@ export const FeatureDetailsOverview = () => {
             <DetailsPage.InfoGridItem
               className="col-span-2"
               label={translate('text_6388b923e514213fed58331c')}
-              value={feature?.description}
+              value={
+                <ShowMoreText
+                  variant="body"
+                  color="grey700"
+                  text={feature.description}
+                  limit={MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT}
+                />
+              }
             />
           )}
         </div>

--- a/src/components/features/__tests__/FeatureDetailsOverview.test.tsx
+++ b/src/components/features/__tests__/FeatureDetailsOverview.test.tsx
@@ -1,0 +1,94 @@
+import { act, render as rtlRender, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { SHOW_MORE_TEXT_BUTTON_TEST_ID } from '~/components/designSystem/ShowMoreText'
+import { GetFeatureForDetailsOverviewDocument } from '~/generated/graphql'
+import { AllTheProviders } from '~/test-utils'
+
+import { FeatureDetailsOverview } from '../FeatureDetailsOverview'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+const featureFixture = {
+  __typename: 'FeatureObject',
+  id: 'feat-1',
+  name: 'Seats',
+  code: 'seats',
+  description: 'Number of seats',
+  privileges: [],
+}
+
+const UNBREAKABLE_DESCRIPTION = 'a'.repeat(500)
+
+const overviewQueryMockFactory = (feature: Record<string, unknown>) => ({
+  request: { query: GetFeatureForDetailsOverviewDocument, variables: { id: 'feat-1' } },
+  result: { data: { feature } },
+})
+
+// forceTypenames + __typename in the fixture: the query spreads fragments, and
+// the cache only writes fragment fields when it can match the typename.
+const renderOverview = (feature: Record<string, unknown> = featureFixture) =>
+  rtlRender(<FeatureDetailsOverview />, {
+    wrapper: ({ children }) => (
+      <AllTheProviders
+        forceTypenames
+        mocks={[overviewQueryMockFactory(feature)]}
+        useParams={{ featureId: 'feat-1' }}
+      >
+        {children}
+      </AllTheProviders>
+    ),
+  })
+
+describe('FeatureDetailsOverview', () => {
+  describe('GIVEN a feature with a short description', () => {
+    describe('WHEN the overview loads', () => {
+      it('THEN displays the name, code and description', async () => {
+        await act(() => renderOverview())
+
+        expect(await screen.findByText('Seats')).toBeInTheDocument()
+        expect(screen.getByText('seats')).toBeInTheDocument()
+        expect(screen.getByText('Number of seats')).toBeInTheDocument()
+        expect(screen.queryByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a feature without a description', () => {
+    describe('WHEN the overview loads', () => {
+      it('THEN omits the description row', async () => {
+        await act(() => renderOverview({ ...featureFixture, description: null }))
+
+        await screen.findByText('Seats')
+
+        expect(screen.queryByText('text_6388b923e514213fed58331c')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a description longer than the display limit', () => {
+    describe('WHEN the overview loads', () => {
+      it('THEN truncates it behind a "See more" button', async () => {
+        await act(() => renderOverview({ ...featureFixture, description: UNBREAKABLE_DESCRIPTION }))
+
+        await screen.findByText('Seats')
+
+        expect(screen.queryByText(UNBREAKABLE_DESCRIPTION)).not.toBeInTheDocument()
+        expect(screen.getByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID)).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN "See more" is clicked', () => {
+      it('THEN reveals the whole description, wrapping mid-word', async () => {
+        await act(() => renderOverview({ ...featureFixture, description: UNBREAKABLE_DESCRIPTION }))
+
+        await screen.findByText('Seats')
+        await userEvent.click(screen.getByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID))
+
+        expect(screen.getByText(UNBREAKABLE_DESCRIPTION)).toHaveClass('line-break-anywhere')
+      })
+    })
+  })
+})

--- a/src/components/plans/PlanSettingsInfo.tsx
+++ b/src/components/plans/PlanSettingsInfo.tsx
@@ -1,3 +1,7 @@
+import {
+  MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT,
+  ShowMoreText,
+} from '~/components/designSystem/ShowMoreText'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { getIntervalTranslationKey } from '~/core/constants/form'
@@ -49,7 +53,14 @@ export const PlanSettingsInfo = ({ plan }: PlanSettingsInfoProps) => {
       {!!plan.description && (
         <DetailsPage.InfoGridItem
           label={translate('text_6388b923e514213fed58331c')}
-          value={plan.description}
+          value={
+            <ShowMoreText
+              variant="body"
+              color="grey700"
+              text={plan.description}
+              limit={MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT}
+            />
+          }
         />
       )}
 

--- a/src/components/plans/__tests__/PlanSettingsInfo.test.tsx
+++ b/src/components/plans/__tests__/PlanSettingsInfo.test.tsx
@@ -1,5 +1,7 @@
 import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
+import { SHOW_MORE_TEXT_BUTTON_TEST_ID } from '~/components/designSystem/ShowMoreText'
 import { CurrencyEnum, PlanInterval } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
@@ -19,6 +21,8 @@ const basePlan = {
   interval: PlanInterval.Monthly,
   amountCurrency: CurrencyEnum.Usd,
 }
+
+const UNBREAKABLE_DESCRIPTION = 'a'.repeat(500)
 
 describe('PlanSettingsInfo', () => {
   it('renders name, code, interval and currency', () => {
@@ -40,6 +44,21 @@ describe('PlanSettingsInfo', () => {
 
     expect(screen.getByText('text_6388b923e514213fed58331c')).toBeInTheDocument()
     expect(screen.getByText('A pro plan')).toBeInTheDocument()
+  })
+
+  it('truncates a description longer than the display limit behind a "See more" button', () => {
+    render(<PlanSettingsInfo plan={{ ...basePlan, description: UNBREAKABLE_DESCRIPTION }} />)
+
+    expect(screen.queryByText(UNBREAKABLE_DESCRIPTION)).not.toBeInTheDocument()
+    expect(screen.getByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID)).toBeInTheDocument()
+  })
+
+  it('reveals the whole description when "See more" is clicked', async () => {
+    render(<PlanSettingsInfo plan={{ ...basePlan, description: UNBREAKABLE_DESCRIPTION }} />)
+
+    await userEvent.click(screen.getByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID))
+
+    expect(screen.getByText(UNBREAKABLE_DESCRIPTION)).toHaveClass('line-break-anywhere')
   })
 
   it('omits the taxes row when the plan has no taxes', () => {

--- a/src/pages/catalog/details/ProductCategoryDetailsOverview.tsx
+++ b/src/pages/catalog/details/ProductCategoryDetailsOverview.tsx
@@ -1,6 +1,10 @@
 import { gql } from '@apollo/client'
 import { useParams } from 'react-router-dom'
 
+import {
+  MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT,
+  ShowMoreText,
+} from '~/components/designSystem/ShowMoreText'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { PageSectionTitle } from '~/components/layouts/Section'
@@ -91,7 +95,14 @@ export const ProductCategoryDetailsOverview = () => {
           <DetailsPage.InfoGridItem
             className="col-span-2"
             label={translate('text_6388b923e514213fed58331c')}
-            value={productCategory?.description || '-'}
+            value={
+              <ShowMoreText
+                variant="body"
+                color="grey700"
+                text={productCategory.description}
+                limit={MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT}
+              />
+            }
           />
         )}
 

--- a/src/pages/catalog/details/__tests__/ProductCategoryDetailsOverview.test.tsx
+++ b/src/pages/catalog/details/__tests__/ProductCategoryDetailsOverview.test.tsx
@@ -1,6 +1,7 @@
 import { act, render as rtlRender, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import { SHOW_MORE_TEXT_BUTTON_TEST_ID } from '~/components/designSystem/ShowMoreText'
 import { GetProductCategoryForDetailsOverviewDocument } from '~/generated/graphql'
 import { AllTheProviders } from '~/test-utils'
 
@@ -33,6 +34,8 @@ const productCategoryFixture = {
   invoiceDisplayName: 'Storage',
   attachedToPlanOrSubscription: false,
 }
+
+const UNBREAKABLE_DESCRIPTION = 'a'.repeat(500)
 
 const overviewQueryMockFactory = (productCategory: Record<string, unknown>) => ({
   request: { query: GetProductCategoryForDetailsOverviewDocument, variables: { id: 'prod-1' } },
@@ -78,6 +81,20 @@ describe('ProductCategoryDetailsOverview', () => {
     // Row labels (translate is mocked to return the key)
     expect(screen.queryByText('text_6388b923e514213fed58331c')).not.toBeInTheDocument()
     expect(screen.queryByText('text_65018c8e5c6b626f030bcf26')).not.toBeInTheDocument()
+  })
+
+  it('truncates a description longer than the display limit behind a "See more" button', async () => {
+    await act(() =>
+      renderOverview({ ...productCategoryFixture, description: UNBREAKABLE_DESCRIPTION }),
+    )
+
+    await screen.findByText('Object storage')
+
+    expect(screen.queryByText(UNBREAKABLE_DESCRIPTION)).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId(SHOW_MORE_TEXT_BUTTON_TEST_ID))
+
+    expect(screen.getByText(UNBREAKABLE_DESCRIPTION)).toHaveClass('line-break-anywhere')
   })
 
   it('opens the edit drawer with the loaded productCategory', async () => {


### PR DESCRIPTION
## Context

A `description` with no spaces (a URL, a token, a pasted blob) was passed raw into `DetailsPage.InfoGridItem`, which wraps it in a `Typography` carrying no break rule. A single unbreakable word has no wrap opportunity, so the text ran past the page gutter instead of wrapping. Long-but-normal descriptions were also uncapped, stretching the section arbitrarily tall.

The product and product filter details overviews already fixed this by rendering the value through the design-system `ShowMoreText`, which applies `line-break-anywhere` in both the collapsed and the expanded state and hides anything past a character limit behind a "See more" button.

## Description

Renders the description through `ShowMoreText` on the four remaining surfaces listed in the ticket:

- `ProductCategoryDetailsOverview`
- `BillableMetricDetailsOverview`
- `FeatureDetailsOverview`
- `PlanSettingsInfo`

`ProductFilterDetailsOverview`, the fifth surface in the ticket, already went through `ShowMoreText` on main, so it needed no change.

Of the two options the ticket left open, this takes the per-surface one. Moving the truncation into `DetailsPage.InfoGridItem` would apply `break-all` and a "See more" button to every details value across the app — codes, names, ids, amounts — none of which has been audited for it.

The limit is the shared `MAX_DESCRIPTION_LENGTH_DISPLAY_LIMIT` (250) that the two already-fixed surfaces use, so every description surface truncates at the same point instead of carrying its own magic number.

`ShowMoreText` also gains an exported `SHOW_MORE_TEXT_BUTTON_TEST_ID` on its "See more" button so the tests can select it without matching on a translation key.

Tests: a new suite for `ShowMoreText` itself (previously untested), new suites for `BillableMetricDetailsOverview` and `FeatureDetailsOverview`, and truncation cases added to the existing `PlanSettingsInfo` and `ProductCategoryDetailsOverview` suites. 7 suites / 43 tests pass.

Out of scope: the ticket's closing note that these description fields are not length-capped on input either. That is a validation change on the write path, not part of this fix.

<!-- Linear link -->
Fixes LAGO-1911

---
_Generated by [Claude Code](https://claude.ai/code/session_01B12rxRYxHrRNZUHtE5RXj8)_