### PR TITLE
fix: preserve AI stream events and load code grammars on demand

### DIFF
--- a/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.tsx
@@ -38,14 +38,22 @@ export const CodeSnippet = memo(
     displayHead = true,
     variant = 'default',
   }: CodeSnippetProps) => {
-    const codeRef = useRef(null)
+    const codeRef = useRef<HTMLElement>(null)
     const { translate } = useInternationalization()
 
     useEffect(() => {
       if (codeRef?.current) {
         Prism.highlightElement(codeRef.current)
       }
-    })
+    }, [code, language, loading])
+
+    useEffect(() => {
+      const pre = codeRef.current?.parentElement
+
+      if (pre) {
+        Prism.plugins.lineNumbers.resize(pre)
+      }
+    }, [className, displayHead, variant, canCopy, loading])
 
     const handleCopy = () => {
       copyToClipboard(code, { ignoreComment: true })

--- a/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.tsx
@@ -95,6 +95,7 @@ export const CodeSnippet = memo(
                 // Line-numbers is a Prism className and is required
                 // https://prismjs.com/plugins/line-numbers/
                 'line-numbers',
+                `language-${language}`,
                 'pb-30',
                 displayHead ? 'h-[calc(100%-theme(space.nav))]' : 'h-full',
                 variant === 'minimal' && '!m-0',

--- a/src/components/CodeSnippet/__tests__/CodeSnippet.test.tsx
+++ b/src/components/CodeSnippet/__tests__/CodeSnippet.test.tsx
@@ -1,0 +1,72 @@
+import { render } from '@testing-library/react'
+import Prism from 'prismjs'
+
+import { CodeSnippet } from '../CodeSnippet'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+describe('CodeSnippet', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  it('highlights mounted code and updates the grammar and line numbers when inputs change', () => {
+    const highlight = jest.spyOn(Prism, 'highlightElement')
+    const { container, rerender } = render(<CodeSnippet loading code="const value = 1" />)
+
+    expect(highlight).not.toHaveBeenCalled()
+
+    rerender(<CodeSnippet loading={false} code={'const value = 1\nconst other = 2'} />)
+
+    expect(highlight).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('.token.keyword')).toHaveTextContent('const')
+    expect(container.querySelectorAll('.line-numbers-rows > span')).toHaveLength(2)
+
+    rerender(<CodeSnippet loading={false} code={'{"value": true}'} language="json" />)
+
+    expect(highlight).toHaveBeenCalledTimes(2)
+    expect(container.querySelector('.token.property')).toHaveTextContent('"value"')
+    expect(container.querySelectorAll('.line-numbers-rows > span')).toHaveLength(1)
+
+    rerender(<CodeSnippet loading code={'{"value": true}'} language="json" />)
+    rerender(<CodeSnippet loading={false} code={'{"value": true}'} language="json" />)
+
+    expect(highlight).toHaveBeenCalledTimes(3)
+    expect(container.querySelectorAll('.line-numbers-rows > span')).toHaveLength(1)
+  })
+
+  it('refreshes line-number layout without re-highlighting on presentation changes', () => {
+    const highlight = jest.spyOn(Prism, 'highlightElement')
+    const resize = jest.spyOn(Prism.plugins.lineNumbers, 'resize')
+    const { container, rerender } = render(<CodeSnippet code={'const a = 1\nconst b = 2'} />)
+    const rows = container.querySelector('.line-numbers-rows')
+
+    highlight.mockClear()
+    resize.mockClear()
+    rerender(
+      <CodeSnippet
+        code={'const a = 1\nconst b = 2'}
+        variant="minimal"
+        className="w-80"
+        displayHead={false}
+        canCopy={false}
+      />,
+    )
+
+    expect(highlight).not.toHaveBeenCalled()
+    expect(resize).toHaveBeenCalledWith(container.querySelector('pre'))
+    expect(container.querySelector('.line-numbers-rows')).toBe(rows)
+    expect(container.querySelectorAll('.line-numbers-rows > span')).toHaveLength(2)
+  })
+
+  it('re-highlights unchanged code when only the language changes', () => {
+    const highlight = jest.spyOn(Prism, 'highlightElement')
+    const { rerender, container } = render(<CodeSnippet code="true" language="javascript" />)
+
+    rerender(<CodeSnippet code="true" language="json" />)
+
+    expect(highlight).toHaveBeenCalledTimes(2)
+    expect(container.querySelector('code')).toHaveClass('language-json')
+    expect(container.querySelector('.token.boolean')).toHaveTextContent('true')
+  })
+})

