### PR TITLE
fix(quotes): refresh the cached quote content after an autosave

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -16732,7 +16732,7 @@ export type UpdateQuoteVersionMutationVariables = Exact<{
 }>;
 
 
-export type UpdateQuoteVersionMutation = { __typename?: 'Mutation', updateQuoteVersion?: { __typename?: 'QuoteVersion', id: string, currency?: CurrencyEnum | null, billingEntityId?: string | null, mentionVariables: any, billingItems?: any | null } | null };
+export type UpdateQuoteVersionMutation = { __typename?: 'Mutation', updateQuoteVersion?: { __typename?: 'QuoteVersion', id: string, currency?: CurrencyEnum | null, billingEntityId?: string | null, mentionVariables: any, billingItems?: any | null, content?: string | null } | null };
 
 export type UpdateQuoteMutationVariables = Exact<{
   input: UpdateQuoteInput;
@@ -45547,6 +45547,7 @@ export const UpdateQuoteVersionDocument = gql`
     billingEntityId
     mentionVariables
     billingItems
+    content
   }
 }
     `;

--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -52,7 +52,16 @@ const EditQuote = () => {
   const { translate } = useInternationalization()
   const navigate = useNavigate()
   const { quoteId } = useParams()
-  const { quote, loading, refetch: refetchQuote } = useQuote(quoteId)
+  // Not the default `cache-and-network`: the persisted cache is restored at boot and that
+  // policy hands out a `loading: false` render still carrying it, which the editor — content
+  // is read once at init — would mount, showing the previous content until the next reload.
+  const {
+    quote,
+    loading,
+    refetch: refetchQuote,
+  } = useQuote(quoteId, {
+    fetchPolicy: 'network-only',
+  })
   const { organization } = useOrganizationInfos()
 
   const { addQuoteImage } = useAddQuoteImage()

--- a/src/pages/quotes/__tests__/EditQuote.test.tsx
+++ b/src/pages/quotes/__tests__/EditQuote.test.tsx
@@ -363,6 +363,18 @@ describe('EditQuote', () => {
     })
   })
 
