### PR TITLE
feat(rate-cards): make pricing unit optional

### DIFF
--- a/src/core/constants/form.ts
+++ b/src/core/constants/form.ts
@@ -67,6 +67,8 @@ export const SEARCH_APPLIES_TO_FEE_TYPE_CLASSNAME = 'searchAppliesToFeeTypeInput
 export const SEARCH_APPLIES_TO_BILLABLE_METRIC_CLASSNAME = 'searchAppliesToBillableMetricInput'
 // Features
 export const SEARCH_PRIVILEGE_SELECT_OPTIONS_INPUT_CLASSNAME = 'searchPrivilegeSelectOptionsInput'
+// Catalog
+export const SEARCH_PRICING_UNIT_FOR_RATE_CARD_CLASSNAME = 'searchPricingUnitForRateCardInput'
 
 /**** DATA ****/
 // Plan form types

--- a/src/pages/catalog/details/RateCardDetailsOverview.tsx
+++ b/src/pages/catalog/details/RateCardDetailsOverview.tsx
@@ -166,16 +166,6 @@ const RateCardDetailsOverview = ({ rateCardId }: { rateCardId: string }) => {
 
   const pricingUnit = pricingUnits.find((unit) => unit.code === rateCard.appliedPricingUnitCode)
 
-  const currencyOrPricingUnitRow = rateCard.appliedPricingUnitCode
-    ? {
-        label: translate('text_1784925227817xt1irx4wum2'),
-        value: pricingUnit?.name || rateCard.appliedPricingUnitCode,
-      }
-    : {
-        label: translate('text_1784925227817bab1mp540x7'),
-        value: rateCard.currency || '-',
-      }
-
   return (
     <section>
       {hasPermissions(['rateCardsUpdate']) && (
@@ -214,7 +204,14 @@ const RateCardDetailsOverview = ({ rateCardId }: { rateCardId: string }) => {
 
         <DetailsPage.InfoGrid
           grid={[
-            currencyOrPricingUnitRow,
+            {
+              label: translate('text_1784925227817bab1mp540x7'),
+              value: rateCard.currency || '-',
+            },
+            {
+              label: translate('text_1784925227817xt1irx4wum2'),
+              value: pricingUnit?.name || rateCard.appliedPricingUnitCode,
+            },
             {
               label: translate('text_1784930440656zu20xor7y71'),
               value: translate(BILLING_TIMING_TRANSLATION_KEY[rateCard.billingTiming]),

--- a/src/pages/catalog/details/RateCardDetailsOverview.tsx
+++ b/src/pages/catalog/details/RateCardDetailsOverview.tsx
@@ -166,6 +166,21 @@ const RateCardDetailsOverview = ({ rateCardId }: { rateCardId: string }) => {
 
   const pricingUnit = pricingUnits.find((unit) => unit.code === rateCard.appliedPricingUnitCode)
 
+  const currencyOrPricingUnitRow = [
+    {
+      label: translate('text_1784925227817bab1mp540x7'),
+      value: rateCard.currency || '-',
+    },
+    ...(pricingUnit?.name || rateCard.appliedPricingUnitCode
+      ? [
+          {
+            label: translate('text_1784925227817xt1irx4wum2'),
+            value: pricingUnit?.name || rateCard.appliedPricingUnitCode,
+          },
+        ]
+      : []),
+  ]
+
   return (
     <section>
       {hasPermissions(['rateCardsUpdate']) && (
@@ -204,14 +219,7 @@ const RateCardDetailsOverview = ({ rateCardId }: { rateCardId: string }) => {
 
         <DetailsPage.InfoGrid
           grid={[
-            {
-              label: translate('text_1784925227817bab1mp540x7'),
-              value: rateCard.currency || '-',
-            },
-            {
-              label: translate('text_1784925227817xt1irx4wum2'),
-              value: pricingUnit?.name || rateCard.appliedPricingUnitCode,
-            },
+            ...currencyOrPricingUnitRow,
             {
               label: translate('text_1784930440656zu20xor7y71'),
               value: translate(BILLING_TIMING_TRANSLATION_KEY[rateCard.billingTiming]),

--- a/src/pages/catalog/details/__tests__/RateCardDetailsOverview.test.tsx
+++ b/src/pages/catalog/details/__tests__/RateCardDetailsOverview.test.tsx
@@ -14,6 +14,9 @@ import RateCardDetailsOverview, {
   RATE_CARD_DETAILS_OVERVIEW_EDIT_TEST_ID,
 } from '../RateCardDetailsOverview'
 
+const CURRENCY_LABEL_KEY = 'text_1784925227817bab1mp540x7'
+const PRICING_UNIT_LABEL_KEY = 'text_1784925227817xt1irx4wum2'
+
 const mockOpenEditRateCardDrawer = jest.fn()
 const mockHasPermissions = jest.fn()
 let mockPricingUnits: Array<{ id: string; name: string; code: string; shortName?: string }> = []
@@ -153,6 +156,13 @@ describe('RateCardDetailsOverview', () => {
         expect(await screen.findByText('USD')).toBeInTheDocument()
       })
 
+      it('THEN omits the pricing unit row entirely', async () => {
+        await act(() => renderOverview())
+
+        expect(await screen.findByText(CURRENCY_LABEL_KEY)).toBeInTheDocument()
+        expect(screen.queryByText(PRICING_UNIT_LABEL_KEY)).not.toBeInTheDocument()
+      })
+
       it('THEN displays the billing timing as a human label', async () => {
         await act(() => renderOverview())
 
@@ -187,13 +197,13 @@ describe('RateCardDetailsOverview', () => {
 
   describe('GIVEN a rate card priced in a custom pricing unit', () => {
     describe('WHEN the pricing unit is known', () => {
-      it('THEN displays the pricing unit name instead of the currency', async () => {
+      it('THEN displays the pricing unit name alongside the currency', async () => {
         mockPricingUnits = [{ id: 'pu-1', name: 'Credits', code: 'credit' }]
 
         await act(() => renderOverview(pricingUnitRateCard))
 
         expect(await screen.findByText('Credits')).toBeInTheDocument()
-        expect(screen.queryByText('USD')).not.toBeInTheDocument()
+        expect(screen.getByText('USD')).toBeInTheDocument()
       })
     })
 

--- a/src/pages/catalog/drawers/rateCard/RateCardDrawerContent.tsx
+++ b/src/pages/catalog/drawers/rateCard/RateCardDrawerContent.tsx
@@ -19,6 +19,11 @@ import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { ChargeInvoicingStrategyOption } from '~/components/plans/chargeAccordion/options/ChargeInvoicingStrategyOption'
 import { LocalUsageChargeInput } from '~/components/plans/types'
 import {
+  MUI_INPUT_BASE_ROOT_CLASSNAME,
+  SEARCH_PRICING_UNIT_FOR_RATE_CARD_CLASSNAME,
+} from '~/core/constants/form'
+import { scrollToAndClickElement } from '~/core/utils/domUtils'
+import {
   AggregationTypeEnum,
   CurrencyEnum,
   ProductTypeEnum,
@@ -37,7 +42,6 @@ import { tw } from '~/styles/utils'
 import {
   mapInvoiceFieldsToStrategy,
   mapStrategyToInvoiceFields,
-  PRICING_UNIT_CURRENCY_OPTION,
   RATE_CARD_FORM_DEFAULTS,
 } from './constants'
 
@@ -89,6 +93,8 @@ export const RATE_CARD_DRAWER_REMOVE_DESCRIPTION_TEST_ID = 'rate-card-drawer-rem
 export const RATE_CARD_DRAWER_AVAILABLE_MODELS_ALERT_TEST_ID =
   'rate-card-drawer-available-models-alert'
 export const RATE_CARD_DRAWER_AVAILABLE_MODEL_CHIP_TEST_ID = 'rate-card-drawer-available-model-chip'
+export const RATE_CARD_DRAWER_SHOW_PRICING_UNIT_TEST_ID = 'rate-card-drawer-show-pricing-unit'
+export const RATE_CARD_DRAWER_REMOVE_PRICING_UNIT_TEST_ID = 'rate-card-drawer-remove-pricing-unit'
 
 export type RateCardComboboxSeed = { value: string; label: string } | null
 
@@ -159,7 +165,9 @@ const RateCardDrawerFormSections = withForm({
     const [shouldDisplayDescription, setShouldDisplayDescription] = useState(
       () => !!form.state.values.description,
     )
-
+    const [shouldDisplayPricingUnit, setShouldDisplayPricingUnit] = useState(
+      () => !!form.state.values.pricingUnit,
+    )
     const productId = useStore(form.store, (state) => state.values.productId)
     const currency = useStore(form.store, (state) => state.values.currency)
     const billingTiming = useStore(form.store, (state) => state.values.billingTiming)
@@ -231,14 +239,12 @@ const RateCardDrawerFormSections = withForm({
     )
 
     const pricingUnitsComboboxData = useMemo(
-      () => [
-        { value: PRICING_UNIT_CURRENCY_OPTION, label: translate('text_1784925227817bab1mp540x7') },
-        ...(pricingUnitsData?.pricingUnits?.collection ?? []).map((unit) => ({
+      () =>
+        (pricingUnitsData?.pricingUnits?.collection ?? []).map((unit) => ({
           value: unit.code,
           label: unit.name,
         })),
-      ],
-      [translate, pricingUnitsData?.pricingUnits?.collection],
+      [pricingUnitsData?.pricingUnits?.collection],
     )
 
     const currencyComboboxData = useMemo(
@@ -296,6 +302,23 @@ const RateCardDrawerFormSections = withForm({
         form.setFieldValue('description', '')
       }
       setShouldDisplayDescription(false)
+    }
+
+    const handleShowPricingUnit = () => {
+      setShouldDisplayPricingUnit(true)
+
+      // The combobox only exists on the next render, hence the deferred click; clicking the
+      // input base both focuses the input and drops the option list open.
+      scrollToAndClickElement({
+        selector: `.${SEARCH_PRICING_UNIT_FOR_RATE_CARD_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+      })
+    }
+
+    const handleHidePricingUnit = () => {
+      if (form.state.values.pricingUnit !== undefined) {
+        form.setFieldValue('pricingUnit', undefined)
+      }
+      setShouldDisplayPricingUnit(false)
     }
 
     return (
@@ -413,17 +436,47 @@ const RateCardDrawerFormSections = withForm({
               )}
             </form.AppField>
 
-            {!!currency && pricingUnitsComboboxData.length > 0 && (
-              <form.AppField name="pricingUnit">
-                {(field) => (
-                  <field.ComboBoxField
-                    disableClearable
-                    label={translate('text_1784925227817xt1irx4wum2')}
-                    data={pricingUnitsComboboxData}
+            {!!currency && pricingUnitsComboboxData.length > 0 && shouldDisplayPricingUnit && (
+              <div className="flex items-center gap-3">
+                <form.AppField name="pricingUnit">
+                  {(field) => (
+                    <field.ComboBoxField
+                      disableClearable
+                      containerClassName="flex-1"
+                      className={SEARCH_PRICING_UNIT_FOR_RATE_CARD_CLASSNAME}
+                      label={translate('text_1784925227817xt1irx4wum2')}
+                      placeholder={translate('text_17884232212443zsb3p8b5he')}
+                      data={pricingUnitsComboboxData}
+                      disabled={isLocked}
+                    />
+                  )}
+                </form.AppField>
+                <Tooltip
+                  className="mt-6"
+                  placement="top-end"
+                  title={translate('text_63aa085d28b8510cd46443ff')}
+                >
+                  <Button
+                    icon="trash"
+                    variant="quaternary"
                     disabled={isLocked}
+                    onClick={handleHidePricingUnit}
+                    data-test={RATE_CARD_DRAWER_REMOVE_PRICING_UNIT_TEST_ID}
                   />
-                )}
-              </form.AppField>
+                </Tooltip>
+              </div>
+            )}
+            {!!currency && pricingUnitsComboboxData.length > 0 && !shouldDisplayPricingUnit && (
+              <Button
+                fitContent
+                startIcon="plus"
+                variant="inline"
+                disabled={isLocked}
+                onClick={handleShowPricingUnit}
+                data-test={RATE_CARD_DRAWER_SHOW_PRICING_UNIT_TEST_ID}
+              >
+                {translate('text_1788423201620lrod4vaj4e8')}
+              </Button>
             )}
           </CenteredPage.PageSection>
 
@@ -505,7 +558,7 @@ const RateCardDrawerFormSections = withForm({
               </div>
             )}
 
-            {!!productId && availableRateModelLabels.length > 0 && (
+            {!!selectedProductMeta && availableRateModelLabels.length > 0 && (
               <Alert
                 type="info"
                 data-test={RATE_CARD_DRAWER_AVAILABLE_MODELS_ALERT_TEST_ID}

--- a/src/pages/catalog/drawers/rateCard/__tests__/RateCardDrawerContent.test.tsx
+++ b/src/pages/catalog/drawers/rateCard/__tests__/RateCardDrawerContent.test.tsx
@@ -1,8 +1,9 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import {
   AggregationTypeEnum,
+  CurrencyEnum,
   GetPricingUnitsForRateCardDrawerDocument,
   GetProductFiltersForRateCardDrawerDocument,
   ProductTypeEnum,
@@ -16,7 +17,9 @@ import {
   RATE_CARD_DRAWER_AVAILABLE_MODELS_ALERT_TEST_ID,
   RATE_CARD_DRAWER_DESCRIPTION_TEST_ID,
   RATE_CARD_DRAWER_REMOVE_DESCRIPTION_TEST_ID,
+  RATE_CARD_DRAWER_REMOVE_PRICING_UNIT_TEST_ID,
   RATE_CARD_DRAWER_SHOW_DESCRIPTION_TEST_ID,
+  RATE_CARD_DRAWER_SHOW_PRICING_UNIT_TEST_ID,
   RateCardDrawerContent,
   RateCardProductSeed,
 } from '../RateCardDrawerContent'
@@ -29,8 +32,13 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
   }),
 }))
 
+// jsdom has no scrollIntoView, and `scrollToAndClickElement` calls it before the click that
+// opens the pricing unit combobox.
+Element.prototype.scrollIntoView = jest.fn()
+
 const DESCRIPTION_PROBE_TEST_ID = 'description-probe'
 const DIRTY_PROBE_TEST_ID = 'dirty-probe'
+const PRICING_UNIT_PROBE_TEST_ID = 'pricing-unit-probe'
 
 const DYNAMIC_MODEL_KEY = 'text_1727711520232zpp50zgnam5'
 const STANDARD_MODEL_KEY = 'text_624aa732d6af4e0103d40e6f'
@@ -42,13 +50,15 @@ const GRADUATED_PERCENTAGE_MODEL_KEY = 'text_64de472463e2da6b31737db0'
 
 const PRODUCT_ID = 'product-1'
 
-const mocks: TestMocksType = [
+const buildMocks = (
+  pricingUnits: Array<{ id: string; name: string; code: string }> = [],
+): TestMocksType => [
   {
     request: {
       query: GetPricingUnitsForRateCardDrawerDocument,
       variables: { page: 1, limit: 100 },
     },
-    result: { data: { pricingUnits: { collection: [] } } },
+    result: { data: { pricingUnits: { collection: pricingUnits } } },
   },
   {
     request: {
@@ -58,6 +68,9 @@ const mocks: TestMocksType = [
     result: { data: { productFilters: { collection: [] } } },
   },
 ]
+
+const mocks = buildMocks()
+const mocksWithPricingUnits = buildMocks([{ id: 'pu-1', name: 'Credits', code: 'credits' }])
 
 const buildUsageSeed = (aggregationType: AggregationTypeEnum): RateCardProductSeed => ({
   value: PRODUCT_ID,
@@ -83,6 +96,9 @@ const Harness = ({ values, productSeed = null }: HarnessProps): JSX.Element => {
       <form.Subscribe selector={(state) => state.isDirty}>
         {(isDirty) => <span data-test={DIRTY_PROBE_TEST_ID}>{String(isDirty)}</span>}
       </form.Subscribe>
+      <form.Subscribe selector={(state) => state.values.pricingUnit}>
+        {(pricingUnit) => <span data-test={PRICING_UNIT_PROBE_TEST_ID}>{String(pricingUnit)}</span>}
+      </form.Subscribe>
       <RateCardDrawerContent
         form={form}
         isEdit={false}
@@ -95,8 +111,18 @@ const Harness = ({ values, productSeed = null }: HarnessProps): JSX.Element => {
   )
 }
 
-const renderContent = (props: HarnessProps = {}): ReturnType<typeof render> =>
-  render(<Harness {...props} />, { mocks })
+const renderContent = (
+  props: HarnessProps = {},
+  testMocks: TestMocksType = mocks,
+): ReturnType<typeof render> => render(<Harness {...props} />, { mocks: testMocks })
+
+const renderWithPricingUnits = (
+  values: Partial<RateCardFormValues> = {},
+): ReturnType<typeof render> =>
+  renderContent({ values: { currency: CurrencyEnum.Usd, ...values } }, mocksWithPricingUnits)
+
+const queryPricingUnitInput = (): HTMLInputElement | null =>
+  document.querySelector<HTMLInputElement>('input[name="pricingUnit"]')
 
 const getDescriptionInput = (): HTMLTextAreaElement =>
   screen
@@ -254,6 +280,104 @@ describe('RateCardDrawerContent', () => {
           PACKAGE_MODEL_KEY,
           VOLUME_MODEL_KEY,
         ])
+      })
+    })
+  })
+
+  describe('GIVEN no currency selected', () => {
+    describe('WHEN the content renders', () => {
+      it('THEN hides both the pricing unit combobox and its add action', async () => {
+        renderContent({}, mocksWithPricingUnits)
+
+        expect(
+          await screen.findByTestId(RATE_CARD_DRAWER_SHOW_DESCRIPTION_TEST_ID),
+        ).toBeInTheDocument()
+        expect(
+          screen.queryByTestId(RATE_CARD_DRAWER_SHOW_PRICING_UNIT_TEST_ID),
+        ).not.toBeInTheDocument()
+        expect(queryPricingUnitInput()).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a currency but no pricing unit defined on the organization', () => {
+    describe('WHEN the content renders', () => {
+      it('THEN hides both the pricing unit combobox and its add action', () => {
+        renderContent({ values: { currency: CurrencyEnum.Usd } })
+
+        expect(
+          screen.queryByTestId(RATE_CARD_DRAWER_SHOW_PRICING_UNIT_TEST_ID),
+        ).not.toBeInTheDocument()
+        expect(queryPricingUnitInput()).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a currency and available pricing units, on a rate card without one', () => {
+    describe('WHEN the content renders', () => {
+      it('THEN shows the add-pricing-unit action only', async () => {
+        renderWithPricingUnits()
+
+        expect(
+          await screen.findByTestId(RATE_CARD_DRAWER_SHOW_PRICING_UNIT_TEST_ID),
+        ).toBeInTheDocument()
+        expect(queryPricingUnitInput()).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the user clicks the add-pricing-unit action', () => {
+      it('THEN reveals the combobox, focuses it and drops its options open', async () => {
+        renderWithPricingUnits()
+
+        await userEvent.click(await screen.findByTestId(RATE_CARD_DRAWER_SHOW_PRICING_UNIT_TEST_ID))
+
+        expect(queryPricingUnitInput()).toBeInTheDocument()
+        expect(
+          screen.queryByTestId(RATE_CARD_DRAWER_SHOW_PRICING_UNIT_TEST_ID),
+        ).not.toBeInTheDocument()
+
+        await waitFor(() => expect(queryPricingUnitInput()).toHaveFocus())
+        expect(await screen.findByRole('listbox')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a rate card already priced in a pricing unit', () => {
+    describe('WHEN the content renders', () => {
+      it('THEN shows the combobox and its remove button', async () => {
+        renderWithPricingUnits({ pricingUnit: 'credits' })
+
+        expect(
+          await screen.findByTestId(RATE_CARD_DRAWER_REMOVE_PRICING_UNIT_TEST_ID),
+        ).toBeInTheDocument()
+        expect(queryPricingUnitInput()).toBeInTheDocument()
+        expect(
+          screen.queryByTestId(RATE_CARD_DRAWER_SHOW_PRICING_UNIT_TEST_ID),
+        ).not.toBeInTheDocument()
+      })
+
+      it('THEN leaves the combobox closed and unfocused', async () => {
+        renderWithPricingUnits({ pricingUnit: 'credits' })
+
+        expect(
+          await screen.findByTestId(RATE_CARD_DRAWER_REMOVE_PRICING_UNIT_TEST_ID),
+        ).toBeVisible()
+        expect(queryPricingUnitInput()).not.toHaveFocus()
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the user removes the pricing unit', () => {
+      it('THEN hides the combobox and clears the value', async () => {
+        renderWithPricingUnits({ pricingUnit: 'credits' })
+
+        await userEvent.click(
+          await screen.findByTestId(RATE_CARD_DRAWER_REMOVE_PRICING_UNIT_TEST_ID),
+        )
+
+        expect(queryPricingUnitInput()).not.toBeInTheDocument()
+        expect(screen.getByTestId(PRICING_UNIT_PROBE_TEST_ID)).toHaveTextContent('undefined')
+        expect(screen.getByTestId(RATE_CARD_DRAWER_SHOW_PRICING_UNIT_TEST_ID)).toBeInTheDocument()
       })
     })
   })

--- a/src/pages/catalog/drawers/rateCard/__tests__/constants.test.ts
+++ b/src/pages/catalog/drawers/rateCard/__tests__/constants.test.ts
@@ -5,7 +5,8 @@ import {
 } from '~/generated/graphql'
 
 import {
-  buildPricingInput,
+  buildCreatePricingInput,
+  buildUpdatePricingInput,
   mapInvoiceFieldsToStrategy,
   mapStrategyToInvoiceFields,
   RATE_CARD_FORM_DEFAULTS,
@@ -68,11 +69,24 @@ describe('rate card constants', () => {
     ).toBe(false)
   })
 
-  it('always includes currency, adding the pricing unit code only when there is one', () => {
-    expect(buildPricingInput({ pricingUnit: undefined, currency: CurrencyEnum.Usd })).toEqual({
+  it('omits the pricing unit code on create when there is none', () => {
+    expect(buildCreatePricingInput({ pricingUnit: undefined, currency: CurrencyEnum.Usd })).toEqual(
+      { currency: CurrencyEnum.Usd },
+    )
+    expect(buildCreatePricingInput({ pricingUnit: 'tokens', currency: CurrencyEnum.Usd })).toEqual({
       currency: CurrencyEnum.Usd,
+      appliedPricingUnitCode: 'tokens',
     })
-    expect(buildPricingInput({ pricingUnit: 'tokens', currency: CurrencyEnum.Usd })).toEqual({
+  })
+
+  it('nulls the pricing unit code on update when there is none', () => {
+    expect(buildUpdatePricingInput({ pricingUnit: undefined, currency: CurrencyEnum.Usd })).toEqual(
+      {
+        currency: CurrencyEnum.Usd,
+        appliedPricingUnitCode: null,
+      },
+    )
+    expect(buildUpdatePricingInput({ pricingUnit: 'tokens', currency: CurrencyEnum.Usd })).toEqual({
       currency: CurrencyEnum.Usd,
       appliedPricingUnitCode: 'tokens',
     })

--- a/src/pages/catalog/drawers/rateCard/__tests__/constants.test.ts
+++ b/src/pages/catalog/drawers/rateCard/__tests__/constants.test.ts
@@ -1,4 +1,8 @@
-import { RateCardBillingTimingEnum, RateCardRegroupPaidFeesEnum } from '~/generated/graphql'
+import {
+  CurrencyEnum,
+  RateCardBillingTimingEnum,
+  RateCardRegroupPaidFeesEnum,
+} from '~/generated/graphql'
 
 import {
   buildPricingInput,
@@ -9,19 +13,19 @@ import {
 } from '../constants'
 
 describe('rate card constants', () => {
-  it('defaults billing timing to arrears and pricing unit to currency', () => {
+  it('defaults billing timing to arrears without a pricing unit', () => {
     expect(RATE_CARD_FORM_DEFAULTS.billingTiming).toBe(RateCardBillingTimingEnum.Arrears)
-    expect(RATE_CARD_FORM_DEFAULTS.pricingUnit).toBe('currency')
+    expect(RATE_CARD_FORM_DEFAULTS.pricingUnit).toBeUndefined()
   })
 
   it('requires currency regardless of the pricing unit', () => {
     const base = { ...RATE_CARD_FORM_DEFAULTS, name: 'N', code: 'c', productId: 'pi_1' }
 
     expect(
-      rateCardDrawerSchema.safeParse({ ...base, pricingUnit: 'currency', currency: '' }).success,
+      rateCardDrawerSchema.safeParse({ ...base, pricingUnit: undefined, currency: '' }).success,
     ).toBe(false)
     expect(
-      rateCardDrawerSchema.safeParse({ ...base, pricingUnit: 'currency', currency: 'USD' }).success,
+      rateCardDrawerSchema.safeParse({ ...base, pricingUnit: undefined, currency: 'USD' }).success,
     ).toBe(true)
     expect(
       rateCardDrawerSchema.safeParse({ ...base, pricingUnit: 'tokens', currency: '' }).success,
@@ -64,12 +68,12 @@ describe('rate card constants', () => {
     ).toBe(false)
   })
 
-  it('always includes currency, adding the pricing unit code only when custom', () => {
-    expect(buildPricingInput({ pricingUnit: 'currency', currency: 'USD' as never })).toEqual({
-      currency: 'USD',
+  it('always includes currency, adding the pricing unit code only when there is one', () => {
+    expect(buildPricingInput({ pricingUnit: undefined, currency: CurrencyEnum.Usd })).toEqual({
+      currency: CurrencyEnum.Usd,
     })
-    expect(buildPricingInput({ pricingUnit: 'tokens', currency: 'USD' as never })).toEqual({
-      currency: 'USD',
+    expect(buildPricingInput({ pricingUnit: 'tokens', currency: CurrencyEnum.Usd })).toEqual({
+      currency: CurrencyEnum.Usd,
       appliedPricingUnitCode: 'tokens',
     })
   })

--- a/src/pages/catalog/drawers/rateCard/__tests__/useRateCardDrawer.test.tsx
+++ b/src/pages/catalog/drawers/rateCard/__tests__/useRateCardDrawer.test.tsx
@@ -71,9 +71,17 @@ jest.mock('../RateCardDrawerContent', () => ({
       setFieldValue: (name: string, value: unknown) => void
     }
   }) => (
-    <button data-test="clear-description" onClick={() => form.setFieldValue('description', '')}>
-      clear
-    </button>
+    <>
+      <button data-test="clear-description" onClick={() => form.setFieldValue('description', '')}>
+        clear description
+      </button>
+      <button
+        data-test="clear-pricing-unit"
+        onClick={() => form.setFieldValue('pricingUnit', undefined)}
+      >
+        clear pricing unit
+      </button>
+    </>
   ),
 }))
 
@@ -207,6 +215,28 @@ describe('useRateCardDrawer edit flow', () => {
     await waitFor(() => expect(mockClose).toHaveBeenCalledTimes(1))
 
     expect(capturedInput.description).toBeNull()
+  })
+
+  it('serializes a removed pricing unit as null', async () => {
+    let capturedInput: Record<string, unknown> = {}
+    const { result } = renderDrawerHook([updateRateCardMock((input) => (capturedInput = input))])
+
+    act(() =>
+      result.current.openDrawer({
+        rateCard: { ...rateCardFixture, appliedPricingUnitCode: 'credits' },
+      }),
+    )
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        {lastDrawerArgs?.children}
+      </MockedProvider>,
+    )
+    await userEvent.click(screen.getByTestId('clear-pricing-unit'))
+    await submit()
+
+    await waitFor(() => expect(mockClose).toHaveBeenCalledTimes(1))
+
+    expect(capturedInput.appliedPricingUnitCode).toBeNull()
   })
 
   it('passes locked flags to the content when the rate card is attached', () => {

--- a/src/pages/catalog/drawers/rateCard/constants.ts
+++ b/src/pages/catalog/drawers/rateCard/constants.ts
@@ -77,13 +77,21 @@ export const mapInvoiceFieldsToStrategy = (args: {
   return 'none'
 }
 
-// Create only: an empty pricing unit is omitted, like the other empty optionals on
-// `CreateRateCardInput`. Update writes the field itself, since clearing a unit there has to
-// serialize to null (undefined is stripped and the previous value would survive).
-export const buildPricingInput = (values: {
-  currency: CurrencyEnum
-  pricingUnit?: string
-}): { currency: CurrencyEnum; appliedPricingUnitCode?: string } => ({
+type PricingFormValues = Pick<RateCardFormValues, 'pricingUnit'> & { currency: CurrencyEnum }
+
+// Create omits an empty pricing unit, like the other empty optionals on `CreateRateCardInput`.
+export const buildCreatePricingInput = (
+  values: PricingFormValues,
+): { currency: CurrencyEnum; appliedPricingUnitCode?: string } => ({
   currency: values.currency,
   ...(values.pricingUnit ? { appliedPricingUnitCode: values.pricingUnit } : {}),
+})
+
+// Update clears with an explicit null: undefined is stripped from the payload, so the
+// previously applied unit would survive.
+export const buildUpdatePricingInput = (
+  values: PricingFormValues,
+): { currency: CurrencyEnum; appliedPricingUnitCode: string | null } => ({
+  currency: values.currency,
+  appliedPricingUnitCode: values.pricingUnit ?? null,
 })

--- a/src/pages/catalog/drawers/rateCard/constants.ts
+++ b/src/pages/catalog/drawers/rateCard/constants.ts
@@ -10,34 +10,9 @@ export const RATE_CARD_FORM_ID = 'rateCardForm'
 
 export const RATE_CARD_FORM_SUBMIT_TEST_ID = 'rate-card-form-submit'
 
-// Sentinel value of `pricingUnit` meaning "priced in the organization's currency"
-// rather than in a custom pricing unit (whose code would be the value instead).
-export const PRICING_UNIT_CURRENCY_OPTION = 'currency'
-
-export type InvoicingStrategy = 'invoiceable' | 'regroupPaidFees' | 'none'
-
-export const RATE_CARD_FORM_DEFAULTS = {
-  name: '',
-  code: '',
-  description: '',
-  productId: '',
-  productFilterId: '',
-  // 'currency' | pricing unit code
-  pricingUnit: PRICING_UNIT_CURRENCY_OPTION as string,
-  currency: '' as CurrencyEnum | '',
-  billingTiming: RateCardBillingTimingEnum.Arrears,
-  invoicingStrategy: 'invoiceable' as InvoicingStrategy,
-  proration: false,
-  walletTargetable: false,
-}
-
-export type RateCardFormValues = typeof RATE_CARD_FORM_DEFAULTS
-
-// Every `RateCardFormValues` field is declared so the schema's inferred type matches
-// `RateCardFormValues` with no cast (mirrors the sibling drawer schemas). Currency is
-// mandatory on every rate card (the schema's `RateCard.currency` / `CreateRateCardInput.currency`
-// are both non-null), independent of whether a custom pricing unit is also applied; the
-// `.superRefine` enforces it since the field type still allows the empty default.
+// Currency is mandatory on every rate card (`CreateRateCardInput.currency` is non-null),
+// independent of whether a custom pricing unit is applied on top; `.superRefine` is what
+// enforces it, since the field still carries the empty default until the user picks one.
 export const rateCardDrawerSchema = z
   .object({
     name: z.string().min(1, 'text_1771342980565bx64zqq2mjs'),
@@ -45,7 +20,7 @@ export const rateCardDrawerSchema = z
     description: z.string(),
     productId: z.string().min(1, 'text_1771342994699klxu2paz7g8'),
     productFilterId: z.string(),
-    pricingUnit: z.string(),
+    pricingUnit: z.string().optional(),
     currency: z.union([z.nativeEnum(CurrencyEnum), z.literal('')]),
     billingTiming: z.nativeEnum(RateCardBillingTimingEnum),
     invoicingStrategy: z.enum(['invoiceable', 'regroupPaidFees', 'none']),
@@ -55,12 +30,30 @@ export const rateCardDrawerSchema = z
   .superRefine((values, ctx) => {
     if (!values.currency) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: 'custom',
         path: ['currency'],
         message: 'text_1784923399556hjnr43vhm5z',
       })
     }
   })
+
+export type RateCardFormValues = z.infer<typeof rateCardDrawerSchema>
+
+export type InvoicingStrategy = RateCardFormValues['invoicingStrategy']
+
+export const RATE_CARD_FORM_DEFAULTS: RateCardFormValues = {
+  name: '',
+  code: '',
+  description: '',
+  productId: '',
+  productFilterId: '',
+  pricingUnit: undefined,
+  currency: '',
+  billingTiming: RateCardBillingTimingEnum.Arrears,
+  invoicingStrategy: 'invoiceable',
+  proration: false,
+  walletTargetable: false,
+}
 
 export const mapStrategyToInvoiceFields = (
   strategy: InvoicingStrategy,
@@ -84,13 +77,13 @@ export const mapInvoiceFieldsToStrategy = (args: {
   return 'none'
 }
 
-// Currency is always sent (mandatory on the input); a custom pricing unit is an
-// optional add-on layered on top of it, so both keys can be present together.
-export const buildPricingInput = (
-  values: Pick<RateCardFormValues, 'pricingUnit' | 'currency'>,
-): { currency: CurrencyEnum; appliedPricingUnitCode?: string } => ({
-  currency: values.currency as CurrencyEnum,
-  ...(values.pricingUnit === PRICING_UNIT_CURRENCY_OPTION
-    ? {}
-    : { appliedPricingUnitCode: values.pricingUnit }),
+// Create only: an empty pricing unit is omitted, like the other empty optionals on
+// `CreateRateCardInput`. Update writes the field itself, since clearing a unit there has to
+// serialize to null (undefined is stripped and the previous value would survive).
+export const buildPricingInput = (values: {
+  currency: CurrencyEnum
+  pricingUnit?: string
+}): { currency: CurrencyEnum; appliedPricingUnitCode?: string } => ({
+  currency: values.currency,
+  ...(values.pricingUnit ? { appliedPricingUnitCode: values.pricingUnit } : {}),
 })

--- a/src/pages/catalog/drawers/rateCard/useRateCardDrawer.tsx
+++ b/src/pages/catalog/drawers/rateCard/useRateCardDrawer.tsx
@@ -23,7 +23,8 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm } from '~/hooks/forms/useAppform'
 
 import {
-  buildPricingInput,
+  buildCreatePricingInput,
+  buildUpdatePricingInput,
   mapInvoiceFieldsToStrategy,
   mapStrategyToInvoiceFields,
   RATE_CARD_FORM_DEFAULTS,
@@ -179,8 +180,7 @@ const useRateCardForm = ({ onSuccess }: { onSuccess: (result: RateCardFormSucces
               billingTiming: value.billingTiming,
               proration: value.proration,
               walletTargetable: value.walletTargetable,
-              currency,
-              appliedPricingUnitCode: value.pricingUnit ?? null,
+              ...buildUpdatePricingInput({ currency, pricingUnit: value.pricingUnit }),
               ...invoiceFields,
             },
           },
@@ -200,7 +200,7 @@ const useRateCardForm = ({ onSuccess }: { onSuccess: (result: RateCardFormSucces
               billingTiming: value.billingTiming,
               proration: value.proration,
               walletTargetable: value.walletTargetable,
-              ...buildPricingInput({ currency, pricingUnit: value.pricingUnit }),
+              ...buildCreatePricingInput({ currency, pricingUnit: value.pricingUnit }),
               ...invoiceFields,
             },
           },

--- a/src/pages/catalog/drawers/rateCard/useRateCardDrawer.tsx
+++ b/src/pages/catalog/drawers/rateCard/useRateCardDrawer.tsx
@@ -26,7 +26,6 @@ import {
   buildPricingInput,
   mapInvoiceFieldsToStrategy,
   mapStrategyToInvoiceFields,
-  PRICING_UNIT_CURRENCY_OPTION,
   RATE_CARD_FORM_DEFAULTS,
   RATE_CARD_FORM_ID,
   RATE_CARD_FORM_SUBMIT_TEST_ID,
@@ -103,7 +102,7 @@ const mapRateCardToFormValues = (rateCard: RateCardForDrawerFragment): RateCardF
   description: rateCard.description || '',
   productId: rateCard.product.id,
   productFilterId: rateCard.productFilter?.id || '',
-  pricingUnit: rateCard.appliedPricingUnitCode ?? PRICING_UNIT_CURRENCY_OPTION,
+  pricingUnit: rateCard.appliedPricingUnitCode ?? undefined,
   currency: rateCard.currency ?? '',
   billingTiming: rateCard.billingTiming,
   invoicingStrategy: mapInvoiceFieldsToStrategy({
@@ -151,6 +150,11 @@ const useRateCardForm = ({ onSuccess }: { onSuccess: (result: RateCardFormSucces
     },
     onSubmit: async ({ value, formApi }) => {
       const editedRateCard = editedRateCardRef.current
+      const { currency } = value
+
+      // `rateCardDrawerSchema` rejects the empty default, so a submit never reaches here
+      // without a currency; the guard is what narrows it out of `CurrencyEnum | ''`.
+      if (!currency) return
 
       // Pay-in-advance carries the invoicing strategy; arrears is always
       // invoiceable so the invoice fields collapse to their default.
@@ -175,7 +179,8 @@ const useRateCardForm = ({ onSuccess }: { onSuccess: (result: RateCardFormSucces
               billingTiming: value.billingTiming,
               proration: value.proration,
               walletTargetable: value.walletTargetable,
-              ...buildPricingInput(value),
+              currency,
+              appliedPricingUnitCode: value.pricingUnit ?? null,
               ...invoiceFields,
             },
           },
@@ -195,7 +200,7 @@ const useRateCardForm = ({ onSuccess }: { onSuccess: (result: RateCardFormSucces
               billingTiming: value.billingTiming,
               proration: value.proration,
               walletTargetable: value.walletTargetable,
-              ...buildPricingInput(value),
+              ...buildPricingInput({ currency, pricingUnit: value.pricingUnit }),
               ...invoiceFields,
             },
           },

--- a/translations/base.json
+++ b/translations/base.json
@@ -4895,5 +4895,7 @@
   "text_1788182491979e5qhb8xgn2m": "#filters",
   "text_17883567168609zwqemkhgbu": "Product filter name",
   "text_1788356716860fkisuga4c97": "Product filter code",
+  "text_1788423201620lrod4vaj4e8": "Add a pricing unit",
+  "text_17884232212443zsb3p8b5he": "Search and select a pricing unit",
   "text_1788431703232ovdpgmdftnt": "This invitation no longer exists, the list has been refreshed."
 }


### PR DESCRIPTION
## Context

Pricing units are optional on rate cards, but the drawer currently presents a synthetic currency option and always shows the selector. The updated flow makes the optional nature explicit and follows the provided Figma designs.

## Description

- Hide the pricing unit selector when creating a rate card or editing one without a selected pricing unit.
- Add an action that reveals the selector, with a trash action that clears the value and hides it again.
- Keep an existing custom pricing unit visible when editing.
- Remove the synthetic currency option and send `null` when an existing pricing unit is removed.
- Add coverage for create, edit, reveal, remove, lock, and payload behavior.

## Validation

- Focused Jest suite: 4 suites, 24 tests passed.
- `pnpm types` passed.
- Pre-push `pnpm code:style` passed with existing repository warnings.
- Translation validation passed.
- Repository-wide parallel Jest run was attempted but stopped after unrelated UI suites hit existing 5-second timeouts and Tooltip snapshot differences.