--- a/src/components/CodeSnippet/__tests__/CodeSnippet.test.tsx
+++ b/src/components/CodeSnippet/__tests__/CodeSnippet.test.tsx
@@ -8,6 +8,16 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 }))
 
 describe('CodeSnippet', () => {
+  const style = document.createElement('style')
+
+  beforeAll(() => {
+    const { readFileSync } = jest.requireActual<typeof import('node:fs')>('node:fs')
+
+    style.textContent = readFileSync(`${__dirname}/../codeSnippet.css`, 'utf8')
+    document.head.appendChild(style)
+  })
+
+  afterAll(() => style.remove())
   afterEach(() => jest.restoreAllMocks())
 
   it('highlights mounted code and updates the grammar and line numbers when inputs change', () => {
@@ -35,29 +45,49 @@ describe('CodeSnippet', () => {
     expect(container.querySelectorAll('.line-numbers-rows > span')).toHaveLength(1)
   })
 
-  it('refreshes line-number layout without re-highlighting on presentation changes', () => {
-    const highlight = jest.spyOn(Prism, 'highlightElement')
-    const resize = jest.spyOn(Prism.plugins.lineNumbers, 'resize')
-    const { container, rerender } = render(<CodeSnippet code={'const a = 1\nconst b = 2'} />)
-    const rows = container.querySelector('.line-numbers-rows')
+  it.each([
+    { displayHead: false },
+    { variant: 'minimal' as const },
+    { className: 'w-80' },
+    { canCopy: false },
+  ])(
+    'preserves scrolling and line-number layout without re-highlighting for %j',
+    (presentationProps) => {
+      const highlight = jest.spyOn(Prism, 'highlightElement')
+      const resize = jest.spyOn(Prism.plugins.lineNumbers, 'resize')
+      const code = 'const a = 1\nconst b = 2'
+      const { container, rerender } = render(<CodeSnippet code={code} />)
+      const pre = container.querySelector('pre') as HTMLPreElement
+      const rows = container.querySelector('.line-numbers-rows')
+      const keyword = container.querySelector('.token.keyword')
 
-    highlight.mockClear()
-    resize.mockClear()
-    rerender(
-      <CodeSnippet
-        code={'const a = 1\nconst b = 2'}
-        variant="minimal"
-        className="w-80"
-        displayHead={false}
-        canCopy={false}
-      />,
-    )
+      expect(pre).toHaveClass('language-javascript', 'line-numbers')
+      expect(getComputedStyle(pre).overflow).toBe('auto')
+      expect(keyword).toHaveTextContent('const')
+      expect(rows?.children).toHaveLength(2)
 
-    expect(highlight).not.toHaveBeenCalled()
-    expect(resize).toHaveBeenCalledWith(container.querySelector('pre'))
-    expect(container.querySelector('.line-numbers-rows')).toBe(rows)
-    expect(container.querySelectorAll('.line-numbers-rows > span')).toHaveLength(2)
-  })
+      highlight.mockClear()
+      resize.mockClear()
+      rerender(<CodeSnippet code={code} {...presentationProps} />)
+
+      expect(getComputedStyle(pre).overflow).toBe('auto')
+      expect(pre).toHaveClass('language-javascript', 'line-numbers')
+      expect(highlight).not.toHaveBeenCalled()
+      expect(resize).toHaveBeenCalledWith(pre)
+      expect(container.querySelector('.token.keyword')).toBe(keyword)
+      expect(container.querySelector('.line-numbers-rows')).toBe(rows)
+      expect(rows?.children).toHaveLength(2)
+
+      rerender(<CodeSnippet code={code} />)
+
+      expect(getComputedStyle(pre).overflow).toBe('auto')
+      expect(pre).toHaveClass('language-javascript', 'line-numbers')
+      expect(highlight).not.toHaveBeenCalled()
+      expect(container.querySelector('.token.keyword')).toBe(keyword)
+      expect(container.querySelector('.line-numbers-rows')).toBe(rows)
+      expect(rows?.children).toHaveLength(2)
+    },
+  )
 
   it('re-highlights unchanged code when only the language changes', () => {
     const highlight = jest.spyOn(Prism, 'highlightElement')
@@ -65,7 +95,12 @@ describe('CodeSnippet', () => {
 
     rerender(<CodeSnippet code="true" language="json" />)
 
+    const pre = container.querySelector('pre') as HTMLPreElement
+
     expect(highlight).toHaveBeenCalledTimes(2)
+    expect(pre).toHaveClass('language-json', 'line-numbers')
+    expect(pre).not.toHaveClass('language-javascript')
+    expect(getComputedStyle(pre).overflow).toBe('auto')
     expect(container.querySelector('code')).toHaveClass('language-json')
     expect(container.querySelector('.token.boolean')).toHaveTextContent('true')
   })

--- a/src/components/aiAgent/ChatConversation.tsx
+++ b/src/components/aiAgent/ChatConversation.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from 'react'
+import { FC } from 'react'
 
 import { ChatMessages } from '~/components/aiAgent/ChatMessages'
 import { Message } from '~/components/aiAgent/llmOutputs'
@@ -14,27 +14,8 @@ interface ChatConversationProps {
 }
 
 export const ChatConversation: FC<ChatConversationProps> = ({ subscription }) => {
-  const { agentType, lastAssistantMessage, state, setChatDone, streamChunk } = useAiAgent()
+  const { agentType, state } = useAiAgent()
   const { translate } = useInternationalization()
-
-  useEffect(() => {
-    if (subscription.data?.aiConversationStreamed.chunk) {
-      if (lastAssistantMessage) {
-        streamChunk({
-          messageId: lastAssistantMessage.id,
-          chunk: subscription.data.aiConversationStreamed.chunk,
-        })
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subscription.data?.aiConversationStreamed.chunk])
-
-  useEffect(() => {
-    if (lastAssistantMessage && subscription.data?.aiConversationStreamed.done) {
-      setChatDone(lastAssistantMessage.id)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subscription.data?.aiConversationStreamed.done])
 
   return (
     <div
@@ -51,7 +32,7 @@ export const ChatConversation: FC<ChatConversationProps> = ({ subscription }) =>
           )
         }
 
-        // Skip the assistant bubble while it has nothing to render yet — the
+        // Skip the assistant bubble while it has nothing to render yet; the
         // loader stands in for the pending reply. An empty Received element
         // would otherwise stack a second gap-6 above the loader.
         if (!message.message && !message.financeAssistantResult) {

--- a/src/components/aiAgent/__tests__/AiAgentImports.test.tsx
+++ b/src/components/aiAgent/__tests__/AiAgentImports.test.tsx
@@ -1,0 +1,52 @@
+import { screen } from '@testing-library/react'
+import { PropsWithChildren } from 'react'
+import { createHighlighter } from 'shiki/bundle/web'
+
+import { AI_AGENT_NAV_TEST_ID, AiAgent } from '~/components/aiAgent/AiAgent'
+import { PANEL_AI_AGENT_WELCOME_TEST_ID } from '~/components/aiAgent/PanelAiAgent'
+import { AiAgentProvider } from '~/hooks/aiAgent/useAiAgent'
+import { render } from '~/test-utils'
+
+jest.mock('shiki/bundle/web', () => ({
+  bundledLanguages: { javascript: jest.fn() },
+  createHighlighter: jest.fn(() => Promise.resolve({})),
+}))
+
+jest.mock('shiki/themes/catppuccin-latte.mjs', () => ({}), { virtual: true })
+
+jest.mock('@llm-ui/code', () => ({ loadHighlighter: jest.fn() }))
+jest.mock('@llm-ui/react', () => ({}))
+jest.mock('@llm-ui/markdown', () => ({}))
+jest.mock('~/components/aiAgent/llmOutputs/Markdown', () => ({ MarkdownContent: () => null }))
+
+jest.mock('react-resizable-panels', () => ({
+  Panel: ({ children }: PropsWithChildren) => <section aria-label="AI panel">{children}</section>,
+}))
+
+jest.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    isPremium: true,
+    currentUser: {
+      id: 'user-1',
+      memberships: [{ id: 'membership-1', organization: { id: 'org-1', slug: 'test-org' } }],
+    },
+  }),
+}))
+
+jest.mock('~/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasPermissions: () => true }),
+}))
+
+it('keeps the closed AI panel shell mounted without initializing a highlighter', () => {
+  window.history.pushState({}, '', '/test-org/analytics')
+  render(
+    <AiAgentProvider>
+      <AiAgent />
+    </AiAgentProvider>,
+  )
+
+  expect(screen.getByTestId(AI_AGENT_NAV_TEST_ID)).toBeInTheDocument()
+  expect(screen.getByRole('region', { name: 'AI panel' })).toBeInTheDocument()
+  expect(screen.queryByTestId(PANEL_AI_AGENT_WELCOME_TEST_ID)).not.toBeInTheDocument()
+  expect(createHighlighter).not.toHaveBeenCalled()
+})

--- a/src/components/aiAgent/__tests__/ChatConversation.test.tsx
+++ b/src/components/aiAgent/__tests__/ChatConversation.test.tsx
@@ -23,9 +23,6 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
   }),
 }))
 
-const mockStreamChunk = jest.fn()
-const mockSetChatDone = jest.fn()
-
 let mockState: ChatState
 let mockAgentType: AiAgentTypeEnum
 
@@ -34,11 +31,6 @@ jest.mock('~/hooks/aiAgent/useAiAgent', () => ({
   useAiAgent: () => ({
     agentType: mockAgentType,
     state: mockState,
-    lastAssistantMessage: mockState.messages
-      .filter((message: ChatMessage) => message.role === 'assistant')
-      .pop(),
-    streamChunk: mockStreamChunk,
-    setChatDone: mockSetChatDone,
   }),
 }))
 
