### PR TITLE
docs(agents): let the loop pipeline run in the current checkout

### DIFF
--- a/.agents/skills/loop-build/SKILL.md
+++ b/.agents/skills/loop-build/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: loop-build
-description: 'Phase 2 of the loop pipeline for lago-front. Takes an ISSUE-ID, reads spec.md from the run state dir, implements the change in a dedicated worktree, and gets lint + types + translations gates green. Use when user says "/loop-build <ISSUE-ID>" or the loop-run orchestrator invokes the build phase.'
+description: 'Phase 2 of the loop pipeline for lago-front. Takes an ISSUE-ID, reads spec.md from the run state dir, implements the change in a dedicated worktree — or in the current checkout with `--in-place` (automatic inside a Conductor workspace) — and gets lint + types + translations gates green. Use when user says "/loop-build <ISSUE-ID> [--in-place]" or the loop-run orchestrator invokes the build phase.'
 ---
 
 # Loop Build — phase 2 of loop-run
 
 **Input:** an ISSUE-ID (e.g. `LAGO-1745`). State dir: `$LOOP_STATE_DIR/<ISSUE-ID>/` (default `~/.claude/loop-state/<ISSUE-ID>/`). Requires `spec.md` there — if missing, stop and tell the operator to run loop-spec first.
 
-**Repo:** lago-front checkout at `front/` in the lago monorepo; worktrees in `front-worktrees/` beside it.
+**Repo:** a lago-front checkout. Two layouts, resolved by loop-run and defined in its `## Layout` section — `worktree` (the default: `front/` in the lago monorepo, worktrees in `front-worktrees/` beside it) and `in-place` (the current checkout is the worktree; automatic inside a Conductor workspace, forced with `--in-place`). Invoked directly without loop-run, resolve it the same way: `$CONDUCTOR_WORKSPACE_PATH` set or `--in-place` passed → `in-place`, else `worktree`.
 
 ## Modes
 
@@ -16,12 +16,28 @@ description: 'Phase 2 of the loop pipeline for lago-front. Takes an ISSUE-ID, re
 
 ## Steps (fresh build)
 
-1. **Preflight** (both must hold, else STOP and ask the operator):
+1. **Preflight** — the `worktree` layout creates its workspace, `in-place` validates the one it was handed:
+
+   **`worktree` layout** (all must hold, else STOP and ask the operator):
    - Main docker stack running: `docker ps --format '{{.Names}}' | grep lago_front_dev`.
    - Local `main` in `front/` up to date: `git -C front pull --ff-only origin main`. If it fails (dirty checkout, diverged), STOP — never stash, reset, or force.
    - If a `front-worktrees/<ISSUE-ID>-*` dir already exists from an aborted run, STOP and ask — never delete or force.
 
