### PR TITLE
refactor(search): tighten debounce and pagination contracts

### DIFF
--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
@@ -16,6 +16,7 @@ import {
   PlanInterval,
 } from '~/generated/graphql'
 import { usePlanFormSetup } from '~/hooks/plans/usePlanFormSetup'
+import type { UseDebouncedSearch } from '~/hooks/useDebouncedSearch'
 import type { QuoteCustomer } from '~/pages/quotes/hooks/useSubscriptionPricingDrawer'
 import { render } from '~/test-utils'
 
@@ -60,8 +61,11 @@ jest.mock('@tanstack/react-virtual', () => ({
 }))
 
 jest.mock('~/hooks/useDebouncedSearch', () => ({
-  useDebouncedSearch: (searchQuery: unknown) => ({
-    debouncedSearch: searchQuery,
+  useDebouncedSearch: (): ReturnType<UseDebouncedSearch> => ({
+    debouncedSearch: Object.assign(jest.fn<void, [string]>(), {
+      cancel: jest.fn(),
+      flush: jest.fn(),
+    }),
     isLoading: false,
   }),
 }))

--- a/src/components/developers/webhooks/__tests__/WebhookLogs.test.tsx
+++ b/src/components/developers/webhooks/__tests__/WebhookLogs.test.tsx
@@ -1,4 +1,4 @@
-import { render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { useGetWebhookLogLazyQuery } from '~/generated/graphql'
@@ -140,6 +140,14 @@ describe('WebhookLogs', () => {
         expect(screen.getByTestId('filters-component-mock')).toBeInTheDocument()
       })
     })
+  })
+
+  it('passes the typed search string to the debounce handler', () => {
+    renderWithParams(<WebhookLogs webhookId="webhook-123" />)
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'customer.created' } })
+
+    expect(mockDebouncedSearch).toHaveBeenCalledWith('customer.created')
   })
 
   describe('GIVEN no logId in params and data has logs', () => {

--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -63,16 +63,13 @@ export const ComboBox = ({
   }, [rawData])
   const prevRawData = prevRawDataRef.current
 
-  // when `data` gets updated, make sure that if the current value is not belonging to
-  //   a deleted option
-  // N.B: we compute the diff to not delete a "freeForm" value
+  // Only clear removed options; values that were never options may be free-form.
   useEffect(() => {
     if (prevRawData && data) {
-      const deletedOptions = prevRawData.filter(
-        ({ value: oldVal }) => !data.find(({ value: newVal }) => oldVal === newVal),
-      )
+      const wasAnOption = prevRawData.some((option) => option.value === value)
+      const isStillAnOption = data.some((option) => option.value === value)
 
-      if (deletedOptions.find(({ value: deletedValue }) => value === deletedValue)) {
+      if (wasAnOption && !isStillAnOption) {
         onChange('')
       }
     }

--- a/src/components/form/ComboBox/__tests__/ComboBox.test.tsx
+++ b/src/components/form/ComboBox/__tests__/ComboBox.test.tsx
@@ -1,0 +1,111 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+
+import { DEBOUNCE_SEARCH_MS } from '~/hooks/useDebouncedSearch'
+
+import { ComboBox } from '../ComboBox'
+import { BasicComboBoxData } from '../types'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string): string => key }),
+}))
+
+const options: BasicComboBoxData[] = [
+  { value: 'alpha', label: 'Alpha' },
+  { value: 'beta', label: 'Beta' },
+]
+
+const advanceDebounce = (): void => {
+  act(() => {
+    jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS)
+  })
+}
+
+describe('ComboBox', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('clears a selected option when that option is removed', () => {
+    const onChange = jest.fn()
+    const { rerender } = render(
+      <ComboBox data={options} value="alpha" allowAddValue onChange={onChange} />,
+    )
+
+    expect(onChange).not.toHaveBeenCalled()
+    rerender(<ComboBox data={[options[1]]} value="alpha" allowAddValue onChange={onChange} />)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('retains the selection when only another option or a duplicate is removed', () => {
+    const onChange = jest.fn()
+    const { rerender } = render(
+      <ComboBox data={[...options, options[0]]} value="alpha" onChange={onChange} />,
+    )
+
+    rerender(<ComboBox data={[options[0]]} value="alpha" onChange={onChange} />)
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByRole('combobox')).toHaveValue('Alpha')
+  })
+
+  it('retains a free-form value when all options are removed', () => {
+    const onChange = jest.fn()
+    const { rerender } = render(
+      <ComboBox data={options} value="custom" allowAddValue onChange={onChange} />,
+    )
+
+    rerender(<ComboBox data={[]} value="custom" allowAddValue onChange={onChange} />)
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByRole('combobox')).toHaveValue('custom')
+  })
+
+  it('filters local options and accepts a free-form value without a query', () => {
+    const onChange = jest.fn()
+
+    render(<ComboBox data={options} allowAddValue virtualized={false} onChange={onChange} />)
+    advanceDebounce()
+
+    const input = screen.getByRole('combobox')
+
+    fireEvent.change(input, { target: { value: 'Al' } })
+    expect(screen.getByRole('option', { name: /Alpha$/ })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Beta$/ })).not.toBeInTheDocument()
+
+    fireEvent.change(input, { target: { value: 'custom' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    advanceDebounce()
+    expect(onChange).toHaveBeenLastCalledWith('custom')
+  })
+
+  it('debounces typed strings and restores an unfiltered remote query on blur', () => {
+    const searchQuery = jest.fn()
+
+    render(
+      <ComboBox
+        data={options}
+        searchQuery={searchQuery}
+        virtualized={false}
+        onChange={jest.fn()}
+      />,
+    )
+    expect(searchQuery).toHaveBeenCalledTimes(1)
+    advanceDebounce()
+
+    const input = screen.getByRole('combobox')
+
+    fireEvent.change(input, { target: { value: 'alp' } })
+    expect(searchQuery).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('option', { name: /Beta$/ })).toBeInTheDocument()
+    advanceDebounce()
+    expect(searchQuery).toHaveBeenLastCalledWith({ variables: { searchTerm: 'alp' } })
+
+    fireEvent.blur(input)
+    advanceDebounce()
+    expect(searchQuery).toHaveBeenCalledTimes(3)
+    expect(searchQuery).toHaveBeenLastCalledWith({ variables: { searchTerm: undefined } })
+  })
+})

--- a/src/core/apolloClient/cacheHelpers.ts
+++ b/src/core/apolloClient/cacheHelpers.ts
@@ -28,6 +28,18 @@ export const mergePaginatedCollection = (
   }
 }
 
+const createPaginationKeyArgs = (additionalExclusions: string[] = []): FieldPolicy['keyArgs'] => {
+  const excludedArgs = new Set(['page', 'limit', 'offset', ...additionalExclusions])
+
+  return (args) => {
+    if (!args) return false
+
+    return Object.keys(args)
+      .filter((key) => !excludedArgs.has(key))
+      .sort((a, b) => a.localeCompare(b))
+  }
+}
+
 /**
  * Creates a standard field policy for paginated queries.
  *
@@ -48,20 +60,7 @@ export const mergePaginatedCollection = (
  * ```
  */
 export const createPaginatedFieldPolicy = (additionalExclusions: string[] = []): FieldPolicy => ({
-  keyArgs(args) {
-    // If no args, return false to use single shared cache entry
-    if (!args) return false
-
-    // Standard pagination args that should NOT affect cache key
-    const excludedArgs = new Set(['page', 'limit', 'offset', ...additionalExclusions])
-
-    // Return sorted array of arg keys to include in cache key
-    // Sorting ensures consistent cache keys regardless of argument order
-    // Apollo will automatically hash the values
-    return Object.keys(args)
-      .filter((key) => !excludedArgs.has(key))
-      .sort((a, b) => a.localeCompare(b))
-  },
+  keyArgs: createPaginationKeyArgs(additionalExclusions),
   merge: mergePaginatedCollection,
 })
 