@@ -151,46 +143,6 @@ describe('ChatConversation', () => {
         render(<ChatConversation subscription={idleSubscription} />)
 
         expect(screen.getByTestId(CHAT_MESSAGE_ERROR_TEST_ID)).toBeInTheDocument()
-      })
-    })
-  })
-
-  describe('GIVEN the subscription streams', () => {
-    describe('WHEN a chunk arrives', () => {
-      it('THEN should append the chunk to the last assistant message', () => {
-        render(
-          <ChatConversation
-            subscription={
-              {
-                data: { aiConversationStreamed: { chunk: 'partial', done: false } },
-                error: undefined,
-              } as unknown as OnConversationSubscriptionHookResult
-            }
-          />,
-        )
-
-        expect(mockStreamChunk).toHaveBeenCalledWith({
-          messageId: 'assistant-1',
-          chunk: 'partial',
-        })
-      })
-    })
-
-    describe('WHEN the stream completes', () => {
-      it('THEN should mark the last assistant message as done', () => {
-        render(
-          <ChatConversation
-            subscription={
-              {
-                data: { aiConversationStreamed: { chunk: null, done: true } },
-                error: undefined,
-              } as unknown as OnConversationSubscriptionHookResult
-            }
-          />,
-        )
-
-        expect(mockSetChatDone).toHaveBeenCalledWith('assistant-1')
-        expect(mockStreamChunk).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/components/aiAgent/hooks/__tests__/useOnConversation.test.tsx
+++ b/src/components/aiAgent/hooks/__tests__/useOnConversation.test.tsx
@@ -1,0 +1,204 @@
+import { ApolloClient, ApolloLink, ApolloProvider, InMemoryCache, Observable } from '@apollo/client'
+import { act, render, waitFor } from '@testing-library/react'
+import { PropsWithChildren } from 'react'
+
+import { ChatConversation } from '~/components/aiAgent/ChatConversation'
+import { OnConversationSubscription } from '~/generated/graphql'
+import { ChatMessage, ChatStatus } from '~/hooks/aiAgent/aiAgentReducer'
+import { AiAgentProvider, AiAgentTypeEnum, useAiAgent } from '~/hooks/aiAgent/useAiAgent'
+
+import { useOnConversation } from '../useOnConversation'
+
+jest.mock('~/components/aiAgent/llmOutputs', () => ({
+  Message: ({ message }: { message: ChatMessage }) => <span>{message.message}</span>,
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+type Stream = {
+  id: string
+  next: (chunk: string | null, done?: boolean) => void
+  error: (error: Error) => void
+  unsubscribe: jest.Mock
+}
+
+type ConversationResult = ReturnType<typeof useAiAgent> & {
+  subscription: ReturnType<typeof useOnConversation>
+}
+
+const renderConversation = (): ReturnType<typeof render> & {
+  streams: Stream[]
+  result: { current: ConversationResult }
+} => {
+  const streams: Stream[] = []
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new ApolloLink(
+      (operation) =>
+        new Observable((observer) => {
+          const unsubscribe = jest.fn()
+
+          streams.push({
+            id: operation.variables.id,
+            next: (chunk, done = false) => {
+              const data: OnConversationSubscription = { aiConversationStreamed: { chunk, done } }
+
+              observer.next({ data })
+            },
+            error: (error) => observer.error(error),
+            unsubscribe,
+          })
+          return unsubscribe
+        }),
+    ),
+  })
+  const wrapper = ({ children }: PropsWithChildren): JSX.Element => (
+    <ApolloProvider client={client}>
+      <AiAgentProvider>{children}</AiAgentProvider>
+    </ApolloProvider>
+  )
+  let current: ConversationResult | undefined
+  const Conversation = (): JSX.Element => {
+    const agent = useAiAgent()
+    const subscription = useOnConversation({
+      conversationId:
+        agent.agentType === AiAgentTypeEnum.billing ? agent.conversationId : undefined,
+    })
+
+    current = { ...agent, subscription }
+    return <ChatConversation subscription={subscription} />
+  }
+  const view = render(<Conversation />, { wrapper })
+  const result = {
+    get current(): ConversationResult {
+      if (!current) throw new Error('Conversation has not rendered')
+      return current
+    },
+  }
+
+  act(() => result.current.setAgentType(AiAgentTypeEnum.billing))
+  act(() => result.current.startNewConversation({ convId: 'conversation-1', message: 'hello' }))
+
+  return { ...view, result, streams }
+}
+
+describe('useOnConversation', () => {
+  const scrollTo = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollTo')
+
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: jest.fn(),
+    })
+  })
+
+  afterAll(() => {
+    if (scrollTo) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollTo', scrollTo)
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, 'scrollTo')
+    }
+  })
+
+  beforeEach(() => localStorage.clear())
+
+  it('appends identical consecutive events even across separate renders', () => {
+    const { result, streams } = renderConversation()
+
+    act(() => streams[0].next('ha'))
+    act(() => streams[0].next('ha'))
+
+    expect(result.current.lastAssistantMessage?.message).toBe('haha')
+    expect(result.current.state.isStreaming).toBe(true)
+  })
+
+  it('preserves batched chunks and appends the final chunk before marking the message done', () => {
+    const { result, streams } = renderConversation()
+
+    act(() => {
+      streams[0].next('one ')
+      streams[0].next('two ')
+      streams[0].next('three', true)
+      streams[0].next('late chunk')
+    })
+
+    expect(result.current.lastAssistantMessage).toMatchObject({
+      message: 'one two three',
+      status: ChatStatus.done,
+    })
+    expect(result.current.state.isStreaming).toBe(false)
+    expect(result.current.state.isLoading).toBe(false)
+  })
+
+  it('routes a restarted subscription to the new assistant message', () => {
+    const { result, streams } = renderConversation()
+
+    act(() => streams[0].next('first answer', true))
+    act(() => {
+      result.current.addNewMessage('follow up')
+      result.current.subscription.restart()
+    })
+    act(() => streams[streams.length - 1].next('second answer', true))
+
+    expect(result.current.state.messages.map(({ message }) => message)).toEqual([
+      'hello',
+      'first answer',
+      'follow up',
+      'second answer',
+    ])
+    expect(result.current.lastAssistantMessage?.status).toBe(ChatStatus.done)
+  })
+
+  it('ignores events from a replaced conversation and releases its subscription', async () => {
+    const { result, streams } = renderConversation()
+
+    act(() => result.current.startNewConversation({ convId: 'conversation-2', message: 'new' }))
+    act(() => {
+      streams[0].next('stale', true)
+      streams[1].next('current', true)
+    })
+
+    expect(result.current.lastAssistantMessage?.message).toBe('current')
+    await waitFor(() => expect(streams[0].unsubscribe).toHaveBeenCalledTimes(1))
+  })
+
+  it('ignores late billing events after switching agents and cancels on unmount', async () => {
+    const { result, streams, unmount } = renderConversation()
+
+    act(() => result.current.setAgentType(AiAgentTypeEnum.finance))
+    act(() => {
+      result.current.addNewMessage('finance question', 'finance-exchange')
+      streams[0].next('stale billing answer', true)
+    })
+
+    expect(result.current.lastAssistantMessage).toMatchObject({
+      id: 'finance-exchange',
+      message: '',
+      status: ChatStatus.pending,
+    })
+    expect(result.current.state.isLoading).toBe(true)
+    await waitFor(() => expect(streams[0].unsubscribe).toHaveBeenCalledTimes(1))
+
+    act(() => result.current.setAgentType(AiAgentTypeEnum.billing))
+    act(() => result.current.startNewConversation({ convId: 'conversation-2', message: 'new' }))
+    unmount()
+    act(() => streams[1].next('after unmount', true))
+    await waitFor(() => expect(streams[1].unsubscribe).toHaveBeenCalledTimes(1))
+  })
+
+  it('keeps subscription errors available to the conversation and supports restarting', () => {
+    const { result, streams } = renderConversation()
+
+    act(() => streams[0].error(new Error('stream failed')))
+
+    expect(result.current.subscription.error?.message).toContain('stream failed')
+
+    act(() => result.current.subscription.restart())
+    act(() => streams[1].next('recovered', true))
+
+    expect(result.current.subscription.error).toBeUndefined()
+    expect(result.current.lastAssistantMessage?.message).toBe('recovered')
+  })
+})

--- a/src/components/aiAgent/hooks/useOnConversation.ts
+++ b/src/components/aiAgent/hooks/useOnConversation.ts
@@ -1,6 +1,11 @@
 import { gql } from '@apollo/client'
 
-import { useOnConversationSubscription } from '~/generated/graphql'
+import {
+  OnConversationSubscriptionHookResult,
+  useOnConversationSubscription,
+} from '~/generated/graphql'
+import { ChatStatus } from '~/hooks/aiAgent/aiAgentReducer'
+import { useAiAgent } from '~/hooks/aiAgent/useAiAgent'
 
 gql`
   subscription onConversation($id: ID!) {
@@ -15,13 +20,37 @@ type UseOnConversationProps = {
   conversationId: string | undefined
 }
 
-export const useOnConversation = ({ conversationId }: UseOnConversationProps) => {
+export const useOnConversation = ({
+  conversationId,
+}: UseOnConversationProps): OnConversationSubscriptionHookResult => {
+  const { lastAssistantMessage, streamChunk, setChatDone } = useAiAgent()
   const subscription = useOnConversationSubscription({
     skip: !conversationId,
     variables: {
       id: conversationId ?? '',
     },
     fetchPolicy: 'no-cache',
+    onData: ({ data }) => {
+      const event = data.data?.aiConversationStreamed
+
+      if (
+        !conversationId ||
+        data.variables?.id !== conversationId ||
+        !event ||
+        !lastAssistantMessage ||
+        lastAssistantMessage.status === ChatStatus.done
+      ) {
+        return
+      }
+
+      if (event.chunk) {
+        streamChunk({ messageId: lastAssistantMessage.id, chunk: event.chunk })
+      }
+
+      if (event.done) {
+        setChatDone(lastAssistantMessage.id)
+      }
+    },
   })
 
   return subscription

--- a/src/components/aiAgent/llmOutputs/Codeblock.tsx
+++ b/src/components/aiAgent/llmOutputs/Codeblock.tsx
@@ -1,90 +1,71 @@
 /* eslint-disable react/prop-types */
-import {
-  type CodeToHtmlOptions,
-  loadHighlighter,
-  parseCompleteMarkdownCodeBlock,
-} from '@llm-ui/code'
+import { parseCompleteMarkdownCodeBlock } from '@llm-ui/code'
 import { type LLMOutputComponent } from '@llm-ui/react'
 import parseHtml from 'html-react-parser'
-import { useEffect, useReducer, useState } from 'react'
-import { bundledLanguages, createHighlighter } from 'shiki/bundle/web'
+import { useEffect, useState } from 'react'
 import type { HighlighterCore } from 'shiki/core'
-import catppuccinLatte from 'shiki/themes/catppuccin-latte.mjs'
 
-import './codeblock.css'
+import { ensureLanguage, getHighlighter } from './highlighter'
+import { PlaintextCodeblock } from './PlaintextCodeblock'
 
-// Eagerly load only the common web-bundle languages (78) for fast startup.
-// When a code block uses a language outside this set, we dynamically import
-// shiki/bundle/full (code-split by Vite) and lazy-load the grammar on demand.
-const highlighterHandle = loadHighlighter(
-  createHighlighter({
-    langs: Object.keys(bundledLanguages),
-    themes: [catppuccinLatte],
-  }),
-)
-
-const codeToHtmlOptions: CodeToHtmlOptions = {
-  theme: 'catppuccin-latte',
-}
-
-// Track languages already requested for lazy-loading so we don't re-trigger
-// loadLanguage on every re-render while the promise settles.
-const lazyLoadRequested = new Set<string>()
-
-async function lazyLoadLanguage(shiki: HighlighterCore, lang: string): Promise<boolean> {
-  const { bundledLanguages: fullLanguages } = await import('shiki/bundle/full')
-
-  if (!(lang in fullLanguages)) return false
-
-  const key = lang as keyof typeof fullLanguages
-
-  await shiki.loadLanguage(fullLanguages[key])
-  return true
+type Highlighting = {
+  highlighter: HighlighterCore
+  requestedLanguage: string
+  language: string
 }
 
 export const Codeblock: LLMOutputComponent = ({ blockMatch }) => {
-  const [shiki, setShiki] = useState(highlighterHandle.getHighlighter())
-  const [, forceRender] = useReducer((x: number) => x + 1, 0)
+  const { code = '\n', language = 'text' } = parseCompleteMarkdownCodeBlock(blockMatch.output)
+  const [highlighting, setHighlighting] = useState<Highlighting>()
 
   useEffect(() => {
-    if (!shiki) {
-      highlighterHandle.highlighterPromise.then((h) => setShiki(h))
+    if (highlighting?.requestedLanguage === language) return
+
+    let cancelled = false
+
+    const highlight = async (): Promise<void> => {
+      try {
+        const highlighter = await getHighlighter()
+
+        if (cancelled) return
+
+        const loaded = await ensureLanguage(highlighter, language)
+
+        if (!cancelled) {
+          setHighlighting({
+            highlighter,
+            requestedLanguage: language,
+            language: loaded ? language : 'text',
+          })
+        }
+      } catch {
+        // Keep plaintext after a load failure; the next streamed render can retry.
+      }
     }
-  }, [shiki])
 
-  const { code = '\n', language } = parseCompleteMarkdownCodeBlock(blockMatch.output)
-  const lang = language ?? 'text'
+    void highlight()
 
-  if (!shiki) {
-    return (
-      <pre className="shiki">
-        <code>{code}</code>
-      </pre>
-    )
+    return () => {
+      cancelled = true
+    }
+  }, [blockMatch, language, highlighting])
+
+  if (highlighting?.requestedLanguage !== language) {
+    return <PlaintextCodeblock blockMatch={blockMatch} />
   }
-
-  let html: string
 
   try {
-    html = shiki.codeToHtml(code, { ...codeToHtmlOptions, lang })
+    return (
+      <>
+        {parseHtml(
+          highlighting.highlighter.codeToHtml(code, {
+            theme: 'catppuccin-latte',
+            lang: highlighting.language,
+          }),
+        )}
+      </>
+    )
   } catch {
-    // Language not in the web bundle — lazy-load it from the full bundle
-    // (code-split by Vite), then re-render. Show plaintext in the meantime.
-    if (!lazyLoadRequested.has(lang)) {
-      lazyLoadRequested.add(lang)
-      lazyLoadLanguage(shiki, lang)
-        .then((loaded) => {
-          if (loaded) forceRender()
-        })
-        .catch(() => {
-          // Chunk load or grammar registration failed — remove from the set
-          // so a subsequent render can retry (e.g. after a transient network error).
-          lazyLoadRequested.delete(lang)
-        })
-    }
-
-    html = shiki.codeToHtml(code, { ...codeToHtmlOptions, lang: 'text' })
+    return <PlaintextCodeblock blockMatch={blockMatch} />
   }
-
-  return <>{parseHtml(html)}</>
 }

--- a/src/components/aiAgent/llmOutputs/LazyCodeblock.tsx
+++ b/src/components/aiAgent/llmOutputs/LazyCodeblock.tsx
@@ -1,6 +1,6 @@
 import { type LLMOutputComponent } from '@llm-ui/react'
 import { ErrorBoundary } from '@sentry/react'
-import { lazy, LazyExoticComponent, Suspense, useState } from 'react'
+import { lazy, LazyExoticComponent, Suspense, useRef, useState } from 'react'
 
 import { Button } from '~/components/designSystem/Button'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -11,20 +11,26 @@ const createLazyCodeblock = (): LazyExoticComponent<LLMOutputComponent> =>
   lazy(() => import('./Codeblock').then(({ Codeblock }) => ({ default: Codeblock })))
 
 export const LazyCodeblock: LLMOutputComponent = (props) => {
+  const errorBoundaryRef = useRef<ErrorBoundary>(null)
   const [Codeblock, setCodeblock] = useState(createLazyCodeblock)
   const { translate } = useInternationalization()
 
   return (
     <ErrorBoundary
+      ref={errorBoundaryRef}
       onReset={() => setCodeblock(createLazyCodeblock)}
-      fallback={({ resetError }) => (
+      fallback={
         <>
           <PlaintextCodeblock {...props} />
-          <Button variant="quaternary" size="small" onClick={resetError}>
+          <Button
+            variant="quaternary"
+            size="small"
+            onClick={() => errorBoundaryRef.current?.resetErrorBoundary()}
+          >
             {translate('text_63e27c56dfe64b846474efa3')}
           </Button>
         </>
-      )}
+      }
     >
       <Suspense fallback={<PlaintextCodeblock {...props} />}>
         <Codeblock {...props} />

--- a/src/components/aiAgent/llmOutputs/LazyCodeblock.tsx
+++ b/src/components/aiAgent/llmOutputs/LazyCodeblock.tsx
@@ -1,0 +1,34 @@
+import { type LLMOutputComponent } from '@llm-ui/react'
+import { ErrorBoundary } from '@sentry/react'
+import { lazy, LazyExoticComponent, Suspense, useState } from 'react'
+
+import { Button } from '~/components/designSystem/Button'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+import { PlaintextCodeblock } from './PlaintextCodeblock'
+
+const createLazyCodeblock = (): LazyExoticComponent<LLMOutputComponent> =>
+  lazy(() => import('./Codeblock').then(({ Codeblock }) => ({ default: Codeblock })))
+
+export const LazyCodeblock: LLMOutputComponent = (props) => {
+  const [Codeblock, setCodeblock] = useState(createLazyCodeblock)
+  const { translate } = useInternationalization()
+
+  return (
+    <ErrorBoundary
+      onReset={() => setCodeblock(createLazyCodeblock)}
+      fallback={({ resetError }) => (
+        <>
+          <PlaintextCodeblock {...props} />
+          <Button variant="quaternary" size="small" onClick={resetError}>
+            {translate('text_63e27c56dfe64b846474efa3')}
+          </Button>
+        </>
+      )}
+    >
+      <Suspense fallback={<PlaintextCodeblock {...props} />}>
+        <Codeblock {...props} />
+      </Suspense>
+    </ErrorBoundary>
+  )
+}

--- a/src/components/aiAgent/llmOutputs/PlaintextCodeblock.tsx
+++ b/src/components/aiAgent/llmOutputs/PlaintextCodeblock.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable react/prop-types */
+import { parseCompleteMarkdownCodeBlock } from '@llm-ui/code'
+import { type LLMOutputComponent } from '@llm-ui/react'
+
+import './codeblock.css'
+
+export const PlaintextCodeblock: LLMOutputComponent = ({ blockMatch }) => {
+  const { code = '\n' } = parseCompleteMarkdownCodeBlock(blockMatch.output)
+
+  return (
+    <pre className="shiki">
+      <code>{code}</code>
+    </pre>
+  )
+}

--- a/src/components/aiAgent/llmOutputs/__tests__/Codeblock.test.tsx
+++ b/src/components/aiAgent/llmOutputs/__tests__/Codeblock.test.tsx
@@ -1,300 +1,147 @@
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { HighlighterCore } from 'shiki/core'
 
-// ---------------------------------------------------------------------------
-// Component under test — imported AFTER mocks are installed.
-// ---------------------------------------------------------------------------
+import { createBlockMatch } from './fixtures'
 
 import { Codeblock } from '../Codeblock'
 
-// ---------------------------------------------------------------------------
-// Mocks — these run before any module code thanks to Jest hoisting.
-//
-// The codeToHtml / loadLanguage jest.fn() instances must be created INSIDE
-// the factory to avoid temporal dead zone issues with `const` + jest.mock
-// hoisting. They are exposed via `__*` keys for test manipulation.
-// ---------------------------------------------------------------------------
+const mockGetHighlighter = jest.fn()
+const mockEnsureLanguage = jest.fn()
+const mockCodeToHtml = jest.fn()
+const highlighter: Pick<HighlighterCore, 'codeToHtml'> = { codeToHtml: mockCodeToHtml }
 
-jest.mock('shiki/bundle/web', () => {
-  const codeToHtmlMock = jest.fn()
-  const loadLanguageMock = jest.fn(() => Promise.resolve())
-
-  return {
-    bundledLanguages: { javascript: jest.fn(), typescript: jest.fn(), css: jest.fn() },
-    createHighlighter: jest.fn(() =>
-      Promise.resolve({
-        codeToHtml: codeToHtmlMock,
-        loadLanguage: loadLanguageMock,
-      }),
-    ),
-    __codeToHtmlMock: codeToHtmlMock,
-    __loadLanguageMock: loadLanguageMock,
-  }
-})
-
-jest.mock('shiki/bundle/full', () => ({
-  // 'go' is in the full bundle (can be lazy-loaded), 'brainfuck' is not.
-  bundledLanguages: { go: jest.fn(), ruby: jest.fn() },
+jest.mock('../highlighter', () => ({
+  getHighlighter: () => mockGetHighlighter(),
+  ensureLanguage: (...args: unknown[]) => mockEnsureLanguage(...args),
 }))
-
-jest.mock('shiki/themes/catppuccin-latte.mjs', () => ({}), { virtual: true })
 
 jest.mock('@llm-ui/code', () => ({
-  loadHighlighter: (highlighterPromise: Promise<unknown>) => {
-    let instance: unknown
+  parseCompleteMarkdownCodeBlock: (output: string) => {
+    const [fence, ...lines] = output.split('\n')
 
-    return {
-      getHighlighter: () => instance,
-      highlighterPromise: highlighterPromise.then((h) => {
-        instance = h
-        return h
-      }),
-    }
-  },
-
-  // Minimal reimplementation — extracts language & code from a fenced block.
-  parseCompleteMarkdownCodeBlock: (codeBlock: string) => {
-    const lines = codeBlock.split('\n')
-    const match = lines[0]?.match(/^`{3}([a-zA-Z0-9_-]*)/)
-    const language = match?.[1] || undefined
-
-    return {
-      language: language || undefined,
-      code: lines.slice(1, -1).join('\n'),
-      metaString: undefined,
-    }
+    return { language: fence.slice(3) || undefined, code: lines.slice(0, -1).join('\n') }
   },
 }))
 
