### PR TITLE
fix(catalog): relations grid and rate card field locking

### DIFF
--- a/src/components/form/NameAndCodeGroup/NameAndCodeGroup.tsx
+++ b/src/components/form/NameAndCodeGroup/NameAndCodeGroup.tsx
@@ -14,6 +14,8 @@ type NameAndCodeGroupProps = {
   disableAutoGenerateCode?: boolean
   nameProps?: Partial<TextInputProps>
   codeProps?: Partial<TextInputProps>
+  nameDataTest?: string
+  codeDataTest?: string
 }
 
 const defaultValues: NameAndCodeGroupValues = {
@@ -35,6 +37,8 @@ const NameAndCodeGroup = withFieldGroup({
     disableAutoGenerateCode,
     nameProps,
     codeProps,
+    nameDataTest,
+    codeDataTest,
   }) {
     const { translate } = useInternationalization()
 
@@ -68,6 +72,7 @@ const NameAndCodeGroup = withFieldGroup({
               label={translate('text_629728388c4d2300e2d38091')}
               placeholder={translate('text_629728388c4d2300e2d380a5')}
               {...nameProps}
+              data-test={nameDataTest}
             />
           )}
         </group.AppField>
@@ -77,8 +82,9 @@ const NameAndCodeGroup = withFieldGroup({
               label={translate('text_629728388c4d2300e2d380b7')}
               beforeChangeFormatter="code"
               placeholder={translate('text_629728388c4d2300e2d380d9')}
-              disabled={disableCodeInput}
               {...codeProps}
+              disabled={disableCodeInput}
+              data-test={codeDataTest}
             />
           )}
         </group.AppField>

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -916,6 +916,15 @@ export type CatalogPlan = {
   updatedAt: Scalars['ISO8601DateTime']['output'];
 };
 
+/** CatalogPlanCollection type */
+export type CatalogPlanCollection = {
+  __typename?: 'CatalogPlanCollection';
+  /** A collection of paginated CatalogPlanCollection */
+  collection: Array<CatalogPlan>;
+  /** Pagination Metadata for navigating the Pagination */
+  metadata: CollectionMetadata;
+};
+
 export type Charge = {
   __typename?: 'Charge';
   appliedPricingUnit?: Maybe<AppliedPricingUnit>;
@@ -1163,7 +1172,7 @@ export type Contract = {
   externalId: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   name?: Maybe<Scalars['String']['output']>;
-  plan?: Maybe<Plan>;
+  plan?: Maybe<CatalogPlan>;
   startedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   status: ContractStatusEnum;
   terminatedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -8408,6 +8417,10 @@ export type Query = {
   billingEntity?: Maybe<BillingEntity>;
   /** Query taxes of a billing entity */
   billingEntityTaxes: TaxCollection;
+  /** Query a single catalog plan of an organization */
+  catalogPlan?: Maybe<CatalogPlan>;
+  /** Query catalog plans of an organization */
+  catalogPlans: CatalogPlanCollection;
   /** Query a single contract of an organization */
   contract?: Maybe<Contract>;
   /** Query contracts of an organization */
@@ -8769,6 +8782,18 @@ export type QueryBillingEntityArgs = {
 
 export type QueryBillingEntityTaxesArgs = {
   billingEntityId: Scalars['ID']['input'];
+};
+
+
+export type QueryCatalogPlanArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryCatalogPlansArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  searchTerm?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -9369,7 +9394,6 @@ export type QueryPlanAppliedRateCardsArgs = {
 export type QueryPlansArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   page?: InputMaybe<Scalars['Int']['input']>;
-  productCategoryId?: InputMaybe<Scalars['ID']['input']>;
   searchTerm?: InputMaybe<Scalars['String']['input']>;
   withDeleted?: InputMaybe<Scalars['Boolean']['input']>;
 };
@@ -16033,14 +16057,14 @@ export type GetProductForDetailsQueryVariables = Exact<{
 
 export type GetProductForDetailsQuery = { __typename?: 'Query', product?: { __typename?: 'Product', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, productType: ProductTypeEnum, attachedToPlanOrSubscription: boolean, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, filters?: Array<{ __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> }> | null } | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string } | null } | null };
 
-export type ProductForDetailsOverviewFragment = { __typename?: 'Product', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, productType: ProductTypeEnum, attachedToPlanOrSubscription: boolean, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, code: string, name: string } | null };
+export type ProductForDetailsOverviewFragment = { __typename?: 'Product', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, productType: ProductTypeEnum, attachedToPlanOrSubscription: boolean, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, code: string, name: string } | null };
 
 export type GetProductForDetailsOverviewQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetProductForDetailsOverviewQuery = { __typename?: 'Query', product?: { __typename?: 'Product', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, productType: ProductTypeEnum, attachedToPlanOrSubscription: boolean, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, code: string, name: string } | null } | null };
+export type GetProductForDetailsOverviewQuery = { __typename?: 'Query', product?: { __typename?: 'Product', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, productType: ProductTypeEnum, attachedToPlanOrSubscription: boolean, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, code: string, name: string } | null } | null };
 
 export type ProductFilterActivityLogsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -16061,14 +16085,14 @@ export type GetProductFilterForDetailsQueryVariables = Exact<{
 
 export type GetProductFilterForDetailsQuery = { __typename?: 'Query', productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, attachedToPlanOrSubscription: boolean, product: { __typename?: 'Product', id: string, name: string, code: string }, values: Array<{ __typename?: 'ProductFilterValue', id: string, value?: string | null, billableMetricFilter: { __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> } }> } | null };
 
-export type ProductFilterForDetailsOverviewFragment = { __typename?: 'ProductFilter', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, attachedToPlanOrSubscription: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string } | null }, values: Array<{ __typename?: 'ProductFilterValue', id: string, key: string, value?: string | null, billableMetricFilter: { __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> } }> };
+export type ProductFilterForDetailsOverviewFragment = { __typename?: 'ProductFilter', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, attachedToPlanOrSubscription: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string, invoiceDisplayName?: string | null } | null }, values: Array<{ __typename?: 'ProductFilterValue', id: string, key: string, value?: string | null, billableMetricFilter: { __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> } }> };
 
 export type GetProductFilterForDetailsOverviewQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetProductFilterForDetailsOverviewQuery = { __typename?: 'Query', productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, attachedToPlanOrSubscription: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string } | null }, values: Array<{ __typename?: 'ProductFilterValue', id: string, key: string, value?: string | null, billableMetricFilter: { __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> } }> } | null };
+export type GetProductFilterForDetailsOverviewQuery = { __typename?: 'Query', productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, attachedToPlanOrSubscription: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string, invoiceDisplayName?: string | null } | null }, values: Array<{ __typename?: 'ProductFilterValue', id: string, key: string, value?: string | null, billableMetricFilter: { __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> } }> } | null };
 
 export type ProductForFilterPreviewFragment = { __typename?: 'Product', id: string, name: string, code: string, billableMetric?: { __typename?: 'BillableMetric', id: string, filters?: Array<{ __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> }> | null } | null };
 
@@ -16098,16 +16122,16 @@ export type GetRateCardForDetailsQueryVariables = Exact<{
 }>;
 
 
-export type GetRateCardForDetailsQuery = { __typename?: 'Query', rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null, activeRate?: { __typename?: 'RateCardRate', id: string, effectiveFrom: any } | null } | null };
+export type GetRateCardForDetailsQuery = { __typename?: 'Query', rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, ratesCount: number, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null, activeRate?: { __typename?: 'RateCardRate', id: string, effectiveFrom: any } | null } | null };
 
-export type RateCardForDetailsOverviewFragment = { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productType: ProductTypeEnum, productCategory?: { __typename?: 'ProductCategory', id: string, name: string } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null };
+export type RateCardForDetailsOverviewFragment = { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, ratesCount: number, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productType: ProductTypeEnum, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string, invoiceDisplayName?: string | null } | null };
 
 export type GetRateCardForDetailsOverviewQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetRateCardForDetailsOverviewQuery = { __typename?: 'Query', rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productType: ProductTypeEnum, productCategory?: { __typename?: 'ProductCategory', id: string, name: string } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null } | null };
+export type GetRateCardForDetailsOverviewQuery = { __typename?: 'Query', rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, ratesCount: number, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productType: ProductTypeEnum, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string, invoiceDisplayName?: string | null } | null } | null };
 
 export type RateCardForPreviewProductFragment = { __typename?: 'Product', id: string, name: string };
 
@@ -16139,9 +16163,9 @@ export type GetRateCardRateForDetailsQueryVariables = Exact<{
 }>;
 
 
-export type GetRateCardRateForDetailsQuery = { __typename?: 'Query', rateCardRate?: { __typename?: 'RateCardRate', id: string, code: string, effectiveFrom: any, status: RateCardRateStatusEnum, rateModel: RateCardRateModelEnum, billingIntervalCount: number, billingIntervalUnit: RateCardRateBillingIntervalUnitEnum, minAmountCents: any, appliedPricingUnitConversionRate?: number | null, rateProperties: { __typename?: 'Properties', amount?: string | null, rate?: string | null, packageSize?: any | null, pricingGroupKeys?: Array<string> | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', perUnitAmount: string, flatAmount: string, fromValue: number, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', rate: string, flatAmount: string, fromValue: number, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', perUnitAmount: string, flatAmount: string, fromValue: any, toValue?: any | null }> | null } } | null, rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, productType: ProductTypeEnum, productCategory?: { __typename?: 'ProductCategory', id: string, name: string } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, aggregationType: AggregationTypeEnum } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string } | null, activeRate?: { __typename?: 'RateCardRate', id: string, effectiveFrom: any } | null } | null };
+export type GetRateCardRateForDetailsQuery = { __typename?: 'Query', rateCardRate?: { __typename?: 'RateCardRate', id: string, code: string, effectiveFrom: any, status: RateCardRateStatusEnum, rateModel: RateCardRateModelEnum, billingIntervalCount: number, billingIntervalUnit: RateCardRateBillingIntervalUnitEnum, minAmountCents: any, appliedPricingUnitConversionRate?: number | null, rateProperties: { __typename?: 'Properties', amount?: string | null, rate?: string | null, packageSize?: any | null, pricingGroupKeys?: Array<string> | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', perUnitAmount: string, flatAmount: string, fromValue: number, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', rate: string, flatAmount: string, fromValue: number, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', perUnitAmount: string, flatAmount: string, fromValue: any, toValue?: any | null }> | null } } | null, rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, invoiceDisplayName?: string | null, productType: ProductTypeEnum, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, aggregationType: AggregationTypeEnum } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, invoiceDisplayName?: string | null } | null, activeRate?: { __typename?: 'RateCardRate', id: string, effectiveFrom: any } | null } | null };
 
-export type RateCardForRateDetailsFragment = { __typename?: 'RateCard', id: string, name: string, code: string, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, product: { __typename?: 'Product', id: string, name: string, productCategory?: { __typename?: 'ProductCategory', id: string, name: string } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string } | null };
+export type RateCardForRateDetailsFragment = { __typename?: 'RateCard', id: string, name: string, code: string, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, product: { __typename?: 'Product', id: string, name: string, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, invoiceDisplayName?: string | null } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, invoiceDisplayName?: string | null } | null };
 
 export type RateCardRatesQueryVariables = Exact<{
   rateCardId: Scalars['ID']['input'];
@@ -16296,21 +16320,21 @@ export type GetPricingUnitsForRateCardDrawerQueryVariables = Exact<{
 
 export type GetPricingUnitsForRateCardDrawerQuery = { __typename?: 'Query', pricingUnits: { __typename?: 'PricingUnitCollection', collection: Array<{ __typename?: 'PricingUnit', id: string, name: string, code: string }> } };
 
-export type RateCardForDrawerFragment = { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null };
+export type RateCardForDrawerFragment = { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, ratesCount: number, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null };
 
 export type CreateRateCardMutationVariables = Exact<{
   input: CreateRateCardInput;
 }>;
 
 
-export type CreateRateCardMutation = { __typename?: 'Mutation', createRateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null } | null };
+export type CreateRateCardMutation = { __typename?: 'Mutation', createRateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, ratesCount: number, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null } | null };
 
 export type UpdateRateCardMutationVariables = Exact<{
   input: UpdateRateCardInput;
 }>;
 
 
-export type UpdateRateCardMutation = { __typename?: 'Mutation', updateRateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null } | null };
+export type UpdateRateCardMutation = { __typename?: 'Mutation', updateRateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, ratesCount: number, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null } | null };
 
 export type PropertiesForRateCardRateFragment = { __typename?: 'Properties', amount?: string | null, rate?: string | null, packageSize?: any | null, pricingGroupKeys?: Array<string> | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', perUnitAmount: string, flatAmount: string, fromValue: number, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', rate: string, flatAmount: string, fromValue: number, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', perUnitAmount: string, flatAmount: string, fromValue: any, toValue?: any | null }> | null };
 
@@ -22787,6 +22811,7 @@ export const ProductForDetailsOverviewFragmentDoc = gql`
     id
     name
     code
+    invoiceDisplayName
   }
   billableMetric {
     id
@@ -22833,6 +22858,7 @@ export const ProductFilterForDetailsOverviewFragmentDoc = gql`
       id
       name
       code
+      invoiceDisplayName
     }
   }
   values {
@@ -22868,6 +22894,7 @@ export const RateCardForDrawerFragmentDoc = gql`
   walletTargetable
   attachedToPlanOrSubscription
   attachedToSubscriptions
+  ratesCount
   product {
     id
     name
@@ -22909,12 +22936,14 @@ export const RateCardForDetailsOverviewFragmentDoc = gql`
     productCategory {
       id
       name
+      invoiceDisplayName
     }
   }
   productFilter {
     id
     name
     code
+    invoiceDisplayName
   }
   ...RateCardForDrawer
 }
@@ -23003,14 +23032,17 @@ export const RateCardForRateDetailsFragmentDoc = gql`
   product {
     id
     name
+    invoiceDisplayName
     productCategory {
       id
       name
+      invoiceDisplayName
     }
   }
   productFilter {
     id
     name
+    invoiceDisplayName
   }
 }
     `;

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -16001,6 +16001,12 @@ export type RateCardsQueryVariables = Exact<{
 
 export type RateCardsQuery = { __typename?: 'Query', rateCards: { __typename?: 'RateCardCollection', collection: Array<{ __typename?: 'RateCard', id: string, name: string, code: string, createdAt: any, ratesCount: number, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, description?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null, activeRate?: { __typename?: 'RateCardRate', id: string, rateModel: RateCardRateModelEnum, minAmountCents: any, rateProperties: { __typename?: 'Properties', amount?: string | null, rate?: string | null, packageSize?: any | null, pricingGroupKeys?: Array<string> | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', perUnitAmount: string, flatAmount: string, fromValue: number, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', rate: string, flatAmount: string, fromValue: number, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', perUnitAmount: string, flatAmount: string, fromValue: any, toValue?: any | null }> | null } } | null }>, metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number, totalCount: number } } };
 
+export type ProductCategoryForCatalogRelationsFragment = { __typename?: 'ProductCategory', id: string, name: string, invoiceDisplayName?: string | null };
+
+export type ProductForCatalogRelationsFragment = { __typename?: 'Product', id: string, name: string, invoiceDisplayName?: string | null };
+
+export type ProductFilterForCatalogRelationsFragment = { __typename?: 'ProductFilter', id: string, name: string, invoiceDisplayName?: string | null };
+
 export type ProductActivityLogsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -16057,14 +16063,14 @@ export type GetProductForDetailsQueryVariables = Exact<{
 
 export type GetProductForDetailsQuery = { __typename?: 'Query', product?: { __typename?: 'Product', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, productType: ProductTypeEnum, attachedToPlanOrSubscription: boolean, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, filters?: Array<{ __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> }> | null } | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string } | null } | null };
 
-export type ProductForDetailsOverviewFragment = { __typename?: 'Product', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, productType: ProductTypeEnum, attachedToPlanOrSubscription: boolean, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, code: string, name: string } | null };
+export type ProductForDetailsOverviewFragment = { __typename?: 'Product', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, productType: ProductTypeEnum, attachedToPlanOrSubscription: boolean, productCategory?: { __typename?: 'ProductCategory', id: string, code: string, name: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, code: string, name: string } | null };
 
 export type GetProductForDetailsOverviewQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetProductForDetailsOverviewQuery = { __typename?: 'Query', product?: { __typename?: 'Product', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, productType: ProductTypeEnum, attachedToPlanOrSubscription: boolean, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, code: string, name: string } | null } | null };
+export type GetProductForDetailsOverviewQuery = { __typename?: 'Query', product?: { __typename?: 'Product', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, productType: ProductTypeEnum, attachedToPlanOrSubscription: boolean, productCategory?: { __typename?: 'ProductCategory', id: string, code: string, name: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, code: string, name: string } | null } | null };
 
 export type ProductFilterActivityLogsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -16085,14 +16091,14 @@ export type GetProductFilterForDetailsQueryVariables = Exact<{
 
 export type GetProductFilterForDetailsQuery = { __typename?: 'Query', productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, attachedToPlanOrSubscription: boolean, product: { __typename?: 'Product', id: string, name: string, code: string }, values: Array<{ __typename?: 'ProductFilterValue', id: string, value?: string | null, billableMetricFilter: { __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> } }> } | null };
 
-export type ProductFilterForDetailsOverviewFragment = { __typename?: 'ProductFilter', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, attachedToPlanOrSubscription: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string, invoiceDisplayName?: string | null } | null }, values: Array<{ __typename?: 'ProductFilterValue', id: string, key: string, value?: string | null, billableMetricFilter: { __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> } }> };
+export type ProductFilterForDetailsOverviewFragment = { __typename?: 'ProductFilter', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, attachedToPlanOrSubscription: boolean, product: { __typename?: 'Product', id: string, code: string, name: string, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, code: string, name: string, invoiceDisplayName?: string | null } | null }, values: Array<{ __typename?: 'ProductFilterValue', id: string, key: string, value?: string | null, billableMetricFilter: { __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> } }> };
 
 export type GetProductFilterForDetailsOverviewQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetProductFilterForDetailsOverviewQuery = { __typename?: 'Query', productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, attachedToPlanOrSubscription: boolean, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, code: string, invoiceDisplayName?: string | null } | null }, values: Array<{ __typename?: 'ProductFilterValue', id: string, key: string, value?: string | null, billableMetricFilter: { __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> } }> } | null };