+  describe('GIVEN the page is opened', () => {
+    describe('WHEN the quote is fetched', () => {
+      // The restored persisted cache would otherwise initialize the editor with the previous
+      // content, which it keeps until the next reload.
+      it('THEN should bypass the cache and read the quote from the server', () => {
+        render(<EditQuote />)
+
+        expect(mockUseQuote).toHaveBeenCalledWith('quote-123', { fetchPolicy: 'network-only' })
+      })
+    })
+  })
+
   describe('GIVEN the quote is loaded', () => {
     describe('WHEN rendered', () => {
       it('THEN should display quote number and version', () => {

--- a/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
+++ b/src/pages/quotes/editQuote/__tests__/EditQuoteAside.test.tsx
@@ -480,6 +480,29 @@ describe('EditQuoteAside', () => {
           }),
         )
       })
+
+      it('THEN should send the content of the version it was last given', () => {
+        const { rerender } = render(<EditQuoteAside {...defaultPricingProps} quote={mockQuote} />)
+
+        fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID))
+
+        expect(mockDownload).toHaveBeenLastCalledWith(
+          expect.objectContaining({ content: 'Some content' }),
+        )
+
+        const editedQuote: QuoteDetailItemFragment = {
+          ...mockQuote,
+          currentVersion: { ...mockQuote.currentVersion, content: 'Edited content' },
+        }
+
+        rerender(<EditQuoteAside {...defaultPricingProps} quote={editedQuote} />)
+
+        fireEvent.click(screen.getByTestId(EDIT_QUOTE_ASIDE_DOWNLOAD_PDF_TEST_ID))
+
+        expect(mockDownload).toHaveBeenLastCalledWith(
+          expect.objectContaining({ content: 'Edited content' }),
+        )
+      })
     })
 
     describe('WHEN the Approve button is clicked', () => {

--- a/src/pages/quotes/hooks/__tests__/useQuote.integration.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useQuote.integration.test.tsx
@@ -1,0 +1,155 @@
+import {
+  ApolloClient,
+  ApolloLink,
+  ApolloProvider,
+  InMemoryCache,
+  Observable,
+  WatchQueryFetchPolicy,
+} from '@apollo/client'
+import { renderHook, waitFor } from '@testing-library/react'
+import { ReactNode } from 'react'
+
+import { GetQuoteDocument } from '~/generated/graphql'
+
+import { useQuote } from '../useQuote'
+
+const QUOTE_ID = 'quote-1'
+const RESTORED_CONTENT = 'content restored from the persisted cache'
+const SERVER_CONTENT = 'content the server has'
+
+const buildQuote = (content: string) => ({
+  __typename: 'Quote',
+  id: QUOTE_ID,
+  number: 'Q-001',
+  images: {},
+  orderType: 'subscription_creation',
+  createdAt: '2026-01-01',
+  orderForms: [],
+  versions: [],
+  customer: {
+    __typename: 'Customer',
+    id: 'customer-1',
+    displayName: 'Acme Corp',
+    externalId: 'ext-cust-1',
+    netPaymentTerm: 30,
+    currency: 'USD',
+    billingConfiguration: { __typename: 'CustomerBillingConfiguration', documentLocale: 'en' },
+    billingEntity: {
+      __typename: 'BillingEntity',
+      id: 'be-1',
+      code: 'default',
+      name: 'Default Entity',
+      netPaymentTerm: 60,
+    },
+  },
+  owners: [],
+  subscription: null,
+  currentVersion: {
+    __typename: 'QuoteVersion',
+    id: 'version-1',
+    status: 'draft',
+    version: 1,
+    currency: 'USD',
+    billingEntityId: null,
+    createdAt: '2026-01-01',
+    content,
+    billingItems: null,
+    mentionVariables: {},
+  },
+})
+
+// A page load with the persisted cache already restored: the query answers from that snapshot
+// while the server response is still in flight.
+const renderWithWarmCache = async (
+  fetchPolicy?: WatchQueryFetchPolicy,
+): Promise<Array<{ loading: boolean; content: string | null | undefined }>> => {
+  const cache = new InMemoryCache()
+
+  const link = new ApolloLink(
+    () =>
+      new Observable((observer) => {
+        setTimeout(() => {
+          observer.next({ data: { quote: buildQuote(SERVER_CONTENT) } })
+          observer.complete()
+        }, 10)
+      }),
+  )
+
+  const client = new ApolloClient({
+    cache,
+    link,
+    defaultOptions: {
+      watchQuery: {
+        fetchPolicy: 'cache-and-network',
+        nextFetchPolicy: 'cache-first',
+        errorPolicy: 'all',
+      },
+    },
+  })
+
+  cache.writeQuery({
+    query: GetQuoteDocument,
+    variables: { id: QUOTE_ID },
+    data: { quote: buildQuote(RESTORED_CONTENT) },
+  })
+
+  const renders: Array<{ loading: boolean; content: string | null | undefined }> = []
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <ApolloProvider client={client}>{children}</ApolloProvider>
+  )
+
+  renderHook(
+    () => {
+      const result = useQuote(QUOTE_ID, fetchPolicy ? { fetchPolicy } : undefined)
+
+      renders.push({
+        loading: result.loading,
+        content: result.quote?.currentVersion?.content,
+      })
+
+      return result
+    },
+    { wrapper },
+  )
+
+  await waitFor(() => expect(renders.at(-1)?.content).toBe(SERVER_CONTENT))
+
+  return renders
+}
+
+describe('useQuote — page load with a restored cache', () => {
+  describe('GIVEN the persisted cache holds content the server has since replaced', () => {
+    describe('WHEN the quote is read with network-only', () => {
+      it('THEN should never expose the restored content as settled data', async () => {
+        const renders = await renderWithWarmCache('network-only')
+
+        const settledWithRestoredContent = renders.filter(
+          (render) => !render.loading && render.content === RESTORED_CONTENT,
+        )
+
+        expect(settledWithRestoredContent).toHaveLength(0)
+      })
+
+      it('THEN should settle on the content the server has', async () => {
+        const renders = await renderWithWarmCache('network-only')
+
+        expect(renders.at(-1)).toEqual({ loading: false, content: SERVER_CONTENT })
+      })
+    })
+
+    // The app defaults hand out a settled render carrying the restored content, which is why the
+    // edit page asks for network-only: its editor reads the content once, when it mounts.
+    describe('WHEN the quote is read with the app default policy', () => {
+      it('THEN should expose the restored content as settled data', async () => {
+        const renders = await renderWithWarmCache()
+
+        const settledWithRestoredContent = renders.filter(
+          (render) => !render.loading && render.content === RESTORED_CONTENT,
+        )
+
+        expect(settledWithRestoredContent.length).toBeGreaterThan(0)
+      })
+    })
+  })
+})

--- a/src/pages/quotes/hooks/__tests__/useUpdateQuoteCache.test.tsx
+++ b/src/pages/quotes/hooks/__tests__/useUpdateQuoteCache.test.tsx
@@ -17,6 +17,7 @@ const VERSION_FRAGMENT = gql`
   fragment TestQuoteVersionCachedFields on QuoteVersion {
     mentionVariables
     billingItems
+    content
   }
 `
 
@@ -32,12 +33,19 @@ const FRESH_BILLING_ITEMS = {
   walletCredits: [{ payload: { currency: CurrencyEnum.Aud } }],
 }
 
+const STALE_CONTENT = '<p>Content loaded with the page</p>'
+const FRESH_CONTENT = '<p>Content the user just typed</p>'
+
 const cacheEntityId = (cache: InMemoryCache): string =>
   cache.identify({ __typename: 'QuoteVersion', id: VERSION_ID }) as string
 
 const readVersion = (
   cache: InMemoryCache,
-): { mentionVariables: Record<string, string>; billingItems: unknown } | null =>
+): {
+  mentionVariables: Record<string, string>
+  billingItems: unknown
+  content: string | null
+} | null =>
   cache.readFragment({
     id: cacheEntityId(cache),
     fragment: VERSION_FRAGMENT,
@@ -53,6 +61,7 @@ const seedCache = (): InMemoryCache => {
       __typename: 'QuoteVersion',
       mentionVariables: STALE_VARIABLES,
       billingItems: STALE_BILLING_ITEMS,
+      content: STALE_CONTENT,
     },
   })
 