-jest.mock('html-react-parser', () => ({
-  __esModule: true,
-  default: (html: string) => <div dangerouslySetInnerHTML={{ __html: html }} />,
-}))
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-interface WebBundleMocks {
-  __codeToHtmlMock: jest.Mock
-  __loadLanguageMock: jest.Mock
-}
-
-function getWebBundleMocks(): WebBundleMocks {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  return require('shiki/bundle/web') as WebBundleMocks
-}
-
-function renderCodeblock(markdownCodeBlock: string) {
-  return render(
-    <Codeblock
-      // Only `output` is used by the component — the other BlockMatch fields
-      // are irrelevant for these tests so we cast to avoid boilerplate.
-      blockMatch={{ output: markdownCodeBlock } as Parameters<typeof Codeblock>[0]['blockMatch']}
-    />,
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+const renderCodeblock = (output: string): ReturnType<typeof render> =>
+  render(<Codeblock blockMatch={createBlockMatch(output)} />)
 
 describe('Codeblock', () => {
-  let mockCodeToHtml: jest.Mock
-  let mockLoadLanguage: jest.Mock
-
   beforeEach(() => {
-    const mocks = getWebBundleMocks()
-
-    mockCodeToHtml = mocks.__codeToHtmlMock
-    mockLoadLanguage = mocks.__loadLanguageMock
+    jest.clearAllMocks()
+    mockGetHighlighter.mockResolvedValue(highlighter)
+    mockEnsureLanguage.mockResolvedValue(true)
+    mockCodeToHtml.mockImplementation(
+      (code: string, { lang }: { lang: string }) =>
+        `<pre class="shiki"><code class="language-${lang}">${code}</code></pre>`,
+    )
   })
 
-  afterEach(() => {
-    cleanup()
-    mockCodeToHtml.mockReset()
-    mockLoadLanguage.mockReset()
+  it('shows plaintext during initialization and highlights every block sharing a pending grammar', async () => {
+    let resolveGrammar: (loaded: boolean) => void = () => undefined
+    const grammar = new Promise<boolean>((resolve) => {
+      resolveGrammar = resolve
+    })
+
+    mockEnsureLanguage.mockReturnValue(grammar)
+    const { container } = render(
+      <>
+        <Codeblock blockMatch={createBlockMatch('```go\npackage first\n```')} />
+        <Codeblock blockMatch={createBlockMatch('```go\npackage second\n```')} />
+      </>,
+    )
+
+    expect(screen.getByText('package first')).toBeInTheDocument()
+    expect(screen.getByText('package second')).toBeInTheDocument()
+    expect(mockCodeToHtml).not.toHaveBeenCalled()
+
+    await act(async () => resolveGrammar(true))
+
+    expect(container.querySelectorAll('code.language-go')).toHaveLength(2)
   })
 
-  describe('when Shiki throws "Language not found" (original bug)', () => {
-    it('catches the error and falls back to text instead of crashing', async () => {
-      // Reproduce the exact Shiki error users were hitting.
-      // Use a language NOT in bundledLanguages (full bundle) so no lazy-load
-      // is attempted — this isolates the try-catch fallback behavior.
-      //
-      // Before the fix, useCodeBlockToHtml from @llm-ui/code called
-      // codeToHtml without a try-catch, so this error crashed the
-      // entire React component tree.
-      mockCodeToHtml.mockImplementation((_code: string, options: { lang: string }) => {
-        if (options.lang === 'brainfuck') {
-          throw new Error('Language `brainfuck` not found, you may need to load it first')
-        }
+  it('falls back to text for an unknown language', async () => {
+    mockEnsureLanguage.mockResolvedValue(false)
+    const { container } = renderCodeblock('```unknown-language\nplain text\n```')
 
-        return `<pre class="shiki"><code>${_code}</code></pre>`
-      })
+    await waitFor(() => expect(container.querySelector('code.language-text')).toBeInTheDocument())
+    expect(screen.getByText('plain text')).toBeInTheDocument()
+  })
 
-      await act(async () => {
-        renderCodeblock('```brainfuck\n++++[>++++++++<-]\n```')
-      })
+  it('uses text when the code block has no language', async () => {
+    renderCodeblock('```\nsome code\n```')
 
-      await waitFor(() => {
-        expect(mockCodeToHtml).toHaveBeenCalled()
-      })
-
-      // First call attempted the original language…
+    await waitFor(() =>
       expect(mockCodeToHtml).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ lang: 'brainfuck' }),
-      )
-
-      // …then the catch block retried with text.
-      expect(mockCodeToHtml).toHaveBeenCalledWith(
-        expect.anything(),
+        'some code',
         expect.objectContaining({ lang: 'text' }),
-      )
-
-      // No lazy-load attempted because 'brainfuck' isn't in the full bundle.
-      expect(mockLoadLanguage).not.toHaveBeenCalled()
-
-      // The component rendered successfully — no crash.
-      expect(screen.getByText('++++[>++++++++<-]')).toBeInTheDocument()
-    })
-
-    it('lazy-loads a language from the full bundle then re-renders with highlighting', async () => {
-      // 'go' is in the full bundle but NOT in the web bundle.
-      // First render: codeToHtml('go') throws → shows text + triggers lazy-load.
-      // After loadLanguage resolves: re-render → codeToHtml('go') succeeds.
-      let goLoaded = false
-
-      mockCodeToHtml.mockImplementation((_code: string, options: { lang: string }) => {
-        if (options.lang === 'go' && !goLoaded) {
-          throw new Error('Language `go` not found, you may need to load it first')
-        }
-
-        return `<pre class="shiki"><code>${_code}</code></pre>`
-      })
-
-      mockLoadLanguage.mockImplementation(() => {
-        goLoaded = true
-        return Promise.resolve()
-      })
-
-      await act(async () => {
-        renderCodeblock('```go\npackage main\n```')
-      })
-
-      // loadLanguage was called for the missing 'go' grammar.
-      expect(mockLoadLanguage).toHaveBeenCalled()
-
-      // After the lazy-load resolves, the component re-renders with 'go'.
-      await waitFor(() => {
-        expect(mockCodeToHtml).toHaveBeenCalledWith(
-          expect.anything(),
-          expect.objectContaining({ lang: 'go' }),
-        )
-      })
-
-      expect(screen.getByText('package main')).toBeInTheDocument()
-    })
-
-    it('retries lazy-loading after a transient failure', async () => {
-      // Simulate a network error on the first lazy-load attempt (e.g. chunk
-      // failed to fetch). The .catch() handler should remove the language from
-      // lazyLoadRequested so the next render can retry.
-      let rubyLoaded = false
-
-      mockCodeToHtml.mockImplementation((_code: string, options: { lang: string }) => {
-        if (options.lang === 'ruby' && !rubyLoaded) {
-          throw new Error('Language `ruby` not found, you may need to load it first')
-        }
-
-        return `<pre class="shiki"><code>${_code}</code></pre>`
-      })
-
-      // First attempt: reject (transient network failure).
-      mockLoadLanguage.mockRejectedValueOnce(new Error('Failed to fetch chunk'))
-
-      const { rerender } = await act(async () => renderCodeblock('```ruby\nputs "hello"\n```'))
-
-      // The lazy-load was attempted and failed.
-      await waitFor(() => {
-        expect(mockLoadLanguage).toHaveBeenCalledTimes(1)
-      })
-
-      // Component shows text fallback — no crash.
-      expect(screen.getByText('puts "hello"')).toBeInTheDocument()
-
-      // Second attempt: succeed now that the "network" is back.
-      mockLoadLanguage.mockImplementation(() => {
-        rubyLoaded = true
-        return Promise.resolve()
-      })
-
-      // Trigger a re-render (e.g. parent streams a new token).
-      await act(async () => {
-        rerender(
-          <Codeblock
-            blockMatch={
-              { output: '```ruby\nputs "hello"\n```' } as Parameters<
-                typeof Codeblock
-              >[0]['blockMatch']
-            }
-          />,
-        )
-      })
-
-      // The retry succeeded — loadLanguage called a second time.
-      await waitFor(() => {
-        expect(mockLoadLanguage).toHaveBeenCalledTimes(2)
-      })
-
-      expect(screen.getByText('puts "hello"')).toBeInTheDocument()
-    })
+      ),
+    )
   })
 
-  describe('when the language is already loaded (web bundle)', () => {
-    it('renders highlighted code on the first attempt without lazy-loading', async () => {
-      mockCodeToHtml.mockReturnValue('<pre class="shiki"><code>const x = 1</code></pre>')
+  it.each(['initialization', 'grammar'])(
+    'retries a failed %s on the next render',
+    async (failure) => {
+      const failingLoad = failure === 'initialization' ? mockGetHighlighter : mockEnsureLanguage
 
-      await act(async () => {
-        renderCodeblock('```javascript\nconst x = 1\n```')
-      })
+      failingLoad.mockRejectedValueOnce(new Error('network unavailable'))
+      const output = '```ruby\nputs "hello"\n```'
+      const { rerender, container } = renderCodeblock(output)
 
-      await waitFor(() => {
-        expect(mockCodeToHtml).toHaveBeenCalled()
-      })
+      await act(async () => undefined)
+      expect(screen.getByText('puts "hello"')).toBeInTheDocument()
+      expect(mockCodeToHtml).not.toHaveBeenCalled()
 
-      // Only one call — no fallback needed.
-      expect(mockCodeToHtml).toHaveBeenCalledTimes(1)
-      expect(mockCodeToHtml).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ lang: 'javascript' }),
-      )
+      rerender(<Codeblock blockMatch={createBlockMatch(output)} />)
 
-      // No lazy-loading triggered.
-      expect(mockLoadLanguage).not.toHaveBeenCalled()
+      await waitFor(() => expect(container.querySelector('code.language-ruby')).toBeInTheDocument())
+      expect(failingLoad).toHaveBeenCalledTimes(2)
+    },
+  )
 
-      expect(screen.getByText('const x = 1')).toBeInTheDocument()
-    })
+  it('ignores a stale grammar completion after the language changes', async () => {
+    let resolveOldGrammar: (loaded: boolean) => void = () => undefined
+
+    mockEnsureLanguage.mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        resolveOldGrammar = resolve
+      }),
+    )
+    const { rerender, container } = renderCodeblock('```go\nold code\n```')
+
+    await act(async () => undefined)
+    rerender(<Codeblock blockMatch={createBlockMatch('```ruby\nnew code\n```')} />)
+    await waitFor(() => expect(container.querySelector('code.language-ruby')).toBeInTheDocument())
+    await act(async () => resolveOldGrammar(true))
+
+    expect(container.querySelector('code.language-ruby')).toHaveTextContent('new code')
+    expect(container.querySelector('code.language-go')).not.toBeInTheDocument()
   })
 
