### PR TITLE
fix(conductor): check pnpm volume disk space

### DIFF
--- a/scripts/conductor-front-container.sh
+++ b/scripts/conductor-front-container.sh
@@ -186,7 +186,10 @@ check_image() {
 
 require_disk() {
   local free
-  free="$(docker run --rm --entrypoint df front_dev -P / 2>/dev/null | awk 'NR==2 {print int($4/1024)}')" || free=""
+  free="$(docker run --rm \
+    --mount "type=volume,src=${PNPM_STORE_VOL},dst=/app/.pnpm-store,readonly" \
+    --entrypoint df front_dev -P /app/.pnpm-store 2>/dev/null \
+    | awk 'NR==2 {print int($4/1024)}')" || free=""
   # Probe failed: never block a boot on a failed measurement.
   if [[ -z "$free" ]]; then return 0; fi
 
@@ -210,13 +213,13 @@ cmd_up() {
   # Before the disk check, so reclaimed space counts towards it.
   sweep_stale
   check_image
+  # Create before probing so df reads the same volume-backed filesystem that
+  # pnpm and each workspace's node_modules volume use.
+  docker volume create "$PNPM_STORE_VOL" >/dev/null
   require_disk
 
   patch_env
   gen_compose
-
-  # Idempotent; external in the compose file, so nothing else creates it.
-  docker volume create "$PNPM_STORE_VOL" >/dev/null
 
   # Shadowed by the shared store volume from here on, so whatever it already
   # holds is dead weight on the host disk.

--- a/scripts/conductor-front-container.test.sh
+++ b/scripts/conductor-front-container.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_root="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$test_root"
+}
+trap cleanup EXIT
+
+mkdir -p "$test_root/bin" "$test_root/lago/front" "$test_root/workspace"
+docker_calls="$test_root/docker.calls"
+
+cat > "$test_root/bin/docker" <<'FAKE_DOCKER'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$DOCKER_CALLS"
+
+case "${1:-} ${2:-}" in
+  "ps --format")
+    echo "lago_front_dev"
+    ;;
+  "image inspect")
+    if [[ "$*" == *"--format"* ]]; then
+      echo "NODE_VERSION=24.20.0"
+    fi
+    ;;
+  "volume create")
+    echo "${3:-}"
+    ;;
+  "run --rm")
+    if [[ "$*" == *"lago_front_pnpm_store"* ]]; then
+      cat <<'DF'
+Filesystem 1024-blocks Used Available Capacity Mounted on
+/dev/vdb1 10485760 10383360 102400 100% /app/.pnpm-store
+DF
+    else
+      cat <<'DF'
+Filesystem 1024-blocks Used Available Capacity Mounted on
+overlay 20971520 10485760 10485760 50% /
+DF
+    fi
+    ;;
+esac
+FAKE_DOCKER
+chmod +x "$test_root/bin/docker"
+
+set +e
+output="$({
+  PATH="$test_root/bin:$PATH" \
+    DOCKER_CALLS="$docker_calls" \
+    CONDUCTOR_WORKSPACE_NAME="disk-probe-test" \
+    CONDUCTOR_WORKSPACE_PATH="$test_root/workspace" \
+    CONDUCTOR_ROOT_PATH="$test_root/lago/front" \
+    CONDUCTOR_PORT="55030" \
+    "$repo_root/scripts/conductor-front-container.sh" up
+} 2>&1)"
+exit_code=$?
+set -e
+
+if [[ $exit_code -eq 0 ]]; then
+  echo "FAIL: container startup continued despite a nearly full pnpm volume" >&2
+  exit 1
+fi
+
+if [[ "$output" != *"100MB free on the Docker disk"* ]]; then
+  echo "FAIL: expected the error to report the pnpm volume's 100MB free" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if grep -q '^compose .* up ' "$docker_calls"; then
+  echo "FAIL: Docker Compose started after the disk check failed" >&2
+  exit 1
+fi
+
+echo "PASS: startup checks free space on the pnpm volume"


### PR DESCRIPTION
## Context

Conductor's startup guard checked free space on the image root filesystem. Under OrbStack, the shared pnpm store volume can reach its Docker disk quota while that root probe still reports enough space. The workspace then starts and repeatedly fails during `pnpm install` with `ERR_PNPM_ENOSPC`.

## Description

- Create the external pnpm store volume before checking disk capacity.
- Mount that volume read-only in the probe container and run `df` against its mount point.
- Add a hermetic regression test where the image root has 10 GB free but the pnpm volume has only 100 MB free.
- Verify startup stops before Docker Compose is invoked when the volume is below the existing threshold.

## Testing

- `bash scripts/conductor-front-container.test.sh`
- `bash -n scripts/conductor-front-container.sh scripts/conductor-front-container.test.sh`
- `shellcheck -S warning scripts/conductor-front-container.sh scripts/conductor-front-container.test.sh`
