### PR TITLE
fix(invoices): gate the void invoice page on the invoice status

### DIFF
--- a/src/core/apolloClient/graphqlResolvers.tsx
+++ b/src/core/apolloClient/graphqlResolvers.tsx
@@ -30,6 +30,7 @@ export const typeDefs = gql`
     invoices_not_overdue
     invoices_not_ready_for_payment_processing
     no_active_subscription
+    not_voidable
     payment_processor_is_currently_handling_payment
     plan_overlapping
     url_is_invalid

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -5357,6 +5357,7 @@ export enum LagoApiError {
   NoActiveSubscription = 'no_active_subscription',
   NotFound = 'not_found',
   NotOrganizationMember = 'not_organization_member',
+  NotVoidable = 'not_voidable',
   OktaLoginMethodNotAuthorized = 'okta_login_method_not_authorized',
   OktaUserinfoError = 'okta_userinfo_error',
   PaymentProcessorIsCurrentlyHandlingPayment = 'payment_processor_is_currently_handling_payment',

--- a/src/pages/CustomerInvoiceVoid.tsx
+++ b/src/pages/CustomerInvoiceVoid.tsx
@@ -70,7 +70,7 @@ const CustomerInvoiceVoid = () => {
   const { isPremium } = useCurrentUser()
   const { canVoid } = usePermissionsInvoiceActions()
 
-  const { data, loading, error } = useGetInvoiceDetailsQuery({
+  const { data, loading, error, refetch } = useGetInvoiceDetailsQuery({
     variables: { id: invoiceId as string },
     skip: !invoiceId,
   })
@@ -79,7 +79,7 @@ const CustomerInvoiceVoid = () => {
     customerId,
   })
 
-  const [voidInvoice] = useVoidInvoiceMutation({
+  const [voidInvoice, { loading: voidLoading }] = useVoidInvoiceMutation({
     context: { silentErrorCodes: [LagoApiError.NotVoidable] },
     update(cache, { data: invoiceData }) {
       if (!invoiceData?.voidInvoice) return
@@ -133,6 +133,8 @@ const CustomerInvoiceVoid = () => {
           translateKey: 'text_1788518648182t6oetew3x8x',
           severity: 'danger',
         })
+
+        await refetch()
       }
 
       return
@@ -345,6 +347,7 @@ const CustomerInvoiceVoid = () => {
               <Button
                 variant="primary"
                 danger
+                loading={voidLoading}
                 data-test={CUSTOMER_INVOICE_VOID_SUBMIT_BUTTON_TEST_ID}
                 onClick={() => onSubmit()}
               >

--- a/src/pages/CustomerInvoiceVoid.tsx
+++ b/src/pages/CustomerInvoiceVoid.tsx
@@ -8,7 +8,7 @@ import { Status } from '~/components/designSystem/Status'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
-import { addToast } from '~/core/apolloClient'
+import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { paymentStatusMapping } from '~/core/constants/statusInvoiceMapping'
 import { CustomerInvoiceDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -24,6 +24,7 @@ import {
   InvoiceForVoidInvoiceDialogFragment,
   InvoiceForVoidInvoiceDialogFragmentDoc,
   InvoiceListItemFragmentDoc,
+  LagoApiError,
   useGetInvoiceDetailsQuery,
   useVoidInvoiceMutation,
   VoidInvoiceInput,
@@ -33,6 +34,8 @@ import { useLocationHistory } from '~/hooks/core/useLocationHistory'
 import { useCustomerHasActiveWallet } from '~/hooks/customer/useCustomerHasActiveWallet'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
+import { usePermissionsInvoiceActions } from '~/hooks/usePermissionsInvoiceActions'
+import EmptyImage from '~/public/images/maneki/empty.svg'
 import ErrorImage from '~/public/images/maneki/error.svg'
 import { FormLoadingSkeleton } from '~/styles/mainObjectsForm'
 
@@ -56,6 +59,8 @@ gql`
   ${AllInvoiceDetailsForCustomerInvoiceDetailsFragmentDoc}
 `
 
+export const CUSTOMER_INVOICE_VOID_SUBMIT_BUTTON_TEST_ID = 'customer-invoice-void-submit-button'
+
 const CustomerInvoiceVoid = () => {
   const { translate } = useInternationalization()
   const { goBack } = useLocationHistory()
@@ -63,6 +68,7 @@ const CustomerInvoiceVoid = () => {
   const { timezone } = useOrganizationInfos()
   const navigate = useNavigate()
   const { isPremium } = useCurrentUser()
+  const { canVoid } = usePermissionsInvoiceActions()
 
   const { data, loading, error } = useGetInvoiceDetailsQuery({
     variables: { id: invoiceId as string },
@@ -74,22 +80,7 @@ const CustomerInvoiceVoid = () => {
   })
 
   const [voidInvoice] = useVoidInvoiceMutation({
-    onCompleted(voidedData) {
-      if (voidedData?.voidInvoice && customerId && invoiceId) {
-        addToast({
-          message: translate('text_65269b43d4d2b15dd929a254'),
-          severity: 'success',
-        })
-
-        navigate(
-          generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
-            customerId,
-            invoiceId,
-            tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
-          }),
-        )
-      }
-    },
+    context: { silentErrorCodes: [LagoApiError.NotVoidable] },
     update(cache, { data: invoiceData }) {
       if (!invoiceData?.voidInvoice) return
 
@@ -120,19 +111,45 @@ const CustomerInvoiceVoid = () => {
 
   const hasActiveCustomer = !invoice?.customer?.deletedAt
 
-  const onSubmit = async () => {
-    if (invoiceId) {
-      const input: VoidInvoiceInput = {
-        id: invoiceId,
-        generateCreditNote: false,
+  const isVoidable = !!invoice && canVoid({ status: invoice.status })
+
+  const onSubmit = async (): Promise<void> => {
+    if (!invoiceId || !customerId) return
+
+    const input: VoidInvoiceInput = {
+      id: invoiceId,
+      generateCreditNote: false,
+    }
+
+    const result = await voidInvoice({
+      variables: {
+        input,
+      },
+    })
+
+    if (!result.data?.voidInvoice) {
+      if (hasDefinedGQLError('NotVoidable', result.errors)) {
+        addToast({
+          translateKey: 'text_1788518648182t6oetew3x8x',
+          severity: 'danger',
+        })
       }
 
-      await voidInvoice({
-        variables: {
-          input,
-        },
-      })
+      return
     }
+
+    addToast({
+      message: translate('text_65269b43d4d2b15dd929a254'),
+      severity: 'success',
+    })
+
+    navigate(
+      generatePath(CUSTOMER_INVOICE_DETAILS_ROUTE, {
+        customerId,
+        invoiceId,
+        tab: CustomerInvoiceDetailsTabsOptionsEnum.overview,
+      }),
+    )
   }
 
   const canRegenerate =
@@ -154,6 +171,16 @@ const CustomerInvoiceVoid = () => {
     }
   }
 
+  const header = (
+    <CenteredPage.Header>
+      <Typography className="font-medium text-grey-700">
+        {translate('text_65269b43d4d2b15dd929a259')}
+      </Typography>
+
+      <Button variant="quaternary" icon="close" onClick={() => onClose()} />
+    </CenteredPage.Header>
+  )
+
   if (error) {
     return (
       <GenericPlaceholder
@@ -168,15 +195,26 @@ const CustomerInvoiceVoid = () => {
     )
   }
 
+  if (!loading && !isVoidable) {
+    return (
+      <CenteredPage.Wrapper>
+        {header}
+
+        <CenteredPage.Container>
+          <GenericPlaceholder
+            className="pt-12"
+            title={translate('text_1788518648182zhwh917bcvs')}
+            subtitle={translate('text_1788518648182tnlbh6pdxdd')}
+            image={<EmptyImage width="136" height="104" />}
+          />
+        </CenteredPage.Container>
+      </CenteredPage.Wrapper>
+    )
+  }
+
   return (
     <CenteredPage.Wrapper>
-      <CenteredPage.Header>
-        <Typography className="font-medium text-grey-700">
-          {translate('text_65269b43d4d2b15dd929a259')}
-        </Typography>
-
-        <Button variant="quaternary" icon="close" onClick={() => onClose()} />
-      </CenteredPage.Header>
+      {header}
 
       {loading && (
         <CenteredPage.Container>
@@ -288,27 +326,34 @@ const CustomerInvoiceVoid = () => {
         </CenteredPage.Container>
       )}
 
-      <CenteredPage.StickyFooter>
-        <div className="flex w-full items-center justify-between">
-          <div>
-            {!!canRegenerate && (
-              <Link to={regeneratePath(invoice as Invoice)}>
-                {translate('text_1750678506388eexnh1b36o4')}
-              </Link>
-            )}
-          </div>
+      {!loading && (
+        <CenteredPage.StickyFooter>
+          <div className="flex w-full items-center justify-between">
+            <div>
+              {!!canRegenerate && (
+                <Link to={regeneratePath(invoice as Invoice)}>
+                  {translate('text_1750678506388eexnh1b36o4')}
+                </Link>
+              )}
+            </div>
 
-          <div className="flex gap-3">
-            <Button variant="quaternary" onClick={() => onClose()}>
-              {translate('text_6411e6b530cb47007488b027')}
-            </Button>
+            <div className="flex gap-3">
+              <Button variant="quaternary" onClick={() => onClose()}>
+                {translate('text_6411e6b530cb47007488b027')}
+              </Button>
 
-            <Button variant="primary" danger onClick={() => onSubmit()}>
-              {translate('text_65269b43d4d2b15dd929a259')}
-            </Button>
+              <Button
+                variant="primary"
+                danger
+                data-test={CUSTOMER_INVOICE_VOID_SUBMIT_BUTTON_TEST_ID}
+                onClick={() => onSubmit()}
+              >
+                {translate('text_65269b43d4d2b15dd929a259')}
+              </Button>
+            </div>
           </div>
-        </div>
-      </CenteredPage.StickyFooter>
+        </CenteredPage.StickyFooter>
+      )}
     </CenteredPage.Wrapper>
   )
 }

--- a/src/pages/__tests__/CustomerInvoiceVoid.test.tsx
+++ b/src/pages/__tests__/CustomerInvoiceVoid.test.tsx
@@ -8,6 +8,7 @@ import {
   InvoicePaymentStatusTypeEnum,
   InvoiceStatusTypeEnum,
   InvoiceTypeEnum,
+  LagoApiError,
 } from '~/generated/graphql'
 import { render, testMockNavigateFn } from '~/test-utils'
 
@@ -18,6 +19,9 @@ import CustomerInvoiceVoid, {
 const mockUseGetInvoiceDetailsQuery = jest.fn()
 const mockVoidInvoice = jest.fn()
 const mockHasPermissions = jest.fn()
+const mockRefetch = jest.fn()
+
+let capturedVoidMutationOptions: { context?: { silentErrorCodes?: unknown[] } } | undefined
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({ translate: (key: string) => key }),
@@ -47,7 +51,11 @@ jest.mock('~/generated/graphql', () => {
   return {
     ...actual,
     useGetInvoiceDetailsQuery: () => mockUseGetInvoiceDetailsQuery(),
-    useVoidInvoiceMutation: () => [mockVoidInvoice],
+    useVoidInvoiceMutation: (options: { context?: { silentErrorCodes?: unknown[] } }) => {
+      capturedVoidMutationOptions = options
+
+      return [mockVoidInvoice, { loading: false }]
+    },
     useGetCustomerWalletListQuery: () => ({ data: undefined }),
   }
 })
@@ -85,6 +93,7 @@ const mockQueryResult = ({
     data: status ? { invoice: buildInvoice(status) } : undefined,
     loading,
     error: undefined,
+    refetch: mockRefetch,
   })
 }
 
@@ -93,6 +102,7 @@ const renderPage = () => render(<CustomerInvoiceVoid />, { useParams: { customer
 describe('CustomerInvoiceVoid', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    capturedVoidMutationOptions = undefined
     mockHasPermissions.mockReturnValue(true)
   })
 
@@ -155,6 +165,16 @@ describe('CustomerInvoiceVoid', () => {
         renderPage()
 
         expect(screen.queryByTestId(GENERIC_PLACEHOLDER_TEST_ID)).not.toBeInTheDocument()
+      })
+
+      it('THEN should silence only the not_voidable code on the void mutation', () => {
+        mockQueryResult({ status: InvoiceStatusTypeEnum.Finalized })
+
+        renderPage()
+
+        expect(capturedVoidMutationOptions?.context?.silentErrorCodes).toEqual([
+          LagoApiError.NotVoidable,
+        ])
       })
     })
   })
@@ -226,6 +246,28 @@ describe('CustomerInvoiceVoid', () => {
         expect(addToast).toHaveBeenCalledTimes(1)
         expect(addToast).not.toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
         expect(testMockNavigateFn).not.toHaveBeenCalled()
+      })
+
+      it('THEN should refetch the invoice so the page stops offering the action', async () => {
+        mockVoidInvoice.mockResolvedValueOnce({
+          data: null,
+          errors: [
+            {
+              message: 'Method Not Allowed',
+              extensions: { code: 'not_voidable', status: 405 },
+            },
+          ],
+        })
+
+        const user = userEvent.setup()
+
+        renderPage()
+
+        await user.click(screen.getByTestId(CUSTOMER_INVOICE_VOID_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockRefetch).toHaveBeenCalled()
+        })
       })
     })
 

--- a/src/pages/__tests__/CustomerInvoiceVoid.test.tsx
+++ b/src/pages/__tests__/CustomerInvoiceVoid.test.tsx
@@ -1,0 +1,254 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { GENERIC_PLACEHOLDER_TEST_ID } from '~/components/designSystem/GenericPlaceholder'
+import { addToast } from '~/core/apolloClient'
+import {
+  CurrencyEnum,
+  InvoicePaymentStatusTypeEnum,
+  InvoiceStatusTypeEnum,
+  InvoiceTypeEnum,
+} from '~/generated/graphql'
+import { render, testMockNavigateFn } from '~/test-utils'
+
+import CustomerInvoiceVoid, {
+  CUSTOMER_INVOICE_VOID_SUBMIT_BUTTON_TEST_ID,
+} from '../CustomerInvoiceVoid'
+
+const mockUseGetInvoiceDetailsQuery = jest.fn()
+const mockVoidInvoice = jest.fn()
+const mockHasPermissions = jest.fn()
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+jest.mock('~/hooks/core/useLocationHistory', () => ({
+  useLocationHistory: () => ({ goBack: jest.fn() }),
+}))
+
+jest.mock('~/hooks/useOrganizationInfos', () => {
+  const { TimezoneEnum } = jest.requireActual('~/generated/graphql')
+
+  return { useOrganizationInfos: () => ({ timezone: TimezoneEnum.TzUtc }) }
+})
+
+jest.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ isPremium: false }),
+}))
+
+jest.mock('~/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasPermissions: mockHasPermissions }),
+}))
+
+jest.mock('~/generated/graphql', () => {
+  const actual = jest.requireActual('~/generated/graphql')
+
+  return {
+    ...actual,
+    useGetInvoiceDetailsQuery: () => mockUseGetInvoiceDetailsQuery(),
+    useVoidInvoiceMutation: () => [mockVoidInvoice],
+    useGetCustomerWalletListQuery: () => ({ data: undefined }),
+  }
+})
+
+jest.mock('~/core/apolloClient', () => ({
+  ...jest.requireActual('~/core/apolloClient'),
+  addToast: jest.fn(),
+}))
+
+const customerId = 'customer-1'
+const invoiceId = 'invoice-1'
+
+const buildInvoice = (status: InvoiceStatusTypeEnum) => ({
+  id: invoiceId,
+  number: 'INV-2026-0001',
+  status,
+  invoiceType: InvoiceTypeEnum.Subscription,
+  paymentStatus: InvoicePaymentStatusTypeEnum.Pending,
+  currency: CurrencyEnum.Usd,
+  totalAmountCents: 10000,
+  totalPaidAmountCents: 0,
+  totalDueAmountCents: 10000,
+  issuingDate: '2026-09-01',
+  customer: { id: customerId, deletedAt: null },
+})
+
+const mockQueryResult = ({
+  status,
+  loading = false,
+}: {
+  status?: InvoiceStatusTypeEnum
+  loading?: boolean
+}) => {
+  mockUseGetInvoiceDetailsQuery.mockReturnValue({
+    data: status ? { invoice: buildInvoice(status) } : undefined,
+    loading,
+    error: undefined,
+  })
+}
+
+const renderPage = () => render(<CustomerInvoiceVoid />, { useParams: { customerId, invoiceId } })
+
+describe('CustomerInvoiceVoid', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockHasPermissions.mockReturnValue(true)
+  })
+
+  describe('GIVEN an invoice the API would refuse to void', () => {
+    describe.each([
+      ['voided', InvoiceStatusTypeEnum.Voided],
+      ['draft', InvoiceStatusTypeEnum.Draft],
+      ['pending', InvoiceStatusTypeEnum.Pending],
+      ['failed', InvoiceStatusTypeEnum.Failed],
+    ])('WHEN the invoice is %s', (_, status) => {
+      it('THEN should display the placeholder instead of the void form', () => {
+        mockQueryResult({ status })
+
+        renderPage()
+
+        expect(screen.getByTestId(GENERIC_PLACEHOLDER_TEST_ID)).toBeInTheDocument()
+      })
+
+      it('THEN should not display the submit button', () => {
+        mockQueryResult({ status })
+
+        renderPage()
+
+        expect(
+          screen.queryByTestId(CUSTOMER_INVOICE_VOID_SUBMIT_BUTTON_TEST_ID),
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN the user lacks the void permission', () => {
+    describe('WHEN the invoice is finalized', () => {
+      it('THEN should display the placeholder instead of the void form', () => {
+        mockHasPermissions.mockReturnValue(false)
+        mockQueryResult({ status: InvoiceStatusTypeEnum.Finalized })
+
+        renderPage()
+
+        expect(screen.getByTestId(GENERIC_PLACEHOLDER_TEST_ID)).toBeInTheDocument()
+        expect(
+          screen.queryByTestId(CUSTOMER_INVOICE_VOID_SUBMIT_BUTTON_TEST_ID),
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a finalized invoice', () => {
+    describe('WHEN the page renders', () => {
+      it('THEN should display the submit button', () => {
+        mockQueryResult({ status: InvoiceStatusTypeEnum.Finalized })
+
+        renderPage()
+
+        expect(screen.getByTestId(CUSTOMER_INVOICE_VOID_SUBMIT_BUTTON_TEST_ID)).toBeInTheDocument()
+      })
+
+      it('THEN should not display the placeholder', () => {
+        mockQueryResult({ status: InvoiceStatusTypeEnum.Finalized })
+
+        renderPage()
+
+        expect(screen.queryByTestId(GENERIC_PLACEHOLDER_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN the invoice query has not settled', () => {
+    describe('WHEN the page renders', () => {
+      it('THEN should display neither the submit button nor the placeholder', () => {
+        mockQueryResult({ loading: true })
+
+        renderPage()
+
+        expect(
+          screen.queryByTestId(CUSTOMER_INVOICE_VOID_SUBMIT_BUTTON_TEST_ID),
+        ).not.toBeInTheDocument()
+        expect(screen.queryByTestId(GENERIC_PLACEHOLDER_TEST_ID)).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a finalized invoice and the void action', () => {
+    beforeEach(() => {
+      mockQueryResult({ status: InvoiceStatusTypeEnum.Finalized })
+    })
+
+    describe('WHEN the mutation succeeds', () => {
+      it('THEN should toast the success and navigate to the invoice overview', async () => {
+        mockVoidInvoice.mockResolvedValueOnce({
+          data: { voidInvoice: { id: invoiceId, status: InvoiceStatusTypeEnum.Voided } },
+        })
+
+        const user = userEvent.setup()
+
+        renderPage()
+
+        await user.click(screen.getByTestId(CUSTOMER_INVOICE_VOID_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+        })
+
+        expect(testMockNavigateFn).toHaveBeenCalledWith(
+          `/customer/${customerId}/invoice/${invoiceId}/overview`,
+        )
+      })
+    })
+
+    describe('WHEN the mutation is rejected with not_voidable', () => {
+      it('THEN should toast the dedicated error and stay on the page', async () => {
+        mockVoidInvoice.mockResolvedValueOnce({
+          data: null,
+          errors: [
+            {
+              message: 'Method Not Allowed',
+              extensions: { code: 'not_voidable', status: 405 },
+            },
+          ],
+        })
+
+        const user = userEvent.setup()
+
+        renderPage()
+
+        await user.click(screen.getByTestId(CUSTOMER_INVOICE_VOID_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'danger' }))
+        })
+
+        expect(addToast).toHaveBeenCalledTimes(1)
+        expect(addToast).not.toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+        expect(testMockNavigateFn).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('WHEN the mutation is rejected with any other code', () => {
+      it('THEN should not toast, leaving the global error link to report it', async () => {
+        mockVoidInvoice.mockResolvedValueOnce({
+          data: null,
+          errors: [{ message: 'Internal Error', extensions: { code: 'internal_error' } }],
+        })
+
+        const user = userEvent.setup()
+
+        renderPage()
+
+        await user.click(screen.getByTestId(CUSTOMER_INVOICE_VOID_SUBMIT_BUTTON_TEST_ID))
+
+        await waitFor(() => {
+          expect(mockVoidInvoice).toHaveBeenCalled()
+        })
+
+        expect(addToast).not.toHaveBeenCalled()
+        expect(testMockNavigateFn).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/translations/base.json
+++ b/translations/base.json
@@ -4897,5 +4897,8 @@
   "text_1788356716860fkisuga4c97": "Product filter code",
   "text_1788423201620lrod4vaj4e8": "Add a pricing unit",
   "text_17884232212443zsb3p8b5he": "Search and select a pricing unit",
-  "text_1788431703232ovdpgmdftnt": "This invitation no longer exists, the list has been refreshed."
+  "text_1788431703232ovdpgmdftnt": "This invitation no longer exists, the list has been refreshed.",
+  "text_1788518648182zhwh917bcvs": "This invoice cannot be voided",
+  "text_1788518648182tnlbh6pdxdd": "Only finalized invoices can be voided. This invoice’s status doesn’t allow this action.",
+  "text_1788518648182t6oetew3x8x": "This invoice can no longer be voided because its status has changed"
 }


### PR DESCRIPTION
## Context

A production Sentry event (FRONT-17T) shows the `voidInvoice` mutation being
rejected with `not_voidable` (HTTP 405) from
`/customer/:customerId/invoice/void/:invoiceId`, a URL only the void invoice
page serves. The backend is right to refuse: `Invoices::VoidService` rejects an
invoice that is already voided, or whose status does not allow the
`finalized -> voided` transition.

The page itself consults nothing about the invoice's state. It renders an
enabled, danger-styled "Void invoice" button for any invoice — voided, draft,
pending or failed — and its sticky footer sits outside the loading guard, so the
button is clickable before the invoice has even been fetched. The mutation
declares no error handling either, so the expected business rejection falls
through to the global Apollo error link: it is reported to Sentry as an
application error and the user gets the generic "something went wrong" toast
with no explanation.

Note that the gate is the invoice status, not `invoice.voidable`: that field is
stricter than the API, and gating on it would remove a void that succeeds today
on a paid invoice or one carrying a live credit note.

## Description

- Gate the page on `usePermissionsInvoiceActions().canVoid({ status })`, the
  same predicate the three entry-point action menus already use. When the query
  has settled and the invoice is not voidable, the page renders a placeholder
  instead of a submittable form.
- Move the sticky footer inside the `!loading` branch so the submit button can
  no longer fire while the invoice is undefined.
- Handle a racing `not_voidable` rejection locally: add the code to the
  client-side `LagoApiError` typeDefs enum, silence only that code on this
  mutation, and read the whole mutation outcome — success and handled failure —
  off the resolved result, replacing `onCompleted`. Any other error code is
  left to the global link, so a real failure still reaches Sentry and the user.
- Refetch the invoice after a `not_voidable` rejection, so the page flips to the
  placeholder rather than keeping an action the API will keep refusing, and pass
  the mutation's loading state to the submit button so a double-click cannot
  land both a success and a not-voidable toast.
- Export a test id for the submit button and add
  `src/pages/__tests__/CustomerInvoiceVoid.test.tsx` (17 cases).

`src/generated/graphql.tsx` carries only the new `NotVoidable` enum member: a
full regeneration would also drop unrelated `Contract` schema types, which the
committed file currently holds ahead of the API's main branch.

<!-- Linear link -->
Fixes ING-641