-  describe('when no language is specified in the code block', () => {
-    it('defaults to text', async () => {
-      mockCodeToHtml.mockReturnValue('<pre class="shiki"><code>some code</code></pre>')
+  it('does not render a pending highlighter after unmount', async () => {
+    let resolveHighlighter: (value: typeof highlighter) => void = () => undefined
 
-      await act(async () => {
-        renderCodeblock('```\nsome code\n```')
-      })
+    mockGetHighlighter.mockReturnValue(
+      new Promise((resolve) => {
+        resolveHighlighter = resolve
+      }),
+    )
+    const { unmount } = renderCodeblock('```go\npackage main\n```')
 
-      await waitFor(() => {
-        expect(mockCodeToHtml).toHaveBeenCalled()
-      })
+    unmount()
+    await act(async () => resolveHighlighter(highlighter))
 
-      expect(mockCodeToHtml).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ lang: 'text' }),
-      )
+    expect(mockEnsureLanguage).not.toHaveBeenCalled()
+    expect(mockCodeToHtml).not.toHaveBeenCalled()
+  })
 
-      expect(screen.getByText('some code')).toBeInTheDocument()
+  it('keeps code readable if the highlighter throws during rendering', async () => {
+    mockCodeToHtml.mockImplementation(() => {
+      throw new Error('invalid grammar')
     })
+    renderCodeblock('```go\npackage main\n```')
+
+    await waitFor(() => expect(mockCodeToHtml).toHaveBeenCalled())
+    expect(screen.getByText('package main')).toBeInTheDocument()
   })
 })

