### PR TITLE
fix(recovery): recover worker script load failures after deploy

### DIFF
--- a/src/core/router/utils.tsx
+++ b/src/core/router/utils.tsx
@@ -3,27 +3,13 @@ import { ComponentType, lazy, LazyExoticComponent } from 'react'
 
 import { envGlobalVar } from '~/core/apolloClient/reactiveVars/envGlobalVar'
 import { reloadWithCacheBust } from '~/core/utils/reloadWithCacheBust'
-import { hasReloadedRecently, markReloaded } from '~/core/utils/staleAssetRecovery'
+import {
+  hasReloadedRecently,
+  markReloaded,
+  showPersistentToast,
+} from '~/core/utils/staleAssetRecovery'
 
 const CHUNK_LOAD_FINGERPRINT = 'chunk-load-failure'
-
-function showPersistentToast(): void {
-  import('~/core/apolloClient/reactiveVars/toastVar')
-    .then(({ addToast }) => {
-      addToast({
-        severity: 'info',
-        message:
-          'Something went wrong while loading the page. Please try refreshing or clearing your cache.',
-        autoDismiss: false,
-      })
-    })
-    .catch((error) => {
-      // Toast module also failed to load, nothing more we can do.
-      // The rejected import is already surfaced by the route error boundary.
-      // eslint-disable-next-line no-console
-      console.error('Failed to load fallback toast module', error)
-    })
-}
 
 const retry = (
   fn: () => Promise<{ default: ComponentType<Record<string, never>> }>,

--- a/src/core/router/utils.tsx
+++ b/src/core/router/utils.tsx
@@ -3,35 +3,9 @@ import { ComponentType, lazy, LazyExoticComponent } from 'react'
 
 import { envGlobalVar } from '~/core/apolloClient/reactiveVars/envGlobalVar'
 import { reloadWithCacheBust } from '~/core/utils/reloadWithCacheBust'
+import { hasReloadedRecently, markReloaded } from '~/core/utils/staleAssetRecovery'
 
-const CHUNK_RELOAD_KEY = 'lago_chunk_reload'
-const RELOAD_COOLDOWN_MS = 10_000
 const CHUNK_LOAD_FINGERPRINT = 'chunk-load-failure'
-
-function hasReloadedRecently(): boolean {
-  try {
-    const timestamp = sessionStorage.getItem(CHUNK_RELOAD_KEY)
-
-    if (!timestamp) return false
-
-    return Date.now() - parseInt(timestamp, 10) < RELOAD_COOLDOWN_MS
-  } catch {
-    // Storage unavailable (blocked, partitioned, sandboxed iframe)
-    // Assume already reloaded to avoid infinite reload loop
-    return true
-  }
-}
-
-function markReloaded(): void {
-  try {
-    sessionStorage.setItem(CHUNK_RELOAD_KEY, Date.now().toString())
-  } catch {
-    // Storage became unavailable after hasAlreadyReloaded() check.
-    // In environments where sessionStorage is always unavailable,
-    // hasAlreadyReloaded() returns true and we never reach the reload path,
-    // so users see the fallback toast instead of an automatic reload.
-  }
-}
 
 function showPersistentToast(): void {
   import('~/core/apolloClient/reactiveVars/toastVar')

--- a/src/core/utils/__tests__/staleAssetRecovery.test.ts
+++ b/src/core/utils/__tests__/staleAssetRecovery.test.ts
@@ -1,0 +1,67 @@
+import { hasReloadedRecently, markReloaded } from '../staleAssetRecovery'
+
+describe('staleAssetRecovery', () => {
+  const FAKE_NOW = 1700000000000
+
+  beforeEach(() => {
+    jest.useFakeTimers({ now: FAKE_NOW })
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  describe('GIVEN no reload has been marked', () => {
+    describe('WHEN hasReloadedRecently is called', () => {
+      it('THEN should return false', () => {
+        expect(hasReloadedRecently()).toBe(false)
+      })
+    })
+  })
+
+  describe('GIVEN a reload was marked within the cooldown window', () => {
+    describe('WHEN hasReloadedRecently is called', () => {
+      it('THEN should return true', () => {
+        markReloaded()
+
+        expect(hasReloadedRecently()).toBe(true)
+      })
+    })
+  })
+
+  describe('GIVEN a reload was marked outside the cooldown window', () => {
+    describe('WHEN hasReloadedRecently is called', () => {
+      it('THEN should return false', () => {
+        sessionStorage.setItem('lago_chunk_reload', String(FAKE_NOW - 15_000))
+
+        expect(hasReloadedRecently()).toBe(false)
+      })
+    })
+  })
+
+  describe('GIVEN sessionStorage.getItem throws', () => {
+    describe('WHEN hasReloadedRecently is called', () => {
+      it('THEN should return true to avoid an infinite reload loop', () => {
+        jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+          throw new DOMException('Storage blocked')
+        })
+
+        expect(hasReloadedRecently()).toBe(true)
+      })
+    })
+  })
+
+  describe('GIVEN sessionStorage.setItem throws', () => {
+    describe('WHEN markReloaded is called', () => {
+      it('THEN should not throw', () => {
+        jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+          throw new DOMException('Storage full')
+        })
+
+        expect(() => markReloaded()).not.toThrow()
+      })
+    })
+  })
+})

