### PR TITLE
fix(plans): keep charge and quote form state current

### DIFF
--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
@@ -232,9 +232,23 @@ export function SubscriptionPricingContent({
   const formDescription = useStore(planForm.store, (s) => s.values.description)
   const formCode = useStore(planForm.store, (s) => s.values.code)
   const formInterval = useStore(planForm.store, (s) => s.values.interval)
-  // Full form values — snapshot into formValuesRef so the serializer can derive
-  // both the plan payload and the overrides from a single source of truth.
-  const formValues = useStore(planForm.store, (s) => s.values)
+
+  useEffect(() => {
+    if (!formReady || !selectedPlanId) {
+      formValuesRef.current = null
+      return
+    }
+
+    formValuesRef.current = planForm.state.values
+    const subscription = planForm.store.subscribe(() => {
+      formValuesRef.current = planForm.state.values
+    })
+
+    return () => {
+      subscription.unsubscribe()
+      formValuesRef.current = null
+    }
+  }, [planForm, formReady, selectedPlanId, formValuesRef])
 
   const displayCurrency = currency ?? CurrencyEnum.Usd
   const displayInterval = formInterval || PlanInterval.Monthly
@@ -245,9 +259,6 @@ export function SubscriptionPricingContent({
   const basePlanName =
     planData?.name ?? billingItemPlan?.payload.name ?? initialState?.basePlanName ?? formName
 
-  // Sync to stateRef + formValuesRef + basePlanFormValuesRef. Overrides are no longer
-  // computed here: toPlanBillingItems() derives them from the two form value refs
-  // (see buildPlanOverrides).
   useEffect(() => {
     if (!formReady || !selectedPlanId) {
       stateRef.current = null
@@ -264,7 +275,6 @@ export function SubscriptionPricingContent({
       invoicingSettings,
     }
 
-    formValuesRef.current = formValues
     basePlanFormValuesRef.current = basePlanFormValues ?? null
   }, [
     formReady,
@@ -278,10 +288,8 @@ export function SubscriptionPricingContent({
     basePlanName,
     formDescription,
     formCode,
-    formValues,
     basePlanFormValues,
     stateRef,
-    formValuesRef,
     basePlanFormValuesRef,
   ])
 

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.integration.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.integration.test.tsx
@@ -1,0 +1,214 @@
+import { act, renderHook } from '@testing-library/react'
+
+import type { PlanFormInput } from '~/components/plans/types'
+import {
+  DEFAULT_INVOICING_SETTINGS,
+  DEFAULT_SUBSCRIPTION_SETTINGS,
+  type SubscriptionPricingState,
+} from '~/core/serializers/serializeQuotePlanBillingItems'
+import {
+  AggregationTypeEnum,
+  ChargeModelEnum,
+  CurrencyEnum,
+  PlanInterval,
+} from '~/generated/graphql'
+import { usePlanFormSetup } from '~/hooks/plans/usePlanFormSetup'
+import { useSubscriptionPricingDrawer } from '~/pages/quotes/hooks/useSubscriptionPricingDrawer'
+import { render } from '~/test-utils'
+
+import { SubscriptionPricingContent } from '../SubscriptionPricingContent'
+
+const mockOpen = jest.fn()
+const mockGetPlans = jest.fn()
+const mockPlan = {
+  id: 'plan_1',
+  name: 'Starter',
+  code: 'starter',
+  amountCurrency: CurrencyEnum.Usd,
+}
+const mockDefaultValues: PlanFormInput = {
+  name: 'Starter',
+  code: 'starter',
+  description: '',
+  interval: PlanInterval.Yearly,
+  amountCents: '100',
+  amountCurrency: CurrencyEnum.Usd,
+  payInAdvance: false,
+  trialPeriod: 0,
+  taxes: [],
+  billChargesMonthly: true,
+  billFixedChargesMonthly: false,
+  fixedCharges: [],
+  charges: [
+    {
+      billableMetric: {
+        id: 'bm_1',
+        code: 'api_calls',
+        name: 'API Calls',
+        aggregationType: AggregationTypeEnum.CountAgg,
+        recurring: false,
+        filters: [],
+      },
+      chargeModel: ChargeModelEnum.Standard,
+      properties: { amount: '50' },
+      invoiceable: true,
+      filters: [],
+    },
+  ],
+  minimumCommitment: { amountCents: '100' },
+  entitlements: [],
+}
+
+jest.mock('~/components/drawers/useDrawer', () => ({
+  useDrawer: () => ({ open: jest.fn(), close: jest.fn() }),
+  useFormDrawer: () => ({ open: mockOpen, close: jest.fn() }),
+}))
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  usePlansLazyQuery: () => [
+    mockGetPlans,
+    { data: { plans: { collection: [mockPlan] } }, loading: false },
+  ],
+  useGetSinglePlanQuery: () => ({ data: { plan: mockPlan }, loading: false }),
+  useGetSubscriptionForQuotePricingQuery: () => ({ data: undefined }),
+}))
+
+jest.mock('~/hooks/plans/usePlanForm', () => ({
+  buildDefaultValues: () => mockDefaultValues,
+}))
+
+jest.mock('~/hooks/plans/usePlanFormSetup', () => {
+  const actual = jest.requireActual('~/hooks/plans/usePlanFormSetup')
+
+  return { ...actual, usePlanFormSetup: jest.fn(actual.usePlanFormSetup) }
+})
+
+jest.mock('../useSubscriptionSettingsDrawer', () => ({
+  useSubscriptionSettingsDrawer: () => ({ openDrawer: jest.fn() }),
+}))
+
+jest.mock('../useQuotePlanSettingsDrawer', () => ({
+  useQuotePlanSettingsDrawer: () => ({ openDrawer: jest.fn() }),
+}))
+
+jest.mock('../QuoteInvoicingPaymentsSettings', () => ({
+  QuoteInvoicingPaymentsSettings: () => null,
+}))
+
+jest.mock('~/components/plans/form/FixedChargesSection', () => ({
+  FixedChargesSection: () => null,
+}))
+
+jest.mock('~/components/plans/UsageChargesSection', () => ({
+  UsageChargesSection: () => null,
+}))
+
+jest.mock('~/components/plans/CommitmentsSection', () => ({
+  CommitmentsSection: () => null,
+}))
+
+jest.mock('~/components/plans/ProgressiveBillingSection', () => ({
+  ProgressiveBillingSection: () => null,
+}))
+
+jest.mock('~/components/plans/drawers/subscriptionFee/SubscriptionFeeDrawer', () => ({
+  SubscriptionFeeDrawer: () => null,
+}))
+
+const initialState: SubscriptionPricingState = {
+  planId: 'plan_1',
+  planCode: 'starter',
+  planName: 'Starter',
+  planDescription: '',
+  subscriptionSettings: DEFAULT_SUBSCRIPTION_SETTINGS,
+  invoicingSettings: DEFAULT_INVOICING_SETTINGS,
+}
+
+const getPlanForm = (): ReturnType<typeof usePlanFormSetup>['form'] => {
+  const setup = jest.mocked(usePlanFormSetup).mock.results.at(-1)
+
+  if (setup?.type !== 'return') throw new Error('Plan form was not initialized')
+
+  return setup.value.form
+}
+
+describe('SubscriptionPricingContent with the real plan setup hook', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('saves current nested overrides without rerendering the pricing content', async () => {
+    const { result } = renderHook(() => useSubscriptionPricingDrawer())
+    const onSave = jest.fn().mockResolvedValue({ ok: true })
+
+    act(() => result.current.onPricingCommand({ onSave }))
+    const opened = mockOpen.mock.calls[0][0]
+    const rendered = render(
+      <SubscriptionPricingContent {...opened.children.props} initialState={initialState} />,
+    )
+    const form = getPlanForm()
+    const rendersBeforeEdit = jest.mocked(usePlanFormSetup).mock.calls.length
+
+    act(() => {
+      form.setFieldValue('charges[0].properties.amount', '75')
+      form.setFieldValue('minimumCommitment.amountCents', '200')
+    })
+
+    expect(jest.mocked(usePlanFormSetup).mock.calls).toHaveLength(rendersBeforeEdit)
+    expect(form.state.values.billChargesMonthly).toBe(true)
+    await act(async () => opened.form.submit())
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave.mock.calls[0][2].plans[0].overrides).toEqual({
+      charges: [
+        {
+          billableMetricCode: 'api_calls',
+          chargeModel: ChargeModelEnum.Standard,
+          properties: { amount: '75' },
+        },
+      ],
+      minimumCommitment: { amountCents: 20000 },
+    })
+    expect(mockDefaultValues.charges[0].properties?.amount).toBe('50')
+    rendered.unmount()
+  })
+
+  it('clears the live snapshot on unmount and ignores later updates', () => {
+    const stateRef = { current: null as SubscriptionPricingState | null }
+    const formValuesRef = { current: null as PlanFormInput | null }
+    const basePlanFormValuesRef = { current: null as PlanFormInput | null }
+    const rendered = render(
+      <SubscriptionPricingContent
+        stateRef={stateRef}
+        formValuesRef={formValuesRef}
+        basePlanFormValuesRef={basePlanFormValuesRef}
+        initialState={initialState}
+      />,
+    )
+    const form = getPlanForm()
+
+    expect(formValuesRef.current).not.toBeNull()
+    rendered.unmount()
+    act(() => form.setFieldValue('minimumCommitment.amountCents', '500'))
+    expect(formValuesRef.current).toBeNull()
+  })
+
+  it.each(['charges', 'interval'] as const)(
+    'resets monthly billing when annual usage billing loses its %s condition',
+    async (condition) => {
+      const { result } = renderHook(() => usePlanFormSetup({ planIdToFetch: 'plan_1' }))
+      const form = result.current.form
+
+      expect(form.state.values.billChargesMonthly).toBe(true)
+
+      await act(async () => {
+        if (condition === 'charges') {
+          await form.removeFieldValue('charges', 0)
+        } else {
+          form.setFieldValue('interval', PlanInterval.Monthly)
+        }
+      })
+
+      expect(form.state.values.billChargesMonthly).toBe(false)
+    },
+  )
+})

--- a/src/components/plans/UsageChargesSection.tsx
+++ b/src/components/plans/UsageChargesSection.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { useStore } from '@tanstack/react-form'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { Chip } from '~/components/designSystem/Chip'
@@ -64,7 +64,6 @@ export const UsageChargesSection = ({
   const hasAnyCharge = !!charges.length
   const { openRemoveChargeWarningDialog } = useRemoveChargeWarningDialog()
   const usageChargeDrawerRef = useRef<UsageChargeDrawerRef>(null)
-  const [alreadyUsedBmsIds, setAlreadyUsedBmsIds] = useState<Map<string, number>>(new Map())
 
   const handleDrawerSave = useCallback(
     (charge: LocalUsageChargeInput, index: number | null) => {
@@ -90,23 +89,17 @@ export const UsageChargesSection = ({
     [form],
   )
 
-  useEffect(() => {
-    const BmIdsMap = new Map()
+  const alreadyUsedBmsIds = useMemo(() => {
+    const counts = new Map<string, number>()
 
-    for (let i = 0; i < charges.length; i++) {
-      const element = charges[i]
-      const bmId = element.billableMetric.id
+    for (const charge of charges) {
+      const id = charge.billableMetric.id
 
-      if (BmIdsMap.has(bmId)) {
-        BmIdsMap.set(bmId, BmIdsMap.get(bmId) + 1)
-      } else {
-        BmIdsMap.set(bmId, 1)
-      }
+      counts.set(id, (counts.get(id) ?? 0) + 1)
     }
 
-    setAlreadyUsedBmsIds(BmIdsMap)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [charges.length])
+    return counts
+  }, [charges])
 
   const isAnnual = [PlanInterval.Semiannual, PlanInterval.Yearly].includes(interval)
 

--- a/src/components/plans/__tests__/UsageChargesSection.test.tsx
+++ b/src/components/plans/__tests__/UsageChargesSection.test.tsx
@@ -1,7 +1,10 @@
-import { screen } from '@testing-library/react'
+import { revalidateLogic } from '@tanstack/react-form'
+import { act, renderHook, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import { planFormSchema } from '~/formValidation/planFormSchema'
 import { AggregationTypeEnum, ChargeModelEnum } from '~/generated/graphql'
+import { useAppForm } from '~/hooks/forms/useAppform'
 import { render } from '~/test-utils'
 import { createMockPlanForm } from '~/test-utils/createMockPlanForm'
 
@@ -247,5 +250,47 @@ describe('UsageChargesSection', () => {
         expect(screen.getByTestId('usage-charge-selector-0')).toBeInTheDocument()
       })
     })
+  })
+})
+
+describe('Usage charge duplicate warnings with a real form', () => {
+  it('refreshes duplicate warnings after same-length resets, additions and removals', async () => {
+    const user = userEvent.setup()
+    const first = createMockCharge({ invoiceDisplayName: 'First charge' })
+    const duplicate = createMockCharge({ id: 'charge-2', invoiceDisplayName: 'Second charge' })
+    const other = createMockCharge({
+      id: 'charge-3',
+      invoiceDisplayName: 'Second charge',
+      billableMetric: { ...first.billableMetric, id: 'other-catalog-item' },
+    })
+    const { result } = renderHook(() =>
+      useAppForm({
+        defaultValues: createForm({ charges: [first, duplicate] }).state.values,
+        validationLogic: revalidateLogic(),
+        validators: { onDynamic: planFormSchema },
+      }),
+    )
+    const form = result.current
+
+    render(<UsageChargesSection form={form} isEdition={false} />)
+
+    const expectWarning = async (expected: string | undefined): Promise<void> => {
+      await user.click(screen.getByText('First charge'))
+      expect(mockOpenDrawer).toHaveBeenLastCalledWith(
+        first,
+        0,
+        expect.objectContaining({ alreadyUsedChargeAlertMessage: expected }),
+      )
+    }
+
+    await expectWarning('translated_text_6435895831d323008a47911f')
+    act(() => form.reset({ ...form.state.values, charges: [first, other] }))
+    await expectWarning(undefined)
+    act(() => form.reset({ ...form.state.values, charges: [first, duplicate] }))
+    await expectWarning('translated_text_6435895831d323008a47911f')
+    await act(async () => form.removeFieldValue('charges', 1))
+    await expectWarning(undefined)
+    act(() => form.pushFieldValue('charges', duplicate))
+    await expectWarning('translated_text_6435895831d323008a47911f')
   })
 })

--- a/src/components/plans/drawers/featureEntitlement/__tests__/PrivilegesTable.test.tsx
+++ b/src/components/plans/drawers/featureEntitlement/__tests__/PrivilegesTable.test.tsx
@@ -1,990 +1,254 @@
-import { render } from '@testing-library/react'
+import { revalidateLogic } from '@tanstack/react-form'
+import { act, renderHook, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComponentProps } from 'react'
 
+import type { LocalPrivilegeInput } from '~/components/plans/types'
 import { PrivilegeValueTypeEnum } from '~/generated/graphql'
-import { useFieldContext } from '~/hooks/forms/formContext'
 import { useAppForm } from '~/hooks/forms/useAppform'
+import { render } from '~/test-utils'
 
-import { type FeatureEntitlementFormValues } from '../constants'
+import { DEFAULT_VALUES } from '../constants'
 import { FeatureEntitlementDrawerContent } from '../FeatureEntitlementDrawerContent'
 
-// --- Mocks ---
-
-// --- Mocks ---
-
-const mockTranslate = jest.fn((key: string) => `translated_${key}`)
-
-jest.mock('~/hooks/core/useInternationalization', () => ({
-  useInternationalization: () => ({
-    translate: mockTranslate,
+// jsdom has no layout measurements for the real combobox's virtualized options.
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 56,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index,
+        start: index * 56,
+        size: 56,
+      })),
+    scrollToIndex: jest.fn(),
+    measureElement: jest.fn(),
   }),
 }))
 
-jest.mock('~/generated/graphql', () => {
-  const actual = jest.requireActual('~/generated/graphql')
-
-  return {
-    ...actual,
-    useGetFeatureDetailsForFeatureEntitlementPrivilegeSectionQuery: jest.fn(() => ({
-      data: null,
-      loading: false,
-    })),
-    useGetFeaturesListForPlanSectionLazyQuery: jest.fn(() => [jest.fn(), { data: null }]),
-  }
-})
-
-// Mock TanStack form infrastructure
-const mockHandleSubmit = jest.fn()
-const mockReset = jest.fn()
-const mockHandleChange = jest.fn()
-const mockHandleBlur = jest.fn()
-const mockSetFieldValue = jest.fn()
-const mockRemoveFieldValue = jest.fn()
-
-jest.mock('~/hooks/forms/formContext', () => ({
-  useFieldContext: jest.fn(),
+// Local privilege options do not need the search hook's loading timer.
+jest.mock('~/hooks/useDebouncedSearch', () => ({
+  useDebouncedSearch: () => ({ debouncedSearch: undefined, isLoading: false }),
 }))
 
-jest.mock('@tanstack/react-form', () => ({
-  useStore: jest.fn((store, selector) => {
-    if (typeof store?.getState === 'function') {
-      return selector(store.getState())
-    }
-    return false
+jest.mock('~/components/drawers/useDrawer', () => ({
+  useDrawer: () => ({ open: jest.fn(), close: jest.fn() }),
+  useFormDrawer: () => ({ open: jest.fn(), close: jest.fn() }),
+}))
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useGetFeatureDetailsForFeatureEntitlementPrivilegeSectionQuery: () => ({
+    data: null,
+    loading: false,
   }),
-  revalidateLogic: jest.fn(() => ({})),
+  useGetFeaturesListForPlanSectionLazyQuery: () => [jest.fn(), { data: null }],
 }))
 
-// Captures props passed to PrivilegeValueCell via the mocked form infrastructure
-let mockAppFieldChildren: Map<
-  string,
-  { children: (field: unknown) => React.ReactNode; name: string }
->
-
-// Store for overriding form values per test
-let mockFormValuesOverride: Record<string, unknown> | null = null
-
-jest.mock('~/hooks/forms/useAppform', () => ({
-  withForm: ({
-    render: Render,
-  }: {
-    defaultValues: Record<string, unknown>
-    props: Record<string, unknown>
-    render: React.FC<{ form: unknown; [key: string]: unknown }>
-  }) => {
-    return (props: { form: unknown; [key: string]: unknown }) => <Render {...props} />
-  },
-  useAppForm: jest.fn(
-    ({
-      onSubmit,
-      defaultValues,
-    }: {
-      onSubmit?: (args: { value: Record<string, unknown> }) => void
-      defaultValues: Record<string, unknown>
-    }) => {
-      const currentValues = mockFormValuesOverride ?? defaultValues
-
-      const store = {
-        subscribe: jest.fn(() => jest.fn()),
-        getState: jest.fn(() => ({ isDirty: false, values: currentValues })),
-      }
-
-      return {
-        store,
-        state: { values: currentValues },
-        reset: mockReset,
-        setFieldValue: mockSetFieldValue,
-        removeFieldValue: mockRemoveFieldValue,
-        handleSubmit: () => {
-          mockHandleSubmit()
-          onSubmit?.({ value: currentValues })
-        },
-        AppField: ({
-          children,
-          name,
-        }: {
-          children: (field: ReturnType<typeof createFieldCtx>) => React.ReactNode
-          name: string
-        }) => {
-          mockAppFieldChildren.set(name, { children: children as never, name })
-
-          const fieldCtx = createFieldCtx(name, currentValues[name] ?? '')
-
-          return <>{children(fieldCtx)}</>
-        },
-        Subscribe: ({
-          children,
-          selector,
-        }: {
-          children: (value: unknown) => React.ReactNode
-          selector: (state: { canSubmit: boolean; values: Record<string, unknown> }) => unknown
-        }) => {
-          const value = selector({ canSubmit: true, values: currentValues })
-
-          return <>{children(value)}</>
-        },
-      }
-    },
-  ),
-}))
-
-// Mock Tooltip to expose its props for assertions
-jest.mock('~/components/designSystem/Tooltip', () => ({
-  Tooltip: ({
-    children,
-    title,
-    disableHoverListener,
-    placement,
-  }: {
-    children: React.ReactNode
-    title?: string
-    disableHoverListener?: boolean
-    placement?: string
-  }) => (
-    <div
-      data-test="mocked-tooltip"
-      data-tooltip-title={title || ''}
-      data-tooltip-disabled={String(!!disableHoverListener)}
-      data-tooltip-placement={placement || ''}
-    >
-      {children}
-    </div>
-  ),
-}))
-
-// Mock ComboBox to expose its props
-jest.mock('~/components/form', () => ({
-  ComboBox: ({
-    value,
-    error,
-    placeholder,
-    onChange,
-    variant,
-    data,
-    className,
-    disableClearable,
-  }: {
-    value?: string
-    error?: boolean
-    placeholder?: string
-    onChange?: (v: string) => void
-    variant?: string
-    data?: { label: string; value: string }[]
-    className?: string
-    disableClearable?: boolean
-  }) => (
-    <div
-      data-test="mocked-combobox"
-      data-value={value || ''}
-      data-error={String(!!error)}
-      data-placeholder={placeholder || ''}
-      data-variant={variant || ''}
-      data-option-count={String(data?.length ?? 0)}
-      data-classname={className || ''}
-      data-disable-clearable={String(!!disableClearable)}
-    >
-      {data?.map((item, i) => (
-        <button
-          key={i}
-          data-test={`combobox-option-${i}`}
-          data-option-value={item.value}
-          onClick={() => onChange?.(item.value)}
-        />
-      ))}
-      <button data-test="combobox-trigger" onClick={() => onChange?.(data?.[0]?.value ?? '')} />
-    </div>
-  ),
-  ComboboxItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}))
-
-// Mock TextInput to expose its props
-jest.mock('~/components/form/TextInput/TextInput', () => ({
-  TextInput: ({
-    error,
-    variant,
-    placeholder,
-    beforeChangeFormatter,
-    value,
-    onChange,
-    name,
-  }: {
-    error?: boolean
-    variant?: string
-    placeholder?: string
-    beforeChangeFormatter?: string[]
-    value?: string
-    onChange?: (value: string) => void
-    name?: string
-  }) => (
-    <div
-      data-test="mocked-text-input"
-      data-error={String(!!error)}
-      data-variant={variant || ''}
-      data-placeholder={placeholder || ''}
-      data-formatter={beforeChangeFormatter?.join(',') || ''}
-      data-value={value || ''}
-      data-name={name || ''}
-    >
-      <input
-        data-test="text-input-field"
-        value={value || ''}
-        onChange={(e) => onChange?.(e.target.value)}
-      />
-    </div>
-  ),
-}))
-
-jest.mock('~/components/designSystem/Table/ChargeTable', () => ({
-  ChargeTable: ({
-    data,
-    columns,
-    onDeleteRow,
-  }: {
-    data: Record<string, unknown>[]
-    columns: {
-      content: (row: Record<string, unknown>, index: number) => React.ReactNode
-    }[]
-    onDeleteRow?: (row: Record<string, unknown>, index: number) => void
-  }) => (
-    <div data-test="mocked-charge-table">
-      {data.map((row, i) => (
-        <div key={i} data-test={`charge-table-row-${i}`}>
-          {columns.map((col, j) => (
-            <div key={j} data-test={`charge-table-cell-${i}-${j}`}>
-              {typeof col.content === 'function' ? col.content(row, i) : null}
-            </div>
-          ))}
-          {onDeleteRow && (
-            <button data-test={`delete-row-${i}`} onClick={() => onDeleteRow(row, i)} />
-          )}
-        </div>
-      ))}
-    </div>
-  ),
-}))
-
-jest.mock('~/components/designSystem/Button', () => ({
-  Button: ({
-    children,
-    onClick,
-    variant,
-    icon,
-    startIcon,
-    disabled,
-    ...rest
-  }: {
-    children?: React.ReactNode
-    onClick?: () => void
-    variant?: string
-    icon?: string
-    startIcon?: string
-    disabled?: boolean
-    [key: string]: unknown
-  }) => (
-    <button
-      data-test={rest['data-test'] as string}
-      data-variant={variant || ''}
-      data-icon={icon || ''}
-      data-start-icon={startIcon || ''}
-      disabled={disabled}
-      onClick={onClick}
-    >
-      {children}
-    </button>
-  ),
-}))
-
-jest.mock('~/components/designSystem/Selector', () => ({
-  Selector: ({ title, subtitle }: { icon?: string; title?: string; subtitle?: string }) => (
-    <div data-test="mocked-selector" data-title={title} data-subtitle={subtitle} />
-  ),
-}))
-
-jest.mock('~/core/utils/domUtils', () => ({
-  scrollToAndClickElement: jest.fn(),
-}))
-
-const createFieldCtx = (name: string, value: unknown, errors: { message: string }[] = []) => ({
-  name,
-  state: { value },
-  store: {
-    subscribe: jest.fn(() => jest.fn()),
-    getState: jest.fn(() => ({
-      meta: { errors, errorMap: {} },
-      values: { [name]: value },
-    })),
-  },
-  handleChange: mockHandleChange,
-  handleBlur: mockHandleBlur,
-  ComboBoxField: (props: Record<string, unknown>) => <input name={name} {...props} />,
-  TextInputField: (props: Record<string, unknown>) => <input name={name} {...props} />,
+const buildPrivilege = (overrides: Partial<LocalPrivilegeInput> = {}): LocalPrivilegeInput => ({
+  privilegeCode: 'first',
+  privilegeName: 'First privilege',
+  value: 'original string',
+  valueType: PrivilegeValueTypeEnum.String,
+  ...overrides,
 })
 
-const mockedUseFieldContext = useFieldContext as jest.Mock
+const renderContent = (
+  privileges: LocalPrivilegeInput[],
+): ReturnType<typeof render> & {
+  form: ComponentProps<typeof FeatureEntitlementDrawerContent>['form']
+  onSubmit: jest.Mock
+} => {
+  const onSubmit = jest.fn()
+  const { result } = renderHook(() =>
+    useAppForm({
+      defaultValues: {
+        ...DEFAULT_VALUES,
+        featureId: 'feature-1',
+        featureCode: 'feature',
+        privileges,
+      },
+      validationLogic: revalidateLogic(),
+      onSubmit: ({ value }) => onSubmit(value),
+    }),
+  )
+  const rendered = render(
+    <FeatureEntitlementDrawerContent form={result.current} existingFeatureCodes={[]} />,
+  )
+
+  return { ...rendered, form: result.current, onSubmit }
+}
+
+const getPrivilegeRow = (name: string): HTMLElement => {
+  const row = screen.getByText(name).closest('tr')
+
+  if (!row) throw new Error(`Missing privilege row: ${name}`)
+
+  return row
+}
 
 describe('PrivilegesTable', () => {
-  const defaultFormValues: FeatureEntitlementFormValues = {
-    featureId: 'feature-1',
-    featureName: 'Feature One',
-    featureCode: 'feature_one',
-    privileges: [],
-  }
+  it('hides the table when there are no privileges', () => {
+    renderContent([])
 
-  const privilegeRow = {
-    privilegeCode: 'priv-1',
-    privilegeName: 'Privilege One',
-    value: '',
-    valueType: PrivilegeValueTypeEnum.String,
-    config: undefined,
-  }
-
-  const renderContent = (overrides?: Partial<FeatureEntitlementFormValues>) => {
-    if (overrides) {
-      mockFormValuesOverride = { ...defaultFormValues, ...overrides }
-    }
-
-    const form = (useAppForm as jest.Mock)({
-      defaultValues: defaultFormValues,
-    })
-
-    return render(<FeatureEntitlementDrawerContent form={form} existingFeatureCodes={[]} />)
-  }
-
-  beforeEach(() => {
-    jest.clearAllMocks()
-    mockAppFieldChildren = new Map()
-    mockFormValuesOverride = null
-    mockedUseFieldContext.mockReturnValue(createFieldCtx('testField', ''))
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
   })
 
-  afterEach(() => {
-    jest.restoreAllMocks()
+  it.each([
+    {
+      valueType: PrivilegeValueTypeEnum.String,
+      input: 'updated string',
+      expected: 'updated string',
+    },
+    { valueType: PrivilegeValueTypeEnum.Integer, input: '-12.5abc', expected: '125' },
+  ])(
+    'edits only the second $valueType row and submits its formatted value',
+    async ({ valueType, input, expected }) => {
+      const user = userEvent.setup()
+      const { form, onSubmit } = renderContent([
+        buildPrivilege(),
+        buildPrivilege({
+          privilegeCode: 'second',
+          privilegeName: 'Second privilege',
+          valueType,
+          value: '',
+        }),
+      ])
+
+      await user.type(within(getPrivilegeRow('Second privilege')).getByRole('textbox'), input)
+      await act(async () => form.handleSubmit())
+
+      expect(form.state.values.privileges.map(({ value }) => value)).toEqual([
+        'original string',
+        expected,
+      ])
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ privileges: form.state.values.privileges }),
+      )
+    },
+  )
+
+  it.each([
+    {
+      valueType: PrivilegeValueTypeEnum.Boolean,
+      option: 'False',
+      expected: 'false',
+      config: undefined,
+    },
+    {
+      valueType: PrivilegeValueTypeEnum.Select,
+      option: 'Premium',
+      expected: 'Premium',
+      config: { selectOptions: ['Basic', 'Premium'] },
+    },
+  ])(
+    'selects and submits a new value only for the second $valueType row',
+    async ({ valueType, option, expected, config }) => {
+      const user = userEvent.setup()
+      const { form, onSubmit } = renderContent([
+        buildPrivilege(),
+        buildPrivilege({
+          privilegeCode: 'second',
+          privilegeName: 'Second privilege',
+          valueType,
+          value: '',
+          config,
+        }),
+      ])
+
+      await user.click(within(getPrivilegeRow('Second privilege')).getByRole('combobox'))
+      await user.click(screen.getByRole('option', { name: new RegExp(option) }))
+      await act(async () => form.handleSubmit())
+
+      expect(form.state.values.privileges.map(({ value }) => value)).toEqual([
+        'original string',
+        expected,
+      ])
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ privileges: form.state.values.privileges }),
+      )
+    },
+  )
+
+  it.each([0, 1])('deletes row %s and keeps the remaining row editable', async (index) => {
+    const user = userEvent.setup()
+    const privileges = [
+      buildPrivilege(),
+      buildPrivilege({
+        privilegeCode: 'second',
+        privilegeName: 'Second privilege',
+        value: 'second value',
+      }),
+    ]
+    const { form } = renderContent(privileges)
+
+    await user.click(
+      within(
+        getPrivilegeRow(privileges[index].privilegeName || privileges[index].privilegeCode),
+      ).getByRole('button', {
+        hidden: true,
+      }),
+    )
+
+    const remaining = privileges[1 - index]
+
+    expect(form.state.values.privileges).toEqual([remaining])
+    const input = within(
+      getPrivilegeRow(remaining.privilegeName || remaining.privilegeCode),
+    ).getByRole('textbox')
+
+    await user.clear(input)
+    await user.type(input, 'edited after deletion')
+    expect(form.state.values.privileges[0].value).toBe('edited after deletion')
   })
 
-  // --- Privilege table rendering ---
+  it.each(Object.values(PrivilegeValueTypeEnum))(
+    'shows validation errors on the correct %s field',
+    async (valueType) => {
+      const user = userEvent.setup()
+      const { form } = renderContent([
+        buildPrivilege(),
+        buildPrivilege({
+          privilegeCode: 'second',
+          privilegeName: 'Second privilege',
+          valueType,
+          value: '',
+        }),
+      ])
+      const row = getPrivilegeRow('Second privilege')
+      const role = [PrivilegeValueTypeEnum.Select, PrivilegeValueTypeEnum.Boolean].includes(
+        valueType,
+      )
+        ? 'combobox'
+        : 'textbox'
+      const input = within(row).getByRole(role)
 
-  describe('GIVEN the privilege table', () => {
-    describe('WHEN privileges array has items', () => {
-      it('THEN should render the ChargeTable', () => {
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [privilegeRow],
-        }
-
-        const { container } = renderContent()
-
-        expect(container.querySelector('[data-test="mocked-charge-table"]')).toBeTruthy()
-      })
-    })
-
-    describe('WHEN privileges array is empty', () => {
-      it('THEN should not render the ChargeTable', () => {
-        mockFormValuesOverride = { ...defaultFormValues, privileges: [] }
-
-        const { container } = renderContent()
-
-        expect(container.querySelector('[data-test="mocked-charge-table"]')).toBeNull()
-      })
-    })
-
-    describe('WHEN a privilege row is deleted', () => {
-      it('THEN should call removeFieldValue with the correct index', () => {
-        const secondPrivilege = {
-          ...privilegeRow,
-          privilegeCode: 'priv-2',
-          privilegeName: 'Privilege Two',
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [privilegeRow, secondPrivilege],
-        }
-
-        const { container } = renderContent()
-
-        const deleteBtn = container.querySelector('[data-test="delete-row-0"]') as HTMLButtonElement
-
-        expect(deleteBtn).toBeTruthy()
-        deleteBtn.click()
-
-        expect(mockRemoveFieldValue).toHaveBeenCalledWith('privileges', 0)
+      expect(input).toHaveAttribute('aria-invalid', 'false')
+      act(() => {
+        form.setFieldMeta('privileges[1].value', (meta) => ({
+          ...meta,
+          errorMap: { onChange: { message: 'text_1771342994699klxu2paz7g8' } },
+        }))
       })
 
-      it('THEN should remove the correct index when deleting a later row', () => {
-        const secondPrivilege = {
-          ...privilegeRow,
-          privilegeCode: 'priv-2',
-          privilegeName: 'Privilege Two',
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [privilegeRow, secondPrivilege],
-        }
-
-        const { container } = renderContent()
-
-        const deleteBtn = container.querySelector('[data-test="delete-row-1"]') as HTMLButtonElement
-
-        expect(deleteBtn).toBeTruthy()
-        deleteBtn.click()
-
-        expect(mockRemoveFieldValue).toHaveBeenCalledWith('privileges', 1)
-      })
-    })
-  })
-
-  // --- PrivilegeValueCell rendering per value type ---
-
-  describe('GIVEN the PrivilegeValueCell component', () => {
-    describe('WHEN the privilege valueType is String', () => {
-      it('THEN should render a TextInput with error state and outlined variant', () => {
-        const stringPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.String,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [stringPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const textInput = container.querySelector('[data-test="mocked-text-input"]')
-
-        expect(textInput).toBeTruthy()
-        expect(textInput?.getAttribute('data-variant')).toBe('outlined')
-      })
-
-      it('THEN should render the string placeholder', () => {
-        const stringPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.String,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [stringPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const textInput = container.querySelector('[data-test="mocked-text-input"]')
-
-        expect(textInput?.getAttribute('data-placeholder')).toBe(
-          'translated_text_1753864223060d5jej59ti86',
-        )
-      })
-
-      it('THEN should not apply beforeChangeFormatter', () => {
-        const stringPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.String,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [stringPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const textInput = container.querySelector('[data-test="mocked-text-input"]')
-
-        expect(textInput?.getAttribute('data-formatter')).toBe('')
-      })
-    })
-
-    describe('WHEN the privilege valueType is Integer', () => {
-      it('THEN should render a TextInputField with int and positiveNumber formatters', () => {
-        const intPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Integer,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [intPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const textInput = container.querySelector('[data-test="mocked-text-input"]')
-
-        expect(textInput).toBeTruthy()
-        expect(textInput?.getAttribute('data-formatter')).toBe('int,positiveNumber')
-      })
-
-      it('THEN should render the integer placeholder', () => {
-        const intPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Integer,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [intPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const textInput = container.querySelector('[data-test="mocked-text-input"]')
-
-        expect(textInput?.getAttribute('data-placeholder')).toBe(
-          'translated_text_1753864223060bxskzw3877s',
-        )
-      })
-    })
-
-    describe('WHEN the privilege valueType is Select', () => {
-      it('THEN should render a ComboBox with the select options', () => {
-        const selectPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Select,
-          config: { selectOptions: ['option_a', 'option_b', 'option_c'] },
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [selectPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const comboBox = container.querySelector('[data-test="mocked-combobox"]')
-
-        expect(comboBox).toBeTruthy()
-        expect(comboBox?.getAttribute('data-variant')).toBe('outlined')
-        expect(comboBox?.getAttribute('data-option-count')).toBe('3')
-      })
-
-      it('THEN should render the select placeholder', () => {
-        const selectPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Select,
-          config: { selectOptions: ['opt1'] },
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [selectPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const comboBox = container.querySelector('[data-test="mocked-combobox"]')
-
-        expect(comboBox?.getAttribute('data-placeholder')).toBe(
-          'translated_text_66ab42d4ece7e6b7078993b1',
-        )
-      })
-
-      it('THEN should display the current field value', () => {
-        const selectPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Select,
-          value: 'option_a',
-          config: { selectOptions: ['option_a', 'option_b'] },
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [selectPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', 'option_a'))
-
-        const { container } = renderContent()
-
-        const comboBox = container.querySelector('[data-test="mocked-combobox"]')
-
-        expect(comboBox?.getAttribute('data-value')).toBe('option_a')
-      })
-
-      it('THEN should handle missing config selectOptions gracefully', () => {
-        const selectPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Select,
-          config: undefined,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [selectPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const comboBox = container.querySelector('[data-test="mocked-combobox"]')
-
-        expect(comboBox).toBeTruthy()
-        expect(comboBox?.getAttribute('data-option-count')).toBe('0')
-      })
-    })
-
-    describe('WHEN the privilege valueType is Boolean', () => {
-      it('THEN should render a ComboBox with true/false options', () => {
-        const boolPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Boolean,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [boolPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const comboBox = container.querySelector('[data-test="mocked-combobox"]')
-
-        expect(comboBox).toBeTruthy()
-        expect(comboBox?.getAttribute('data-option-count')).toBe('2')
-      })
-
-      it('THEN should render the boolean placeholder', () => {
-        const boolPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Boolean,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [boolPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const comboBox = container.querySelector('[data-test="mocked-combobox"]')
-
-        expect(comboBox?.getAttribute('data-placeholder')).toBe(
-          'translated_text_1753864223060ji5l38phiya',
-        )
-      })
-    })
-  })
-
-  // --- Validation error tooltip ---
-
-  describe('GIVEN the validation error tooltip', () => {
-    describe('WHEN a String field has no validation errors', () => {
-      it('THEN should render the tooltip with disableHoverListener true', () => {
-        const stringPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.String,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [stringPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', '', []))
-
-        const { container } = renderContent()
-
-        const tooltip = container.querySelector(
-          '[data-test="charge-table-cell-0-1"] [data-test="mocked-tooltip"]',
-        )
-
-        expect(tooltip).toBeTruthy()
-        expect(tooltip?.getAttribute('data-tooltip-disabled')).toBe('true')
-        expect(tooltip?.getAttribute('data-tooltip-title')).toBe('')
-      })
-    })
-
-    describe('WHEN a String field has a validation error', () => {
-      it('THEN should render the tooltip with the translated error message', () => {
-        const stringPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.String,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [stringPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(
-          createFieldCtx('privileges[0].value', '', [{ message: 'text_1771342994699klxu2paz7g8' }]),
-        )
-
-        const { container } = renderContent()
-
-        const tooltip = container.querySelector(
-          '[data-test="charge-table-cell-0-1"] [data-test="mocked-tooltip"]',
-        )
-
-        expect(tooltip).toBeTruthy()
-        expect(tooltip?.getAttribute('data-tooltip-disabled')).toBe('false')
-        expect(tooltip?.getAttribute('data-tooltip-title')).toBe(
-          'translated_text_1771342994699klxu2paz7g8',
-        )
-      })
-    })
-
-    describe('WHEN a Select field has a validation error', () => {
-      it('THEN should show the error tooltip and set error on ComboBox', () => {
-        const selectPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Select,
-          config: { selectOptions: ['opt1'] },
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [selectPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(
-          createFieldCtx('privileges[0].value', '', [{ message: 'text_1771342994699klxu2paz7g8' }]),
-        )
-
-        const { container } = renderContent()
-
-        const tooltip = container.querySelector(
-          '[data-test="charge-table-cell-0-1"] [data-test="mocked-tooltip"]',
-        )
-        const comboBox = container.querySelector(
-          '[data-test="charge-table-cell-0-1"] [data-test="mocked-combobox"]',
-        )
-
-        expect(tooltip?.getAttribute('data-tooltip-disabled')).toBe('false')
-        expect(comboBox?.getAttribute('data-error')).toBe('true')
-      })
-    })
-
-    describe('WHEN a Boolean field has a validation error', () => {
-      it('THEN should show the error tooltip and set error on ComboBox', () => {
-        const boolPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Boolean,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [boolPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(
-          createFieldCtx('privileges[0].value', '', [{ message: 'text_1771342994699klxu2paz7g8' }]),
-        )
-
-        const { container } = renderContent()
-
-        const tooltip = container.querySelector(
-          '[data-test="charge-table-cell-0-1"] [data-test="mocked-tooltip"]',
-        )
-        const comboBox = container.querySelector(
-          '[data-test="charge-table-cell-0-1"] [data-test="mocked-combobox"]',
-        )
-
-        expect(tooltip?.getAttribute('data-tooltip-disabled')).toBe('false')
-        expect(comboBox?.getAttribute('data-error')).toBe('true')
-      })
-    })
-
-    describe('WHEN a Select field has no validation errors', () => {
-      it('THEN should disable the tooltip and not set error on ComboBox', () => {
-        const selectPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Select,
-          config: { selectOptions: ['opt1'] },
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [selectPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', '', []))
-
-        const { container } = renderContent()
-
-        const tooltip = container.querySelector(
-          '[data-test="charge-table-cell-0-1"] [data-test="mocked-tooltip"]',
-        )
-        const comboBox = container.querySelector(
-          '[data-test="charge-table-cell-0-1"] [data-test="mocked-combobox"]',
-        )
-
-        expect(tooltip?.getAttribute('data-tooltip-disabled')).toBe('true')
-        expect(comboBox?.getAttribute('data-error')).toBe('false')
-      })
-    })
-
-    describe('WHEN the tooltip placement is set', () => {
-      it('THEN should use top placement', () => {
-        const stringPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.String,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [stringPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const tooltip = container.querySelector(
-          '[data-test="charge-table-cell-0-1"] [data-test="mocked-tooltip"]',
-        )
-
-        expect(tooltip?.getAttribute('data-tooltip-placement')).toBe('top')
-      })
-    })
-  })
-
-  // --- Multiple privileges ---
-
-  describe('GIVEN multiple privileges with different value types', () => {
-    describe('WHEN rendering a mix of String and Boolean privileges', () => {
-      it('THEN should render the correct input type for each row', () => {
-        const stringPrivilege = {
-          ...privilegeRow,
-          privilegeCode: 'priv-string',
-          valueType: PrivilegeValueTypeEnum.String,
-        }
-        const boolPrivilege = {
-          ...privilegeRow,
-          privilegeCode: 'priv-bool',
-          valueType: PrivilegeValueTypeEnum.Boolean,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [stringPrivilege, boolPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        // Row 0 should have TextInputField (String type)
-        const row0Cell = container.querySelector('[data-test="charge-table-cell-0-1"]')
-
-        expect(row0Cell?.querySelector('[data-test="mocked-text-input"]')).toBeTruthy()
-
-        // Row 1 should have ComboBox (Boolean type)
-        const row1Cell = container.querySelector('[data-test="charge-table-cell-1-1"]')
-
-        expect(row1Cell?.querySelector('[data-test="mocked-combobox"]')).toBeTruthy()
-      })
-    })
-  })
-
-  // --- ComboBox onChange handlers in PrivilegeValueCell ---
-
-  describe('GIVEN the ComboBox onChange handlers in PrivilegeValueCell', () => {
-    describe('WHEN a Select ComboBox value is changed', () => {
-      it('THEN should call field.handleChange with the new value', () => {
-        const selectPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Select,
-          config: { selectOptions: ['option_a', 'option_b'] },
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [selectPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const comboBoxTrigger = container.querySelector(
-          '[data-test="charge-table-cell-0-1"] [data-test="combobox-trigger"]',
-        ) as HTMLButtonElement
-
-        expect(comboBoxTrigger).toBeTruthy()
-        comboBoxTrigger.click()
-
-        expect(mockHandleChange).toHaveBeenCalled()
-      })
-    })
-
-    describe('WHEN a Boolean ComboBox value is changed', () => {
-      it('THEN should call field.handleChange with the new value', () => {
-        const boolPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Boolean,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [boolPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(createFieldCtx('privileges[0].value', ''))
-
-        const { container } = renderContent()
-
-        const comboBoxTrigger = container.querySelector(
-          '[data-test="charge-table-cell-0-1"] [data-test="combobox-trigger"]',
-        ) as HTMLButtonElement
-
-        expect(comboBoxTrigger).toBeTruthy()
-        comboBoxTrigger.click()
-
-        expect(mockHandleChange).toHaveBeenCalled()
-      })
-    })
-  })
-
-  // --- Integer field error handling ---
-
-  describe('GIVEN the Integer field error handling', () => {
-    describe('WHEN an Integer field has a validation error', () => {
-      it('THEN should show the error tooltip on TextInputField', () => {
-        const intPrivilege = {
-          ...privilegeRow,
-          valueType: PrivilegeValueTypeEnum.Integer,
-        }
-
-        mockFormValuesOverride = {
-          ...defaultFormValues,
-          privileges: [intPrivilege],
-        }
-
-        mockedUseFieldContext.mockReturnValue(
-          createFieldCtx('privileges[0].value', '', [{ message: 'text_1771342994699klxu2paz7g8' }]),
-        )
-
-        const { container } = renderContent()
-
-        const tooltip = container.querySelector(
-          '[data-test="charge-table-cell-0-1"] [data-test="mocked-tooltip"]',
-        )
-
-        expect(tooltip?.getAttribute('data-tooltip-disabled')).toBe('false')
-        expect(tooltip?.getAttribute('data-tooltip-title')).toBe(
-          'translated_text_1771342994699klxu2paz7g8',
-        )
-      })
-    })
+      expect(input).toHaveAttribute('aria-invalid', 'true')
+      expect(within(getPrivilegeRow('First privilege')).getByRole('textbox')).toHaveAttribute(
+        'aria-invalid',
+        'false',
+      )
+      await user.hover(input)
+      expect(await screen.findByRole('tooltip')).toHaveTextContent('Field is required')
+    },
+  )
+
+  it('renders a select value when options are missing', async () => {
+    const user = userEvent.setup()
+
+    renderContent([buildPrivilege({ valueType: PrivilegeValueTypeEnum.Select, value: '' })])
+
+    await user.click(screen.getByRole('combobox'))
+
+    expect(screen.queryByRole('option')).not.toBeInTheDocument()
   })
 })

--- a/src/components/plans/drawers/featureEntitlement/__tests__/PrivilegesTable.test.tsx
+++ b/src/components/plans/drawers/featureEntitlement/__tests__/PrivilegesTable.test.tsx
@@ -29,7 +29,7 @@ jest.mock('@tanstack/react-virtual', () => ({
 
 // Local privilege options do not need the search hook's loading timer.
 jest.mock('~/hooks/useDebouncedSearch', () => ({
-  useDebouncedSearch: () => ({ debouncedSearch: undefined, isLoading: false }),
+  useDebouncedSearch: () => ({ debouncedSearch: jest.fn(), isLoading: false }),
 }))
 
 jest.mock('~/components/drawers/useDrawer', () => ({

--- a/src/components/plans/form/FixedChargesSection.tsx
+++ b/src/components/plans/form/FixedChargesSection.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { useStore } from '@tanstack/react-form'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { Chip } from '~/components/designSystem/Chip'
@@ -87,7 +87,6 @@ export const FixedChargesSection = ({
   const hasAnyFixedCharge = !!fixedCharges.length
   const { openRemoveChargeWarningDialog } = useRemoveChargeWarningDialog()
   const fixedChargeDrawerRef = useRef<FixedChargeDrawerRef>(null)
-  const [alreadyUsedAddOnIds, setAlreadyUsedAddOnIds] = useState<Map<string, number>>(new Map())
 
   const handleDrawerSave = useCallback(
     (charge: LocalFixedChargeInput, index: number | null) => {
@@ -113,16 +112,17 @@ export const FixedChargesSection = ({
     [form],
   )
 
-  useEffect(() => {
-    setAlreadyUsedAddOnIds(
-      fixedCharges?.reduce((prev, curr) => {
-        const id = curr.addOn.id
+  const alreadyUsedAddOnIds = useMemo(() => {
+    const counts = new Map<string, number>()
 
-        return prev.set(id, (prev.get(id) || 0) + 1)
-      }, new Map()),
-    )
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fixedCharges?.length])
+    for (const charge of fixedCharges) {
+      const id = charge.addOn.id
+
+      counts.set(id, (counts.get(id) ?? 0) + 1)
+    }
+
+    return counts
+  }, [fixedCharges])
 
   const isAnnual = [PlanInterval.Semiannual, PlanInterval.Yearly].includes(interval)
 

--- a/src/components/plans/form/__tests__/FixedChargesSection.test.tsx
+++ b/src/components/plans/form/__tests__/FixedChargesSection.test.tsx
@@ -1,7 +1,10 @@
-import { screen } from '@testing-library/react'
+import { revalidateLogic } from '@tanstack/react-form'
+import { act, renderHook, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import { planFormSchema } from '~/formValidation/planFormSchema'
 import { ChargeModelEnum } from '~/generated/graphql'
+import { useAppForm } from '~/hooks/forms/useAppform'
 import { render } from '~/test-utils'
 import { createMockPlanForm } from '~/test-utils/createMockPlanForm'
 
@@ -202,5 +205,47 @@ describe('FixedChargesSection', () => {
         expect(screen.getByTestId('fixed-charge-selector-0')).toBeInTheDocument()
       })
     })
+  })
+})
+
+describe('Fixed charge duplicate warnings with a real form', () => {
+  it('refreshes duplicate warnings after same-length resets, additions and removals', async () => {
+    const user = userEvent.setup()
+    const first = createMockFixedCharge({ invoiceDisplayName: 'First charge' })
+    const duplicate = createMockFixedCharge({ id: 'charge-2', invoiceDisplayName: 'Second charge' })
+    const other = createMockFixedCharge({
+      id: 'charge-3',
+      invoiceDisplayName: 'Second charge',
+      addOn: { ...first.addOn, id: 'other-catalog-item' },
+    })
+    const { result } = renderHook(() =>
+      useAppForm({
+        defaultValues: createForm({ fixedCharges: [first, duplicate] }).state.values,
+        validationLogic: revalidateLogic(),
+        validators: { onDynamic: planFormSchema },
+      }),
+    )
+    const form = result.current
+
+    render(<FixedChargesSection form={form} alreadyExistingFixedChargesIds={[]} />)
+
+    const expectWarning = async (expected: string | undefined): Promise<void> => {
+      await user.click(screen.getByText('First charge'))
+      expect(mockOpenDrawer).toHaveBeenLastCalledWith(
+        first,
+        0,
+        expect.objectContaining({ alreadyUsedChargeAlertMessage: expected }),
+      )
+    }
+
+    await expectWarning('translated_text_1760729707268h378x60alri')
+    act(() => form.reset({ ...form.state.values, fixedCharges: [first, other] }))
+    await expectWarning(undefined)
+    act(() => form.reset({ ...form.state.values, fixedCharges: [first, duplicate] }))
+    await expectWarning('translated_text_1760729707268h378x60alri')
+    await act(async () => form.removeFieldValue('fixedCharges', 1))
+    await expectWarning(undefined)
+    act(() => form.pushFieldValue('fixedCharges', duplicate))
+    await expectWarning('translated_text_1760729707268h378x60alri')
   })
 })

--- a/src/hooks/plans/__tests__/useChargeMutationsWithCascade.test.tsx
+++ b/src/hooks/plans/__tests__/useChargeMutationsWithCascade.test.tsx
@@ -6,11 +6,12 @@ import { ReactNode } from 'react'
 
 import { FORM_DIALOG_NAME } from '~/components/dialogs/const'
 import FormDialog from '~/components/dialogs/FormDialog'
-import { LocalUsageChargeInput } from '~/components/plans/types'
+import { LocalPricingUnitType, LocalUsageChargeInput } from '~/components/plans/types'
 import { FORM_ERRORS_ENUM } from '~/core/constants/form'
 import {
   ChargeCreateInput,
   ChargeModelEnum,
+  ChargeUpdateInput,
   CreateChargeDocument,
   CurrencyEnum,
   DestroyChargeDocument,
@@ -92,6 +93,96 @@ const wrapper = (mocks: MockedResponse[]) =>
   }
 
 describe('useChargeMutationsWithCascade', () => {
+  it.each([
+    { currency: CurrencyEnum.Usd, payInAdvance: false, expectedMinimum: 1234 },
+    { currency: CurrencyEnum.Jpy, payInAdvance: false, expectedMinimum: 12 },
+    { currency: CurrencyEnum.Usd, payInAdvance: true, expectedMinimum: undefined },
+  ])(
+    'keeps create and update fields equal for $currency, payInAdvance=$payInAdvance',
+    async ({ currency, payInAdvance, expectedMinimum }) => {
+      let createInput: ChargeCreateInput | undefined
+      let updateInput: ChargeUpdateInput | undefined
+      const mocks: MockedResponse[] = [
+        {
+          request: { query: CreateChargeDocument },
+          variableMatcher: (vars) => {
+            createInput = vars.input
+            return true
+          },
+          result: { data: { createCharge: chargeResult } },
+        },
+        {
+          request: { query: UpdateChargeDocument },
+          variableMatcher: (vars) => {
+            updateInput = vars.input
+            return true
+          },
+          result: { data: { updateCharge: chargeResult } },
+        },
+      ]
+      const charge = buildCharge({
+        code: 'api_custom',
+        invoiceDisplayName: 'Custom usage',
+        payInAdvance,
+        prorated: true,
+        minAmountCents: currency === CurrencyEnum.Jpy ? '12' : '12.34',
+        appliedPricingUnit: {
+          type: LocalPricingUnitType.Custom,
+          code: 'credits',
+          shortName: 'cr',
+          conversionRate: '2.5',
+        },
+        taxes: [{ id: 'tax_1', code: 'vat', name: 'VAT', rate: 20 }],
+        filters: [
+          {
+            values: ['{"region":"eu"}'],
+            invoiceDisplayName: 'Europe',
+            properties: { amount: '15' },
+          },
+        ],
+      })
+      const { result } = renderHook(
+        () =>
+          useChargeMutationsWithCascade({ planId: PLAN_ID, hasOverriddenPlans: false, currency }),
+        { wrapper: wrapper(mocks) },
+      )
+
+      await act(async () => {
+        await result.current.handleSaveCharge(charge, null)
+        await result.current.handleSaveCharge({ ...charge, id: 'ch_1' }, 0)
+      })
+
+      expect(createInput).toMatchObject({ planId: PLAN_ID, billableMetricId: 'bm_1' })
+      if (!createInput) throw new Error('Missing create input')
+
+      const { planId, billableMetricId, ...fields } = createInput
+
+      expect(planId).toBe(PLAN_ID)
+      expect(billableMetricId).toBe('bm_1')
+      expect(updateInput).toEqual({ id: 'ch_1', ...fields })
+      expect(fields).toMatchObject({
+        code: 'api_custom',
+        chargeModel: ChargeModelEnum.Standard,
+        invoiceDisplayName: 'Custom usage',
+        invoiceable: true,
+        appliedPricingUnit: { code: 'credits', conversionRate: 2.5 },
+        minAmountCents: expectedMinimum,
+        payInAdvance,
+        prorated: true,
+        cascadeUpdates: false,
+        taxCodes: ['vat'],
+        properties: { amount: '10' },
+        filters: [
+          {
+            values: { region: ['eu'] },
+            invoiceDisplayName: 'Europe',
+            properties: { amount: '15' },
+          },
+        ],
+      })
+    },
+  )
+
   it('createCharge fires direct when hasOverriddenPlans=false', async () => {
     let called = false
     const createMock: MockedResponse = {

--- a/src/hooks/plans/__tests__/useFixedChargeMutationsWithCascade.test.tsx
+++ b/src/hooks/plans/__tests__/useFixedChargeMutationsWithCascade.test.tsx
@@ -13,6 +13,7 @@ import {
   DestroyFixedChargeDocument,
   FixedChargeChargeModelEnum,
   FixedChargeCreateInput,
+  FixedChargeUpdateInput,
   PropertiesInput,
   UpdateFixedChargeDocument,
 } from '~/generated/graphql'
@@ -75,6 +76,69 @@ const wrapper = (mocks: MockedResponse[]) =>
   }
 
 describe('useFixedChargeMutationsWithCascade', () => {
+  it.each(['2.5', '0'])('keeps create and update fields equal for units=%s', async (units) => {
+    let createInput: FixedChargeCreateInput | undefined
+    let updateInput: FixedChargeUpdateInput | undefined
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: CreateFixedChargeDocument },
+        variableMatcher: (vars) => {
+          createInput = vars.input
+          return true
+        },
+        result: { data: { createFixedCharge: fixedChargeResult } },
+      },
+      {
+        request: { query: UpdateFixedChargeDocument },
+        variableMatcher: (vars) => {
+          updateInput = vars.input
+          return true
+        },
+        result: { data: { updateFixedCharge: fixedChargeResult } },
+      },
+    ]
+    const charge = buildCharge({
+      code: 'setup_custom',
+      invoiceDisplayName: 'Custom setup',
+      units,
+      applyUnitsImmediately: true,
+      payInAdvance: true,
+      prorated: true,
+      properties: { amount: '12.34' },
+      taxes: [{ id: 'tax_1', code: 'vat', name: 'VAT', rate: 20 }],
+    })
+    const { result } = renderHook(
+      () => useFixedChargeMutationsWithCascade({ planId: PLAN_ID, hasOverriddenPlans: false }),
+      { wrapper: wrapper(mocks) },
+    )
+
+    await act(async () => {
+      await result.current.handleSaveCharge(charge, null)
+      await result.current.handleSaveCharge({ ...charge, id: 'fc_1' }, 0)
+    })
+
+    expect(createInput).toMatchObject({ planId: PLAN_ID, addOnId: 'addon_1' })
+    if (!createInput) throw new Error('Missing create input')
+
+    const { planId, addOnId, ...fields } = createInput
+
+    expect(planId).toBe(PLAN_ID)
+    expect(addOnId).toBe('addon_1')
+    expect(updateInput).toEqual({ id: 'fc_1', ...fields })
+    expect(fields).toEqual({
+      code: 'setup_custom',
+      chargeModel: FixedChargeChargeModelEnum.Standard,
+      invoiceDisplayName: 'Custom setup',
+      units,
+      applyUnitsImmediately: true,
+      payInAdvance: true,
+      prorated: true,
+      cascadeUpdates: false,
+      properties: { amount: '12.34' },
+      taxCodes: ['vat'],
+    })
+  })
+
   it('createFixedCharge fires direct when hasOverriddenPlans=false', async () => {
     let called = false
 

--- a/src/hooks/plans/useChargeMutationsWithCascade.ts
+++ b/src/hooks/plans/useChargeMutationsWithCascade.ts
@@ -60,6 +60,31 @@ const serializeAppliedPricingUnit = (
         conversionRate: Number(appliedPricingUnit.conversionRate),
       }
 
+const serializeUsageChargeFields = (
+  charge: LocalUsageChargeInput,
+  currency: CurrencyEnum,
+  cascadeUpdates: boolean,
+): Omit<ChargeCreateInput, 'planId' | 'billableMetricId'> => ({
+  chargeModel: charge.chargeModel,
+  code: charge.code || undefined,
+  appliedPricingUnit: serializeAppliedPricingUnit(charge.appliedPricingUnit),
+  invoiceDisplayName: charge.invoiceDisplayName || undefined,
+  invoiceable: charge.invoiceable,
+  minAmountCents:
+    !!charge.minAmountCents && !charge.payInAdvance
+      ? Number(serializeAmount(charge.minAmountCents, currency) || 0)
+      : undefined,
+  payInAdvance: charge.payInAdvance || false,
+  prorated: charge.prorated || false,
+  regroupPaidFees: charge.regroupPaidFees || undefined,
+  taxCodes: charge.taxes?.map((t) => t.code) ?? [],
+  properties: charge.properties
+    ? serializeProperties(charge.properties, charge.chargeModel)
+    : undefined,
+  filters: serializeFilters(charge.filters, charge.chargeModel),
+  cascadeUpdates,
+})
+
 export const useChargeMutationsWithCascade = ({ planId, hasOverriddenPlans, currency }: Args) => {
   const { translate } = useInternationalization()
   const { openCascadeDialog } = useCascadeFormDialog()
@@ -108,24 +133,7 @@ export const useChargeMutationsWithCascade = ({ planId, hasOverriddenPlans, curr
   ): ChargeCreateInput => ({
     planId,
     billableMetricId: charge.billableMetric.id,
-    chargeModel: charge.chargeModel,
-    code: charge.code || undefined,
-    appliedPricingUnit: serializeAppliedPricingUnit(charge.appliedPricingUnit),
-    invoiceDisplayName: charge.invoiceDisplayName || undefined,
-    invoiceable: charge.invoiceable,
-    minAmountCents:
-      !!charge.minAmountCents && !charge.payInAdvance
-        ? Number(serializeAmount(charge.minAmountCents, currency) || 0)
-        : undefined,
-    payInAdvance: charge.payInAdvance || false,
-    prorated: charge.prorated || false,
-    regroupPaidFees: charge.regroupPaidFees || undefined,
-    taxCodes: charge.taxes?.map((t) => t.code) ?? [],
-    properties: charge.properties
-      ? serializeProperties(charge.properties, charge.chargeModel)
-      : undefined,
-    filters: serializeFilters(charge.filters, charge.chargeModel),
-    cascadeUpdates,
+    ...serializeUsageChargeFields(charge, currency, cascadeUpdates),
   })
 
   const buildUpdateInput = (
@@ -133,24 +141,7 @@ export const useChargeMutationsWithCascade = ({ planId, hasOverriddenPlans, curr
     cascadeUpdates: boolean,
   ): ChargeUpdateInput => ({
     id: charge.id ?? '',
-    chargeModel: charge.chargeModel,
-    code: charge.code || undefined,
-    appliedPricingUnit: serializeAppliedPricingUnit(charge.appliedPricingUnit),
-    invoiceDisplayName: charge.invoiceDisplayName || undefined,
-    invoiceable: charge.invoiceable,
-    minAmountCents:
-      !!charge.minAmountCents && !charge.payInAdvance
-        ? Number(serializeAmount(charge.minAmountCents, currency) || 0)
-        : undefined,
-    payInAdvance: charge.payInAdvance || false,
-    prorated: charge.prorated || false,
-    regroupPaidFees: charge.regroupPaidFees || undefined,
-    taxCodes: charge.taxes?.map((t) => t.code) ?? [],
-    properties: charge.properties
-      ? serializeProperties(charge.properties, charge.chargeModel)
-      : undefined,
-    filters: serializeFilters(charge.filters, charge.chargeModel),
-    cascadeUpdates,
+    ...serializeUsageChargeFields(charge, currency, cascadeUpdates),
   })
 
   const handleSaveCharge = async (

--- a/src/hooks/plans/useFixedChargeMutationsWithCascade.ts
+++ b/src/hooks/plans/useFixedChargeMutationsWithCascade.ts
@@ -47,6 +47,32 @@ type Args = {
   hasOverriddenPlans: boolean
 }
 
+const serializeFixedChargeFields = (
+  charge: LocalFixedChargeInput,
+  cascadeUpdates: boolean,
+): Omit<FixedChargeCreateInput, 'planId' | 'addOnId'> => ({
+  chargeModel: charge.chargeModel,
+  code: charge.code || undefined,
+  invoiceDisplayName: charge.invoiceDisplayName || undefined,
+  payInAdvance: charge.payInAdvance ?? false,
+  properties: charge.properties
+    ? serializeFixedChargeProperties(charge.properties, charge.chargeModel)
+    : undefined,
+  prorated: charge.prorated ?? false,
+  units: charge.units ? String(charge.units) : '0',
+  taxCodes: charge.taxes?.map((t) => t.code) ?? [],
+  applyUnitsImmediately: charge.applyUnitsImmediately ?? false,
+  cascadeUpdates,
+})
+
+const buildUpdateInput = (
+  charge: LocalFixedChargeInput,
+  cascadeUpdates: boolean,
+): FixedChargeUpdateInput => ({
+  id: charge.id ?? '',
+  ...serializeFixedChargeFields(charge, cascadeUpdates),
+})
+
 export const useFixedChargeMutationsWithCascade = ({ planId, hasOverriddenPlans }: Args) => {
   const { translate } = useInternationalization()
   const { openCascadeDialog } = useCascadeFormDialog()
@@ -104,37 +130,7 @@ export const useFixedChargeMutationsWithCascade = ({ planId, hasOverriddenPlans 
   ): FixedChargeCreateInput => ({
     planId,
     addOnId: charge.addOn.id,
-    chargeModel: charge.chargeModel,
-    code: charge.code || undefined,
-    invoiceDisplayName: charge.invoiceDisplayName || undefined,
-    payInAdvance: charge.payInAdvance ?? false,
-    properties: charge.properties
-      ? serializeFixedChargeProperties(charge.properties, charge.chargeModel)
-      : undefined,
-    prorated: charge.prorated ?? false,
-    units: charge.units ? String(charge.units) : '0',
-    taxCodes: charge.taxes?.map((t) => t.code) ?? [],
-    applyUnitsImmediately: charge.applyUnitsImmediately ?? false,
-    cascadeUpdates,
-  })
-
-  const buildUpdateInput = (
-    charge: LocalFixedChargeInput,
-    cascadeUpdates: boolean,
-  ): FixedChargeUpdateInput => ({
-    id: charge.id ?? '',
-    chargeModel: charge.chargeModel,
-    code: charge.code || undefined,
-    invoiceDisplayName: charge.invoiceDisplayName || undefined,
-    payInAdvance: charge.payInAdvance ?? false,
-    properties: charge.properties
-      ? serializeFixedChargeProperties(charge.properties, charge.chargeModel)
-      : undefined,
-    prorated: charge.prorated ?? false,
-    units: charge.units ? String(charge.units) : '0',
-    taxCodes: charge.taxes?.map((t) => t.code) ?? [],
-    applyUnitsImmediately: charge.applyUnitsImmediately ?? false,
-    cascadeUpdates,
+    ...serializeFixedChargeFields(charge, cascadeUpdates),
   })
 
   const handleSaveCharge = async (

--- a/src/hooks/plans/usePlanFormSetup.ts
+++ b/src/hooks/plans/usePlanFormSetup.ts
@@ -188,17 +188,16 @@ export const usePlanFormSetup = ({
   }, [effectivePlan, billingItemData, formType, currency, hasAnyPricingUnitConfigured, form])
 
   // Auto-reset billChargesMonthly when conditions aren't met
-  const charges = useStore(form.store, (s) => s.values.charges)
+  const hasCharges = useStore(form.store, (s) => s.values.charges.length > 0)
   const billChargesMonthly = useStore(form.store, (s) => s.values.billChargesMonthly)
   const interval = useStore(form.store, (s) => s.values.interval)
   const isAnnual = isPlanIntervalAnnual(interval)
 
   useEffect(() => {
-    if ((!charges?.length || !isAnnual) && !!billChargesMonthly) {
+    if ((!hasCharges || !isAnnual) && billChargesMonthly) {
       form.setFieldValue('billChargesMonthly', false)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [charges, billChargesMonthly, interval])
+  }, [hasCharges, billChargesMonthly, isAnnual, form])
 
   const loading = planLoading || (!!subscriptionId && !subscriptionData && !billingItemPlan)
 


### PR DESCRIPTION
Refresh duplicate-charge warnings when charges are replaced by a collection of the same length. Keep quote pricing callbacks connected to current form values without subscribing the whole content to nested changes, and make plan setup observe charge presence so billing resets stay current.

Share typed serializers across usage and fixed charge create/update mutations. Exercise privilege controls and plan setup through their real form bindings so the tests cover field updates and subscriptions.
