### PR TITLE
fix(activity-logs): select id on CatalogPlan resource

### DIFF
--- a/src/components/developers/activityLogs/ActivityLogDetails.tsx
+++ b/src/components/developers/activityLogs/ActivityLogDetails.tsx
@@ -60,6 +60,9 @@ gql`
         id
         code
       }
+      ... on CatalogPlan {
+        id
+      }
       ... on Coupon {
         id
       }


### PR DESCRIPTION
## Context

The backend (getlago/lago-api#6315) adds `CatalogPlan` to the `ActivityLogResourceObject` GraphQL union. The activity-log detail view reads `resource.id` across every union member, but the `ActivityLogDetails` query fragment did not select `id` on the new `CatalogPlan` branch. Once frontend types are regenerated against the updated schema, `resource.id` fails to resolve on the `{ __typename?: "CatalogPlan" }` branch (`Property 'id' does not exist`).

## Description

Add the missing `... on CatalogPlan { id }` inline fragment to the activity-log `resource` selection, so `resource.id` resolves on that branch. `CatalogPlan` is not a `ResourceTypeEnum` key, so `getResourceLink` hits its `default` path and the resource renders its id without a link — the correct safe default until a route is wired.

The generated `src/generated/graphql.tsx` is intentionally left untouched; it regenerates in the normal codegen flow against the merged backend schema.

## Coordination

Lands alongside backend getlago/lago-api#6315.