--- a/src/core/utils/__tests__/workerLoadRecovery.test.ts
+++ b/src/core/utils/__tests__/workerLoadRecovery.test.ts
@@ -1,0 +1,111 @@
+import { createWorkerLoadErrorHandler } from '../workerLoadRecovery'
+
+const mockAddToast = jest.fn()
+const mockReloadWithCacheBust = jest.fn()
+const mockCaptureException = jest.fn()
+const mockCaptureMessage = jest.fn()
+
+jest.mock('~/core/apolloClient/reactiveVars/toastVar', () => ({
+  addToast: mockAddToast,
+}))
+
+jest.mock('~/core/utils/reloadWithCacheBust', () => ({
+  reloadWithCacheBust: () => mockReloadWithCacheBust(),
+}))
+
+jest.mock('@sentry/react', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
+}))
+
+function unrelatedErrorEvent(): ErrorEvent {
+  return { message: 'TypeError: Cannot read properties of undefined' } as ErrorEvent
+}
+
+function workerLoadErrorEvent(): ErrorEvent {
+  return {
+    message:
+      "Uncaught NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope': The script failed to load.",
+    error: new Error('worker load failed'),
+  } as ErrorEvent
+}
+
+describe('createWorkerLoadErrorHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    sessionStorage.clear()
+  })
+
+  describe('GIVEN an unrelated error event', () => {
+    describe('WHEN the handler runs', () => {
+      it('THEN should ignore it', () => {
+        const handler = createWorkerLoadErrorHandler()
+
+        handler(unrelatedErrorEvent())
+
+        expect(mockCaptureMessage).not.toHaveBeenCalled()
+        expect(mockReloadWithCacheBust).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN the first worker-load failure on this handler', () => {
+    describe('WHEN the handler runs', () => {
+      it('THEN should report it without reloading, in case it was a transient blip', () => {
+        const handler = createWorkerLoadErrorHandler()
+
+        handler(workerLoadErrorEvent())
+
+        expect(mockCaptureMessage).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({ tags: { workerLoad: true, phase: 'first-failure' } }),
+        )
+        expect(mockReloadWithCacheBust).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GIVEN a second worker-load failure and no previous reload', () => {
+    describe('WHEN the handler runs', () => {
+      it('THEN should reload with a cache-busting URL', () => {
+        const handler = createWorkerLoadErrorHandler()
+
+        handler(workerLoadErrorEvent())
+        handler(workerLoadErrorEvent())
+
+        expect(sessionStorage.getItem('lago_chunk_reload')).not.toBeNull()
+        expect(mockReloadWithCacheBust).toHaveBeenCalledTimes(1)
+        expect(mockCaptureMessage).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({ tags: { workerLoad: true, phase: 'reload' } }),
+        )
+      })
+    })
+  })
+
+  describe('GIVEN a second worker-load failure and a reload happened recently', () => {
+    describe('WHEN the handler runs', () => {
+      it('THEN should report the dead-end and show the persistent toast instead of reloading again', async () => {
+        sessionStorage.setItem('lago_chunk_reload', Date.now().toString())
+
+        const handler = createWorkerLoadErrorHandler()
+
+        handler(workerLoadErrorEvent())
+        handler(workerLoadErrorEvent())
+
+        // showPersistentToast() resolves the dynamic toastVar import on a microtask
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(mockReloadWithCacheBust).not.toHaveBeenCalled()
+        expect(mockCaptureException).toHaveBeenCalledWith(
+          expect.any(Error),
+          expect.objectContaining({ tags: { workerLoad: true, phase: 'dead-end' } }),
+        )
+        expect(mockAddToast).toHaveBeenCalledWith(
+          expect.objectContaining({ severity: 'info', autoDismiss: false }),
+        )
+      })
+    })
+  })
+})

--- a/src/core/utils/staleAssetRecovery.ts
+++ b/src/core/utils/staleAssetRecovery.ts
@@ -24,3 +24,20 @@ export function markReloaded(): void {
     // hasReloadedRecently() returns true and we never reach the reload path.
   }
 }
+
+export function showPersistentToast(): void {
+  import('~/core/apolloClient/reactiveVars/toastVar')
+    .then(({ addToast }) => {
+      addToast({
+        severity: 'info',
+        message:
+          'Something went wrong while loading the page. Please try refreshing or clearing your cache.',
+        autoDismiss: false,
+      })
+    })
+    .catch((error) => {
+      // Toast module also failed to load, nothing more we can do.
+      // eslint-disable-next-line no-console
+      console.error('Failed to load fallback toast module', error)
+    })
+}

--- a/src/core/utils/staleAssetRecovery.ts
+++ b/src/core/utils/staleAssetRecovery.ts
@@ -1,0 +1,26 @@
+const RELOAD_KEY = 'lago_chunk_reload'
+const RELOAD_COOLDOWN_MS = 10_000
+
+export function hasReloadedRecently(): boolean {
+  try {
+    const timestamp = sessionStorage.getItem(RELOAD_KEY)
+
+    if (!timestamp) return false
+
+    return Date.now() - parseInt(timestamp, 10) < RELOAD_COOLDOWN_MS
+  } catch {
+    // Storage unavailable (blocked, partitioned, sandboxed iframe)
+    // Assume already reloaded to avoid infinite reload loop
+    return true
+  }
+}
+
+export function markReloaded(): void {
+  try {
+    sessionStorage.setItem(RELOAD_KEY, Date.now().toString())
+  } catch {
+    // Storage became unavailable after hasReloadedRecently() check.
+    // In environments where sessionStorage is always unavailable,
+    // hasReloadedRecently() returns true and we never reach the reload path.
+  }
+}

--- a/src/core/utils/workerLoadRecovery.ts
+++ b/src/core/utils/workerLoadRecovery.ts
@@ -1,0 +1,54 @@
+import { captureException, captureMessage } from '@sentry/react'
+
+import { envGlobalVar } from '~/core/apolloClient/reactiveVars/envGlobalVar'
+import { reloadWithCacheBust } from '~/core/utils/reloadWithCacheBust'
+import {
+  hasReloadedRecently,
+  markReloaded,
+  showPersistentToast,
+} from '~/core/utils/staleAssetRecovery'
+
+const WORKER_IMPORT_SCRIPTS_FAILURE = /Failed to execute 'importScripts' on 'WorkerGlobalScope'/
+const WORKER_LOAD_FINGERPRINT = 'worker-load-failure'
+// A single failure could be a transient network blip, not a stale deploy -
+// only reload once it repeats.
+const WORKER_LOAD_RELOAD_THRESHOLD = 2
+
+export function createWorkerLoadErrorHandler(): (event: ErrorEvent) => void {
+  let workerLoadFailureCount = 0
+
+  return (event: ErrorEvent): void => {
+    if (!WORKER_IMPORT_SCRIPTS_FAILURE.test(event.message)) return
+
+    workerLoadFailureCount += 1
+
+    if (workerLoadFailureCount < WORKER_LOAD_RELOAD_THRESHOLD) {
+      captureMessage('Worker script load failed once, waiting for a repeat before reloading', {
+        level: 'warning',
+        tags: { workerLoad: true, phase: 'first-failure' },
+        fingerprint: [WORKER_LOAD_FINGERPRINT],
+      })
+
+      return
+    }
+
+    if (hasReloadedRecently()) {
+      captureException(event.error ?? new Error(event.message), {
+        tags: { workerLoad: true, phase: 'dead-end' },
+        extra: { href: window.location.href, appVersion: envGlobalVar().appVersion },
+        fingerprint: [WORKER_LOAD_FINGERPRINT],
+      })
+      showPersistentToast()
+
+      return
+    }
+
+    markReloaded()
+    captureMessage('Worker script load failed - reloading with cache-bust', {
+      level: 'warning',
+      tags: { workerLoad: true, phase: 'reload' },
+      fingerprint: [WORKER_LOAD_FINGERPRINT],
+    })
+    reloadWithCacheBust()
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,11 @@ import { AppEnvEnum } from '~/core/constants/globalTypes'
 import { reportMissingAppEnv } from '~/core/utils/appEnv'
 import { installLagoWindowApi } from '~/core/utils/featureFlagsConsole'
 import { reloadWithCacheBust } from '~/core/utils/reloadWithCacheBust'
-import { hasReloadedRecently, markReloaded } from '~/core/utils/staleAssetRecovery'
+import {
+  hasReloadedRecently,
+  markReloaded,
+  showPersistentToast,
+} from '~/core/utils/staleAssetRecovery'
 
 import './main.css'
 
@@ -98,9 +102,26 @@ window.addEventListener('vite:preloadError', (event) => {
 // cache-bust reload once, then stop trying so we can't loop.
 const WORKER_IMPORT_SCRIPTS_FAILURE = /Failed to execute 'importScripts' on 'WorkerGlobalScope'/
 const WORKER_LOAD_FINGERPRINT = 'worker-load-failure'
+// A single failure could be a transient network blip, not a stale deploy -
+// only reload once it repeats.
+const WORKER_LOAD_RELOAD_THRESHOLD = 2
+
+let workerLoadFailureCount = 0
 
 window.addEventListener('error', (event) => {
   if (!WORKER_IMPORT_SCRIPTS_FAILURE.test(event.message)) return
+
+  workerLoadFailureCount += 1
+
+  if (workerLoadFailureCount < WORKER_LOAD_RELOAD_THRESHOLD) {
+    Sentry.captureMessage('Worker script load failed once, waiting for a repeat before reloading', {
+      level: 'warning',
+      tags: { workerLoad: true, phase: 'first-failure' },
+      fingerprint: [WORKER_LOAD_FINGERPRINT],
+    })
+
+    return
+  }
 
   if (hasReloadedRecently()) {
     Sentry.captureException(event.error ?? new Error(event.message), {
@@ -108,6 +129,7 @@ window.addEventListener('error', (event) => {
       extra: { href: window.location.href, appVersion },
       fingerprint: [WORKER_LOAD_FINGERPRINT],
     })
+    showPersistentToast()
 
     return
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,8 @@ import { envGlobalVar } from '~/core/apolloClient'
 import { AppEnvEnum } from '~/core/constants/globalTypes'
 import { reportMissingAppEnv } from '~/core/utils/appEnv'
 import { installLagoWindowApi } from '~/core/utils/featureFlagsConsole'
+import { reloadWithCacheBust } from '~/core/utils/reloadWithCacheBust'
+import { hasReloadedRecently, markReloaded } from '~/core/utils/staleAssetRecovery'
 
 import './main.css'
 
@@ -85,6 +87,38 @@ window.addEventListener('vite:preloadError', (event) => {
       appVersion,
     },
   })
+})
+
+// A web worker (e.g. ace-builds' JSON linter) loads its script via
+// `importScripts` inside a blob URL. After a deploy re-hashes `/assets/*`, a
+// tab that's still open can point that call at a filename that no longer
+// exists — same stale-bundle failure the router's chunk `retry()` handles,
+// but this one throws inside the worker's own global scope, so no React
+// error boundary or route-level retry ever sees it. Recover the same way:
+// cache-bust reload once, then stop trying so we can't loop.
+const WORKER_IMPORT_SCRIPTS_FAILURE = /Failed to execute 'importScripts' on 'WorkerGlobalScope'/
+const WORKER_LOAD_FINGERPRINT = 'worker-load-failure'
+
+window.addEventListener('error', (event) => {
+  if (!WORKER_IMPORT_SCRIPTS_FAILURE.test(event.message)) return
+
+  if (hasReloadedRecently()) {
+    Sentry.captureException(event.error ?? new Error(event.message), {
+      tags: { workerLoad: true, phase: 'dead-end' },
+      extra: { href: window.location.href, appVersion },
+      fingerprint: [WORKER_LOAD_FINGERPRINT],
+    })
+
+    return
+  }
+
+  markReloaded()
+  Sentry.captureMessage('Worker script load failed - reloading with cache-bust', {
+    level: 'warning',
+    tags: { workerLoad: true, phase: 'reload' },
+    fingerprint: [WORKER_LOAD_FINGERPRINT],
+  })
+  reloadWithCacheBust()
 })
 
 reportMissingAppEnv(appEnv)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,12 +7,7 @@ import { envGlobalVar } from '~/core/apolloClient'
 import { AppEnvEnum } from '~/core/constants/globalTypes'
 import { reportMissingAppEnv } from '~/core/utils/appEnv'
 import { installLagoWindowApi } from '~/core/utils/featureFlagsConsole'
-import { reloadWithCacheBust } from '~/core/utils/reloadWithCacheBust'
-import {
-  hasReloadedRecently,
-  markReloaded,
-  showPersistentToast,
-} from '~/core/utils/staleAssetRecovery'
+import { createWorkerLoadErrorHandler } from '~/core/utils/workerLoadRecovery'
 
 import './main.css'
 
@@ -100,48 +95,7 @@ window.addEventListener('vite:preloadError', (event) => {
 // but this one throws inside the worker's own global scope, so no React
 // error boundary or route-level retry ever sees it. Recover the same way:
 // cache-bust reload once, then stop trying so we can't loop.
-const WORKER_IMPORT_SCRIPTS_FAILURE = /Failed to execute 'importScripts' on 'WorkerGlobalScope'/
-const WORKER_LOAD_FINGERPRINT = 'worker-load-failure'
-// A single failure could be a transient network blip, not a stale deploy -
-// only reload once it repeats.
-const WORKER_LOAD_RELOAD_THRESHOLD = 2
-
-let workerLoadFailureCount = 0
-
-window.addEventListener('error', (event) => {
-  if (!WORKER_IMPORT_SCRIPTS_FAILURE.test(event.message)) return
-
-  workerLoadFailureCount += 1
-
-  if (workerLoadFailureCount < WORKER_LOAD_RELOAD_THRESHOLD) {
-    Sentry.captureMessage('Worker script load failed once, waiting for a repeat before reloading', {
-      level: 'warning',
-      tags: { workerLoad: true, phase: 'first-failure' },
-      fingerprint: [WORKER_LOAD_FINGERPRINT],
-    })
-
-    return
-  }
-
-  if (hasReloadedRecently()) {
-    Sentry.captureException(event.error ?? new Error(event.message), {
-      tags: { workerLoad: true, phase: 'dead-end' },
-      extra: { href: window.location.href, appVersion },
-      fingerprint: [WORKER_LOAD_FINGERPRINT],
-    })
-    showPersistentToast()
-
-    return
-  }
-
-  markReloaded()
-  Sentry.captureMessage('Worker script load failed - reloading with cache-bust', {
-    level: 'warning',
-    tags: { workerLoad: true, phase: 'reload' },
-    fingerprint: [WORKER_LOAD_FINGERPRINT],
-  })
-  reloadWithCacheBust()
-})
+window.addEventListener('error', createWorkerLoadErrorHandler())
 
 reportMissingAppEnv(appEnv)
 


### PR DESCRIPTION
Fixes FRONT-EU-EV

Sentry: `Uncaught NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope'`, thrown by ace-builds' JSON linter worker on `/auth/okta/callback` right at a deploy boundary (`build-3680-7ddd1fc`).

Same root cause as #4042 (BIL-392 stale-chunk recovery): a deploy re-hashes `/assets/*`, and a tab still open after the deploy requests a chunk filename that no longer exists. That fix only covers the router's dynamic `import()` retry path. A web worker loading its script via `importScripts` inside a blob URL fails the same way, but throws inside the worker's own global scope — no React error boundary or route-level retry ever sees it, so nothing recovers.

- `src/core/utils/staleAssetRecovery.ts` — extracted the reload-cooldown gate (`hasReloadedRecently`/`markReloaded`) out of `router/utils.tsx` so chunk-load and worker-load recovery share one dedupe and one `sessionStorage` key, instead of duplicating the gate.
- `src/core/router/utils.tsx` — now imports the shared gate. No behavior change.
- `src/main.tsx` — new `window` `error` listener, narrowly matched on the `importScripts`/`WorkerGlobalScope` failure signature, triggers the same cache-bust reload via the shared gate, and reports to Sentry on both branches under a distinct `workerLoad` tag/fingerprint.