### PR TITLE
refactor(dunning): migrate request overdue payment form to TanStack Form

### DIFF
--- a/src/formValidation/zodCustoms.ts
+++ b/src/formValidation/zodCustoms.ts
@@ -36,7 +36,7 @@ export const EMAIL_REGEX: RegExp =
 const DOMAIN_REGEX: RegExp =
   /^((?!-))(xn--)?[a-z0-9][a-z0-9-_]{0,61}[a-z0-9]{0,1}\.(xn--)?([a-z0-9-]{1,61}|[a-z0-9-]{1,30}\.[a-z]{2,})$/
 
-export const zodMultipleEmails = z.string().refine((val) => {
+export const isMultipleEmailsValid = (val: string): boolean => {
   if (!val) return true
   if (typeof val !== 'string') return false
   const separatedEmails = val.split(',').map((mail) => mail.trim())
@@ -48,7 +48,11 @@ export const zodMultipleEmails = z.string().refine((val) => {
   }
 
   return true
-}, 'text_620bc4d4269a55014d493fc3')
+}
+
+export const zodMultipleEmails = z
+  .string()
+  .refine(isMultipleEmailsValid, 'text_620bc4d4269a55014d493fc3')
 
 export const zodDomain = z.string().refine((val) => {
   if (typeof val !== 'string') return false

--- a/src/pages/CustomerRequestOverduePayment/__tests__/index.test.tsx
+++ b/src/pages/CustomerRequestOverduePayment/__tests__/index.test.tsx
@@ -4,14 +4,11 @@ import userEvent from '@testing-library/user-event'
 
 import { addToast } from '~/core/apolloClient'
 import { ERROR_404_ROUTE } from '~/core/router'
-import { initializeYup } from '~/formValidation/initializeYup'
 import { LagoApiError } from '~/generated/graphql'
 import * as useIsCustomerReadyForOverduePaymentModule from '~/hooks/useIsCustomerReadyForOverduePayment'
 import { render } from '~/test-utils'
 
 import CustomerRequestOverduePayment, { SUBMIT_PAYMENT_REQUEST_TEST_ID } from '../index'
-
-initializeYup()
 
 const mockNavigate = jest.fn()
 const mockGoBack = jest.fn()

--- a/src/pages/CustomerRequestOverduePayment/__tests__/validationSchema.test.ts
+++ b/src/pages/CustomerRequestOverduePayment/__tests__/validationSchema.test.ts
@@ -1,0 +1,80 @@
+import {
+  CustomerRequestOverduePaymentForm,
+  requestOverduePaymentValidationSchema,
+} from '../validationSchema'
+
+const buildValues = (
+  overrides: Partial<CustomerRequestOverduePaymentForm> = {},
+): CustomerRequestOverduePaymentForm => ({
+  emails: 'billing@acme.com',
+  paymentMethod: { paymentMethodId: undefined, paymentMethodType: undefined },
+  ...overrides,
+})
+
+describe('requestOverduePaymentValidationSchema', () => {
+  describe.each([
+    ['a single email', 'billing@acme.com'],
+    ['several emails separated by commas', 'billing@acme.com,accounting@acme.com'],
+    ['several emails separated by commas and spaces', 'billing@acme.com, accounting@acme.com'],
+  ])('GIVEN emails is %s', (_, emails) => {
+    describe('WHEN it is parsed', () => {
+      it('THEN should report no issue', () => {
+        expect(
+          requestOverduePaymentValidationSchema.safeParse(buildValues({ emails })).success,
+        ).toBe(true)
+      })
+    })
+  })
+
+  describe('GIVEN emails is empty', () => {
+    describe('WHEN it is parsed', () => {
+      // The empty value must surface the required message only: chaining the
+      // multi-email rule on top would stack a second message on the field.
+      it('THEN should report the required issue alone', () => {
+        const result = requestOverduePaymentValidationSchema.safeParse(buildValues({ emails: '' }))
+
+        expect(result.success).toBe(false)
+
+        if (!result.success) {
+          expect(result.error.issues).toEqual([
+            expect.objectContaining({
+              path: ['emails'],
+              message: 'text_620bc4d4269a55014d493f3d',
+            }),
+          ])
+        }
+      })
+    })
+  })
+
+  describe.each([
+    ['a single invalid email', 'not-an-email'],
+    ['one invalid email among valid ones', 'billing@acme.com, not-an-email'],
+    ['a trailing separator', 'billing@acme.com,'],
+  ])('GIVEN emails is %s', (_, emails) => {
+    describe('WHEN it is parsed', () => {
+      it('THEN should report the invalid-emails issue on emails', () => {
+        const result = requestOverduePaymentValidationSchema.safeParse(buildValues({ emails }))
+
+        expect(result.success).toBe(false)
+
+        if (!result.success) {
+          expect(result.error.issues).toEqual([
+            expect.objectContaining({
+              path: ['emails'],
+              message: 'text_66b258f62100490d0eb5ca8b',
+            }),
+          ])
+        }
+      })
+    })
+  })
+
+  describe('GIVEN no payment method is selected', () => {
+    describe('WHEN it is parsed', () => {
+      it('THEN should report no issue', () => {
+        expect(requestOverduePaymentValidationSchema.safeParse(buildValues()).success).toBe(true)
+      })
+    })
+  })
+})

--- a/src/pages/CustomerRequestOverduePayment/components/RequestPaymentForm.tsx
+++ b/src/pages/CustomerRequestOverduePayment/components/RequestPaymentForm.tsx
@@ -1,15 +1,13 @@
 import { gql } from '@apollo/client'
 import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
-import { FormikProps } from 'formik'
 import { DateTime } from 'luxon'
-import { FC, useMemo } from 'react'
+import { useMemo } from 'react'
 
 import { Alert } from '~/components/designSystem/Alert'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Table } from '~/components/designSystem/Table/Table'
 import { Typography } from '~/components/designSystem/Typography'
-import { TextInputField } from '~/components/form'
 import { OverviewCard } from '~/components/OverviewCard'
 import { PaymentMethodComboBox } from '~/components/paymentMethodSelection/PaymentMethodComboBox'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -20,9 +18,10 @@ import {
   CurrencyEnum,
   InvoicesForRequestOverduePaymentFormFragment,
   LastPaymentRequestFragment,
-  PaymentMethodReferenceInput,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { withForm } from '~/hooks/forms/useAppform'
+import { requestOverduePaymentDefaultValues } from '~/pages/CustomerRequestOverduePayment/validationSchema'
 
 gql`
   fragment CustomerForRequestOverduePaymentForm on Customer {
@@ -42,14 +41,8 @@ gql`
   }
 `
 
-export interface CustomerRequestOverduePaymentForm {
-  emails: string
-  paymentMethod: PaymentMethodReferenceInput
-}
-
 interface RequestPaymentFormProps {
   invoicesLoading: boolean
-  formikProps: FormikProps<CustomerRequestOverduePaymentForm>
   overdueAmount: number
   currency: CurrencyEnum
   invoices: InvoicesForRequestOverduePaymentFormFragment[]
@@ -57,133 +50,159 @@ interface RequestPaymentFormProps {
   externalCustomerId?: string
 }
 
-export const RequestPaymentForm: FC<RequestPaymentFormProps> = ({
-  invoicesLoading,
-  formikProps,
-  overdueAmount,
-  currency,
-  invoices,
-  lastSentDate,
-  externalCustomerId,
-}) => {
-  const { translate } = useInternationalization()
-
-  const amount = intlFormatNumber(overdueAmount, { currency, currencyDisplay: 'narrowSymbol' })
-  const count = invoices.length
-
-  const date = useMemo(() => DateTime.fromISO(lastSentDate?.createdAt).toUTC(), [lastSentDate])
-  const today = useMemo(() => DateTime.now().toUTC(), [])
-
-  return (
-    <div className="flex flex-col gap-10 md:max-w-168">
-      {isSameDay(date, today) && (
-        <Alert type="info">
-          <Typography variant="body" color="textSecondary">
-            {translate('text_66b4f00bd67ccc185ea75c70', {
-              relativeDay: date.toRelativeCalendar({ locale: LocaleEnum.en }),
-              time: date.toLocaleString(DateTime.TIME_24_WITH_SHORT_OFFSET),
-            })}
-          </Typography>
-        </Alert>
-      )}
-      {invoicesLoading ? (
-        <div>
-          <Box marginBottom={10}>
-            <Skeleton variant="text" className="w-80" />
-          </Box>
-          <Stack gap={6}>
-            <Skeleton variant="text" className="w-120" />
-            <Skeleton variant="text" className="w-40" />
-          </Stack>
-        </div>
-      ) : (
-        <>
-          <header className="flex flex-col gap-3">
-            <Typography variant="headline" color="textSecondary">
-              {translate('text_66b258f62100490d0eb5ca86', { amount })}
-            </Typography>
-            <Typography>{translate('text_66b258f62100490d0eb5ca87')}</Typography>
-          </header>
-
-          <TextInputField
-            formikProps={formikProps}
-            name="emails"
-            beforeChangeFormatter={['lowercase']}
-            placeholder={translate('text_66b25bc7a069220091457628')}
-            label={translate('text_66b258f62100490d0eb5ca88')}
-            description={translate('text_66b258f62100490d0eb5ca89')}
-          />
-        </>
-      )}
-      <OverviewCard
-        title={translate('text_6670a7222702d70114cc795a')}
-        caption={translate('text_6670a7222702d70114cc795c', { count }, count)}
-        tooltipContent={translate('text_6670a2a7ae3562006c4ee3e7')}
-        content={amount}
-        isAccentContent
-        isLoading={invoicesLoading}
-      />
-      <Table
-        name="overdue-invoices"
-        containerSize={{
-          default: 0,
-        }}
-        data={invoices}
-        isLoading={invoicesLoading}
-        columns={[
-          {
-            key: 'number',
-            title: translate('text_634687079be251fdb43833fb'),
-            maxSpace: true,
-            content: ({ number }) => (
-              <Typography variant="body" noWrap>
-                {number}
-              </Typography>
-            ),
-          },
-          {
-            key: 'totalDueAmountCents',
-            title: translate('text_17374735502775afvcm9pqxk'),
-            textAlign: 'right',
-            content: (row) => (
-              <Typography variant="bodyHl" color="textSecondary" noWrap>
-                {intlFormatNumber(
-                  deserializeAmount(row.totalDueAmountCents, row.currency || currency),
-                  {
-                    currency: row.currency || currency,
-                    currencyDisplay: 'narrowSymbol',
-                  },
-                )}
-              </Typography>
-            ),
-          },
-          {
-            key: 'issuingDate',
-            title: translate('text_634687079be251fdb4383407'),
-            content: ({ issuingDate }) => (
-              <Typography variant="body" noWrap>
-                {DateTime.fromISO(issuingDate).toLocaleString(DateTime.DATE_MED, {
-                  locale: LocaleEnum.en,
-                })}
-              </Typography>
-            ),
-          },
-        ]}
-      />
-
-      <div className="flex flex-col gap-1 pb-12">
-        <Typography variant="captionHl" color="textSecondary">
-          {translate('text_1766485465416wt41tyyecwa')}
-        </Typography>
-        <Typography variant="caption" className="mb-2">
-          {translate('text_1766485465416p3b95l4ng0m')}
-        </Typography>
-        <PaymentMethodComboBox
-          externalCustomerId={externalCustomerId}
-          selectedPaymentMethod={formikProps.values.paymentMethod}
-          setSelectedPaymentMethod={(value) => formikProps.setFieldValue('paymentMethod', value)}
-        />
-      </div>
-    </div>
-  )
+const EMPTY_PAYMENT_METHOD = {
+  paymentMethodId: undefined,
+  paymentMethodType: undefined,
 }
+
+const defaultProps: RequestPaymentFormProps = {
+  invoicesLoading: false,
+  overdueAmount: 0,
+  currency: CurrencyEnum.Usd,
+  invoices: [],
+  lastSentDate: undefined,
+  externalCustomerId: undefined,
+}
+
+export const RequestPaymentForm = withForm({
+  defaultValues: requestOverduePaymentDefaultValues,
+  props: defaultProps,
+  render: function Render({
+    form,
+    invoicesLoading,
+    overdueAmount,
+    currency,
+    invoices,
+    lastSentDate,
+    externalCustomerId,
+  }) {
+    const { translate } = useInternationalization()
+
+    const amount = intlFormatNumber(overdueAmount, { currency, currencyDisplay: 'narrowSymbol' })
+    const count = invoices.length
+
+    const date = useMemo(() => DateTime.fromISO(lastSentDate?.createdAt).toUTC(), [lastSentDate])
+    const today = useMemo(() => DateTime.now().toUTC(), [])
+
+    return (
+      <div className="flex flex-col gap-10 md:max-w-168">
+        {isSameDay(date, today) && (
+          <Alert type="info">
+            <Typography variant="body" color="textSecondary">
+              {translate('text_66b4f00bd67ccc185ea75c70', {
+                relativeDay: date.toRelativeCalendar({ locale: LocaleEnum.en }),
+                time: date.toLocaleString(DateTime.TIME_24_WITH_SHORT_OFFSET),
+              })}
+            </Typography>
+          </Alert>
+        )}
+        {invoicesLoading ? (
+          <div>
+            <Box marginBottom={10}>
+              <Skeleton variant="text" className="w-80" />
+            </Box>
+            <Stack gap={6}>
+              <Skeleton variant="text" className="w-120" />
+              <Skeleton variant="text" className="w-40" />
+            </Stack>
+          </div>
+        ) : (
+          <>
+            <header className="flex flex-col gap-3">
+              <Typography variant="headline" color="textSecondary">
+                {translate('text_66b258f62100490d0eb5ca86', { amount })}
+              </Typography>
+              <Typography>{translate('text_66b258f62100490d0eb5ca87')}</Typography>
+            </header>
+
+            <form.AppField name="emails">
+              {(field) => (
+                <field.TextInputField
+                  beforeChangeFormatter={['lowercase']}
+                  placeholder={translate('text_66b25bc7a069220091457628')}
+                  label={translate('text_66b258f62100490d0eb5ca88')}
+                  description={translate('text_66b258f62100490d0eb5ca89')}
+                />
+              )}
+            </form.AppField>
+          </>
+        )}
+        <OverviewCard
+          title={translate('text_6670a7222702d70114cc795a')}
+          caption={translate('text_6670a7222702d70114cc795c', { count }, count)}
+          tooltipContent={translate('text_6670a2a7ae3562006c4ee3e7')}
+          content={amount}
+          isAccentContent
+          isLoading={invoicesLoading}
+        />
+        <Table
+          name="overdue-invoices"
+          containerSize={{
+            default: 0,
+          }}
+          data={invoices}
+          isLoading={invoicesLoading}
+          columns={[
+            {
+              key: 'number',
+              title: translate('text_634687079be251fdb43833fb'),
+              maxSpace: true,
+              content: ({ number }) => (
+                <Typography variant="body" noWrap>
+                  {number}
+                </Typography>
+              ),
+            },
+            {
+              key: 'totalDueAmountCents',
+              title: translate('text_17374735502775afvcm9pqxk'),
+              textAlign: 'right',
+              content: (row) => (
+                <Typography variant="bodyHl" color="textSecondary" noWrap>
+                  {intlFormatNumber(
+                    deserializeAmount(row.totalDueAmountCents, row.currency || currency),
+                    {
+                      currency: row.currency || currency,
+                      currencyDisplay: 'narrowSymbol',
+                    },
+                  )}
+                </Typography>
+              ),
+            },
+            {
+              key: 'issuingDate',
+              title: translate('text_634687079be251fdb4383407'),
+              content: ({ issuingDate }) => (
+                <Typography variant="body" noWrap>
+                  {DateTime.fromISO(issuingDate).toLocaleString(DateTime.DATE_MED, {
+                    locale: LocaleEnum.en,
+                  })}
+                </Typography>
+              ),
+            },
+          ]}
+        />
+
+        <div className="flex flex-col gap-1 pb-12">
+          <Typography variant="captionHl" color="textSecondary">
+            {translate('text_1766485465416wt41tyyecwa')}
+          </Typography>
+          <Typography variant="caption" className="mb-2">
+            {translate('text_1766485465416p3b95l4ng0m')}
+          </Typography>
+          <form.AppField name="paymentMethod">
+            {(field) => (
+              <PaymentMethodComboBox
+                externalCustomerId={externalCustomerId}
+                selectedPaymentMethod={field.state.value}
+                setSelectedPaymentMethod={(value) =>
+                  field.handleChange(value ?? EMPTY_PAYMENT_METHOD)
+                }
+              />
+            )}
+          </form.AppField>
+        </div>
+      </div>
+    )
+  },
+})

--- a/src/pages/CustomerRequestOverduePayment/components/__tests__/RequestPaymentForm.test.tsx
+++ b/src/pages/CustomerRequestOverduePayment/components/__tests__/RequestPaymentForm.test.tsx
@@ -1,0 +1,198 @@
+import { revalidateLogic } from '@tanstack/react-form'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { CurrencyEnum } from '~/generated/graphql'
+import { useAppForm } from '~/hooks/forms/useAppform'
+import {
+  CustomerRequestOverduePaymentForm,
+  requestOverduePaymentDefaultValues,
+  requestOverduePaymentValidationSchema,
+} from '~/pages/CustomerRequestOverduePayment/validationSchema'
+import { render } from '~/test-utils'
+
+import { RequestPaymentForm } from '../RequestPaymentForm'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('~/components/paymentMethodSelection/PaymentMethodComboBox', () => ({
+  PaymentMethodComboBox: ({
+    selectedPaymentMethod,
+    setSelectedPaymentMethod,
+  }: {
+    selectedPaymentMethod?: { paymentMethodId?: string | null } | null
+    setSelectedPaymentMethod: (value: {
+      paymentMethodId: string
+      paymentMethodType: string
+    }) => void
+  }) => (
+    <div>
+      <span data-test="selected-payment-method">
+        {selectedPaymentMethod?.paymentMethodId || 'none'}
+      </span>
+      <button
+        type="button"
+        data-test="select-payment-method"
+        onClick={() =>
+          setSelectedPaymentMethod({ paymentMethodId: 'pm_123', paymentMethodType: 'provider' })
+        }
+      >
+        select
+      </button>
+    </div>
+  ),
+}))
+
+const SUBMIT_TEST_ID = 'submit'
+
+const TestWrapper = ({
+  initialValues = requestOverduePaymentDefaultValues,
+  onSubmit,
+}: {
+  initialValues?: CustomerRequestOverduePaymentForm
+  onSubmit: (values: CustomerRequestOverduePaymentForm) => void
+}) => {
+  const form = useAppForm({
+    defaultValues: initialValues,
+    validationLogic: revalidateLogic(),
+    validators: { onDynamic: requestOverduePaymentValidationSchema },
+    onSubmit: async ({ value }) => onSubmit(value),
+  })
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        form.handleSubmit()
+      }}
+    >
+      <RequestPaymentForm
+        form={form}
+        invoicesLoading={false}
+        overdueAmount={100}
+        currency={CurrencyEnum.Usd}
+        invoices={[]}
+      />
+      <form.AppForm>
+        <form.SubmitButton dataTest={SUBMIT_TEST_ID}>submit</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  )
+}
+
+describe('RequestPaymentForm', () => {
+  describe('GIVEN the recipient field is filled with an uppercase email', () => {
+    describe('WHEN the form is submitted', () => {
+      it('THEN should submit the lowercased email', async () => {
+        const user = userEvent.setup()
+        const onSubmit = jest.fn()
+
+        render(<TestWrapper onSubmit={onSubmit} />)
+
+        await user.type(screen.getByRole('textbox'), 'Billing@ACME.com')
+        await user.click(screen.getByTestId(SUBMIT_TEST_ID))
+
+        await waitFor(() => {
+          expect(onSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({ emails: 'billing@acme.com' }),
+          )
+        })
+      })
+    })
+  })
+
+  describe('GIVEN the recipient field is focused', () => {
+    describe('WHEN Enter is pressed', () => {
+      it('THEN should submit the form', async () => {
+        const user = userEvent.setup()
+        const onSubmit = jest.fn()
+
+        render(<TestWrapper onSubmit={onSubmit} />)
+
+        await user.type(screen.getByRole('textbox'), 'billing@acme.com{enter}')
+
+        await waitFor(() => {
+          expect(onSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({ emails: 'billing@acme.com' }),
+          )
+        })
+      })
+    })
+  })
+
+  describe('GIVEN a payment method is picked', () => {
+    describe('WHEN the form is submitted', () => {
+      // BIL-410: the combobox is driven manually, so a shape mismatch between
+      // what it publishes and what the schema accepts would silently keep the
+      // submit button disabled instead of sending the selection.
+      it('THEN should submit the selected payment method', async () => {
+        const user = userEvent.setup()
+        const onSubmit = jest.fn()
+
+        render(
+          <TestWrapper
+            initialValues={{ ...requestOverduePaymentDefaultValues, emails: 'billing@acme.com' }}
+            onSubmit={onSubmit}
+          />,
+        )
+
+        await user.click(screen.getByTestId('select-payment-method'))
+
+        expect(screen.getByTestId('selected-payment-method')).toHaveTextContent('pm_123')
+
+        await user.click(screen.getByTestId(SUBMIT_TEST_ID))
+
+        await waitFor(() => {
+          expect(onSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+              paymentMethod: { paymentMethodId: 'pm_123', paymentMethodType: 'provider' },
+            }),
+          )
+        })
+      })
+    })
+  })
+
+  describe('GIVEN the recipient field is empty', () => {
+    describe('WHEN the form is submitted', () => {
+      it('THEN should show the required error and not submit', async () => {
+        const user = userEvent.setup()
+        const onSubmit = jest.fn()
+
+        render(<TestWrapper onSubmit={onSubmit} />)
+
+        await user.click(screen.getByTestId(SUBMIT_TEST_ID))
+
+        await waitFor(() => {
+          expect(screen.getByText('text_620bc4d4269a55014d493f3d')).toBeInTheDocument()
+        })
+
+        expect(onSubmit).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN the recipient field holds one invalid email among valid ones', () => {
+    describe('WHEN the form is submitted', () => {
+      it('THEN should show the invalid-emails error and not submit', async () => {
+        const user = userEvent.setup()
+        const onSubmit = jest.fn()
+
+        render(<TestWrapper onSubmit={onSubmit} />)
+
+        await user.type(screen.getByRole('textbox'), 'billing@acme.com,nope')
+        await user.click(screen.getByTestId(SUBMIT_TEST_ID))
+
+        await waitFor(() => {
+          expect(screen.getByText('text_66b258f62100490d0eb5ca8b')).toBeInTheDocument()
+        })
+
+        expect(onSubmit).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/pages/CustomerRequestOverduePayment/index.tsx
+++ b/src/pages/CustomerRequestOverduePayment/index.tsx
@@ -1,14 +1,14 @@
 import { gql } from '@apollo/client'
-import { useFormik } from 'formik'
-import { FC, useEffect, useRef } from 'react'
+import { revalidateLogic } from '@tanstack/react-form'
+import { FC, FormEvent, useEffect, useRef } from 'react'
 import { generatePath, useParams, useSearchParams } from 'react-router-dom'
-import { object, string } from 'yup'
 
 import { Button } from '~/components/designSystem/Button'
 import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Typography } from '~/components/designSystem/Typography'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import { CustomerDetailsTabsOptions } from '~/core/constants/tabsOptions'
+import { scrollToFirstInputError } from '~/core/form/scrollToFirstInputError'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import {
   CUSTOMER_DETAILS_ROUTE,
@@ -32,18 +32,21 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useLocationHistory } from '~/hooks/core/useLocationHistory'
+import { useAppForm } from '~/hooks/forms/useAppform'
 import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { useIsCustomerReadyForOverduePayment } from '~/hooks/useIsCustomerReadyForOverduePayment'
 import { EmailPreview } from '~/pages/CustomerRequestOverduePayment/components/EmailPreview'
 import { PageHeader } from '~/styles'
 
 import { FreemiumAlert } from './components/FreemiumAlert'
+import { RequestPaymentForm } from './components/RequestPaymentForm'
 import {
   CustomerRequestOverduePaymentForm,
-  RequestPaymentForm,
-} from './components/RequestPaymentForm'
+  requestOverduePaymentValidationSchema,
+} from './validationSchema'
 
 export const SUBMIT_PAYMENT_REQUEST_TEST_ID = 'submit-payment-request'
+const CUSTOMER_REQUEST_OVERDUE_PAYMENT_FORM_ID = 'customer-request-overdue-payment-form'
 
 gql`
   query getRequestOverduePaymentInfos(
@@ -246,20 +249,21 @@ const CustomerRequestOverduePayment: FC = () => {
     (organization?.billingConfiguration?.documentLocale as Locale) ||
     'en'
 
-  const formikProps = useFormik<CustomerRequestOverduePaymentForm>({
-    initialValues: {
-      emails: customer?.email || '',
-      paymentMethod: {
-        paymentMethodId: undefined,
-        paymentMethodType: undefined,
-      },
+  const defaultValues: CustomerRequestOverduePaymentForm = {
+    emails: customer?.email || '',
+    paymentMethod: {
+      paymentMethodId: undefined,
+      paymentMethodType: undefined,
     },
-    validationSchema: object({
-      emails: string().required('').emails('text_66b258f62100490d0eb5ca8b'),
-    }),
-    validateOnMount: true,
-    enableReinitialize: true,
-    onSubmit: async (values) => {
+  }
+
+  const form = useAppForm({
+    defaultValues,
+    validationLogic: revalidateLogic(),
+    validators: {
+      onDynamic: requestOverduePaymentValidationSchema,
+    },
+    onSubmit: async ({ value }) => {
       if (!hasDunningIntegration) {
         return
       }
@@ -268,19 +272,39 @@ const CustomerRequestOverduePayment: FC = () => {
         variables: {
           input: {
             externalCustomerId: customer?.externalId ?? '',
-            email: values.emails.replaceAll(' ', ''),
+            email: value.emails.replaceAll(' ', ''),
             lagoInvoiceIds: invoices?.collection?.map((invoice) => invoice.id),
-            paymentMethod: values.paymentMethod.paymentMethodId
+            paymentMethod: value.paymentMethod.paymentMethodId
               ? {
-                  paymentMethodId: values.paymentMethod.paymentMethodId,
-                  paymentMethodType: values.paymentMethod.paymentMethodType,
+                  paymentMethodId: value.paymentMethod.paymentMethodId,
+                  paymentMethodType: value.paymentMethod.paymentMethodType,
                 }
               : undefined,
           },
         },
       })
     },
+    onSubmitInvalid({ formApi }) {
+      scrollToFirstInputError(
+        CUSTOMER_REQUEST_OVERDUE_PAYMENT_FORM_ID,
+        formApi.state.errorMap.onDynamic || {},
+      )
+    },
   })
+
+  // The recipient default comes from the query, which resolves after the form has
+  // already mounted on an empty email.
+  useEffect(() => {
+    if (!customer?.email) return
+
+    form.reset(defaultValues)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [customer?.email])
+
+  const handleSubmit = (event: FormEvent): void => {
+    event.preventDefault()
+    form.handleSubmit()
+  }
 
   const defaultCurrency = customer?.currency || organization?.defaultCurrency || CurrencyEnum.Usd
   const invoicesCollection = invoices?.collection ?? []
@@ -336,7 +360,7 @@ const CustomerRequestOverduePayment: FC = () => {
   if (isUnscopedAccess) return null
 
   return (
-    <>
+    <form id={CUSTOMER_REQUEST_OVERDUE_PAYMENT_FORM_ID} onSubmit={handleSubmit}>
       <PageHeader.Wrapper>
         {loading ? (
           <Skeleton variant="text" className="w-60" />
@@ -372,8 +396,8 @@ const CustomerRequestOverduePayment: FC = () => {
           {!hasDunningIntegration && <FreemiumAlert />}
           <div className="px-4 py-12 md:px-12">
             <RequestPaymentForm
+              form={form}
               invoicesLoading={loading}
-              formikProps={formikProps}
               overdueAmount={totalAmount}
               currency={defaultCurrency}
               invoices={invoicesCollection}
@@ -410,18 +434,19 @@ const CustomerRequestOverduePayment: FC = () => {
           >
             {translate('text_6411e6b530cb47007488b027')}
           </Button>
-          <Button
-            variant="primary"
-            size="large"
-            onClick={formikProps.submitForm}
-            data-test={SUBMIT_PAYMENT_REQUEST_TEST_ID}
-            disabled={!hasDunningIntegration || totalAmount === 0 || !formikProps.isValid}
-          >
-            {translate('text_66b258f62100490d0eb5caa2')}
-          </Button>
+          <form.AppForm>
+            <form.SubmitButton
+              variant="primary"
+              size="large"
+              dataTest={SUBMIT_PAYMENT_REQUEST_TEST_ID}
+              disabled={!hasDunningIntegration || totalAmount === 0}
+            >
+              {translate('text_66b258f62100490d0eb5caa2')}
+            </form.SubmitButton>
+          </form.AppForm>
         </div>
       </footer>
-    </>
+    </form>
   )
 }
 

--- a/src/pages/CustomerRequestOverduePayment/validationSchema.ts
+++ b/src/pages/CustomerRequestOverduePayment/validationSchema.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+
+import { isMultipleEmailsValid } from '~/formValidation/zodCustoms'
+import { PaymentMethodTypeEnum } from '~/generated/graphql'
+
+export const requestOverduePaymentValidationSchema = z.object({
+  // `zodMultipleEmails` carries the same rule, but its message is worded for a
+  // single address — this field takes a comma-separated list.
+  emails: z
+    .string()
+    .min(1, { message: 'text_620bc4d4269a55014d493f3d' })
+    .refine(isMultipleEmailsValid, 'text_66b258f62100490d0eb5ca8b'),
+  paymentMethod: z.object({
+    paymentMethodId: z.string().nullish(),
+    paymentMethodType: z.enum(PaymentMethodTypeEnum).nullish(),
+  }),
+})
+
+export type CustomerRequestOverduePaymentForm = z.infer<
+  typeof requestOverduePaymentValidationSchema
+>
+
+export const requestOverduePaymentDefaultValues: CustomerRequestOverduePaymentForm = {
+  emails: '',
+  paymentMethod: {
+    paymentMethodId: undefined,
+    paymentMethodType: undefined,
+  },
+}


### PR DESCRIPTION
## Context

Part of the Formik → TanStack Form migration ([LAGO-1148](https://linear.app/getlago/issue/LAGO-1148/initiative-form-migration-strategy)). The customer "request overdue payment" page was still on Formik + yup, and its `no-restricted-imports` lint warnings are two of the remaining ones.

This page was picked because it is one of the smallest and most isolated forms left: two fields (`emails`, `paymentMethod`), one sub-component, no drawer/dialog machinery, and no shared form state with anything else.

## Description

**`validationSchema.ts` (new)** — holds the zod schema, the inferred `CustomerRequestOverduePaymentForm` type (previously hand-written in `RequestPaymentForm.tsx`) and the default values.

Validation parity with the previous yup schema:

| Field | Before (yup) | After (zod) |
| --- | --- | --- |
| `emails` | `.required('')` | `.min(1, 'text_620bc4d4269a55014d493f3d')` — yup's empty message could never render, and Zod v4 substitutes a raw "Invalid input" for `message: ''`, so the existing "Email is required" key is used |
| `emails` | `.emails('text_66b258f62100490d0eb5ca8b')` | `.refine(isMultipleEmailsValid, 'text_66b258f62100490d0eb5ca8b')` — same semantics, same message key, and it still short-circuits on an empty value so the field never shows two messages at once |
| `paymentMethod` | not validated | `z.object` mirroring `PaymentMethodReferenceInput`, both members optional |

**`zodCustoms.ts`** — the comma-separated email check is extracted out of `zodMultipleEmails` as `isMultipleEmailsValid`, so this schema reuses the shared implementation instead of duplicating the split-and-regex logic. `zodMultipleEmails` itself is unchanged for its existing callers; this field only differs in its message, whose copy is written for a list of recipients rather than a single address.

**`RequestPaymentForm.tsx`** — becomes a `withForm` section instead of taking a `formikProps` prop, so the form is handed down through the mechanism already used everywhere else in the app. `TextInputField` becomes `form.AppField` + `field.TextInputField` (keeping `beforeChangeFormatter={['lowercase']}`), and the manually-driven `PaymentMethodComboBox` is bound to a `form.AppField name="paymentMethod"` calling `field.handleChange(value)`, so its whole-object value stays in form state exactly as before.

**`index.tsx`** — `useFormik` → `useAppForm` with `revalidateLogic()`. The page body is wrapped in a real `<form>`, which also brings the native browser behaviours the Formik version lacked: pressing Enter in the recipient input now submits. No extra classes were needed on the wrapper — the header is `sticky`, `main` carries its own viewport heights and the footer is `fixed`, none of which the added block node disturbs. The footer button becomes `form.SubmitButton`, keeping the genuinely external `!hasDunningIntegration || totalAmount === 0` gate and dropping the `!isValid` gate that `canSubmit` now owns. `onSubmitInvalid` wires `scrollToFirstInputError`. `enableReinitialize` is replaced by a `form.reset` effect on the customer email, which lands after the query resolves.

### Behaviour change to know about

Formik used `validateOnMount`, so an invalid form disabled the submit button immediately and never showed the "required" message. With `revalidateLogic()` the button stays enabled and the error surfaces on the first submit attempt, then live — same rules, different moment. This is the convention across every migrated form.

## Tests

- `__tests__/validationSchema.test.ts` — single/multiple emails, the required message on an empty value (asserting a single issue), and the invalid-emails message including a trailing separator
- `components/__tests__/RequestPaymentForm.test.tsx` — lowercasing on submit, Enter-to-submit, payment-method select-then-submit (the BIL-410 shape-mismatch guard), and both error messages blocking submit
- the existing `__tests__/index.test.tsx` passes unchanged, minus its now-unused `initializeYup()` call

`pnpm code:style` and `pnpm test` are green.

<!-- Linear link -->
Fixes LAGO-1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdirPHN4tyNn5CYuHYNuhf