@@ -75,15 +74,7 @@ export const createPaginatedFieldPolicy = (additionalExclusions: string[] = []):
  * scroll; navigate pages with `fetchMore({ variables: { page } })`.
  */
 export const createSinglePageFieldPolicy = (additionalExclusions: string[] = []): FieldPolicy => ({
-  keyArgs(args) {
-    if (!args) return false
-
-    const excludedArgs = new Set(['page', 'limit', 'offset', ...additionalExclusions])
-
-    return Object.keys(args)
-      .filter((key) => !excludedArgs.has(key))
-      .sort((a, b) => a.localeCompare(b))
-  },
+  keyArgs: createPaginationKeyArgs(additionalExclusions),
   merge: (_existing, incoming) => incoming,
 })
 

--- a/src/hooks/__tests__/useDebouncedSearch.test.ts
+++ b/src/hooks/__tests__/useDebouncedSearch.test.ts
@@ -1,167 +1,186 @@
 import { act, renderHook } from '@testing-library/react'
 
 import { DEBOUNCE_SEARCH_MS, useDebouncedSearch } from '~/hooks/useDebouncedSearch'
-import { AllTheProviders } from '~/test-utils'
 
-beforeEach(() => {
-  jest.useFakeTimers()
-})
-
-afterEach(() => {
-  jest.clearAllTimers()
-})
-
-async function prepare({ initialLoadingState = false }: { initialLoadingState: boolean }) {
-  const callback = jest.fn()
-  const customWrapper = ({ children }: { children: React.ReactNode }) =>
-    AllTheProviders({
-      children,
-    })
-
-  const { result } = renderHook(() => useDebouncedSearch(callback, initialLoadingState), {
-    wrapper: customWrapper,
+const advanceTime = (milliseconds: number): void => {
+  act(() => {
+    jest.advanceTimersByTime(milliseconds)
   })
-
-  return { result: result, callback }
 }
 
 describe('useDebouncedSearch', () => {
-  it('instantiate the hook with the correct initial state', async () => {
-    const { result, callback } = await prepare({ initialLoadingState: false })
-
-    expect(result.current.isLoading).toBe(true)
-    expect(callback).toHaveBeenCalled()
-    expect(callback).toHaveBeenCalledTimes(1)
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(0)
   })
 
-  it('should stop loading after debounce time is passed', async () => {
-    const { result } = await prepare({ initialLoadingState: false })
-
-    expect(result.current.isLoading).toBe(true)
-
-    // Fast-forward until all timers have been executed
-    await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
-
-    act(() => {
-      expect(result.current.isLoading).toBe(false)
-    })
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
-  it('should trigger loading after the callback method is called', async () => {
-    const { result, callback } = await prepare({ initialLoadingState: false })
+  it('fetches once on mount and keeps the initial spinner for the debounce interval', () => {
+    const searchQuery = jest.fn()
+    const { result, rerender } = renderHook(() => useDebouncedSearch(searchQuery, false))
 
+    expect(searchQuery).toHaveBeenCalledTimes(1)
+    expect(searchQuery).toHaveBeenCalledWith()
     expect(result.current.isLoading).toBe(true)
-    expect(callback).toHaveBeenCalled()
-    expect(callback).toHaveBeenCalledTimes(1)
+    rerender()
+    expect(searchQuery).toHaveBeenCalledTimes(1)
 
-    // Fast-forward until all timers have been executed
-    await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
-
-    act(() => {
-      expect(result.current.isLoading).toBe(false)
-    })
-
-    // Trigger the callback
-    result?.current?.debouncedSearch?.('test')
-    await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
-
-    // Note: We cannot check that result.current.isLoading is true
-    // As the value comes from initialLoadingState that cannot change in this context
-
-    // Fast-forward until all timers have been executed
-    expect(callback).toHaveBeenCalled()
-    expect(callback).toHaveBeenCalledTimes(2)
-
-    // Fast-forward until all timers have been executed
-    await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
-
-    // Loading keeps being false
+    advanceTime(DEBOUNCE_SEARCH_MS - 1)
+    expect(result.current.isLoading).toBe(true)
+    advanceTime(1)
     expect(result.current.isLoading).toBe(false)
   })
 
-  describe('minimum search characters', () => {
-    it('does not trigger the search query when typing less than 3 characters', async () => {
-      const { result, callback } = await prepare({ initialLoadingState: false })
+  it('returns a callable and cancellable handler when no query or loading state is supplied', () => {
+    const { result } = renderHook(() => useDebouncedSearch())
 
-      // Initial query on mount
-      expect(callback).toHaveBeenCalledTimes(1)
+    result.current.debouncedSearch('local option')
+    advanceTime(DEBOUNCE_SEARCH_MS)
 
-      result?.current?.debouncedSearch?.('a')
-      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
-      result?.current?.debouncedSearch?.('ab')
-      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+    expect(result.current.isLoading).toBe(false)
+    result.current.debouncedSearch('another option')
+    result.current.debouncedSearch.cancel()
+    expect(jest.getTimerCount()).toBe(0)
+  })
 
-      expect(callback).toHaveBeenCalledTimes(1)
+  it('debounces rapid edits and keeps the handler stable across loading changes', () => {
+    const searchQuery = jest.fn()
+    const { result, rerender } = renderHook(
+      ({ loading }) => useDebouncedSearch(searchQuery, loading),
+      {
+        initialProps: { loading: false },
+      },
+    )
+    const handler = result.current.debouncedSearch
+
+    handler('first')
+    advanceTime(DEBOUNCE_SEARCH_MS - 1)
+    handler('latest')
+    rerender({ loading: true })
+    expect(result.current.debouncedSearch).toBe(handler)
+    advanceTime(DEBOUNCE_SEARCH_MS - 1)
+    expect(searchQuery).toHaveBeenCalledTimes(1)
+    advanceTime(1)
+    expect(searchQuery).toHaveBeenCalledTimes(2)
+    expect(searchQuery).toHaveBeenLastCalledWith({ variables: { searchTerm: 'latest' } })
+  })
+
+  it('cancels pending searches and spinner timers on unmount', () => {
+    const searchQuery = jest.fn()
+    const { result, unmount } = renderHook(() => useDebouncedSearch(searchQuery, false))
+
+    result.current.debouncedSearch('cancelled')
+    unmount()
+    expect(jest.getTimerCount()).toBe(0)
+    advanceTime(DEBOUNCE_SEARCH_MS)
+    expect(searchQuery).toHaveBeenCalledTimes(1)
+  })
+
+  describe('search normalization', () => {
+    it.each(['', 'a', 'ab', '  ab  '])(
+      'does not repeat the initial unfiltered query for %j',
+      (value) => {
+        const searchQuery = jest.fn()
+        const { result } = renderHook(() => useDebouncedSearch(searchQuery))
+
+        result.current.debouncedSearch(value)
+        advanceTime(DEBOUNCE_SEARCH_MS)
+        expect(searchQuery).toHaveBeenCalledTimes(1)
+      },
+    )
+
+    it.each(['abc', '  abc  '])('preserves the original search value for %j', (value) => {
+      const searchQuery = jest.fn()
+      const { result } = renderHook(() => useDebouncedSearch(searchQuery))
+
+      result.current.debouncedSearch(value)
+      advanceTime(DEBOUNCE_SEARCH_MS)
+      expect(searchQuery).toHaveBeenLastCalledWith({ variables: { searchTerm: value } })
     })
 
-    it('triggers the search query with 3 characters or more', async () => {
-      const { result, callback } = await prepare({ initialLoadingState: false })
+    it.each(['', 'ab', '  ab  '])(
+      'restores the unfiltered list once when returning to %j',
+      (value) => {
+        const searchQuery = jest.fn()
+        const { result } = renderHook(() => useDebouncedSearch(searchQuery))
 
-      result?.current?.debouncedSearch?.('abc')
-      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+        result.current.debouncedSearch('abc')
+        advanceTime(DEBOUNCE_SEARCH_MS)
+        result.current.debouncedSearch(value)
+        advanceTime(DEBOUNCE_SEARCH_MS)
+        result.current.debouncedSearch('a')
+        advanceTime(DEBOUNCE_SEARCH_MS)
 
-      expect(callback).toHaveBeenCalledTimes(2)
-      expect(callback).toHaveBeenLastCalledWith({ variables: { searchTerm: 'abc' } })
-    })
+        expect(searchQuery).toHaveBeenCalledTimes(3)
+        expect(searchQuery).toHaveBeenLastCalledWith({ variables: { searchTerm: undefined } })
+      },
+    )
 
-    it('restores the unfiltered list when going back under 3 characters after a search', async () => {
-      const { result, callback } = await prepare({ initialLoadingState: false })
+    it('does not repeat the same search term', () => {
+      const searchQuery = jest.fn()
+      const { result } = renderHook(() => useDebouncedSearch(searchQuery))
 
-      result?.current?.debouncedSearch?.('abc')
-      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
-      result?.current?.debouncedSearch?.('ab')
-      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
-
-      expect(callback).toHaveBeenCalledTimes(3)
-      expect(callback).toHaveBeenLastCalledWith({ variables: { searchTerm: undefined } })
-    })
-
-    it('restores the unfiltered list when the search is cleared after a search', async () => {
-      const { result, callback } = await prepare({ initialLoadingState: false })
-
-      result?.current?.debouncedSearch?.('abc')
-      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
-      result?.current?.debouncedSearch?.('')
-      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
-
-      expect(callback).toHaveBeenCalledTimes(3)
-      expect(callback).toHaveBeenLastCalledWith({ variables: { searchTerm: undefined } })
-    })
-
-    it('ignores surrounding whitespace when counting characters', async () => {
-      const { result, callback } = await prepare({ initialLoadingState: false })
-
-      result?.current?.debouncedSearch?.('  ab  ')
-      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
-
-      expect(callback).toHaveBeenCalledTimes(1)
-    })
-
-    it('does not re-trigger the search query for the same term', async () => {
-      const { result, callback } = await prepare({ initialLoadingState: false })
-
-      result?.current?.debouncedSearch?.('abc')
-      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
-      result?.current?.debouncedSearch?.('abc')
-      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
-
-      expect(callback).toHaveBeenCalledTimes(2)
+      result.current.debouncedSearch('abc')
+      advanceTime(DEBOUNCE_SEARCH_MS)
+      result.current.debouncedSearch('abc')
+      advanceTime(DEBOUNCE_SEARCH_MS)
+      expect(searchQuery).toHaveBeenCalledTimes(2)
     })
   })
 
-  describe('anti-regression', () => {
-    // Fixes https://github.com/getlago/lago-front/pull/1272
-    it('should fallback loading to initial if debounce timer is passed', async () => {
-      const { result } = await prepare({ initialLoadingState: true })
+  describe('minimum spinner duration', () => {
+    it('keeps a fast request visible for the remaining interval, including a start time of zero', () => {
+      const { result, rerender } = renderHook(
+        ({ loading }) => useDebouncedSearch(undefined, loading),
+        {
+          initialProps: { loading: true },
+        },
+      )
 
+      advanceTime(100)
+      rerender({ loading: false })
+      advanceTime(DEBOUNCE_SEARCH_MS - 101)
       expect(result.current.isLoading).toBe(true)
+      advanceTime(1)
+      expect(result.current.isLoading).toBe(false)
+    })
 
-      // Fast-forward until all timers have been executed
-      await act(() => jest.advanceTimersByTime(DEBOUNCE_SEARCH_MS))
+    it('stays visible for a slow request and stops as soon as the request finishes', () => {
+      const { result, rerender } = renderHook(
+        ({ loading }) => useDebouncedSearch(undefined, loading),
+        {
+          initialProps: { loading: true },
+        },
+      )
 
-      act(() => {
-        expect(result.current.isLoading).toBe(true)
-      })
+      advanceTime(DEBOUNCE_SEARCH_MS + 100)
+      expect(result.current.isLoading).toBe(true)
+      rerender({ loading: false })
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    it('cancels an old hide timer when another request starts', () => {
+      const { result, rerender } = renderHook(
+        ({ loading }) => useDebouncedSearch(undefined, loading),
+        {
+          initialProps: { loading: true },
+        },
+      )
+
+      advanceTime(100)
+      rerender({ loading: false })
+      advanceTime(100)
+      rerender({ loading: true })
+      expect(jest.getTimerCount()).toBe(0)
+      advanceTime(100)
+      rerender({ loading: false })
+      advanceTime(DEBOUNCE_SEARCH_MS - 101)
+      expect(result.current.isLoading).toBe(true)
+      advanceTime(1)
+      expect(result.current.isLoading).toBe(false)
     })
   })
 })

--- a/src/hooks/customer/useCustomersListHeaderFilters.tsx
+++ b/src/hooks/customer/useCustomersListHeaderFilters.tsx
@@ -13,7 +13,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
 interface UseCustomersListFiltersSectionParams {
-  debouncedSearch?: (value: string) => void
+  debouncedSearch: (value: string) => void
 }
 
 export function useCustomersListHeaderFilters({

--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -1,6 +1,6 @@
 import { LazyQueryExecFunction } from '@apollo/client'
-import { debounce, DebouncedFunc } from 'lodash'
-import { DateTime } from 'luxon'
+import { DebouncedFunc } from 'lodash'
+import debounce from 'lodash/debounce'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 export const DEBOUNCE_SEARCH_MS = window.Cypress ? 0 : 500
@@ -15,13 +15,13 @@ export type UseDebouncedSearch = (
   >,
   loading?: boolean,
 ) => {
-  debouncedSearch?: DebouncedFunc<(value: unknown) => void>
+  debouncedSearch: DebouncedFunc<(value: string) => void>
   isLoading: boolean
 }
 
 export const useDebouncedSearch: UseDebouncedSearch = (searchQuery, loading) => {
   const [isLoading, setIsLoading] = useState(true)
-  const startLoading = useRef<DateTime | null>(null)
+  const startLoading = useRef<number | null>(null)
   const lastSearchTerm = useRef<string | undefined>(undefined)
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -36,10 +36,7 @@ export const useDebouncedSearch: UseDebouncedSearch = (searchQuery, loading) => 
 
       lastSearchTerm.current = searchTerm
 
-      searchQuery &&
-        searchQuery({
-          variables: { searchTerm },
-        })
+      searchQuery?.({ variables: { searchTerm } })
     }, DEBOUNCE_SEARCH_MS),
     [],
   )
@@ -49,22 +46,15 @@ export const useDebouncedSearch: UseDebouncedSearch = (searchQuery, loading) => 
 
     if (loading) {
       setIsLoading(true)
-      // If query is loading, save the start time
-      startLoading.current = DateTime.now()
+      startLoading.current = Date.now()
     } else {
-      // If query is not loading anymore, get the diff between the start time and now
-      const diff =
-        DateTime.now().diff(startLoading.current || DateTime.now(), 'milliseconds')?.milliseconds ||
-        0
+      const elapsed = Date.now() - (startLoading.current ?? Date.now())
 
-      // If the diff is bellow the minimum debounce time
-      if (diff <= DEBOUNCE_SEARCH_MS) {
-        // Timeout the loading to be set to false, to prevent loading blink (if loading is too fast)
+      if (elapsed <= DEBOUNCE_SEARCH_MS) {
         loadingStateTimeOut = setTimeout(() => {
           setIsLoading(false)
-        }, DEBOUNCE_SEARCH_MS - diff)
+        }, DEBOUNCE_SEARCH_MS - elapsed)
       } else {
-        // If time diff is acceptable already, set loading to false
         setIsLoading(false)
       }
     }
@@ -75,7 +65,7 @@ export const useDebouncedSearch: UseDebouncedSearch = (searchQuery, loading) => 
   }, [loading])
 
   useEffect(() => {
-    searchQuery && searchQuery()
+    searchQuery?.()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -85,5 +75,5 @@ export const useDebouncedSearch: UseDebouncedSearch = (searchQuery, loading) => 
     }
   }, [debouncedSearch])
 
-  return { debouncedSearch: debouncedSearch || undefined, isLoading: isLoading || loading || false }
+  return { debouncedSearch, isLoading: isLoading || !!loading }
 }

--- a/src/pages/AddOnsList.tsx
+++ b/src/pages/AddOnsList.tsx
@@ -124,7 +124,7 @@ const AddOnsList = () => {
           <SearchInput
             onChange={(value) => {
               goToPage(1)
-              debouncedSearch?.(value)
+              debouncedSearch(value)
             }}
             placeholder={translate('text_63bee4e10e2d53912bfe4db8')}
           />

--- a/src/pages/BillableMetricsList.tsx
+++ b/src/pages/BillableMetricsList.tsx
@@ -219,7 +219,7 @@ const BillableMetricsList = () => {
           <SearchInput
             onChange={(value) => {
               goToPage(1)
-              debouncedSearch?.(value)
+              debouncedSearch(value)
             }}
             placeholder={translate('text_63ba9ee977a67c9693f50aea')}
           />

--- a/src/pages/CouponsList.tsx
+++ b/src/pages/CouponsList.tsx
@@ -188,7 +188,7 @@ const CouponsList = () => {
           <SearchInput
             onChange={(value) => {
               goToPage(1)
-              debouncedSearch?.(value)
+              debouncedSearch(value)
             }}
             placeholder={translate('text_63beebbf4f60e2f553232782')}
           />

--- a/src/pages/CreditNotesPage.tsx
+++ b/src/pages/CreditNotesPage.tsx
@@ -246,7 +246,7 @@ const CreditNotesPage = () => {
               <SearchInput
                 onChange={(value) => {
                   goToPage(1)
-                  creditNoteDebounceSearch?.(value)
+                  creditNoteDebounceSearch(value)
                 }}
                 placeholder={translate('text_63c6edd80c57d0dfaae3898e')}
               />

--- a/src/pages/CustomersList.tsx
+++ b/src/pages/CustomersList.tsx
@@ -132,7 +132,7 @@ const CustomersList = () => {
 
   const searchAndResetPage = (value: string) => {
     goToPage(1)
-    debouncedSearch?.(value)
+    debouncedSearch(value)
   }
 
   const headerActions = useCustomersListHeaderActions()

--- a/src/pages/InvoicesPage.tsx
+++ b/src/pages/InvoicesPage.tsx
@@ -322,7 +322,7 @@ const InvoicesPage = () => {
                 <SearchInput
                   onChange={(value) => {
                     goToPage(1)
-                    invoiceDebounceSearch?.(value)
+                    invoiceDebounceSearch(value)
                   }}
                   placeholder={translate('text_63c68131568d582a38233e84')}
                 />

--- a/src/pages/PaymentsPage.tsx
+++ b/src/pages/PaymentsPage.tsx
@@ -100,7 +100,7 @@ const PaymentsPage = () => {
           <SearchInput
             onChange={(value) => {
               goToPage(1)
-              paymentsDebounceSearch?.(value)
+              paymentsDebounceSearch(value)
             }}
             placeholder={translate('text_17370296250897aidak5kjcg')}
           />

--- a/src/pages/PlansList.tsx
+++ b/src/pages/PlansList.tsx
@@ -119,7 +119,7 @@ const PlansList = () => {
           <SearchInput
             onChange={(value) => {
               goToPage(1)
-              debouncedSearch?.(value)
+              debouncedSearch(value)
             }}
             placeholder={translate('text_63bee1cc88d85f04deb0d63c')}
           />

--- a/src/pages/SubscriptionsPage.tsx
+++ b/src/pages/SubscriptionsPage.tsx
@@ -133,7 +133,7 @@ const SubscriptionsPage = () => {
   // out-of-range page (filter changes reset the page centrally in useFilters).
   const searchAndResetPage = (value: string) => {
     goToPage(1)
-    debouncedSearch?.(value)
+    debouncedSearch(value)
   }
 
   const subscriptions = data?.subscriptions.collection as Subscription[]

--- a/src/pages/__tests__/AddOnsList.test.tsx
+++ b/src/pages/__tests__/AddOnsList.test.tsx
@@ -1,14 +1,20 @@
+import { fireEvent, screen } from '@testing-library/react'
+
+import { MainHeaderConfig } from '~/components/MainHeader/types'
 import { render } from '~/test-utils'
 
 import AddOnsList from '../AddOnsList'
 
-const mockMainHeaderConfigure = jest.fn()
+const mockMainHeaderConfigure = jest.fn<void, [MainHeaderConfig]>()
 const mockTableProps = jest.fn()
 const mockHasPermissions = jest.fn()
+const mockGoToPage = jest.fn()
+const mockDebouncedSearch = jest.fn()
+let mockPage = 1
 
 jest.mock('~/components/MainHeader/MainHeader', () => ({
   MainHeader: {
-    Configure: (props: Record<string, unknown>) => {
+    Configure: (props: MainHeaderConfig): null => {
       mockMainHeaderConfigure(props)
       return null
     },
@@ -24,11 +30,7 @@ jest.mock('~/components/designSystem/Table/Table', () => ({
 
 jest.mock('~/components/designSystem/Pagination', () => ({
   PaginatedContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  usePageSearchParam: () => ({ page: 1, goToPage: jest.fn() }),
-}))
-
-jest.mock('~/components/SearchInput', () => ({
-  SearchInput: () => null,
+  usePageSearchParam: () => ({ page: mockPage, goToPage: mockGoToPage }),
 }))
 
 jest.mock('~/components/addOns/DeleteAddOnDialog', () => ({
@@ -57,7 +59,7 @@ jest.mock('~/hooks/useOrganizationInfos', () => ({
 
 jest.mock('~/hooks/useDebouncedSearch', () => ({
   useDebouncedSearch: () => ({
-    debouncedSearch: jest.fn(),
+    debouncedSearch: mockDebouncedSearch,
     isLoading: false,
   }),
 }))
@@ -73,6 +75,47 @@ jest.mock('~/generated/graphql', () => ({
 describe('AddOnsList', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockPage = 1
+  })
+
+  describe('GIVEN the list is on page 3', (): void => {
+    it('WHEN search is edited or cleared THEN resets the page before searching', (): void => {
+      mockPage = 3
+      mockHasPermissions.mockReturnValue(false)
+
+      render(<AddOnsList />)
+
+      const [headerConfig] = mockMainHeaderConfigure.mock.calls[0]
+
+      render(<>{headerConfig.filtersSection}</>)
+
+      const searchInput = screen.getByRole('textbox')
+
+      fireEvent.change(searchInput, { target: { value: 'new query' } })
+
+      expect(searchInput).toHaveValue('new query')
+      expect(mockGoToPage).toHaveBeenCalledTimes(1)
+      expect(mockGoToPage).toHaveBeenCalledWith(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledWith('new query')
+      expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+        mockDebouncedSearch.mock.invocationCallOrder[0],
+      )
+
+      mockGoToPage.mockClear()
+      mockDebouncedSearch.mockClear()
+
+      fireEvent.change(searchInput, { target: { value: '' } })
+
+      expect(searchInput).toHaveValue('')
+      expect(mockGoToPage).toHaveBeenCalledTimes(1)
+      expect(mockGoToPage).toHaveBeenCalledWith(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledWith('')
+      expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+        mockDebouncedSearch.mock.invocationCallOrder[0],
+      )
+    })
   })
 
   describe('GIVEN the component is rendered', () => {

--- a/src/pages/__tests__/BillableMetricsList.test.tsx
+++ b/src/pages/__tests__/BillableMetricsList.test.tsx
@@ -1,14 +1,20 @@
+import { fireEvent, screen } from '@testing-library/react'
+
+import { MainHeaderConfig } from '~/components/MainHeader/types'
 import { render } from '~/test-utils'
 
 import BillableMetricsList from '../BillableMetricsList'
 
-const mockMainHeaderConfigure = jest.fn()
+const mockMainHeaderConfigure = jest.fn<void, [MainHeaderConfig]>()
 const mockTableProps = jest.fn()
 const mockHasPermissions = jest.fn()
+const mockGoToPage = jest.fn()
+const mockDebouncedSearch = jest.fn()
+let mockPage = 1
 
 jest.mock('~/components/MainHeader/MainHeader', () => ({
   MainHeader: {
-    Configure: (props: Record<string, unknown>) => {
+    Configure: (props: MainHeaderConfig): null => {
       mockMainHeaderConfigure(props)
       return null
     },
@@ -24,11 +30,7 @@ jest.mock('~/components/designSystem/Table/Table', () => ({
 
 jest.mock('~/components/designSystem/Pagination', () => ({
   PaginatedContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  usePageSearchParam: () => ({ page: 1, goToPage: jest.fn() }),
-}))
-
-jest.mock('~/components/SearchInput', () => ({
-  SearchInput: () => null,
+  usePageSearchParam: () => ({ page: mockPage, goToPage: mockGoToPage }),
 }))
 
 jest.mock('~/components/billableMetrics/DeleteBillableMetricDialog', () => ({
@@ -57,7 +59,7 @@ jest.mock('~/hooks/useOrganizationInfos', () => ({
 
 jest.mock('~/hooks/useDebouncedSearch', () => ({
   useDebouncedSearch: () => ({
-    debouncedSearch: jest.fn(),
+    debouncedSearch: mockDebouncedSearch,
     isLoading: false,
   }),
 }))
@@ -73,6 +75,47 @@ jest.mock('~/generated/graphql', () => ({
 describe('BillableMetricsList', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockPage = 1
+  })
+
+  describe('GIVEN the list is on page 3', (): void => {
+    it('WHEN search is edited or cleared THEN resets the page before searching', (): void => {
+      mockPage = 3
+      mockHasPermissions.mockReturnValue(false)
+
+      render(<BillableMetricsList />)
+
+      const [headerConfig] = mockMainHeaderConfigure.mock.calls[0]
+
+      render(<>{headerConfig.filtersSection}</>)
+
+      const searchInput = screen.getByRole('textbox')
+
+      fireEvent.change(searchInput, { target: { value: 'new query' } })
+
+      expect(searchInput).toHaveValue('new query')
+      expect(mockGoToPage).toHaveBeenCalledTimes(1)
+      expect(mockGoToPage).toHaveBeenCalledWith(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledWith('new query')
+      expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+        mockDebouncedSearch.mock.invocationCallOrder[0],
+      )
+
+      mockGoToPage.mockClear()
+      mockDebouncedSearch.mockClear()
+
+      fireEvent.change(searchInput, { target: { value: '' } })
+
+      expect(searchInput).toHaveValue('')
+      expect(mockGoToPage).toHaveBeenCalledTimes(1)
+      expect(mockGoToPage).toHaveBeenCalledWith(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledWith('')
+      expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+        mockDebouncedSearch.mock.invocationCallOrder[0],
+      )
+    })
   })
 
   describe('GIVEN the component is rendered', () => {

--- a/src/pages/__tests__/CouponsList.test.tsx
+++ b/src/pages/__tests__/CouponsList.test.tsx
@@ -1,10 +1,16 @@
+import { fireEvent, screen } from '@testing-library/react'
+
+import { MainHeaderConfig } from '~/components/MainHeader/types'
 import { CouponStatusEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
 import CouponsList from '../CouponsList'
 
-const mockMainHeaderConfigure = jest.fn()
+const mockMainHeaderConfigure = jest.fn<void, [MainHeaderConfig]>()
 const mockTableProps = jest.fn()
+const mockGoToPage = jest.fn()
+const mockDebouncedSearch = jest.fn()
+let mockPage = 1
 
 const mockCanCreate = jest.fn()
 const mockCanEdit = jest.fn()
@@ -13,7 +19,7 @@ const mockCanDelete = jest.fn()
 
 jest.mock('~/components/MainHeader/MainHeader', () => ({
   MainHeader: {
-    Configure: (props: Record<string, unknown>) => {
+    Configure: (props: MainHeaderConfig): null => {
       mockMainHeaderConfigure(props)
       return null
     },
@@ -29,11 +35,7 @@ jest.mock('~/components/designSystem/Table/Table', () => ({
 
 jest.mock('~/components/designSystem/Pagination', () => ({
   PaginatedContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  usePageSearchParam: () => ({ page: 1, goToPage: jest.fn() }),
-}))
-
-jest.mock('~/components/SearchInput', () => ({
-  SearchInput: () => null,
+  usePageSearchParam: () => ({ page: mockPage, goToPage: mockGoToPage }),
 }))
 
 jest.mock('~/components/coupons/useDeleteCoupon', () => ({
@@ -79,7 +81,7 @@ jest.mock('~/hooks/useOrganizationInfos', () => ({
 
 jest.mock('~/hooks/useDebouncedSearch', () => ({
   useDebouncedSearch: () => ({
-    debouncedSearch: jest.fn(),
+    debouncedSearch: mockDebouncedSearch,
     isLoading: false,
   }),
 }))
@@ -99,10 +101,50 @@ jest.mock('~/core/constants/statusCouponMapping', () => ({
 describe('CouponsList', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockPage = 1
     mockCanCreate.mockReturnValue(true)
     mockCanEdit.mockReturnValue(true)
     mockCanTerminate.mockReturnValue(true)
     mockCanDelete.mockReturnValue(true)
+  })
+
+  describe('GIVEN the list is on page 3', (): void => {
+    it('WHEN search is edited or cleared THEN resets the page before searching', (): void => {
+      mockPage = 3
+
+      render(<CouponsList />)
+
+      const [headerConfig] = mockMainHeaderConfigure.mock.calls[0]
+
+      render(<>{headerConfig.filtersSection}</>)
+
+      const searchInput = screen.getByRole('textbox')
+
+      fireEvent.change(searchInput, { target: { value: 'new query' } })
+
+      expect(searchInput).toHaveValue('new query')
+      expect(mockGoToPage).toHaveBeenCalledTimes(1)
+      expect(mockGoToPage).toHaveBeenCalledWith(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledWith('new query')
+      expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+        mockDebouncedSearch.mock.invocationCallOrder[0],
+      )
+
+      mockGoToPage.mockClear()
+      mockDebouncedSearch.mockClear()
+
+      fireEvent.change(searchInput, { target: { value: '' } })
+
+      expect(searchInput).toHaveValue('')
+      expect(mockGoToPage).toHaveBeenCalledTimes(1)
+      expect(mockGoToPage).toHaveBeenCalledWith(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledWith('')
+      expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+        mockDebouncedSearch.mock.invocationCallOrder[0],
+      )
+    })
   })
 
   describe('GIVEN the component is rendered', () => {

--- a/src/pages/__tests__/CreditNotesPage.test.tsx
+++ b/src/pages/__tests__/CreditNotesPage.test.tsx
@@ -1,5 +1,7 @@
-import { screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
+import { ComponentProps } from 'react'
 
+import { Filters } from '~/components/Filters'
 import { MainHeaderConfig } from '~/components/MainHeader/types'
 import { GetCreditNotesListDocument, GetCreditNotesListQueryVariables } from '~/generated/graphql'
 import { render } from '~/test-utils'
@@ -35,12 +37,30 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 }))
 
 const mockDebouncedSearch = jest.fn()
+const mockGoToPage = jest.fn()
+let mockPage = 1
+
+jest.mock('~/components/Filters', () => ({
+  ...jest.requireActual('~/components/Filters'),
+  Filters: {
+    Provider: ({ children }: ComponentProps<typeof Filters.Provider>): JSX.Element => (
+      <>{children}</>
+    ),
+    Component: (): null => null,
+    QuickFilters: (): null => null,
+  },
+}))
 
 jest.mock('~/hooks/useDebouncedSearch', () => ({
   useDebouncedSearch: () => ({
     debouncedSearch: mockDebouncedSearch,
     isLoading: false,
   }),
+}))
+
+jest.mock('~/components/designSystem/Pagination', () => ({
+  ...jest.requireActual('~/components/designSystem/Pagination'),
+  usePageSearchParam: () => ({ page: mockPage, goToPage: mockGoToPage }),
 }))
 
 jest.mock('~/hooks/useOrganizationInfos', () => ({
@@ -88,8 +108,35 @@ jest.mock('~/components/exports/ExportDialog', () => ({
 describe('CreditNotesPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockPage = 1
     capturedConfig = null
     capturedListVariables = null
+  })
+
+  describe('GIVEN the list is on page 3', (): void => {
+    it('WHEN search is edited or cleared THEN resets the page before searching', (): void => {
+      mockPage = 3
+      render(<CreditNotesPage />)
+      render(<>{capturedConfig?.filtersSection}</>)
+
+      const input = screen.getByRole('textbox')
+
+      for (const value of [' new query ', '']) {
+        mockGoToPage.mockClear()
+        mockDebouncedSearch.mockClear()
+
+        fireEvent.change(input, { target: { value } })
+
+        expect(input).toHaveValue(value)
+        expect(mockGoToPage).toHaveBeenCalledTimes(1)
+        expect(mockGoToPage).toHaveBeenCalledWith(1)
+        expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+        expect(mockDebouncedSearch).toHaveBeenCalledWith(value)
+        expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+          mockDebouncedSearch.mock.invocationCallOrder[0],
+        )
+      }
+    })
   })
 
   describe('GIVEN the page is rendered', () => {

--- a/src/pages/__tests__/CustomersList.test.tsx
+++ b/src/pages/__tests__/CustomersList.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { ComponentProps } from 'react'
+
+import { PaginatedContent } from '~/components/designSystem/Pagination'
+import { Filters } from '~/components/Filters'
+import { MainHeaderConfig } from '~/components/MainHeader/types'
+import { render } from '~/test-utils'
+
+import CustomersList from '../CustomersList'
+
+const mockMainHeaderConfigure = jest.fn<void, [MainHeaderConfig]>()
+const mockGoToPage = jest.fn()
+const mockDebouncedSearch = jest.fn()
+
+jest.mock('~/components/MainHeader/MainHeader', () => ({
+  MainHeader: {
+    Configure: (props: MainHeaderConfig): null => {
+      mockMainHeaderConfigure(props)
+      return null
+    },
+  },
+}))
+
+jest.mock('~/components/designSystem/Table/Table', () => ({
+  Table: (): null => null,
+}))
+
+jest.mock('~/components/designSystem/Pagination', () => ({
+  PaginatedContent: ({ children }: ComponentProps<typeof PaginatedContent>): JSX.Element => (
+    <>{children}</>
+  ),
+  usePageSearchParam: () => ({ page: 3, goToPage: mockGoToPage }),
+}))
+
+jest.mock('~/components/Filters', () => ({
+  ...jest.requireActual('~/components/Filters'),
+  Filters: {
+    Provider: ({ children }: ComponentProps<typeof Filters.Provider>): JSX.Element => (
+      <>{children}</>
+    ),
+    Component: (): null => null,
+    QuickFilters: (): null => null,
+  },
+}))
+
+jest.mock('~/components/customers/DeleteCustomerDialog', () => ({
+  useDeleteCustomerDialog: () => ({ openDeleteCustomerDialog: jest.fn() }),
+}))
+
+jest.mock('~/hooks/customer/useCustomersListHeaderActions', () => ({
+  useCustomersListHeaderActions: () => [],
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string): string => key }),
+}))
+
+jest.mock('~/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasPermissions: (): boolean => false }),
+}))
+
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  useOrganizationInfos: () => ({
+    intlFormatDateTimeOrgaTZ: () => ({ date: '2024-01-01' }),
+    hasOrganizationPremiumAddon: (): boolean => false,
+  }),
+}))
+
+jest.mock('~/hooks/useDebouncedSearch', () => ({
+  useDebouncedSearch: () => ({
+    debouncedSearch: mockDebouncedSearch,
+    isLoading: false,
+  }),
+}))
+
+jest.mock('~/generated/graphql', () => ({
+  ...jest.requireActual('~/generated/graphql'),
+  useCustomersLazyQuery: () => [
+    jest.fn(),
+    { data: undefined, error: undefined, loading: false, variables: {} },
+  ],
+}))
+
+describe('CustomersList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GIVEN the list is on page 3', (): void => {
+    it('WHEN search is edited or cleared THEN resets the page before searching', (): void => {
+      render(<CustomersList />)
+
+      const config = mockMainHeaderConfigure.mock.calls[0][0]
+
+      render(<>{config.filtersSection}</>)
+
+      const input = screen.getByRole('textbox')
+
+      for (const value of [' new query ', '']) {
+        mockGoToPage.mockClear()
+        mockDebouncedSearch.mockClear()
+
+        fireEvent.change(input, { target: { value } })
+
+        expect(input).toHaveValue(value)
+        expect(mockGoToPage).toHaveBeenCalledTimes(1)
+        expect(mockGoToPage).toHaveBeenCalledWith(1)
+        expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+        expect(mockDebouncedSearch).toHaveBeenCalledWith(value)
+        expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+          mockDebouncedSearch.mock.invocationCallOrder[0],
+        )
+      }
+    })
+  })
+})

--- a/src/pages/__tests__/InvoicesPage.test.tsx
+++ b/src/pages/__tests__/InvoicesPage.test.tsx
@@ -1,5 +1,7 @@
-import { screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
+import { ComponentProps } from 'react'
 
+import { Filters } from '~/components/Filters'
 import { MainHeaderConfig } from '~/components/MainHeader/types'
 import { GetInvoicesListDocument, GetInvoicesListQueryVariables } from '~/generated/graphql'
 import { TranslateFunc } from '~/hooks/core/useInternationalization'
@@ -38,12 +40,30 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 }))
 
 const mockDebouncedSearch = jest.fn()
+const mockGoToPage = jest.fn()
+let mockPage = 1
+
+jest.mock('~/components/Filters', () => ({
+  ...jest.requireActual('~/components/Filters'),
+  Filters: {
+    Provider: ({ children }: ComponentProps<typeof Filters.Provider>): JSX.Element => (
+      <>{children}</>
+    ),
+    Component: (): null => null,
+    QuickFilters: (): null => null,
+  },
+}))
 
 jest.mock('~/hooks/useDebouncedSearch', () => ({
   useDebouncedSearch: () => ({
     debouncedSearch: mockDebouncedSearch,
     isLoading: false,
   }),
+}))
+
+jest.mock('~/components/designSystem/Pagination', () => ({
+  ...jest.requireActual('~/components/designSystem/Pagination'),
+  usePageSearchParam: () => ({ page: mockPage, goToPage: mockGoToPage }),
 }))
 
 jest.mock('~/hooks/useOrganizationInfos', () => ({
@@ -143,9 +163,36 @@ const openExportDialogFromHeader = (): void => {
 describe('InvoicesPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockPage = 1
     capturedConfig = null
     capturedListVariables = null
     mockInvoicesMetadata = UNCAPPED_METADATA
+  })
+
+  describe('GIVEN the list is on page 3', (): void => {
+    it('WHEN search is edited or cleared THEN resets the page before searching', (): void => {
+      mockPage = 3
+      render(<InvoicesPage />)
+      render(<>{capturedConfig?.filtersSection}</>)
+
+      const input = screen.getByRole('textbox')
+
+      for (const value of [' new query ', '']) {
+        mockGoToPage.mockClear()
+        mockDebouncedSearch.mockClear()
+
+        fireEvent.change(input, { target: { value } })
+
+        expect(input).toHaveValue(value)
+        expect(mockGoToPage).toHaveBeenCalledTimes(1)
+        expect(mockGoToPage).toHaveBeenCalledWith(1)
+        expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+        expect(mockDebouncedSearch).toHaveBeenCalledWith(value)
+        expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+          mockDebouncedSearch.mock.invocationCallOrder[0],
+        )
+      }
+    })
   })
 
   describe('GIVEN the page is rendered', () => {

--- a/src/pages/__tests__/PaymentsPage.test.tsx
+++ b/src/pages/__tests__/PaymentsPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 
 import { MainHeaderConfig } from '~/components/MainHeader/types'
 import { render, testMockNavigateFn } from '~/test-utils'
@@ -23,6 +23,13 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 }))
 
 const mockDebouncedSearch = jest.fn()
+const mockGoToPage = jest.fn()
+let mockPage = 1
+
+jest.mock('~/components/designSystem/Pagination', () => ({
+  ...jest.requireActual('~/components/designSystem/Pagination'),
+  usePageSearchParam: () => ({ page: mockPage, goToPage: mockGoToPage }),
+}))
 
 jest.mock('~/hooks/useDebouncedSearch', () => ({
   useDebouncedSearch: () => ({
@@ -74,9 +81,36 @@ jest.mock('~/components/dialogs/PremiumWarningDialog', () => ({
 describe('PaymentsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockPage = 1
     capturedConfig = null
     mockIsPremium.mockReturnValue(true)
     mockOpenPremiumWarningDialog.mockClear()
+  })
+
+  describe('GIVEN the list is on page 3', (): void => {
+    it('WHEN search is edited or cleared THEN resets the page before searching', (): void => {
+      mockPage = 3
+      render(<PaymentsPage />)
+      render(<>{capturedConfig?.filtersSection}</>)
+
+      const input = screen.getByRole('textbox')
+
+      for (const value of [' new query ', '']) {
+        mockGoToPage.mockClear()
+        mockDebouncedSearch.mockClear()
+
+        fireEvent.change(input, { target: { value } })
+
+        expect(input).toHaveValue(value)
+        expect(mockGoToPage).toHaveBeenCalledTimes(1)
+        expect(mockGoToPage).toHaveBeenCalledWith(1)
+        expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+        expect(mockDebouncedSearch).toHaveBeenCalledWith(value)
+        expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+          mockDebouncedSearch.mock.invocationCallOrder[0],
+        )
+      }
+    })
   })
 
   describe('GIVEN the page is rendered', () => {

--- a/src/pages/__tests__/PlansList.test.tsx
+++ b/src/pages/__tests__/PlansList.test.tsx
@@ -1,14 +1,20 @@
+import { fireEvent, screen } from '@testing-library/react'
+
+import { MainHeaderConfig } from '~/components/MainHeader/types'
 import { render } from '~/test-utils'
 
 import PlansList from '../PlansList'
 
-const mockMainHeaderConfigure = jest.fn()
+const mockMainHeaderConfigure = jest.fn<void, [MainHeaderConfig]>()
 const mockTableProps = jest.fn()
 const mockHasPermissions = jest.fn()
+const mockGoToPage = jest.fn()
+const mockDebouncedSearch = jest.fn()
+let mockPage = 1
 
 jest.mock('~/components/MainHeader/MainHeader', () => ({
   MainHeader: {
-    Configure: (props: Record<string, unknown>) => {
+    Configure: (props: MainHeaderConfig): null => {
       mockMainHeaderConfigure(props)
       return null
     },
@@ -24,11 +30,7 @@ jest.mock('~/components/designSystem/Table/Table', () => ({
 
 jest.mock('~/components/designSystem/Pagination', () => ({
   PaginatedContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  usePageSearchParam: () => ({ page: 1, goToPage: jest.fn() }),
-}))
-
-jest.mock('~/components/SearchInput', () => ({
-  SearchInput: () => null,
+  usePageSearchParam: () => ({ page: mockPage, goToPage: mockGoToPage }),
 }))
 
 jest.mock('~/components/plans/DeletePlanDialog', () => ({
@@ -57,7 +59,7 @@ jest.mock('~/hooks/useOrganizationInfos', () => ({
 
 jest.mock('~/hooks/useDebouncedSearch', () => ({
   useDebouncedSearch: () => ({
-    debouncedSearch: jest.fn(),
+    debouncedSearch: mockDebouncedSearch,
     isLoading: false,
   }),
 }))
@@ -77,6 +79,47 @@ jest.mock('~/generated/graphql', () => ({
 describe('PlansList', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockPage = 1
+  })
+
+  describe('GIVEN the list is on page 3', (): void => {
+    it('WHEN search is edited or cleared THEN resets the page before searching', (): void => {
+      mockPage = 3
+      mockHasPermissions.mockReturnValue(false)
+
+      render(<PlansList />)
+
+      const [headerConfig] = mockMainHeaderConfigure.mock.calls[0]
+
+      render(<>{headerConfig.filtersSection}</>)
+
+      const searchInput = screen.getByRole('textbox')
+
+      fireEvent.change(searchInput, { target: { value: 'new query' } })
+
+      expect(searchInput).toHaveValue('new query')
+      expect(mockGoToPage).toHaveBeenCalledTimes(1)
+      expect(mockGoToPage).toHaveBeenCalledWith(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledWith('new query')
+      expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+        mockDebouncedSearch.mock.invocationCallOrder[0],
+      )
+
+      mockGoToPage.mockClear()
+      mockDebouncedSearch.mockClear()
+
+      fireEvent.change(searchInput, { target: { value: '' } })
+
+      expect(searchInput).toHaveValue('')
+      expect(mockGoToPage).toHaveBeenCalledTimes(1)
+      expect(mockGoToPage).toHaveBeenCalledWith(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledWith('')
+      expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+        mockDebouncedSearch.mock.invocationCallOrder[0],
+      )
+    })
   })
 
   describe('GIVEN the component is rendered', () => {

--- a/src/pages/__tests__/SubscriptionsPage.test.tsx
+++ b/src/pages/__tests__/SubscriptionsPage.test.tsx
@@ -1,5 +1,7 @@
-import { screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
+import { ComponentProps } from 'react'
 
+import { Filters } from '~/components/Filters'
 import { MainHeaderConfig } from '~/components/MainHeader/types'
 import { render } from '~/test-utils'
 
@@ -23,6 +25,19 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 }))
 
 const mockDebouncedSearch = jest.fn()
+const mockGoToPage = jest.fn()
+let mockPage = 1
+
+jest.mock('~/components/Filters', () => ({
+  ...jest.requireActual('~/components/Filters'),
+  Filters: {
+    Provider: ({ children }: ComponentProps<typeof Filters.Provider>): JSX.Element => (
+      <>{children}</>
+    ),
+    Component: (): null => null,
+    QuickFilters: (): null => null,
+  },
+}))
 
 jest.mock('~/hooks/useDebouncedSearch', () => ({
   useDebouncedSearch: () => ({
@@ -61,14 +76,41 @@ jest.mock('~/components/subscriptions/SubscriptionsList', () => ({
 
 jest.mock('~/components/designSystem/Pagination', () => ({
   PaginatedContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  usePageSearchParam: () => ({ page: 1, goToPage: jest.fn() }),
+  usePageSearchParam: () => ({ page: mockPage, goToPage: mockGoToPage }),
 }))
 
 describe('SubscriptionsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockPage = 1
     capturedConfig = null
     capturedListProps = null
+  })
+
+  describe('GIVEN the list is on page 3', (): void => {
+    it('WHEN search is edited or cleared THEN resets the page before searching', (): void => {
+      mockPage = 3
+      render(<SubscriptionsPage />)
+      render(<>{capturedConfig?.filtersSection}</>)
+
+      const input = screen.getByRole('textbox')
+
+      for (const value of [' new query ', '']) {
+        mockGoToPage.mockClear()
+        mockDebouncedSearch.mockClear()
+
+        fireEvent.change(input, { target: { value } })
+
+        expect(input).toHaveValue(value)
+        expect(mockGoToPage).toHaveBeenCalledTimes(1)
+        expect(mockGoToPage).toHaveBeenCalledWith(1)
+        expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+        expect(mockDebouncedSearch).toHaveBeenCalledWith(value)
+        expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+          mockDebouncedSearch.mock.invocationCallOrder[0],
+        )
+      }
+    })
   })
 
   describe('GIVEN the page is rendered', () => {

--- a/src/pages/catalog/ProductCategoriesList.tsx
+++ b/src/pages/catalog/ProductCategoriesList.tsx
@@ -100,7 +100,7 @@ const ProductCategoriesList = () => {
   const searchInputOnChange = useCallback(
     (value: string) => {
       goToPage(1)
-      debouncedSearch?.(value)
+      debouncedSearch(value)
     },
     [goToPage, debouncedSearch],
   )

--- a/src/pages/catalog/ProductFiltersList.tsx
+++ b/src/pages/catalog/ProductFiltersList.tsx
@@ -106,7 +106,7 @@ const ProductFiltersList = () => {
   const searchInputOnChange = useCallback(
     (value: string) => {
       goToPage(1)
-      debouncedSearch?.(value)
+      debouncedSearch(value)
     },
     [goToPage, debouncedSearch],
   )

--- a/src/pages/catalog/ProductsList.tsx
+++ b/src/pages/catalog/ProductsList.tsx
@@ -105,7 +105,7 @@ const ProductsList = () => {
   const searchInputOnChange = useCallback(
     (value: string) => {
       goToPage(1)
-      debouncedSearch?.(value)
+      debouncedSearch(value)
     },
     [goToPage, debouncedSearch],
   )

--- a/src/pages/catalog/RateCardsList.tsx
+++ b/src/pages/catalog/RateCardsList.tsx
@@ -89,7 +89,7 @@ const RateCardsList = () => {
   const searchInputOnChange = useCallback(
     (value: string) => {
       goToPage(1)
-      debouncedSearch?.(value)
+      debouncedSearch(value)
     },
     [goToPage, debouncedSearch],
   )

--- a/src/pages/catalog/details/ProductCategoryDetailsProducts.tsx
+++ b/src/pages/catalog/details/ProductCategoryDetailsProducts.tsx
@@ -107,7 +107,7 @@ const ProductsPreview = ({ productCategory }: { productCategory: ProductCategory
   return (
     <div className="flex flex-col gap-4">
       <SearchInput
-        onChange={(value) => debouncedSearch?.(value)}
+        onChange={debouncedSearch}
         placeholder={translate('text_1783980718114714izppxdwq')}
         data-test="product-details-product-items-search-input"
       />

--- a/src/pages/catalog/details/ProductFilterPreview.tsx
+++ b/src/pages/catalog/details/ProductFilterPreview.tsx
@@ -143,7 +143,7 @@ const ProductFilterPreviewList = ({ product }: { product: ProductForFilterPrevie
   return (
     <div className="flex flex-col gap-4">
       <SearchInput
-        onChange={(value) => debouncedSearch?.(value)}
+        onChange={debouncedSearch}
         placeholder={translate('text_17845854002450t175dwblcq')}
         data-test="product-item-filter-preview-search-input"
       />

--- a/src/pages/catalog/details/RateCardPreview.tsx
+++ b/src/pages/catalog/details/RateCardPreview.tsx
@@ -230,7 +230,7 @@ const RateCardPreviewListForProduct = ({
       isLoading={isLoading}
       hasError={!!error}
       isSearching={!!variables?.searchTerm}
-      onSearch={(value) => debouncedSearch?.(value)}
+      onSearch={debouncedSearch}
       viewAllTo={viewAllTo}
     />
   )
@@ -268,7 +268,7 @@ const RateCardPreviewListForProductFilter = ({
       isLoading={isLoading}
       hasError={!!error}
       isSearching={!!variables?.searchTerm}
-      onSearch={(value) => debouncedSearch?.(value)}
+      onSearch={debouncedSearch}
       viewAllTo={viewAllTo}
     />
   )

--- a/src/pages/features/FeaturesList.tsx
+++ b/src/pages/features/FeaturesList.tsx
@@ -137,7 +137,7 @@ const FeaturesList = () => {
           <SearchInput
             onChange={(value) => {
               goToPage(1)
-              debouncedSearch?.(value)
+              debouncedSearch(value)
             }}
             placeholder={translate('text_1752692673070xf4wtgsrsum')}
           />

--- a/src/pages/features/__tests__/FeaturesList.test.tsx
+++ b/src/pages/features/__tests__/FeaturesList.test.tsx
@@ -1,14 +1,20 @@
+import { fireEvent, screen } from '@testing-library/react'
+
+import { MainHeaderConfig } from '~/components/MainHeader/types'
 import { render } from '~/test-utils'
 
 import FeaturesList from '../FeaturesList'
 
-const mockMainHeaderConfigure = jest.fn()
+const mockMainHeaderConfigure = jest.fn<void, [MainHeaderConfig]>()
 const mockTableProps = jest.fn()
 const mockHasPermissions = jest.fn()
+const mockGoToPage = jest.fn()
+const mockDebouncedSearch = jest.fn()
+let mockPage = 1
 
 jest.mock('~/components/MainHeader/MainHeader', () => ({
   MainHeader: {
-    Configure: (props: Record<string, unknown>) => {
+    Configure: (props: MainHeaderConfig): null => {
       mockMainHeaderConfigure(props)
       return null
     },
@@ -24,11 +30,7 @@ jest.mock('~/components/designSystem/Table/Table', () => ({
 
 jest.mock('~/components/designSystem/Pagination', () => ({
   PaginatedContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  usePageSearchParam: () => ({ page: 1, goToPage: jest.fn() }),
-}))
-
-jest.mock('~/components/SearchInput', () => ({
-  SearchInput: () => null,
+  usePageSearchParam: () => ({ page: mockPage, goToPage: mockGoToPage }),
 }))
 
 jest.mock('~/components/features/DeleteFeatureDialog', () => ({
@@ -51,7 +53,7 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 
 jest.mock('~/hooks/useDebouncedSearch', () => ({
   useDebouncedSearch: () => ({
-    debouncedSearch: jest.fn(),
+    debouncedSearch: mockDebouncedSearch,
     isLoading: false,
   }),
 }))
@@ -73,6 +75,47 @@ jest.mock('~/generated/graphql', () => ({
 describe('FeaturesList', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockPage = 1
+  })
+
+  describe('GIVEN the list is on page 3', (): void => {
+    it('WHEN search is edited or cleared THEN resets the page before searching', (): void => {
+      mockPage = 3
+      mockHasPermissions.mockReturnValue(false)
+
+      render(<FeaturesList />)
+
+      const [headerConfig] = mockMainHeaderConfigure.mock.calls[0]
+
+      render(<>{headerConfig.filtersSection}</>)
+
+      const searchInput = screen.getByRole('textbox')
+
+      fireEvent.change(searchInput, { target: { value: 'new query' } })
+
+      expect(searchInput).toHaveValue('new query')
+      expect(mockGoToPage).toHaveBeenCalledTimes(1)
+      expect(mockGoToPage).toHaveBeenCalledWith(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledWith('new query')
+      expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+        mockDebouncedSearch.mock.invocationCallOrder[0],
+      )
+
+      mockGoToPage.mockClear()
+      mockDebouncedSearch.mockClear()
+
+      fireEvent.change(searchInput, { target: { value: '' } })
+
+      expect(searchInput).toHaveValue('')
+      expect(mockGoToPage).toHaveBeenCalledTimes(1)
+      expect(mockGoToPage).toHaveBeenCalledWith(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledTimes(1)
+      expect(mockDebouncedSearch).toHaveBeenCalledWith('')
+      expect(mockGoToPage.mock.invocationCallOrder[0]).toBeLessThan(
+        mockDebouncedSearch.mock.invocationCallOrder[0],
+      )
+    })
   })
 
   describe('GIVEN the component is rendered', () => {

--- a/src/pages/settings/teamAndSecurity/members/MembersInvitationList.tsx
+++ b/src/pages/settings/teamAndSecurity/members/MembersInvitationList.tsx
@@ -205,7 +205,7 @@ const MembersInvitationList = () => {
         setSearchQuery={(value) => {
           goToPage(1)
           setSearchQuery(value)
-          debouncedSearch?.(value)
+          debouncedSearch(value)
         }}
         type="invitations"
       />

--- a/src/pages/settings/teamAndSecurity/members/MembersList.tsx
+++ b/src/pages/settings/teamAndSecurity/members/MembersList.tsx
@@ -174,7 +174,7 @@ const MemberList = () => {
         setSearchQuery={(value) => {
           goToPage(1)
           setSearchQuery(value)
-          debouncedSearch?.(value)
+          debouncedSearch(value)
         }}
         type="members"
       />


### PR DESCRIPTION
Check selected-value membership directly when combobox options change, avoiding a full deletion diff while preserving free-form values.

Require a string handler from the search hook and express its minimum spinner duration in milliseconds. Share pagination cache-key construction across the two named policies to remove duplication while retaining their existing append and replace behavior.

Exercise list search entry and clearing to ensure each page resets to page 1 before forwarding the input.
