### PR TITLE
fix(charts): preserve inputs and clear hover immediately

### DIFF
--- a/src/components/analytics/AnalyticsStateContext.tsx
+++ b/src/components/analytics/AnalyticsStateContext.tsx
@@ -1,12 +1,4 @@
-import {
-  createContext,
-  ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
+import { createContext, ReactNode, useCallback, useContext, useState } from 'react'
 
 interface RevenueStreamsStateContextValue {
   hoverDataIndex: number | undefined
@@ -16,56 +8,15 @@ interface RevenueStreamsStateContextValue {
   handleMouseLeave: () => void
 }
 
-const MIN_UPDATE_INTERVAL = 1000 / 60 // Cap at 60fps
-const MOUSE_LEAVE_DELAY = 10 // ms
-
 const AnalyticsStateContext = createContext<RevenueStreamsStateContextValue | undefined>(undefined)
 
 export const AnalyticsStateProvider = ({ children }: { children: ReactNode }) => {
-  const [hoverDataIndex, setHoverDataIndexState] = useState<number | undefined>(undefined)
-  const [clickedDataIndex, setClickedDataIndexState] = useState<number | undefined>(undefined)
+  const [hoverDataIndex, setHoverDataIndex] = useState<number | undefined>(undefined)
+  const [clickedDataIndex, setClickedDataIndex] = useState<number | undefined>(undefined)
 
-  const prevHoverIndex = useRef<number | undefined>(undefined)
-  const lastUpdateTime = useRef<number>(0)
-  const mouseLeaveTimeoutRef = useRef<NodeJS.Timeout>()
-
-  const clearMouseLeaveTimeout = useCallback(() => {
-    if (mouseLeaveTimeoutRef.current) {
-      clearTimeout(mouseLeaveTimeoutRef.current)
-    }
+  const handleMouseLeave = useCallback((): void => {
+    setHoverDataIndex(undefined)
   }, [])
-
-  // Cleanup timeout on unmount
-  useEffect(() => {
-    return () => {
-      clearMouseLeaveTimeout()
-    }
-  }, [clearMouseLeaveTimeout])
-
-  // Optimized setter for hover state to prevent too many updates
-  const setHoverDataIndex = useCallback((index: number | undefined) => {
-    const now = performance.now()
-
-    if (index !== prevHoverIndex.current && now - lastUpdateTime.current >= MIN_UPDATE_INTERVAL) {
-      prevHoverIndex.current = index
-      lastUpdateTime.current = now
-      setHoverDataIndexState(index)
-    }
-  }, [])
-
-  const setClickedDataIndex = useCallback((index: number | undefined) => {
-    setClickedDataIndexState(index)
-  }, [])
-
-  const handleMouseLeave = useCallback(() => {
-    // Clear any existing timeout
-    clearMouseLeaveTimeout()
-
-    // Set a new timeout to update hover state
-    mouseLeaveTimeoutRef.current = setTimeout(() => {
-      setHoverDataIndex(undefined)
-    }, MOUSE_LEAVE_DELAY)
-  }, [setHoverDataIndex, clearMouseLeaveTimeout])
 
   const value = {
     hoverDataIndex,

--- a/src/components/creditNote/CreditNoteDetailsOverview.tsx
+++ b/src/components/creditNote/CreditNoteDetailsOverview.tsx
@@ -1,6 +1,6 @@
 import { gql, MutationFunction } from '@apollo/client'
 import { ConditionalWrapper } from 'lago-design-system'
-import { FC, useMemo } from 'react'
+import { FC } from 'react'
 import { generatePath, useParams } from 'react-router-dom'
 
 import { CreditNoteDetailsOverviewTable } from '~/components/creditNote/CreditNoteDetailsOverviewTable'
@@ -102,13 +102,10 @@ export const CreditNoteDetailsOverview: FC<CreditNoteDetailsOverviewProps> = ({
     ? creditNoteRefundStatusMapping(creditNote?.refundStatus)
     : creditNoteCreditStatusMapping(creditNote?.creditStatus)
 
-  const canDownloadCreditNote = useMemo(() => {
-    return !hasError && !loading && hasPermissions(['creditNotesView']) && !disablePdfGeneration
-  }, [hasError, loading, hasPermissions])
+  const canDownloadCreditNote =
+    !hasError && !loading && hasPermissions(['creditNotesView']) && !disablePdfGeneration
 
-  const canDownloadXmlFile = useMemo(() => {
-    return creditNote?.billingEntity.einvoicing || !!creditNote?.xmlUrl
-  }, [creditNote])
+  const canDownloadXmlFile = creditNote?.billingEntity.einvoicing || !!creditNote?.xmlUrl
 
   return (
     <div>

--- a/src/components/designSystem/graphs/AreaChart.tsx
+++ b/src/components/designSystem/graphs/AreaChart.tsx
@@ -1,5 +1,4 @@
-import debounce from 'lodash/debounce'
-import { memo, useCallback, useMemo } from 'react'
+import { memo } from 'react'
 import {
   Area,
   AreaChart as RechartAreaChart,
@@ -76,20 +75,6 @@ const AreaChart = memo(
     const { hoverDataIndex, setHoverDataIndex, setClickedDataIndex, handleMouseLeave } =
       useAnalyticsState()
 
-    const handleHoverUpdate = useCallback(
-      (index: number | undefined) => {
-        setHoverDataIndex(index)
-      },
-      [setHoverDataIndex],
-    )
-
-    // Use the hover data index from context
-    const { localHoverDataIndex } = useMemo(() => {
-      return {
-        localHoverDataIndex: hoverDataIndex,
-      }
-    }, [hoverDataIndex])
-
     return (
       <ChartWrapper blur={blur}>
         <ResponsiveContainer width="100%" height={height}>
@@ -105,26 +90,11 @@ const AreaChart = memo(
               typeof event?.activeTooltipIndex === 'number' &&
               setClickedDataIndex(event.activeTooltipIndex)
             }
-            onMouseMove={useMemo(
-              () =>
-                debounce(
-                  (event) => {
-                    const newIndex = event?.activeTooltipIndex
-
-                    if (typeof newIndex === 'number') {
-                      handleHoverUpdate(newIndex)
-                    }
-                  },
-                  // Scale debounce time more aggressively for larger datasets
-                  // For 300 elements: ~8ms
-                  // For 1000 elements: ~49ms
-                  Math.max(1, Math.round(Math.pow((data?.length || 0) / 300, 1.5) * 8)),
-                  {
-                    leading: true,
-                  },
-                ),
-              [handleHoverUpdate, data?.length],
-            )}
+            onMouseMove={(event) => {
+              if (typeof event?.activeTooltipIndex === 'number') {
+                setHoverDataIndex(event.activeTooltipIndex)
+              }
+            }}
             onMouseLeave={handleMouseLeave}
           >
             <defs>
@@ -254,8 +224,8 @@ const AreaChart = memo(
             {!loading && (
               <RechartTooltip
                 isAnimationActive={false}
-                defaultIndex={localHoverDataIndex}
-                active={typeof localHoverDataIndex === 'number'}
+                defaultIndex={hoverDataIndex}
+                active={typeof hoverDataIndex === 'number'}
                 cursor={{
                   stroke: `${theme.palette.grey[500]}`,
                   strokeDasharray: '2 2',

--- a/src/components/designSystem/graphs/MultipleLineChart.tsx
+++ b/src/components/designSystem/graphs/MultipleLineChart.tsx
@@ -1,5 +1,4 @@
-import debounce from 'lodash/debounce'
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import {
   Line,
   LineChart,
@@ -36,6 +35,8 @@ import {
 } from './utils'
 
 const LOADING_TICK_SIZE = 32
+const DEFAULT_TOOLTIP_Y_GAP = 60
+const TOOLTIP_INNER_LINE_HEIGHT = 31
 
 type DotPrefix<T extends string> = T extends '' ? '' : `.${T}`
 type DotNestedKeys<T> = (
@@ -167,13 +168,6 @@ const MultipleLineChart = <T extends DataItem>({
   const { hoverDataIndex, setHoverDataIndex, setClickedDataIndex, handleMouseLeave } =
     useAnalyticsState()
 
-  const handleHoverUpdate = useCallback(
-    (index: number | undefined) => {
-      setHoverDataIndex(index)
-    },
-    [setHoverDataIndex],
-  )
-
   const { localData, localLines } = useMemo(() => {
     if (loading || !data) {
       return {
@@ -194,19 +188,7 @@ const MultipleLineChart = <T extends DataItem>({
     }
   }, [blur, data, lines, loading])
 
-  // Use the hover data index from context
-  const { localHoverDataIndex } = useMemo(() => {
-    return {
-      localHoverDataIndex: hoverDataIndex,
-    }
-  }, [hoverDataIndex])
-
-  const yTooltipPosition = useMemo(() => {
-    const DEFAULT_TOOLTIP_Y_GAP = 60
-    const TOOLTIP_INNER_LINE_HEIGHT = 31
-
-    return -(DEFAULT_TOOLTIP_Y_GAP + (lines.length || 0) * TOOLTIP_INNER_LINE_HEIGHT)
-  }, [lines.length])
+  const yTooltipPosition = -(DEFAULT_TOOLTIP_Y_GAP + lines.length * TOOLTIP_INNER_LINE_HEIGHT)
 
   const hasOnlyZeroValues: boolean = useMemo(() => {
     if (!localData?.length || loading) {
@@ -238,26 +220,11 @@ const MultipleLineChart = <T extends DataItem>({
             typeof event?.activeTooltipIndex === 'number' &&
             setClickedDataIndex(event.activeTooltipIndex)
           }
-          onMouseMove={useMemo(
-            () =>
-              debounce(
-                (event) => {
-                  const newIndex = event?.activeTooltipIndex
-
-                  if (typeof newIndex === 'number') {
-                    handleHoverUpdate(newIndex)
-                  }
-                },
-                // Scale debounce time more aggressively for larger datasets
-                // For 300 elements: ~8ms
-                // For 1000 elements: ~49ms
-                Math.max(1, Math.round(Math.pow((localData?.length || 0) / 300, 1.5) * 8)),
-                {
-                  leading: true,
-                },
-              ),
-            [handleHoverUpdate, localData?.length],
-          )}
+          onMouseMove={(event) => {
+            if (typeof event?.activeTooltipIndex === 'number') {
+              setHoverDataIndex(event.activeTooltipIndex)
+            }
+          }}
           onMouseLeave={handleMouseLeave}
         >
           <XAxis
@@ -413,8 +380,8 @@ const MultipleLineChart = <T extends DataItem>({
           })}
           {!loading && (
             <RechartTooltip
-              defaultIndex={localHoverDataIndex}
-              active={typeof localHoverDataIndex === 'number'}
+              defaultIndex={hoverDataIndex}
+              active={typeof hoverDataIndex === 'number'}
               includeHidden={true}
               cursor={{
                 stroke: `${theme.palette.grey[500]}`,

--- a/src/components/designSystem/graphs/StackedBarChart.tsx
+++ b/src/components/designSystem/graphs/StackedBarChart.tsx
@@ -1,6 +1,5 @@
 import { tw } from 'lago-design-system'
-import debounce from 'lodash/debounce'
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import {
   Bar,
   BarChart,
@@ -88,6 +87,8 @@ type StackedBarChartProps<T> = {
 }
 
 const LOADING_TICK_SIZE = 32
+const DEFAULT_TOOLTIP_Y_GAP = 60
+const TOOLTIP_INNER_LINE_HEIGHT = 31
 
 type CustomTooltipProps<T> = {
   includeHidden: boolean
@@ -146,7 +147,7 @@ const CustomTooltip = <T,>({
       </Typography>
 
       <div className="flex flex-col gap-2">
-        {bars
+        {[...bars]
           .sort((a, b) => (a?.tooltipIndex || 0) - (b?.tooltipIndex || 0))
           .map((bar, i) => (
             <div key={i} className="flex items-center justify-between gap-2">
@@ -184,13 +185,6 @@ const StackedBarChart = <T extends DataItem>({
   const { setClickedDataIndex, setHoverDataIndex, hoverDataIndex, handleMouseLeave } =
     useAnalyticsState()
 
-  const handleHoverUpdate = useCallback(
-    (index: number | undefined) => {
-      setHoverDataIndex(index)
-    },
-    [setHoverDataIndex],
-  )
-
   const { localData, localBars } = useMemo(() => {
     const fakeData = {
       localData: multipleStackedBarChartLoadingFakeData as unknown as T[],
@@ -209,18 +203,7 @@ const StackedBarChart = <T extends DataItem>({
     }
   }, [blur, data, bars, loading])
 
-  const { localHoverDataIndex } = useMemo(() => {
-    return {
-      localHoverDataIndex: hoverDataIndex,
-    }
-  }, [hoverDataIndex])
-
-  const yTooltipPosition = useMemo(() => {
-    const DEFAULT_TOOLTIP_Y_GAP = 60
-    const TOOLTIP_INNER_LINE_HEIGHT = 31
-
-    return -(DEFAULT_TOOLTIP_Y_GAP + (bars.length || 0) * TOOLTIP_INNER_LINE_HEIGHT)
-  }, [bars.length])
+  const yTooltipPosition = -(DEFAULT_TOOLTIP_Y_GAP + bars.length * TOOLTIP_INNER_LINE_HEIGHT)
 
   const hasOnlyZeroValues: boolean = useMemo(() => {
     if (!localData?.length || loading) {
@@ -266,15 +249,11 @@ const StackedBarChart = <T extends DataItem>({
           data={localData}
           stackOffset="sign"
           onMouseLeave={handleMouseLeave}
-          onMouseMove={useMemo(
-            () =>
-              debounce((event) => {
-                const index = event?.activeTooltipIndex
-
-                if (typeof index === 'number') handleHoverUpdate(index)
-              }, 16),
-            [handleHoverUpdate],
-          )}
+          onMouseMove={(event) => {
+            if (typeof event?.activeTooltipIndex === 'number') {
+              setHoverDataIndex(event.activeTooltipIndex)
+            }
+          }}
           onClick={(event) => {
             if (typeof event?.activeTooltipIndex === 'number') {
               setClickedDataIndex(event.activeTooltipIndex)
@@ -469,9 +448,9 @@ const StackedBarChart = <T extends DataItem>({
 
           {!loading && (
             <RechartTooltip
-              defaultIndex={localHoverDataIndex}
+              defaultIndex={hoverDataIndex}
               cursor={false}
-              active={typeof localHoverDataIndex === 'number'}
+              active={typeof hoverDataIndex === 'number'}
               includeHidden={true}
               offset={0}
               position={{ y: yTooltipPosition }}
@@ -498,14 +477,14 @@ const StackedBarChart = <T extends DataItem>({
             />
           )}
 
-          {typeof localHoverDataIndex === 'number' && (
+          {typeof hoverDataIndex === 'number' && (
             <>
               <Customized
                 // @ts-expect-error Recharts xAxisMap and yAxisMap prop typing is incomplete
                 component={({ xAxisMap, yAxisMap }) => {
                   const xAxis = xAxisMap[Object.keys(xAxisMap)[0]]
                   const yAxis = yAxisMap[Object.keys(yAxisMap)[0]]
-                  const xValue = data?.[localHoverDataIndex]?.[xAxisDataKey]
+                  const xValue = data?.[hoverDataIndex]?.[xAxisDataKey]
 
                   if (!xAxis || !xValue || typeof xAxis.scale !== 'function') return null
 
@@ -530,7 +509,7 @@ const StackedBarChart = <T extends DataItem>({
             </>
           )}
 
-          {localBars
+          {[...localBars]
             .sort((a, b) => (a?.barIndex || -100) - (b?.barIndex || -100))
             .map((line) => (
               <Bar

--- a/src/components/designSystem/graphs/__tests__/chartInteractions.test.tsx
+++ b/src/components/designSystem/graphs/__tests__/chartInteractions.test.tsx
@@ -1,0 +1,260 @@
+import { act, render, screen } from '@testing-library/react'
+import { Settings } from 'luxon'
+import { ComponentProps, ReactElement } from 'react'
+import { Bar, BarChart, LineChart, AreaChart as RechartAreaChart, Tooltip } from 'recharts'
+
+import {
+  AnalyticsStateProvider,
+  useAnalyticsState,
+} from '~/components/analytics/AnalyticsStateContext'
+import { CurrencyEnum, TimeGranularityEnum } from '~/generated/graphql'
+
+import AreaChart from '../AreaChart'
+import { multipleStackedBarChartLoadingFakeBars } from '../fixtures'
+import MultipleLineChart from '../MultipleLineChart'
+import StackedBarChart, { StackedBarChartBar } from '../StackedBarChart'
+
+jest.mock('recharts', () => ({
+  Area: () => null,
+  AreaChart: jest.fn(),
+  Bar: jest.fn(() => null),
+  BarChart: jest.fn(),
+  Customized: () => null,
+  Line: () => null,
+  LineChart: jest.fn(),
+  ReferenceLine: () => null,
+  ResponsiveContainer: ({ children }: ComponentProps<typeof BarChart>) => children,
+  Tooltip: (props: ComponentProps<typeof Tooltip>) => mockTooltip(props),
+  XAxis: () => null,
+  YAxis: () => null,
+}))
+
+const mockTooltip = jest.fn<ReactElement | null, [ComponentProps<typeof Tooltip>]>(() => null)
+
+const data = [
+  {
+    startOfPeriodDt: '2024-01-01',
+    endOfPeriodDt: '2024-01-31',
+    first: 100,
+    second: 200,
+    third: 300,
+  },
+  {
+    startOfPeriodDt: '2024-02-01',
+    endOfPeriodDt: '2024-02-29',
+    first: 400,
+    second: 500,
+    third: 600,
+  },
+]
+
+const bars: StackedBarChartBar<(typeof data)[number]>[] = [
+  { dataKey: 'first', tooltipLabel: 'First', colorHex: '#111', barIndex: 3, tooltipIndex: 2 },
+  { dataKey: 'second', tooltipLabel: 'Second', colorHex: '#222', barIndex: 1, tooltipIndex: 3 },
+  { dataKey: 'third', tooltipLabel: 'Third', colorHex: '#333', barIndex: 2, tooltipIndex: 1 },
+]
+
+const chartProps = {
+  currency: CurrencyEnum.Usd,
+  data,
+  loading: false,
+  xAxisDataKey: 'startOfPeriodDt',
+  timeGranularity: TimeGranularityEnum.Monthly,
+} satisfies Omit<ComponentProps<typeof StackedBarChart<(typeof data)[number]>>, 'bars'>
+
+const StateProbe = (): ReactElement => {
+  const { hoverDataIndex, clickedDataIndex, handleMouseLeave } = useAnalyticsState()
+
+  return (
+    <>
+      <output aria-label="Hovered index">{hoverDataIndex ?? 'none'}</output>
+      <output aria-label="Clicked index">{clickedDataIndex ?? 'none'}</output>
+      <button onClick={handleMouseLeave}>Clear hover</button>
+    </>
+  )
+}
+
+const withProvider = (chart: ReactElement | null): ReactElement => (
+  <AnalyticsStateProvider>
+    {chart}
+    <StateProbe />
+  </AnalyticsStateProvider>
+)
+
+const chartCases = [
+  {
+    name: 'StackedBarChart',
+    chart: <StackedBarChart {...chartProps} bars={bars} />,
+    chartMock: jest.mocked(BarChart),
+  },
+  {
+    name: 'MultipleLineChart',
+    chart: <MultipleLineChart {...chartProps} lines={bars} />,
+    chartMock: jest.mocked(LineChart),
+  },
+  {
+    name: 'AreaChart',
+    chart: (
+      <AreaChart
+        blur={false}
+        currency={CurrencyEnum.Usd}
+        data={[
+          { axisName: 'January', value: 100, tooltipLabel: 'January: 100' },
+          { axisName: 'February', value: 200, tooltipLabel: 'February: 200' },
+        ]}
+      />
+    ),
+    chartMock: jest.mocked(RechartAreaChart),
+  },
+]
+
+const originalDefaultZone = Settings.defaultZone
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  jest.advanceTimersByTime(100)
+  jest.clearAllMocks()
+  Settings.defaultZone = 'UTC'
+
+  for (const { chartMock } of chartCases) {
+    chartMock.mockImplementation(({ children }) => <div>{children}</div>)
+  }
+  jest.mocked(RechartAreaChart).mockImplementation(({ children }) => <svg>{children}</svg>)
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+  Settings.defaultZone = originalDefaultZone
+})
+
+describe.each(chartCases)('$name hover behavior', ({ chart, chartMock }) => {
+  const moveTo = (index: number): void => {
+    act(() => {
+      chartMock.mock.calls.at(-1)?.[0].onMouseMove?.({ activeTooltipIndex: index }, undefined)
+    })
+  }
+
+  const leave = (): void => {
+    act(() => {
+      chartMock.mock.calls.at(-1)?.[0].onMouseLeave?.({}, undefined)
+    })
+  }
+
+  it('keeps the final hovered index when movement ends within one frame', () => {
+    render(withProvider(chart))
+
+    moveTo(0)
+    expect(screen.getByLabelText('Hovered index')).toHaveTextContent('0')
+    moveTo(1)
+    act(() => jest.advanceTimersByTime(100))
+
+    expect(screen.getByLabelText('Hovered index')).toHaveTextContent('1')
+    expect(mockTooltip.mock.calls.at(-1)?.[0]).toMatchObject({
+      active: true,
+      defaultIndex: 1,
+    })
+  })
+
+  it('clears immediately on rapid mouse leave and never restores a trailing hover', () => {
+    render(withProvider(chart))
+
+    moveTo(0)
+    moveTo(1)
+    leave()
+
+    expect(screen.getByLabelText('Hovered index')).toHaveTextContent('none')
+    expect(mockTooltip.mock.calls.at(-1)?.[0].active).toBe(false)
+    act(() => jest.advanceTimersByTime(100))
+    expect(screen.getByLabelText('Hovered index')).toHaveTextContent('none')
+  })
+
+  it('allows immediate reentry to the same index without a delayed clear', () => {
+    render(withProvider(chart))
+
+    moveTo(0)
+    leave()
+    moveTo(0)
+    act(() => jest.advanceTimersByTime(100))
+
+    expect(screen.getByLabelText('Hovered index')).toHaveTextContent('0')
+  })
+
+  it('leaves no pending chart update after unmounting inside a shared provider', () => {
+    const { rerender } = render(withProvider(chart))
+
+    moveTo(0)
+    moveTo(1)
+    rerender(withProvider(null))
+    act(() => screen.getByRole('button', { name: 'Clear hover' }).click())
+    act(() => jest.advanceTimersByTime(100))
+
+    expect(screen.getByLabelText('Hovered index')).toHaveTextContent('none')
+  })
+
+  it('keeps click selection independent of hover clearing', () => {
+    render(withProvider(chart))
+
+    act(() => {
+      chartMock.mock.calls.at(-1)?.[0].onClick?.({ activeTooltipIndex: 1 }, undefined)
+    })
+    moveTo(0)
+    leave()
+
+    expect(screen.getByLabelText('Clicked index')).toHaveTextContent('1')
+  })
+})
+
+describe('StackedBarChart input ordering', () => {
+  it('renders frozen bars and data in independent graph and tooltip orders', () => {
+    const frozenBars = [...bars]
+    const frozenData = data.map((item) => Object.freeze({ ...item }))
+
+    Object.freeze(frozenBars)
+    Object.freeze(frozenData)
+    mockTooltip.mockImplementation((props) => {
+      if (!props.active || typeof props.content !== 'function') return null
+
+      return (
+        <section aria-label="Chart tooltip">
+          {props.content({ ...props, payload: [{ payload: frozenData[0] }] })}
+        </section>
+      )
+    })
+
+    render(withProvider(<StackedBarChart {...chartProps} bars={frozenBars} data={frozenData} />))
+
+    const getRenderedBarKeys = (): unknown[] =>
+      jest
+        .mocked(Bar)
+        .mock.calls.slice(-bars.length)
+        .map(([props]) => props.dataKey)
+
+    expect(getRenderedBarKeys()).toEqual(['second', 'third', 'first'])
+    act(() => {
+      jest
+        .mocked(BarChart)
+        .mock.calls.at(-1)?.[0]
+        .onMouseMove?.({ activeTooltipIndex: 0 }, undefined)
+      jest.advanceTimersByTime(100)
+    })
+
+    expect(screen.getByLabelText('Chart tooltip')).toHaveTextContent(/Third.*First.*Second/)
+    expect(getRenderedBarKeys()).toEqual(['second', 'third', 'first'])
+    expect(frozenBars.map((bar) => bar.dataKey)).toEqual(['first', 'second', 'third'])
+    expect(frozenData).toEqual(data)
+  })
+
+  it.each([{ loading: true }, { blur: true }])(
+    'renders the shared frozen fixture without mutating it for %j',
+    (props) => {
+      const originalOrder = multipleStackedBarChartLoadingFakeBars.map((bar) => bar.dataKey)
+
+      Object.freeze(multipleStackedBarChartLoadingFakeBars)
+      render(withProvider(<StackedBarChart {...chartProps} bars={bars} {...props} />))
+
+      expect(multipleStackedBarChartLoadingFakeBars.map((bar) => bar.dataKey)).toEqual(
+        originalOrder,
+      )
+    },
+  )
+})


### PR DESCRIPTION
Sort copied chart arrays so rendering and tooltip ordering do not mutate caller-owned data. Update hover state directly across stacked bar, line, and area charts so rapid movement is retained and leaving a chart clears its tooltip immediately.

Remove memoized aliases and simple booleans that add bookkeeping without avoiding meaningful work.