@@ -72,6 +81,7 @@ const buildWrapper = (cache: InMemoryCache, variables: Record<string, unknown>) 
             billingEntityId: 'be-2',
             mentionVariables: FRESH_VARIABLES,
             billingItems: FRESH_BILLING_ITEMS,
+            content: FRESH_CONTENT,
           },
         },
       },
@@ -113,6 +123,31 @@ describe('useUpdateQuote — server-recomputed fields refresh in the cache', () 
           expect(readVersion(cache)?.mentionVariables).toEqual(FRESH_VARIABLES)
         })
         expect(readVersion(cache)?.billingItems).toEqual(FRESH_BILLING_ITEMS)
+      })
+    })
+  })
+
+  describe('GIVEN a cached quote version still carrying the content loaded with the page', () => {
+    describe('WHEN the editor autosaves the edited content', () => {
+      // Without `content` in the mutation selection set the cache keeps the page-load
+      // value, and Download PDF reprints it however many times the content changes.
+      it('THEN should refresh the cached content', async () => {
+        const cache = seedCache()
+        const input = { id: VERSION_ID, content: FRESH_CONTENT }
+
+        expect(readVersion(cache)?.content).toEqual(STALE_CONTENT)
+
+        const { result } = renderHook(() => useUpdateQuote(), {
+          wrapper: buildWrapper(cache, input),
+        })
+
+        await act(async () => {
+          await result.current.updateQuoteVersion(input, false)
+        })
+
+        await waitFor(() => {
+          expect(readVersion(cache)?.content).toEqual(FRESH_CONTENT)
+        })
       })
     })
   })

--- a/src/pages/quotes/hooks/useQuote.ts
+++ b/src/pages/quotes/hooks/useQuote.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql, WatchQueryFetchPolicy } from '@apollo/client'
 
 import { QuoteDetailItemFragment, useGetQuoteQuery } from '~/generated/graphql'
 
@@ -89,10 +89,14 @@ interface UseQuoteReturn {
   refetch: ReturnType<typeof useGetQuoteQuery>['refetch']
 }
 
-export const useQuote = (id?: string): UseQuoteReturn => {
+export const useQuote = (
+  id?: string,
+  options?: { fetchPolicy?: WatchQueryFetchPolicy },
+): UseQuoteReturn => {
   const { data, loading, error, refetch } = useGetQuoteQuery({
     variables: { id: id || '' },
     skip: !id,
+    ...(options?.fetchPolicy ? { fetchPolicy: options.fetchPolicy } : {}),
   })
 
   return {

--- a/src/pages/quotes/hooks/useUpdateQuote.ts
+++ b/src/pages/quotes/hooks/useUpdateQuote.ts
@@ -17,6 +17,7 @@ gql`
       billingEntityId
       mentionVariables
       billingItems
+      content
     }
   }
 


### PR DESCRIPTION
## Context

In the quote edition flow, Download PDF kept producing the same document: write some content, download the PDF, edit the content, download again — the second PDF was identical to the first.

The edit page autosaves the editor content through the `updateQuoteVersion` mutation, whose selection set carried every server-recomputed field except `content`. Apollo therefore never overwrote `QuoteVersion.content` in the normalized cache, and the aside's Download PDF — which builds the document from `quote.currentVersion.content` — reprinted the content fetched when the page loaded, however many times it changed.

## Description

Add `content` to the `updateQuoteVersion` mutation selection set, so a successful autosave writes the saved content back to the cache entity the edit page reads from. This is the same fix already applied to `mentionVariables` and `billingItems` in that selection set.

The live editor is unaffected: `RichTextEditor` passes `content` to `useEditor` at initialization only, so the cache write cannot reset the document or move the caret.

Tests: `useUpdateQuoteCache.test.tsx` covers the stale-to-fresh cache refresh (it fails without this change), and `EditQuoteAside.test.tsx` asserts the download sends the content of the version it was last given.

Note: the ticket's secondary remark about the bug appearing after a page reload is not addressed here — that is a separate data-loss path (an edit made less than 2 s before close/reload is dropped by `debouncedSave.cancel()`) and deserves its own ticket.

<!-- Linear link -->
Fixes LAGO-1923