--- a/src/components/aiAgent/llmOutputs/__tests__/LazyCodeblock.test.tsx
+++ b/src/components/aiAgent/llmOutputs/__tests__/LazyCodeblock.test.tsx
@@ -56,4 +56,33 @@ describe('LazyCodeblock', () => {
     await act(async () => undefined)
     expect(screen.getByText(/highlighted:/)).toBeInTheDocument()
   })
+
+  it('preserves fallback DOM and retry focus across parent updates after import failure', async () => {
+    const { rerender } = render(
+      <LazyCodeblock blockMatch={createBlockMatch('```go\npackage main\n```')} />,
+    )
+    const retry = await screen.findByRole('button', { name: 'Retry' })
+    const plaintext = screen.getByText('package main')
+
+    retry.focus()
+    expect(retry).toHaveFocus()
+
+    rerender(<LazyCodeblock blockMatch={createBlockMatch('```go\npackage main\n```')} />)
+
+    expect(screen.getByRole('button', { name: 'Retry' })).toBe(retry)
+    expect(screen.getByText('package main')).toBe(plaintext)
+    expect(retry).toHaveFocus()
+
+    rerender(<LazyCodeblock blockMatch={createBlockMatch('```go\npackage updated\n```')} />)
+
+    expect(screen.getByRole('button', { name: 'Retry' })).toBe(retry)
+    expect(screen.getByText('package updated')).toBe(plaintext)
+    expect(retry).toHaveFocus()
+
+    mockFailImport = false
+    await userEvent.click(retry)
+
+    expect(await screen.findByText(/highlighted:/)).toHaveTextContent('package updated')
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument()
+  })
 })

