### PR TITLE
feat(quotes): hide individual fees from the quote document

### DIFF
--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPlanPreviewTable.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPlanPreviewTable.tsx
@@ -85,6 +85,8 @@ export const SubscriptionPlanPreviewTable = ({
   currency,
   locale,
 }: SubscriptionPlanPreviewTableProps) => {
+  if (data.rows.length === 0) return null
+
   const formatValue = (v: PreviewCellValue): string => {
     switch (v.type) {
       case 'count':

--- a/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/SubscriptionPricingContent.tsx
@@ -435,6 +435,7 @@ export function SubscriptionPricingContent({
               form={planForm}
               alreadyExistingFixedChargesIds={planData?.fixedCharges?.map((c) => c.id) || []}
               isInSubscriptionForm
+              isInQuoteForm
               isEdition={false}
             />
 
@@ -442,6 +443,7 @@ export function SubscriptionPricingContent({
               form={planForm}
               alreadyExistingCharges={(planData?.charges ?? []) as LocalUsageChargeInput[]}
               isInSubscriptionForm
+              isInQuoteForm
               isEdition={false}
             />
 

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/PricingBlockView.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/PricingBlockView.test.tsx
@@ -416,6 +416,39 @@ describe('PricingBlockView', () => {
       })
     })
 
+    describe('WHEN every charge of the resolved plan is hidden from the document', () => {
+      const hiddenPlanEntity: EntityData = {
+        entityId: 'plan-1',
+        entityType: 'plan',
+        name: 'My Plan',
+        code: 'plan_code',
+        plan: { rows: [] },
+      }
+
+      it('THEN should render no table in preview mode', () => {
+        renderPricingBlockView({
+          mode: 'preview',
+          entities: { 'plan-1': hiddenPlanEntity },
+          attrs: { pricingType: 'plan', entityIds: ['plan-1'], localEntityIds: [] },
+        })
+
+        expect(
+          screen.queryByTestId(SUBSCRIPTION_PLAN_PREVIEW_TABLE_TEST_ID),
+        ).not.toBeInTheDocument()
+      })
+
+      it('THEN should still render the editable block in edit mode', () => {
+        renderPricingBlockView({
+          mode: 'edit',
+          entities: { 'plan-1': hiddenPlanEntity },
+          attrs: { pricingType: 'plan', entityIds: ['plan-1'], localEntityIds: [] },
+        })
+
+        expect(screen.getByTestId(SLASH_COMMAND_BLOCK_VIEW_TEST_ID)).toBeInTheDocument()
+        expect(screen.getByText('My Plan')).toBeInTheDocument()
+      })
+    })
+
     describe('WHEN rendered with plan pricing type but no resolved plan', () => {
       it('THEN should render nothing (no Select-pricing button)', () => {
         renderPricingBlockView({

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPlanPreviewTable.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPlanPreviewTable.test.tsx
@@ -309,4 +309,22 @@ describe('SubscriptionPlanPreviewTable', () => {
       expect(screen.getByText('Flat fee for 101 units and above')).toBeInTheDocument()
     })
   })
+
+  describe('GIVEN every row is hidden', () => {
+    describe('WHEN the data holds no rows', () => {
+      it('THEN should render nothing rather than empty table chrome', () => {
+        const { container } = render(
+          <SubscriptionPlanPreviewTable {...defaultProps} data={{ rows: [] }} />,
+        )
+
+        expect(
+          screen.queryByTestId(SUBSCRIPTION_PLAN_PREVIEW_TABLE_TEST_ID),
+        ).not.toBeInTheDocument()
+        expect(
+          screen.queryByTestId('preview-table-subscription-plan-preview'),
+        ).not.toBeInTheDocument()
+        expect(container.querySelectorAll('th')).toHaveLength(0)
+      })
+    })
+  })
 })

--- a/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
+++ b/src/components/designSystem/RichTextEditor/PricingBlock/__tests__/SubscriptionPricingContent.test.tsx
@@ -190,11 +190,19 @@ jest.mock('../useQuotePlanSettingsDrawer', () => ({
 
 // Mock reused section components
 jest.mock('~/components/plans/form/FixedChargesSection', () => ({
-  FixedChargesSection: () => <div data-test="fixed-charges-section">Fixed Charges</div>,
+  FixedChargesSection: ({ isInQuoteForm }: { isInQuoteForm?: boolean }) => (
+    <div data-test="fixed-charges-section" data-in-quote-form={String(!!isInQuoteForm)}>
+      Fixed Charges
+    </div>
+  ),
 }))
 
 jest.mock('~/components/plans/UsageChargesSection', () => ({
-  UsageChargesSection: () => <div data-test="usage-charges-section">Usage Charges</div>,
+  UsageChargesSection: ({ isInQuoteForm }: { isInQuoteForm?: boolean }) => (
+    <div data-test="usage-charges-section" data-in-quote-form={String(!!isInQuoteForm)}>
+      Usage Charges
+    </div>
+  ),
 }))
 
 jest.mock('~/components/plans/CommitmentsSection', () => ({
@@ -289,6 +297,16 @@ describe('SubscriptionPricingContent', () => {
     expect(screen.getByTestId('usage-charges-section')).toBeInTheDocument()
     expect(screen.getByTestId('commitments-section')).toBeInTheDocument()
     expect(screen.getByTestId('progressive-billing-section')).toBeInTheDocument()
+
+    // Gates the quote-only "display in quote document" switch inside the charge drawers
+    expect(screen.getByTestId('fixed-charges-section')).toHaveAttribute(
+      'data-in-quote-form',
+      'true',
+    )
+    expect(screen.getByTestId('usage-charges-section')).toHaveAttribute(
+      'data-in-quote-form',
+      'true',
+    )
   })
 
   it('syncs state to stateRef when plan is selected', async () => {

--- a/src/components/plans/UsageChargesSection.tsx
+++ b/src/components/plans/UsageChargesSection.tsx
@@ -40,6 +40,7 @@ interface UsageChargesSectionProps {
   alreadyExistingCharges?: LocalUsageChargeInput[] | null
   canBeEdited?: boolean
   isInSubscriptionForm?: boolean
+  isInQuoteForm?: boolean
   isEdition: boolean
   subscriptionFormType?: keyof typeof FORM_TYPE_ENUM
 }
@@ -49,6 +50,7 @@ export const UsageChargesSection = ({
   alreadyExistingCharges,
   canBeEdited,
   isInSubscriptionForm,
+  isInQuoteForm,
   isEdition,
   subscriptionFormType,
 }: UsageChargesSectionProps) => {
@@ -213,6 +215,7 @@ export const UsageChargesSection = ({
         ref={usageChargeDrawerRef}
         disabled={isEdition && !canBeEdited}
         isInSubscriptionForm={isInSubscriptionForm}
+        isInQuoteForm={isInQuoteForm}
         subscriptionFormType={subscriptionFormType}
         onSave={handleDrawerSave}
         onDelete={handleChargeDelete}

--- a/src/components/plans/chargeAccordion/options/ChargeDisplayInQuoteDocumentOption.tsx
+++ b/src/components/plans/chargeAccordion/options/ChargeDisplayInQuoteDocumentOption.tsx
@@ -1,0 +1,49 @@
+import { Typography } from '~/components/designSystem/Typography'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { withFieldGroup } from '~/hooks/forms/useAppform'
+
+type ChargeDisplayInQuoteDocumentOptionValues = {
+  displayInQuoteDocument: boolean
+}
+
+type ChargeDisplayInQuoteDocumentOptionProps = {
+  disabled?: boolean
+}
+
+const defaultValues: ChargeDisplayInQuoteDocumentOptionValues = {
+  displayInQuoteDocument: true,
+}
+
+const defaultProps: ChargeDisplayInQuoteDocumentOptionProps = {
+  disabled: false,
+}
+
+export const ChargeDisplayInQuoteDocumentOption = withFieldGroup({
+  defaultValues,
+  props: defaultProps,
+  render: function Render({ group, disabled }) {
+    const { translate } = useInternationalization()
+
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <Typography variant="captionHl" color="grey700">
+            {translate('text_1788938888298p8mb2uxfk5l')}
+          </Typography>
+          <Typography variant="caption" color="grey600">
+            {translate('text_1788938888298tobp5ik7edt')}
+          </Typography>
+        </div>
+
+        <group.AppField name="displayInQuoteDocument">
+          {(field) => (
+            <field.SwitchField
+              label={translate('text_1788938888298p8mb2uxfk5l')}
+              disabled={disabled}
+            />
+          )}
+        </group.AppField>
+      </div>
+    )
+  },
+})

--- a/src/components/plans/chargeAccordion/options/__tests__/ChargeDisplayInQuoteDocumentOption.test.tsx
+++ b/src/components/plans/chargeAccordion/options/__tests__/ChargeDisplayInQuoteDocumentOption.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { useAppForm } from '~/hooks/forms/useAppform'
+import { render } from '~/test-utils'
+
+import { ChargeDisplayInQuoteDocumentOption } from '../ChargeDisplayInQuoteDocumentOption'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({
+    translate: (key: string) => key,
+  }),
+}))
+
+const LABEL_KEY = 'text_1788938888298p8mb2uxfk5l'
+const DESCRIPTION_KEY = 'text_1788938888298tobp5ik7edt'
+
+// Only the values slice is read back, so the ref is typed to just that.
+let formRef: { state: { values: { displayInQuoteDocument: boolean } } } | null = null
+
+const Wrapper = ({
+  displayInQuoteDocument = true,
+  disabled = false,
+}: {
+  displayInQuoteDocument?: boolean
+  disabled?: boolean
+}) => {
+  const form = useAppForm({ defaultValues: { displayInQuoteDocument } })
+
+  formRef = form
+
+  return (
+    <form.AppForm>
+      <form>
+        <ChargeDisplayInQuoteDocumentOption
+          form={form}
+          fields={{ displayInQuoteDocument: 'displayInQuoteDocument' }}
+          disabled={disabled}
+        />
+      </form>
+    </form.AppForm>
+  )
+}
+
+describe('ChargeDisplayInQuoteDocumentOption', () => {
+  afterEach(() => {
+    cleanup()
+    formRef = null
+  })
+
+  describe('GIVEN the option renders', () => {
+    describe('WHEN the charge is shown in the quote document', () => {
+      it('THEN should render the heading, the description and a checked switch', () => {
+        render(<Wrapper displayInQuoteDocument />)
+
+        expect(screen.getAllByText(LABEL_KEY).length).toBeGreaterThan(0)
+        expect(screen.getByText(DESCRIPTION_KEY)).toBeInTheDocument()
+        expect(screen.getByRole('checkbox')).toBeChecked()
+      })
+    })
+
+    describe('WHEN the charge is hidden from the quote document', () => {
+      it('THEN should render an unchecked switch', () => {
+        render(<Wrapper displayInQuoteDocument={false} />)
+
+        expect(screen.getByRole('checkbox')).not.toBeChecked()
+      })
+    })
+  })
+
+  describe('GIVEN the user toggles the switch', () => {
+    describe('WHEN it is turned off', () => {
+      it('THEN should write false to the form field', async () => {
+        const user = userEvent.setup()
+
+        render(<Wrapper displayInQuoteDocument />)
+
+        await user.click(screen.getByRole('checkbox'))
+
+        expect(formRef?.state.values).toEqual({ displayInQuoteDocument: false })
+      })
+    })
+  })
+
+  describe('GIVEN the drawer is read-only', () => {
+    describe('WHEN disabled is passed', () => {
+      it('THEN should disable the switch', () => {
+        render(<Wrapper disabled />)
+
+        expect(screen.getByRole('checkbox')).toBeDisabled()
+      })
+    })
+  })
+})

--- a/src/components/plans/drawers/fixedCharge/FixedChargeDrawer.tsx
+++ b/src/components/plans/drawers/fixedCharge/FixedChargeDrawer.tsx
@@ -44,6 +44,7 @@ const buildFixedChargeDrawerSchema = (requireCode: boolean) =>
       applyUnitsImmediately: z.boolean(),
       chargeModel: z.enum(FixedChargeChargeModelEnum),
       code: buildChargeCodeSchema(requireCode),
+      displayInQuoteDocument: z.boolean(),
       id: z.string().optional(),
       invoiceDisplayName: z.string(),
       payInAdvance: z.boolean(),
@@ -76,6 +77,7 @@ interface FixedChargeDrawerProps {
   disabled?: boolean
   isEdition?: boolean
   isInSubscriptionForm?: boolean
+  isInQuoteForm?: boolean
   // TEMP (LAGO-1498): drop showCode + existingChargeCodes once the old
   // plan/subscription forms are retired and the Code field becomes unconditional.
   showCode?: boolean
@@ -98,6 +100,7 @@ export const FixedChargeDrawer = forwardRef<FixedChargeDrawerRef, FixedChargeDra
       disabled,
       isEdition,
       isInSubscriptionForm,
+      isInQuoteForm,
       showCode = false,
       existingChargeCodes,
       onSave,
@@ -128,6 +131,7 @@ export const FixedChargeDrawer = forwardRef<FixedChargeDrawerRef, FixedChargeDra
           applyUnitsImmediately: value.applyUnitsImmediately,
           chargeModel: value.chargeModel,
           code: value.code || undefined,
+          displayInQuoteDocument: value.displayInQuoteDocument,
           id: value.id,
           invoiceDisplayName: value.invoiceDisplayName || undefined,
           payInAdvance: value.payInAdvance,
@@ -199,6 +203,7 @@ export const FixedChargeDrawer = forwardRef<FixedChargeDrawerRef, FixedChargeDra
               isCreateMode={isCreateModeRef.current}
               isEdition={isEdition || false}
               isInSubscriptionForm={isInSubscriptionForm || false}
+              isInQuoteForm={isInQuoteForm || false}
               disabled={disabled || false}
               alertMessage={alertMessageRef.current}
               showCode={showCode}
@@ -240,6 +245,7 @@ export const FixedChargeDrawer = forwardRef<FixedChargeDrawerRef, FixedChargeDra
               applyUnitsImmediately: charge.applyUnitsImmediately || false,
               chargeModel: charge.chargeModel,
               code: charge.code || '',
+              displayInQuoteDocument: charge.displayInQuoteDocument ?? true,
               id: charge.id,
               invoiceDisplayName: charge.invoiceDisplayName || '',
               payInAdvance: charge.payInAdvance || false,

--- a/src/components/plans/drawers/fixedCharge/FixedChargeDrawerContent.tsx
+++ b/src/components/plans/drawers/fixedCharge/FixedChargeDrawerContent.tsx
@@ -64,6 +64,7 @@ interface FixedChargeDrawerContentExtraProps {
   isCreateMode: boolean
   isEdition: boolean
   isInSubscriptionForm: boolean
+  isInQuoteForm: boolean
   disabled: boolean
   alertMessage?: string
   // TEMP (LAGO-1498): Code is shown only via the v2 details/edition UI.
@@ -75,6 +76,7 @@ const fixedChargeDrawerContentDefaultProps: FixedChargeDrawerContentExtraProps =
   isCreateMode: false,
   isEdition: false,
   isInSubscriptionForm: false,
+  isInQuoteForm: false,
   disabled: false,
   alertMessage: undefined,
   showCode: false,
@@ -89,6 +91,7 @@ export const FixedChargeDrawerContent = withForm({
     isCreateMode,
     isEdition,
     isInSubscriptionForm,
+    isInQuoteForm,
     disabled,
     alertMessage,
     showCode,
@@ -346,6 +349,28 @@ export const FixedChargeDrawerContent = withForm({
                   )}
                 </form.AppField>
               </div>
+
+              {isInQuoteForm && (
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-1">
+                    <Typography variant="captionHl" color="grey700">
+                      {translate('text_1788938888298p8mb2uxfk5l')}
+                    </Typography>
+                    <Typography variant="caption" color="grey600">
+                      {translate('text_1788938888298tobp5ik7edt')}
+                    </Typography>
+                  </div>
+
+                  <form.AppField name="displayInQuoteDocument">
+                    {(field) => (
+                      <field.SwitchField
+                        label={translate('text_1788938888298p8mb2uxfk5l')}
+                        disabled={disabled}
+                      />
+                    )}
+                  </form.AppField>
+                </div>
+              )}
 
               <TaxesSelectorSection
                 title={translate('text_1760729707267seik64l67k8')}

--- a/src/components/plans/drawers/fixedCharge/FixedChargeDrawerContent.tsx
+++ b/src/components/plans/drawers/fixedCharge/FixedChargeDrawerContent.tsx
@@ -9,6 +9,7 @@ import { Typography } from '~/components/designSystem/Typography'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { ChargeModelSelector } from '~/components/plans/chargeAccordion/ChargeModelSelector'
 import { ChargeWrapperSwitch } from '~/components/plans/chargeAccordion/ChargeWrapperSwitch'
+import { ChargeDisplayInQuoteDocumentOption } from '~/components/plans/chargeAccordion/options/ChargeDisplayInQuoteDocumentOption'
 import { ChargePayInAdvanceOption } from '~/components/plans/chargeAccordion/options/ChargePayInAdvanceOption'
 import { seedChargeCode } from '~/components/plans/drawers/common/chargeCode'
 import ChargeCodeField from '~/components/plans/drawers/common/ChargeCodeField'
@@ -351,25 +352,11 @@ export const FixedChargeDrawerContent = withForm({
               </div>
 
               {isInQuoteForm && (
-                <div className="flex flex-col gap-4">
-                  <div className="flex flex-col gap-1">
-                    <Typography variant="captionHl" color="grey700">
-                      {translate('text_1788938888298p8mb2uxfk5l')}
-                    </Typography>
-                    <Typography variant="caption" color="grey600">
-                      {translate('text_1788938888298tobp5ik7edt')}
-                    </Typography>
-                  </div>
-
-                  <form.AppField name="displayInQuoteDocument">
-                    {(field) => (
-                      <field.SwitchField
-                        label={translate('text_1788938888298p8mb2uxfk5l')}
-                        disabled={disabled}
-                      />
-                    )}
-                  </form.AppField>
-                </div>
+                <ChargeDisplayInQuoteDocumentOption
+                  form={form}
+                  fields={{ displayInQuoteDocument: 'displayInQuoteDocument' }}
+                  disabled={disabled}
+                />
               )}
 
               <TaxesSelectorSection

--- a/src/components/plans/drawers/fixedCharge/__tests__/FixedChargeDrawer.test.tsx
+++ b/src/components/plans/drawers/fixedCharge/__tests__/FixedChargeDrawer.test.tsx
@@ -383,6 +383,7 @@ describe('FixedChargeDrawer', () => {
           applyUnitsImmediately: false,
           chargeModel: 'standard' as FixedChargeDrawerFormValues['chargeModel'],
           code: 'setup',
+          displayInQuoteDocument: true,
           invoiceDisplayName: 'Test',
           payInAdvance: false,
           properties: { amount: '100' },
@@ -399,6 +400,7 @@ describe('FixedChargeDrawer', () => {
             code: 'setup',
             payInAdvance: false,
             units: '5',
+            displayInQuoteDocument: true,
           }),
           -1,
         )
@@ -469,6 +471,8 @@ describe('FixedChargeDrawer', () => {
             prorated: false,
             taxes: [],
             units: '',
+            // A charge stored before the flag existed must open with the switch on
+            displayInQuoteDocument: true,
           }),
           { keepDefaultValues: true },
         )

--- a/src/components/plans/drawers/fixedCharge/__tests__/FixedChargeDrawerContent.test.tsx
+++ b/src/components/plans/drawers/fixedCharge/__tests__/FixedChargeDrawerContent.test.tsx
@@ -11,6 +11,7 @@ const FixedChargeDrawerContent = OriginalFixedChargeDrawerContent as unknown as 
   isEdition?: boolean
   disabled?: boolean
   isInSubscriptionForm?: boolean
+  isInQuoteForm?: boolean
   alertMessage?: string
   showCode?: boolean
   existingChargeCodes?: (string | null | undefined)[]
@@ -567,6 +568,33 @@ describe('FixedChargeDrawerContent', () => {
         })
 
         expect(mockSetFieldValue).not.toHaveBeenCalledWith('code', expect.anything())
+      })
+    })
+  })
+
+  describe('GIVEN the quote-only "display in quote document" switch', () => {
+    describe('WHEN the drawer is not opened from a quote', () => {
+      it('THEN should not render the switch', () => {
+        render(<FixedChargeDrawerContent isCreateMode={false} />)
+
+        expect(screen.queryByTestId('field-displayInQuoteDocument')).not.toBeInTheDocument()
+      })
+
+      it('THEN should not render it either inside the subscription form', () => {
+        render(<FixedChargeDrawerContent isCreateMode={false} isInSubscriptionForm />)
+
+        expect(screen.queryByTestId('field-displayInQuoteDocument')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the drawer is opened from a quote', () => {
+      it('THEN should render the switch, enabled even inside the subscription form', () => {
+        render(<FixedChargeDrawerContent isCreateMode={false} isInSubscriptionForm isInQuoteForm />)
+
+        const field = screen.getByTestId('field-displayInQuoteDocument')
+
+        expect(field).toBeInTheDocument()
+        expect(field).not.toBeDisabled()
       })
     })
   })

--- a/src/components/plans/drawers/fixedCharge/__tests__/FixedChargeDrawerContent.test.tsx
+++ b/src/components/plans/drawers/fixedCharge/__tests__/FixedChargeDrawerContent.test.tsx
@@ -30,6 +30,7 @@ let capturedAppFieldListeners: Record<string, { onChange?: (arg: { value: unknow
 const CHARGE_MODEL_SELECTOR_TEST_ID = 'charge-model-selector'
 const CHARGE_WRAPPER_SWITCH_TEST_ID = 'charge-wrapper-switch'
 const CHARGE_PAY_IN_ADVANCE_OPTION_TEST_ID = 'charge-pay-in-advance-option'
+const CHARGE_DISPLAY_IN_QUOTE_DOCUMENT_OPTION_TEST_ID = 'charge-display-in-quote-document-option'
 
 // --- Mock form values ---
 
@@ -233,6 +234,15 @@ jest.mock('~/components/plans/chargeAccordion/ChargeWrapperSwitch', () => ({
       <div data-test={CHARGE_WRAPPER_SWITCH_TEST_ID} data-disabled={String(!!props.disabled)} />
     )
   },
+}))
+
+jest.mock('~/components/plans/chargeAccordion/options/ChargeDisplayInQuoteDocumentOption', () => ({
+  ChargeDisplayInQuoteDocumentOption: (props: Record<string, unknown>) => (
+    <div
+      data-test={CHARGE_DISPLAY_IN_QUOTE_DOCUMENT_OPTION_TEST_ID}
+      data-disabled={String(!!props.disabled)}
+    />
+  ),
 }))
 
 jest.mock('~/components/plans/chargeAccordion/options/ChargePayInAdvanceOption', () => ({
@@ -577,13 +587,17 @@ describe('FixedChargeDrawerContent', () => {
       it('THEN should not render the switch', () => {
         render(<FixedChargeDrawerContent isCreateMode={false} />)
 
-        expect(screen.queryByTestId('field-displayInQuoteDocument')).not.toBeInTheDocument()
+        expect(
+          screen.queryByTestId(CHARGE_DISPLAY_IN_QUOTE_DOCUMENT_OPTION_TEST_ID),
+        ).not.toBeInTheDocument()
       })
 
       it('THEN should not render it either inside the subscription form', () => {
         render(<FixedChargeDrawerContent isCreateMode={false} isInSubscriptionForm />)
 
-        expect(screen.queryByTestId('field-displayInQuoteDocument')).not.toBeInTheDocument()
+        expect(
+          screen.queryByTestId(CHARGE_DISPLAY_IN_QUOTE_DOCUMENT_OPTION_TEST_ID),
+        ).not.toBeInTheDocument()
       })
     })
 
@@ -591,10 +605,10 @@ describe('FixedChargeDrawerContent', () => {
       it('THEN should render the switch, enabled even inside the subscription form', () => {
         render(<FixedChargeDrawerContent isCreateMode={false} isInSubscriptionForm isInQuoteForm />)
 
-        const field = screen.getByTestId('field-displayInQuoteDocument')
+        const field = screen.getByTestId(CHARGE_DISPLAY_IN_QUOTE_DOCUMENT_OPTION_TEST_ID)
 
         expect(field).toBeInTheDocument()
-        expect(field).not.toBeDisabled()
+        expect(field).toHaveAttribute('data-disabled', 'false')
       })
     })
   })

--- a/src/components/plans/drawers/fixedCharge/constants.ts
+++ b/src/components/plans/drawers/fixedCharge/constants.ts
@@ -12,6 +12,7 @@ export interface FixedChargeDrawerFormValues {
   applyUnitsImmediately: boolean
   chargeModel: FixedChargeChargeModelEnum
   code: string
+  displayInQuoteDocument: boolean
   id?: string
   invoiceDisplayName: string
   payInAdvance: boolean
@@ -27,6 +28,7 @@ export const DEFAULT_VALUES: FixedChargeDrawerFormValues = {
   applyUnitsImmediately: false,
   chargeModel: FixedChargeChargeModelEnum.Standard,
   code: '',
+  displayInQuoteDocument: true,
   id: undefined,
   invoiceDisplayName: '',
   payInAdvance: false,

--- a/src/components/plans/drawers/usageCharge/UsageChargeDrawer.tsx
+++ b/src/components/plans/drawers/usageCharge/UsageChargeDrawer.tsx
@@ -157,6 +157,7 @@ const buildUsageChargeDrawerSchema = (requireCode: boolean) =>
       appliedPricingUnit: z.custom<LocalPricingUnitInput>().optional(),
       chargeModel: z.enum(ChargeModelEnum),
       code: buildChargeCodeSchema(requireCode),
+      displayInQuoteDocument: z.boolean(),
       id: z.string().optional(),
       invoiceDisplayName: z.string(),
       invoiceable: z.boolean(),
@@ -231,6 +232,7 @@ export interface UsageChargeDrawerRef {
 interface UsageChargeDrawerProps {
   disabled?: boolean
   isInSubscriptionForm?: boolean
+  isInQuoteForm?: boolean
   // TEMP (LAGO-1498): drop showCode + existingChargeCodes once the old
   // plan/subscription forms are retired and the Code field becomes unconditional.
   showCode?: boolean
@@ -258,6 +260,7 @@ export const UsageChargeDrawer = forwardRef<UsageChargeDrawerRef, UsageChargeDra
     {
       disabled,
       isInSubscriptionForm,
+      isInQuoteForm,
       showCode = false,
       existingChargeCodes,
       subscriptionFormType,
@@ -291,6 +294,7 @@ export const UsageChargeDrawer = forwardRef<UsageChargeDrawerRef, UsageChargeDra
           appliedPricingUnit: value.appliedPricingUnit,
           chargeModel: value.chargeModel,
           code: value.code || undefined,
+          displayInQuoteDocument: value.displayInQuoteDocument,
           id: value.id,
           invoiceDisplayName: value.invoiceDisplayName || undefined,
           invoiceable: value.invoiceable,
@@ -365,6 +369,7 @@ export const UsageChargeDrawer = forwardRef<UsageChargeDrawerRef, UsageChargeDra
               isCreateMode={isCreateModeRef.current}
               disabled={disabled}
               isInSubscriptionForm={isInSubscriptionForm}
+              isInQuoteForm={isInQuoteForm}
               showCode={showCode}
               existingChargeCodes={existingChargeCodes}
               subscriptionFormType={subscriptionFormType}
@@ -412,6 +417,7 @@ export const UsageChargeDrawer = forwardRef<UsageChargeDrawerRef, UsageChargeDra
               appliedPricingUnit: charge.appliedPricingUnit,
               chargeModel: charge.chargeModel,
               code: charge.code || '',
+              displayInQuoteDocument: charge.displayInQuoteDocument ?? true,
               id: charge.id,
               invoiceDisplayName: charge.invoiceDisplayName || '',
               invoiceable: charge.invoiceable ?? true,

--- a/src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx
+++ b/src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx
@@ -14,6 +14,7 @@ import { buildChargeFilterAddFilterButtonId } from '~/components/plans/chargeAcc
 import { ChargeModelSelector } from '~/components/plans/chargeAccordion/ChargeModelSelector'
 import { ChargeWrapperSwitch } from '~/components/plans/chargeAccordion/ChargeWrapperSwitch'
 import { CustomPricingUnitSelector } from '~/components/plans/chargeAccordion/CustomPricingUnitSelector'
+import { ChargeDisplayInQuoteDocumentOption } from '~/components/plans/chargeAccordion/options/ChargeDisplayInQuoteDocumentOption'
 import { ChargeInvoicingStrategyOption } from '~/components/plans/chargeAccordion/options/ChargeInvoicingStrategyOption'
 import { ChargePayInAdvanceOption } from '~/components/plans/chargeAccordion/options/ChargePayInAdvanceOption'
 import { SpendingMinimumOptionSection } from '~/components/plans/chargeAccordion/SpendingMinimumOptionSection'
@@ -699,25 +700,11 @@ export const UsageChargeDrawerContent = withForm({
               )}
 
               {isInQuoteForm && (
-                <div className="flex flex-col gap-4">
-                  <div className="flex flex-col gap-1">
-                    <Typography variant="captionHl" color="grey700">
-                      {translate('text_1788938888298p8mb2uxfk5l')}
-                    </Typography>
-                    <Typography variant="caption" color="grey600">
-                      {translate('text_1788938888298tobp5ik7edt')}
-                    </Typography>
-                  </div>
-
-                  <form.AppField name="displayInQuoteDocument">
-                    {(field) => (
-                      <field.SwitchField
-                        label={translate('text_1788938888298p8mb2uxfk5l')}
-                        disabled={disabled}
-                      />
-                    )}
-                  </form.AppField>
-                </div>
+                <ChargeDisplayInQuoteDocumentOption
+                  form={form}
+                  fields={{ displayInQuoteDocument: 'displayInQuoteDocument' }}
+                  disabled={disabled}
+                />
               )}
 
               {!formValues.payInAdvance && (

--- a/src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx
+++ b/src/components/plans/drawers/usageCharge/UsageChargeDrawerContent.tsx
@@ -63,6 +63,7 @@ interface UsageChargeDrawerContentExtraProps {
   isCreateMode: boolean
   disabled?: boolean
   isInSubscriptionForm?: boolean
+  isInQuoteForm?: boolean
   // TEMP (LAGO-1498): Code is shown only via the v2 details/edition UI.
   showCode?: boolean
   existingChargeCodes?: (string | null | undefined)[]
@@ -79,6 +80,7 @@ const usageChargeDrawerContentDefaultProps: UsageChargeDrawerContentExtraProps =
   isCreateMode: false,
   disabled: false,
   isInSubscriptionForm: false,
+  isInQuoteForm: false,
   showCode: false,
   existingChargeCodes: undefined,
   subscriptionFormType: undefined,
@@ -98,6 +100,7 @@ export const UsageChargeDrawerContent = withForm({
     isCreateMode,
     disabled,
     isInSubscriptionForm,
+    isInQuoteForm,
     showCode,
     existingChargeCodes,
     subscriptionFormType,
@@ -689,6 +692,28 @@ export const UsageChargeDrawerContent = withForm({
                               })
                             : ''
                         }
+                      />
+                    )}
+                  </form.AppField>
+                </div>
+              )}
+
+              {isInQuoteForm && (
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-1">
+                    <Typography variant="captionHl" color="grey700">
+                      {translate('text_1788938888298p8mb2uxfk5l')}
+                    </Typography>
+                    <Typography variant="caption" color="grey600">
+                      {translate('text_1788938888298tobp5ik7edt')}
+                    </Typography>
+                  </div>
+
+                  <form.AppField name="displayInQuoteDocument">
+                    {(field) => (
+                      <field.SwitchField
+                        label={translate('text_1788938888298p8mb2uxfk5l')}
+                        disabled={disabled}
                       />
                     )}
                   </form.AppField>

--- a/src/components/plans/drawers/usageCharge/__tests__/UsageChargeDrawer.test.tsx
+++ b/src/components/plans/drawers/usageCharge/__tests__/UsageChargeDrawer.test.tsx
@@ -370,6 +370,7 @@ describe('UsageChargeDrawer', () => {
           },
           chargeModel: 'standard' as UsageChargeDrawerFormValues['chargeModel'],
           code: 'calls',
+          displayInQuoteDocument: true,
           invoiceDisplayName: 'Test',
           invoiceable: true,
           minAmountCents: '100',
@@ -389,6 +390,7 @@ describe('UsageChargeDrawer', () => {
             code: 'calls',
             invoiceable: true,
             payInAdvance: false,
+            displayInQuoteDocument: true,
           }),
           -1,
         )
@@ -504,6 +506,7 @@ describe('UsageChargeDrawer', () => {
       },
       chargeModel: 'standard',
       code: 'api_calls',
+      displayInQuoteDocument: true,
       invoiceDisplayName: '',
       invoiceable: true,
       minAmountCents: '',
@@ -577,6 +580,8 @@ describe('UsageChargeDrawer', () => {
             filters: [],
             regroupPaidFees: null,
             taxes: [],
+            // A charge stored before the flag existed must open with the switch on
+            displayInQuoteDocument: true,
           }),
           { keepDefaultValues: true },
         )

--- a/src/components/plans/drawers/usageCharge/__tests__/UsageChargeDrawerContent.test.tsx
+++ b/src/components/plans/drawers/usageCharge/__tests__/UsageChargeDrawerContent.test.tsx
@@ -12,6 +12,7 @@ const UsageChargeDrawerContent = OriginalUsageChargeDrawerContent as unknown as 
   isCreateMode: boolean
   disabled?: boolean
   isInSubscriptionForm?: boolean
+  isInQuoteForm?: boolean
   showCode?: boolean
   existingChargeCodes?: (string | null | undefined)[]
   amountCurrency?: string
@@ -153,7 +154,12 @@ const mockForm = {
         </div>
       ),
       SwitchField: (props: Record<string, unknown>) => (
-        <input type="checkbox" data-test={`field-${name}`} aria-label={props.label as string} />
+        <input
+          type="checkbox"
+          data-test={`field-${name}`}
+          aria-label={props.label as string}
+          disabled={props.disabled as boolean}
+        />
       ),
     }
 
@@ -935,5 +941,62 @@ describe('VirtualFilterList drift test', () => {
     )
 
     expect(capturedVirtualList.props?.items).toHaveLength(3)
+  })
+
+  describe('GIVEN the quote-only "display in quote document" switch', () => {
+    describe('WHEN the drawer is not opened from a quote', () => {
+      it('THEN should not render the switch', () => {
+        mockCurrentFormValues = mockEditFormValues
+
+        render(
+          <UsageChargeDrawerContent
+            isCreateMode={false}
+            editIndex={0}
+            currency="USD"
+            interval="monthly"
+          />,
+        )
+
+        expect(screen.queryByTestId('field-displayInQuoteDocument')).not.toBeInTheDocument()
+      })
+
+      it('THEN should not render it either inside the subscription form', () => {
+        mockCurrentFormValues = mockEditFormValues
+
+        render(
+          <UsageChargeDrawerContent
+            isCreateMode={false}
+            isInSubscriptionForm
+            editIndex={0}
+            currency="USD"
+            interval="monthly"
+          />,
+        )
+
+        expect(screen.queryByTestId('field-displayInQuoteDocument')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the drawer is opened from a quote', () => {
+      it('THEN should render the switch, enabled even inside the subscription form', () => {
+        mockCurrentFormValues = mockEditFormValues
+
+        render(
+          <UsageChargeDrawerContent
+            isCreateMode={false}
+            isInSubscriptionForm
+            isInQuoteForm
+            editIndex={0}
+            currency="USD"
+            interval="monthly"
+          />,
+        )
+
+        const field = screen.getByTestId('field-displayInQuoteDocument')
+
+        expect(field).toBeInTheDocument()
+        expect(field).not.toBeDisabled()
+      })
+    })
   })
 })

--- a/src/components/plans/drawers/usageCharge/__tests__/UsageChargeDrawerContent.test.tsx
+++ b/src/components/plans/drawers/usageCharge/__tests__/UsageChargeDrawerContent.test.tsx
@@ -37,6 +37,7 @@ const CHARGE_MODEL_SELECTOR_TEST_ID = 'charge-model-selector'
 const CHARGE_WRAPPER_SWITCH_TEST_ID = 'charge-wrapper-switch'
 const PLAN_BILLING_PERIOD_INFO_SECTION_TEST_ID = 'plan-billing-period-info-section'
 const CHARGE_PAY_IN_ADVANCE_OPTION_TEST_ID = 'charge-pay-in-advance-option'
+const CHARGE_DISPLAY_IN_QUOTE_DOCUMENT_OPTION_TEST_ID = 'charge-display-in-quote-document-option'
 const TAXES_SELECTOR_SECTION_TEST_ID = 'taxes-selector-section'
 const BM_PICKER_COMBOBOX_TEST_ID = 'bm-picker-combobox'
 
@@ -293,6 +294,15 @@ jest.mock('~/components/plans/chargeAccordion/CustomPricingUnitSelector', () => 
 
 jest.mock('~/components/plans/drawers/common/PlanBillingPeriodInfoSection', () => ({
   PlanBillingPeriodInfoSection: () => <div data-test={PLAN_BILLING_PERIOD_INFO_SECTION_TEST_ID} />,
+}))
+
+jest.mock('~/components/plans/chargeAccordion/options/ChargeDisplayInQuoteDocumentOption', () => ({
+  ChargeDisplayInQuoteDocumentOption: (props: Record<string, unknown>) => (
+    <div
+      data-test={CHARGE_DISPLAY_IN_QUOTE_DOCUMENT_OPTION_TEST_ID}
+      data-disabled={String(!!props.disabled)}
+    />
+  ),
 }))
 
 jest.mock('~/components/plans/chargeAccordion/options/ChargePayInAdvanceOption', () => ({
@@ -957,7 +967,9 @@ describe('VirtualFilterList drift test', () => {
           />,
         )
 
-        expect(screen.queryByTestId('field-displayInQuoteDocument')).not.toBeInTheDocument()
+        expect(
+          screen.queryByTestId(CHARGE_DISPLAY_IN_QUOTE_DOCUMENT_OPTION_TEST_ID),
+        ).not.toBeInTheDocument()
       })
 
       it('THEN should not render it either inside the subscription form', () => {
@@ -973,7 +985,9 @@ describe('VirtualFilterList drift test', () => {
           />,
         )
 
-        expect(screen.queryByTestId('field-displayInQuoteDocument')).not.toBeInTheDocument()
+        expect(
+          screen.queryByTestId(CHARGE_DISPLAY_IN_QUOTE_DOCUMENT_OPTION_TEST_ID),
+        ).not.toBeInTheDocument()
       })
     })
 
@@ -992,10 +1006,10 @@ describe('VirtualFilterList drift test', () => {
           />,
         )
 
-        const field = screen.getByTestId('field-displayInQuoteDocument')
+        const field = screen.getByTestId(CHARGE_DISPLAY_IN_QUOTE_DOCUMENT_OPTION_TEST_ID)
 
         expect(field).toBeInTheDocument()
-        expect(field).not.toBeDisabled()
+        expect(field).toHaveAttribute('data-disabled', 'false')
       })
     })
   })

--- a/src/components/plans/drawers/usageCharge/constants.ts
+++ b/src/components/plans/drawers/usageCharge/constants.ts
@@ -14,6 +14,7 @@ export interface UsageChargeDrawerFormValues {
   appliedPricingUnit?: LocalPricingUnitInput
   chargeModel: ChargeModelEnum
   code: string
+  displayInQuoteDocument: boolean
   id?: string
   invoiceDisplayName: string
   invoiceable: boolean
@@ -38,6 +39,7 @@ export const DEFAULT_VALUES: UsageChargeDrawerFormValues = {
   appliedPricingUnit: undefined,
   chargeModel: ChargeModelEnum.Standard,
   code: '',
+  displayInQuoteDocument: true,
   id: undefined,
   invoiceDisplayName: '',
   invoiceable: true,

--- a/src/components/plans/form/FixedChargesSection.tsx
+++ b/src/components/plans/form/FixedChargesSection.tsx
@@ -68,6 +68,7 @@ interface FixedChargesSectionProps {
   alreadyExistingFixedChargesIds: string[]
   canBeEdited?: boolean
   isInSubscriptionForm?: boolean
+  isInQuoteForm?: boolean
   isEdition?: boolean
 }
 
@@ -76,6 +77,7 @@ export const FixedChargesSection = ({
   alreadyExistingFixedChargesIds,
   canBeEdited,
   isInSubscriptionForm,
+  isInQuoteForm,
   isEdition = false,
 }: FixedChargesSectionProps) => {
   const { translate } = useInternationalization()
@@ -229,6 +231,7 @@ export const FixedChargesSection = ({
         disabled={isEdition && !canBeEdited}
         isEdition={isEdition}
         isInSubscriptionForm={isInSubscriptionForm}
+        isInQuoteForm={isInQuoteForm}
         onSave={handleDrawerSave}
         onDelete={handleChargeDelete}
         openRemoveChargeWarningDialog={openRemoveChargeWarningDialog}

--- a/src/components/plans/types.ts
+++ b/src/components/plans/types.ts
@@ -44,6 +44,8 @@ export type LocalFixedChargeInput = Omit<FixedChargeInput, 'addOnId'> & {
   taxes?: TaxForTaxesSelectorSectionFragment[] | null
   // NOTE: used for display purpose, replaced by addOnId on save
   addOn: AddOnForFixedChargesSectionFragment
+  // NOTE: quote document only, never sent to the API
+  displayInQuoteDocument?: boolean
 }
 
 export type LocalUsageChargeInput = Omit<
@@ -58,6 +60,8 @@ export type LocalUsageChargeInput = Omit<
   filters?: LocalChargeFilterInput[]
   // NOTE: this is used for display purpose but will be replaced by taxCodes[] on save
   taxes?: TaxForTaxesSelectorSectionFragment[] | null
+  // NOTE: quote document only, never sent to the API
+  displayInQuoteDocument?: boolean
 }
 
 export type LocalUsageThresholdInput = UsageThresholdInput

--- a/src/core/serializers/__tests__/buildPlanPreviewData.test.ts
+++ b/src/core/serializers/__tests__/buildPlanPreviewData.test.ts
@@ -572,4 +572,176 @@ describe('buildPlanPreviewData', () => {
 
     expect(main).toMatchObject({ timing: 'endOfPeriod' })
   })
+
+  describe('displayInQuoteDocument', () => {
+    it('drops a hidden usage charge and its detail rows, keeping the visible one', () => {
+      const data = buildPlanPreviewData(
+        baseForm({
+          charges: [
+            {
+              chargeModel: ChargeModelEnum.Standard,
+              payInAdvance: false,
+              invoiceDisplayName: 'Hidden',
+              billableMetric: { name: 'Hidden', code: 'hidden' },
+              properties: { amount: '9.99' },
+              filters: [],
+              displayInQuoteDocument: false,
+            },
+            {
+              chargeModel: ChargeModelEnum.Standard,
+              payInAdvance: false,
+              invoiceDisplayName: 'Visible',
+              billableMetric: { name: 'Visible', code: 'visible' },
+              properties: { amount: '1.20' },
+              filters: [],
+            },
+          ] as unknown as PlanFormInput['charges'],
+        }),
+      )
+
+      const mainRows = data.rows.filter((r) => r.kind === 'main' && r.rowType === 'usageCharge')
+
+      expect(mainRows).toHaveLength(1)
+      expect(mainRows[0]).toMatchObject({ name: 'Visible' })
+      expect(data.rows).not.toContainEqual(
+        expect.objectContaining({ value: { type: 'displayAmount', amount: '9.99' } }),
+      )
+    })
+
+    it('drops the tier rows of a hidden graduated usage charge', () => {
+      const data = buildPlanPreviewData(
+        baseForm({
+          charges: [
+            {
+              chargeModel: ChargeModelEnum.Graduated,
+              payInAdvance: false,
+              billableMetric: { name: 'Graduated', code: 'graduated' },
+              filters: [],
+              properties: {
+                graduatedRanges: [
+                  { fromValue: 0, toValue: 10, perUnitAmount: '0.10', flatAmount: '10.00' },
+                ],
+              },
+              displayInQuoteDocument: false,
+            },
+          ] as unknown as PlanFormInput['charges'],
+        }),
+      )
+
+      expect(data.rows).toEqual([])
+    })
+
+    it('drops the minimum-spending row of a hidden usage charge', () => {
+      const data = buildPlanPreviewData(
+        baseForm({
+          charges: [
+            {
+              chargeModel: ChargeModelEnum.Standard,
+              payInAdvance: false,
+              billableMetric: { name: 'Usage', code: 'u' },
+              filters: [],
+              properties: { amount: '1.20' },
+              minAmountCents: '100.00',
+              displayInQuoteDocument: false,
+            },
+          ] as unknown as PlanFormInput['charges'],
+        }),
+      )
+
+      expect(data.rows).toEqual([])
+    })
+
+    it('drops a hidden standard fixed charge', () => {
+      const data = buildPlanPreviewData(
+        baseForm({
+          fixedCharges: [
+            {
+              chargeModel: FixedChargeChargeModelEnum.Standard,
+              payInAdvance: false,
+              units: '5',
+              invoiceDisplayName: 'Seats',
+              properties: { amount: '200.00' },
+              addOn: { name: 'Seat add-on', code: 'seat' },
+              displayInQuoteDocument: false,
+            },
+          ] as unknown as PlanFormInput['fixedCharges'],
+        }),
+      )
+
+      expect(data.rows).toEqual([])
+    })
+
+    it('drops a hidden graduated fixed charge along with its tier rows', () => {
+      const data = buildPlanPreviewData(
+        baseForm({
+          fixedCharges: [
+            {
+              chargeModel: FixedChargeChargeModelEnum.Graduated,
+              payInAdvance: false,
+              units: '5',
+              invoiceDisplayName: 'Graduated FC',
+              properties: {
+                graduatedRanges: [
+                  { fromValue: 0, toValue: 10, perUnitAmount: '0.10', flatAmount: '10.00' },
+                ],
+              },
+              displayInQuoteDocument: false,
+            },
+          ] as unknown as PlanFormInput['fixedCharges'],
+        }),
+      )
+
+      expect(data.rows).toEqual([])
+    })
+
+    // Charges stored before the flag existed carry no key and must stay visible.
+    it.each([undefined, true])('renders the charge when the flag is %s', (flag) => {
+      const data = buildPlanPreviewData(
+        baseForm({
+          charges: [
+            {
+              chargeModel: ChargeModelEnum.Standard,
+              payInAdvance: false,
+              invoiceDisplayName: 'API calls',
+              billableMetric: { name: 'API calls', code: 'api' },
+              properties: { amount: '1.20' },
+              filters: [],
+              displayInQuoteDocument: flag,
+            },
+          ] as unknown as PlanFormInput['charges'],
+        }),
+      )
+
+      expect(data.rows.find((r) => r.kind === 'main' && r.rowType === 'usageCharge')).toMatchObject(
+        { name: 'API calls' },
+      )
+    })
+
+    it('leaves the subscription-fee and minimum-commitment rows untouched', () => {
+      const data = buildPlanPreviewData(
+        baseForm({
+          amountCents: '13050',
+          minimumCommitment: {
+            amountCents: '1000.00',
+            invoiceDisplayName: undefined,
+          } as unknown as PlanFormInput['minimumCommitment'],
+          charges: [
+            {
+              chargeModel: ChargeModelEnum.Standard,
+              payInAdvance: false,
+              billableMetric: { name: 'Hidden', code: 'hidden' },
+              properties: { amount: '1.20' },
+              filters: [],
+              displayInQuoteDocument: false,
+            },
+          ] as unknown as PlanFormInput['charges'],
+        }),
+      )
+
+      expect(data.rows.map((r) => (r.kind === 'main' ? r.rowType : 'detail'))).toEqual([
+        'subscriptionFee',
+        'minimumCommitment',
+      ])
+    })
+  })
 })

--- a/src/core/serializers/__tests__/buildPlanPreviewData.test.ts
+++ b/src/core/serializers/__tests__/buildPlanPreviewData.test.ts
@@ -137,6 +137,30 @@ describe('buildPlanPreviewData', () => {
     })
   })
 
+  // `deserializeMinimumCommitment` returns `{}` for a plan with no negotiated commitment,
+  // which is truthy — a bare truthiness guard rendered a phantom "0" commitment row.
+  it.each([
+    ['an empty object (what the deserializer returns for none)', {}],
+    ['an explicit zero amount', { amountCents: '0' }],
+    ['an empty amount', { amountCents: '' }],
+    ['no commitment at all', undefined],
+  ])('omits the minimum-commitment row for %s', (_label, minimumCommitment) => {
+    const data = buildPlanPreviewData(
+      baseForm({
+        amountCents: '13050',
+        minimumCommitment: minimumCommitment as PlanFormInput['minimumCommitment'],
+      }),
+    )
+
+    expect(
+      data.rows.find((r) => r.kind === 'main' && r.rowType === 'minimumCommitment'),
+    ).toBeUndefined()
+    // the rest of the plan still renders
+    expect(
+      data.rows.find((r) => r.kind === 'main' && r.rowType === 'subscriptionFee'),
+    ).toBeDefined()
+  })
+
   it('renders graduated ranges: per-unit row per tier, flat-fee row only when present', () => {
     const data = buildPlanPreviewData(
       baseForm({

--- a/src/core/serializers/__tests__/serializePlanInput.test.ts
+++ b/src/core/serializers/__tests__/serializePlanInput.test.ts
@@ -486,6 +486,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             minAmountCents: 10003,
             payInAdvance: false,
             chargeModel: 'graduated',
@@ -576,6 +577,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             minAmountCents: 10003,
             payInAdvance: false,
             chargeModel: 'graduated_percentage',
@@ -666,6 +668,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             chargeModel: 'package',
             appliedPricingUnit: undefined,
             filters: [],
@@ -744,6 +747,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             chargeModel: 'percentage',
             appliedPricingUnit: undefined,
             minAmountCents: undefined,
@@ -822,6 +826,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             chargeModel: 'standard',
             appliedPricingUnit: undefined,
             minAmountCents: undefined,
@@ -898,6 +903,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             chargeModel: 'standard',
             appliedPricingUnit: undefined,
             minAmountCents: undefined,
@@ -975,6 +981,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             chargeModel: 'standard',
             appliedPricingUnit: undefined,
             minAmountCents: undefined,
@@ -1078,6 +1085,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             chargeModel: 'standard',
             minAmountCents: undefined,
             appliedPricingUnit: undefined,
@@ -1193,6 +1201,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             chargeModel: 'volume',
             appliedPricingUnit: undefined,
             minAmountCents: undefined,
@@ -1282,6 +1291,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             chargeModel: 'custom',
             appliedPricingUnit: undefined,
             minAmountCents: undefined,
@@ -1557,6 +1567,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             chargeModel: 'standard',
             minAmountCents: undefined,
             payInAdvance: false,
@@ -1638,6 +1649,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             chargeModel: 'standard',
             minAmountCents: undefined,
             appliedPricingUnit: undefined,
@@ -1782,6 +1794,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             chargeModel: 'standard',
             minAmountCents: 10000,
             appliedPricingUnit: undefined,
@@ -1856,6 +1869,7 @@ describe('serializePlanInput()', () => {
         charges: [
           {
             billableMetricId: '1234',
+            displayInQuoteDocument: undefined,
             chargeModel: 'standard',
             minAmountCents: undefined,
             appliedPricingUnit: undefined,
@@ -1932,6 +1946,7 @@ describe('serializePlanInput()', () => {
               addOnId: '5678',
               addon: undefined,
               taxes: undefined,
+              displayInQuoteDocument: undefined,
               // Only amount is valid for a standard FixedChargePropertiesInput;
               // usage-only fields must not leak through.
               properties: {
@@ -1994,6 +2009,7 @@ describe('serializePlanInput()', () => {
               addOnId: '5678',
               addon: undefined,
               taxes: undefined,
+              displayInQuoteDocument: undefined,
               // Only volumeRanges is valid for a volume FixedChargePropertiesInput.
               properties: {
                 volumeRanges: [
@@ -2070,6 +2086,7 @@ describe('serializePlanInput()', () => {
               units: '10.123456',
               addon: undefined,
               taxes: undefined,
+              displayInQuoteDocument: undefined,
               properties: {
                 amount: '5',
               },
@@ -2145,6 +2162,7 @@ describe('serializePlanInput()', () => {
               addOnId: '5678',
               addon: undefined,
               taxes: undefined,
+              displayInQuoteDocument: undefined,
               properties: {
                 graduatedRanges: [
                   {
@@ -2231,6 +2249,7 @@ describe('serializePlanInput()', () => {
               addOnId: '5678',
               addon: undefined,
               taxes: undefined,
+              displayInQuoteDocument: undefined,
               properties: {
                 graduatedRanges: [
                   {
@@ -2316,5 +2335,54 @@ describe('serializeProperties — presentationGroupKeys', () => {
     )
 
     expect(result.presentationGroupKeys).toBeUndefined()
+  })
+
+  // The charge drawers are shared with the quote form, so a quote-only field can reach
+  // this serializer; the API rejects an undeclared key on ChargeInput / FixedChargeInput.
+  describe('a plan whose charges carry the quote-only displayInQuoteDocument', () => {
+    it('never forwards the key to the API input', () => {
+      const plan = serializePlanInput({
+        amountCents: '1',
+        amountCurrency: CurrencyEnum.Eur,
+        billChargesMonthly: true,
+        fixedCharges: [
+          {
+            chargeModel: FixedChargeChargeModelEnum.Standard,
+            addOn: { id: '5678', name: 'simpleAddOn', code: 'simple-add-on' },
+            units: '1',
+            properties: { amount: '1' },
+            taxCodes: [],
+            displayInQuoteDocument: false,
+          },
+        ],
+        charges: [
+          {
+            chargeModel: ChargeModelEnum.Standard,
+            billableMetric: {
+              id: '1234',
+              name: 'simpleBM',
+              code: 'simple-bm',
+              recurring: false,
+              aggregationType: AggregationTypeEnum.CountAgg,
+            },
+            properties: fullProperty,
+            taxCodes: [],
+            displayInQuoteDocument: false,
+          },
+        ],
+        code: 'my-plan',
+        interval: PlanInterval.Monthly,
+        name: 'My plan',
+        payInAdvance: true,
+        trialPeriod: 1,
+        taxCodes: [],
+        nonRecurringUsageThresholds: [],
+        recurringUsageThreshold: undefined,
+        entitlements: [],
+      } as unknown as PlanFormInput)
+
+      expect(plan.charges[0].displayInQuoteDocument).toBeUndefined()
+      expect(plan.fixedCharges[0].displayInQuoteDocument).toBeUndefined()
+    })
   })
 })

--- a/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
+++ b/src/core/serializers/__tests__/serializeQuotePlanBillingItems.test.ts
@@ -3,6 +3,7 @@ import type {
   LocalUsageChargeInput,
   PlanFormInput,
 } from '~/components/plans/types'
+import { comparable } from '~/core/utils/comparableValue'
 import { planFormSchema } from '~/formValidation/planFormSchema'
 import {
   AggregationTypeEnum,
@@ -880,6 +881,7 @@ describe('round-trip: toPlanBillingItems → fromPlanBillingItems', () => {
       prorated: false,
       invoiceable: true,
       taxCodes: [],
+      displayInQuoteDocument: false,
     }
 
     const formValues: PlanFormInput = {
@@ -907,6 +909,7 @@ describe('round-trip: toPlanBillingItems → fromPlanBillingItems', () => {
     expect(roundTrippedCharge?.invoiceDisplayName).toBe('CPU Compute')
     expect(roundTrippedCharge?.billableMetric.filters).toHaveLength(1)
     expect(roundTrippedCharge?.billableMetric.filters?.[0]?.key).toBe('region')
+    expect(roundTrippedCharge?.displayInQuoteDocument).toBe(false)
   })
 
   it('round-trips fixed charges and minimum commitment', () => {
@@ -925,6 +928,7 @@ describe('round-trip: toPlanBillingItems → fromPlanBillingItems', () => {
       prorated: false,
       properties: { amount: '500' } as LocalFixedChargeInput['properties'],
       taxCodes: [],
+      displayInQuoteDocument: false,
     }
 
     const formValues: PlanFormInput = {
@@ -951,6 +955,7 @@ describe('round-trip: toPlanBillingItems → fromPlanBillingItems', () => {
     expect(rtFixedCharge.addOn.name).toBe('Premium Support')
     expect(rtFixedCharge.units).toBe('1')
     expect(rtFixedCharge.invoiceDisplayName).toBe('Support Package')
+    expect(rtFixedCharge.displayInQuoteDocument).toBe(false)
 
     // Minimum commitment round-trip
     expect(fv.minimumCommitment).toBeDefined()
@@ -1419,5 +1424,74 @@ describe('toPlanBillingItems — snapshot ids are bound to the quoted plan', () 
         expect(result.plans[0].payload.charges?.[0].id).toBe('child_charge')
       })
     })
+  })
+})
+
+describe('displayInQuoteDocument', () => {
+  // The backend closes `overrides.*` with `additionalProperties: {not: {}}`; an extra key
+  // there returns a 422 the front end swallows via silentErrorCodes, so the quote would
+  // silently stop saving.
+  it('never reaches the overrides payload, and toggling it leaves overrides identical', () => {
+    const visible: PlanFormInput = {
+      ...baseFormValues,
+      charges: [usageCharge('charge_1', 'count_bm')],
+      fixedCharges: [fixedCharge('fc_1', 'support')],
+    }
+    const hidden: PlanFormInput = {
+      ...visible,
+      charges: [{ ...visible.charges[0], displayInQuoteDocument: false }],
+      fixedCharges: [{ ...visible.fixedCharges[0], displayInQuoteDocument: false }],
+    }
+
+    const visibleOverrides = toPlanBillingItems(basePricingState, visible).plans[0].overrides
+    const hiddenOverrides = toPlanBillingItems(basePricingState, hidden).plans[0].overrides
+
+    expect(comparable(hiddenOverrides)).toBe(comparable(visibleOverrides))
+    expect(hiddenOverrides.charges?.[0]).not.toHaveProperty('displayInQuoteDocument')
+    expect(hiddenOverrides.fixedCharges?.[0]).not.toHaveProperty('displayInQuoteDocument')
+  })
+
+  it('lands in the payload for both charge kinds', () => {
+    const formValues: PlanFormInput = {
+      ...baseFormValues,
+      charges: [{ ...usageCharge('charge_1', 'count_bm'), displayInQuoteDocument: false }],
+      fixedCharges: [{ ...fixedCharge('fc_1', 'support'), displayInQuoteDocument: false }],
+    }
+
+    const { payload } = toPlanBillingItems(basePricingState, formValues).plans[0]
+
+    expect(payload.charges?.[0].displayInQuoteDocument).toBe(false)
+    expect(payload.fixedCharges?.[0].displayInQuoteDocument).toBe(false)
+  })
+
+  it('defaults to true when a stored payload predates the flag', () => {
+    const formValues: PlanFormInput = {
+      ...baseFormValues,
+      charges: [usageCharge('charge_1', 'count_bm')],
+      fixedCharges: [fixedCharge('fc_1', 'support')],
+    }
+    const { plans } = toPlanBillingItems(basePricingState, formValues)
+
+    delete plans[0].payload.charges?.[0].displayInQuoteDocument
+    delete plans[0].payload.fixedCharges?.[0].displayInQuoteDocument
+
+    const { formValues: restored } = fromPlanBillingItems(plans)
+
+    expect(restored?.charges[0].displayInQuoteDocument).toBe(true)
+    expect(restored?.fixedCharges[0].displayInQuoteDocument).toBe(true)
+  })
+
+  it('survives an amendment round-trip (omitStartDate)', () => {
+    const formValues: PlanFormInput = {
+      ...baseFormValues,
+      charges: [{ ...usageCharge('charge_1', 'count_bm'), displayInQuoteDocument: false }],
+    }
+
+    const { plans } = toPlanBillingItems(basePricingState, formValues, undefined, {
+      omitStartDate: true,
+    })
+    const { formValues: restored } = fromPlanBillingItems(plans)
+
+    expect(restored?.charges[0].displayInQuoteDocument).toBe(false)
   })
 })

--- a/src/core/serializers/buildPlanPreviewData.ts
+++ b/src/core/serializers/buildPlanPreviewData.ts
@@ -386,18 +386,22 @@ export const buildPlanPreviewData = (formValues: PlanFormInput | null): PlanPrev
   }
 
   // 4) Plan minimum commitment (own row)
-  if (formValues.minimumCommitment) {
+  // `deserializeMinimumCommitment` returns `{}` for "no commitment", which is truthy, so
+  // gate on the amount the way the subscription fee above does.
+  const minimumCommitment = formValues.minimumCommitment
+
+  if (minimumCommitment && num(minimumCommitment.amountCents) > 0) {
     rows.push({
       kind: 'main',
       rowType: 'minimumCommitment',
-      name: formValues.minimumCommitment.invoiceDisplayName || undefined,
+      name: minimumCommitment.invoiceDisplayName || undefined,
       description: undefined,
       interval: formValues.interval,
       timing: fixedTiming(formValues.payInAdvance),
       units: { type: 'count', value: 1 },
       price: {
         type: 'displayAmount',
-        amount: String(formValues.minimumCommitment.amountCents ?? '0'),
+        amount: String(minimumCommitment.amountCents),
       },
     })
   }

--- a/src/core/serializers/buildPlanPreviewData.ts
+++ b/src/core/serializers/buildPlanPreviewData.ts
@@ -278,14 +278,11 @@ const usageDetailRows = (charge: LocalUsageChargeInput): PlanPreviewDetailRow[] 
   }
 }
 
-export const buildPlanPreviewData = (formValues: PlanFormInput | null): PlanPreviewData => {
-  if (!formValues) return { rows: [] }
+const subscriptionFeeRows = (formValues: PlanFormInput): PlanPreviewRow[] => {
+  if (num(formValues.amountCents) <= 0) return []
 
-  const rows: PlanPreviewRow[] = []
-
-  // 1) Subscription fee
-  if (num(formValues.amountCents) > 0) {
-    rows.push({
+  return [
+    {
       kind: 'main',
       rowType: 'subscriptionFee',
       name: formValues.invoiceDisplayName || undefined,
@@ -294,117 +291,107 @@ export const buildPlanPreviewData = (formValues: PlanFormInput | null): PlanPrev
       timing: fixedTiming(formValues.payInAdvance),
       units: { type: 'count', value: 1 },
       price: { type: 'displayAmount', amount: String(formValues.amountCents) },
+    },
+  ]
+}
+
+const fixedChargeRows = (
+  charge: LocalFixedChargeInput,
+  formValues: PlanFormInput,
+): PlanPreviewRow[] => {
+  // Filter here, not in the table: SubscriptionPlanPreviewTable groups a charge with its
+  // detail rows by array index, so a gap there would misplace the dividers.
+  if (charge.displayInQuoteDocument === false) return []
+
+  const props = (charge.properties ?? {}) as Record<string, unknown>
+  const mainRow = (price: PreviewCellValue): PlanPreviewRow => ({
+    kind: 'main',
+    rowType: 'fixedCharge',
+    name: charge.invoiceDisplayName || charge.addOn?.name || undefined,
+    description: undefined,
+    interval: fixedInterval(formValues),
+    timing: fixedTiming(charge.payInAdvance ?? false),
+    units: { type: 'count', value: num(charge.units) },
+    price,
+  })
+
+  if (charge.chargeModel === FixedChargeChargeModelEnum.Graduated) {
+    return [mainRow({ type: 'empty' }), ...tierRows((props.graduatedRanges ?? []) as Range[])]
+  }
+
+  if (charge.chargeModel === FixedChargeChargeModelEnum.Volume) {
+    return [mainRow({ type: 'empty' }), ...tierRows((props.volumeRanges ?? []) as Range[])]
+  }
+
+  return [mainRow({ type: 'displayAmount', amount: amountStr(props.amount) })]
+}
+
+const usageChargeRows = (
+  charge: LocalUsageChargeInput,
+  formValues: PlanFormInput,
+): PlanPreviewRow[] => {
+  if (charge.displayInQuoteDocument === false) return []
+
+  const rows: PlanPreviewRow[] = [
+    {
+      kind: 'main',
+      rowType: 'usageCharge',
+      name: chargeName(charge) || undefined,
+      description: undefined,
+      interval: usageInterval(formValues),
+      timing: usageChargeTiming(charge),
+      units: { type: 'usageBased' },
+      price: { type: 'variesWithUsage' },
+    },
+    ...usageDetailRows(charge),
+  ]
+
+  if (num(charge.minAmountCents) > 0) {
+    rows.push({
+      kind: 'detail',
+      label: { type: 'text', key: 'labelMinimumSpending' },
+      qualifier: { type: 'commitment' },
+      value: { type: 'displayAmount', amount: String(charge.minAmountCents) },
     })
   }
 
-  // 2) Fixed charges
-  for (const fc of formValues.fixedCharges ?? []) {
-    const typedFc = fc as LocalFixedChargeInput
+  return rows
+}
 
-    // Filter here, not in the table: SubscriptionPlanPreviewTable groups a charge with its
-    // detail rows by array index, so a gap there would misplace the dividers.
-    if (typedFc.displayInQuoteDocument === false) continue
+const minimumCommitmentRows = (formValues: PlanFormInput): PlanPreviewRow[] => {
+  const commitment = formValues.minimumCommitment
 
-    const fcProps = (typedFc.properties ?? {}) as Record<string, unknown>
-    const fcName = typedFc.invoiceDisplayName || typedFc.addOn?.name || undefined
-    const fcInterval = fixedInterval(formValues)
-    const fcTiming = fixedTiming(typedFc.payInAdvance ?? false)
-    const fcUnits: PreviewCellValue = { type: 'count', value: num(typedFc.units) }
-
-    if (typedFc.chargeModel === FixedChargeChargeModelEnum.Graduated) {
-      rows.push(
-        {
-          kind: 'main',
-          rowType: 'fixedCharge',
-          name: fcName,
-          description: undefined,
-          interval: fcInterval,
-          timing: fcTiming,
-          units: fcUnits,
-          price: { type: 'empty' },
-        },
-        ...tierRows((fcProps.graduatedRanges ?? []) as Range[]),
-      )
-    } else if (typedFc.chargeModel === FixedChargeChargeModelEnum.Volume) {
-      rows.push(
-        {
-          kind: 'main',
-          rowType: 'fixedCharge',
-          name: fcName,
-          description: undefined,
-          interval: fcInterval,
-          timing: fcTiming,
-          units: fcUnits,
-          price: { type: 'empty' },
-        },
-        ...tierRows((fcProps.volumeRanges ?? []) as Range[]),
-      )
-    } else {
-      // Standard (default)
-      rows.push({
-        kind: 'main',
-        rowType: 'fixedCharge',
-        name: fcName,
-        description: undefined,
-        interval: fcInterval,
-        timing: fcTiming,
-        units: fcUnits,
-        price: { type: 'displayAmount', amount: amountStr(fcProps.amount) },
-      })
-    }
-  }
-
-  // 3) Usage charges (each is a main row + model-specific detail rows)
-  for (const charge of formValues.charges ?? []) {
-    const typedCharge = charge as LocalUsageChargeInput
-
-    if (typedCharge.displayInQuoteDocument === false) continue
-
-    rows.push(
-      {
-        kind: 'main',
-        rowType: 'usageCharge',
-        name: chargeName(typedCharge) || undefined,
-        description: undefined,
-        interval: usageInterval(formValues),
-        timing: usageChargeTiming(typedCharge),
-        units: { type: 'usageBased' },
-        price: { type: 'variesWithUsage' },
-      },
-      ...usageDetailRows(typedCharge),
-    )
-    const minAmount = typedCharge.minAmountCents
-
-    if (num(minAmount) > 0) {
-      rows.push({
-        kind: 'detail',
-        label: { type: 'text', key: 'labelMinimumSpending' },
-        qualifier: { type: 'commitment' },
-        value: { type: 'displayAmount', amount: String(minAmount) },
-      })
-    }
-  }
-
-  // 4) Plan minimum commitment (own row)
   // `deserializeMinimumCommitment` returns `{}` for "no commitment", which is truthy, so
-  // gate on the amount the way the subscription fee above does.
-  const minimumCommitment = formValues.minimumCommitment
+  // gate on the amount the way the subscription fee does.
+  if (!commitment || num(commitment.amountCents) <= 0) return []
 
-  if (minimumCommitment && num(minimumCommitment.amountCents) > 0) {
-    rows.push({
+  return [
+    {
       kind: 'main',
       rowType: 'minimumCommitment',
-      name: minimumCommitment.invoiceDisplayName || undefined,
+      name: commitment.invoiceDisplayName || undefined,
       description: undefined,
       interval: formValues.interval,
       timing: fixedTiming(formValues.payInAdvance),
       units: { type: 'count', value: 1 },
-      price: {
-        type: 'displayAmount',
-        amount: String(minimumCommitment.amountCents),
-      },
-    })
-  }
+      price: { type: 'displayAmount', amount: String(commitment.amountCents) },
+    },
+  ]
+}
 
-  return { rows }
+export const buildPlanPreviewData = (formValues: PlanFormInput | null): PlanPreviewData => {
+  if (!formValues) return { rows: [] }
+
+  return {
+    rows: [
+      ...subscriptionFeeRows(formValues),
+      ...(formValues.fixedCharges ?? []).flatMap((fc) =>
+        fixedChargeRows(fc as LocalFixedChargeInput, formValues),
+      ),
+      ...(formValues.charges ?? []).flatMap((charge) =>
+        usageChargeRows(charge as LocalUsageChargeInput, formValues),
+      ),
+      ...minimumCommitmentRows(formValues),
+    ],
+  }
 }

--- a/src/core/serializers/buildPlanPreviewData.ts
+++ b/src/core/serializers/buildPlanPreviewData.ts
@@ -300,6 +300,11 @@ export const buildPlanPreviewData = (formValues: PlanFormInput | null): PlanPrev
   // 2) Fixed charges
   for (const fc of formValues.fixedCharges ?? []) {
     const typedFc = fc as LocalFixedChargeInput
+
+    // Filter here, not in the table: SubscriptionPlanPreviewTable groups a charge with its
+    // detail rows by array index, so a gap there would misplace the dividers.
+    if (typedFc.displayInQuoteDocument === false) continue
+
     const fcProps = (typedFc.properties ?? {}) as Record<string, unknown>
     const fcName = typedFc.invoiceDisplayName || typedFc.addOn?.name || undefined
     const fcInterval = fixedInterval(formValues)
@@ -352,6 +357,8 @@ export const buildPlanPreviewData = (formValues: PlanFormInput | null): PlanPrev
   // 3) Usage charges (each is a main row + model-specific detail rows)
   for (const charge of formValues.charges ?? []) {
     const typedCharge = charge as LocalUsageChargeInput
+
+    if (typedCharge.displayInQuoteDocument === false) continue
 
     rows.push(
       {

--- a/src/core/serializers/serializePlanInput.ts
+++ b/src/core/serializers/serializePlanInput.ts
@@ -271,6 +271,7 @@ export const serializePlanInput = (values: PlanFormInput) => {
       // Cleaning display only attributes, see plans/types.ts for details
       addon: undefined,
       taxes: undefined,
+      displayInQuoteDocument: undefined,
       properties: serializeFixedChargeProperties(fixedCharge.properties, fixedCharge.chargeModel),
     })),
     minimumCommitment: serializeMinimumCommitment(minimumCommitment, values.amountCurrency),
@@ -314,6 +315,8 @@ export const serializePlanInput = (values: PlanFormInput) => {
               }
             : undefined,
           ...charge,
+          // Must stay after the spread, which would otherwise re-introduce it
+          displayInQuoteDocument: undefined,
         }
       },
     ),

--- a/src/core/serializers/serializeQuotePlanBillingItems.ts
+++ b/src/core/serializers/serializeQuotePlanBillingItems.ts
@@ -98,6 +98,7 @@ interface SerializedCharge {
   taxes: SerializedTax[]
   filters: SerializedChargeFilter[]
   appliedPricingUnit: SerializedAppliedPricingUnit | null
+  displayInQuoteDocument?: boolean
 }
 
 interface SerializedAddOn {
@@ -118,6 +119,7 @@ interface SerializedFixedCharge {
   properties: Record<string, unknown>
   taxCodes: string[]
   taxes: SerializedTax[]
+  displayInQuoteDocument?: boolean
 }
 
 interface SerializedMinimumCommitment {
@@ -273,6 +275,7 @@ const serializeCharge = (charge: LocalUsageChargeInput): SerializedCharge => {
           conversionRate: charge.appliedPricingUnit.conversionRate ?? '',
         }
       : null,
+    displayInQuoteDocument: charge.displayInQuoteDocument ?? true,
   }
 }
 
@@ -317,6 +320,7 @@ const serializeFixedCharge = (charge: LocalFixedChargeInput): SerializedFixedCha
     properties: charge.properties ?? {},
     taxCodes: charge.taxCodes ?? [],
     taxes: serializeTaxes(charge.taxes),
+    displayInQuoteDocument: charge.displayInQuoteDocument ?? true,
   }
 }
 
@@ -643,6 +647,7 @@ const deserializeCharge = (charge: SerializedCharge): LocalUsageChargeInput => {
           conversionRate: charge.appliedPricingUnit.conversionRate,
         } as LocalUsageChargeInput['appliedPricingUnit'])
       : undefined,
+    displayInQuoteDocument: charge.displayInQuoteDocument ?? true,
   }
 }
 
@@ -663,6 +668,7 @@ const deserializeFixedCharge = (charge: SerializedFixedCharge): LocalFixedCharge
     properties: charge.properties,
     taxCodes: charge.taxCodes,
     taxes: deserializeTaxes(charge.taxes),
+    displayInQuoteDocument: charge.displayInQuoteDocument ?? true,
   }
 }
 

--- a/translations/base.json
+++ b/translations/base.json
@@ -4917,5 +4917,7 @@
   "text_1788518648182tnlbh6pdxdd": "Only finalized invoices can be voided. This invoice’s status doesn’t allow this action.",
   "text_1788518648182t6oetew3x8x": "This invoice can no longer be voided because its status has changed",
   "text_178851170779693if5ma3vv3": "Connection successfully set as default",
-  "text_1788511707796mofp375vjec": "Default on customer"
+  "text_1788511707796mofp375vjec": "Default on customer",
+  "text_1788938888298p8mb2uxfk5l": "Display in quote document",
+  "text_1788938888298tobp5ik7edt": "When turned off, this charge is hidden from the quote’s pricing table. It is still part of the quote and is billed normally once the quote is approved."
 }


### PR DESCRIPTION
## Context

In a subscription quote, every usage and fixed charge of the selected plan is rendered in the pricing block table, with no way to keep a fee in the quote's commercial terms while hiding its row from the document the customer reads.

## Description

Adds a per-charge "Display in quote document" switch to the usage and fixed charge drawers, shown only when they are opened from a quote — the plan form and the subscription form are untouched. Unchecking it drops that fee's main row and its detail/tier rows from the quote's pricing table and from the downloaded PDF; no amount changes, and the executed subscription and generated invoice are unaffected. The flag rides in the quote's `billingItems` under `payload.charges[]` / `payload.fixedCharges[]`, which the backend JSON schema leaves open, so no backend or GraphQL change is needed; it is deliberately kept out of `overrides.*`, where an undeclared key returns a 422 that `useUpdateQuote` silences (autosave would die with no visible error), and out of `serializePlanInput`, which the shared drawers also feed into `createPlan` / `createSubscription`. A plan whose rows all end up hidden now renders no table at all instead of bare column headers and a tax footer — a case that was already reachable for a free plan with no charges.

<!-- Linear link -->