### PR TITLE
chore(jest): stop collecting coverage by default and cap local workers

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -42,9 +42,13 @@ export default {
     '!src/**/*Const.ts',
   ],
   coverageReporters: ['text-summary', 'lcov'],
-  collectCoverage: true,
 
   testEnvironment: 'jsdom',
+
+  // Each worker is a full jsdom + babel process, so an uncapped run starves a
+  // dev machine also hosting the Docker stack. CI passes --shard on top of this.
+  maxWorkers: '50%',
+  workerIdleMemoryLimit: '512MB',
 
   // Load early setup for console suppression (runs before test framework and imports)
   setupFiles: ['./jest-setup-early.ts'],


### PR DESCRIPTION
## Why

Running Jest locally was heavy enough to seize up a dev machine, so scoping a run to a handful of suites was the only safe option.

Two causes, both in `jest.config.ts`:

- `collectCoverage: true` meant every run instrumented all of `src` (via `collectCoverageFrom`), even when a single test file was requested.
- `maxWorkers` was unset, so Jest spawned one worker per available core minus one. Each worker is a full jsdom + babel process, and the same machine hosts the Docker dev stack.

## What changed

- Dropped the `collectCoverage: true` default.
- Added `maxWorkers: '50%'` and `workerIdleMemoryLimit: '512MB'`.

Measured on the same single suite (`NavigationTab.test.tsx`):

| | before | after |
|---|---|---|
| wall clock | 22.7s | 1.9s |

## Coverage is unaffected

`collectCoverageFrom` is untouched, and the only Jest invocation in CI passes `--coverage` explicitly, as does `pnpm test:coverage`:

- `.github/workflows/tests.yml` runs `pnpm jest --config jest.config.ts --coverage --shard=N/4`
- each shard uploads `coverage/lcov.info`, the merge job combines them with `lcov --add-tracefile`
- SonarQube reads `sonar.javascript.lcov.reportPaths=coverage/lcov.info`

Verified on a single-suite run with the new config: the report still counts 35801 statements across 1517 files and includes sources the test never imported, so the coverage denominator is intact rather than narrowed to the imported graph.

The only behaviour change is local: `pnpm test` no longer prints a coverage summary. `pnpm test:coverage` still does.