### PR TITLE
test: cover settings navigation and persisted subscription cancellation

### DIFF
--- a/cypress/e2e/t10-add-subscription.cy.ts
+++ b/cypress/e2e/t10-add-subscription.cy.ts
@@ -1,5 +1,12 @@
 import { DateTime } from 'luxon'
 
+import { CENTRALIZED_DIALOG_CONFIRM_BUTTON_TEST_ID } from '~/components/dialogs/const'
+import {
+  SUBSCRIPTION_DETAILS_ACTIONS_TEST_ID,
+  SUBSCRIPTION_DETAILS_CANCEL_TEST_ID,
+  SUBSCRIPTION_INFORMATION_FIELDS_TEST_ID,
+} from '~/components/subscriptions/subscriptionTestIds'
+
 import { customerName } from '../support/reusableConstants'
 
 describe('Subscriptions', () => {
@@ -16,11 +23,11 @@ describe('Subscriptions', () => {
     cy.get(`[data-test="add-subscription"]`).click({ force: true })
     cy.url().should('include', '/create/subscription')
 
-    // Submit without selecting a plan — should show validation error
+    // Submit without selecting a plan to show validation error
     cy.get('[data-test="submit"]').should('not.be.disabled').click()
     cy.get('input[name="planId"]').should('exist')
 
-    // Select a plan from the combobox — form sections appear
+    // Select a plan from the combobox to show form sections
     cy.get('input[name="planId"]').click({ force: true })
     cy.get('[data-option-index="0"]', { timeout: 10000 }).click({ force: true })
 
@@ -44,11 +51,45 @@ describe('Subscriptions', () => {
     cy.get(`[data-test="${subscriptionName}"]`).should('exist')
     cy.get(`[data-test="${subscriptionName}"]`).click({ force: true })
 
-    cy.get('[data-test="status"]').should('have.text', 'Pending')
-    cy.get('[data-test="subscription-details-actions"]').click()
-    cy.get('[data-test="subscription-details-cancel"]').click()
+    cy.get(`[data-test="${SUBSCRIPTION_INFORMATION_FIELDS_TEST_ID}"]`)
+      .should('contain.text', subscriptionName)
+      .and('contain.text', 'Pending')
 
-    // Pending subscriptions use a CentralizedDialog (not FormDialog)
-    cy.get('[data-test="centralized-confirm"]').click({ force: true })
+    cy.location('pathname').then((pathname) => {
+      const subscriptionPath = pathname.replace(/^\/[^/]+/, '')
+
+      cy.intercept('POST', '**/graphql', (request) => {
+        if (request.body.operationName === 'terminateCustomerSubscription') {
+          request.alias = 'cancelSubscription'
+        }
+      })
+
+      cy.get(`[data-test="${SUBSCRIPTION_DETAILS_ACTIONS_TEST_ID}"]`).click()
+      cy.get(`[data-test="${SUBSCRIPTION_DETAILS_CANCEL_TEST_ID}"]`).click()
+      cy.get(`[data-test="${CENTRALIZED_DIALOG_CONFIRM_BUTTON_TEST_ID}"]`).click()
+
+      cy.wait('@cancelSubscription')
+        .its('response.body.data.terminateSubscription.status')
+        .should('eq', 'canceled')
+      cy.location('pathname').should('match', /^\/[^/]+\/customer\/[^/]+$/)
+
+      cy.visitApp(subscriptionPath)
+      cy.get(`[data-test="${SUBSCRIPTION_INFORMATION_FIELDS_TEST_ID}"]`)
+        .should('contain.text', subscriptionName)
+        .and('contain.text', 'Canceled')
+
+      cy.intercept('POST', '**/graphql', (request) => {
+        if (request.body.operationName === 'getSubscriptionForDetails') {
+          request.alias = 'reloadedSubscription'
+        }
+      })
+      cy.reload()
+      cy.wait('@reloadedSubscription')
+        .its('response.body.data.subscription')
+        .should('include', { name: subscriptionName, status: 'canceled' })
+      cy.get(`[data-test="${SUBSCRIPTION_INFORMATION_FIELDS_TEST_ID}"]`)
+        .should('contain.text', subscriptionName)
+        .and('contain.text', 'Canceled')
+    })
   })
 })

--- a/src/components/subscriptions/SubscriptionInformationFields.tsx
+++ b/src/components/subscriptions/SubscriptionInformationFields.tsx
@@ -26,6 +26,8 @@ import {
 import { TranslateFunc, useInternationalization } from '~/hooks/core/useInternationalization'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
+import { SUBSCRIPTION_INFORMATION_FIELDS_TEST_ID } from './subscriptionTestIds'
+
 gql`
   fragment SubscriptionInformationFields on Subscription {
     id
@@ -271,7 +273,10 @@ export const SubscriptionInformationFields = ({
   const parentPlanId = subscription?.plan?.parent?.id
 
   return (
-    <div className="flex max-w-168 flex-col gap-4">
+    <div
+      className="flex max-w-168 flex-col gap-4"
+      data-test={SUBSCRIPTION_INFORMATION_FIELDS_TEST_ID}
+    >
       <SubscriptionDetailAlerts subscription={subscription} />
 
       <DetailsPage.InfoGridItem

--- a/src/components/subscriptions/subscriptionTestIds.ts
+++ b/src/components/subscriptions/subscriptionTestIds.ts
@@ -1,0 +1,3 @@
+export const SUBSCRIPTION_DETAILS_ACTIONS_TEST_ID = 'subscription-details-actions'
+export const SUBSCRIPTION_DETAILS_CANCEL_TEST_ID = 'subscription-details-cancel'
+export const SUBSCRIPTION_INFORMATION_FIELDS_TEST_ID = 'subscription-information-fields'

--- a/src/core/router/__tests__/SettingRoutes.test.tsx
+++ b/src/core/router/__tests__/SettingRoutes.test.tsx
@@ -1,142 +1,62 @@
-// Test route constants without importing the full module to avoid circular dependencies
-describe('SettingRoutes', () => {
-  // Define expected route constants locally to validate structure
-  const SETTINGS_ROUTE = '/settings'
-  const INVOICE_SETTINGS_ROUTE = `${SETTINGS_ROUTE}/invoice-sections`
-  const TAXES_SETTINGS_ROUTE = `${SETTINGS_ROUTE}/taxes`
-  const ROOT_INTEGRATIONS_ROUTE = `${SETTINGS_ROUTE}/integrations`
-  const INTEGRATIONS_ROUTE = `${ROOT_INTEGRATIONS_ROUTE}/:integrationGroup`
-  const MEMBERS_ROUTE = `${SETTINGS_ROUTE}/members`
-  const MEMBERS_TAB_ROUTE = `${SETTINGS_ROUTE}/members/:tab`
-  const AUTHENTICATION_ROUTE = `${SETTINGS_ROUTE}/authentication`
-  const OKTA_AUTHENTICATION_ROUTE = `${AUTHENTICATION_ROUTE}/okta/:integrationId`
-  const ENTRA_ID_AUTHENTICATION_ROUTE = `${AUTHENTICATION_ROUTE}/entra/:integrationId`
-  const DUNNINGS_SETTINGS_ROUTE = `${SETTINGS_ROUTE}/dunnings`
-  const BILLING_ENTITY_BASE = `${SETTINGS_ROUTE}/billing-entity`
-  const BILLING_ENTITY_BASE_WITH_CODE = `${BILLING_ENTITY_BASE}/:billingEntityCode`
-  const BILLING_ENTITY_ROUTE = BILLING_ENTITY_BASE_WITH_CODE
-  const BILLING_ENTITY_GENERAL_ROUTE = `${BILLING_ENTITY_BASE_WITH_CODE}/general`
-  const BILLING_ENTITY_EMAIL_SCENARIOS_ROUTE = `${BILLING_ENTITY_BASE_WITH_CODE}/email-scenarios`
-  const BILLING_ENTITY_EMAIL_SCENARIOS_CONFIG_ROUTE = `${BILLING_ENTITY_BASE_WITH_CODE}/email-scenarios/:type`
-  const BILLING_ENTITY_DUNNING_CAMPAIGNS_ROUTE = `${BILLING_ENTITY_BASE_WITH_CODE}/dunning-campaigns`
-  const BILLING_ENTITY_INVOICE_SETTINGS_ROUTE = `${BILLING_ENTITY_BASE_WITH_CODE}/invoice-settings`
-  const BILLING_ENTITY_INVOICE_CUSTOM_SECTIONS_ROUTE = `${BILLING_ENTITY_BASE_WITH_CODE}/invoice-custom-sections`
-  const BILLING_ENTITY_TAXES_SETTINGS_ROUTE = `${BILLING_ENTITY_BASE_WITH_CODE}/taxes`
-  const ROLES_LIST_ROUTE = `${SETTINGS_ROUTE}/roles`
-  const ROLE_DETAILS_ROUTE = `${ROLES_LIST_ROUTE}/:roleId`
-  const ROLE_CREATE_ROUTE = `${ROLES_LIST_ROUTE}/create`
-  const ROLE_EDIT_ROUTE = `${ROLES_LIST_ROUTE}/:roleId/edit`
-  const BILLING_ENTITY_CREATE_ROUTE = `${BILLING_ENTITY_BASE}/create`
-  const BILLING_ENTITY_UPDATE_ROUTE = `${BILLING_ENTITY_BASE_WITH_CODE}/edit`
-  const CREATE_DUNNING_ROUTE = `${SETTINGS_ROUTE}/dunnings/create`
-  const UPDATE_DUNNING_ROUTE = `${SETTINGS_ROUTE}/dunnings/:campaignId/edit`
-  const CREATE_INVOICE_CUSTOM_SECTION = `${INVOICE_SETTINGS_ROUTE}/custom-section/create`
-  const EDIT_INVOICE_CUSTOM_SECTION = `${INVOICE_SETTINGS_ROUTE}/custom-section/:sectionId/edit`
-  const CREATE_PRICING_UNIT = `${INVOICE_SETTINGS_ROUTE}/pricing-unit/create`
-  const EDIT_PRICING_UNIT = `${INVOICE_SETTINGS_ROUTE}/pricing-unit/:pricingUnitId/edit`
+import { matchRoutes } from 'react-router-dom'
 
-  describe('route constants', () => {
-    it('defines base settings route', () => {
-      expect(SETTINGS_ROUTE).toBe('/settings')
-    })
+import {
+  OKTA_AUTHENTICATION_ROUTE,
+  ROLE_CREATE_ROUTE,
+  ROLE_DETAILS_ROUTE,
+  ROLE_EDIT_ROUTE,
+  settingRoutes,
+  TEAM_AND_SECURITY_GROUP_ROUTE,
+} from '../SettingRoutes'
 
-    it('defines organization settings routes', () => {
-      expect(INVOICE_SETTINGS_ROUTE).toBe('/settings/invoice-sections')
-      expect(TAXES_SETTINGS_ROUTE).toBe('/settings/taxes')
-      expect(ROOT_INTEGRATIONS_ROUTE).toBe('/settings/integrations')
-      expect(INTEGRATIONS_ROUTE).toBe('/settings/integrations/:integrationGroup')
-      expect(MEMBERS_ROUTE).toBe('/settings/members')
-      expect(MEMBERS_TAB_ROUTE).toBe('/settings/members/:tab')
-      expect(DUNNINGS_SETTINGS_ROUTE).toBe('/settings/dunnings')
-    })
+const routes = settingRoutes
+  .flatMap((route) => route.children ?? [route])
+  .flatMap((route) => {
+    const paths = Array.isArray(route.path) ? route.path : [route.path]
 
-    it('defines authentication routes', () => {
-      expect(AUTHENTICATION_ROUTE).toBe('/settings/authentication')
-      expect(OKTA_AUTHENTICATION_ROUTE).toBe('/settings/authentication/okta/:integrationId')
-      expect(ENTRA_ID_AUTHENTICATION_ROUTE).toBe('/settings/authentication/entra/:integrationId')
-    })
-
-    it('defines billing entity routes', () => {
-      expect(BILLING_ENTITY_ROUTE).toBe('/settings/billing-entity/:billingEntityCode')
-      expect(BILLING_ENTITY_GENERAL_ROUTE).toBe(
-        '/settings/billing-entity/:billingEntityCode/general',
-      )
-      expect(BILLING_ENTITY_EMAIL_SCENARIOS_ROUTE).toBe(
-        '/settings/billing-entity/:billingEntityCode/email-scenarios',
-      )
-      expect(BILLING_ENTITY_EMAIL_SCENARIOS_CONFIG_ROUTE).toBe(
-        '/settings/billing-entity/:billingEntityCode/email-scenarios/:type',
-      )
-      expect(BILLING_ENTITY_DUNNING_CAMPAIGNS_ROUTE).toBe(
-        '/settings/billing-entity/:billingEntityCode/dunning-campaigns',
-      )
-      expect(BILLING_ENTITY_INVOICE_SETTINGS_ROUTE).toBe(
-        '/settings/billing-entity/:billingEntityCode/invoice-settings',
-      )
-      expect(BILLING_ENTITY_INVOICE_CUSTOM_SECTIONS_ROUTE).toBe(
-        '/settings/billing-entity/:billingEntityCode/invoice-custom-sections',
-      )
-      expect(BILLING_ENTITY_TAXES_SETTINGS_ROUTE).toBe(
-        '/settings/billing-entity/:billingEntityCode/taxes',
-      )
-    })
-
-    it('defines roles routes', () => {
-      expect(ROLES_LIST_ROUTE).toBe('/settings/roles')
-      expect(ROLE_DETAILS_ROUTE).toBe('/settings/roles/:roleId')
-      expect(ROLE_CREATE_ROUTE).toBe('/settings/roles/create')
-      expect(ROLE_EDIT_ROUTE).toBe('/settings/roles/:roleId/edit')
-    })
-
-    it('defines creation routes', () => {
-      expect(BILLING_ENTITY_CREATE_ROUTE).toBe('/settings/billing-entity/create')
-      expect(BILLING_ENTITY_UPDATE_ROUTE).toBe('/settings/billing-entity/:billingEntityCode/edit')
-      expect(CREATE_DUNNING_ROUTE).toBe('/settings/dunnings/create')
-      expect(UPDATE_DUNNING_ROUTE).toBe('/settings/dunnings/:campaignId/edit')
-      expect(CREATE_INVOICE_CUSTOM_SECTION).toBe('/settings/invoice-sections/custom-section/create')
-      expect(EDIT_INVOICE_CUSTOM_SECTION).toBe(
-        '/settings/invoice-sections/custom-section/:sectionId/edit',
-      )
-      expect(CREATE_PRICING_UNIT).toBe('/settings/invoice-sections/pricing-unit/create')
-      expect(EDIT_PRICING_UNIT).toBe('/settings/invoice-sections/pricing-unit/:pricingUnitId/edit')
-    })
+    return paths.map((path) => ({ path, handle: route }))
   })
 
-  describe('route structure validation', () => {
-    it('all settings routes follow consistent pattern', () => {
-      // All settings routes should start with /settings
-      expect(SETTINGS_ROUTE).toMatch(/^\/settings$/)
-      expect(INVOICE_SETTINGS_ROUTE).toMatch(/^\/settings\//)
-      expect(TAXES_SETTINGS_ROUTE).toMatch(/^\/settings\//)
-      expect(MEMBERS_ROUTE).toMatch(/^\/settings\//)
-      expect(DUNNINGS_SETTINGS_ROUTE).toMatch(/^\/settings\//)
-      expect(BILLING_ENTITY_ROUTE).toMatch(/^\/settings\//)
-      expect(ROLES_LIST_ROUTE).toMatch(/^\/settings\//)
-    })
+describe('settings route resolution', () => {
+  it.each([
+    {
+      url: '/settings/team-and-security/roles/billing-manager',
+      path: ROLE_DETAILS_ROUTE,
+      permissions: ['rolesView'],
+    },
+    {
+      url: '/settings/team-and-security/roles/create',
+      path: ROLE_CREATE_ROUTE,
+      permissionsOr: ['rolesCreate', 'rolesUpdate'],
+    },
+    {
+      url: '/settings/team-and-security/roles/billing-manager/edit',
+      path: ROLE_EDIT_ROUTE,
+      permissionsOr: ['rolesCreate', 'rolesUpdate'],
+    },
+    {
+      url: '/settings/team-and-security/roles',
+      path: TEAM_AND_SECURITY_GROUP_ROUTE,
+      permissionsOr: [
+        'organizationMembersView',
+        'rolesView',
+        'authenticationMethodsView',
+        'securityLogsView',
+      ],
+    },
+    {
+      url: '/settings/team-and-security/authentication/okta/okta-id',
+      path: OKTA_AUTHENTICATION_ROUTE,
+      permissions: ['organizationIntegrationsView', 'authenticationMethodsView'],
+    },
+  ])('resolves $url with its access requirements', ({ url, path, ...permissions }) => {
+    const match = matchRoutes(routes, url)?.at(-1)
 
-    it('route parameter patterns use colons', () => {
-      expect(BILLING_ENTITY_ROUTE).toContain(':billingEntityCode')
-      expect(ROLE_DETAILS_ROUTE).toContain(':roleId')
-      expect(OKTA_AUTHENTICATION_ROUTE).toContain(':integrationId')
-      expect(ENTRA_ID_AUTHENTICATION_ROUTE).toContain(':integrationId')
-      expect(EDIT_INVOICE_CUSTOM_SECTION).toContain(':sectionId')
-      expect(EDIT_PRICING_UNIT).toContain(':pricingUnitId')
-    })
+    expect(match?.route.path).toBe(path)
+    expect(match?.route.handle).toMatchObject({ private: true, ...permissions })
+  })
 
-    it('creation routes use consistent naming', () => {
-      expect(CREATE_DUNNING_ROUTE).toContain('/create')
-      expect(CREATE_INVOICE_CUSTOM_SECTION).toContain('/create')
-      expect(CREATE_PRICING_UNIT).toContain('/create')
-      expect(BILLING_ENTITY_CREATE_ROUTE).toContain('/create')
-      expect(ROLE_CREATE_ROUTE).toContain('/create')
-    })
-
-    it('edit routes use consistent naming', () => {
-      expect(UPDATE_DUNNING_ROUTE).toContain('/edit')
-      expect(EDIT_INVOICE_CUSTOM_SECTION).toContain('/edit')
-      expect(EDIT_PRICING_UNIT).toContain('/edit')
-      expect(BILLING_ENTITY_UPDATE_ROUTE).toContain('/edit')
-      expect(ROLE_EDIT_ROUTE).toContain('/edit')
-    })
+  it('does not resolve the obsolete roles URL outside team and security', () => {
+    expect(matchRoutes(routes, '/settings/roles/billing-manager')).toBeNull()
   })
 })

--- a/src/layouts/MainNavLayout/__tests__/OrganizationSwitcher.test.tsx
+++ b/src/layouts/MainNavLayout/__tests__/OrganizationSwitcher.test.tsx
@@ -5,11 +5,8 @@ import { render } from '~/test-utils'
 
 import {
   ORGANIZATION_SWITCHER_BUTTON_TEST_ID,
-  ORGANIZATION_SWITCHER_LOGOUT_TEST_ID,
   ORGANIZATION_SWITCHER_NAME_TEST_ID,
-  ORGANIZATION_SWITCHER_ORG_ITEM_TEST_ID,
   ORGANIZATION_SWITCHER_TEST_ID,
-  ORGANIZATION_SWITCHER_VERSION_LINK_TEST_ID,
   OrganizationSwitcher,
 } from '../OrganizationSwitcher'
 
@@ -66,10 +63,7 @@ describe('OrganizationSwitcher', () => {
     authenticatedMethod: 'EMAIL',
   }
 
-  // Visual identity in OrganizationSwitcher is now derived from the URL slug
-  // (`useParams().organizationSlug`) + `currentUser.memberships`. Tests must
-  // mock `organizationSlug` so the lookup resolves to a membership.
-  const renderOptions = { useParams: { organizationSlug: 'test-org' } }
+  const renderOptions = { useParams: { organizationSlug: 'another-org' } }
 
   const defaultProps = {
     client: mockClient,
@@ -87,32 +81,6 @@ describe('OrganizationSwitcher', () => {
     jest.clearAllMocks()
   })
 
-  describe('Test ID constants', () => {
-    it('exports expected test ID constants', () => {
-      expect(ORGANIZATION_SWITCHER_TEST_ID).toBe('organization-switcher')
-      expect(ORGANIZATION_SWITCHER_BUTTON_TEST_ID).toBe('side-nav-user-infos')
-      expect(ORGANIZATION_SWITCHER_NAME_TEST_ID).toBe('side-nav-name')
-      expect(ORGANIZATION_SWITCHER_LOGOUT_TEST_ID).toBe('side-nav-logout')
-      expect(ORGANIZATION_SWITCHER_ORG_ITEM_TEST_ID).toBe('organization-switcher-org-item')
-      expect(ORGANIZATION_SWITCHER_VERSION_LINK_TEST_ID).toBe('organization-switcher-version-link')
-    })
-
-    it('test ID constants follow kebab-case naming convention', () => {
-      const testIds = [
-        ORGANIZATION_SWITCHER_TEST_ID,
-        ORGANIZATION_SWITCHER_BUTTON_TEST_ID,
-        ORGANIZATION_SWITCHER_NAME_TEST_ID,
-        ORGANIZATION_SWITCHER_LOGOUT_TEST_ID,
-        ORGANIZATION_SWITCHER_ORG_ITEM_TEST_ID,
-        ORGANIZATION_SWITCHER_VERSION_LINK_TEST_ID,
-      ]
-
-      testIds.forEach((testId) => {
-        expect(testId).toMatch(/^[a-z-]+$/)
-      })
-    })
-  })
-
   describe('Component rendering', () => {
     it('renders the organization switcher container', () => {
       render(<OrganizationSwitcher {...defaultProps} />, renderOptions)
@@ -126,11 +94,14 @@ describe('OrganizationSwitcher', () => {
       expect(screen.getByTestId(ORGANIZATION_SWITCHER_BUTTON_TEST_ID)).toBeInTheDocument()
     })
 
-    it('renders the organization name', () => {
+    it('renders the URL organization name when the organization prop is stale', () => {
       render(<OrganizationSwitcher {...defaultProps} />, renderOptions)
 
       expect(screen.getByTestId(ORGANIZATION_SWITCHER_NAME_TEST_ID)).toBeInTheDocument()
       expect(screen.getByTestId(ORGANIZATION_SWITCHER_NAME_TEST_ID)).toHaveTextContent(
+        'Another Org',
+      )
+      expect(screen.getByTestId(ORGANIZATION_SWITCHER_NAME_TEST_ID)).not.toHaveTextContent(
         'Test Organization',
       )
     })
@@ -139,13 +110,6 @@ describe('OrganizationSwitcher', () => {
       render(<OrganizationSwitcher {...defaultProps} isLoading={true} />, renderOptions)
 
       expect(screen.getByTestId(ORGANIZATION_SWITCHER_BUTTON_TEST_ID)).toBeDisabled()
-    })
-  })
-
-  describe('Component exports', () => {
-    it('exports successfully', () => {
-      expect(OrganizationSwitcher).toBeDefined()
-      expect(typeof OrganizationSwitcher).toBe('function')
     })
   })
 })

--- a/src/layouts/__tests__/SettingsNavLayout.test.tsx
+++ b/src/layouts/__tests__/SettingsNavLayout.test.tsx
@@ -1,39 +1,115 @@
-import SettingsNavLayout, {
-  SETTINGS_NAV_BACK_BUTTON_TEST_ID,
-  SETTINGS_NAV_BILLING_ENTITY_ITEM_TEST_ID,
-  SETTINGS_NAV_BURGER_BUTTON_TEST_ID,
-  SETTINGS_NAV_CREATE_BILLING_ENTITY_BUTTON_TEST_ID,
-} from '../SettingsNavLayout'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
-describe('SettingsNavLayout test IDs', () => {
-  it('exports expected test ID constants', () => {
-    expect(SETTINGS_NAV_BURGER_BUTTON_TEST_ID).toBe('settings-nav-burger-button')
-    expect(SETTINGS_NAV_BACK_BUTTON_TEST_ID).toBe('settings-nav-back-button')
-    expect(SETTINGS_NAV_CREATE_BILLING_ENTITY_BUTTON_TEST_ID).toBe(
-      'settings-nav-create-billing-entity-button',
+import { GetBillingEntitiesDocument } from '~/generated/graphql'
+import { TMembershipPermissions } from '~/hooks/usePermissions'
+import { render } from '~/test-utils'
+
+import SettingsNavLayout, { SETTINGS_NAV_BACK_BUTTON_TEST_ID } from '../SettingsNavLayout'
+
+const mockPermissions = new Set<keyof TMembershipPermissions>()
+
+jest.mock('~/hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    hasPermissions: (permissions: Array<keyof TMembershipPermissions>) =>
+      permissions.every((permission) => mockPermissions.has(permission)),
+  }),
+}))
+
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  useOrganizationInfos: () => ({ organization: { canCreateBillingEntity: false } }),
+}))
+
+jest.mock('~/hooks/core/useLocationHistory', () => ({
+  useLocationHistory: () => ({ goBack: jest.fn() }),
+}))
+
+jest.mock('~/components/dialogs/PremiumWarningDialog', () => ({
+  usePremiumWarningDialog: () => ({ open: jest.fn() }),
+}))
+
+const renderSettings = () =>
+  render(<SettingsNavLayout />, {
+    useParams: { organizationSlug: 'acme' },
+    mocks: [
+      {
+        request: { query: GetBillingEntitiesDocument, variables: {} },
+        result: { data: { billingEntities: { collection: [] } } },
+      },
+    ],
+  })
+
+describe('SettingsNavLayout', () => {
+  const originalScrollTo = HTMLElement.prototype.scrollTo
+
+  beforeAll(() => {
+    HTMLElement.prototype.scrollTo = jest.fn()
+  })
+
+  afterAll(() => {
+    HTMLElement.prototype.scrollTo = originalScrollTo
+  })
+
+  beforeEach(() => {
+    mockPermissions.clear()
+    window.history.replaceState({}, '', '/acme/settings/general')
+  })
+
+  it('renders the settings navigation without links for restricted sections', () => {
+    renderSettings()
+
+    expect(screen.getByTestId(SETTINGS_NAV_BACK_BUTTON_TEST_ID)).toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it.each<{ permission: keyof TMembershipPermissions; name: string; path: string }>([
+    { permission: 'organizationView', name: 'General', path: '/settings/general' },
+    {
+      permission: 'organizationIntegrationsView',
+      name: 'Integrations',
+      path: '/settings/integrations/lago',
+    },
+    {
+      permission: 'organizationInvoicesView',
+      name: 'Invoices',
+      path: '/settings/invoice-sections',
+    },
+    {
+      permission: 'dunningCampaignsView',
+      name: 'Dunning',
+      path: '/settings/dunnings',
+    },
+    { permission: 'organizationTaxesView', name: 'Taxes', path: '/settings/taxes' },
+  ])('shows only $name when $permission is granted', ({ permission, name, path }) => {
+    mockPermissions.add(permission)
+    renderSettings()
+
+    expect(screen.getAllByRole('link')).toHaveLength(1)
+    expect(screen.getByRole('link', { name })).toHaveAttribute('href', `/acme${path}`)
+  })
+
+  it.each<keyof TMembershipPermissions>([
+    'organizationMembersView',
+    'rolesView',
+    'authenticationMethodsView',
+    'securityLogsView',
+  ])('shows Team & Security with only %s access', (permission) => {
+    mockPermissions.add(permission)
+    renderSettings()
+
+    expect(screen.getAllByRole('link')).toHaveLength(1)
+    expect(screen.getByRole('link', { name: 'Team & Security' })).toHaveAttribute(
+      'href',
+      '/acme/settings/team-and-security',
     )
-    expect(SETTINGS_NAV_BILLING_ENTITY_ITEM_TEST_ID).toBe('settings-nav-billing-entity-item')
   })
 
-  it('test ID constants follow kebab-case naming convention', () => {
-    const testIds = [
-      SETTINGS_NAV_BURGER_BUTTON_TEST_ID,
-      SETTINGS_NAV_BACK_BUTTON_TEST_ID,
-      SETTINGS_NAV_CREATE_BILLING_ENTITY_BUTTON_TEST_ID,
-      SETTINGS_NAV_BILLING_ENTITY_ITEM_TEST_ID,
-    ]
+  it('navigates to taxes in the organization from the URL', async () => {
+    mockPermissions.add('organizationTaxesView')
+    renderSettings()
 
-    testIds.forEach((testId) => {
-      expect(testId).toMatch(/^[a-z-]+$/)
-    })
-  })
-})
+    await userEvent.click(screen.getByRole('link', { name: 'Taxes' }))
 
-describe('SettingsNavLayout generateTabs function', () => {
-  // Import the component to test the generateTabs function behavior indirectly
-
-  it('component exports successfully', () => {
-    expect(SettingsNavLayout).toBeDefined()
-    expect(typeof SettingsNavLayout).toBe('function')
+    expect(window.location.pathname).toBe('/acme/settings/taxes')
   })
 })

--- a/src/pages/subscriptions/SubscriptionDetails.tsx
+++ b/src/pages/subscriptions/SubscriptionDetails.tsx
@@ -14,6 +14,10 @@ import { SubscriptionActivityLogs } from '~/components/subscriptions/Subscriptio
 import { SubscriptionAlertsList } from '~/components/subscriptions/SubscriptionAlertsList'
 import { SubscriptionEntitlementsTabContent } from '~/components/subscriptions/SubscriptionEntitlementsTabContent'
 import { SubscriptionProgressiveBillingTab } from '~/components/subscriptions/SubscriptionProgressiveBillingTab/SubscriptionProgressiveBillingTab'
+import {
+  SUBSCRIPTION_DETAILS_ACTIONS_TEST_ID,
+  SUBSCRIPTION_DETAILS_CANCEL_TEST_ID,
+} from '~/components/subscriptions/subscriptionTestIds'
 import { SubscriptionUsageTabContent } from '~/components/subscriptions/SubscriptionUsageTabContent'
 import { addToast } from '~/core/apolloClient'
 import { isSubscriptionCancellation } from '~/core/constants/statusSubscriptionMapping'
@@ -40,6 +44,8 @@ import { useCurrentUser } from '~/hooks/useCurrentUser'
 import { useNotFoundRedirect } from '~/hooks/useNotFoundRedirect'
 import { usePermissions } from '~/hooks/usePermissions'
 import { useSubscriptionPermissionsActions } from '~/hooks/useSubscriptionPermissionsActions'
+
+export { SUBSCRIPTION_DETAILS_CANCEL_TEST_ID } from '~/components/subscriptions/subscriptionTestIds'
 
 gql`
   query getSubscriptionForDetails($subscriptionId: ID!) {
@@ -69,12 +75,9 @@ gql`
   ${SubscriptionForProgressiveBillingTabFragmentDoc}
 `
 
-const SUBSCRIPTION_DETAILS_ACTIONS_TEST_ID = 'subscription-details-actions'
-
 export const SUBSCRIPTION_DETAILS_UPGRADE_DOWNGRADE_TEST_ID =
   'subscription-details-upgrade-downgrade'
 export const SUBSCRIPTION_DETAILS_TERMINATE_TEST_ID = 'subscription-details-terminate'
-export const SUBSCRIPTION_DETAILS_CANCEL_TEST_ID = 'subscription-details-cancel'
 
 const SubscriptionDetails = () => {
   const navigate = useNavigate()


### PR DESCRIPTION
Replace copied settings route constants and export-only assertions with tests that exercise production route resolution, permission-sensitive links, organization-aware navigation, and stale organization names.

Make the subscription cancellation browser test wait for the mutation and navigation, then reload and check the saved canceled status through a fresh backend response. Move shared Cypress selectors into a plain TypeScript module so importing them does not register another test suite.
