### PR TITLE
feat(quotes): add a documentation link to the quote editor

### DIFF
--- a/src/core/constants/externalUrls.ts
+++ b/src/core/constants/externalUrls.ts
@@ -12,6 +12,7 @@ export const DOCUMENTATION_ENV_VARS =
   'https://docs.getlago.com/guide/lago-self-hosted/docker#environment-variables'
 export const DOCUMENTATION_EINVOICING =
   'https://docs.getlago.com/guide/invoicing/e-invoicing/overview'
+export const DOCUMENTATION_QUOTE_EDITOR = 'https://getlago.com/docs/guide/quotes/quote-editor'
 export const FEATURE_REQUESTS_URL = 'https://getlago.canny.io/feature-requests'
 export const ADYEN_SUCCESS_LINK_SPEC_URL =
   'https://docs.adyen.com/api-explorer/Checkout/latest/post/payments#request-returnUrl'

--- a/src/core/constants/externalUrls.ts
+++ b/src/core/constants/externalUrls.ts
@@ -12,7 +12,7 @@ export const DOCUMENTATION_ENV_VARS =
   'https://docs.getlago.com/guide/lago-self-hosted/docker#environment-variables'
 export const DOCUMENTATION_EINVOICING =
   'https://docs.getlago.com/guide/invoicing/e-invoicing/overview'
-export const DOCUMENTATION_QUOTE_EDITOR = 'https://getlago.com/docs/guide/quotes/quote-editor'
+export const DOCUMENTATION_QUOTE_EDITOR = 'https://docs.getlago.com/guide/quotes/quote-editor'
 export const FEATURE_REQUESTS_URL = 'https://getlago.canny.io/feature-requests'
 export const ADYEN_SUCCESS_LINK_SPEC_URL =
   'https://docs.adyen.com/api-explorer/Checkout/latest/post/payments#request-returnUrl'

--- a/src/pages/quotes/EditQuote.tsx
+++ b/src/pages/quotes/EditQuote.tsx
@@ -21,6 +21,7 @@ import { Skeleton } from '~/components/designSystem/Skeleton'
 import { Status, StatusType } from '~/components/designSystem/Status'
 import { Typography } from '~/components/designSystem/Typography'
 import { RightAsidePage } from '~/components/layouts/RightAsidePage'
+import { DOCUMENTATION_QUOTE_EDITOR } from '~/core/constants/externalUrls'
 import { QuoteDetailsTabsOptionsEnum } from '~/core/constants/tabsOptions'
 import { QUOTE_DETAILS_ROUTE, useNavigate } from '~/core/router'
 import type { BillingItemsPayload } from '~/core/serializers/serializeQuoteBillingItems'
@@ -42,6 +43,7 @@ import { useUpdateQuote } from './hooks/useUpdateQuote'
 const AUTO_SAVE_DELAY_MS = 2000
 
 export const EDIT_QUOTE_PRICING_CTA_TEST_ID = 'edit-quote-pricing-cta'
+export const EDIT_QUOTE_DOCUMENTATION_TEST_ID = 'edit-quote-documentation'
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
 
@@ -566,6 +568,14 @@ const EditQuote = () => {
         onClose={handleClose}
         isCloseButtonDisabled={isUpdating}
       >
+        <Button
+          variant="quaternary"
+          startIcon="book"
+          data-test={EDIT_QUOTE_DOCUMENTATION_TEST_ID}
+          onClick={() => window.open(DOCUMENTATION_QUOTE_EDITOR, '_blank')}
+        >
+          {translate('text_6295e58352f39200d902b01c')}
+        </Button>
         <Button
           variant="tertiary"
           onClick={() => setEditorMode((m) => (m === 'edit' ? 'preview' : 'edit'))}

--- a/src/pages/quotes/__tests__/EditQuote.test.tsx
+++ b/src/pages/quotes/__tests__/EditQuote.test.tsx
@@ -549,7 +549,7 @@ describe('EditQuote', () => {
         await user.click(screen.getByTestId(EDIT_QUOTE_DOCUMENTATION_TEST_ID))
 
         expect(openSpy).toHaveBeenCalledWith(
-          'https://getlago.com/docs/guide/quotes/quote-editor',
+          'https://docs.getlago.com/guide/quotes/quote-editor',
           '_blank',
         )
 

--- a/src/pages/quotes/__tests__/EditQuote.test.tsx
+++ b/src/pages/quotes/__tests__/EditQuote.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { act } from 'react'
 
@@ -7,7 +7,10 @@ import { makeEmptyWalletItem, toWallets } from '~/core/serializers/serializeQuot
 import { CurrencyEnum } from '~/generated/graphql'
 import { render, testMockNavigateFn } from '~/test-utils'
 
-import EditQuote, { EDIT_QUOTE_PRICING_CTA_TEST_ID } from '../EditQuote'
+import EditQuote, {
+  EDIT_QUOTE_DOCUMENTATION_TEST_ID,
+  EDIT_QUOTE_PRICING_CTA_TEST_ID,
+} from '../EditQuote'
 
 // --- Shared state for mocks ---
 
@@ -521,6 +524,49 @@ describe('EditQuote', () => {
         await waitFor(() => {
           expect(screen.getByText('text_1779278937735vlpgsllouzy')).toBeInTheDocument()
         })
+      })
+    })
+  })
+
+  describe('GIVEN the documentation link', () => {
+    describe('WHEN the quote is loaded', () => {
+      it('THEN should display the documentation button in the header', () => {
+        render(<EditQuote />)
+
+        const header = screen.getByTestId(RIGHT_ASIDE_PAGE_HEADER_TEST_ID)
+
+        expect(within(header).getByTestId(EDIT_QUOTE_DOCUMENTATION_TEST_ID)).toBeInTheDocument()
+      })
+    })
+
+    describe('WHEN the documentation button is clicked', () => {
+      it('THEN should open the quote editor documentation in a new tab', async () => {
+        const user = userEvent.setup()
+        const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
+
+        render(<EditQuote />)
+
+        await user.click(screen.getByTestId(EDIT_QUOTE_DOCUMENTATION_TEST_ID))
+
+        expect(openSpy).toHaveBeenCalledWith(
+          'https://getlago.com/docs/guide/quotes/quote-editor',
+          '_blank',
+        )
+
+        openSpy.mockRestore()
+      })
+
+      it('THEN should not navigate away from the editor', async () => {
+        const user = userEvent.setup()
+        const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
+
+        render(<EditQuote />)
+
+        await user.click(screen.getByTestId(EDIT_QUOTE_DOCUMENTATION_TEST_ID))
+
+        expect(testMockNavigateFn).not.toHaveBeenCalled()
+
+        openSpy.mockRestore()
       })
     })
   })


### PR DESCRIPTION
## Context

Users editing a quote have no pointer to the quote-editor documentation, so they do not discover everything the editor supports while writing the quote content. The ticket asks for quick access to https://getlago.com/docs/guide/quotes/quote-editor from the quote edition screen. No design was provided.

## Description

- Add a `DOCUMENTATION_QUOTE_EDITOR` constant in `src/core/constants/externalUrls.ts`, next to the other `DOCUMENTATION_*` entries.
- Render a "Documentation" button in the `EditQuote` page header, first in the right-hand action group, before the edit/preview toggle. It uses the `book` start icon and opens the documentation in a new tab, following the pattern already used on the integrations settings pages.
- Reuse the existing "Documentation" translation key — no new key added.
- Cover the new button with tests: presence in the header, the click opening the doc URL in a new tab, and no navigation away from the editor.

<!-- Linear link -->
Fixes LAGO-1926