+export type GetProductFilterForDetailsOverviewQuery = { __typename?: 'Query', productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string, description?: string | null, invoiceDisplayName?: string | null, attachedToPlanOrSubscription: boolean, product: { __typename?: 'Product', id: string, code: string, name: string, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, code: string, name: string, invoiceDisplayName?: string | null } | null }, values: Array<{ __typename?: 'ProductFilterValue', id: string, key: string, value?: string | null, billableMetricFilter: { __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> } }> } | null };
 
 export type ProductForFilterPreviewFragment = { __typename?: 'Product', id: string, name: string, code: string, billableMetric?: { __typename?: 'BillableMetric', id: string, filters?: Array<{ __typename?: 'BillableMetricFilter', id: string, key: string, values: Array<string> }> | null } | null };
 
@@ -16124,14 +16130,14 @@ export type GetRateCardForDetailsQueryVariables = Exact<{
 
 export type GetRateCardForDetailsQuery = { __typename?: 'Query', rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, ratesCount: number, product: { __typename?: 'Product', id: string, name: string, code: string, productType: ProductTypeEnum, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string } | null, activeRate?: { __typename?: 'RateCardRate', id: string, effectiveFrom: any } | null } | null };
 
-export type RateCardForDetailsOverviewFragment = { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, ratesCount: number, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productType: ProductTypeEnum, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string, invoiceDisplayName?: string | null } | null };
+export type RateCardForDetailsOverviewFragment = { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, ratesCount: number, product: { __typename?: 'Product', id: string, code: string, name: string, productType: ProductTypeEnum, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, code: string, name: string, invoiceDisplayName?: string | null } | null };
 
 export type GetRateCardForDetailsOverviewQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetRateCardForDetailsOverviewQuery = { __typename?: 'Query', rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, ratesCount: number, product: { __typename?: 'Product', id: string, name: string, code: string, invoiceDisplayName?: string | null, productType: ProductTypeEnum, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, code: string, invoiceDisplayName?: string | null } | null } | null };
+export type GetRateCardForDetailsOverviewQuery = { __typename?: 'Query', rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, description?: string | null, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, displayOnInvoice: boolean, regroupPaidFees: RateCardRegroupPaidFeesEnum, proration: boolean, walletTargetable?: boolean | null, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, ratesCount: number, product: { __typename?: 'Product', id: string, code: string, name: string, productType: ProductTypeEnum, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, code: string, name: string, invoiceDisplayName?: string | null } | null } | null };
 
 export type RateCardForPreviewProductFragment = { __typename?: 'Product', id: string, name: string };
 
@@ -16163,7 +16169,7 @@ export type GetRateCardRateForDetailsQueryVariables = Exact<{
 }>;
 
 