-2. **Create the worktree** with the repo's own tool (handles branch, .env copy, pnpm install, port slot, dedicated docker containers, isolated API worktree):
+   **`in-place` layout**:
+
+   ```bash
+   FRONT="$(git rev-parse --show-toplevel)"
+   [ -x "$FRONT/scripts/iter-budget.sh" ] || { echo "not a lago-front checkout"; exit 1; }
+   BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+   git fetch origin main
+   ```
+
+   - **Branch guard**: STOP if `BRANCH` is `main` (or `$CONDUCTOR_DEFAULT_BRANCH`), or is `HEAD` (detached). The loop only ever works on a feature branch.
+   - **`git fetch origin main` is required**: the review phase diffs against `origin/main`, so a stale base produces a misleading diff. Fetch only — NEVER pull, rebase, merge, stash or reset (the checkout is the operator's, and it may hold work the loop did not create).
+   - **State conflict**: if `state.md` already exists for this ISSUE-ID and its `worktree:` is a different path, STOP — that state belongs to another checkout; the operator must pick one.
+   - **Docker stack** (`docker ps --format '{{.Names}}' | grep lago_front_dev`): missing → **warn only, never block**. Gates run on the host; Docker is only needed for the app restart and manual QA.
+
+2. **Create the worktree** — **`worktree` layout ONLY**; in `in-place` skip this step entirely (nothing is created, `lago-worktree` is never called). Use the repo's own tool (handles branch, .env copy, pnpm install, port slot, dedicated docker containers, isolated API worktree):
 
    ```bash
    lago-worktree create <BRANCH> --from-front=main --from-api=main
@@ -31,17 +47,24 @@ description: 'Phase 2 of the loop pipeline for lago-front. Takes an ISSUE-ID, re
 
    **Branch naming** — `<BRANCH>` = `<ISSUE-ID>-<topic-slug>`: the Linear issue ID first, UPPERCASE, then a short kebab-case slug of the ticket's main topic (3-6 words). Examples: `ING-517-swap-customer-overview-connection`, `LAGO-5739-update-customer-information-view`. No Linear ticket (edge case, e.g. tooling change requested directly) → just the kebab-case topic slug of the changes: `clean-vite-cache-on-worktree-start`. Worktree dir name = branch name. The session stays in the lago root — no folder switch; operate on the worktree via `git -C` / `cd` in subshells.
 
-3. **Record state**: write `state.md` in the state dir (the state dir stays keyed on the bare ISSUE-ID):
+   In `in-place` the branch is whatever the checkout already carried and is **never renamed** (`git branch -m` is forbidden: Conductor persists the branch name in its own database, so a git-side rename desyncs its diff view and its archive-time branch deletion).
+
+3. **Record state**: write `state.md` in the state dir (the state dir stays keyed on the bare ISSUE-ID). Key names are load-bearing — `loop-review`, `loop-revise` and loop-run's restart step read them:
 
    ```markdown
-   worktree: <absolute path to front-worktrees/<BRANCH>>
+   layout: <worktree | in-place>
+   worktree: <absolute path — front-worktrees/<BRANCH> in worktree layout, the checkout itself in in-place>
    branch: <BRANCH>
-   port: <front port printed by lago-worktree>
+   port: <front port printed by lago-worktree, or $CONDUCTOR_PORT in in-place>
+   workspace: <$CONDUCTOR_WORKSPACE_NAME — in-place under Conductor only>
+   container: <lago_front_wt_<SAN(branch)> | lago_front_ct_<SAN(workspace)> — omit when there is none>
    ```
+
+   `SAN` = `tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g'` on the branch (worktree layout, the rule `lago-worktree` uses) or on the workspace name (`in-place`, the rule `scripts/conductor-front-container.sh` uses).
 
 4. **Load the coding styleguide**: fetch the Frontend coding styleguide via the Notion MCP `notion-fetch` tool — page `https://app.notion.com/p/getlago/Frontend-coding-styleguide-29cef63110d28002b33afe26ddc59d88`. Apply its rules wherever applicable. If the fetch fails, warn in the report and continue with codebase conventions.
 
-5. **Implement** per spec.md, inside the worktree only:
+5. **Implement** per spec.md, inside the `worktree:` path from state.md only (in `in-place` that is the cwd):
    - Follow "Files to touch" — if reality diverges from the spec, update spec.md with a note and continue only if the divergence is minor; otherwise stop and report.
    - **Design system first**: before writing any new UI element, search the design system package (`lago-design-system`) and existing shared components for one that already does the job — reuse or extend, never duplicate. A new bespoke component is a last resort and must be justified in the report.
    - **Translations** (`translations/base.json`):
@@ -55,7 +78,7 @@ description: 'Phase 2 of the loop pipeline for lago-front. Takes an ISSUE-ID, re
    - **A redirect in a `useEffect` does not stop its own render** — the body paints before the navigate commits. Pair every guard effect with an early `return null` on the same condition (after all hooks), and assert `container.firstChild` is null.
    - If GraphQL documents change: run `pnpm codegen` and include regenerated files.
 
-6. **Tests — ALWAYS**: after the implementation is complete, invoke the `make-tests` skill on the worktree changes. NEVER hand-write tests.
+6. **Tests — ALWAYS**: after the implementation is complete, invoke the `make-tests` skill on the changes. NEVER hand-write tests.
 
 7. **Gates** (run in the worktree, all must pass):
    - `pnpm lint` (use `pnpm lint:fix` first if there are formatting issues)
@@ -68,20 +91,21 @@ description: 'Phase 2 of the loop pipeline for lago-front. Takes an ISSUE-ID, re
 
 ## Steps (fix mode)
 
-1. Read the numbered issues from `review.md` (or the failure report in `ci-failure.md`).
+1. Read the numbered issues from `review.md` (or the failure report in `ci-failure.md`). `ci-failure.md` is already distilled by loop-run — **never open the `ci-raw-<N>.log` it references**; if it looks insufficient, grep that raw file for the one specific symbol you need, never read it whole.
 2. **Escalating retry — attempt N>1 must not be a blind rerun of attempt N-1:**
    - Read the full history too: `review-history.md` / `ci-failure-history.md` in the state dir (written by loop-run before each re-entry).
    - Before coding, state explicitly (in your working notes for the report): for each issue, what the previous attempt did and what THIS attempt does differently.
    - **Same issue failed twice** → the previous strategy is wrong, don't refine it a third time in the same direction: change strategy — re-read spec.md acceptance criteria from scratch, broaden the investigation (callers, related components, existing tests), question the diagnosis itself. Consume the retry, but on a different path.
    - **Oscillation check**: before applying a fix, verify against the history that it does not revert (fully or partially) a change made by a PREVIOUS iteration. Fix A breaks B, fix B re-breaks A is a loop-killer the gates won't surface. Detected → declare it in the report, do NOT apply either of the two oscillating fixes again: find the third option that satisfies both constraints (usually one level up from where both fixes were applied). Note the oscillation in the working notes so loop-run's flywheel picks it up.
-   - Never STOP early for a repeated failure — the 3-attempt budget belongs to loop-run and is enforced by `front/scripts/iter-budget.sh`; exhausting it is the ONLY human touchpoint.
-3. Fix only those issues in the existing worktree.
+   - Never STOP early for a repeated failure — the 3-attempt budget belongs to loop-run and is enforced by `<checkout>/scripts/iter-budget.sh`; exhausting it is the ONLY human touchpoint.
+3. Fix only those issues, in the `worktree:` path from state.md — never a different one.
 4. Re-run the gates (step 7 above). If the fix touched testable logic, re-invoke `make-tests` for the affected paths.
 5. Report what changed per issue number, including the "what's different from the previous attempt" line for each.
 
 ## Hard rules
 
-- All edits in the worktree, never in the main checkout.
+- All edits in the `worktree:` path from state.md. In the `worktree` layout that means never the main `front/` checkout; in `in-place` never `$CONDUCTOR_ROOT_PATH` and never another workspace.
+- **`in-place` creates and destroys nothing**: no `lago-worktree`, no branch rename, no Conductor workspace created, archived or renamed — the operator does that in the app.
 - No commit, no push, no PR in this phase.
 - Never run the full jest suite.
 - Tests only via the make-tests skill.

--- a/.agents/skills/loop-clean/SKILL.md
+++ b/.agents/skills/loop-clean/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: loop-clean
-description: 'Cleanup phase of the loop pipeline for lago-front. Finds local worktrees whose PR is merged and destroys them via lago-worktree destroy, after user confirmation. Use when user says "/loop-clean", asks to clean up merged worktrees, or the loop-run orchestrator runs its sweep step.'
+description: 'Cleanup phase of the loop pipeline for lago-front, for the `worktree` layout only. Finds local worktrees in front-worktrees/ whose PR is merged and destroys them via lago-worktree destroy, after user confirmation. Use when user says "/loop-clean", asks to clean up merged worktrees, or the loop-run orchestrator runs its sweep step.'
 ---
 
 # Loop Clean — sweep worktrees of merged PRs
 
 **Repo:** the lago monorepo root; worktrees in `front-worktrees/`, slot registry in `.worktree-slots`.
+
+**Scope:** the `worktree` layout only. Runs made with `loop-run --in-place` (a Conductor workspace, a plain `git worktree`, a second clone) own no `front-worktrees/` entry and are invisible here — their cleanup belongs to whoever owns the checkout, which under Conductor means archiving the workspace. loop-run skips the sweep entirely in that layout; invoked directly from a Conductor workspace, report "nothing to do — in-place layout" and stop.
 
 ## Steps
 

--- a/.agents/skills/loop-review/SKILL.md
+++ b/.agents/skills/loop-review/SKILL.md
@@ -5,7 +5,7 @@ description: 'Phase 3 of the loop pipeline for lago-front. Takes an ISSUE-ID, re
 
 # Loop Review — phase 3 of loop-run
 
-**Input:** an ISSUE-ID. State dir: `$LOOP_STATE_DIR/<ISSUE-ID>/` (default `~/.claude/loop-state/<ISSUE-ID>/`). Requires `spec.md` and `state.md` (worktree path). If missing, stop and say which phase to run first.
+**Input:** an ISSUE-ID. State dir: `$LOOP_STATE_DIR/<ISSUE-ID>/` (default `~/.claude/loop-state/<ISSUE-ID>/`). Requires `spec.md` and `state.md` (worktree path). If missing, stop and say which phase to run first. The `worktree:` path is all this skill needs — it is a `front-worktrees/` worktree in the `worktree` layout and the operator's own checkout in `in-place`, and every command below is the same either way.
 
 **Clean context:** this skill is designed to run with NO knowledge of how the code was written (loop-run dispatches it in a fresh subagent). Judge only what spec.md, the sources it links, and the diff say. Never assume good intent from the build phase.
 

--- a/.agents/skills/loop-revise/SKILL.md
+++ b/.agents/skills/loop-revise/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: loop-revise
-description: 'Post-PR revision phase of the loop pipeline for lago-front. Takes an ISSUE-ID and feedback on the open PR, applies ONLY the requested changes in the existing worktree, re-runs gates, commits, pushes, and watches CI. Use when user says "/loop-revise <ISSUE-ID> <feedback>", or asks to change something in a PR the loop opened.'
+description: 'Post-PR revision phase of the loop pipeline for lago-front. Takes an ISSUE-ID (or nothing, when run inside the checkout that owns the PR) and feedback, applies ONLY the requested changes in the worktree recorded in state.md — a lago-worktree worktree or, in the `in-place` layout, the current checkout — re-runs gates, commits, pushes, and watches CI. Use when user says "/loop-revise <ISSUE-ID> <feedback>", or asks to change something in a PR the loop opened.'
 ---
 
 # Loop Revise — apply feedback to an open loop PR
 
 **Input:** a task reference + feedback. The reference can be ANY of:
 - an ISSUE-ID (`ING-538`) — direct key of the state dir;
-- a PR number (`4065` / `#4065`) or PR URL — resolve it: `gh pr view <n> --json headRefName` → branch → the `$LOOP_STATE_DIR/*/state.md` whose `branch:` matches → that dir's ISSUE-ID.
+- a PR number (`4065` / `#4065`) or PR URL — resolve it: `gh pr view <n> --json headRefName` → branch → the `$LOOP_STATE_DIR/*/state.md` whose `branch:` matches → that dir's ISSUE-ID;
+- **nothing at all**, when the session already sits in the checkout that owns the PR (the `in-place` layout): resolve from `git rev-parse --abbrev-ref HEAD` → the state dir whose `branch:` matches.
+
+**Layout:** read `layout:` from `state.md` (`worktree` | `in-place`, written by loop-build; missing key = `worktree`, the historical default). It changes exactly two things below — how the app is restarted, and that `in-place` never touches a worktree it did not receive. Scripts live in `<worktree>/scripts` in `in-place` and in `front/scripts` in the `worktree` layout; `$SCRIPTS` below means whichever applies.
 
 **State dir:** `$LOOP_STATE_DIR/<ISSUE-ID>/` (default `~/.claude/loop-state/<ISSUE-ID>/`).
 
@@ -35,24 +38,29 @@ No free-text feedback given → default to the unanswered external PR comments a
    - Verify claims before agreeing: if the feedback asserts something about the code ("this rerenders twice"), check it in the code first. Never implement performatively to please.
    - This evaluation applies IDENTICALLY to external comments (colleagues/bots): a Copilot suggestion gets the same scrutiny as anyone else's. For external feedback, "push back" means the polite not-applied reply of step 8 — only escalate to the operator when the comment is sound but conflicts with the spec.
 
-3. **Apply — ONLY the agreed points.** In the worktree from state.md:
+3. **Apply — ONLY the agreed points.** In the `worktree:` path from state.md (the cwd itself in `in-place`):
    - No opportunistic refactors, no scope creep beyond the agreed feedback.
    - Same build rules as loop-build: design system first, reuse `translations/base.json` labels, no dead keys, follow the Frontend coding styleguide, no dead code.
    - Feedback ambiguous → STOP and ask before coding.
 
-4. **Gates** (in the worktree, all must pass):
+4. **Gates** (in that same path, all must pass):
    - `pnpm lint`, `pnpm types`, `pnpm translations:inspect`, `pnpm translations:ensure-consistency`.
    - If the change touched testable logic: re-invoke the `make-tests` skill on the affected paths, then scoped jest on those paths only. NEVER the full suite.
 
-5. **Restart the worktree app** (reload on the fixed code; the start script cleans the vite cache itself):
+5. **Restart the app** (reload on the fixed code). Use the `container:` name from state.md, or derive it from the layout:
 
    ```bash
-   # BRANCH from state.md (container name derives from the full branch name)
-   SAN=$(echo "<BRANCH>" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g')
-   docker restart lago_front_wt_${SAN}
+   # in-place: lago_front_ct_<SAN(workspace)>   worktree: lago_front_wt_<SAN(branch)>
+   CT="<container: from state.md>"
+   if docker ps --format '{{.Names}}' | grep -qx "$CT"; then
+     docker exec "$CT" sh -c 'rm -rf /app/node_modules/.vite' 2>/dev/null || true
+     docker restart "$CT"
+   else
+     echo "no container $CT — skipping restart"
+   fi
    ```
 
-   Container not running → skip with a warning, don't block.
+   Container absent → skip with a warning, don't block. Clearing `node_modules/.vite` first is what keeps a restart mid-dep-optimization from serving `504 Outdated Optimize Dep`.
 
 6. **Commit and push** on the existing branch:
 
@@ -69,7 +77,7 @@ No free-text feedback given → default to the unanswered external PR comments a
 
    Then `git push` — the open PR updates itself.
 
-7. **CI gate**: `gh pr checks <PR> --watch`. Red → same recovery as loop-run, INCLUDING its pre-budget triage of special cases (codegen companion-PR, code-scanning re-fingerprint — loop-run CI-gate step 5.3); neither applies → charge the budget first with `front/scripts/iter-budget.sh <ISSUE-ID> ci-revise` (exit 1 = exhausted → STOP path), capture failed logs to `ci-failure.md` (previous one appended to `ci-failure-history.md`), fix, recommit. On STOP: write `impediment.md` and notify exactly like loop-run's "Exit notification" section — send via `front/scripts/loop-notify.sh "<MESSAGE>"` (prints `CH`/`TS`/`USER` for the feedback-wait polling); fallback to PushNotification + MCP self-DM if the script fails.
+7. **CI gate**: `gh pr checks <PR> --watch`. Red → same recovery as loop-run, INCLUDING its pre-budget triage of special cases (codegen companion-PR, code-scanning re-fingerprint — loop-run CI-gate step 5.3); neither applies → charge the budget first with `"$SCRIPTS/iter-budget.sh" <ISSUE-ID> ci-revise` (exit 1 = exhausted → STOP path), capture the failure per loop-run's **CI log protocol** (raw log redirected to `ci-raw-<N>.log`, never into context; `ci-failure.md` holds the distilled version, the previous one appended to `ci-failure-history.md`), fix, recommit. On STOP: write `impediment.md` and notify exactly like loop-run's "Exit notification" section — send via `"$SCRIPTS/loop-notify.sh" "<MESSAGE>"` (prints `CH`/`TS`/`USER` for the feedback-wait polling); fallback to PushNotification + MCP self-DM if the script fails.
 
 8. **Reply to every external comment on GitHub — ALWAYS** (colleagues and bots alike, whether the suggestion was applied or not). Short, friendly, in English, no AI attribution:
    - Applied → thank + confirm: `Good catch, thanks! Applied in <short-sha>.`
@@ -92,7 +100,7 @@ No free-text feedback given → default to the unanswered external PR comments a
 ## Hard rules
 
 - **No AI attribution**: commit message contains exactly the template above — no Co-Authored-By: Claude, no "Generated with" lines.
-- Only the existing worktree and branch from state.md — never a new branch, never the main checkout.
+- Only the existing worktree and branch from state.md — never a new branch, never the main checkout, and in `in-place` never `$CONDUCTOR_ROOT_PATH`, another workspace, or a branch rename.
 - Only the changes the feedback asks for.
 - Humans merge. Never merge, never approve.
 - Never run the full jest suite.

--- a/.agents/skills/loop-run/README.md
+++ b/.agents/skills/loop-run/README.md
@@ -7,9 +7,9 @@ Six skills, one per phase:
 | Skill | Phase | What it does |
 |---|---|---|
 | `loop-run` | orchestrator | runs the whole thing; owns the retry budgets, ship, CI gate, Slack |
-| `loop-clean` | sweep | destroys worktrees whose PR is already merged (asks first) |
+| `loop-clean` | sweep | destroys worktrees whose PR is already merged (asks first) — `worktree` layout only |
 | `loop-spec` | 1 | reads Linear + Notion + the codebase, writes an operational spec |
-| `loop-build` | 2 | implements in a dedicated worktree, gets lint/types/translations green |
+| `loop-build` | 2 | implements in the run's worktree, gets lint/types/translations green |
 | `loop-review` | 3 | reviews the diff against the spec in a clean context, PASS/FAIL |
 | `loop-revise` | post-PR | applies feedback to an open loop PR, replies to PR comments |
 
@@ -20,6 +20,37 @@ Usual entry point:
 ```
 
 Optionally with Notion spec pages: `/loop-run <linear-url> <notion-url> <notion-url>`.
+
+## Two layouts: a fresh worktree, or the current one
+
+The pipeline is identical either way — the layout only decides who owns the workspace it builds in.
+`loop-run` resolves it once and records it in `state.md`; every phase reads it from there.
+
+|  | `worktree` (default) | `in-place` (`--in-place`) |
+|---|---|---|
+| Workspace | `lago-worktree create` builds `front-worktrees/<BRANCH>/` | the checkout the session already sits in — nothing is created |
+| Branch | forced to `<ISSUE-ID>-<topic-slug>` | whatever the checkout carries, **never renamed** |
+| Working dir | lago monorepo root, `git -C <worktree>` everywhere | the checkout itself, plain cwd |
+| Scripts | `front/scripts/` | `<checkout>/scripts/` |
+| Container | `lago_front_wt_<branch>` | `lago_front_ct_<workspace>` under Conductor, none otherwise |
+| Sweep / cleanup | `loop-clean` + `lago-worktree destroy` | the checkout's owner — under Conductor, archiving the workspace |
+| Docker preflight | hard STOP without the stack | warning only; the restart step skips itself when there is no container |
+
+`in-place` turns on automatically when `$CONDUCTOR_WORKSPACE_PATH` is set, so inside a
+[Conductor](https://www.conductor.build) workspace the plain entry point already does the right
+thing — the workspace **is** the worktree, the branch, the port and the container, and archiving it
+is the cleanup. Anywhere else, pass the flag explicitly:
+
+```bash
+/loop-run https://linear.app/getlago/issue/LAGO-1234/some-ticket --in-place
+```
+
+Use it when you are already on the branch you want the PR to carry: a Conductor workspace, a plain
+`git worktree`, a second clone. **One checkout, one ticket** — start a fresh workspace per ticket.
+
+Why the branch is never renamed in `in-place`: Conductor persists `workspaces.branch` in its own
+SQLite database. A `git branch -m` inside the workspace changes git but not that record, which
+desyncs Conductor's diff view and its archive-time branch deletion.
 
 ## Why it is built this way
 
@@ -36,7 +67,7 @@ Nothing about any specific person is in these files. Each developer configures t
 **1. Required tooling**
 
 - `gh` authenticated (`gh auth status`) — the PR self-assigns to whoever runs the loop.
-- Docker stack up (`lago_front_dev` running) and the `lago-worktree` helper available (`front/scripts/lago-worktree.sh`).
+- Docker stack up (`lago_front_dev` running). The `worktree` layout also needs the `lago-worktree` helper (`front/scripts/lago-worktree.sh`) and hard-stops without the stack; `in-place` only warns, since its gates run on the host.
 - MCP connectors: Linear (read ticket, move to In Review), Notion (specs + Frontend coding styleguide), Slack (the `#frontend` announcement).
 - `jq` and `curl` for the notification script.
 
@@ -51,7 +82,9 @@ The loop DMs you when it gives up. It needs a bot token because a self-DM throug
 
 **3. Environment**
 
-Put these in your shell profile or your own `.claude/settings.local.json` (never in a tracked file):
+Put these in your shell profile or your own `.claude/settings.local.json` (never in a tracked file).
+Under Conductor the script environment captures your login shell, so the same profile works; per
+repository you can also use `.conductor/settings.local.toml` (gitignored).
 
 | Variable | Required | Meaning |
 |---|---|---|
@@ -64,7 +97,8 @@ Put these in your shell profile or your own `.claude/settings.local.json` (never
 **4. Verify**
 
 ```bash
-front/scripts/loop-notify.sh --check
+front/scripts/loop-notify.sh --check          # worktree layout
+"$(git rev-parse --show-toplevel)/scripts/loop-notify.sh" --check   # in-place
 ```
 
 Prints the resolved recipient and DM channel without sending anything.
@@ -73,13 +107,13 @@ Prints the resolved recipient and DM channel without sending anything.
 
 Adopting the loop means accepting these. They are enforced in the skills as hard rules.
 
-- **The pipeline commits, pushes and opens the PR.** It is the one place where an agent performs git write operations, and only ever on its own branch in its own worktree. It never force-pushes and never touches the main checkout.
+- **The pipeline commits, pushes and opens the PR.** It is the one place where an agent performs git write operations, and only ever on its own branch in the worktree recorded in `state.md`. It never force-pushes and never touches the main checkout (`$CONDUCTOR_ROOT_PATH` included).
 - **Humans merge.** No self-approval, no merge, no auto-merge flag — ever.
 - **No AI attribution** in commits, PR bodies or Slack messages.
 - **`#frontend` is posted only when CI is green** — sole exception: a red `Run Codegen` caused by a verified unmerged companion lago-api PR (loop-run CI-gate step 5.3), which is announced anyway since only the API merge plus a rerun stand between it and green.
 - **The full jest suite is never run.** Only scoped paths for the touched domain.
 - **Every external PR comment gets a reply** — applied with the sha, or not applied with a one-line technical reason.
-- **Destructive cleanup always asks.** `loop-clean` never destroys a dirty worktree or one with unpushed commits.
+- **Destructive cleanup always asks.** `loop-clean` never destroys a dirty worktree or one with unpushed commits — and in `in-place` the pipeline manages no workspace at all: it never creates, archives or renames one, and never renames a branch.
 
 ## Run state
 
@@ -88,10 +122,11 @@ Per-developer, outside the repo, in `$LOOP_STATE_DIR/<ISSUE-ID>/`:
 | File | Written by | Purpose |
 |---|---|---|
 | `spec.md` | loop-spec | the operational spec the whole run is judged against |
-| `state.md` | loop-build | worktree path, branch, dev port |
+| `state.md` | loop-build | layout, worktree path, branch, dev port, workspace + container when there is one |
 | `review.md` | loop-review | current PASS/FAIL verdict |
 | `review-history.md` | loop-run | every previous FAIL verdict — fuel for the escalating retry |
-| `ci-failure.md` / `ci-failure-history.md` | loop-run | current and past CI failure logs |
+| `ci-failure.md` / `ci-failure-history.md` | loop-run | current and past CI failures, **distilled** (~60 lines: failing job, matched error lines, file:line) |
+| `ci-raw-<N>.log` | loop-run / loop-revise | the raw `--log-failed` output, on disk for you — never read into an agent's context |
 | `feedback.md` | loop-revise | every round of human feedback |
 | `impediment.md` | loop-run / loop-revise | why the loop gave up: stage, cause, what it tried, what it needs |
 | `counters/` | iter-budget.sh | the retry budgets |
@@ -102,4 +137,4 @@ Plus two files shared across runs: `_journal.md` (one row per run — iterations
 
 Every run that struggles writes down why. `_flywheel.md` collects proposed edits to the skills, evidence attached; the loop never edits its own instructions. Read it when you have a moment, and turn a proposal that keeps recurring into a PR against `.agents/skills/loop-*`. `_journal.md` is how you tell whether such a change actually helped — average iterations per run should fall.
 
-Scripts live in `front/scripts/`: `iter-budget.sh` (retry budget) and `loop-notify.sh` (exit DM). Both are standalone and documented in their headers.
+Scripts live in the front checkout's `scripts/` (`front/scripts/` from the monorepo root): `iter-budget.sh` (retry budget) and `loop-notify.sh` (exit DM). Both are standalone and documented in their headers.

--- a/.agents/skills/loop-run/SKILL.md
+++ b/.agents/skills/loop-run/SKILL.md
@@ -1,51 +1,90 @@
 ---
 name: loop-run
-description: 'Orchestrator of the loop pipeline for lago-front: sweep → spec → build ↔ review → ship (commit, PR, Linear, CI gate, Slack #frontend). Takes a Linear ticket URL and optionally Notion spec URLs. Use when user says "/loop-run <linear-url> [notion-urls...]" or asks to run the full loop on a ticket.'
+description: 'Orchestrator of the loop pipeline for lago-front: sweep → spec → build ↔ review → ship (commit, PR, Linear, CI gate, Slack #frontend). Creates a dedicated worktree by default, or runs in the current checkout with `--in-place` (automatic inside a Conductor workspace). Takes a Linear ticket URL and optionally Notion spec URLs. Use when user says "/loop-run <linear-url> [notion-urls...] [--in-place]" or asks to run the full loop on a ticket, in a fresh worktree or in the current one.'
 ---
 
 # Loop Run — full pipeline orchestrator
 
-**Input:** a Linear ticket URL (required) + optional Notion spec page URLs. If the Linear URL is missing, ask and stop.
+**Input:** a Linear ticket URL (required) + optional Notion spec page URLs + the optional `--in-place` flag. If the Linear URL is missing, ask and stop.
 
-**Repo guard:** this pipeline works ONLY on lago-front (`front/` in the lago monorepo). Any other repo: STOP.
+**Repo guard:** this pipeline works ONLY on lago-front. Any other repo: STOP.
 
 **Principle: humans merge.** This pipeline NEVER merges or approves a PR, never bypasses a gate, never force-pushes.
 
 **Autonomy contract:** between the input and the final Slack post the pipeline runs alone. The ONLY thing that asks the operator for help is an exhausted retry budget (3 review cycles or 3 CI cycles), a `needs-operator-adjudication` triage STOP (CI gate step 5.3), or an unrecoverable external failure. Never pause for approval mid-run.
 
+## Layout — resolved ONCE, before anything else
+
+Two layouts, one pipeline. Resolve the layout at the very start, pass it to every phase through
+`state.md`, and never re-derive it later in the run:
+
+```bash
+if [ -n "${CONDUCTOR_WORKSPACE_PATH:-}" ] || [ "<--in-place passed>" = yes ]; then
+  LAYOUT=in-place
+  FRONT="$(git rev-parse --show-toplevel)"   # the checkout this session already sits in
+else
+  LAYOUT=worktree
+  FRONT="$PWD/front"                         # lago monorepo root, front/ beside it
+fi
+SCRIPTS="$FRONT/scripts"
+[ -x "$SCRIPTS/iter-budget.sh" ] || { echo "not a lago-front checkout"; exit 1; }   # repo guard
+```
+
+- **`worktree`** (default): `loop-build` creates `front-worktrees/<ISSUE-ID>-<slug>/` through
+  `lago-worktree`, the session stays in the lago monorepo root and reaches the worktree with
+  `git -C`. Cleanup is `loop-clean` + `lago-worktree destroy`.
+- **`in-place`** (automatic inside a Conductor workspace, forced anywhere with `--in-place`): the
+  current checkout IS the worktree, IS the branch, IS the cwd. Nothing is created and nothing is
+  destroyed — `lago-worktree` is NEVER called, the branch is NEVER renamed, and cleanup belongs to
+  whoever owns the checkout (under Conductor: archiving the workspace, which deletes the branch and
+  tears the container down).
+
+`--in-place` outside Conductor is allowed (a plain `git worktree`, a second clone): everything
+below behaves the same, minus the container steps that need `$CONDUCTOR_WORKSPACE_NAME`.
+
 ## Conventions used throughout
 
 - **Operator** = the developer who started this run. Identity comes from their own tooling (`gh` auth, `git config user.email`, their Slack config) — nothing about any specific person is hardcoded.
 - **State dir** = `$LOOP_STATE_DIR/<ISSUE-ID>/` (default `~/.claude/loop-state/<ISSUE-ID>/`) — per-developer, outside the repo, never committed.
-- **Scripts** = `front/scripts/iter-budget.sh` and `front/scripts/loop-notify.sh`, run from the lago monorepo root. Setup and configuration: `.agents/skills/loop-run/README.md`.
+- **Scripts** = `$SCRIPTS/iter-budget.sh` and `$SCRIPTS/loop-notify.sh`, with `$SCRIPTS` from the Layout section above (`front/scripts` in the `worktree` layout, `<checkout>/scripts` in `in-place`). Setup and configuration: `.agents/skills/loop-run/README.md`.
 
 ## Pipeline
 
-0. **Sweep**: invoke the `loop-clean` skill first — it proposes destroying worktrees of already-merged PRs (operator confirms; skipping is fine, the pipeline continues either way).
+0. **Sweep** (`worktree` layout ONLY — skip it entirely in `in-place`, where the pipeline owns no worktree): invoke the `loop-clean` skill first — it proposes destroying worktrees of already-merged PRs (operator confirms; skipping is fine, the pipeline continues either way).
 
-1. **Spec**: invoke the `loop-spec` skill with the URL(s). Extract `<ISSUE-ID>`. Then reset the iteration budget: `front/scripts/iter-budget.sh <ISSUE-ID> reset`.
+1. **Spec**: invoke the `loop-spec` skill with the URL(s). Extract `<ISSUE-ID>`. Then reset the iteration budget: `"$SCRIPTS/iter-budget.sh" <ISSUE-ID> reset`.
 
 2. **Build ↔ review cycle** (max 3 iterations — the cap is MECHANICAL, enforced by iter-budget.sh, not by counting in your head):
-   1. Charge the budget: `front/scripts/iter-budget.sh <ISSUE-ID> review`. Exit code 1 → budget exhausted: go straight to the 3-FAIL STOP path below, regardless of what you believe the count is.
-   2. Invoke `loop-build` with `<ISSUE-ID>`. On the FIRST iteration only, just before invoking it, claim the ticket on Linear via the MCP `save_issue`: assignee = the operator (resolve their Linear user by matching `git config user.email` against Linear users), status = "Dev in Progress". A Linear failure here warns and continues — it never blocks the build.
+   1. Charge the budget: `"$SCRIPTS/iter-budget.sh" <ISSUE-ID> review`. Exit code 1 → budget exhausted: go straight to the 3-FAIL STOP path below, regardless of what you believe the count is.
+   2. Invoke `loop-build` with `<ISSUE-ID>` and the resolved layout. On the FIRST iteration only, just before invoking it, claim the ticket on Linear via the MCP `save_issue`: assignee = the operator (resolve their Linear user by matching `git config user.email` against Linear users), status = "Dev in Progress". A Linear failure here warns and continues — it never blocks the build.
    3. **Dispatch the review in a FRESH subagent** (clean context — the reviewer must not inherit the builder's reasoning or bias): use the Agent tool with a prompt like "Invoke the loop-review skill for <ISSUE-ID> and follow it exactly", general-purpose agent type. Do NOT run loop-review inline in this session.
    4. Read the first line of `state dir`/`review.md`:
       - `Verdict: PASS` → go to Ship.
       - `Verdict: FAIL` → **archive the verdict first**: append the full review.md under a `## Iteration <N>` header to `review-history.md` in the state dir, then next iteration (build runs in fix mode off review.md + the history — see loop-build's escalating-retry rules).
    5. After 3 FAIL verdicts (or iter-budget exit 1): STOP. Write `impediment.md` (see below), send the exit DM, and report the surviving issues to the operator. No git artifacts exist yet — nothing to clean up.
 
-3. **Restart the worktree app** (right after review PASS — reloads the container on the just-built code). ⚠️ The start script (`start.dev.sh` = `pnpm install && pnpm run dev`) does NOT clean the vite cache, and a restart that interrupts a running dep-optimization leaves `node_modules/.vite` corrupted (browser gets `504 Outdated Optimize Dep`). ALWAYS clear it before restarting:
+3. **Restart the app** (right after review PASS — reloads the container on the just-built code). ⚠️ Neither start script cleans the vite cache, and a restart that interrupts a running dep-optimization leaves `node_modules/.vite` corrupted (browser gets `504 Outdated Optimize Dep`). ALWAYS clear it before restarting. The container name is the only thing the layout changes:
 
    ```bash
-   # BRANCH from state.md (container name derives from the full branch name)
-   SAN=$(echo "<BRANCH>" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g')
-   docker exec lago_front_wt_${SAN} sh -c 'rm -rf /app/node_modules/.vite' 2>/dev/null || true
-   docker restart lago_front_wt_${SAN}
+   # LAYOUT and BRANCH from state.md
+   if [ "$LAYOUT" = in-place ]; then
+     SAN=$(echo "$CONDUCTOR_WORKSPACE_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g')
+     CT="lago_front_ct_${SAN}"      # the rule scripts/conductor-front-container.sh uses
+   else
+     SAN=$(echo "<BRANCH>" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g')
+     CT="lago_front_wt_${SAN}"      # lago-worktree derives it from the full branch name
+   fi
+   if docker ps --format '{{.Names}}' | grep -qx "$CT"; then
+     docker exec "$CT" sh -c 'rm -rf /app/node_modules/.vite' 2>/dev/null || true
+     docker restart "$CT"
+   else
+     echo "no container $CT (host run mode, --in-place outside Conductor, or app not running) — skipping restart"
+   fi
    ```
 
-   Container not running → skip with a warning, don't block.
+   Container absent → skip with that one-line warning, never block. This is the only step that needs Docker.
 
-4. **Ship** (only after PASS), all inside the worktree recorded in `state.md`:
+4. **Ship** (only after PASS), all inside the `worktree:` path recorded in `state.md` — in the `in-place` layout that path is the cwd, so drop the `git -C`:
    1. **Commit** — stage all pipeline changes and commit with EXACTLY this message structure:
 
       ```
@@ -64,18 +103,43 @@ description: 'Orchestrator of the loop pipeline for lago-front: sweep → spec �
       ```
 
       `<type>(<context>)`: conventional-commit type implied by the ticket (feat/fix/refactor/chore) + short domain context; `<Title>` sentence-case, imperative.
-   2. **Push**: `git push -u origin <branch>` (branch from state.md).
+   2. **Push**: `git push -u origin <branch>` (branch from state.md). In `in-place` that is whatever branch the checkout already carried — push it as is and let the PR carry that name; **never** rename it to match the ticket (Conductor persists the branch in its own database, so a git-side rename desyncs its diff view and its archive-time branch deletion).
    3. **PR** (ready, not draft): `gh pr create --assignee @me` — title = the commit's first line; body = the commit body (same Context/Description/Fixes structure). `@me` is the authenticated `gh` user, so the PR self-assigns to whoever runs the loop.
    4. **Linear**: move the issue to "In Review" via the Linear MCP `save_issue` tool.
 
-5. **CI gate** (max 3 fix cycles — cap enforced by iter-budget.sh):
+5. **CI gate** (max 3 fix cycles — cap enforced by iter-budget.sh, identical in both layouts):
    1. `gh pr checks <PR> --watch` and wait for completion.
    2. All green → go to Announce.
    3. Any red → triage the special cases FIRST (they must not consume budget):
       - **`Run Codegen` red with an unmerged companion API PR**: CI builds the GraphQL schema from lago-api `main`, so when the frontend change consumes schema that still sits in an open lago-api PR, `Run Codegen` CANNOT go green frontend-side and is not a failure — the API PR has its own reviewer, and once it merges a rerun goes green. Qualifying requires BOTH: (a) a concrete companion PR identified from the ticket/spec, or named by the codegen errors matching exactly the fields it adds; AND (b) a one-time verification that it exists and is still open — `gh pr view <N> --repo getlago/lago-api --json state,title` — recorded in the state dir (never re-checked on later watch cycles). Both hold → skip fix mode, continue to Announce and post the plain template anyway; note the pending API merge in the journal row and put in the final report: "after <api-PR> merges, rerun the `Run Codegen` check". No verifiable companion PR, or any OTHER red check alongside it → real failure, handle normally.
       - **CodeQL (or any code-scanning gate) red**: before writing ci-failure.md, list the repo's alerts — `gh api --paginate 'repos/getlago/lago-front/code-scanning/alerts?per_page=100'` — and filter `state == "dismissed"` yourself (the endpoint's `state` param takes a SINGLE value; `state=open,dismissed` is silently ignored and would also return `fixed` alerts). A dismissed alert with the same `rule.id`, same file AND overlapping code region as the new one means the new alert is a re-fingerprint (CodeQL fingerprints by location, so ANY edit to the function re-raises it) and NO code change can clear the check. Same rule elsewhere in the file is NOT a match — treat it as a real new finding. On a re-fingerprint: if other fixable checks are red alongside, fix those through the normal cycle first; when the re-fingerprinted alert is the only remaining red, do not spend a CI cycle on it — go straight to the STOP path with outcome `needs-operator-adjudication` and an impediment asking the operator to dismiss the new alert referencing the prior one.
-      - **Neither special case applies** → charge the budget: `front/scripts/iter-budget.sh <ISSUE-ID> ci`. Exit code 1 → go straight to the 3-red STOP path. Otherwise `gh run view <run-id> --log-failed` to capture failure logs, write them to `ci-failure.md` in the state dir. If a previous ci-failure.md existed, first append it under a `## CI cycle <N>` header to `ci-failure-history.md`. Then re-enter the build ↔ review cycle in fix mode against that report. After fixes: commit (`fix(<context>): address CI failures` + short body), push, watch checks again.
-   4. After 3 red cycles (or iter-budget exit 1): STOP. Write `impediment.md`, send the exit DM, and report to the operator with the PR URL and the last failure log. **NEVER post to Slack channels while CI is red** (the codegen exception never reaches this step — it exits at triage in 5.3).
+      - **Neither special case applies** → charge the budget: `"$SCRIPTS/iter-budget.sh" <ISSUE-ID> ci`. Exit code 1 → go straight to the 3-red STOP path. Otherwise capture the failure per the **CI log protocol** below, then re-enter the build ↔ review cycle in fix mode against `ci-failure.md`. After fixes: commit (`fix(<context>): address CI failures` + short body), push, watch checks again.
+   4. After 3 red cycles (or iter-budget exit 1): STOP. Write `impediment.md`, send the exit DM, and report to the operator with the PR URL and the distilled `ci-failure.md` (link the raw log path, never paste it). **NEVER post to Slack channels while CI is red** (the codegen exception never reaches this step — it exits at triage in 5.3).
+
+### CI log protocol — the raw log NEVER enters context
+
+A failed CI log is tens of thousands of tokens and gets read twice (once live, once when archived to history). It goes to disk, and only the decisive lines are read:
+
+```bash
+STATE="${LOOP_STATE_DIR:-$HOME/.claude/loop-state}/<ISSUE-ID>"
+N=<cycle number>                       # 1, 2, 3 — same number the budget just charged
+gh run view <run-id> --repo getlago/lago-front --log-failed > "$STATE/ci-raw-$N.log"  # redirect, never let it print
+wc -l "$STATE/ci-raw-$N.log"
+
+# the decisive lines only — job name kept, step+timestamp prefix stripped
+grep -nE '●|FAIL |Error:|error TS[0-9]+|AssertionError|ELIFECYCLE|[0-9]+:[0-9]+ +error|Tests: +[0-9]+ failed|Test Suites: +[0-9]+ failed|Process completed with exit code' \
+  "$STATE/ci-raw-$N.log" \
+  | grep -v '● Console' \
+  | sed -E 's/\t[A-Z ]*STEP\t[0-9-]+T[0-9:.]+Z / | /' \
+  | head -40
+```
+
+  Measured on a real lago-front failure: 3201 raw lines → 18 kept, containing the failing job, `FAIL <file>`, the `● suite › test` name, the root-cause line and the `Tests: N failed` summary. Pattern notes: jest prints no `✕` in CI (non-TTY) — `●` is the failure header; `● Console` is filtered because it prefixes every captured console line.
+
+- **Never `cat` / `Read` the raw log, never run `gh run view` without redirecting.** Grep with `head` caps, widen with `grep -B3 -A8` around a specific hit only when a match is genuinely ambiguous.
+- Greps come back empty (an infra or setup failure with no recognizable marker) → `tail -60` on the raw log, that is the whole budget.
+- **Write `ci-failure.md` distilled**, not raw: failing job name, the matched lines, the file:line each points at, and `raw: <path to ci-raw-$N.log>`. Cap it at ~60 lines. The builder reads this file, never the raw one.
+- A previous `ci-failure.md` is appended under a `## CI cycle <N>` header to `ci-failure-history.md` before the new one is written. Since it is already distilled, the history stays cheap to re-read across cycles. Raw logs are never archived, only kept beside it for a human.
 
 6. **Announce** (only with CI fully green — sole carve-out: the verified codegen exception of step 5.3) — post to the Slack channel `#frontend` via the Slack MCP, EXACTLY this format, no extra text:
 
@@ -94,7 +158,7 @@ description: 'Orchestrator of the loop pipeline for lago-front: sweep → spec �
 
 7. **External comments check**: before closing, fetch PR comments (`gh api repos/getlago/lago-front/pulls/<PR>/comments` + `gh pr view <PR> --json comments`). Any comment authored by someone other than the operator — colleague or bot (e.g. Copilot); the operator's own login is `gh api user --jq .login` → handle it with the loop-revise protocol: evaluate critically, apply if sound, and ALWAYS reply on GitHub — short thanks + applied (with sha) or not applied (with a one-line technical reason). Never leave an external comment unanswered.
 
-8. **Final report** to the operator: PR URL, Linear state, CI status, Slack link, replies posted, cycle counts.
+8. **Final report** to the operator: PR URL, Linear state, CI status, Slack link, replies posted, cycle counts. End with the cleanup line for the layout: `worktree` → `loop-clean` destroys the worktree once the PR is merged; `in-place` → nothing to clean up here, under Conductor the operator archives the workspace after the merge (`delete_branch_on_archive` removes the branch, the archive hook tears the container down).
 
 ## Journal & flywheel — SILENT, on EVERY terminal outcome
 
@@ -128,7 +192,7 @@ Run these two steps on every way the pipeline ends — happy path (after Announc
 
 ## Exit notification — bot DM (real ping) + feedback-wait
 
-The DM goes to whoever runs the loop: `front/scripts/loop-notify.sh` resolves the recipient from `$SLACK_LOOP_USER_ID`, else from `git config user.email` via `users.lookupByEmail`, and sends through the bot token in `$SLACK_LOOP_BOT_TOKEN`. Configuration: `.agents/skills/loop-run/README.md`.
+The DM goes to whoever runs the loop: `$SCRIPTS/loop-notify.sh` resolves the recipient from `$SLACK_LOOP_USER_ID`, else from `git config user.email` via `users.lookupByEmail`, and sends through the bot token in `$SLACK_LOOP_BOT_TOKEN`. Configuration: `.agents/skills/loop-run/README.md`.
 
 On EVERY exit that needs the operator's attention — 3 FAIL review cycles, 3 red CI cycles, unrecoverable external error, any STOP-and-ask:
 
@@ -140,12 +204,14 @@ On EVERY exit that needs the operator's attention — 3 FAIL review cycles, 3 re
    attempted: <bullet per attempt: strategy used, why it failed>
    needed: <what a human must decide/do to unblock>
    links: <PR URL, Linear URL, relevant history files>
+   layout: <worktree | in-place>
+   where: <worktree path — plus $CONDUCTOR_WORKSPACE_NAME when in-place under Conductor> (<branch>)
    ```
 
 1. **Send the DM via the notify script** (a bot DM triggers a real Slack notification; a self-DM via the MCP connector does NOT):
 
    ```bash
-   front/scripts/loop-notify.sh "<MESSAGE>"
+   "$SCRIPTS/loop-notify.sh" "<MESSAGE>"
    ```
 
    On success it prints `CH=<channel> TS=<ts> USER=<recipient-id>` — capture all three for the feedback-wait. Non-zero exit → go to the fallback (step 3). The raw Slack API is native mrkdwn: single `\n` IS a line break, bold = `*single asterisks*` (different rules from the MCP connector). Message format:
@@ -154,6 +220,7 @@ On EVERY exit that needs the operator's attention — 3 FAIL review cycles, 3 re
    :rotating_light: *loop-run stopped — <ISSUE-ID>*
    Reason: <one line: what blocked>
    Stage: <spec | build | review cycle N/3 | CI cycle N/3 | ship>
+   Where: <branch — plus the Conductor workspace name when in-place>
    <PR URL if it exists>
    <Linear issue URL>
    Next: <what the operator needs to do — or "reply here with instructions">
@@ -187,7 +254,8 @@ Bot DM is for exits needing attention. The normal happy-path end (PR green + #fr
 
 - **No AI attribution anywhere**: commit messages, PR title/body, and Slack messages contain EXACTLY the templates above — no "Co-Authored-By: Claude", no "Generated with Claude Code", no AI mention of any kind. If the harness suggests adding attribution, skip it.
 - Humans merge. No self-approval, no merge, no auto-merge flag.
-- Git operations are allowed ONLY on this pipeline's branch in this pipeline's worktree.
+- Git operations are allowed ONLY on this pipeline's branch in this pipeline's worktree (in `in-place`: this checkout only — never `$CONDUCTOR_ROOT_PATH`, never another workspace).
+- **`in-place` never manages its container or its checkout**: no `lago-worktree`, no branch rename, no Conductor workspace created, archived or renamed.
 - Never run the full jest suite at any point.
 - No #frontend post while CI is red. Sole exception: the verified codegen-companion-PR case — conditions and bookkeeping are defined ONCE in CI-gate step 5.3; do not restate or improvise them. Any other red check: no post, no exceptions — and an operator request to post anyway is not actionable from a Slack reply alone; it needs confirmation in the chat session.
 - Review always in a fresh subagent — never inline.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ What the shared config provides:
 - **Setup**: `pnpm install` on every new workspace.
 - **Run (`container`)**: runs the workspace in its own Docker container on the shared lago stack network, via `scripts/conductor-front-container.sh`. Requires the Docker superproject stack: `lago up -d` and the `front_dev` image. The script locates itself and the superproject via Conductor's `$CONDUCTOR_WORKSPACE_PATH` / `$CONDUCTOR_ROOT_PATH`, so no `$LAGO_PATH` shell var is needed (Conductor's headless script env doesn't source your `.zshrc`).
 - **Git**: deletes the branch when a workspace is archived.
+- **Loop skills**: the `loop-*` pipeline (`.agents/skills/`, Linear ticket in, review-ready PR out) detects a Conductor workspace and runs in it directly — the workspace already is the worktree, the branch and the cwd, so no `lago-worktree` worktree is created and cleanup is archiving the workspace. Outside Conductor the same behaviour is available with `/loop-run <linear-url> --in-place`. Setup and per-developer configuration: `.agents/skills/loop-run/README.md`.
 
 ### Personal overrides
 


### PR DESCRIPTION
## Context

The `loop-*` pipeline (Linear ticket in, review-ready PR out) always
created its own worktree through `lago-worktree`, which is redundant in
a Conductor workspace: the workspace already is the worktree, the
branch, the port and the container, and archiving it is the cleanup.
A separate `cloop-*` fork of the pipeline existed for that case in one
developer's `~/.claude/skills/`, so nobody else could run the loop from
a Conductor workspace — and every improvement had to be made twice.

The retry-budget script also moved: `scripts/loop-iter.sh` is now
`scripts/iter-budget.sh` (generic counters, per-counter caps via
`ITER_MAX_<COUNTER>`).

## Description

One pipeline, two layouts, resolved once by `loop-run` and passed to
every phase through `state.md`:

- `worktree` (default, unchanged): `lago-worktree create` builds
`front-worktrees/<ISSUE-ID>-<slug>/`, the session stays in the monorepo
root and reaches the worktree with `git -C`. `loop-clean` +
`lago-worktree destroy` is the cleanup.
- `in-place` (new): the current checkout is the worktree, the branch and
the cwd. Nothing is created or destroyed, `lago-worktree` is never
called and the branch is never renamed. Turns on automatically when
`$CONDUCTOR_WORKSPACE_PATH` is set, or explicitly with
`/loop-run <linear-url> --in-place` in any checkout (a plain
`git worktree`, a second clone).

Per skill:

- `loop-run`: new `## Layout` section resolving the layout and the
`$SCRIPTS` path; sweep restricted to the `worktree` layout; app-restart
step picks `lago_front_wt_<branch>` or `lago_front_ct_<workspace>` and
skips when the container is absent; ship/push documents the never-rename
rule; impediment and exit DM carry the layout.
- `loop-build`: preflight split per layout (`in-place` validates the
checkout, guards against `main`/detached HEAD, fetches `origin/main`
without ever pulling or stashing, warns instead of blocking on Docker);
worktree creation skipped in `in-place`; `state.md` gains `layout:`,
`workspace:` and `container:`.
- `loop-revise`: resolves the run from the current branch when no
reference is given, restarts the container recorded in `state.md`.
- `loop-clean`: documents that it only serves the `worktree` layout.
- `loop-review`: unchanged behaviour — it only ever needed `worktree:`.

Also folded in from the fork: the CI log protocol that redirects
`gh run view --log-failed` to `ci-raw-<N>.log` and greps the decisive
lines, so a 3000-line log never enters an agent's context, and
`ci-failure.md` stays a ~60-line distilled report.

All guards and budget charges now point at `scripts/iter-budget.sh`, and
the loop-run README documents `ITER_MAX` / `ITER_STATE_DIR`
(`LOOP_MAX_ITER` remains a deprecated alias).