### PR TITLE
fix(quotes): display the quote currency in the charge currency combobox

### DIFF
--- a/src/components/plans/chargeAccordion/CustomPricingUnitSelector.tsx
+++ b/src/components/plans/chargeAccordion/CustomPricingUnitSelector.tsx
@@ -30,6 +30,24 @@ export const CustomPricingUnitSelector = ({
   const { translate } = useInternationalization()
   const { pricingUnits } = useCustomPricingUnits()
 
+  const fiatPricingUnitOption = useMemo(
+    () => ({
+      label: currency,
+      value: `${currency}${CUSTOM_PRICING_UNIT_SEPARATOR}${currency}${CUSTOM_PRICING_UNIT_SEPARATOR}${LocalPricingUnitType.Fiat}`,
+      labelNode: (
+        <ComboboxItem>
+          <Typography variant="body" color="grey700" noWrap>
+            {currency}
+          </Typography>
+          <Typography variant="caption" color="grey600" noWrap>
+            {translate('text_1750411499858a87tkuylqms')}
+          </Typography>
+        </ComboboxItem>
+      ),
+    }),
+    [currency, translate],
+  )
+
   const pricingUnitDataForCombobox = useMemo(() => {
     const formatedPricingUnits = pricingUnits.map((pricingUnit) => ({
       label: pricingUnit.name,
@@ -46,24 +64,24 @@ export const CustomPricingUnitSelector = ({
       ),
     }))
 
-    return [
-      {
-        label: currency,
-        value: `${currency}${CUSTOM_PRICING_UNIT_SEPARATOR}${currency}${CUSTOM_PRICING_UNIT_SEPARATOR}${LocalPricingUnitType.Fiat}`,
-        labelNode: (
-          <ComboboxItem>
-            <Typography variant="body" color="grey700" noWrap>
-              {currency}
-            </Typography>
-            <Typography variant="caption" color="grey600" noWrap>
-              {translate('text_1750411499858a87tkuylqms')}
-            </Typography>
-          </ComboboxItem>
-        ),
-      },
-      ...formatedPricingUnits,
-    ]
-  }, [currency, pricingUnits, translate])
+    return [fiatPricingUnitOption, ...formatedPricingUnits]
+  }, [fiatPricingUnitOption, pricingUnits])
+
+  // `ComboBox` only resolves a label when the value is one of the options' joined triples,
+  // so a bare `appliedPricingUnit.code` would render raw or, when absent, render nothing.
+  const selectedPricingUnitValue = useMemo(() => {
+    const appliedPricingUnit = localCharge.appliedPricingUnit
+
+    if (appliedPricingUnit?.type !== LocalPricingUnitType.Custom) {
+      return fiatPricingUnitOption.value
+    }
+
+    const matchingOption = pricingUnitDataForCombobox.find(
+      ({ value }) => value.split(CUSTOM_PRICING_UNIT_SEPARATOR)[0] === appliedPricingUnit.code,
+    )
+
+    return matchingOption?.value ?? appliedPricingUnit.code
+  }, [localCharge.appliedPricingUnit, pricingUnitDataForCombobox, fiatPricingUnitOption])
 
   return (
     <div className="flex flex-col gap-3">
@@ -75,7 +93,7 @@ export const CustomPricingUnitSelector = ({
         label={translate('text_1750411499858etvdxpxm4vd')}
         sortValues={false}
         data={pricingUnitDataForCombobox}
-        value={localCharge.appliedPricingUnit?.code}
+        value={selectedPricingUnitValue}
         onChange={(value) => {
           const [code, shortName, type] = value.split(CUSTOM_PRICING_UNIT_SEPARATOR)
 

--- a/src/components/plans/chargeAccordion/__tests__/CustomPricingUnitSelector.test.tsx
+++ b/src/components/plans/chargeAccordion/__tests__/CustomPricingUnitSelector.test.tsx
@@ -150,4 +150,68 @@ describe('CustomPricingUnitSelector', () => {
       })
     })
   })
+  describe('GIVEN the charge currency displayed value', () => {
+    describe('WHEN no pricing unit is applied', () => {
+      it('THEN should display the context currency', () => {
+        render(<CustomPricingUnitSelector {...defaultProps} localCharge={buildLocalCharge()} />)
+
+        const input = screen
+          .getByTestId(PRICING_UNIT_COMBOBOX_TEST_ID)
+          .querySelector('input') as HTMLInputElement
+
+        expect(input.value).toBe(CurrencyEnum.Usd)
+      })
+    })
+
+    describe('WHEN the applied pricing unit is fiat with a code differing from the currency', () => {
+      it('THEN should display the context currency', () => {
+        render(
+          <CustomPricingUnitSelector
+            {...defaultProps}
+            localCharge={buildLocalCharge({ type: LocalPricingUnitType.Fiat, code: 'EUR' })}
+          />,
+        )
+
+        const input = screen
+          .getByTestId(PRICING_UNIT_COMBOBOX_TEST_ID)
+          .querySelector('input') as HTMLInputElement
+
+        expect(input.value).toBe(CurrencyEnum.Usd)
+      })
+    })
+
+    describe('WHEN a known custom pricing unit is applied', () => {
+      it('THEN should display the pricing unit name', () => {
+        render(
+          <CustomPricingUnitSelector
+            {...defaultProps}
+            localCharge={buildLocalCharge({ code: 'credits' })}
+          />,
+        )
+
+        const input = screen
+          .getByTestId(PRICING_UNIT_COMBOBOX_TEST_ID)
+          .querySelector('input') as HTMLInputElement
+
+        expect(input.value).toBe('Credits')
+      })
+    })
+
+    describe('WHEN the applied custom pricing unit is no longer configured', () => {
+      it('THEN should display its raw code', () => {
+        render(
+          <CustomPricingUnitSelector
+            {...defaultProps}
+            localCharge={buildLocalCharge({ code: 'deleted-unit' })}
+          />,
+        )
+
+        const input = screen
+          .getByTestId(PRICING_UNIT_COMBOBOX_TEST_ID)
+          .querySelector('input') as HTMLInputElement
+
+        expect(input.value).toBe('deleted-unit')
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Context

In the quote editor, opening a plan → a usage charge showed a **Pricing unit settings** section whose disabled **Charge currency** combobox rendered empty instead of the quote's currency.

## Description

`CustomPricingUnitSelector` passed the bare `appliedPricingUnit.code` as the ComboBox value while every option's value is the `code::-::shortName::-::type` triple, so no option ever matched — and in the quote editor that code is `undefined` altogether (`usePlanFormSetup` runs there without `hasAnyPricingUnitConfigured`, and a saved quote only serializes an applied pricing unit when one was set), which is what left the field blank. The selected value is now resolved to a real option: a custom unit maps to its own option (so it displays the unit's name rather than its code), and anything else — `undefined` or fiat — maps to the fiat option, which carries the context currency (the quote currency here, `amountCurrency` in the plan form). This stays display-only since both serializers send `appliedPricingUnit: null` for fiat, making "no applied pricing unit" and "fiat in the context currency" the same payload. Four cases were added to the existing test suite.

<!-- Linear link -->