### PR TITLE
chore(router): enable v7_relativeSplatPath, hold transitions

### DIFF
--- a/jest-setup-early.ts
+++ b/jest-setup-early.ts
@@ -34,10 +34,6 @@ const SUPPRESSED_PATTERNS: string[][] = [
   // Apollo cache merge warnings (test environment artifact)
   ['Cache data may be lost when replacing'],
 
-  // React Router v7 future flag warnings
-  ['React Router Future Flag Warning', 'v7_startTransition'],
-  ['React Router Future Flag Warning', 'v7_relativeSplatPath'],
-
   // GraphQL fragment duplicate warnings (test environment artifact)
   ['Warning: fragment with name', 'already exists'],
 

--- a/jest-setup-early.ts
+++ b/jest-setup-early.ts
@@ -34,6 +34,10 @@ const SUPPRESSED_PATTERNS: string[][] = [
   // Apollo cache merge warnings (test environment artifact)
   ['Cache data may be lost when replacing'],
 
+  // `v7_startTransition` stays off: transitions keep the leaving page mounted, so its pending
+  // effect-driven redirect can replace the URL you just navigated to (`SettingsHomePage`).
+  ['React Router Future Flag Warning', 'v7_startTransition'],
+
   // GraphQL fragment duplicate warnings (test environment artifact)
   ['Warning: fragment with name', 'already exists'],
 

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,5 +1,6 @@
 // Console suppression is handled in jest-setup-early.ts (runs before imports)
 import '@testing-library/jest-dom'
+import type { ComponentType } from 'react'
 
 // Registers the default Zod error message for every suite — pure schema tests never go
 // through `test-utils`, so they would otherwise see a different default than the app.
@@ -25,10 +26,17 @@ const mockNavigate = jest.fn()
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom')
+  const React = jest.requireActual('react')
   const mockUseParams = jest.fn(actual.useParams)
+  const FUTURE = { v7_startTransition: true, v7_relativeSplatPath: true }
+  const withFuture =
+    (Router: ComponentType<Record<string, unknown>>) => (props: Record<string, unknown>) =>
+      React.createElement(Router, { future: FUTURE, ...props })
 
   return {
     ...actual,
+    BrowserRouter: withFuture(actual.BrowserRouter),
+    MemoryRouter: withFuture(actual.MemoryRouter),
     useNavigate: () => mockNavigate,
     useParams: mockUseParams,
   }

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,6 +1,5 @@
 // Console suppression is handled in jest-setup-early.ts (runs before imports)
 import '@testing-library/jest-dom'
-import type { ComponentType } from 'react'
 
 // Registers the default Zod error message for every suite — pure schema tests never go
 // through `test-utils`, so they would otherwise see a different default than the app.
@@ -26,17 +25,12 @@ const mockNavigate = jest.fn()
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom')
-  const React = jest.requireActual('react')
+  const { withRouterFuture } = jest.requireActual('~/test-utils/routerFutureMock')
   const mockUseParams = jest.fn(actual.useParams)
-  const FUTURE = { v7_startTransition: true, v7_relativeSplatPath: true }
-  const withFuture =
-    (Router: ComponentType<Record<string, unknown>>) => (props: Record<string, unknown>) =>
-      React.createElement(Router, { future: FUTURE, ...props })
 
   return {
     ...actual,
-    BrowserRouter: withFuture(actual.BrowserRouter),
-    MemoryRouter: withFuture(actual.MemoryRouter),
+    ...withRouterFuture(actual),
     useNavigate: () => mockNavigate,
     useParams: mockUseParams,
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import {
 } from '~/core/apolloClient'
 import { AppEnvEnum } from '~/core/constants/globalTypes'
 import '~/core/overlays/registeredDialogs'
+import { ROUTER_FUTURE_FLAGS } from '~/core/router/futureFlags'
 import { initializeYup } from '~/formValidation/initializeYup'
 import '~/formValidation/initializeZod'
 import { AiAgentProvider } from '~/hooks/aiAgent/useAiAgent'
@@ -124,10 +125,7 @@ const App = () => {
                 <NiceModalProvider>
                   <QuotePdfProvider>
                     <PanelGroup direction="vertical" autoSaveId={DEVTOOL_AUTO_SAVE_ID}>
-                      <BrowserRouter
-                        basename="/"
-                        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-                      >
+                      <BrowserRouter basename="/" future={ROUTER_FUTURE_FLAGS}>
                         <Panel id="app-panel-group">
                           <PanelGroup direction="horizontal">
                             <Panel id="app-panel">
@@ -140,10 +138,7 @@ const App = () => {
                         </Panel>
                         <ToastContainer />
                       </BrowserRouter>
-                      <MemoryRouter
-                        initialEntries={[DEVTOOL_ROUTE]}
-                        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-                      >
+                      <MemoryRouter initialEntries={[DEVTOOL_ROUTE]} future={ROUTER_FUTURE_FLAGS}>
                         <DevtoolsErrorBoundary>
                           <DevtoolsView />
                         </DevtoolsErrorBoundary>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,7 +124,10 @@ const App = () => {
                 <NiceModalProvider>
                   <QuotePdfProvider>
                     <PanelGroup direction="vertical" autoSaveId={DEVTOOL_AUTO_SAVE_ID}>
-                      <BrowserRouter basename="/">
+                      <BrowserRouter
+                        basename="/"
+                        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+                      >
                         <Panel id="app-panel-group">
                           <PanelGroup direction="horizontal">
                             <Panel id="app-panel">
@@ -137,7 +140,10 @@ const App = () => {
                         </Panel>
                         <ToastContainer />
                       </BrowserRouter>
-                      <MemoryRouter initialEntries={[DEVTOOL_ROUTE]}>
+                      <MemoryRouter
+                        initialEntries={[DEVTOOL_ROUTE]}
+                        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+                      >
                         <DevtoolsErrorBoundary>
                           <DevtoolsView />
                         </DevtoolsErrorBoundary>

--- a/src/components/MainHeader/__tests__/useMainHeaderTabContent.test.tsx
+++ b/src/components/MainHeader/__tests__/useMainHeaderTabContent.test.tsx
@@ -7,7 +7,15 @@ import { MainHeaderConfig, MainHeaderTab } from '../types'
 import { useMainHeaderTabContent } from '../useMainHeaderTabContent'
 
 // We need a real router for pathname matching, so don't use the global mock
-jest.unmock('react-router-dom')
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom')
+  const { withRouterFuture } = jest.requireActual('~/test-utils/routerFutureMock')
+
+  return {
+    ...actual,
+    ...withRouterFuture(actual),
+  }
+})
 
 const createWrapper = (initialPath: string): FC<PropsWithChildren> => {
   const Wrapper: FC<PropsWithChildren> = ({ children }) => (

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -46,9 +46,8 @@ const PageWrapper = ({ children, routeConfig }: PageWrapperProps) => {
   return <>{children}</>
 }
 
-const routesFormatter: (routesToFormat: CustomRouteObject[], loggedIn: boolean) => RouteObject[] = (
+const routesFormatter: (routesToFormat: CustomRouteObject[]) => RouteObject[] = (
   routesToFormat,
-  loggedIn,
 ) => {
   return routesToFormat.reduce<RouteObject[]>((acc, route) => {
     // A route chunk that cannot be downloaded rejects instead of hanging, so the
@@ -62,7 +61,7 @@ const routesFormatter: (routesToFormat: CustomRouteObject[], loggedIn: boolean) 
           </ErrorBoundary>
         </PageWrapper>
       ),
-      ...(route?.children ? { children: routesFormatter(route.children, loggedIn) } : {}),
+      ...(route?.children ? { children: routesFormatter(route.children) } : {}),
     }
 
     if (route.index) {
@@ -119,7 +118,7 @@ export const RouteWrapper = () => {
     setMainRouterUrl('')
   }, [mainRouterUrl, location.pathname, navigate, setMainRouterUrl])
 
-  const formattedRoutes = routesFormatter(routes, isAuthenticated)
+  const formattedRoutes = routesFormatter(routes)
 
   return useRoutes(formattedRoutes)
 }

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -8,7 +8,6 @@ import { ErrorBoundary } from '~/components/ErrorBoundary'
 import { ErrorFallback } from '~/components/ErrorFallback'
 import { CustomRouteObject, routes, useLocation, useNavigate } from '~/core/router'
 import { NEVER_SLUG_PREFIXES } from '~/core/router/slugPrefixes'
-import { useIsAuthenticated } from '~/hooks/auth/useIsAuthenticated'
 import { useLocationHistory } from '~/hooks/core/useLocationHistory'
 import { DEVTOOL_TAB_PARAMS, useDeveloperTool } from '~/hooks/useDeveloperTool'
 
@@ -90,7 +89,6 @@ const routesFormatter: (routesToFormat: CustomRouteObject[]) => RouteObject[] = 
 }
 
 export const RouteWrapper = () => {
-  const { isAuthenticated } = useIsAuthenticated()
   const location = useLocation()
   const navigate = useNavigate()
   const { mainRouterUrl, setMainRouterUrl } = useDeveloperTool()

--- a/src/components/__tests__/RouteWrapper.test.tsx
+++ b/src/components/__tests__/RouteWrapper.test.tsx
@@ -37,12 +37,6 @@ jest.mock('~/hooks/useDeveloperTool', () => ({
   }),
 }))
 
-jest.mock('~/hooks/auth/useIsAuthenticated', () => ({
-  useIsAuthenticated: () => ({
-    isAuthenticated: true,
-  }),
-}))
-
 jest.mock('~/hooks/core/useLocationHistory', () => ({
   useLocationHistory: () => ({
     onRouteEnter: jest.fn(),

--- a/src/components/__tests__/RouteWrapper.test.tsx
+++ b/src/components/__tests__/RouteWrapper.test.tsx
@@ -15,10 +15,16 @@ jest.mock('~/core/apolloClient/reactiveVars/toastVar', () => ({
   addToast: (...args: unknown[]) => mockAddToast(...args),
 }))
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate,
-}))
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom')
+  const { withRouterFuture } = jest.requireActual('~/test-utils/routerFutureMock')
+
+  return {
+    ...actual,
+    ...withRouterFuture(actual),
+    useNavigate: () => mockNavigate,
+  }
+})
 
 const mockSetMainRouterUrl = jest.fn()
 let mockMainRouterUrl = ''

--- a/src/components/invoices/details/ViewFeeDetailsDrawer.tsx
+++ b/src/components/invoices/details/ViewFeeDetailsDrawer.tsx
@@ -14,6 +14,7 @@ import { useDrawer } from '~/components/drawers/useDrawer'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { DetailRow, GRID } from '~/components/wallets/WalletDetailsDrawer'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { ROUTER_FUTURE_FLAGS } from '~/core/router/futureFlags'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { FeeForViewFeeDetailsDrawerFragment, FeeTypesEnum } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -409,7 +410,7 @@ const ViewFeeDetailsBody = ({ fee }: { fee: FeeForViewFeeDetailsDrawerFragment }
   const hasBreakdowns = (fee.presentationBreakdowns?.length ?? 0) > 0
 
   return (
-    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+    <MemoryRouter future={ROUTER_FUTURE_FLAGS}>
       <div data-test={VIEW_FEE_DETAILS_DRAWER_TEST_ID}>
         <CenteredPage.SectionWrapper>
           <div>

--- a/src/components/invoices/details/ViewFeeDetailsDrawer.tsx
+++ b/src/components/invoices/details/ViewFeeDetailsDrawer.tsx
@@ -409,7 +409,7 @@ const ViewFeeDetailsBody = ({ fee }: { fee: FeeForViewFeeDetailsDrawerFragment }
   const hasBreakdowns = (fee.presentationBreakdowns?.length ?? 0) > 0
 
   return (
-    <MemoryRouter>
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <div data-test={VIEW_FEE_DETAILS_DRAWER_TEST_ID}>
         <CenteredPage.SectionWrapper>
           <div>

--- a/src/core/router/futureFlags.ts
+++ b/src/core/router/futureFlags.ts
@@ -1,0 +1,8 @@
+import type { FutureConfig } from 'react-router-dom'
+
+// Delete with the v7 bump: v7 has no `future` prop, and the jest mock passes it
+// through untyped, so nothing would fail if this were left behind.
+export const ROUTER_FUTURE_FLAGS: Partial<FutureConfig> = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: true,
+}

--- a/src/core/router/futureFlags.ts
+++ b/src/core/router/futureFlags.ts
@@ -3,6 +3,5 @@ import type { FutureConfig } from 'react-router-dom'
 // Delete with the v7 bump: v7 has no `future` prop, and the jest mock passes it
 // through untyped, so nothing would fail if this were left behind.
 export const ROUTER_FUTURE_FLAGS: Partial<FutureConfig> = {
-  v7_startTransition: true,
   v7_relativeSplatPath: true,
 }

--- a/src/pages/auth/__tests__/LoginEntraId.test.tsx
+++ b/src/pages/auth/__tests__/LoginEntraId.test.tsx
@@ -15,10 +15,16 @@ const mockSetItemFromLS = setItemFromLS as jest.Mock
 const mockFetchEntraIdAuthorizeUrl = jest.fn()
 const mockUseLocation = jest.fn()
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useLocation: () => mockUseLocation(),
-}))
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom')
+  const { withRouterFuture } = jest.requireActual('~/test-utils/routerFutureMock')
+
+  return {
+    ...actual,
+    ...withRouterFuture(actual),
+    useLocation: () => mockUseLocation(),
+  }
+})
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({

--- a/src/pages/auth/__tests__/LoginOkta.test.tsx
+++ b/src/pages/auth/__tests__/LoginOkta.test.tsx
@@ -14,10 +14,16 @@ const mockSetItemFromLS = setItemFromLS as jest.Mock
 const mockFetchOktaAuthorizeUrl = jest.fn()
 const mockUseLocation = jest.fn()
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useLocation: () => mockUseLocation(),
-}))
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom')
+  const { withRouterFuture } = jest.requireActual('~/test-utils/routerFutureMock')
+
+  return {
+    ...actual,
+    ...withRouterFuture(actual),
+    useLocation: () => mockUseLocation(),
+  }
+})
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -43,7 +43,7 @@ export const AllTheProviders = ({
   !!useParams && jest.spyOn(Router, 'useParams').mockReturnValue(useParams)
 
   return (
-    <BrowserRouter basename="/">
+    <BrowserRouter basename="/" future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <MockedProvider addTypename={forceTypenames} mocks={mocks}>
         <ThemeProvider theme={theme}>
           <MainHeaderProvider>{children}</MainHeaderProvider>

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -7,6 +7,7 @@ import Router, { BrowserRouter } from 'react-router-dom'
 
 import { MainHeaderProvider } from '~/components/MainHeader/MainHeaderContext'
 import { initializeTranslations } from '~/core/apolloClient'
+import { ROUTER_FUTURE_FLAGS } from '~/core/router/futureFlags'
 import { initializeYup } from '~/formValidation/initializeYup'
 import { theme } from '~/styles'
 
@@ -43,7 +44,7 @@ export const AllTheProviders = ({
   !!useParams && jest.spyOn(Router, 'useParams').mockReturnValue(useParams)
 
   return (
-    <BrowserRouter basename="/" future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+    <BrowserRouter basename="/" future={ROUTER_FUTURE_FLAGS}>
       <MockedProvider addTypename={forceTypenames} mocks={mocks}>
         <ThemeProvider theme={theme}>
           <MainHeaderProvider>{children}</MainHeaderProvider>

--- a/src/test-utils/routerFutureMock.ts
+++ b/src/test-utils/routerFutureMock.ts
@@ -1,0 +1,15 @@
+import { ComponentType, createElement } from 'react'
+
+const FUTURE = { v7_startTransition: true, v7_relativeSplatPath: true }
+
+type RouterModule = {
+  BrowserRouter: ComponentType<Record<string, unknown>>
+  MemoryRouter: ComponentType<Record<string, unknown>>
+}
+
+export const withRouterFuture = (actual: RouterModule): RouterModule => ({
+  BrowserRouter: (props: Record<string, unknown>) =>
+    createElement(actual.BrowserRouter, { future: FUTURE, ...props }),
+  MemoryRouter: (props: Record<string, unknown>) =>
+    createElement(actual.MemoryRouter, { future: FUTURE, ...props }),
+})

--- a/src/test-utils/routerFutureMock.ts
+++ b/src/test-utils/routerFutureMock.ts
@@ -1,6 +1,6 @@
-import { ComponentType, createElement } from 'react'
+import { ComponentType, createElement, ReactElement } from 'react'
 
-const FUTURE = { v7_startTransition: true, v7_relativeSplatPath: true }
+import { ROUTER_FUTURE_FLAGS } from '~/core/router/futureFlags'
 
 type RouterModule = {
   BrowserRouter: ComponentType<Record<string, unknown>>
@@ -8,8 +8,8 @@ type RouterModule = {
 }
 
 export const withRouterFuture = (actual: RouterModule): RouterModule => ({
-  BrowserRouter: (props: Record<string, unknown>) =>
-    createElement(actual.BrowserRouter, { future: FUTURE, ...props }),
-  MemoryRouter: (props: Record<string, unknown>) =>
-    createElement(actual.MemoryRouter, { future: FUTURE, ...props }),
+  BrowserRouter: (props: Record<string, unknown>): ReactElement =>
+    createElement(actual.BrowserRouter, { future: ROUTER_FUTURE_FLAGS, ...props }),
+  MemoryRouter: (props: Record<string, unknown>): ReactElement =>
+    createElement(actual.MemoryRouter, { future: ROUTER_FUTURE_FLAGS, ...props }),
 })


### PR DESCRIPTION
Fixes LAGO-1859

Stage 2 of 4. No dependency version moves here.

# The initiative

`react-router-dom` v6 reached end of life on 2026-06-18. There are no further backports:
`6.30.6` fixed CVE-2026-53668 and the remaining Dependabot alerts against react-router stay
open on v6 forever. Four alerts are open today (#250, #251, #252, #253), and #251 and #253
both declare `first_patched_version: 7.18.0`, so moving to v7 is the only way to close them.

Target is `react-router-dom@7.18.3` (dist-tag `version-7`), not v8:

| | version | node engine | react peer | module format |
| --- | --- | --- | --- | --- |
| current | `6.30.6` | `>=14.0.0` | `>=16.8` | CJS + ESM |
| target | `7.18.3` | `>=20.0.0` (we pin 24.20.0) | `>=18` | CJS + ESM |
| v8 latest | `8.3.1` | `>=22.22.0` | `>=19.2.7` | ESM-only |

Two independent blockers on v8: we pin `react@18.3.1` and `@mui/material@5.18.0`, which has
no React 19 support; and v8 is ESM-only, which would join the `transformIgnorePatterns`
allow-list Jest maintains one package at a time. v8 is a follow-up gated on a React 19 major.

One stage per PR, so a security bump reverts in one click:

| stage | what | dependency change | status |
| --- | --- | --- | --- |
| 1 | Harden the redirect surface on v6 | none | merged, #4242 |
| 2 | Turn on `v7_relativeSplatPath`; measure `v7_startTransition` and hold it | none | **THIS PR** |
| 3 | Bump `6.30.6` -> `7.18.3`, swap the flags for `useTransitions={false}` | the bump | closes #250-253 |
| 4 | Drop the `react-router-dom` shim, rename to `react-router` (540 occurrences, 434 files) | specifier only | cleanup |

This stage comes first so the rendering-behaviour question lands in a diff with no dependency
change. If route rendering regresses after stage 3, we need to know whether the flags or the
version did it, and that is only answerable if they land separately.

# What `v7_startTransition` does, and why it is not on

`RouteWrapper` wraps every route element in `<Suspense fallback={<Spinner />}>`
(`src/components/RouteWrapper.tsx:59`) and every page is a module-scope `React.lazy`
(`src/core/router/*Routes.tsx`). With the flag on, the router's `setState` goes through
`React.startTransition`, and React 18 keeps already-visible content rather than showing a
fallback that is not newly mounted. On a top-level route change `useRoutes` renders the same
`PageWrapper` component type at the same position, so React reuses that fiber and the Suspense
boundary is not a new mount.

Concretely: navigating `/:slug/customers` -> `/:slug/plans` on a cold chunk cache used to swap
to `<Spinner />` immediately. With the flag on, the previous page stays on screen with no
feedback until the chunk resolves. Nothing in the app consumes `useNavigation().state`, so
there is no pending UI to take the spinner's place.

Two upstream caveats, and only one of them applies to us. `React.useSyncExternalStore` updates
cannot be transitions, and upstream documents that this can force fallbacks to show where they
otherwise would not: Apollo Client uses `useSyncExternalStore` throughout, so this app is
squarely in the population that caveat is written for. The caveat that does NOT apply is
`React.lazy` created inside a component - all our `lazyLoad()` calls are module-scope consts.

`v7_relativeSplatPath` is inert here, verified: the repo has zero relative navigations (no
`navigate('..')`, no `to=".."`, no `./`), and both splat routes render leaf 404 pages. The one
multi-segment splat, `EVENT_LOG_ROUTE = '/devtool/events/*'`
(`src/components/developers/devtoolsRoutes.ts:10`), is consumed through
`generatePath(EVENT_LOG_ROUTE, { '*': ... })` and `useParams()['*']`, neither of which the flag
touches. The `matchPath(`${CUSTOMER_PORTAL_ROUTE}/*`, ...)` calls in `authHeaders.ts`,
`cachePersistor.ts` and `init.ts` are pattern matching, not relative resolution.

**The finding, measured by the e2e suite before any human opened a browser: the flag turns a
latent race in effect-driven redirects into a bounce-back.** It is worse than the missing
spinner this section predicted.

`cypress/e2e/00-auth/t30-multi-org-redirect.cy.ts` failed in its `before all` hook on the
first run of this branch (run 34102749941, attempt 1):

    AssertionError: Timed out retrying after 4000ms: expected
    'http://localhost/multi-org-test-organization-b/settings/billing-entity/multi_org_test_-_organization_b'
    to include '/settings/team-and-security'

The two command-log lines above that assertion are the whole story - the navigation happened
and was then undone:

    (new url)  http://localhost/multi-org-test-organization-b/settings/team-and-security
    (new url)  http://localhost/multi-org-test-organization-b/settings/billing-entity/multi_org_test_-_organization_b

`src/pages/settings/SettingsHomePage.tsx` is the element for `/settings`: it renders a
`<Spinner />` and redirects in an effect once its `billingEntities` query resolves, with
`fetchPolicy: 'no-cache'` so it is always a network round trip. Clicking a settings nav item
while that query is in flight pushes the new URL synchronously, but the router's `setState` is
now a transition, the target route is a module-scope `React.lazy` so the transition suspends,
and React keeps the old tree mounted and its effects live. The query then resolves and
`navigate(..., { replace: true })` fires from a page the user has already left.

On v6 semantics the same code is safe: the router's `setState` is synchronous, so
`SettingsHomePage` unmounts at the click and its pending effect never runs.

It is a race, not a determinism: re-running the same job with no code change passed, so the
window is chunk-load-time wide and the flake fires sometimes. That makes it worse for CI than
a hard failure, not better. Three other tests in the failing run (`t10-create-taxes` "assign
tax to billing entity", `t50-edit-plan` x2) failed once and passed on retry with shapes
consistent with deferred updates, but that is unproven: `cypress.yml` uploads artifacts only
`if: failure()`, so green runs carry nothing to baseline the flake rate against.

Blast radius, measured by sweeping for the pattern: 11 files run an effect-driven
`navigate(..., { replace: true })` - `SettingsHomePage.tsx`, `TeamAndSecurity.tsx`,
`BillingEntity.tsx`, `Home.tsx`, `RootRedirect.tsx`, `Quotes.tsx`, `QuoteDetails.tsx`,
`PlanDetails.tsx`, `CustomerDetails.tsx`, `ProductCatalog.tsx`, `NewAnalytics.tsx`. All the
same shape; which of them actually bounce depends on whether their data resolves inside the
chunk-load window.

The fix pattern, for whoever owns transitions later: guard each such effect on
`window.location.pathname` rather than `useLocation()`. During a pending transition the router
location is still the old one, while `window.location` was updated synchronously by
`history.push` - which is exactly why `src/components/RouteWrapper.tsx:104` already derives the
org slug from the raw URL rather than from router state.

Browser QA of the two remaining surfaces (the devtools `MemoryRouter` -> `BrowserRouter` bridge
and `ViewFeeDetailsDrawer`'s inner `MemoryRouter`) is still outstanding and is called out as
such rather than quietly assumed.

**Browser QA, run by @ansmonjol on `412549f8d`.** Four of the five checks are settled.

| check | result |
| --- | --- |
| Route navigation, Slow 3G (positive control that transitions are off) | Spinner shows, i.e. v6 rendering restored |
| Devtools Events tab, the only `v7_relativeSplatPath` surface (`/devtool/events/*`) | Works. Browser back moves the main app and leaves the panel on the last clicked event - by design, not a regression: the panel is a separate `<MemoryRouter>` (`src/App.tsx:141`) with its own in-memory history that never listens to `popstate`. Unchanged by this PR and unrelated to the flag |
| `ViewFeeDetailsDrawer`'s inner `MemoryRouter` | Tabs switch, browser URL never changes |
| Logout / login from a deep page, plus org switch | Works, confirming in the browser what `ea6e82371` was reasoned to be safe on statically |

The devtools -> main-app bridge check is being re-run: the first pass clicked a webhook row,
which is a panel-internal navigation to `WEBHOOK_ROUTE` (`Webhooks.tsx:136`,
`/devtool/webhooks/:webhookId`) rather than the bridge. The bridge is the row's Edit action and
the "Create webhook" button (`Webhooks.tsx:81`, `:144`), which pair `setMainRouterUrl` with
`closePanel`.

**What this PR does with that: holds the flag.** `412549f8d` takes `v7_startTransition` back
out of `ROUTER_FUTURE_FLAGS` and restores its one suppression line, with a comment naming the
bounce-back so nobody deletes it as leftover noise. `v7_relativeSplatPath` stays on. LAGO-1915
owns transitions from here, with this repro and the guard pattern written down.

That is not a retreat from the stage's purpose - it is the stage's purpose. The question was
whether transitions are acceptable, the answer is "not until the redirects are fixed", and it
cost one CI run instead of a post-bump incident. Stage 3 was already going to ship
`useTransitions={false}`, so the path to closing #250-253 is unchanged; the only thing that
changed is that we now know why that prop is there.

# The changes, and why each one is here

## The flag work (`f6f9f7493`, `a6afc74d0`, `412549f8d`)

Four Router instances, all of them declarative (`BrowserRouter` / `MemoryRouter`), no data
router anywhere in the repo: `src/App.tsx:127` and `:140`,
`src/components/invoices/details/ViewFeeDetailsDrawer.tsx:413`, `src/test-utils.tsx:47`. Only
two of the six v7 flags fire for us - `logV6DeprecationWarnings` in 6.30.6 gates the other four
(`v7_fetcherPersist`, `v7_normalizeFormMethod`, `v7_partialHydration`,
`v7_skipActionErrorRevalidation`) on `routerFuture`, which only a data router populates, so they
are unreachable and need no action.

They are exercised here rather than in the bump PR because the bump would change rendering
behaviour and the version at once. If route rendering regressed after stage 3, "which one did
it" is only answerable if the two land separately - and that separation is what earned this PR
its finding: the bounce-back surfaced against an unchanged `6.30.6`, so it cannot be confused
with a version regression. `f6f9f7493` turned both flags on, `412549f8d` takes
`v7_startTransition` back off, and the intermediate state stays on the record rather than being
squashed away.

`a6afc74d0` hoists the flags into one exported const, `ROUTER_FUTURE_FLAGS`
(`src/core/router/futureFlags.ts`), for two reasons. The inline literal was a fresh object on
every parent render, and 6.30.6's `Router` builds its `NavigationContext` value with
`useMemo(..., [basename, future, navigator, staticProp])`, so a new identity invalidated that
memo and re-rendered every `NavigationContext` consumer in the subtree. And it gives stage 3 a
single greppable deletion point - which matters more than it looks, see the next section.

## The suppressions die with the flags they hid (`e9117c1b1`, `412549f8d`)

`jest-setup-early.ts` carried `['React Router Future Flag Warning', 'v7_startTransition']` and
the `v7_relativeSplatPath` twin. `...actual` in the global `jest.mock('react-router-dom', ...)`
means tests render the REAL Routers, so those warnings fire from test Routers too. Keeping a
suppression for a flag we claim to have enabled makes the gate fake: the flag could be missing
from any test Router and nothing would say so. Both went in `e9117c1b1`, and a warning line in
CI output became the signal that some Router is not covered - which is exactly how the two gaps
below were found.

`412549f8d` puts the `v7_startTransition` line back, because that flag is now deliberately off
and its warning is the expected output rather than a gap. The `v7_relativeSplatPath` suppression
stays deleted, so the gate still holds for the flag this PR does turn on.

## The 16 test files are covered in the jest factory, not edited (`e9117c1b1`, `a0bd170b4`, `7b2481105`)

16 test files render `MemoryRouter` / `BrowserRouter` directly, 70 occurrences. v7 removes the
`future` prop, so every call-site edit would be an edit now plus a revert at stage 3. Instead
`jest-setup.ts:26` - the single choke point for router behaviour in tests - wraps
`BrowserRouter` and `MemoryRouter` so they get the flags with `...props` spread AFTER `future`,
leaving call-site props like `initialEntries` and `basename` still winning.

`withRouterFuture` lives in `src/test-utils/routerFutureMock.ts` rather than inline in the
factory because of `babel-plugin-jest-hoist`: a `jest.mock` factory may only reference
out-of-scope names beginning with `mock` (which is why the pre-existing `mockNavigate`
reference is legal) or `jest.*` calls. The helper is therefore pulled in with
`jest.requireActual('~/test-utils/routerFutureMock')` from inside the factory. Its only import
of the mocked module is `import type { FutureConfig }`, erased by
`@babel/preset-typescript`, so there is no self-referential require through the module being
mocked, and `futureFlags.ts` deliberately sits outside the `~/core/router` barrel so the
factory cannot drag route definitions in.

Then two files' worth of gaps, both surfaced by the un-suppressed warnings:

| file | how it escaped the global factory | fix |
| --- | --- | --- |
| `RouteWrapper.test.tsx`, `LoginOkta.test.tsx`, `LoginEntraId.test.tsx` | each declares its own `jest.mock('react-router-dom', ...)`, which shadows the global factory for its whole module graph | `...withRouterFuture(actual)` added to each local factory, spread before their own overrides so `useNavigate` / `useLocation` still win (`a0bd170b4`) |
| `useMainHeaderTabContent.test.tsx` | `jest.unmock('react-router-dom')` - it wants the real router for pathname matching | the `unmock` becomes a block-body `jest.mock` returning `{ ...actual, ...withRouterFuture(actual) }` and nothing else, so `useNavigate` / `useLocation` / `useParams` stay real (`7b2481105`) |

That is the whole population: `jest.unmock('react-router-dom')` has exactly one hit in the
repo, and every Router-rendering suite now emits zero future-flag warnings.

Load-bearing vs defence in depth, since the two paths overlap: the `test-utils.tsx` prop is
load-bearing, not belt-and-braces. 67 test files declare their own
`jest.mock('react-router-dom', ...)` and 64 of them render through `AllTheProviders`, so that
one prop is the only thing applying the flags for those 64 suites. Deleting it as "redundant"
would silently drop them.

## Dead code the flags work uncovered (`302880ade`, `ea6e82371`)

`routesFormatter` in `src/components/RouteWrapper.tsx` took a `loggedIn` parameter that was
declared, threaded through the recursion and never read; `302880ade` drops it. That made
`isAuthenticated` its only remaining consumer, so `ea6e82371` drops the
`useIsAuthenticated()` call and its import too.

Verified before removing, because the subscription looked load-bearing and is not:
`logOut()` (`src/core/apolloClient/cacheUtils.ts:35`) never navigates, so the post-logout
redirect to `/login` depends on `PageWrapper`'s `onRouteEnter` effect re-firing. That effect
still fires - `PageWrapper` -> `useLocationHistory()` -> `useCurrentUser()`
(`src/hooks/useCurrentUser.ts:51`) and `useOrganizationInfos()`
(`src/hooks/useOrganizationInfos.ts:63`) each call `useIsAuthenticated()`, so `PageWrapper`
keeps two independent `useReactiveVar(authTokenVar)` subscriptions. The one removed was
redundant for both `authTokenVar` and `customerPortalTokenVar`.

# Corrections to the record

Three claims made while preparing this stage turned out to be wrong. Stating them so nobody
inherits them:

| claim | status |
| --- | --- |
| "`isAuthenticated` is still used elsewhere in `RouteWrapper`, leave the `useIsAuthenticated()` call alone" | **Wrong.** `RouteWrapper.tsx:93` was its only site. Dropping the parameter without the call left a real `@typescript-eslint/no-unused-vars` error and `pnpm code:style` exiting 1. Both had to go. |
| "The `future` prop on `test-utils.tsx` is redundant belt-and-braces, the jest factory already covers it" | **Wrong**, and load-bearing in the opposite direction: 64 suites locally re-mock `react-router-dom` and render through `AllTheProviders`, so that prop is the only thing applying the flags for them. |
| "Covering the Routers in the `jest-setup.ts` factory covers every test file" | **Incomplete.** Three files shadow the factory with their own `jest.mock`, and one opts out with `jest.unmock`. The first search for these used `grep -rl "jest.mock('react-router-dom'"`, which cannot see a `jest.unmock`. |

| "`v7_startTransition` is real, and it is the whole reason this stage exists" | **Half right.** It fires, and it earned its own stage - but the plan assumed the outcome would be a spinner judgement call. It is a bounce-back race in effect-driven redirects, so the flag ships off and LAGO-1915 owns it. |

One trap worth naming, since it is why `ROUTER_FUTURE_FLAGS` exists as a const with a comment
on it: the 4 app call sites are self-policing at stage 3, because v7's `BrowserRouterProps` /
`MemoryRouterProps` have no `future` and `tsc` will force the edit. The jest helper is the
opposite - it passes `future` through `createElement` as `Record<string, unknown>`, so in v7 it
becomes an unknown prop that is ignored with no type error and no runtime warning. Left
unattended it would survive stage 3 as dead indirection that nothing reports.

# Deliberately out of scope

- **The route guard architecture.** `RouteWrapper`'s effect-driven guard,
  `useLocationHistory.ts`'s `onRouteEnter` and the `Home` / `RootRedirect` effects are 803 lines
  with 19 redirect decision points. `loader` + `throw redirect()` is the router-native fix, but
  it is an architecture change riding on a CVE fix, it is strictly easier once v7 has landed,
  and loaders cannot call `useCurrentUser()` / `usePermissions()`, so it needs an awaited root
  loader query that changes load sequencing app-wide. Own spec, own QA matrix. The dead
  `loggedIn` parameter is the only piece of that area touched here.
- **`useTransitions`.** The prop does not exist in 6.30.6. Stage 3 owns it.
- **Any dependency change.** `react-router-dom` stays `6.30.6` at `package.json:175`;
  `git diff $(git merge-base origin/main HEAD) -- package.json pnpm-lock.yaml` is empty.
- **The four `Link.test.tsx` tripwire expectations.** They pin v6 behaviour, and the
  `/\evil.com` row is expected to flip at stage 3. Moving them here would spend the tripwire
  before the bump it exists to catch.
- **`src/pages/home/RootRedirect.tsx` staying unguarded.** Stage 1 verified every hostile shape
  fails its `accessibleMemberships` validation.
- **Dismissing any Dependabot alert.** #250-253 close at stage 3, when the version actually
  moves.

# Follow-ups I am not doing here

- **Stage 3**: bump `6.30.6` -> `7.18.3`, replace `future={ROUTER_FUTURE_FLAGS}` with
  `useTransitions={false}`, delete `src/core/router/futureFlags.ts`,
  `src/test-utils/routerFutureMock.ts` and the five factory spreads that use it, and move the
  `Link.test.tsx` tripwire. That PR is the one that closes #250-253.
- **LAGO-1915**, filed from this PR: fix the 11 effect-driven redirects (guard on
  `window.location.pathname`, or the loader rewrite), add pending UI via
  `useNavigation().state`, characterise the Apollo `useSyncExternalStore` interaction, then turn
  transitions on. It carries the repro above.
- **v8**, gated on a React 19 major (React 18.3.1 + MUI 5.18.0 today) and on ESM-only entering
  the Jest `transformIgnorePatterns` allow-list.
- **The route-guard rewrite**, per the out-of-scope note. I did not take it here because it is a
  large architecture change and it is cheaper after v7. Happy to spec it separately if you would
  rather it came first.


