### PR TITLE
fix(connections): gate the connection code field behind the flag

### DIFF
--- a/src/components/customerConnections/CustomerConnectionDrawer.tsx
+++ b/src/components/customerConnections/CustomerConnectionDrawer.tsx
@@ -7,6 +7,7 @@ import { focusFirstInput } from '~/components/drawers/useFocusTrap'
 import { CenteredPage } from '~/components/layouts/CenteredPage'
 import { clearExistingCodeError } from '~/core/form/existingCodeError'
 import {
+  FeatureFlagEnum,
   HubspotTargetedObjectsEnum,
   IntegrationTypeEnum,
   ProviderPaymentMethodsEnum,
@@ -14,6 +15,7 @@ import {
 } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { useAppForm } from '~/hooks/forms/useAppform'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
 import { ConnectionComboBoxDataItem } from './ConnectionComboBox'
 import { ConnectionDrawerSection } from './ConnectionDrawerSection'
@@ -192,6 +194,8 @@ export const CustomerConnectionDrawer = forwardRef<
 >(({ onSave, connectionOptions, renderProviderContent }, ref) => {
   const { translate } = useInternationalization()
   const drawer = useFormDrawer()
+  const { hasFeatureFlag } = useOrganizationInfos()
+  const isMultiConnectionEnabled = hasFeatureFlag(FeatureFlagEnum.MultiConnection)
 
   const [context, setContext] = useState<{
     category: ConnectionCategory
@@ -246,19 +250,21 @@ export const CustomerConnectionDrawer = forwardRef<
                 lockedSelection={lockedSelection}
               />
 
-              <form.AppField
-                name="code"
-                listeners={{ onChange: () => clearExistingCodeError(form) }}
-              >
-                {(field) => (
-                  <field.TextInputField
-                    data-test={CONNECTION_CODE_FIELD_TEST_ID}
-                    label={translate('text_629728388c4d2300e2d380b7')}
-                    placeholder={translate('text_1788433814031zeagk490c7a')}
-                    beforeChangeFormatter="code"
-                  />
-                )}
-              </form.AppField>
+              {isMultiConnectionEnabled && (
+                <form.AppField
+                  name="code"
+                  listeners={{ onChange: () => clearExistingCodeError(form) }}
+                >
+                  {(field) => (
+                    <field.TextInputField
+                      data-test={CONNECTION_CODE_FIELD_TEST_ID}
+                      label={translate('text_629728388c4d2300e2d380b7')}
+                      placeholder={translate('text_1788433814031zeagk490c7a')}
+                      beforeChangeFormatter="code"
+                    />
+                  )}
+                </form.AppField>
+              )}
             </ConnectionDrawerSection>
 
             {renderProviderContent?.(form, { category, isEdition })}

--- a/src/components/customerConnections/__tests__/CustomerConnectionDrawer.test.tsx
+++ b/src/components/customerConnections/__tests__/CustomerConnectionDrawer.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { createRef } from 'react'
 
 import { applyExistingCodeError } from '~/core/form/existingCodeError'
+import { FeatureFlagEnum } from '~/generated/graphql'
 import { render } from '~/test-utils'
 
 import {
@@ -17,6 +18,7 @@ import { CONNECTION_CATEGORY_SHORT_LABEL_KEYS, ConnectionCategory } from '../typ
 
 const mockOpen = jest.fn()
 const mockClose = jest.fn()
+const mockHasFeatureFlag = jest.fn(() => true)
 
 jest.mock('~/components/drawers/useDrawer', () => ({
   useFormDrawer: () => ({ open: mockOpen, close: mockClose }),
@@ -24,6 +26,11 @@ jest.mock('~/components/drawers/useDrawer', () => ({
 
 jest.mock('~/hooks/core/useInternationalization', () => ({
   useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  ...jest.requireActual('~/hooks/useOrganizationInfos'),
+  useOrganizationInfos: () => ({ hasFeatureFlag: mockHasFeatureFlag }),
 }))
 
 const FORM_ID = 'customer-connection-drawer-form'
@@ -34,6 +41,11 @@ const VALID_PAYMENT_VALUES: Partial<ConnectionFormValues> = {
   externalCustomerId: 'cus_123',
   syncWithProvider: false,
   providerPaymentMethods: { card: true },
+}
+
+const PAYMENT_VALUES_WITH_CODE: Partial<ConnectionFormValues> = {
+  ...VALID_PAYMENT_VALUES,
+  code: 'connection-1',
 }
 
 const renderDrawer = (overrides?: {
@@ -71,6 +83,7 @@ const getCodeInput = (): HTMLInputElement =>
 describe('CustomerConnectionDrawer', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockHasFeatureFlag.mockReturnValue(true)
   })
 
   describe('GIVEN the drawer is opened in create mode', () => {
@@ -349,6 +362,66 @@ describe('CustomerConnectionDrawer', () => {
           expect.objectContaining({ code: '' }),
           expect.anything(),
         )
+      })
+    })
+  })
+  describe('GIVEN the multi-connection feature flag gates the code field', () => {
+    describe('WHEN the drawer renders', () => {
+      it('THEN should read the gate from the multi-connection flag', () => {
+        renderDrawer()
+
+        expect(mockHasFeatureFlag).toHaveBeenCalledWith(FeatureFlagEnum.MultiConnection)
+      })
+    })
+
+    describe('WHEN the flag is disabled', () => {
+      beforeEach(() => {
+        mockHasFeatureFlag.mockReturnValue(false)
+      })
+
+      it.each([
+        ['create', undefined],
+        ['edit of a connection that already carries a code', PAYMENT_VALUES_WITH_CODE],
+      ])('THEN should not display the code input in %s mode', (_, initialValues) => {
+        const { ref } = renderDrawer()
+
+        act(() => ref.current?.openDrawer(ConnectionCategory.Payment, initialValues))
+
+        render(<>{getLastOpenArgs().children}</>)
+
+        expect(screen.queryByTestId(CONNECTION_CODE_FIELD_TEST_ID)).not.toBeInTheDocument()
+      })
+
+      it('THEN should leave the rest of the drawer untouched, the provider combobox still rendering', () => {
+        const { ref } = renderDrawer()
+
+        act(() => ref.current?.openDrawer(ConnectionCategory.Payment))
+
+        render(<>{getLastOpenArgs().children}</>)
+
+        expect(screen.getByRole('combobox')).toBeInTheDocument()
+      })
+
+      it('THEN should round-trip the code the connection was loaded with through onSave, unrendered', async () => {
+        const onSave = jest.fn().mockResolvedValue(true)
+        const { ref } = renderDrawer({ onSave })
+
+        act(() => ref.current?.openDrawer(ConnectionCategory.Payment, PAYMENT_VALUES_WITH_CODE))
+
+        render(<>{getLastOpenArgs().children}</>)
+
+        expect(screen.queryByTestId(CONNECTION_CODE_FIELD_TEST_ID)).not.toBeInTheDocument()
+
+        await act(async () => {
+          await getLastOpenArgs().form.submit()
+        })
+
+        expect(onSave).toHaveBeenCalledWith(
+          ConnectionCategory.Payment,
+          expect.objectContaining({ providerCode: 'stripe-1', code: 'connection-1' }),
+          expect.anything(),
+        )
+        expect(mockClose).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/src/components/customers/connectionsSection/__tests__/useCustomerConnectionsPersistence.test.ts
+++ b/src/components/customers/connectionsSection/__tests__/useCustomerConnectionsPersistence.test.ts
@@ -13,6 +13,7 @@ import {
 } from '~/core/constants/integrationPolling'
 import {
   AddCustomerDrawerFragment,
+  FeatureFlagEnum,
   HubspotTargetedObjectsEnum,
   IntegrationTypeEnum,
   LagoApiError,
@@ -62,6 +63,7 @@ const mockSetIntegrationDefault = jest.fn(() =>
 const mockClientQuery = jest.fn(() => Promise.resolve({ data: { customer: null } }))
 const mockAddToast = jest.fn()
 const mockApplyExistingCodeError = jest.fn()
+const mockHasFeatureFlag = jest.fn(() => true)
 
 const formApi = {} as CustomerConnectionDrawerFormApi
 
@@ -110,6 +112,11 @@ jest.mock('~/core/apolloClient', () => ({
 jest.mock('~/core/form/existingCodeError', () => ({
   ...jest.requireActual('~/core/form/existingCodeError'),
   applyExistingCodeError: (...args: unknown[]) => mockApplyExistingCodeError(...args),
+}))
+
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  ...jest.requireActual('~/hooks/useOrganizationInfos'),
+  useOrganizationInfos: () => ({ hasFeatureFlag: mockHasFeatureFlag }),
 }))
 
 /** The backend's non-persisted manual placeholder, prepended to the array */
@@ -185,6 +192,7 @@ const setup = () =>
 describe('useCustomerConnectionsPersistence', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockHasFeatureFlag.mockReturnValue(true)
   })
 
   describe('GIVEN a payment connection save', () => {
@@ -857,6 +865,24 @@ describe('useCustomerConnectionsPersistence', () => {
       )
     })
 
+    const ALREADY_USED_CODE_VALUES = {
+      code: 'already-used',
+      providerCode: 'stripe-eu',
+      providerType: ProviderTypeEnum.Stripe,
+      externalCustomerId: 'cus_123',
+    } as ConnectionFormValues
+
+    const rejectPaymentUpdateOnCode = (): void => {
+      mockUpdatePayment.mockResolvedValueOnce({
+        errors: [
+          {
+            message: 'Unprocessable Entity',
+            extensions: { details: { code: ['value_already_exist'] } },
+          },
+        ],
+      } as never)
+    }
+
     describe('WHEN the backend rejects another field as already used', () => {
       it('THEN should report it on a toast rather than on the Code input', async () => {
         mockUpdatePayment.mockResolvedValueOnce({
@@ -887,35 +913,48 @@ describe('useCustomerConnectionsPersistence', () => {
       })
     })
 
-    describe('WHEN the backend rejects the code as already used', () => {
-      it('THEN should surface it on the drawer Code input', async () => {
-        mockUpdatePayment.mockResolvedValueOnce({
-          errors: [
-            {
-              message: 'Unprocessable Entity',
-              extensions: { details: { code: ['value_already_exist'] } },
-            },
-          ],
-        } as never)
+    describe('WHEN the backend rejects the code as already used and the flag is enabled', () => {
+      it('THEN should surface it on the drawer Code input, not on the danger toast', async () => {
+        mockHasFeatureFlag.mockReturnValue(true)
+        rejectPaymentUpdateOnCode()
 
         const result = setup()
 
         const succeeded = await result.current.saveConnection(
           ConnectionCategory.Payment,
-          {
-            code: 'already-used',
-            providerCode: 'stripe-eu',
-            providerType: ProviderTypeEnum.Stripe,
-            externalCustomerId: 'cus_123',
-          } as ConnectionFormValues,
+          ALREADY_USED_CODE_VALUES,
           { isEdition: true, formApi },
         )
 
+        expect(mockHasFeatureFlag).toHaveBeenCalledWith(FeatureFlagEnum.MultiConnection)
         expect(succeeded).toBe(false)
         expect(mockApplyExistingCodeError).toHaveBeenCalledWith(formApi)
         expect(mockAddToast).not.toHaveBeenCalledWith(
+          expect.objectContaining({ severity: 'danger' }),
+        )
+        expect(mockAddToast).not.toHaveBeenCalledWith(
           expect.objectContaining({ severity: 'success' }),
         )
+      })
+    })
+
+    describe('WHEN the backend rejects the code as already used and the flag is disabled', () => {
+      it('THEN should surface it on the danger toast, never on the unrendered Code input', async () => {
+        mockHasFeatureFlag.mockReturnValue(false)
+        rejectPaymentUpdateOnCode()
+
+        const result = setup()
+
+        const succeeded = await result.current.saveConnection(
+          ConnectionCategory.Payment,
+          ALREADY_USED_CODE_VALUES,
+          { isEdition: true, formApi },
+        )
+
+        expect(mockHasFeatureFlag).toHaveBeenCalledWith(FeatureFlagEnum.MultiConnection)
+        expect(succeeded).toBe(false)
+        expect(mockApplyExistingCodeError).not.toHaveBeenCalled()
+        expect(mockAddToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'danger' }))
       })
     })
   })

--- a/src/components/customers/connectionsSection/useCustomerConnectionsPersistence.ts
+++ b/src/components/customers/connectionsSection/useCustomerConnectionsPersistence.ts
@@ -21,6 +21,7 @@ import {
 import { applyExistingCodeError } from '~/core/form/existingCodeError'
 import {
   AddCustomerDrawerFragment,
+  FeatureFlagEnum,
   GetCustomerDocument,
   GetCustomerQuery,
   LagoApiError,
@@ -34,6 +35,7 @@ import {
   useUpdateCustomerIntegrationConnectionMutation,
   useUpdateCustomerPaymentConnectionMutation,
 } from '~/generated/graphql'
+import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
 gql`
   mutation createCustomerPaymentConnection($input: CreatePaymentProviderCustomerInput!) {
@@ -125,6 +127,8 @@ export const useCustomerConnectionsPersistence = ({
   connectionOptions,
 }: UseCustomerConnectionsPersistenceProps): UseCustomerConnectionsPersistenceReturn => {
   const client = useApolloClient()
+  const { hasFeatureFlag } = useOrganizationInfos()
+  const isMultiConnectionEnabled = hasFeatureFlag(FeatureFlagEnum.MultiConnection)
 
   const silenceExistingCodeError = {
     context: { silentErrorDetails: [LagoApiError.ValueAlreadyExist] },
@@ -186,7 +190,13 @@ export const useCustomerConnectionsPersistence = ({
       const { data, errors } = await mutate()
 
       if (hasDefinedGQLError('ValueAlreadyExist', errors)) {
-        if (formApi && hasDefinedGQLError('ValueAlreadyExist', errors, 'code')) {
+        // Gated off, the code input is not rendered: painting the error on it
+        // would leave a silent failure behind a permanently invalid form
+        if (
+          formApi &&
+          isMultiConnectionEnabled &&
+          hasDefinedGQLError('ValueAlreadyExist', errors, 'code')
+        ) {
           applyExistingCodeError(formApi)
         } else {
           addToast({ severity: 'danger', translateKey: 'text_622f7a3dc32ce100c46a5154' })


### PR DESCRIPTION
## Context

The `code` input in the connection drawers shipped ungated, on a team decision that has now been reversed: it belongs behind `multi_connection` like the rest of the multi-connection UI. Flag off must restore the drawer exactly as it was before the field existed.

## Description

Render the code input only when the org carries the flag, mirroring the hook call the connections section already uses.

Gating the input alone was not enough. Shipping the field also moved the backend "code already exists" error off the danger toast and onto the input itself, so with the field unrendered that error painted onto nothing: no message anywhere, and a form left permanently invalid behind a dead Save button — worse than the behaviour the flag off is meant to restore. The persistence hook now routes that error by the same gate and falls back to the toast.

Tests cover both flag states on both surfaces, including that a connection which already carries a code — set while the field was live ungated — still round-trips that value untouched with the field hidden.

<!-- Linear link -->
Fixes ING-668