--- a/src/components/aiAgent/llmOutputs/__tests__/LazyCodeblock.test.tsx
+++ b/src/components/aiAgent/llmOutputs/__tests__/LazyCodeblock.test.tsx
@@ -1,0 +1,59 @@
+import { LLMOutputComponent } from '@llm-ui/react'
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { createBlockMatch } from './fixtures'
+
+import { LazyCodeblock } from '../LazyCodeblock'
+
+let mockFailImport = true
+
+jest.mock('../Codeblock', () => {
+  if (mockFailImport) throw new Error('chunk unavailable')
+
+  const Codeblock = ({ blockMatch }: Parameters<LLMOutputComponent>[0]): JSX.Element => (
+    <div>{`highlighted: ${blockMatch.output}`}</div>
+  )
+
+  return { Codeblock }
+})
+
+jest.mock('@llm-ui/code', () => ({
+  parseCompleteMarkdownCodeBlock: (output: string) => ({
+    code: output.split('\n').slice(1, -1).join('\n'),
+  }),
+}))
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: () => 'Retry' }),
+}))
+
+describe('LazyCodeblock', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    mockFailImport = true
+  })
+
+  it('keeps plaintext on import failure and retries the named export when requested', async () => {
+    render(<LazyCodeblock blockMatch={createBlockMatch('```go\npackage main\n```')} />)
+
+    expect(screen.getByText('package main')).toBeInTheDocument()
+    const retry = await screen.findByRole('button', { name: 'Retry' })
+
+    expect(screen.getByText('package main')).toBeInTheDocument()
+    mockFailImport = false
+    await userEvent.click(retry)
+
+    expect(await screen.findByText(/highlighted:/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument()
+  })
+
+  it('renders plaintext while loading and then renders the named Codeblock export', async () => {
+    mockFailImport = false
+    render(<LazyCodeblock blockMatch={createBlockMatch('```go\npackage other\n```')} />)
+
+    expect(screen.getByText('package other')).toBeInTheDocument()
+    await act(async () => undefined)
+    expect(screen.getByText(/highlighted:/)).toBeInTheDocument()
+  })
+})

--- a/src/components/aiAgent/llmOutputs/__tests__/fixtures.ts
+++ b/src/components/aiAgent/llmOutputs/__tests__/fixtures.ts
@@ -1,0 +1,17 @@
+import { BlockMatch } from '@llm-ui/react'
+
+export const createBlockMatch = (output: string): BlockMatch => ({
+  output,
+  outputRaw: output,
+  llmOutput: output,
+  startIndex: 0,
+  endIndex: output.length,
+  visibleText: output,
+  isVisible: true,
+  isComplete: true,
+  priority: 0,
+  block: {
+    component: () => null,
+    lookBack: () => ({ output, visibleText: output }),
+  },
+})

