### PR TITLE
fix(auth): validate redirect targets, drop unused router dep

### DIFF
--- a/packages/configs/eslint-rules/no-direct-rrd-nav-import.js
+++ b/packages/configs/eslint-rules/no-direct-rrd-nav-import.js
@@ -1,6 +1,7 @@
 /**
  * ESLint rule to forbid importing `useNavigate`, `Link`, `useLocation`, and
- * `useMatch` directly from `react-router-dom`. These must be imported from
+ * `useMatch` directly from `react-router-dom` or `react-router`. These must be
+ * imported from
  * `~/core/router` so the org slug is automatically prepended (for
  * `useNavigate`/`Link`) or `strippedPathname` is available (for
  * `useLocation`). `useMatch` is banned because it matches against the
@@ -12,26 +13,29 @@
  */
 
 const RESTRICTED = new Set(['useNavigate', 'Link', 'useLocation', 'useMatch'])
+// Both specifiers: v7's `react-router-dom` is a re-export of `react-router`, so
+// either import bypasses the slug wrappers.
+const RESTRICTED_SOURCES = new Set(['react-router-dom', 'react-router'])
 
 export default {
   meta: {
     type: 'problem',
     docs: {
       description:
-        "Disallow importing useNavigate, Link, useLocation, and useMatch from 'react-router-dom'. Use '~/core/router' for slug-aware wrappers. useMatch is banned — use matchPath + strippedPathname instead.",
+        "Disallow importing useNavigate, Link, useLocation, and useMatch from 'react-router-dom' or 'react-router'. Use '~/core/router' for slug-aware wrappers. useMatch is banned — use matchPath + strippedPathname instead.",
       recommended: true,
     },
     fixable: null,
     schema: [],
     messages: {
       noDirectImport:
-        "Import '{{name}}' from '~/core/router' instead of 'react-router-dom' to ensure the org slug is prepended automatically (useNavigate/Link) or strippedPathname is available (useLocation). useMatch is banned — use matchPath + strippedPathname instead.",
+        "Import '{{name}}' from '~/core/router' instead of 'react-router-dom' or 'react-router' to ensure the org slug is prepended automatically (useNavigate/Link) or strippedPathname is available (useLocation). useMatch is banned — use matchPath + strippedPathname instead.",
     },
   },
   create(context) {
     return {
       ImportDeclaration(node) {
-        if (node.source.value !== 'react-router-dom') return
+        if (!RESTRICTED_SOURCES.has(node.source.value)) return
 
         for (const specifier of node.specifiers) {
           if (specifier.type !== 'ImportSpecifier') continue

--- a/packages/configs/eslint-rules/no-direct-rrd-nav-import.js
+++ b/packages/configs/eslint-rules/no-direct-rrd-nav-import.js
@@ -1,8 +1,7 @@
 /**
  * ESLint rule to forbid importing `useNavigate`, `Link`, `useLocation`, and
  * `useMatch` directly from `react-router-dom` or `react-router`. These must be
- * imported from
- * `~/core/router` so the org slug is automatically prepended (for
+ * imported from `~/core/router` so the org slug is automatically prepended (for
  * `useNavigate`/`Link`) or `strippedPathname` is available (for
  * `useLocation`). `useMatch` is banned because it matches against the
  * full pathname (including the slug prefix), so route constants never

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -29,8 +29,7 @@
     "@mui/material": "5.18.0",
     "@mui/x-date-pickers": "6.20.2",
     "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "react-router-dom": "6.30.6"
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
     "@svgr/core": "8.1.0",

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -39,12 +39,11 @@ export default defineConfig({
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
-          'react-router-dom': 'ReactRouterDOM',
           '@mui/material': 'MaterialUI',
           '@mui/x-date-pickers': 'MaterialUIXDatePickers',
         },
       },
-      external: ['react', 'react-dom', 'react-router-dom', '@mui/material', '@mui/x-date-pickers'],
+      external: ['react', 'react-dom', '@mui/material', '@mui/x-date-pickers'],
     },
     cssCodeSplit: false,
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,9 +496,6 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
-      react-router-dom:
-        specifier: 6.30.6
-        version: 6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@svgr/core':
         specifier: 8.1.0

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
   },
   "packageRules": [
     {
-      "description": "LAGO-1859 owns the 6->7 major. Vulnerability alerts bypass minimumReleaseAge and the schedule, so park it on the dashboard instead of letting Renovate open (and reopen) the PR.",
+      "description": "LAGO-1859 owns the 6->7 major: park the ordinary major on the dependency dashboard so Renovate does not open (and reopen) the PR. This does NOT park the vulnerability-alert path - Renovate's synthetic vulnerabilityAlerts rule force-overrides dependencyDashboardApproval to false - and that is deliberate: alerts #250-253 are the EOL signal and must stay visible until stage 3 lands.",
       "matchPackageNames": ["react-router", "react-router-dom"],
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true

--- a/renovate.json
+++ b/renovate.json
@@ -24,12 +24,18 @@
   },
   "packageRules": [
     {
+      "description": "LAGO-1859 owns the 6->7 major. Vulnerability alerts bypass minimumReleaseAge and the schedule, so park it on the dashboard instead of letting Renovate open (and reopen) the PR.",
+      "matchPackageNames": ["react-router", "react-router-dom"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
       "matchDepTypes": ["overrides", "pnpm.overrides"],
       "enabled": false,
       "description": "Disable updates for pnpm overrides used to pin transitive security patches"
     },
     {
-      "matchPackageNames": ["@types/react", "@types/react-dom", "@types/react-router-dom"],
+      "matchPackageNames": ["@types/react", "@types/react-dom"],
       "groupName": "React types",
       "commitMessagePrefix": "chore(deps):"
     },
@@ -99,7 +105,6 @@
         "@babel/*",
         "@types/react",
         "@types/react-dom",
-        "@types/react-router-dom",
         "@testing-library/*",
         "cypress",
         "typescript",

--- a/src/core/router/__tests__/Link.test.tsx
+++ b/src/core/router/__tests__/Link.test.tsx
@@ -72,6 +72,52 @@ describe('Link', () => {
     })
   })
 
+  // Tripwire pinning v6 router behaviour for these inputs; stage 3's bump to
+  // react-router 7.18 is EXPECTED to change them, so a failure here is the signal.
+  describe('GIVEN a protocol-relative or backslash-tricked "to" prop', () => {
+    describe('WHEN rendering "//evil.com" with an organization slug', () => {
+      it('THEN should render the v6-observed href', () => {
+        renderWithRouter(<Link to="//evil.com">Evil</Link>)
+
+        const link = screen.getByText('Evil')
+
+        expect(link).toHaveAttribute('href', '/acme/evil.com')
+      })
+    })
+
+    describe('WHEN rendering "/\\evil.com" with an organization slug', () => {
+      it('THEN should render the v6-observed href', () => {
+        renderWithRouter(<Link to={'/\\evil.com'}>Evil</Link>)
+
+        const link = screen.getByText('Evil')
+
+        expect(link).toHaveAttribute('href', '/acme/\\evil.com')
+      })
+    })
+
+    describe('WHEN rendering "/acme//evil.com" with an organization slug', () => {
+      it('THEN should render the v6-observed href', () => {
+        renderWithRouter(<Link to="/acme//evil.com">Evil</Link>)
+
+        const link = screen.getByText('Evil')
+
+        expect(link).toHaveAttribute('href', '/acme/evil.com')
+      })
+    })
+
+    describe('WHEN rendering "//evil.com" with no organization slug', () => {
+      it('THEN should render the v6-observed href', () => {
+        mockUseParams.mockReturnValue({})
+
+        renderWithRouter(<Link to="//evil.com">Evil</Link>)
+
+        const link = screen.getByText('Evil')
+
+        expect(link).toHaveAttribute('href', '//evil.com')
+      })
+    })
+  })
+
   describe('GIVEN a ref is passed to Link', () => {
     describe('WHEN the component renders', () => {
       it('THEN should forward the ref to the anchor element', () => {

--- a/src/core/router/utils/__tests__/isSafeInAppPath.test.ts
+++ b/src/core/router/utils/__tests__/isSafeInAppPath.test.ts
@@ -43,4 +43,13 @@ describe('isSafeInAppPath', () => {
       },
     )
   })
+
+  describe('GIVEN a non-string value from an untyped caller', () => {
+    it.each([123, null, undefined, true, { redirectPath: '/acme' }, ['/acme']])(
+      'THEN %s is rejected',
+      (path) => {
+        expect(isSafeInAppPath(path as unknown as string)).toBe(false)
+      },
+    )
+  })
 })

--- a/src/core/router/utils/__tests__/isSafeInAppPath.test.ts
+++ b/src/core/router/utils/__tests__/isSafeInAppPath.test.ts
@@ -1,0 +1,46 @@
+import { isSafeInAppPath } from '../isSafeInAppPath'
+
+describe('isSafeInAppPath', () => {
+  describe('GIVEN an absolute same-origin in-app path', () => {
+    it.each([
+      '/',
+      '/customers',
+      '/acme/customers',
+      '/acme/plans/123?tab=overview#section',
+      '/acme/customers/id-with-%2F-encoded-slash',
+    ])('THEN %s is safe', (path) => {
+      expect(isSafeInAppPath(path)).toBe(true)
+    })
+  })
+
+  describe('GIVEN a protocol-relative or backslash-tricked path', () => {
+    it.each([
+      '//evil.com',
+      '///evil.com',
+      '/\\evil.com',
+      '\\/evil.com',
+      '\\\\evil.com',
+      '/acme/\\evil.com',
+    ])('THEN %s is rejected', (path) => {
+      expect(isSafeInAppPath(path)).toBe(false)
+    })
+  })
+
+  describe('GIVEN a scheme-qualified URL', () => {
+    it.each(['https://evil.com', 'http://evil.com', 'javascript:alert(1)//', 'mailto:a@b.co'])(
+      'THEN %s is rejected',
+      (path) => {
+        expect(isSafeInAppPath(path)).toBe(false)
+      },
+    )
+  })
+
+  describe('GIVEN a non-absolute value', () => {
+    it.each(['', 'customers', './customers', '../customers', '#anchor', '?tab=1'])(
+      'THEN %s is rejected',
+      (path) => {
+        expect(isSafeInAppPath(path)).toBe(false)
+      },
+    )
+  })
+})

--- a/src/core/router/utils/__tests__/orgSlug.test.ts
+++ b/src/core/router/utils/__tests__/orgSlug.test.ts
@@ -186,4 +186,26 @@ describe('ensureSlugPrefix', () => {
       expect(ensureSlugPrefix('/org-b/settings', 'org-a', currentUser)).toBe('/org-b/settings')
     })
   })
+
+  describe('GIVEN a hostile off-origin path', () => {
+    const ORIGIN = 'https://app.lago.dev'
+    const HOSTILE_PATHS = [
+      '//evil.com',
+      '///evil.com',
+      '/\\evil.com',
+      '\\/evil.com',
+      '\\\\evil.com',
+      'https://evil.com',
+      'javascript:alert(1)//',
+    ]
+
+    // `ensureSlugPrefix` rejects nothing; it prefixes unconditionally, adding
+    // the `/` separator itself when the input lacks one. That leading
+    // `/${slug}` is what keeps every shape same-origin, on v6 and on v7.
+    it.each(HOSTILE_PATHS)('THEN the result stays same-origin for %s', (input) => {
+      const result = ensureSlugPrefix(input, 'org-a', currentUser)
+
+      expect(new URL(result, ORIGIN).origin).toBe(ORIGIN)
+    })
+  })
 })

--- a/src/core/router/utils/__tests__/prependOrgSlug.test.ts
+++ b/src/core/router/utils/__tests__/prependOrgSlug.test.ts
@@ -102,7 +102,7 @@ describe('prependOrgSlug', () => {
       // Characterization, not endorsement. These survive the helper unchanged
       // and resolve off-origin. Safe today only because no untrusted value
       // reaches a `navigate()` or `<Link to>`; `isSafeInAppPath` is what makes
-      // that a guarantee rather than an audit. See Task 3.
+      // that a guarantee rather than an audit.
       it.each(PASS_THROUGH_HOSTILE)('THEN %s is returned unchanged, with a slug', (input) => {
         expect(prependOrgSlug(input, 'acme')).toBe(input)
       })

--- a/src/core/router/utils/__tests__/prependOrgSlug.test.ts
+++ b/src/core/router/utils/__tests__/prependOrgSlug.test.ts
@@ -71,4 +71,52 @@ describe('prependOrgSlug', () => {
       expect(prependOrgSlug(input, 'acme')).toBe(expected)
     })
   })
+
+  describe('GIVEN a hostile off-origin path', () => {
+    const ORIGIN = 'https://app.lago.dev'
+
+    // Absolute, so the helper prefixes them. These are the cases whose
+    // same-origin outcome depends on downstream normalisation.
+    const ABSOLUTE_HOSTILE = ['//evil.com', '///evil.com', '/\\evil.com']
+
+    // Not absolute, so the helper returns them untouched whether or not a slug
+    // is present. `prependOrgSlug` is not a validator.
+    const PASS_THROUGH_HOSTILE = [
+      '\\/evil.com',
+      '\\\\evil.com',
+      'https://evil.com',
+      'javascript:alert(1)//',
+    ]
+
+    describe('WHEN an org slug is present and the path is absolute', () => {
+      // Pins the property, not the string: `//evil.com` becomes
+      // `/acme//evil.com`, which is same-origin only because the leading
+      // `/acme` stops it being read as protocol-relative. v7.18 widened the
+      // regex that classifies exactly these shapes.
+      it.each(ABSOLUTE_HOSTILE)('THEN the result stays same-origin for %s', (input) => {
+        expect(new URL(prependOrgSlug(input, 'acme'), ORIGIN).origin).toBe(ORIGIN)
+      })
+    })
+
+    describe('WHEN the path is not absolute', () => {
+      // Characterization, not endorsement. These survive the helper unchanged
+      // and resolve off-origin. Safe today only because no untrusted value
+      // reaches a `navigate()` or `<Link to>`; `isSafeInAppPath` is what makes
+      // that a guarantee rather than an audit. See Task 3.
+      it.each(PASS_THROUGH_HOSTILE)('THEN %s is returned unchanged, with a slug', (input) => {
+        expect(prependOrgSlug(input, 'acme')).toBe(input)
+      })
+    })
+
+    describe('WHEN no org slug is present', () => {
+      // With no slug the helper is a pass-through for every shape, absolute
+      // included, so an off-origin value survives.
+      it.each([...ABSOLUTE_HOSTILE, ...PASS_THROUGH_HOSTILE])(
+        'THEN %s is returned unchanged',
+        (input) => {
+          expect(prependOrgSlug(input, undefined)).toBe(input)
+        },
+      )
+    })
+  })
 })

--- a/src/core/router/utils/isSafeInAppPath.ts
+++ b/src/core/router/utils/isSafeInAppPath.ts
@@ -1,0 +1,20 @@
+/**
+ * True only for absolute paths that stay on the app's own origin.
+ *
+ * The `URL` check alone is not enough, in two ways a reader cannot see:
+ * `new URL('customers', origin)` is same-origin, so the leading-slash
+ * requirement is what rejects relative values; and `/acme/\evil.com` resolves
+ * same-origin too, while a browser normalises the `\` to `/` when it loads the
+ * href. A legitimate in-app path never contains a raw backslash.
+ */
+export const isSafeInAppPath = (path: string): boolean => {
+  if (!path.startsWith('/')) return false
+  if (path.startsWith('//')) return false
+  if (path.includes('\\')) return false
+
+  try {
+    return new URL(path, window.location.origin).origin === window.location.origin
+  } catch {
+    return false
+  }
+}

--- a/src/core/router/utils/isSafeInAppPath.ts
+++ b/src/core/router/utils/isSafeInAppPath.ts
@@ -8,6 +8,7 @@
  * href. A legitimate in-app path never contains a raw backslash.
  */
 export const isSafeInAppPath = (path: string): boolean => {
+  if (typeof path !== 'string') return false
   if (!path.startsWith('/')) return false
   if (path.startsWith('//')) return false
   if (path.includes('\\')) return false

--- a/src/pages/auth/GoogleAuthCallback.tsx
+++ b/src/pages/auth/GoogleAuthCallback.tsx
@@ -7,6 +7,7 @@ import { generatePath, useNavigate, useSearchParams } from 'react-router-dom'
 import { GoogleAuthModeEnum } from '~/components/auth/GoogleAuthButton'
 import { hasDefinedGQLError, LagoGQLError, onLogIn } from '~/core/apolloClient'
 import { INVITATION_ROUTE_FORM, LOGIN_ROUTE, SIGN_UP_ROUTE } from '~/core/router'
+import { isSafeInAppPath } from '~/core/router/utils/isSafeInAppPath'
 import { setItemFromLS } from '~/core/utils/localStorage'
 import { REDIRECT_AFTER_LOGIN_LS_KEY } from '~/core/utils/localStorageKeys'
 import { LagoApiError, useGoogleLoginUserMutation } from '~/generated/graphql'
@@ -93,7 +94,9 @@ const GoogleAuthCallback = () => {
       // authTokenVar, the guard may redirect to HOME before this callback
       // can navigate — localStorage ensures Home.tsx can still find the path.
       // Home.tsx is the SINGLE point of cleanup for REDIRECT_AFTER_LOGIN_LS_KEY.
-      if (redirectPath) {
+      // `state.redirectPath` comes straight off the URL query, so it is
+      // attacker-controlled. Validate before it reaches localStorage.
+      if (redirectPath && isSafeInAppPath(redirectPath)) {
         setItemFromLS(REDIRECT_AFTER_LOGIN_LS_KEY, redirectPath)
       }
 

--- a/src/pages/auth/__tests__/GoogleAuthCallback.test.tsx
+++ b/src/pages/auth/__tests__/GoogleAuthCallback.test.tsx
@@ -155,6 +155,40 @@ describe('GoogleAuthCallback', () => {
     })
   })
 
+  describe('GIVEN a successful Google login with an off-origin redirect path', () => {
+    // `state` is parsed straight off the URL query at GoogleAuthCallback.tsx:35,
+    // so this value is attacker-controlled.
+    it.each([
+      '//evil.com',
+      '///evil.com',
+      '/\\evil.com',
+      '\\/evil.com',
+      'https://evil.com',
+      'javascript:alert(1)//',
+    ])('THEN %s is never persisted to localStorage', async (redirectPath) => {
+      mockUseSearchParams.mockReturnValue(
+        buildSearchParams({
+          code: 'google-auth-code',
+          state: JSON.stringify({ mode: 'login', redirectPath }),
+        }),
+      )
+      mockGoogleLoginUser.mockResolvedValue({
+        data: { googleLoginUser: { token: 'test-token' } },
+      })
+
+      renderHook(() => GoogleAuthCallback())
+
+      await waitFor(() => {
+        expect(mockOnLogIn).toHaveBeenCalled()
+      })
+
+      expect(mockSetItemFromLS).not.toHaveBeenCalledWith(
+        REDIRECT_AFTER_LOGIN_LS_KEY,
+        expect.anything(),
+      )
+    })
+  })
+
   describe('GIVEN Google login returns an error', () => {
     beforeEach(() => {
       mockUseSearchParams.mockReturnValue(

--- a/src/pages/auth/__tests__/LoginOkta.test.tsx
+++ b/src/pages/auth/__tests__/LoginOkta.test.tsx
@@ -112,6 +112,52 @@ describe('LoginOkta', () => {
     })
   })
 
+  describe('GIVEN the redirect location points off-origin', () => {
+    it.each(['//evil.com', '/\\evil.com', 'https://evil.com', 'javascript:alert(1)//'])(
+      'THEN %s is not persisted for the post-login redirect',
+      async (hostilePath) => {
+        mockUseLocation.mockReturnValue({
+          state: {
+            from: { pathname: hostilePath, search: '', hash: '', state: null, key: 'test' },
+          },
+          pathname: '/login/okta',
+          search: '',
+          hash: '',
+          key: 'default',
+        })
+
+        mockFetchOktaAuthorizeUrl.mockResolvedValue({
+          data: { oktaAuthorize: { url: 'https://okta.example.com/authorize?state=test' } },
+        })
+
+        const user = userEvent.setup()
+
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <LoginOkta />
+            </MemoryRouter>,
+          )
+        })
+
+        const emailInput = document.querySelector('input') as HTMLInputElement
+
+        await user.type(emailInput, 'user@example.com')
+
+        await user.click(screen.getByTestId('submit'))
+
+        await waitFor(() => {
+          expect(mockFetchOktaAuthorizeUrl).toHaveBeenCalled()
+        })
+
+        expect(mockSetItemFromLS).not.toHaveBeenCalledWith(
+          REDIRECT_AFTER_LOGIN_LS_KEY,
+          expect.anything(),
+        )
+      },
+    )
+  })
+
   describe('GIVEN the user navigated directly to the Okta login page', () => {
     beforeEach(() => {
       mockUseLocation.mockReturnValue({

--- a/src/pages/auth/components/LoginSSO.tsx
+++ b/src/pages/auth/components/LoginSSO.tsx
@@ -9,6 +9,7 @@ import { Alert } from '~/components/designSystem/Alert'
 import { Typography } from '~/components/designSystem/Typography'
 import { hasDefinedGQLError } from '~/core/apolloClient'
 import { LOGIN_ROUTE, useLocation } from '~/core/router'
+import { isSafeInAppPath } from '~/core/router/utils/isSafeInAppPath'
 import { setItemFromLS } from '~/core/utils/localStorage'
 import { REDIRECT_AFTER_LOGIN_LS_KEY } from '~/core/utils/localStorageKeys'
 import { addValuesToUrlState } from '~/core/utils/urlUtils'
@@ -122,7 +123,7 @@ export const LoginSSO = <TData,>({
 
       setErrorAlert(undefined)
 
-      if (previousLocation) {
+      if (previousLocation && isSafeInAppPath(previousLocation)) {
         setItemFromLS(REDIRECT_AFTER_LOGIN_LS_KEY, previousLocation)
       }
 

--- a/src/pages/home/__tests__/utils.test.ts
+++ b/src/pages/home/__tests__/utils.test.ts
@@ -81,6 +81,31 @@ describe('resolveRedirectTarget()', () => {
     })
   })
 
+  describe('GIVEN ssoRedirectPath is an off-origin value', () => {
+    it.each([
+      '//evil.com',
+      '/\\evil.com',
+      '\\/evil.com',
+      'https://evil.com',
+      'javascript:alert(1)//',
+    ])('THEN %s is ignored and the default branch wins', (ssoRedirectPath) => {
+      mockHasPermissions.mockReturnValueOnce(true) // analytics
+
+      const result = resolveRedirectTarget(baseInput({ ssoRedirectPath }))
+
+      expect(result).toEqual({ to: `/${SLUG}/analytics`, consumesSsoLs: true })
+    })
+
+    // Drained even when it is ignored, or the poisoned value replays on every load.
+    it('THEN the LS key is still drained when the user has no resolvable slug', () => {
+      const result = resolveRedirectTarget(
+        baseInput({ currentUser: undefined, ssoRedirectPath: '//evil.com' }),
+      )
+
+      expect(result).toEqual({ to: '/forbidden', consumesSsoLs: true })
+    })
+  })
+
   describe('GIVEN savedLocation has a slug belonging to the current user', () => {
     it('THEN returns it as a Location object (preserves any extra fields)', () => {
       const savedLocation = { pathname: `/${SLUG}/customers`, search: '?tab=overview', hash: '' }

--- a/src/pages/home/utils.ts
+++ b/src/pages/home/utils.ts
@@ -8,6 +8,7 @@ import {
   FORBIDDEN_ROUTE,
 } from '~/core/router'
 import { LEGACY_APP_PATH_SEGMENTS } from '~/core/router/legacyPaths'
+import { isSafeInAppPath } from '~/core/router/utils/isSafeInAppPath'
 import { ensureSlugPrefix, pathHasValidSlug, resolveOrgSlug } from '~/core/router/utils/orgSlug'
 import { getRouteForPermission } from '~/core/router/utils/permissionRouteMap'
 import { CurrentUserInfosFragment } from '~/generated/graphql'
@@ -76,14 +77,20 @@ export const resolveRedirectTarget = (
 
   const slug = resolveOrgSlug(currentUser)
 
+  // An off-origin stored path is ignored but still drained, otherwise it replays
+  // on every load. `isSafeInAppPath` is the guard; `ensureSlugPrefix` prefixes
+  // and validates nothing.
+  const hasUnsafeSsoPath = !!ssoRedirectPath && !isSafeInAppPath(ssoRedirectPath)
+  const safeSsoRedirectPath = hasUnsafeSsoPath ? undefined : ssoRedirectPath
+
   if (!slug) {
-    return { to: FORBIDDEN_ROUTE, consumesSsoLs: false }
+    return { to: FORBIDDEN_ROUTE, consumesSsoLs: hasUnsafeSsoPath }
   }
 
   // 1. SSO redirect from localStorage (set by auth guard or OAuth callback).
-  if (ssoRedirectPath) {
+  if (safeSsoRedirectPath) {
     return {
-      to: ensureSlugPrefix(ssoRedirectPath, slug, currentUser),
+      to: ensureSlugPrefix(safeSsoRedirectPath, slug, currentUser),
       consumesSsoLs: true,
     }
   }
@@ -99,7 +106,7 @@ export const resolveRedirectTarget = (
     )
 
     if (belongsToCurrentUser) {
-      return { to: savedLocation, consumesSsoLs: false }
+      return { to: savedLocation, consumesSsoLs: hasUnsafeSsoPath }
     }
 
     const isLegacySegment = LEGACY_APP_PATH_SEGMENTS.has(savedSlug ?? '')
@@ -112,7 +119,7 @@ export const resolveRedirectTarget = (
 
       return {
         to: `/${slug}${savedLocation.pathname}${search}${hash}`,
-        consumesSsoLs: false,
+        consumesSsoLs: hasUnsafeSsoPath,
       }
     }
   }
@@ -121,7 +128,7 @@ export const resolveRedirectTarget = (
   const canSeeAnalytics = hasPermissions(['analyticsView', 'dataApiView'])
 
   if (canSeeAnalytics && !hasAccessToAnalyticsDashboardsFeature) {
-    return { to: `/${slug}${ANALYTIC_ROUTE}`, consumesSsoLs: false }
+    return { to: `/${slug}${ANALYTIC_ROUTE}`, consumesSsoLs: hasUnsafeSsoPath }
   }
 
   if (canSeeAnalytics && hasAccessToAnalyticsDashboardsFeature) {
@@ -129,12 +136,12 @@ export const resolveRedirectTarget = (
       to: `/${slug}${generatePath(ANALYTIC_TABS_ROUTE, {
         tab: NewAnalyticsTabsOptionsEnum.revenueStreams,
       })}`,
-      consumesSsoLs: false,
+      consumesSsoLs: hasUnsafeSsoPath,
     }
   }
 
   if (hasPermissions(['customersView'])) {
-    return { to: `/${slug}${CUSTOMERS_LIST_ROUTE}`, consumesSsoLs: false }
+    return { to: `/${slug}${CUSTOMERS_LIST_ROUTE}`, consumesSsoLs: hasUnsafeSsoPath }
   }
 
   const firstViewPermission = findFirstViewPermission()
@@ -143,10 +150,10 @@ export const resolveRedirectTarget = (
   if (routeForPermission) {
     return {
       to: ensureSlugPrefix(routeForPermission, slug, currentUser),
-      consumesSsoLs: false,
+      consumesSsoLs: hasUnsafeSsoPath,
     }
   }
 
   // 4. No accessible route.
-  return { to: FORBIDDEN_ROUTE, consumesSsoLs: false }
+  return { to: FORBIDDEN_ROUTE, consumesSsoLs: hasUnsafeSsoPath }
 }


### PR DESCRIPTION
Starts LAGO-1859

Stage 1 of 4 of the react-router migration. This stage is entirely pre-bump hardening: **no dependency version moves here.** `react-router-dom` stays at `6.30.6` in root `package.json:175`.

---

# The initiative

## Why we are moving at all

Four Dependabot alerts (#250, #251, #252, #253) are open against `react-router-dom@6.30.6`. v6 reached end of life on 2026-06-18, so there are no further backports: 6.30.6 fixes only CVE-2026-53668, and the remaining advisories stay open on v6 forever. Alerts #251 and #253 declare `first_patched_version: 7.18.0`. The only way to close them is to move to v7.

## Target is 7.18.3, not v8

v8 is not reachable, verified against the published tarballs rather than the changelog:

| | version | node engine | react peer | module format |
| --- | --- | --- | --- | --- |
| current | `6.30.6` | `>=14.0.0` | `>=16.8` | CJS + ESM |
| **target** | **`7.18.3`** | `>=20.0.0` (we pin 24.20.0) | `>=18` | CJS + ESM |
| v8 latest | `8.3.1` | `>=22.22.0` | **`>=19.2.7`** | **ESM-only** |

Two independent blockers: we pin `react@18.3.1` and `@mui/material@5.18.0`, which has no React 19 support, so v8 needs a React 19 plus MUI major first; and v8 is ESM-only, which would put it on the `transformIgnorePatterns` allow-list Jest maintains one package at a time. v8 is a follow-up gated on React 19, not this ticket.

7.18.0 is the minimum that closes the advisories. 7.18.3 is the latest v7.

## Four stages, and where we stand

Each stage is one PR and independently revertable, because a security bump has to revert in one click.

| stage | what | dependency change | status |
| --- | --- | --- | --- |
| **1** | **Harden the redirect surface on v6** | **none** | **this PR** |
| 2 | Turn on `v7_startTransition` and `v7_relativeSplatPath` on all four Routers, drop the two `jest-setup-early.ts` warning suppressions | none | next |
| 3 | Bump `6.30.6` to `7.18.3`, swap the stage-2 flags for `useTransitions={false}`, re-verify the absolute-URL `<Link>` surface | **the bump** | closes #250-253 |
| 4 | Drop the `react-router-dom` shim, rename to `react-router` (540 occurrences over 434 files) | specifier only | cleanup |

Stage 2 exists so the rendering-behaviour question lands in a diff with no dependency change, and a regression there cannot be confused with a version regression. Stage 3 is then a one-line version move with the behaviour already proven.

## Why stage 1 has to come first

v7.18 widens `ABSOLUTE_URL_REGEX` to `/^(?:[a-z][a-z0-9+.-]*:|[\\/]{2})/i` and `removeDoubleSlashes` to `/[\\/]{2,}/g`. That is the CVE-2026-53669 fix, and it reclassifies a leading `//` or `\` as an absolute external URL.

The app has exactly one untrusted-input-to-navigation path. `GoogleAuthCallback.tsx:35` parses `state.redirectPath` out of the OAuth query string, into localStorage, into `resolveRedirectTarget`, into `ensureSlugPrefix`. `ensureSlugPrefix` validates nothing: it prefixes unconditionally, and every hostile shape stays same-origin *only* because the resulting `/${slug}` prefix saves it:

| input | `ensureSlugPrefix(input, 'acme', user)` | origin |
| --- | --- | --- |
| `//evil.com` | `/acme//evil.com` | same |
| `https://evil.com` | `/acme/https://evil.com` | same |

That is accidental, and it rides on a third-party normalisation function upstream has rewritten twice in three months with no security guarantee attached to either changelog entry. So the guard goes in at the sink, before the version moves, while the diff is small enough to reason about.

While reading this I confirmed something the original analysis understated: **`//evil.com` is already an off-origin navigation on 6.30.6.** Its `ABSOLUTE_URL_REGEX` (`react-router-dom/dist/index.js:723`) already contains `\/\/`, so `Link` flags it external, detaches the router click handler and emits a plain off-origin `<a href>`. This is a live property of the version we ship today, not a v7 forward risk, which makes the case for the guard stronger rather than weaker.

---

# What happens when a redirect is dropped

This is the one real behaviour change, so it is worth being precise about it.

Nothing throws and nothing 404s. **The user is logged in successfully.** The rejected value is discarded, the localStorage key is drained, and they land on their normal permission-ranked default page instead of the deep link:

1. `/${slug}/analytics`, or `/${slug}/analytics/revenue-streams` if the analytics-dashboards feature is on, when they hold `analyticsView` and `dataApiView`
2. `/${slug}/customers` when they hold `customersView`
3. their first view-permission route
4. `/forbidden` only if nothing at all is accessible

If they have no resolvable org slug, they get `/forbidden` and the key still drains. That was already the behaviour for that case.

At the two write sites the value never reaches localStorage at all, and because both SSO flows leave the origin entirely (`window.location.href = authorizeUrl`, or a round trip through Google), router state is gone too, so it resolves straight to the permission default rather than to a saved location.

Draining is the part that matters and it is why `consumesSsoLs` is threaded through all eight returns rather than short-circuiting early. Ignoring a poisoned value without clearing it would turn a one-shot attack into a permanent one that replays on every page load and survives the fix.

**A drop is currently silent:** no toast, no console warning, no Sentry event. I am comfortable with that as the default here, because the only values that *can* be dropped are ones no app code can produce (see the defence of family 2 below), so a drop means either a genuine attack or a corrupted store, and in both cases landing the user on their home page is the right answer. But it does mean that if this ever fires for a legitimate user we would never hear about it, so I have noted telemetry as a follow-up rather than pretending the gap is not there. `OrganizationLayout.tsx:120`'s `SlugMigrationEvent` is the established shape for exactly this kind of signal.

---

# The changes, and why each one is here

## 1. Characterization tests on the two slug helpers

`b95226148`, test-only.

There was **zero** coverage of the security property: `prependOrgSlug.test.ts` exercised only `/customers`, `''`, `/`, `/acme/customers`, `/acme`, and neither `orgSlug.test.ts` nor `home/__tests__/utils.test.ts` contained a single `//`, `https://` or `javascript:` case.

These tests assert the **resolved origin**, not the literal output string. That is deliberate: `prependOrgSlug('//evil.com', 'acme')` returns `/acme//evil.com` today, and asserting that exact string would pin an implementation accident, whereas asserting `new URL(result, ORIGIN).origin === ORIGIN` pins the thing that actually matters.

The `prependOrgSlug` cases are split three ways on purpose, because the helper treats the groups differently and honest characterization beats an aspirational assertion:

| group | behaviour being pinned |
| --- | --- |
| `ABSOLUTE_HOSTILE` | prefixed, and the result stays same-origin |
| `PASS_THROUGH_HOSTILE` | returned **unchanged**, and resolves **off-origin** |
| no-slug | pass-through for every shape, absolute included |

That second group is the reason the guard cannot live in this helper: `prependOrgSlug` is not a validator in any sense, and making it one would put a validator on the hot path of every navigation in the app. The guard belongs at the sink.

## 2. The `isSafeInAppPath` predicate

`17cdcb134`, new pure module, no React and no react-router.

One definition of "safe same-origin in-app path", so the rule is stated once instead of re-derived per call site.

```ts
if (typeof path !== 'string') return false
if (!path.startsWith('/')) return false
if (path.startsWith('//')) return false
if (path.includes('\\')) return false

try {
  return new URL(path, window.location.origin).origin === window.location.origin
} catch {
  return false
}
```

Defending each clause, because a reviewer should know which are load-bearing and which are defence in depth:

- `typeof` is a **runtime backstop for an `any`**, not belt-and-braces. See family 3.
- `startsWith('/')` is load-bearing: `new URL('customers', origin).origin` is same-origin, so the `URL` check alone accepts every relative value.
- `startsWith('//')` is **strictly redundant** with the `URL` check, and kept on purpose. It is the explicit, greppable statement of the exact shape react-router's regex classifies, which is the entire subject of this migration. Without it, rejection of the headline attack would depend on WHATWG parser behaviour with nothing in the file saying so.
- `includes('\\')` is load-bearing, but **not for the reason you would guess**. The `URL` constructor does *not* preserve a leading backslash: `new URL('/\evil.com', O).origin` is `https://evil.com`, so the parser normalises it exactly as a browser does and the `URL` check already rejects that shape. What this clause actually buys is the *embedded* case: `/acme/\evil.com` resolves to the same-origin `/acme//evil.com`, so the `URL` check alone would accept it. The JSDoc says this, because the first draft of that comment asserted the opposite and a wrong comment about an invisible constraint is worse than no comment.

The signature stays `(path: string): boolean` rather than widening to `unknown`, so every statically-typed caller is still checked at compile time.

## 3. Validate at the read site

`f27015bbe`, `src/pages/home/utils.ts`.

`resolveRedirectTarget` trusted `ssoRedirectPath` completely. It now ignores an unsafe value and drains it.

This half is not redundant with family 4, and that is the point of having both: **a hostile value written before this PR ships is already sitting in users' localStorage.** The write guards stop new ones; only the read guard cleans up the ones already there.

Rejection deliberately does **not** return `FORBIDDEN_ROUTE`. A merely malformed stored path should land the user on their normal default page, not a permission error.

The function stays pure and keeps its exact signature. No localStorage access moved into it; draining stays the caller's job, signalled by the flag, which is why `Home.tsx:51-53` is the single point of cleanup.

## 4. Validate at both write sites

`4d272f0ad`, `GoogleAuthCallback.tsx` and `LoginSSO.tsx`.

`GoogleAuthCallback` is the untrusted one: a crafted `/auth/google/callback?state=...&code=...` link is enough to control the value.

`LoginSSO` writes a `previousLocation` derived from our own router state and is safe by construction. It gets the same guard anyway, so there is **one rule rather than a judgement call per call site**. It also turns out not to be purely theoretical: if the browser URL were `https://app.lago.dev//evil.com`, `location.pathname` would literally be `//evil.com`, and the guard rejects it rather than relying on "no private route matches that shape".

The test asserts `not.toHaveBeenCalledWith(KEY, expect.anything())` rather than the literal hostile value, because the property is that *nothing* is stored, not that one particular string is not stored.

**This commit also fixes a real bug the plan did not anticipate.** `GoogleAuthCallback.tsx:33-36` does `JSON.parse(...)` then reads `.redirectPath`, so the value is `any` and TypeScript checks nothing. With `state={"mode":"login","redirectPath":123}`, `isSafeInAppPath(123)` threw `TypeError: path.startsWith is not a function` inside an async function invoked with no `.catch`, so `await onLogIn(...)` never ran: infinite spinner and a discarded session token. The `typeof` clause in family 2 is what closes it, and it lives in the predicate rather than at the call sites because that is the only place the invariant can be stated once. It repairs the same crash on the read side, where a legacy stored `"123"` parses to a number and previously blanked `Home` behind the error boundary.

## 5. Widen the eslint rule to `react-router`

`0b323be8b`, `packages/configs/eslint-rules/no-direct-rrd-nav-import.js`.

The rule keeps `useNavigate`, `Link`, `useLocation` and `useMatch` behind the slug-aware wrappers in `~/core/router`. It returned early unless the import source was exactly `react-router-dom`.

In v7, `react-router-dom` is a re-export of `react-router`, so **the guard would have died silently the moment stage 4 rewrites the 346 import sites** and nobody would have noticed until a slug-less navigation shipped. Widening it now means stage 4 cannot bypass it.

There are zero bare `react-router` imports today, so this commit is a **no-op against the current tree** and cannot break CI. The rule id and message id are unchanged, so the five existing opt-out sites keep working. Verified with a throwaway fixture and `pnpm eslint`, positive and negative case, fixture deleted; `packages/configs` has no test runner and a security PR is the wrong place to add one.

## 6. Drop the unused design-system dependency

`529ddf52f`, `packages/design-system`.

`packages/design-system/src` has zero react-router references and the built `dist` has zero occurrences. The dep survived in three places only: the peer dep, a UMD global, and a rollup `external` entry.

This makes **root `package.json:175` the single pin site**, which is the actual point. With two pin sites, a partial bump could install a second react-router under `packages/design-system/node_modules`, giving the app two Router contexts and the runtime error `useNavigate() may be used only in the context of a <Router>`. One pin site makes that impossible, which is also why the pnpm `catalog:` idea from the ticket is deliberately skipped: it existed to guard against exactly this drift.

Removing the `external` entry is safe because the package has no `dependencies` field at all, so there is no transitive path by which react-router could be bundled into `dist`. The eslint rule reaches design-system through `lago-configs/eslint`, which its `devDependencies` already pull in, so the peer dep was not acting as an enforcement anchor.

## 7. Park the major in Renovate

`64f870ce1`, `renovate.json`.

`vulnerabilityAlerts: { enabled: true, schedule: "at any time" }` bypasses both `minimumReleaseAge` and the weekend schedule, and #251/#253 declare `first_patched_version: 7.18.0`, so Renovate would open a 6-to-7 major PR on its own and reopen it when closed, in the middle of a four-stage migration.

**Be aware of the limit here, which the rule's `description` now states explicitly.** `dependencyDashboardApproval: true` does *not* park the vulnerability-alert path: `detectVulnerabilityAlerts()` appends a synthetic packageRule last carrying `force: {...config.vulnerabilityAlerts}`, whose schema default sets `dependencyDashboardApproval: false`, and `mergeChildConfig` shallow-applies `force` last, so the alert rule outranks ours. The gate in Renovate's `update/branch/index.ts` has no `isVulnerabilityAlert` exception.

The rule still parks the ordinary major, which is most of the noise. I did not widen it because both remaining levers cost more than they buy: dismissing the alert is off the table, and putting `dependencyDashboardApproval` inside `vulnerabilityAlerts` would park **every** vulnerability alert in the repo, which is a repo-wide policy call and not one to make as a side effect of a migration PR. Practical consequence: Renovate may still open a react-router 7 PR off the alerts during stages 2 and 3, and it should just be closed. Happy to take the broader change if you would rather have it.

Also deletes two dead `@types/react-router-dom` rules. That package is in neither manifest, because react-router has shipped its own types since v6, so both rules were inert.

## 8. The actual v7 tripwire

`c763e1139`, `src/core/router/__tests__/Link.test.tsx`.

The plan claimed the family-1 characterization tests would make the stage 3 bump fail loudly. **They will not, and I would rather say so than let a reviewer rely on it.** `prependOrgSlug.ts` imports only `../slugPrefixes` and `orgSlug.ts` only Apollo reactive vars, so neither touches react-router; those tests assert WHATWG `URL` behaviour and stay green through the bump no matter what v7 does. They still earn their place by pinning the invariant against a future refactor of the helpers themselves.

`Link.test.tsx` is the real tripwire: it renders a real `BrowserRouter` around the real `react-router-dom` `Link`, since `jest-setup.ts` spreads `requireActual` and replaces only `useNavigate` and `useParams`. So it observes what the **router** does, which is what v7 changes. The four expected hrefs were read out of a deliberately-failing run rather than predicted.

| `to` | slug | v6 href (asserted) | flips at 7.18? |
| --- | --- | --- | --- |
| `//evil.com` | `acme` | `/acme/evil.com` | no |
| `/\evil.com` | `acme` | `/acme/\evil.com` | **yes** |
| `/acme//evil.com` | `acme` | `/acme/evil.com` | no |
| `//evil.com` | none | `//evil.com` (external anchor) | no |

Row 2 is the live tripwire: v6 preserves the backslash, and 7.18's widened `removeDoubleSlashes` collapses the `/\` pair to `/acme/evil.com`. That assertion will fail when the bump lands, which is the signal, not a regression to paper over. The comment above the block says so. The other three rows document current behaviour, including row 4, which is the already-off-origin case worth pinning precisely because it is live today.

---

# Deliberately out of scope

**`RootRedirect.tsx` is left unguarded on purpose.** It reads the same localStorage key but takes only `.split('/')[1]` and validates that segment against `accessibleMemberships`. Every hostile shape yields a segment that fails validation (`//evil.com`, `///evil.com`, `https://evil.com` and `javascript:alert(1)//` all give `''`; `/\evil.com` gives `\evil.com`, not a membership slug), and the navigate target is always an element of the user's own membership list. The attacker value cannot influence it. Adding the predicate there would be noise.

**The route guard architecture stays as it is.** `RouteWrapper.tsx`, `useLocationHistory.ts`'s `onRouteEnter`, and the `Home` / `RootRedirect` effects are 803 lines and 19 redirect decision points, and every guard currently runs after render in an effect. `loader` + `throw redirect()` is the router-native fix, but it is an architecture change riding on a CVE fix, it is strictly easier after v7 lands (`route.lazy`, `handle` + `useMatches()`, per-route `ErrorBoundary`), and the real cost is not the router API: loaders run outside React and cannot call `useCurrentUser()` / `usePermissions()`, so permissions and feature flags would need an awaited root-loader query that changes load sequencing app-wide. Own spec, own QA matrix.

**Dependabot #250 to #253 stay open and undismissed.** They are the EOL signal for v6 and they close when stage 3 lands, not before.

# Follow-ups I am not doing here

- Telemetry on a dropped redirect, per the note above.
- `resolveRedirectTarget`'s JSDoc claims it returns `null` when there is no resolvable slug, but that branch returns `{ to: FORBIDDEN_ROUTE, ... }` and no path returns `null`, so the `| null` in the return type is dead and `Home.tsx:49`'s `if (!target) return` is unreachable. Pre-existing; left alone because the `Home` effect architecture is frozen above.
- `prependOrgSlug` remains an audit rather than a guarantee: with no org slug it passes `//evil.com` to a `<Link>` that v6 already renders as an external anchor. No untrusted value reaches it today. If we ever want that closed, the fix is at the call sites, not inside the hot-path helper.