-export type GetRateCardRateForDetailsQuery = { __typename?: 'Query', rateCardRate?: { __typename?: 'RateCardRate', id: string, code: string, effectiveFrom: any, status: RateCardRateStatusEnum, rateModel: RateCardRateModelEnum, billingIntervalCount: number, billingIntervalUnit: RateCardRateBillingIntervalUnitEnum, minAmountCents: any, appliedPricingUnitConversionRate?: number | null, rateProperties: { __typename?: 'Properties', amount?: string | null, rate?: string | null, packageSize?: any | null, pricingGroupKeys?: Array<string> | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', perUnitAmount: string, flatAmount: string, fromValue: number, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', rate: string, flatAmount: string, fromValue: number, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', perUnitAmount: string, flatAmount: string, fromValue: any, toValue?: any | null }> | null } } | null, rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, name: string, invoiceDisplayName?: string | null, productType: ProductTypeEnum, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, aggregationType: AggregationTypeEnum } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, invoiceDisplayName?: string | null } | null, activeRate?: { __typename?: 'RateCardRate', id: string, effectiveFrom: any } | null } | null };
+export type GetRateCardRateForDetailsQuery = { __typename?: 'Query', rateCardRate?: { __typename?: 'RateCardRate', id: string, code: string, effectiveFrom: any, status: RateCardRateStatusEnum, rateModel: RateCardRateModelEnum, billingIntervalCount: number, billingIntervalUnit: RateCardRateBillingIntervalUnitEnum, minAmountCents: any, appliedPricingUnitConversionRate?: number | null, rateProperties: { __typename?: 'Properties', amount?: string | null, rate?: string | null, packageSize?: any | null, pricingGroupKeys?: Array<string> | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, customProperties?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', perUnitAmount: string, flatAmount: string, fromValue: number, toValue?: number | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', rate: string, flatAmount: string, fromValue: number, toValue?: number | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', perUnitAmount: string, flatAmount: string, fromValue: any, toValue?: any | null }> | null } } | null, rateCard?: { __typename?: 'RateCard', id: string, name: string, code: string, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, attachedToPlanOrSubscription: boolean, attachedToSubscriptions: boolean, product: { __typename?: 'Product', id: string, productType: ProductTypeEnum, name: string, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, invoiceDisplayName?: string | null } | null, billableMetric?: { __typename?: 'BillableMetric', id: string, aggregationType: AggregationTypeEnum } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, invoiceDisplayName?: string | null } | null, activeRate?: { __typename?: 'RateCardRate', id: string, effectiveFrom: any } | null } | null };
 
 export type RateCardForRateDetailsFragment = { __typename?: 'RateCard', id: string, name: string, code: string, currency: CurrencyEnum, appliedPricingUnitCode?: string | null, billingTiming: RateCardBillingTimingEnum, product: { __typename?: 'Product', id: string, name: string, invoiceDisplayName?: string | null, productCategory?: { __typename?: 'ProductCategory', id: string, name: string, invoiceDisplayName?: string | null } | null }, productFilter?: { __typename?: 'ProductFilter', id: string, name: string, invoiceDisplayName?: string | null } | null };
 
@@ -22799,6 +22805,13 @@ export const ProductForProductDetailsFragmentDoc = gql`
 ${ProductForFilterPreviewFragmentDoc}
 ${ProductForDrawerFragmentDoc}
 ${ProductForDeleteProductDialogFragmentDoc}`;
+export const ProductCategoryForCatalogRelationsFragmentDoc = gql`
+    fragment ProductCategoryForCatalogRelations on ProductCategory {
+  id
+  name
+  invoiceDisplayName
+}
+    `;
 export const ProductForDetailsOverviewFragmentDoc = gql`
     fragment ProductForDetailsOverview on Product {
   id
@@ -22809,9 +22822,8 @@ export const ProductForDetailsOverviewFragmentDoc = gql`
   productType
   productCategory {
     id
-    name
     code
-    invoiceDisplayName
+    ...ProductCategoryForCatalogRelations
   }
   billableMetric {
     id
@@ -22820,7 +22832,8 @@ export const ProductForDetailsOverviewFragmentDoc = gql`
   }
   ...ProductForDrawer
 }
-    ${ProductForDrawerFragmentDoc}`;
+    ${ProductCategoryForCatalogRelationsFragmentDoc}
+${ProductForDrawerFragmentDoc}`;
 export const RateCardForPreviewProductFilterFragmentDoc = gql`
     fragment RateCardForPreviewProductFilter on ProductFilter {
   id
@@ -22841,6 +22854,13 @@ export const ProductFilterForProductFilterDetailsFragmentDoc = gql`
     ${RateCardForPreviewProductFilterFragmentDoc}
 ${ProductFilterForDrawerFragmentDoc}
 ${ProductFilterForDeleteProductFilterDialogFragmentDoc}`;
+export const ProductForCatalogRelationsFragmentDoc = gql`
+    fragment ProductForCatalogRelations on Product {
+  id
+  name
+  invoiceDisplayName
+}
+    `;
 export const ProductFilterForDetailsOverviewFragmentDoc = gql`
     fragment ProductFilterForDetailsOverview on ProductFilter {
   id
@@ -22851,14 +22871,12 @@ export const ProductFilterForDetailsOverviewFragmentDoc = gql`
   attachedToPlanOrSubscription
   product {
     id
-    name
     code
-    invoiceDisplayName
+    ...ProductForCatalogRelations
     productCategory {
       id
-      name
       code
-      invoiceDisplayName
+      ...ProductCategoryForCatalogRelations
     }
   }
   values {
@@ -22873,10 +22891,19 @@ export const ProductFilterForDetailsOverviewFragmentDoc = gql`
   }
   ...ProductFilterForDrawer
 }
-    ${ProductFilterForDrawerFragmentDoc}`;
+    ${ProductForCatalogRelationsFragmentDoc}
+${ProductCategoryForCatalogRelationsFragmentDoc}
+${ProductFilterForDrawerFragmentDoc}`;
 export const RateCardForRateCardDetailsFragmentDoc = gql`
     fragment RateCardForRateCardDetails on RateCard {
   id
+}
+    `;
+export const ProductFilterForCatalogRelationsFragmentDoc = gql`
+    fragment ProductFilterForCatalogRelations on ProductFilter {
+  id
+  name
+  invoiceDisplayName
 }
     `;
 export const RateCardForDrawerFragmentDoc = gql`
@@ -22930,24 +22957,24 @@ export const RateCardForDetailsOverviewFragmentDoc = gql`
   walletTargetable
   product {
     id
-    name
     code
-    invoiceDisplayName
+    ...ProductForCatalogRelations
     productCategory {
       id
-      name
-      invoiceDisplayName
+      ...ProductCategoryForCatalogRelations
     }
   }
   productFilter {
     id
-    name
     code
-    invoiceDisplayName
+    ...ProductFilterForCatalogRelations
   }
   ...RateCardForDrawer
 }
-    ${RateCardForDrawerFragmentDoc}`;
+    ${ProductForCatalogRelationsFragmentDoc}
+${ProductCategoryForCatalogRelationsFragmentDoc}
+${ProductFilterForCatalogRelationsFragmentDoc}
+${RateCardForDrawerFragmentDoc}`;
 export const PropertiesForActiveRateFragmentDoc = gql`
     fragment PropertiesForActiveRate on Properties {
   amount
@@ -23031,21 +23058,20 @@ export const RateCardForRateDetailsFragmentDoc = gql`
   billingTiming
   product {
     id
-    name
-    invoiceDisplayName
+    ...ProductForCatalogRelations
     productCategory {
       id
-      name
-      invoiceDisplayName
+      ...ProductCategoryForCatalogRelations
     }
   }
   productFilter {
     id
-    name
-    invoiceDisplayName
+    ...ProductFilterForCatalogRelations
   }
 }
-    `;
+    ${ProductForCatalogRelationsFragmentDoc}
+${ProductCategoryForCatalogRelationsFragmentDoc}
+${ProductFilterForCatalogRelationsFragmentDoc}`;
 export const RateCardForRateDrawerFragmentDoc = gql`
     fragment RateCardForRateDrawer on RateCard {
   id

--- a/src/pages/catalog/details/CatalogRelationsInfoGrid.tsx
+++ b/src/pages/catalog/details/CatalogRelationsInfoGrid.tsx
@@ -1,3 +1,4 @@
+import { gql } from '@apollo/client'
 import { ReactNode } from 'react'
 import { generatePath } from 'react-router-dom'
 
@@ -14,20 +15,41 @@ import {
   PRODUCT_DETAILS_ROUTE,
   PRODUCT_FILTER_DETAILS_ROUTE,
 } from '~/core/router'
+import {
+  ProductCategoryForCatalogRelationsFragment,
+  ProductFilterForCatalogRelationsFragment,
+  ProductForCatalogRelationsFragment,
+} from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+gql`
+  fragment ProductCategoryForCatalogRelations on ProductCategory {
+    id
+    name
+    invoiceDisplayName
+  }
+
+  fragment ProductForCatalogRelations on Product {
+    id
+    name
+    invoiceDisplayName
+  }
+
+  fragment ProductFilterForCatalogRelations on ProductFilter {
+    id
+    name
+    invoiceDisplayName
+  }
+`
 
 export const CATALOG_RELATIONS_NO_PRODUCT_CATEGORY_TEST_ID = 'catalog-relations-no-product-category'
 
-type CatalogRelation = {
-  id: string
-  name: string
-  invoiceDisplayName?: string | null
-}
+type CatalogRelation = { name: string; invoiceDisplayName?: string | null }
 
 type CatalogRelationsInfoGridProps = {
-  productCategory: CatalogRelation | null | undefined
-  product?: CatalogRelation
-  productFilter?: CatalogRelation | null
+  productCategory: ProductCategoryForCatalogRelationsFragment | null | undefined
+  product?: ProductForCatalogRelationsFragment
+  productFilter?: ProductFilterForCatalogRelationsFragment | null
 }
 
 const getDisplayName = (relation: CatalogRelation): string =>

--- a/src/pages/catalog/details/CatalogRelationsInfoGrid.tsx
+++ b/src/pages/catalog/details/CatalogRelationsInfoGrid.tsx
@@ -1,0 +1,113 @@
+import { ReactNode } from 'react'
+import { generatePath } from 'react-router-dom'
+
+import { Typography } from '~/components/designSystem/Typography'
+import { DetailsPage } from '~/components/layouts/DetailsPage'
+import {
+  ProductCategoryDetailsTabsOptionsEnum,
+  ProductDetailsTabsOptionsEnum,
+  ProductFilterDetailsTabsOptionsEnum,
+} from '~/core/constants/tabsOptions'
+import {
+  Link,
+  PRODUCT_CATEGORY_DETAILS_ROUTE,
+  PRODUCT_DETAILS_ROUTE,
+  PRODUCT_FILTER_DETAILS_ROUTE,
+} from '~/core/router'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+
+export const CATALOG_RELATIONS_NO_PRODUCT_CATEGORY_TEST_ID = 'catalog-relations-no-product-category'
+
+type CatalogRelation = {
+  id: string
+  name: string
+  invoiceDisplayName?: string | null
+}
+
+type CatalogRelationsInfoGridProps = {
+  productCategory: CatalogRelation | null | undefined
+  product?: CatalogRelation
+  productFilter?: CatalogRelation | null
+}
+
+const getDisplayName = (relation: CatalogRelation): string =>
+  relation.invoiceDisplayName || relation.name
+
+export const CatalogRelationsInfoGrid = ({
+  productCategory,
+  product,
+  productFilter,
+}: CatalogRelationsInfoGridProps): JSX.Element => {
+  const { translate } = useInternationalization()
+
+  const renderProductCategory = (): ReactNode => {
+    if (!productCategory) {
+      return (
+        <Typography
+          variant="body"
+          color="grey600"
+          data-test={CATALOG_RELATIONS_NO_PRODUCT_CATEGORY_TEST_ID}
+        >
+          {translate('text_1784590896872hcbug1hthjl')}
+        </Typography>
+      )
+    }
+
+    return (
+      <Link
+        to={generatePath(PRODUCT_CATEGORY_DETAILS_ROUTE, {
+          productCategoryId: productCategory.id,
+          tab: ProductCategoryDetailsTabsOptionsEnum.overview,
+        })}
+      >
+        {getDisplayName(productCategory)}
+      </Link>
+    )
+  }
+
+  return (
+    <>
+      <DetailsPage.InfoGrid
+        grid={[
+          {
+            label: translate('text_17877372202296ejgkqky70w'),
+            value: renderProductCategory(),
+          },
+          !!product && {
+            label: translate('text_1784925227817ekmphmxz74c'),
+            value: (
+              <Link
+                to={generatePath(PRODUCT_DETAILS_ROUTE, {
+                  productId: product.id,
+                  tab: ProductDetailsTabsOptionsEnum.overview,
+                })}
+              >
+                {getDisplayName(product)}
+              </Link>
+            ),
+          },
+        ]}
+      />
+
+      {!!productFilter && (
+        <DetailsPage.InfoGrid
+          grid={[
+            {
+              label: translate('text_17849304406579sbwz4df14p'),
+              value: (
+                <Link
+                  to={generatePath(PRODUCT_FILTER_DETAILS_ROUTE, {
+                    productFilterId: productFilter.id,
+                    tab: ProductFilterDetailsTabsOptionsEnum.overview,
+                  })}
+                >
+                  {getDisplayName(productFilter)}
+                </Link>
+              ),
+            },
+          ]}
+        />
+      )}
+    </>
+  )
+}

--- a/src/pages/catalog/details/ProductDetailsOverview.tsx
+++ b/src/pages/catalog/details/ProductDetailsOverview.tsx
@@ -9,11 +9,8 @@ import { Typography } from '~/components/designSystem/Typography'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { PageSectionTitle } from '~/components/layouts/Section'
-import {
-  BillableMetricDetailsTabsOptionsEnum,
-  ProductCategoryDetailsTabsOptionsEnum,
-} from '~/core/constants/tabsOptions'
-import { BILLABLE_METRIC_DETAILS_ROUTE, Link, PRODUCT_CATEGORY_DETAILS_ROUTE } from '~/core/router'
+import { BillableMetricDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
+import { BILLABLE_METRIC_DETAILS_ROUTE, Link } from '~/core/router'
 import {
   LagoApiError,
   ProductForDrawerFragmentDoc,
@@ -22,6 +19,8 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { usePermissions } from '~/hooks/usePermissions'
+
+import { CatalogRelationsInfoGrid } from './CatalogRelationsInfoGrid'
 
 import { useProductDrawer } from '../drawers/product/useProductDrawer'
 
@@ -44,6 +43,7 @@ gql`
       id
       name
       code
+      invoiceDisplayName
     }
     billableMetric {
       id
@@ -79,21 +79,6 @@ export const ProductDetailsOverview = () => {
   if (!product && loading) {
     return <DetailsPage.Skeleton />
   }
-
-  const attachedProductCategory = product?.productCategory ? (
-    <Link
-      to={generatePath(PRODUCT_CATEGORY_DETAILS_ROUTE, {
-        productCategoryId: product.productCategory.id,
-        tab: ProductCategoryDetailsTabsOptionsEnum.overview,
-      })}
-    >
-      {product.productCategory.name}
-    </Link>
-  ) : (
-    <Typography variant="body" color="grey600">
-      {translate('text_1784590896872hcbug1hthjl')}
-    </Typography>
-  )
 
   const productType = product?.productType ? (
     <Typography variant="body" color="grey700">
@@ -139,11 +124,7 @@ export const ProductDetailsOverview = () => {
       )}
 
       <div className="flex flex-col gap-4">
-        <DetailsPage.InfoGridItem
-          className="col-span-2"
-          label={translate('text_17877372202296ejgkqky70w')}
-          value={attachedProductCategory}
-        />
+        <CatalogRelationsInfoGrid productCategory={product?.productCategory} />
 
         <DetailsPage.InfoGrid
           grid={[

--- a/src/pages/catalog/details/ProductDetailsOverview.tsx
+++ b/src/pages/catalog/details/ProductDetailsOverview.tsx
@@ -13,6 +13,7 @@ import { BillableMetricDetailsTabsOptionsEnum } from '~/core/constants/tabsOptio
 import { BILLABLE_METRIC_DETAILS_ROUTE, Link } from '~/core/router'
 import {
   LagoApiError,
+  ProductCategoryForCatalogRelationsFragmentDoc,
   ProductForDrawerFragmentDoc,
   ProductTypeEnum,
   useGetProductForDetailsOverviewQuery,
@@ -41,9 +42,8 @@ gql`
     productType
     productCategory {
       id
-      name
       code
-      invoiceDisplayName
+      ...ProductCategoryForCatalogRelations
     }
     billableMetric {
       id
@@ -61,6 +61,7 @@ gql`
   }
 
   ${ProductForDrawerFragmentDoc}
+  ${ProductCategoryForCatalogRelationsFragmentDoc}
 `
 
 export const ProductDetailsOverview = () => {

--- a/src/pages/catalog/details/ProductFilterDetailsOverview.tsx
+++ b/src/pages/catalog/details/ProductFilterDetailsOverview.tsx
@@ -12,7 +12,9 @@ import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import {
   LagoApiError,
+  ProductCategoryForCatalogRelationsFragmentDoc,
   ProductFilterForDrawerFragmentDoc,
+  ProductForCatalogRelationsFragmentDoc,
   useGetProductFilterForDetailsOverviewQuery,
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
@@ -35,14 +37,12 @@ gql`
     attachedToPlanOrSubscription
     product {
       id
-      name
       code
-      invoiceDisplayName
+      ...ProductForCatalogRelations
       productCategory {
         id
-        name
         code
-        invoiceDisplayName
+        ...ProductCategoryForCatalogRelations
       }
     }
     values {
@@ -66,6 +66,8 @@ gql`
   }
 
   ${ProductFilterForDrawerFragmentDoc}
+  ${ProductCategoryForCatalogRelationsFragmentDoc}
+  ${ProductForCatalogRelationsFragmentDoc}
 `
 
 const ProductFilterDetailsOverview = ({ productFilterId }: { productFilterId: string }) => {

--- a/src/pages/catalog/details/ProductFilterDetailsOverview.tsx
+++ b/src/pages/catalog/details/ProductFilterDetailsOverview.tsx
@@ -1,6 +1,5 @@
 import { gql } from '@apollo/client'
 import { Fragment } from 'react'
-import { generatePath } from 'react-router-dom'
 
 import { Chip } from '~/components/designSystem/Chip'
 import {
@@ -12,11 +11,6 @@ import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import {
-  ProductCategoryDetailsTabsOptionsEnum,
-  ProductDetailsTabsOptionsEnum,
-} from '~/core/constants/tabsOptions'
-import { Link, PRODUCT_CATEGORY_DETAILS_ROUTE, PRODUCT_DETAILS_ROUTE } from '~/core/router'
-import {
   LagoApiError,
   ProductFilterForDrawerFragmentDoc,
   useGetProductFilterForDetailsOverviewQuery,
@@ -24,12 +18,12 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { usePermissions } from '~/hooks/usePermissions'
 
+import { CatalogRelationsInfoGrid } from './CatalogRelationsInfoGrid'
+
 import { useProductFilterDrawer } from '../drawers/productFilter/useProductFilterDrawer'
 
 export const PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_EDIT_TEST_ID =
   'product-item-filter-details-overview-edit'
-export const PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_NO_PRODUCT_CATEGORY_TEST_ID =
-  'product-item-filter-details-overview-no-product-category'
 
 gql`
   fragment ProductFilterForDetailsOverview on ProductFilter {
@@ -48,6 +42,7 @@ gql`
         id
         name
         code
+        invoiceDisplayName
       }
     }
     values {
@@ -97,36 +92,6 @@ const ProductFilterDetailsOverview = ({ productFilterId }: { productFilterId: st
 
   const { product, values } = productFilter
 
-  const attachedProductCategory = product.productCategory ? (
-    <Link
-      to={generatePath(PRODUCT_CATEGORY_DETAILS_ROUTE, {
-        productCategoryId: product.productCategory.id,
-        tab: ProductCategoryDetailsTabsOptionsEnum.overview,
-      })}
-    >
-      {product.productCategory.name}
-    </Link>
-  ) : (
-    <Typography
-      variant="body"
-      color="grey600"
-      data-test={PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_NO_PRODUCT_CATEGORY_TEST_ID}
-    >
-      {translate('text_1784590896872hcbug1hthjl')}
-    </Typography>
-  )
-
-  const attachedProduct = (
-    <Link
-      to={generatePath(PRODUCT_DETAILS_ROUTE, {
-        productId: product.id,
-        tab: ProductDetailsTabsOptionsEnum.overview,
-      })}
-    >
-      {product.invoiceDisplayName || product.name}
-    </Link>
-  )
-
   const code = (
     <TypographyWithCopy variant="body" color="grey700">
       {productFilter.code}
@@ -172,10 +137,10 @@ const ProductFilterDetailsOverview = ({ productFilterId }: { productFilterId: st
       )}
 
       <div className="flex flex-col gap-4">
+        <CatalogRelationsInfoGrid productCategory={product.productCategory} product={product} />
+
         <DetailsPage.InfoGrid
           grid={[
-            { label: translate('text_17839807181143h6kt2bdiyi'), value: attachedProductCategory },
-            { label: translate('text_17845790210805g4buh2kivc'), value: attachedProduct },
             { label: translate('text_17883567168609zwqemkhgbu'), value: productFilter.name },
             { label: translate('text_1788356716860fkisuga4c97'), value: code },
           ]}

--- a/src/pages/catalog/details/RateCardDetails.tsx
+++ b/src/pages/catalog/details/RateCardDetails.tsx
@@ -12,6 +12,7 @@ import {
 } from '~/core/constants/tabsOptions'
 import { PRODUCT_CATALOG_TAB_ROUTE, RATE_CARD_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import {
+  GetRateCardForDetailsQuery,
   LagoApiError,
   RateCardForDeleteRateCardDialogFragmentDoc,
   RateCardForDrawerFragmentDoc,
@@ -51,6 +52,28 @@ gql`
   ${RateCardForDeleteRateCardDialogFragmentDoc}
   ${RateCardForRateDrawerFragmentDoc}
 `
+
+// The header config is only re-pushed when this key changes, and its closures capture the
+// rate card, so the key must encode every mutable field they read - including `code`, which
+// the header renders through a React node the config snapshot strips.
+export const buildRateCardSnapshotKey = (
+  rateCard?: GetRateCardForDetailsQuery['rateCard'],
+): string =>
+  [
+    rateCard?.code,
+    rateCard?.description,
+    rateCard?.billingTiming,
+    rateCard?.proration,
+    rateCard?.attachedToPlanOrSubscription,
+    rateCard?.attachedToSubscriptions,
+    rateCard?.ratesCount,
+    rateCard?.currency,
+    rateCard?.appliedPricingUnitCode,
+    rateCard?.walletTargetable,
+    rateCard?.displayOnInvoice,
+    rateCard?.regroupPaidFees,
+    rateCard?.activeRate?.effectiveFrom,
+  ].join('|')
 
 const RATE_CARDS_LIST_PATH = generatePath(PRODUCT_CATALOG_TAB_ROUTE, {
   tab: ProductCatalogTabsOptionsEnum.rateCards,
@@ -122,11 +145,7 @@ const RateCardDetails = () => {
   return (
     <>
       <MainHeader.Configure
-        // The MainHeader config snapshot strips functions, so the action
-        // closures capture `rateCard` from the last push. Encode the mutable
-        // fields the closures depend on (but that the header does not display)
-        // so an edit touching only those re-pushes fresh closures.
-        snapshotKey={`${rateCard?.description}|${rateCard?.billingTiming}|${rateCard?.proration}|${rateCard?.attachedToPlanOrSubscription}|${rateCard?.attachedToSubscriptions}|${rateCard?.currency}|${rateCard?.appliedPricingUnitCode}|${rateCard?.walletTargetable}|${rateCard?.displayOnInvoice}|${rateCard?.regroupPaidFees}|${rateCard?.activeRate?.effectiveFrom}`}
+        snapshotKey={buildRateCardSnapshotKey(rateCard)}
         breadcrumb={[
           {
             label: translate('text_1783019143196z1oi70j03vt'),

--- a/src/pages/catalog/details/RateCardDetailsOverview.tsx
+++ b/src/pages/catalog/details/RateCardDetailsOverview.tsx
@@ -5,6 +5,9 @@ import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import {
   LagoApiError,
+  ProductCategoryForCatalogRelationsFragmentDoc,
+  ProductFilterForCatalogRelationsFragmentDoc,
+  ProductForCatalogRelationsFragmentDoc,
   RateCardBillingTimingEnum,
   RateCardForDrawerFragmentDoc,
   useGetRateCardForDetailsOverviewQuery,
@@ -52,20 +55,17 @@ gql`
     walletTargetable
     product {
       id
-      name
       code
-      invoiceDisplayName
+      ...ProductForCatalogRelations
       productCategory {
         id
-        name
-        invoiceDisplayName
+        ...ProductCategoryForCatalogRelations
       }
     }
     productFilter {
       id
-      name
       code
-      invoiceDisplayName
+      ...ProductFilterForCatalogRelations
     }
     ...RateCardForDrawer
   }
@@ -78,6 +78,9 @@ gql`
   }
 
   ${RateCardForDrawerFragmentDoc}
+  ${ProductCategoryForCatalogRelationsFragmentDoc}
+  ${ProductForCatalogRelationsFragmentDoc}
+  ${ProductFilterForCatalogRelationsFragmentDoc}
 `
 
 const RateCardDetailsOverview = ({ rateCardId }: { rateCardId: string }) => {

--- a/src/pages/catalog/details/RateCardDetailsOverview.tsx
+++ b/src/pages/catalog/details/RateCardDetailsOverview.tsx
@@ -1,21 +1,8 @@
 import { gql } from '@apollo/client'
-import { generatePath } from 'react-router-dom'
 
-import { Typography } from '~/components/designSystem/Typography'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { PageSectionTitle } from '~/components/layouts/Section'
-import {
-  ProductCategoryDetailsTabsOptionsEnum,
-  ProductDetailsTabsOptionsEnum,
-  ProductFilterDetailsTabsOptionsEnum,
-} from '~/core/constants/tabsOptions'
-import {
-  Link,
-  PRODUCT_CATEGORY_DETAILS_ROUTE,
-  PRODUCT_DETAILS_ROUTE,
-  PRODUCT_FILTER_DETAILS_ROUTE,
-} from '~/core/router'
 import {
   LagoApiError,
   RateCardBillingTimingEnum,
@@ -25,6 +12,8 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCustomPricingUnits } from '~/hooks/plans/useCustomPricingUnits'
 import { usePermissions } from '~/hooks/usePermissions'
+
+import { CatalogRelationsInfoGrid } from './CatalogRelationsInfoGrid'
 
 import { InvoicingStrategy, mapInvoiceFieldsToStrategy } from '../drawers/rateCard/constants'
 import {
@@ -69,12 +58,14 @@ gql`
       productCategory {
         id
         name
+        invoiceDisplayName
       }
     }
     productFilter {
       id
       name
       code
+      invoiceDisplayName
     }
     ...RateCardForDrawer
   }
@@ -114,45 +105,6 @@ const RateCardDetailsOverview = ({ rateCardId }: { rateCardId: string }) => {
 
   const { product, productFilter } = rateCard
 
-  const attachedProductCategory = product.productCategory ? (
-    <Link
-      to={generatePath(PRODUCT_CATEGORY_DETAILS_ROUTE, {
-        productCategoryId: product.productCategory.id,
-        tab: ProductCategoryDetailsTabsOptionsEnum.overview,
-      })}
-    >
-      {product.productCategory.name}
-    </Link>
-  ) : (
-    <Typography variant="body" color="grey600">
-      {translate('text_1784590896872hcbug1hthjl')}
-    </Typography>
-  )
-
-  const attachedProduct = (
-    <Link
-      to={generatePath(PRODUCT_DETAILS_ROUTE, {
-        productId: product.id,
-        tab: ProductDetailsTabsOptionsEnum.overview,
-      })}
-    >
-      {product.invoiceDisplayName || product.name}
-    </Link>
-  )
-
-  const attachedProductFilter = productFilter ? (
-    <Link
-      to={generatePath(PRODUCT_FILTER_DETAILS_ROUTE, {
-        productFilterId: productFilter.id,
-        tab: ProductFilterDetailsTabsOptionsEnum.overview,
-      })}
-    >
-      {productFilter.name}
-    </Link>
-  ) : (
-    '-'
-  )
-
   const code = (
     <TypographyWithCopy variant="body" color="grey700">
       {rateCard.code}
@@ -165,21 +117,6 @@ const RateCardDetailsOverview = ({ rateCardId }: { rateCardId: string }) => {
   })
 
   const pricingUnit = pricingUnits.find((unit) => unit.code === rateCard.appliedPricingUnitCode)
-
-  const currencyOrPricingUnitRow = [
-    {
-      label: translate('text_1784925227817bab1mp540x7'),
-      value: rateCard.currency || '-',
-    },
-    ...(pricingUnit?.name || rateCard.appliedPricingUnitCode
-      ? [
-          {
-            label: translate('text_1784925227817xt1irx4wum2'),
-            value: pricingUnit?.name || rateCard.appliedPricingUnitCode,
-          },
-        ]
-      : []),
-  ]
 
   return (
     <section>
@@ -196,14 +133,14 @@ const RateCardDetailsOverview = ({ rateCardId }: { rateCardId: string }) => {
       )}
 
       <div className="flex flex-col gap-4">
+        <CatalogRelationsInfoGrid
+          productCategory={product.productCategory}
+          product={product}
+          productFilter={productFilter}
+        />
+
         <DetailsPage.InfoGrid
           grid={[
-            { label: translate('text_17839807181143h6kt2bdiyi'), value: attachedProductCategory },
-            { label: translate('text_1784925227817ekmphmxz74c'), value: attachedProduct },
-            {
-              label: translate('text_17849304406579sbwz4df14p'),
-              value: attachedProductFilter,
-            },
             { label: translate('text_1784930440656rjmo1lmed8k'), value: rateCard.name },
             { label: translate('text_178493044065618ejwmmneyl'), value: code },
           ]}
@@ -219,7 +156,14 @@ const RateCardDetailsOverview = ({ rateCardId }: { rateCardId: string }) => {
 
         <DetailsPage.InfoGrid
           grid={[
-            ...currencyOrPricingUnitRow,
+            {
+              label: translate('text_1784925227817bab1mp540x7'),
+              value: rateCard.currency || '-',
+            },
+            {
+              label: translate('text_1784925227817xt1irx4wum2'),
+              value: pricingUnit?.name || rateCard.appliedPricingUnitCode || '-',
+            },
             {
               label: translate('text_1784930440656zu20xor7y71'),
               value: translate(BILLING_TIMING_TRANSLATION_KEY[rateCard.billingTiming]),

--- a/src/pages/catalog/details/RateCardRateDetails.tsx
+++ b/src/pages/catalog/details/RateCardRateDetails.tsx
@@ -99,6 +99,7 @@ export const buildRateCardRateSnapshotKey = ({
     rate?.minAmountCents,
     rate?.appliedPricingUnitConversionRate,
     JSON.stringify(rate?.rateProperties),
+    rateCard?.code,
     rateCard?.attachedToSubscriptions,
     rateCard?.attachedToPlanOrSubscription,
     rateCard?.activeRate?.effectiveFrom,

--- a/src/pages/catalog/details/RateCardRateDetailsOverview.tsx
+++ b/src/pages/catalog/details/RateCardRateDetailsOverview.tsx
@@ -14,6 +14,9 @@ import { Link, RATE_CARD_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { intlFormatDateTime } from '~/core/timezone'
 import {
+  ProductCategoryForCatalogRelationsFragmentDoc,
+  ProductFilterForCatalogRelationsFragmentDoc,
+  ProductForCatalogRelationsFragmentDoc,
   RateCardBillingTimingEnum,
   RateCardForRateDetailsFragment,
   RateCardRateForDetailsFragment,
@@ -41,20 +44,21 @@ gql`
     billingTiming
     product {
       id
-      name
-      invoiceDisplayName
+      ...ProductForCatalogRelations
       productCategory {
         id
-        name
-        invoiceDisplayName
+        ...ProductCategoryForCatalogRelations
       }
     }
     productFilter {
       id
-      name
-      invoiceDisplayName
+      ...ProductFilterForCatalogRelations
     }
   }
+
+  ${ProductCategoryForCatalogRelationsFragmentDoc}
+  ${ProductForCatalogRelationsFragmentDoc}
+  ${ProductFilterForCatalogRelationsFragmentDoc}
 `
 
 export const RATE_CARD_RATE_DETAILS_OVERVIEW_EDIT_TEST_ID = 'rate-card-rate-details-overview-edit'

--- a/src/pages/catalog/details/RateCardRateDetailsOverview.tsx
+++ b/src/pages/catalog/details/RateCardRateDetailsOverview.tsx
@@ -2,27 +2,15 @@ import { gql } from '@apollo/client'
 import { generatePath } from 'react-router-dom'
 
 import { Status } from '~/components/designSystem/Status'
-import { Typography } from '~/components/designSystem/Typography'
 import { TypographyWithCopy } from '~/components/designSystem/TypographyWithCopy'
 import { DetailsPage } from '~/components/layouts/DetailsPage'
 import { PageSectionTitle } from '~/components/layouts/Section'
 import { PlanDetailsChargeWrapperSwitch } from '~/components/plans/details/PlanDetailsChargeWrapperSwitch'
 import { chargeModelLookupTranslation } from '~/core/constants/form'
 import { rateCardRateStatusMapping } from '~/core/constants/statusRateCardRateMapping'
-import {
-  ProductCategoryDetailsTabsOptionsEnum,
-  ProductDetailsTabsOptionsEnum,
-  ProductFilterDetailsTabsOptionsEnum,
-  RateCardDetailsTabsOptionsEnum,
-} from '~/core/constants/tabsOptions'
+import { RateCardDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
-import {
-  Link,
-  PRODUCT_CATEGORY_DETAILS_ROUTE,
-  PRODUCT_DETAILS_ROUTE,
-  PRODUCT_FILTER_DETAILS_ROUTE,
-  RATE_CARD_DETAILS_ROUTE,
-} from '~/core/router'
+import { Link, RATE_CARD_DETAILS_ROUTE } from '~/core/router'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { intlFormatDateTime } from '~/core/timezone'
 import {
@@ -34,6 +22,8 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useCustomPricingUnits } from '~/hooks/plans/useCustomPricingUnits'
 import { usePermissions } from '~/hooks/usePermissions'
+
+import { CatalogRelationsInfoGrid } from './CatalogRelationsInfoGrid'
 
 import {
   BILLING_INTERVAL_UNIT_TRANSLATION_KEY,
@@ -52,14 +42,17 @@ gql`
     product {
       id
       name
+      invoiceDisplayName
       productCategory {
         id
         name
+        invoiceDisplayName
       }
     }
     productFilter {
       id
       name
+      invoiceDisplayName
     }
   }
 `
@@ -67,8 +60,6 @@ gql`
 export const RATE_CARD_RATE_DETAILS_OVERVIEW_EDIT_TEST_ID = 'rate-card-rate-details-overview-edit'
 export const RATE_CARD_RATE_DETAILS_OVERVIEW_STATUS_TEST_ID =
   'rate-card-rate-details-overview-status'
-export const RATE_CARD_RATE_DETAILS_OVERVIEW_NO_PRODUCT_CATEGORY_TEST_ID =
-  'rate-card-rate-details-overview-no-product-category'
 
 export const RATE_CARD_RATE_DETAILS_BILLING_INTERVAL_VALUE_KEY = 'text_17877372202287udsa3vj1ul'
 
@@ -91,49 +82,6 @@ const RateCardRateDetailsOverview = ({
   const pricingUnitShortName = pricingUnits.find(
     (unit) => unit.code === rateCard.appliedPricingUnitCode,
   )?.shortName
-
-  const attachedProductCategory = product.productCategory ? (
-    <Link
-      to={generatePath(PRODUCT_CATEGORY_DETAILS_ROUTE, {
-        productCategoryId: product.productCategory.id,
-        tab: ProductCategoryDetailsTabsOptionsEnum.overview,
-      })}
-    >
-      {product.productCategory.name}
-    </Link>
-  ) : (
-    <Typography
-      variant="body"
-      color="grey600"
-      data-test={RATE_CARD_RATE_DETAILS_OVERVIEW_NO_PRODUCT_CATEGORY_TEST_ID}
-    >
-      {translate('text_1784590896872hcbug1hthjl')}
-    </Typography>
-  )
-
-  const attachedProduct = (
-    <Link
-      to={generatePath(PRODUCT_DETAILS_ROUTE, {
-        productId: product.id,
-        tab: ProductDetailsTabsOptionsEnum.overview,
-      })}
-    >
-      {product.name}
-    </Link>
-  )
-
-  const attachedProductFilter = productFilter ? (
-    <Link
-      to={generatePath(PRODUCT_FILTER_DETAILS_ROUTE, {
-        productFilterId: productFilter.id,
-        tab: ProductFilterDetailsTabsOptionsEnum.overview,
-      })}
-    >
-      {productFilter.name}
-    </Link>
-  ) : (
-    '-'
-  )
 
   const attachedRateCard = (
     <Link
@@ -176,20 +124,14 @@ const RateCardRateDetailsOverview = ({
         />
       )}
 
+      <CatalogRelationsInfoGrid
+        productCategory={product.productCategory}
+        product={product}
+        productFilter={productFilter}
+      />
+
       <DetailsPage.InfoGrid
         grid={[
-          {
-            label: translate('text_17877372202296ejgkqky70w'),
-            value: attachedProductCategory,
-          },
-          {
-            label: translate('text_1784925227817ekmphmxz74c'),
-            value: attachedProduct,
-          },
-          {
-            label: translate('text_17849304406579sbwz4df14p'),
-            value: attachedProductFilter,
-          },
           {
             label: translate('text_1787737220228091rkbqj1vl'),
             value: attachedRateCard,

--- a/src/pages/catalog/details/__tests__/ProductDetailsOverview.test.tsx
+++ b/src/pages/catalog/details/__tests__/ProductDetailsOverview.test.tsx
@@ -8,10 +8,13 @@ import {
 } from '~/generated/graphql'
 import { AllTheProviders, TestMocksType } from '~/test-utils'
 
+import { CATALOG_RELATIONS_NO_PRODUCT_CATEGORY_TEST_ID } from '../CatalogRelationsInfoGrid'
 import {
   PRODUCT_ITEM_OVERVIEW_EDIT_TEST_ID,
   ProductDetailsOverview,
 } from '../ProductDetailsOverview'
+
+const PRODUCT_CATEGORY_LABEL_KEY = 'text_17877372202296ejgkqky70w'
 
 const mockOpenEditProductDrawer = jest.fn()
 const mockHasPermissions = jest.fn()
@@ -42,8 +45,20 @@ const fixedProduct: ProductForDetailsOverviewFragment = {
     id: 'prod-1',
     name: 'Object storage',
     code: 'object_storage',
+    invoiceDisplayName: null,
   },
   billableMetric: null,
+}
+
+const invoiceDisplayNameCategoryProduct: ProductForDetailsOverviewFragment = {
+  ...fixedProduct,
+  productCategory: {
+    __typename: 'ProductCategory',
+    id: 'prod-1',
+    name: 'Object storage',
+    code: 'object_storage',
+    invoiceDisplayName: 'Storage (billed)',
+  },
 }
 
 const usageProduct: ProductForDetailsOverviewFragment = {
@@ -193,6 +208,30 @@ describe('ProductDetailsOverview', () => {
         )
 
         expect(screen.getByText(UNBREAKABLE_DESCRIPTION)).toHaveClass('line-break-anywhere')
+      })
+    })
+  })
+
+  describe('GIVEN a product with no product category', () => {
+    describe('WHEN the overview loads', () => {
+      it('THEN keeps the label and shows the no-category placeholder', async () => {
+        await act(() => renderOverview(usageProduct))
+
+        expect(await screen.findByText(PRODUCT_CATEGORY_LABEL_KEY)).toBeInTheDocument()
+        expect(
+          screen.getByTestId(CATALOG_RELATIONS_NO_PRODUCT_CATEGORY_TEST_ID),
+        ).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a product category with an invoice display name', () => {
+    describe('WHEN the overview loads', () => {
+      it('THEN prefers it over the name in the link', async () => {
+        await act(() => renderOverview(invoiceDisplayNameCategoryProduct))
+
+        expect(await screen.findByRole('link', { name: 'Storage (billed)' })).toBeInTheDocument()
+        expect(screen.queryByRole('link', { name: 'Object storage' })).not.toBeInTheDocument()
       })
     })
   })

--- a/src/pages/catalog/details/__tests__/ProductFilterDetailsOverview.test.tsx
+++ b/src/pages/catalog/details/__tests__/ProductFilterDetailsOverview.test.tsx
@@ -7,9 +7,9 @@ import {
 } from '~/generated/graphql'
 import { AllTheProviders, TestMocksType } from '~/test-utils'
 
+import { CATALOG_RELATIONS_NO_PRODUCT_CATEGORY_TEST_ID } from '../CatalogRelationsInfoGrid'
 import ProductFilterDetailsOverview, {
   PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_EDIT_TEST_ID,
-  PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_NO_PRODUCT_CATEGORY_TEST_ID,
 } from '../ProductFilterDetailsOverview'
 
 const mockOpenEditProductFilterDrawer = jest.fn()
@@ -192,7 +192,7 @@ describe('ProductFilterDetailsOverview', () => {
         expect(await screen.findByText('EU pro filter')).toBeInTheDocument()
         expect(screen.queryByRole('link', { name: 'Object storage' })).not.toBeInTheDocument()
         expect(
-          screen.getByTestId(PRODUCT_ITEM_FILTER_DETAILS_OVERVIEW_NO_PRODUCT_CATEGORY_TEST_ID),
+          screen.getByTestId(CATALOG_RELATIONS_NO_PRODUCT_CATEGORY_TEST_ID),
         ).toBeInTheDocument()
       })
     })

--- a/src/pages/catalog/details/__tests__/RateCardDetails.test.tsx
+++ b/src/pages/catalog/details/__tests__/RateCardDetails.test.tsx
@@ -10,6 +10,7 @@ import { GetRateCardForDetailsDocument, RateCardBillingTimingEnum } from '~/gene
 import { AllTheProviders, testMockNavigateFn } from '~/test-utils'
 
 import RateCardDetails, {
+  buildRateCardSnapshotKey,
   RATE_CARD_DETAILS_ACTIONS_TEST_ID,
   RATE_CARD_DETAILS_DELETE_TEST_ID,
   RATE_CARD_DETAILS_EDIT_TEST_ID,
@@ -75,6 +76,7 @@ const rateCardFixture = {
   walletTargetable: false,
   attachedToPlanOrSubscription: false,
   attachedToSubscriptions: false,
+  ratesCount: 0,
   product: {
     __typename: 'Product',
     id: 'pitem-1',
@@ -286,6 +288,35 @@ describe('RateCardDetails', () => {
     await waitFor(() => {
       expect(testMockNavigateFn).toHaveBeenCalledWith('/product-catalog/rate-cards', {
         replace: true,
+      })
+    })
+  })
+})
+
+describe('buildRateCardSnapshotKey', () => {
+  type SnapshotArg = Parameters<typeof buildRateCardSnapshotKey>[0]
+
+  const rateCard = rateCardFixture as unknown as NonNullable<SnapshotArg>
+
+  describe('GIVEN two rate cards differing only in one mutable field', () => {
+    describe('WHEN their snapshot keys are compared', () => {
+      it.each([
+        ['the code', { code: 'renamed_rate_card' }],
+        ['the rate count', { ratesCount: 1 }],
+        ['the description', { description: 'Another description' }],
+        ['the attachment', { attachedToPlanOrSubscription: true }],
+      ])('THEN %s changes the key', (_, override) => {
+        expect(buildRateCardSnapshotKey(rateCard)).not.toBe(
+          buildRateCardSnapshotKey({ ...rateCard, ...override }),
+        )
+      })
+    })
+  })
+
+  describe('GIVEN the very same rate card', () => {
+    describe('WHEN the snapshot keys are compared', () => {
+      it('THEN the key is stable, so the header is not re-pushed on every render', () => {
+        expect(buildRateCardSnapshotKey(rateCard)).toBe(buildRateCardSnapshotKey(rateCard))
       })
     })
   })

--- a/src/pages/catalog/details/__tests__/RateCardDetailsOverview.test.tsx
+++ b/src/pages/catalog/details/__tests__/RateCardDetailsOverview.test.tsx
@@ -10,12 +10,15 @@ import {
 } from '~/generated/graphql'
 import { AllTheProviders, TestMocksType } from '~/test-utils'
 
+import { CATALOG_RELATIONS_NO_PRODUCT_CATEGORY_TEST_ID } from '../CatalogRelationsInfoGrid'
 import RateCardDetailsOverview, {
   RATE_CARD_DETAILS_OVERVIEW_EDIT_TEST_ID,
 } from '../RateCardDetailsOverview'
 
 const CURRENCY_LABEL_KEY = 'text_1784925227817bab1mp540x7'
 const PRICING_UNIT_LABEL_KEY = 'text_1784925227817xt1irx4wum2'
+const PRODUCT_CATEGORY_LABEL_KEY = 'text_17877372202296ejgkqky70w'
+const PRODUCT_FILTER_LABEL_KEY = 'text_17849304406579sbwz4df14p'
 
 const mockOpenEditRateCardDrawer = jest.fn()
 const mockHasPermissions = jest.fn()
@@ -60,6 +63,13 @@ const attachedRateCard: RateCardForDetailsOverviewFragment = {
     id: 'pitem-1',
     name: 'Seats',
     code: 'seats',
+    invoiceDisplayName: null,
+    productCategory: {
+      __typename: 'ProductCategory',
+      id: 'pcat-1',
+      name: 'Compute',
+      invoiceDisplayName: null,
+    },
     productType: 'usage',
     billableMetric: {
       __typename: 'BillableMetric',
@@ -81,6 +91,16 @@ const attachedRateCard: RateCardForDetailsOverviewFragment = {
 const noFilterRateCard: RateCardForDetailsOverviewFragment = {
   ...attachedRateCard,
   productFilter: null,
+}
+
+const noProductCategoryRateCard: RateCardForDetailsOverviewFragment = {
+  ...attachedRateCard,
+  product: { ...attachedRateCard.product, productCategory: null },
+}
+
+const invoiceDisplayNameRateCard: RateCardForDetailsOverviewFragment = {
+  ...attachedRateCard,
+  product: { ...attachedRateCard.product, invoiceDisplayName: 'Seats (billed)' },
 }
 
 const pricingUnitRateCard: RateCardForDetailsOverviewFragment = {
@@ -156,11 +176,12 @@ describe('RateCardDetailsOverview', () => {
         expect(await screen.findByText('USD')).toBeInTheDocument()
       })
 
-      it('THEN omits the pricing unit row entirely', async () => {
+      it('THEN still shows the pricing unit row, with a dash', async () => {
         await act(() => renderOverview())
 
         expect(await screen.findByText(CURRENCY_LABEL_KEY)).toBeInTheDocument()
-        expect(screen.queryByText(PRICING_UNIT_LABEL_KEY)).not.toBeInTheDocument()
+        expect(screen.getByText(PRICING_UNIT_LABEL_KEY)).toBeInTheDocument()
+        expect(screen.getByText('-')).toBeInTheDocument()
       })
 
       it('THEN displays the billing timing as a human label', async () => {
@@ -186,11 +207,37 @@ describe('RateCardDetailsOverview', () => {
 
   describe('GIVEN a rate card with no attached product item filter', () => {
     describe('WHEN the overview loads', () => {
-      it('THEN shows a dash instead of a link', async () => {
+      it('THEN hides the product item filter row entirely', async () => {
         await act(() => renderOverview(noFilterRateCard))
 
         expect(await screen.findByText('Standard rate card')).toBeInTheDocument()
+        expect(screen.queryByText(PRODUCT_FILTER_LABEL_KEY)).not.toBeInTheDocument()
         expect(screen.queryByRole('link', { name: 'EU pro filter' })).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a rate card whose product item has no product category', () => {
+    describe('WHEN the overview loads', () => {
+      it('THEN keeps the label and shows the no-category placeholder', async () => {
+        await act(() => renderOverview(noProductCategoryRateCard))
+
+        expect(await screen.findByText(PRODUCT_CATEGORY_LABEL_KEY)).toBeInTheDocument()
+        expect(
+          screen.getByTestId(CATALOG_RELATIONS_NO_PRODUCT_CATEGORY_TEST_ID),
+        ).toBeInTheDocument()
+        expect(screen.queryByRole('link', { name: 'Compute' })).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('GIVEN a product item with an invoice display name', () => {
+    describe('WHEN the overview loads', () => {
+      it('THEN prefers it over the name in the attached product item link', async () => {
+        await act(() => renderOverview(invoiceDisplayNameRateCard))
+
+        expect(await screen.findByRole('link', { name: 'Seats (billed)' })).toBeInTheDocument()
+        expect(screen.queryByRole('link', { name: 'Seats' })).not.toBeInTheDocument()
       })
     })
   })

--- a/src/pages/catalog/details/__tests__/RateCardRateDetails.test.tsx
+++ b/src/pages/catalog/details/__tests__/RateCardRateDetails.test.tsx
@@ -390,6 +390,19 @@ describe('buildRateCardRateSnapshotKey', () => {
     })
   })
 
+  describe('GIVEN the parent card was renamed', () => {
+    describe('WHEN the snapshot keys are compared', () => {
+      it('THEN the key changes, so the header stops showing the old card code', () => {
+        expect(buildRateCardRateSnapshotKey({ rate, rateCard })).not.toBe(
+          buildRateCardRateSnapshotKey({
+            rate,
+            rateCard: { ...rateCard, code: 'renamed_rate_card' },
+          }),
+        )
+      })
+    })
+  })
+
   describe('GIVEN the card gained an active rate', () => {
     describe('WHEN the snapshot keys are compared', () => {
       it('THEN the key changes, so the append boundary handed down cannot go stale', () => {

--- a/src/pages/catalog/details/__tests__/RateCardRateDetailsOverview.test.tsx
+++ b/src/pages/catalog/details/__tests__/RateCardRateDetailsOverview.test.tsx
@@ -14,10 +14,10 @@ import {
   buildRateCardRate,
   buildRateProperties,
 } from '../../__tests__/fixtures'
+import { CATALOG_RELATIONS_NO_PRODUCT_CATEGORY_TEST_ID } from '../CatalogRelationsInfoGrid'
 import RateCardRateDetailsOverview, {
   RATE_CARD_RATE_DETAILS_BILLING_INTERVAL_VALUE_KEY,
   RATE_CARD_RATE_DETAILS_OVERVIEW_EDIT_TEST_ID,
-  RATE_CARD_RATE_DETAILS_OVERVIEW_NO_PRODUCT_CATEGORY_TEST_ID,
   RATE_CARD_RATE_DETAILS_OVERVIEW_STATUS_TEST_ID,
 } from '../RateCardRateDetailsOverview'
 
@@ -134,9 +134,8 @@ describe('RateCardRateDetailsOverview', () => {
         )
       })
 
-      it('THEN falls back to a dash on the product filter and to a label on the category', () => {
+      it('THEN hides the product filter row and labels the missing category', () => {
         renderOverview({
-          // A spending minimum, so the only dash left is the product filter row.
           rate: buildRateCardRate({ minAmountCents: '2500' }),
           rateCard: buildRateCardForRateDetails({
             product: {
@@ -149,9 +148,9 @@ describe('RateCardRateDetailsOverview', () => {
           }),
         })
 
-        expect(screen.getAllByText('-')).toHaveLength(1)
+        expect(screen.queryByText('text_17849304406579sbwz4df14p')).not.toBeInTheDocument()
         expect(
-          screen.getByTestId(RATE_CARD_RATE_DETAILS_OVERVIEW_NO_PRODUCT_CATEGORY_TEST_ID),
+          screen.getByTestId(CATALOG_RELATIONS_NO_PRODUCT_CATEGORY_TEST_ID),
         ).toBeInTheDocument()
       })
 

--- a/src/pages/catalog/drawers/product/ProductDrawerContent.tsx
+++ b/src/pages/catalog/drawers/product/ProductDrawerContent.tsx
@@ -24,6 +24,7 @@ import { tw } from '~/styles/utils'
 
 import { PRODUCT_ITEM_FORM_DEFAULTS } from './constants'
 
+export const PRODUCT_ITEM_DRAWER_CODE_TEST_ID = 'product-item-drawer-code'
 export const PRODUCT_ITEM_DRAWER_REMOVE_DESCRIPTION_TEST_ID =
   'product-item-drawer-remove-description'
 export const PRODUCT_ITEM_DRAWER_SHOW_DESCRIPTION_TEST_ID = 'product-item-drawer-show-description'
@@ -170,6 +171,7 @@ const ProductDrawerFormSections = withForm({
               fields={{ name: 'name', code: 'code' }}
               disableCodeInput={disableCodeInput}
               disableAutoGenerateCode={isEdit}
+              codeDataTest={PRODUCT_ITEM_DRAWER_CODE_TEST_ID}
               nameProps={{
                 autoFocus: true,
                 placeholder: translate('text_1783980718113x7oxinm95hb'),

--- a/src/pages/catalog/drawers/product/__tests__/useProductDrawer.create.test.tsx
+++ b/src/pages/catalog/drawers/product/__tests__/useProductDrawer.create.test.tsx
@@ -135,6 +135,12 @@ const createProductForProductCategoryMock = (): MockedResponse => ({
 const duplicateCodeError = new GraphQLError('Value already exists', {
   extensions: { code: 'value_already_exist', details: { code: ['value_already_exist'] } },
 })
+const otherFieldError = new GraphQLError('Value already exists', {
+  extensions: {
+    code: 'value_already_exist',
+    details: { productCategoryId: ['value_already_exist'] },
+  },
+})
 
 const renderDrawerHook = (mocks: MockedResponse[] = []) =>
   renderHook(() => useProductDrawer(), {
@@ -248,5 +254,19 @@ describe('useProductDrawer create flow', () => {
     expect(mockClose).not.toHaveBeenCalled()
     expect(mockNavigate).not.toHaveBeenCalled()
     expect(addToast).not.toHaveBeenCalled()
+  })
+
+  it('toasts instead of failing silently when the rejection is on another field', async () => {
+    const { result } = renderDrawerHook([
+      createProductMock({ data: null, errors: [otherFieldError] }),
+    ])
+
+    act(() => result.current.openDrawer())
+    await seedAndSubmit()
+
+    await waitFor(() =>
+      expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'danger' })),
+    )
+    expect(mockClose).not.toHaveBeenCalled()
   })
 })

--- a/src/pages/catalog/drawers/product/__tests__/useProductDrawer.test.tsx
+++ b/src/pages/catalog/drawers/product/__tests__/useProductDrawer.test.tsx
@@ -12,6 +12,7 @@ import {
 import { render } from '~/test-utils'
 
 import {
+  PRODUCT_ITEM_DRAWER_CODE_TEST_ID,
   PRODUCT_ITEM_DRAWER_REMOVE_DESCRIPTION_TEST_ID,
   PRODUCT_ITEM_DRAWER_SHOW_DESCRIPTION_TEST_ID,
 } from '../ProductDrawerContent'
@@ -105,6 +106,9 @@ const renderDrawerBody = () => {
   )
 }
 
+const codeInput = () =>
+  screen.getByTestId(PRODUCT_ITEM_DRAWER_CODE_TEST_ID).querySelector('input') as HTMLInputElement
+
 describe('useProductDrawer', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -170,7 +174,16 @@ describe('useProductDrawer', () => {
       )
       renderDrawerBody()
 
-      await waitFor(() => expect(screen.getByDisplayValue('seats')).toBeDisabled())
+      await waitFor(() => expect(codeInput()).toBeDisabled())
+    })
+
+    it('keeps the code input editable while the item is unattached', async () => {
+      const { result } = renderDrawerHook()
+
+      act(() => result.current.openDrawer({ product: productFixture }))
+      renderDrawerBody()
+
+      await waitFor(() => expect(codeInput()).toBeEnabled())
     })
 
     it('updates the item, closes and toasts without navigating or sending create-only fields', async () => {

--- a/src/pages/catalog/drawers/product/useProductDrawer.tsx
+++ b/src/pages/catalog/drawers/product/useProductDrawer.tsx
@@ -174,7 +174,7 @@ const useProductForm = ({ onSuccess }: { onSuccess: (result: ProductFormSuccess)
 
       // Backend rejected a duplicate code: surface it under the Code input and
       // keep the drawer open.
-      if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
+      if (hasDefinedGQLError('ValueAlreadyExist', errors, 'code')) {
         applyExistingCodeError(formApi)
         return
       }

--- a/src/pages/catalog/drawers/product/useProductDrawer.tsx
+++ b/src/pages/catalog/drawers/product/useProductDrawer.tsx
@@ -179,6 +179,13 @@ const useProductForm = ({ onSuccess }: { onSuccess: (result: ProductFormSuccess)
         return
       }
 
+      // `silentErrorCodes` swallows everything else, so without this the submit looks like a
+      // no-op.
+      if (errors?.length) {
+        addToast({ severity: 'danger', translateKey: 'text_1788957148209uhcnfxybu4e' })
+        return
+      }
+
       if (product) {
         onSuccess({ product, wasEdit: !!editedProduct })
       }

--- a/src/pages/catalog/drawers/productCategory/ProductCategoryDrawerContent.tsx
+++ b/src/pages/catalog/drawers/productCategory/ProductCategoryDrawerContent.tsx
@@ -17,6 +17,7 @@ import { tw } from '~/styles/utils'
 
 import { PRODUCT_FORM_DEFAULTS } from './constants'
 
+export const PRODUCT_DRAWER_CODE_TEST_ID = 'product-drawer-code'
 export const PRODUCT_DRAWER_REMOVE_DESCRIPTION_TEST_ID = 'product-drawer-remove-description'
 export const PRODUCT_DRAWER_SHOW_DESCRIPTION_TEST_ID = 'product-drawer-show-description'
 
@@ -74,6 +75,7 @@ const ProductCategoryDrawerFormSections = withForm({
               fields={{ name: 'name', code: 'code' }}
               disableCodeInput={disableCodeInput}
               disableAutoGenerateCode={isEdit}
+              codeDataTest={PRODUCT_DRAWER_CODE_TEST_ID}
               nameProps={{
                 autoFocus: true,
                 placeholder: translate('text_17836270312839ylvd3gjr17'),

--- a/src/pages/catalog/drawers/productCategory/__tests__/useProductCategoryDrawer.test.tsx
+++ b/src/pages/catalog/drawers/productCategory/__tests__/useProductCategoryDrawer.test.tsx
@@ -14,6 +14,7 @@ import {
 import { render } from '~/test-utils'
 
 import {
+  PRODUCT_DRAWER_CODE_TEST_ID,
   PRODUCT_DRAWER_REMOVE_DESCRIPTION_TEST_ID,
   PRODUCT_DRAWER_SHOW_DESCRIPTION_TEST_ID,
 } from '../ProductCategoryDrawerContent'
@@ -123,6 +124,9 @@ const renderDrawerBody = () => {
     </MockedProvider>,
   )
 }
+
+const codeInput = () =>
+  screen.getByTestId(PRODUCT_DRAWER_CODE_TEST_ID).querySelector('input') as HTMLInputElement
 
 describe('useProductCategoryDrawer', () => {
   beforeEach(() => {
@@ -313,7 +317,7 @@ describe('useProductCategoryDrawer', () => {
       )
       renderDrawerBody()
 
-      await waitFor(() => expect(screen.getByDisplayValue('object_storage')).toBeDisabled())
+      await waitFor(() => expect(codeInput()).toBeDisabled())
     })
 
     it('keeps the code input editable when the productCategory is not attached', async () => {
@@ -322,7 +326,7 @@ describe('useProductCategoryDrawer', () => {
       act(() => result.current.openDrawer(productCategoryFixture))
       renderDrawerBody()
 
-      await waitFor(() => expect(screen.getByDisplayValue('object_storage')).not.toBeDisabled())
+      await waitFor(() => expect(codeInput()).toBeEnabled())
     })
 
     it('updates the productCategory, closes the drawer and toasts without navigating', async () => {

--- a/src/pages/catalog/drawers/productCategory/__tests__/useProductCategoryDrawer.test.tsx
+++ b/src/pages/catalog/drawers/productCategory/__tests__/useProductCategoryDrawer.test.tsx
@@ -101,6 +101,10 @@ const duplicateCodeError = new GraphQLError('Value already exists', {
   extensions: { code: 'value_already_exist', details: { code: ['value_already_exist'] } },
 })
 
+const otherFieldError = new GraphQLError('Value already exists', {
+  extensions: { code: 'value_already_exist', details: { name: ['value_already_exist'] } },
+})
+
 const renderDrawerHook = (mocks: MockedResponse[] = []) =>
   renderHook(() => useProductCategoryDrawer(), {
     wrapper: ({ children }: { children: ReactNode }) => (
@@ -274,6 +278,27 @@ describe('useProductCategoryDrawer', () => {
       )
       expect(mockClose).not.toHaveBeenCalled()
       expect(addToast).not.toHaveBeenCalled()
+    })
+
+    it('toasts instead of failing silently when the rejection is on another field', async () => {
+      const { result } = renderDrawerHook([
+        createProductCategoryMockFactory({ data: null, errors: [otherFieldError] }),
+      ])
+
+      act(() => result.current.openDrawer())
+      renderDrawerBody()
+
+      await userEvent.type(screen.getByPlaceholderText('text_17836270312839ylvd3gjr17'), 'Storage')
+      await waitFor(() => expect(screen.getByDisplayValue('storage')).toBeInTheDocument())
+
+      await act(async () => {
+        await lastDrawerArgs?.form?.submit()
+      })
+
+      await waitFor(() =>
+        expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'danger' })),
+      )
+      expect(mockClose).not.toHaveBeenCalled()
     })
   })
 

--- a/src/pages/catalog/drawers/productCategory/useProductCategoryDrawer.tsx
+++ b/src/pages/catalog/drawers/productCategory/useProductCategoryDrawer.tsx
@@ -140,6 +140,13 @@ const useProductCategoryForm = ({
         return
       }
 
+      // `silentErrorCodes` swallows everything else, so without this the submit looks like a
+      // no-op.
+      if (errors?.length) {
+        addToast({ severity: 'danger', translateKey: 'text_1788957148209wyppwdnny7d' })
+        return
+      }
+
       if (productCategory) {
         onSuccess({ productCategory, wasEdit: !!editedProductCategory })
       }

--- a/src/pages/catalog/drawers/productCategory/useProductCategoryDrawer.tsx
+++ b/src/pages/catalog/drawers/productCategory/useProductCategoryDrawer.tsx
@@ -135,7 +135,7 @@ const useProductCategoryForm = ({
 
       // Backend rejected a duplicate code: surface it under the Code input and
       // keep the drawer open.
-      if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
+      if (hasDefinedGQLError('ValueAlreadyExist', errors, 'code')) {
         applyExistingCodeError(formApi)
         return
       }

--- a/src/pages/catalog/drawers/productFilter/ProductFilterDrawerContent.tsx
+++ b/src/pages/catalog/drawers/productFilter/ProductFilterDrawerContent.tsx
@@ -26,6 +26,7 @@ const PRODUCT_ITEM_FILTER_DRAWER_REMOVE_DESCRIPTION_TEST_ID =
 const PRODUCT_ITEM_FILTER_DRAWER_SHOW_DESCRIPTION_TEST_ID =
   'product-item-filter-drawer-show-description'
 
+export const PRODUCT_ITEM_FILTER_DRAWER_CODE_TEST_ID = 'product-item-filter-drawer-code'
 export const PRODUCT_ITEM_FILTER_DRAWER_MISSING_VALUES_ALERT_TEST_ID =
   'product-item-filter-drawer-missing-values-alert'
 
@@ -162,6 +163,7 @@ const ProductFilterDrawerFormSections = withForm({
               fields={{ name: 'name', code: 'code' }}
               disableCodeInput={disableCodeInput}
               disableAutoGenerateCode={isEdit}
+              codeDataTest={PRODUCT_ITEM_FILTER_DRAWER_CODE_TEST_ID}
               nameProps={{ autoFocus: true }}
             />
 

--- a/src/pages/catalog/drawers/productFilter/__tests__/ProductFilterDrawerContent.test.tsx
+++ b/src/pages/catalog/drawers/productFilter/__tests__/ProductFilterDrawerContent.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '../constants'
 import {
   ComboboxSeed,
+  PRODUCT_ITEM_FILTER_DRAWER_CODE_TEST_ID,
   PRODUCT_ITEM_FILTER_DRAWER_MISSING_VALUES_ALERT_TEST_ID,
   ProductFilterDrawerContent,
 } from '../ProductFilterDrawerContent'
@@ -25,7 +26,6 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 
 // The code input placeholder / product combobox placeholder keys, used to
 // find the inputs (the translate mock echoes the key back).
-const CODE_INPUT_PLACEHOLDER_KEY = 'text_629728388c4d2300e2d380d9'
 const PRODUCT_ITEM_COMBOBOX_PLACEHOLDER_KEY = 'text_1784579021080kajutbc14la'
 
 const SEEDED_FILTERS = [{ id: 'bmf-1', key: 'payment_method', values: ['card', 'cash'] }]
@@ -101,6 +101,11 @@ const findMissingValuesAlert = () =>
 const getValuesEditorInput = () =>
   within(screen.getByTestId(PRODUCT_ITEM_FILTER_VALUES_COMBOBOX_TEST_ID)).getByRole('combobox')
 
+const codeInput = () =>
+  screen
+    .getByTestId(PRODUCT_ITEM_FILTER_DRAWER_CODE_TEST_ID)
+    .querySelector('input') as HTMLInputElement
+
 describe('ProductFilterDrawerContent', () => {
   describe('GIVEN edit mode with an attached filter', () => {
     it('locks the code input and the attached product selector', () => {
@@ -117,7 +122,7 @@ describe('ProductFilterDrawerContent', () => {
         },
       })
 
-      expect(screen.getByPlaceholderText(CODE_INPUT_PLACEHOLDER_KEY)).toBeDisabled()
+      expect(codeInput()).toBeDisabled()
       expect(screen.getByPlaceholderText(PRODUCT_ITEM_COMBOBOX_PLACEHOLDER_KEY)).toBeDisabled()
     })
   })

--- a/src/pages/catalog/drawers/productFilter/__tests__/useProductFilterDrawer.test.tsx
+++ b/src/pages/catalog/drawers/productFilter/__tests__/useProductFilterDrawer.test.tsx
@@ -137,6 +137,10 @@ const duplicateCodeError = new GraphQLError('Value already exists', {
   extensions: { code: 'value_already_exist', details: { code: ['value_already_exist'] } },
 })
 
+const otherFieldError = new GraphQLError('Value already exists', {
+  extensions: { code: 'value_already_exist', details: { values: ['value_already_exist'] } },
+})
+
 const renderDrawerHook = (mocks: MockedResponse[] = []) =>
   renderHook(() => useProductFilterDrawer(), {
     wrapper: ({ children }: { children: ReactNode }) => (
@@ -241,6 +245,20 @@ describe('useProductFilterDrawer', () => {
       expect(mockClose).not.toHaveBeenCalled()
       expect(mockNavigate).not.toHaveBeenCalled()
       expect(addToast).not.toHaveBeenCalled()
+    })
+
+    it('toasts instead of failing silently when the rejection is on another field', async () => {
+      const { result } = renderDrawerHook([
+        createProductFilterMock({ data: null, errors: [otherFieldError] }),
+      ])
+
+      act(() => result.current.openDrawer())
+      await seedAndSubmit()
+
+      await waitFor(() =>
+        expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'danger' })),
+      )
+      expect(mockClose).not.toHaveBeenCalled()
     })
 
     it('seeds the values editor with the prefilled product filters (attachToProduct)', () => {

--- a/src/pages/catalog/drawers/productFilter/useProductFilterDrawer.tsx
+++ b/src/pages/catalog/drawers/productFilter/useProductFilterDrawer.tsx
@@ -218,7 +218,7 @@ const useProductFilterForm = ({
 
       // Backend rejected a duplicate code: surface it under the Code input and
       // keep the drawer open.
-      if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
+      if (hasDefinedGQLError('ValueAlreadyExist', errors, 'code')) {
         applyExistingCodeError(formApi)
         return
       }

--- a/src/pages/catalog/drawers/productFilter/useProductFilterDrawer.tsx
+++ b/src/pages/catalog/drawers/productFilter/useProductFilterDrawer.tsx
@@ -223,6 +223,13 @@ const useProductFilterForm = ({
         return
       }
 
+      // `silentErrorCodes` swallows everything else, so without this the submit looks like a
+      // no-op.
+      if (errors?.length) {
+        addToast({ severity: 'danger', translateKey: 'text_1788957148209054ur2tx4nr' })
+        return
+      }
+
       if (productFilter) {
         onSuccess({ productFilter, wasEdit: !!editedProductFilter })
       }

--- a/src/pages/catalog/drawers/rateCard/RateCardDrawerContent.tsx
+++ b/src/pages/catalog/drawers/rateCard/RateCardDrawerContent.tsx
@@ -87,6 +87,7 @@ gql`
   }
 `
 
+export const RATE_CARD_DRAWER_CODE_TEST_ID = 'rate-card-drawer-code'
 export const RATE_CARD_DRAWER_SHOW_DESCRIPTION_TEST_ID = 'rate-card-drawer-show-description'
 export const RATE_CARD_DRAWER_DESCRIPTION_TEST_ID = 'rate-card-drawer-description'
 export const RATE_CARD_DRAWER_REMOVE_DESCRIPTION_TEST_ID = 'rate-card-drawer-remove-description'
@@ -111,7 +112,8 @@ export type RateCardProductSeed = {
 
 type RateCardDrawerSectionsExtraProps = {
   isEdit: boolean
-  isLocked: boolean
+  isAttached: boolean
+  hasRates: boolean
   disableCodeInput: boolean
   productSeed: RateCardProductSeed
   productFilterSeed: RateCardComboboxSeed
@@ -119,7 +121,8 @@ type RateCardDrawerSectionsExtraProps = {
 
 const rateCardDrawerSectionsDefaultProps: RateCardDrawerSectionsExtraProps = {
   isEdit: false,
-  isLocked: false,
+  isAttached: false,
+  hasRates: false,
   disableCodeInput: false,
   productSeed: null,
   productFilterSeed: null,
@@ -152,7 +155,8 @@ const RateCardDrawerFormSections = withForm({
   render: function RateCardDrawerFormSectionsRender({
     form,
     isEdit,
-    isLocked,
+    isAttached,
+    hasRates,
     disableCodeInput,
     productSeed,
     productFilterSeed,
@@ -343,6 +347,7 @@ const RateCardDrawerFormSections = withForm({
               fields={{ name: 'name', code: 'code' }}
               disableCodeInput={disableCodeInput}
               disableAutoGenerateCode={isEdit}
+              codeDataTest={RATE_CARD_DRAWER_CODE_TEST_ID}
               nameProps={{ autoFocus: true }}
             />
 
@@ -431,7 +436,7 @@ const RateCardDrawerFormSections = withForm({
                   label={translate('text_1784925227817bab1mp540x7')}
                   placeholder={translate('text_632c6e59b73f9a54d4c7224b')}
                   data={currencyComboboxData}
-                  disabled={isLocked}
+                  disabled={hasRates || isAttached}
                 />
               )}
             </form.AppField>
@@ -447,7 +452,7 @@ const RateCardDrawerFormSections = withForm({
                       label={translate('text_1784925227817xt1irx4wum2')}
                       placeholder={translate('text_17884232212443zsb3p8b5he')}
                       data={pricingUnitsComboboxData}
-                      disabled={isLocked}
+                      disabled={hasRates}
                     />
                   )}
                 </form.AppField>
@@ -459,7 +464,7 @@ const RateCardDrawerFormSections = withForm({
                   <Button
                     icon="trash"
                     variant="quaternary"
-                    disabled={isLocked}
+                    disabled={hasRates}
                     onClick={handleHidePricingUnit}
                     data-test={RATE_CARD_DRAWER_REMOVE_PRICING_UNIT_TEST_ID}
                   />
@@ -471,7 +476,7 @@ const RateCardDrawerFormSections = withForm({
                 fitContent
                 startIcon="plus"
                 variant="inline"
-                disabled={isLocked}
+                disabled={hasRates}
                 onClick={handleShowPricingUnit}
                 data-test={RATE_CARD_DRAWER_SHOW_PRICING_UNIT_TEST_ID}
               >
@@ -503,7 +508,7 @@ const RateCardDrawerFormSections = withForm({
                   label={translate('text_6682c52081acea90520743a8')}
                   description={translate('text_1781703119230q5zam349txb')}
                   optionLabelVariant="body"
-                  disabled={isLocked}
+                  disabled={hasRates}
                   options={[
                     {
                       label: translate('text_6682c52081acea90520743ac'),
@@ -521,7 +526,7 @@ const RateCardDrawerFormSections = withForm({
             {isPayInAdvance && (
               <ChargeInvoicingStrategyOption
                 localCharge={strategyLocalCharge}
-                disabled={isLocked}
+                disabled={hasRates}
                 openPremiumDialog={() => openPremiumWarningDialog()}
                 handleUpdate={({ invoiceable, regroupPaidFees }) => {
                   form.setFieldValue(
@@ -551,7 +556,7 @@ const RateCardDrawerFormSections = withForm({
                   {(field) => (
                     <field.SwitchField
                       label={translate('text_177488074309762bkd4znl3p')}
-                      disabled={isLocked}
+                      disabled={hasRates}
                     />
                   )}
                 </form.AppField>
@@ -589,7 +594,7 @@ const RateCardDrawerFormSections = withForm({
                 <field.SwitchField
                   label={translate('text_1784925227817ffwix51pkv1')}
                   subLabel={translate('text_17849252278174oqykkuidsn')}
-                  disabled={isLocked}
+                  disabled={hasRates}
                 />
               )}
             </form.AppField>
@@ -619,7 +624,8 @@ export const RateCardDrawerContent = withForm({
   render: function RateCardDrawerContentRender({
     form,
     isEdit,
-    isLocked,
+    isAttached,
+    hasRates,
     disableCodeInput,
     productSeed,
     productFilterSeed,
@@ -646,7 +652,8 @@ export const RateCardDrawerContent = withForm({
           <RateCardDrawerFormSections
             form={form}
             isEdit={isEdit}
-            isLocked={isLocked}
+            isAttached={isAttached}
+            hasRates={hasRates}
             disableCodeInput={disableCodeInput}
             productSeed={productSeed}
             productFilterSeed={productFilterSeed}

--- a/src/pages/catalog/drawers/rateCard/RateCardDrawerContent.tsx
+++ b/src/pages/catalog/drawers/rateCard/RateCardDrawerContent.tsx
@@ -574,7 +574,7 @@ const RateCardDrawerFormSections = withForm({
                   color="grey700"
                 >{`${translate('text_1784925227817ukilytyxozn')} `}</Typography>
 
-                <span className="flex flex-wrap gap-2">
+                <span className="flex flex-wrap gap-1">
                   {availableRateModelLabels.map((label) => (
                     <Chip
                       key={label}

--- a/src/pages/catalog/drawers/rateCard/__tests__/RateCardDrawerContent.test.tsx
+++ b/src/pages/catalog/drawers/rateCard/__tests__/RateCardDrawerContent.test.tsx
@@ -15,6 +15,7 @@ import { RATE_CARD_FORM_DEFAULTS, RateCardFormValues } from '../constants'
 import {
   RATE_CARD_DRAWER_AVAILABLE_MODEL_CHIP_TEST_ID,
   RATE_CARD_DRAWER_AVAILABLE_MODELS_ALERT_TEST_ID,
+  RATE_CARD_DRAWER_CODE_TEST_ID,
   RATE_CARD_DRAWER_DESCRIPTION_TEST_ID,
   RATE_CARD_DRAWER_REMOVE_DESCRIPTION_TEST_ID,
   RATE_CARD_DRAWER_REMOVE_PRICING_UNIT_TEST_ID,
@@ -81,11 +82,20 @@ const buildUsageSeed = (aggregationType: AggregationTypeEnum): RateCardProductSe
 })
 
 type HarnessProps = {
+  disableCodeInput?: boolean
+  isAttached?: boolean
+  hasRates?: boolean
   values?: Partial<RateCardFormValues>
   productSeed?: RateCardProductSeed
 }
 
-const Harness = ({ values, productSeed = null }: HarnessProps): JSX.Element => {
+const Harness = ({
+  values,
+  productSeed = null,
+  disableCodeInput = false,
+  isAttached = false,
+  hasRates = false,
+}: HarnessProps): JSX.Element => {
   const form = useAppForm({ defaultValues: { ...RATE_CARD_FORM_DEFAULTS, ...values } })
 
   return (
@@ -102,8 +112,9 @@ const Harness = ({ values, productSeed = null }: HarnessProps): JSX.Element => {
       <RateCardDrawerContent
         form={form}
         isEdit={false}
-        isLocked={false}
-        disableCodeInput={false}
+        isAttached={isAttached}
+        hasRates={hasRates}
+        disableCodeInput={disableCodeInput}
         productSeed={productSeed}
         productFilterSeed={null}
       />
@@ -123,6 +134,15 @@ const renderWithPricingUnits = (
 
 const queryPricingUnitInput = (): HTMLInputElement | null =>
   document.querySelector<HTMLInputElement>('input[name="pricingUnit"]')
+
+const currencyInput = (): HTMLInputElement =>
+  document.querySelector('input[name="currency"]') as HTMLInputElement
+
+const walletTargetableSwitch = (): HTMLElement =>
+  screen.getByRole('checkbox', { name: 'walletTargetable' })
+
+const codeInput = (): HTMLInputElement =>
+  screen.getByTestId(RATE_CARD_DRAWER_CODE_TEST_ID).querySelector('input') as HTMLInputElement
 
 const getDescriptionInput = (): HTMLTextAreaElement =>
   screen
@@ -379,6 +399,45 @@ describe('RateCardDrawerContent', () => {
         expect(screen.getByTestId(PRICING_UNIT_PROBE_TEST_ID)).toHaveTextContent('undefined')
         expect(screen.getByTestId(RATE_CARD_DRAWER_SHOW_PRICING_UNIT_TEST_ID)).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('GIVEN the code lock', () => {
+    it('WHEN unlocked THEN the code input stays editable', () => {
+      renderContent()
+
+      expect(codeInput()).toBeEnabled()
+    })
+
+    it('WHEN locked THEN the code input is disabled', () => {
+      renderContent({ disableCodeInput: true })
+
+      expect(codeInput()).toBeDisabled()
+    })
+  })
+
+  // `RateCards::UpdateService`: `LOCKED_WITH_RATES` freezes on `rate_card.rates.exists?`,
+  // and the currency freezes on that OR on `attached_to_plan_or_subscription?`.
+  describe('GIVEN the billing-semantic fields', () => {
+    it('WHEN the card has neither rates nor attachments THEN they stay editable', () => {
+      renderContent()
+
+      expect(currencyInput()).toBeEnabled()
+      expect(walletTargetableSwitch()).toBeEnabled()
+    })
+
+    it('WHEN the card has a rate THEN they freeze', () => {
+      renderContent({ hasRates: true })
+
+      expect(currencyInput()).toBeDisabled()
+      expect(walletTargetableSwitch()).toBeDisabled()
+    })
+
+    it('WHEN the card is attached but has no rate THEN only the currency freezes', () => {
+      renderContent({ isAttached: true })
+
+      expect(currencyInput()).toBeDisabled()
+      expect(walletTargetableSwitch()).toBeEnabled()
     })
   })
 })

--- a/src/pages/catalog/drawers/rateCard/__tests__/useRateCardDrawer.create.test.tsx
+++ b/src/pages/catalog/drawers/rateCard/__tests__/useRateCardDrawer.create.test.tsx
@@ -162,6 +162,9 @@ const createRateCardMock = (
 const duplicateCodeError = new GraphQLError('Value already exists', {
   extensions: { code: 'value_already_exist', details: { code: ['value_already_exist'] } },
 })
+const otherFieldError = new GraphQLError('Value already exists', {
+  extensions: { code: 'value_already_exist', details: { productId: ['value_already_exist'] } },
+})
 
 const renderDrawerHook = (mocks: MockedResponse[] = []) =>
   renderHook(() => useRateCardDrawer(), {
@@ -319,5 +322,21 @@ describe('useRateCardDrawer create flow', () => {
     expect(mockClose).not.toHaveBeenCalled()
     expect(mockNavigate).not.toHaveBeenCalled()
     expect(addToast).not.toHaveBeenCalled()
+  })
+
+  it('toasts instead of failing silently when the rejection is on another field', async () => {
+    const { result } = renderDrawerHook([
+      createRateCardMock(() => undefined, { data: null, errors: [otherFieldError] }),
+    ])
+
+    act(() => result.current.openDrawer())
+    renderDrawerBody()
+    await userEvent.click(screen.getByTestId('seed-base'))
+    await submit()
+
+    await waitFor(() =>
+      expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'danger' })),
+    )
+    expect(mockClose).not.toHaveBeenCalled()
   })
 })

--- a/src/pages/catalog/drawers/rateCard/__tests__/useRateCardDrawer.test.tsx
+++ b/src/pages/catalog/drawers/rateCard/__tests__/useRateCardDrawer.test.tsx
@@ -240,14 +240,16 @@ describe('useRateCardDrawer edit flow', () => {
     expect(capturedInput.appliedPricingUnitCode).toBeNull()
   })
 
-  it('passes the attachment flag to the content when the rate card bills subscriptions', () => {
+  // Locking follows `attached_to_plan_or_subscription?`; the narrower subscriptions flag
+  // must not freeze anything on its own.
+  it('leaves everything editable when only the subscriptions flag is set', () => {
     const { result } = renderDrawerHook()
 
     act(() =>
       result.current.openDrawer({
         rateCard: {
           ...rateCardFixture,
-          attachedToPlanOrSubscription: true,
+          attachedToPlanOrSubscription: false,
           attachedToSubscriptions: true,
         },
       }),
@@ -255,8 +257,8 @@ describe('useRateCardDrawer edit flow', () => {
 
     const contentProps = (lastDrawerArgs?.children as ReactElement)?.props
 
-    expect(contentProps?.isAttached).toBe(true)
-    expect(contentProps?.disableCodeInput).toBe(true)
+    expect(contentProps?.isAttached).toBe(false)
+    expect(contentProps?.disableCodeInput).toBe(false)
   })
 
   // `LOCKED_WITH_RATES` keys off `rate_card.rates.exists?`, not off any attachment.

--- a/src/pages/catalog/drawers/rateCard/__tests__/useRateCardDrawer.test.tsx
+++ b/src/pages/catalog/drawers/rateCard/__tests__/useRateCardDrawer.test.tsx
@@ -99,6 +99,7 @@ const rateCardFixture: RateCardForDrawerFragment = {
   walletTargetable: true,
   attachedToPlanOrSubscription: false,
   attachedToSubscriptions: false,
+  ratesCount: 0,
   product: {
     id: 'pi-1',
     name: 'Metered API',
@@ -167,7 +168,7 @@ describe('useRateCardDrawer edit flow', () => {
     )
   })
 
-  it('updates editable fields only, closes and toasts without navigating', async () => {
+  it('updates the editable fields, closes and toasts without navigating', async () => {
     let capturedInput: Record<string, unknown> = {}
     const { result } = renderDrawerHook([updateRateCardMock((input) => (capturedInput = input))])
 
@@ -186,9 +187,9 @@ describe('useRateCardDrawer edit flow', () => {
       currency: CurrencyEnum.Usd,
       displayOnInvoice: false,
       regroupPaidFees: RateCardRegroupPaidFeesEnum.Invoice,
+      code: 'metered_api',
     })
     // Create-only fields must never be sent on update.
-    expect(capturedInput).not.toHaveProperty('code')
     expect(capturedInput).not.toHaveProperty('productId')
     expect(capturedInput).not.toHaveProperty('productFilterId')
 
@@ -239,29 +240,76 @@ describe('useRateCardDrawer edit flow', () => {
     expect(capturedInput.appliedPricingUnitCode).toBeNull()
   })
 
-  it('passes locked flags to the content when the rate card is attached', () => {
+  it('passes the attachment flag to the content when the rate card bills subscriptions', () => {
     const { result } = renderDrawerHook()
 
     act(() =>
       result.current.openDrawer({
-        rateCard: { ...rateCardFixture, attachedToSubscriptions: true },
+        rateCard: {
+          ...rateCardFixture,
+          attachedToPlanOrSubscription: true,
+          attachedToSubscriptions: true,
+        },
       }),
     )
 
     const contentProps = (lastDrawerArgs?.children as ReactElement)?.props
 
-    expect(contentProps?.isLocked).toBe(true)
+    expect(contentProps?.isAttached).toBe(true)
     expect(contentProps?.disableCodeInput).toBe(true)
   })
 
-  it('locks only the code input (not the whole form) on an unattached edit', () => {
+  // `LOCKED_WITH_RATES` keys off `rate_card.rates.exists?`, not off any attachment.
+  it('flags the billing-semantic fields as frozen as soon as the card has a rate', () => {
+    const { result } = renderDrawerHook()
+
+    act(() => result.current.openDrawer({ rateCard: { ...rateCardFixture, ratesCount: 2 } }))
+
+    const contentProps = (lastDrawerArgs?.children as ReactElement)?.props
+
+    expect(contentProps?.hasRates).toBe(true)
+    expect(contentProps?.isAttached).toBe(false)
+  })
+
+  it('leaves them editable while the card has no rate, even when attached', () => {
+    const { result } = renderDrawerHook()
+
+    act(() =>
+      result.current.openDrawer({
+        rateCard: { ...rateCardFixture, attachedToPlanOrSubscription: true, ratesCount: 0 },
+      }),
+    )
+
+    const contentProps = (lastDrawerArgs?.children as ReactElement)?.props
+
+    expect(contentProps?.hasRates).toBe(false)
+    expect(contentProps?.isAttached).toBe(true)
+  })
+
+  // `RateCards::UpdateService` rejects a changed code on `attached_to_plan_or_subscription?`,
+  // so the input follows that flag rather than the narrower subscriptions one.
+  it('locks the code input as soon as the rate card sits in a plan', () => {
+    const { result } = renderDrawerHook()
+
+    act(() =>
+      result.current.openDrawer({
+        rateCard: { ...rateCardFixture, attachedToPlanOrSubscription: true },
+      }),
+    )
+
+    const contentProps = (lastDrawerArgs?.children as ReactElement)?.props
+
+    expect(contentProps?.disableCodeInput).toBe(true)
+  })
+
+  it('keeps the code input editable on an unattached edit', () => {
     const { result } = renderDrawerHook()
 
     act(() => result.current.openDrawer({ rateCard: rateCardFixture }))
 
     const contentProps = (lastDrawerArgs?.children as ReactElement)?.props
 
-    expect(contentProps?.isLocked).toBe(false)
-    expect(contentProps?.disableCodeInput).toBe(true)
+    expect(contentProps?.isAttached).toBe(false)
+    expect(contentProps?.disableCodeInput).toBe(false)
   })
 })

--- a/src/pages/catalog/drawers/rateCard/constants.ts
+++ b/src/pages/catalog/drawers/rateCard/constants.ts
@@ -15,10 +15,10 @@ export const RATE_CARD_FORM_SUBMIT_TEST_ID = 'rate-card-form-submit'
 // enforces it, since the field still carries the empty default until the user picks one.
 export const rateCardDrawerSchema = z
   .object({
-    name: z.string().min(1, 'text_1771342980565bx64zqq2mjs'),
-    code: z.string().min(1, 'text_1771342994699klxu2paz7g9'),
+    name: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
+    code: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
     description: z.string(),
-    productId: z.string().min(1, 'text_1771342994699klxu2paz7g8'),
+    productId: z.string().min(1, { message: 'text_624ea7c29103fd010732ab7d' }),
     productFilterId: z.string(),
     pricingUnit: z.string().optional(),
     currency: z.union([z.nativeEnum(CurrencyEnum), z.literal('')]),

--- a/src/pages/catalog/drawers/rateCard/useRateCardDrawer.tsx
+++ b/src/pages/catalog/drawers/rateCard/useRateCardDrawer.tsx
@@ -219,6 +219,13 @@ const useRateCardForm = ({ onSuccess }: { onSuccess: (result: RateCardFormSucces
         return
       }
 
+      // `silentErrorCodes` swallows everything else, so without this the submit looks like a
+      // no-op.
+      if (errors?.length) {
+        addToast({ severity: 'danger', translateKey: 'text_1788957148209tdcqiord3ut' })
+        return
+      }
+
       if (rateCard) {
         onSuccess({ rateCard, wasEdit: !!editedRateCard })
       }

--- a/src/pages/catalog/drawers/rateCard/useRateCardDrawer.tsx
+++ b/src/pages/catalog/drawers/rateCard/useRateCardDrawer.tsx
@@ -54,6 +54,7 @@ gql`
     walletTargetable
     attachedToPlanOrSubscription
     attachedToSubscriptions
+    ratesCount
     product {
       id
       name
@@ -168,14 +169,15 @@ const useRateCardForm = ({ onSuccess }: { onSuccess: (result: RateCardFormSucces
       let errors: FetchResult['errors']
 
       // Update serializes cleared optional fields to null (undefined would be
-      // stripped and the previous value would never clear); code, product item
-      // and product item filter are create-only, so they are not sent on update.
+      // stripped and the previous value would never clear); product item and
+      // product item filter are create-only, so they are not sent on update.
       if (editedRateCard) {
         const result = await updateRateCard({
           variables: {
             input: {
               id: editedRateCard.id,
               name: value.name,
+              code: value.code,
               description: value.description || null,
               billingTiming: value.billingTiming,
               proration: value.proration,
@@ -212,7 +214,7 @@ const useRateCardForm = ({ onSuccess }: { onSuccess: (result: RateCardFormSucces
 
       // Backend rejected a duplicate code: surface it under the Code input and
       // keep the drawer open.
-      if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
+      if (hasDefinedGQLError('ValueAlreadyExist', errors, 'code')) {
         applyExistingCodeError(formApi)
         return
       }
@@ -329,9 +331,10 @@ export const useRateCardDrawer = () => {
     resetForm(rateCard, attachToProduct, attachToProductFilter)
 
     const isEdit = !!rateCard
-    // Attaching a rate card to a plan/subscription freezes everything except the
-    // display fields (name / description).
-    const isLocked = !!(rateCard?.attachedToPlanOrSubscription || rateCard?.attachedToSubscriptions)
+    // `RateCards::UpdateService`: `LOCKED_WITH_RATES` freezes the billing-semantic fields
+    // once a rate exists, and the currency additionally freezes on attachment.
+    const isAttached = !!rateCard?.attachedToPlanOrSubscription
+    const hasRates = (rateCard?.ratesCount ?? 0) > 0
 
     const productSource = rateCard?.product ?? attachToProductFilter?.product ?? attachToProduct
     const productSeed: RateCardProductSeed = productSource
@@ -377,8 +380,9 @@ export const useRateCardDrawer = () => {
         <RateCardDrawerContent
           form={form}
           isEdit={isEdit}
-          isLocked={isLocked}
-          disableCodeInput={isLocked || isEdit}
+          isAttached={isAttached}
+          hasRates={hasRates}
+          disableCodeInput={isAttached}
           productSeed={productSeed}
           productFilterSeed={productFilterSeed}
           resetSignal={resetSignal}

--- a/src/pages/catalog/drawers/rateCardRate/RateCardRateDrawerContent.tsx
+++ b/src/pages/catalog/drawers/rateCardRate/RateCardRateDrawerContent.tsx
@@ -15,6 +15,7 @@ import { ChargeModelSelector } from '~/components/plans/chargeAccordion/ChargeMo
 import { ChargeWrapperSwitch } from '~/components/plans/chargeAccordion/ChargeWrapperSwitch'
 import { SpendingMinimumOptionSection } from '~/components/plans/chargeAccordion/SpendingMinimumOptionSection'
 import { useCustomChargeDrawer } from '~/components/plans/drawers/common/useCustomChargeDrawer'
+import { clearExistingCodeError } from '~/core/form/existingCodeError'
 import { getCurrencySymbol } from '~/core/formats/intlFormatNumber'
 import getPropertyShape from '~/core/serializers/getPropertyShape'
 import { getTimezoneConfig } from '~/core/timezone'
@@ -229,6 +230,8 @@ const RateCardRateDrawerFormSections = withForm({
             name="code"
             listeners={{
               onChange: () => {
+                clearExistingCodeError(form)
+
                 if (isSeedingCodeRef.current) return
 
                 isCodeDerivedFromDateRef.current = false
@@ -241,7 +244,7 @@ const RateCardRateDrawerFormSections = withForm({
                 label={translate('text_629728388c4d2300e2d380b7')}
                 placeholder={translate('text_629728388c4d2300e2d380d9')}
                 beforeChangeFormatter="code"
-                disabled={isActiveRate || isCodeLocked}
+                disabled={isCodeLocked}
               />
             )}
           </form.AppField>

--- a/src/pages/catalog/drawers/rateCardRate/__tests__/RateCardRateDrawerContent.test.tsx
+++ b/src/pages/catalog/drawers/rateCardRate/__tests__/RateCardRateDrawerContent.test.tsx
@@ -1,6 +1,7 @@
 import { act, configure, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import { applyExistingCodeError, EXISTING_CODE_ERROR_MESSAGE } from '~/core/form/existingCodeError'
 import {
   AggregationTypeEnum,
   CurrencyEnum,
@@ -27,6 +28,7 @@ const CODE_PROBE_TEST_ID = 'code-probe'
 const DIRTY_PROBE_TEST_ID = 'dirty-probe'
 const CUSTOM_PROPERTIES_PROBE_TEST_ID = 'custom-properties-probe'
 const SET_DATE_BUTTON_TEST_ID = 'set-date'
+const APPLY_CODE_ERROR_BUTTON_TEST_ID = 'apply-code-error'
 const SET_SECOND_DATE_BUTTON_TEST_ID = 'set-second-date'
 const CHANGE_MODEL_BUTTON_TEST_ID = 'change-model'
 const SET_SPENDING_MINIMUM_BUTTON_TEST_ID = 'clear-spending-minimum'
@@ -137,6 +139,12 @@ const Host = ({
 
   return (
     <>
+      <button
+        data-test={APPLY_CODE_ERROR_BUTTON_TEST_ID}
+        onClick={() => applyExistingCodeError(form)}
+      >
+        apply code error
+      </button>
       <button
         data-test={SET_DATE_BUTTON_TEST_ID}
         onClick={() => form.setFieldValue('effectiveFrom', '2026-01-24T00:00:00.000Z')}
@@ -386,13 +394,27 @@ describe('RateCardRateDrawerContent', () => {
 
   describe('GIVEN the edited rate is already active', () => {
     describe('WHEN the drawer body renders', () => {
-      it.each([
-        ['code', RATE_CARD_RATE_DRAWER_CODE_TEST_ID],
-        ['billing interval count', RATE_CARD_RATE_DRAWER_BILLING_INTERVAL_COUNT_TEST_ID],
-      ])('THEN disables the %s input', (_, testId) => {
+      it('THEN disables the billing interval count input', () => {
         render(<Host isEdit isActiveRate />)
 
-        expect(screen.getByTestId(testId).querySelector('input')).toBeDisabled()
+        expect(
+          screen
+            .getByTestId(RATE_CARD_RATE_DRAWER_BILLING_INTERVAL_COUNT_TEST_ID)
+            .querySelector('input'),
+        ).toBeDisabled()
+      })
+
+      // `code` is not in `FROZEN_ON_ACTIVE`; only the parent card's attachment freezes it.
+      it('THEN keeps the code input editable while the parent card is unattached', () => {
+        render(<Host isEdit isActiveRate />)
+
+        expect(codeInput()).toBeEnabled()
+      })
+
+      it('THEN disables the code input once the parent card is attached', () => {
+        render(<Host isEdit isActiveRate isCodeLocked />)
+
+        expect(codeInput()).toBeDisabled()
       })
 
       it('THEN disables the billing interval unit', () => {
@@ -501,6 +523,26 @@ describe('RateCardRateDrawerContent', () => {
           screen.getByTestId(RATE_CARD_RATE_DRAWER_CODE_TEST_ID).querySelector('input'),
         ).not.toBeDisabled()
         expect(mockChargeModelSelectorProps.disabled).toBe(false)
+      })
+    })
+  })
+
+  describe('GIVEN the backend rejected the code as already existing', () => {
+    describe('WHEN the user retypes the code', () => {
+      // Left set, the manual error survives every later validation pass and the
+      // submit button stays disabled until the drawer is reopened.
+      it('THEN clears the error', async () => {
+        const user = userEvent.setup()
+
+        await act(() => render(<Host />))
+
+        await user.click(screen.getByTestId(APPLY_CODE_ERROR_BUTTON_TEST_ID))
+
+        expect(screen.getByText(EXISTING_CODE_ERROR_MESSAGE)).toBeInTheDocument()
+
+        await user.type(codeInput(), 'x')
+
+        expect(screen.queryByText(EXISTING_CODE_ERROR_MESSAGE)).not.toBeInTheDocument()
       })
     })
   })

--- a/src/pages/catalog/drawers/rateCardRate/__tests__/useRateCardRateDrawer.test.tsx
+++ b/src/pages/catalog/drawers/rateCardRate/__tests__/useRateCardRateDrawer.test.tsx
@@ -211,13 +211,14 @@ describe('useRateCardRateDrawer edit flow', () => {
 
         expect(capturedInput).toMatchObject({ id: 'rate-1' })
         expect(capturedInput).toHaveProperty('rateProperties')
-        // FROZEN_ON_ACTIVE + the code, which the design freezes too.
         expect(capturedInput).not.toHaveProperty('effectiveFrom')
         expect(capturedInput).not.toHaveProperty('rateModel')
         expect(capturedInput).not.toHaveProperty('billingIntervalCount')
         expect(capturedInput).not.toHaveProperty('billingIntervalUnit')
         expect(capturedInput).not.toHaveProperty('minAmountCents')
-        expect(capturedInput).not.toHaveProperty('code')
+        // `code` is not in FROZEN_ON_ACTIVE, and the service only rejects it when it
+        // actually changed, so an unchanged code rides along like everywhere else.
+        expect(capturedInput).toHaveProperty('code')
       })
 
       it('THEN tells the body to lock the timeline fields', () => {

--- a/src/pages/catalog/drawers/rateCardRate/useRateCardRateForm.tsx
+++ b/src/pages/catalog/drawers/rateCardRate/useRateCardRateForm.tsx
@@ -185,12 +185,12 @@ export const useRateCardRateForm = ({
         const isActiveRate = editedRate.status === RateCardRateStatusEnum.Active
         const input: UpdateRateCardRateInput = {
           id: editedRate.id,
+          code: value.code,
           rateProperties,
           ...conversionRate,
           ...(isActiveRate
             ? {}
             : {
-                code: value.code,
                 effectiveFrom: value.effectiveFrom,
                 rateModel: value.rateModel,
                 billingIntervalCount: Number(value.billingIntervalCount),

--- a/src/styles/muiTheme.ts
+++ b/src/styles/muiTheme.ts
@@ -153,7 +153,7 @@ export const theme = createTheme({
           outlineOffset: '-1px',
           '&.chip-size--small': {
             minHeight: '20px',
-            padding: '0px 4px',
+            padding: '0px 8px',
           },
           '&.chip-size--big': {
             minHeight: '40px',

--- a/translations/base.json
+++ b/translations/base.json
@@ -4919,5 +4919,9 @@
   "text_178851170779693if5ma3vv3": "Connection successfully set as default",
   "text_1788511707796mofp375vjec": "Default on customer",
   "text_1788938888298p8mb2uxfk5l": "Display in quote document",
-  "text_1788938888298tobp5ik7edt": "When turned off, this charge is hidden from the quote’s pricing table. It is still part of the quote and is billed normally once the quote is approved."
+  "text_1788938888298tobp5ik7edt": "When turned off, this charge is hidden from the quote’s pricing table. It is still part of the quote and is billed normally once the quote is approved.",
+  "text_1788957148209uhcnfxybu4e": "This product could not be saved. Please check its settings and try again.",
+  "text_1788957148209wyppwdnny7d": "This product category could not be saved. Please check its settings and try again.",
+  "text_1788957148209054ur2tx4nr": "This product filter could not be saved. Please check its settings and try again.",
+  "text_1788957148209tdcqiord3ut": "This rate card could not be saved. Please check its settings and try again."
 }


### PR DESCRIPTION
## Context

A batch of adjustments on the product catalog detail pages and drawers. Three
things were off: the product category / product / product filter rows were
duplicated across four overview components and had drifted apart, rate card
field locking did not match what the backend actually accepts on update, and a
duplicate-code rejection could land under the Code input even when the conflict
was on another field.

## Description

**Shared relations grid.** The four detail overviews (`ProductDetailsOverview`,
`ProductFilterDetailsOverview`, `RateCardDetailsOverview`,
`RateCardRateDetailsOverview`) each built their own product category / product /
product filter rows. They had drifted: only two of them preferred
`invoiceDisplayName` over `name`, only two carried a `data-test` on the
"no category" placeholder, and two rendered a dash for a missing product filter
while the others omitted the row. `CatalogRelationsInfoGrid` now owns all of it,
and the fragments select `invoiceDisplayName` everywhere the link is rendered.

Two user-visible consequences, both intentional: the product filter row is now
hidden when there is no filter rather than showing a dash, and the pricing unit
row on the rate card overview always renders (with a dash) instead of
disappearing when no pricing unit is set.

**Rate card locking.** `isLocked` conflated two distinct backend rules. Per
`RateCards::UpdateService`, `LOCKED_WITH_RATES` freezes the billing-semantic
fields once a rate exists, and the currency additionally freezes once the rate
card is attached to a plan or subscription. Split into `hasRates` (from the new
`ratesCount` selection) and `isAttached`. The old flag also froze the code
input, which the backend does accept on update, so `code` is now sent on both
rate card and rate card rate updates and the input is only disabled on
attachment.

**Duplicate-code errors.** `hasDefinedGQLError('ValueAlreadyExist', errors)`
matches any field in `extensions.details`, so a conflict on a different field
surfaced under the Code input. All four catalog drawers now pass the `'code'`
key, matching the pattern already used in `CreateCustomer` and
`useEditOrganizationSlugDialog`. The rate card rate code field also clears the
error as the user types, which the other drawers already did.

**Smaller items.** `NameAndCodeGroup` accepts `nameDataTest` / `codeDataTest` so
the code inputs are addressable from tests; the rate card zod schema uses the
shared required-field message instead of three keys, one of which was borrowed
from the coupon form; small chips get 8px horizontal padding instead of 4px.

`src/generated/graphql.tsx` also picks up unrelated schema drift from the
regeneration (the `catalogPlan` / `catalogPlans` queries, `Contract.plan`
retyped to `CatalogPlan`, and `productCategoryId` dropped from `plans`).
Verified that nothing in `src/` passed `productCategoryId` to the `plans` query,
and the typecheck is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)