--- a/src/components/aiAgent/llmOutputs/__tests__/highlighter.test.ts
+++ b/src/components/aiAgent/llmOutputs/__tests__/highlighter.test.ts
@@ -1,0 +1,106 @@
+import { HighlighterCore } from 'shiki/core'
+
+const mockCreateHighlighter = jest.fn()
+const mockLoadLanguage = jest.fn()
+const mockJavascriptGrammar = jest.fn()
+const mockGoGrammar = jest.fn()
+const mockFullBundleImported = jest.fn()
+const highlighter = {
+  loadLanguage: mockLoadLanguage,
+  getLoadedLanguages: () => [],
+} as unknown as HighlighterCore
+
+jest.mock('shiki/bundle/web', () => ({
+  createHighlighter: (...args: unknown[]) => mockCreateHighlighter(...args),
+  bundledLanguages: { javascript: mockJavascriptGrammar, js: mockJavascriptGrammar },
+}))
+
+jest.mock('shiki/bundle/full', () => {
+  mockFullBundleImported()
+  return { bundledLanguages: { go: mockGoGrammar } }
+})
+
+jest.mock('shiki/themes/catppuccin-latte.mjs', () => ({}), { virtual: true })
+
+describe('AI code highlighter', () => {
+  let resource: typeof import('../highlighter')
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+    mockCreateHighlighter.mockResolvedValue(highlighter)
+    mockLoadLanguage.mockResolvedValue(undefined)
+    resource = jest.requireActual('../highlighter')
+  })
+
+  it('does not initialize on import, and shares one initialization without eager grammars', async () => {
+    expect(mockCreateHighlighter).not.toHaveBeenCalled()
+
+    const first = resource.getHighlighter()
+    const second = resource.getHighlighter()
+
+    expect(first).toBe(second)
+    await expect(first).resolves.toBe(highlighter)
+    expect(mockCreateHighlighter).toHaveBeenCalledTimes(1)
+    expect(mockCreateHighlighter).toHaveBeenCalledWith({ langs: [], themes: [{}] })
+  })
+
+  it('retries initialization after rejection', async () => {
+    mockCreateHighlighter.mockRejectedValueOnce(new Error('initialization failed'))
+
+    await expect(resource.getHighlighter()).rejects.toThrow('initialization failed')
+    await expect(resource.getHighlighter()).resolves.toBe(highlighter)
+    expect(mockCreateHighlighter).toHaveBeenCalledTimes(2)
+  })
+
+  it('shares a grammar load across concurrent blocks and resolves every waiter', async () => {
+    let resolveGrammar: () => void = () => undefined
+
+    mockLoadLanguage.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveGrammar = resolve
+      }),
+    )
+    const first = resource.ensureLanguage(highlighter, 'javascript')
+    const second = resource.ensureLanguage(highlighter, 'javascript')
+
+    expect(first).toBe(second)
+    expect(mockLoadLanguage).toHaveBeenCalledTimes(1)
+    resolveGrammar()
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true])
+    expect(mockFullBundleImported).not.toHaveBeenCalled()
+  })
+
+  it('uses the full bundle only for a grammar absent from the web bundle', async () => {
+    await expect(resource.ensureLanguage(highlighter, 'go')).resolves.toBe(true)
+    expect(mockFullBundleImported).toHaveBeenCalledTimes(1)
+    expect(mockLoadLanguage).toHaveBeenCalledWith(mockGoGrammar)
+  })
+
+  it('retries a rejected grammar without reinitializing the highlighter', async () => {
+    await resource.getHighlighter()
+    mockLoadLanguage.mockRejectedValueOnce(new Error('grammar failed'))
+
+    await expect(resource.ensureLanguage(highlighter, 'js')).rejects.toThrow('grammar failed')
+    await expect(resource.ensureLanguage(highlighter, 'js')).resolves.toBe(true)
+    expect(mockLoadLanguage).toHaveBeenCalledTimes(2)
+    expect(mockCreateHighlighter).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['unknown-language', 'constructor'])(
+    'treats %s as unknown without loading a grammar',
+    async (language) => {
+      await expect(resource.ensureLanguage(highlighter, language)).resolves.toBe(false)
+      expect(mockLoadLanguage).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each(['text', 'plaintext', 'txt', 'ansi'])(
+    'does not load a grammar for %s',
+    async (language) => {
+      await expect(resource.ensureLanguage(highlighter, language)).resolves.toBe(true)
+      expect(mockLoadLanguage).not.toHaveBeenCalled()
+      expect(mockFullBundleImported).not.toHaveBeenCalled()
+    },
+  )
+})

--- a/src/components/aiAgent/llmOutputs/highlighter.ts
+++ b/src/components/aiAgent/llmOutputs/highlighter.ts
@@ -1,0 +1,56 @@
+import { bundledLanguages, createHighlighter } from 'shiki/bundle/web'
+import type { HighlighterCore } from 'shiki/core'
+import catppuccinLatte from 'shiki/themes/catppuccin-latte.mjs'
+
+let highlighterPromise: Promise<HighlighterCore> | undefined
+const languagePromises = new Map<string, Promise<boolean>>()
+
+export const getHighlighter = (): Promise<HighlighterCore> => {
+  highlighterPromise ??= createHighlighter({
+    langs: [],
+    themes: [catppuccinLatte],
+  }).catch((error: unknown) => {
+    highlighterPromise = undefined
+    throw error
+  })
+
+  return highlighterPromise
+}
+
+const loadLanguage = async (highlighter: HighlighterCore, language: string): Promise<boolean> => {
+  if (Object.hasOwn(bundledLanguages, language)) {
+    await highlighter.loadLanguage(bundledLanguages[language as keyof typeof bundledLanguages])
+    return true
+  }
+
+  const { bundledLanguages: fullLanguages } = await import('shiki/bundle/full')
+
+  if (!Object.hasOwn(fullLanguages, language)) return false
+
+  await highlighter.loadLanguage(fullLanguages[language as keyof typeof fullLanguages])
+  return true
+}
+
+export const ensureLanguage = (
+  highlighter: HighlighterCore,
+  language: string,
+): Promise<boolean> => {
+  if (
+    ['text', 'plaintext', 'txt', 'ansi'].includes(language) ||
+    highlighter.getLoadedLanguages().includes(language)
+  ) {
+    return Promise.resolve(true)
+  }
+
+  let promise = languagePromises.get(language)
+
+  if (!promise) {
+    promise = loadLanguage(highlighter, language).catch((error: unknown) => {
+      languagePromises.delete(language)
+      throw error
+    })
+    languagePromises.set(language, promise)
+  }
+
+  return promise
+}

--- a/src/components/aiAgent/llmOutputs/hook.ts
+++ b/src/components/aiAgent/llmOutputs/hook.ts
@@ -2,7 +2,7 @@ import { codeBlockLookBack, findCompleteCodeBlock, findPartialCodeBlock } from '
 import { markdownLookBack } from '@llm-ui/markdown'
 import { throttleBasic, useLLMOutput } from '@llm-ui/react'
 
-import { Codeblock } from './Codeblock'
+import { LazyCodeblock } from './LazyCodeblock'
 import { Markdown } from './Markdown'
 
 const LLM_THROTTLE_MS = 2000
@@ -16,7 +16,7 @@ export const useCustomLLMOutput = (output: string, isStreamFinished: boolean) =>
     },
     blocks: [
       {
-        component: Codeblock,
+        component: LazyCodeblock,
         findCompleteMatch: findCompleteCodeBlock(),
         findPartialMatch: findPartialCodeBlock(),
         lookBack: codeBlockLookBack(),

--- a/src/hooks/aiAgent/aiAgentReducer.ts
+++ b/src/hooks/aiAgent/aiAgentReducer.ts
@@ -112,6 +112,12 @@ export const chatReducer = (state: ChatState, action: ChatAction): ChatState => 
     }
 
     case ChatActionType.STREAMING: {
+      const hasActiveMessage = state.messages.some(
+        (message) => message.id === action.messageId && message.status !== ChatStatus.done,
+      )
+
+      if (!hasActiveMessage) return state
+
       return {
         ...state,
         messages: state.messages.map((message) =>
@@ -129,6 +135,12 @@ export const chatReducer = (state: ChatState, action: ChatAction): ChatState => 
     }
 
     case ChatActionType.DONE: {
+      const hasActiveMessage = state.messages.some(
+        (message) => message.id === action.messageId && message.status !== ChatStatus.done,
+      )
+
+      if (!hasActiveMessage) return state
+
       return {
         ...state,
         messages: state.messages.map((message) =>


### PR DESCRIPTION
Process every AI subscription event so repeated and batched chunks are retained and the final chunk is applied before completion. Ignore late events for completed messages and replaced conversations.

Load AI code rendering and requested Shiki grammars on demand, sharing retryable initialization across waiting code blocks. Separate Prism highlighting from line-number layout updates and keep its language class on the scroll container so presentation changes preserve scrolling and highlighted content without parsing the code again.

Keep the lazy code renderer's plaintext and retry subtree mounted across parent and streaming updates after a failure. Pass a fallback element to Sentry and reset through its boundary ref so retry still recreates the lazy import while updated code and translated text flow into the existing DOM.
