### PR TITLE
fix(invoices): pin date picker to its declared timezone

### DIFF
--- a/src/components/form/DatePicker/DatePicker.tsx
+++ b/src/components/form/DatePicker/DatePicker.tsx
@@ -79,12 +79,15 @@ export const DatePicker = ({
   /**
    * Date will be passed to the parent as ISO
    * So we need to make sure to re-transform to DateTime for the component to read it
+   *
+   * Parsed in `defaultZone` rather than the ambient zone: the `Settings.defaultZone`
+   * effect below only runs after the first render, and MUI freezes the calendar on it.
    */
   const getValueFormatted = useCallback(() => {
     if (!value) return null
 
-    return typeof value === 'string' ? DateTime.fromISO(value) : value
-  }, [value])
+    return typeof value === 'string' ? DateTime.fromISO(value, { zone: defaultZone }) : value
+  }, [defaultZone, value])
 
   const [localDate, setLocalDate] = useState<DateTime | null>(getValueFormatted())
 
@@ -152,6 +155,7 @@ export const DatePicker = ({
           <MuiDatePicker
             name={name}
             format="MM/dd/yyyy"
+            timezone={defaultZone}
             disableFuture={disableFuture}
             disabled={disabled}
             disablePast={disablePast}

--- a/src/components/form/DatePicker/__tests__/DatePicker.integration.test.tsx
+++ b/src/components/form/DatePicker/__tests__/DatePicker.integration.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DateTime, Settings } from 'luxon'
+import { useState } from 'react'
+
+import { DatePicker } from '../DatePicker'
+
+jest.mock('~/hooks/core/useInternationalization', () => ({
+  useInternationalization: () => ({ translate: (key: string) => key }),
+}))
+
+jest.mock('~/hooks/useOrganizationInfos', () => ({
+  useOrganizationInfos: () => ({ organization: { id: 'org-1', timezone: 'TZ_UTC' } }),
+}))
+
+const ControlledPicker = ({
+  initialValue,
+  onPublish,
+}: {
+  initialValue: string
+  onPublish: (value?: string | null) => void
+}) => {
+  const [value, setValue] = useState(initialValue)
+
+  return (
+    <DatePicker
+      name="date"
+      defaultZone="UTC"
+      value={value}
+      onChange={(next) => {
+        onPublish(next)
+        setValue(next ?? '')
+      }}
+    />
+  )
+}
+
+const openCalendarAndPickDay = async (day: string): Promise<void> => {
+  const user = userEvent.setup()
+
+  const openButton = document.querySelector('.open-picker-tooltip button') as HTMLElement
+
+  await user.click(openButton)
+  await user.click(await screen.findByRole('gridcell', { name: day }))
+}
+
+describe('DatePicker integration', () => {
+  const originalDefaultZone = Settings.defaultZone
+
+  afterEach(() => {
+    Settings.defaultZone = originalDefaultZone
+  })
+
+  // Regression: the picker only switched to `defaultZone` from an effect, so the
+  // calendar was built in the ambient zone and carried its local time-of-day onto
+  // the clicked day, publishing the previous UTC day (one-off invoice billing period).
+  describe.each([
+    ['ahead of UTC', 'Europe/Paris', '2026-09-09T22:00:00.000Z'],
+    ['behind UTC', 'America/New_York', '2026-09-10T00:00:00.000Z'],
+  ])('GIVEN an ambient zone %s and a value whose local day differs', (_, zone, initialValue) => {
+    describe('WHEN a day is picked in the calendar', () => {
+      it('THEN should publish that calendar day in the declared zone', async () => {
+        const onPublish = jest.fn()
+
+        Settings.defaultZone = zone
+
+        render(<ControlledPicker initialValue={initialValue} onPublish={onPublish} />)
+        await openCalendarAndPickDay('17')
+
+        const published = onPublish.mock.calls[0][0] as string
+
+        expect(DateTime.fromISO(published, { zone: 'UTC' }).toISODate()).toBe('2026-09-17')
+      })
+    })
+  })
+})

--- a/src/components/invoices/EditFeeBillingPeriod.tsx
+++ b/src/components/invoices/EditFeeBillingPeriod.tsx
@@ -15,6 +15,8 @@ import { useAppForm } from '~/hooks/forms/useAppform'
 
 export const EDIT_FEE_BILLING_PERIOD_FORM_ID = 'edit-fee-billing-period-form'
 
+const BILLING_PERIOD_ZONE = getTimezoneConfig(TimezoneEnum.TzUtc).name
+
 type OpenEditFeeBillingPeriodDialogParams = {
   fromDatetime: string
   toDatetime: string
@@ -89,12 +91,15 @@ export const useEditFeeBillingPeriodDialog = () => {
                 <DatePicker
                   name="fromDatetime"
                   label={translate('text_1754596347194ycmhkuol77d')}
-                  defaultZone={getTimezoneConfig(TimezoneEnum.TzUtc).name}
+                  defaultZone={BILLING_PERIOD_ZONE}
                   value={field.state.value}
                   onChange={(value) => {
-                    // value should be start of day
                     field.handleChange(
-                      value ? DateTime.fromISO(value).startOf('day').toISO() || '' : '',
+                      value
+                        ? DateTime.fromISO(value, { zone: BILLING_PERIOD_ZONE })
+                            .startOf('day')
+                            .toISO() || ''
+                        : '',
                     )
                   }}
                 />
@@ -105,7 +110,7 @@ export const useEditFeeBillingPeriodDialog = () => {
                 <DatePicker
                   name="toDatetime"
                   label={translate('text_1754596347194hgyj8fzogqm')}
-                  defaultZone={getTimezoneConfig(TimezoneEnum.TzUtc).name}
+                  defaultZone={BILLING_PERIOD_ZONE}
                   value={field.state.value}
                   error={
                     field.state.meta.errors?.[0]?.message ===
@@ -115,7 +120,11 @@ export const useEditFeeBillingPeriodDialog = () => {
                   }
                   onChange={(value) => {
                     field.handleChange(
-                      value ? DateTime.fromISO(value).endOf('day').toISO() || '' : '',
+                      value
+                        ? DateTime.fromISO(value, { zone: BILLING_PERIOD_ZONE })
+                            .endOf('day')
+                            .toISO() || ''
+                        : '',
                     )
                   }}
                 />

--- a/src/components/invoices/__tests__/EditFeeBillingPeriod.test.tsx
+++ b/src/components/invoices/__tests__/EditFeeBillingPeriod.test.tsx
@@ -25,16 +25,21 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 
 const FROM_DATETIME = '2024-01-01T00:00:00.000Z'
 const TO_DATETIME = '2024-01-31T23:59:59.999Z'
-const PARIS_MIDNIGHT_FROM_DATETIME = '2026-09-09T22:00:00.000Z'
-const PARIS_END_OF_DAY_TO_DATETIME = '2026-09-30T21:59:59.999Z'
+const UTC_DAY_FROM_DATETIME = '2026-09-10T00:00:00.000Z'
+const UTC_DAY_TO_DATETIME = '2026-09-30T23:59:59.999Z'
 
 describe('useEditFeeBillingPeriodDialog', () => {
   const customWrapper = ({ children }: { children: React.ReactNode }) =>
     AllTheProviders({ children })
+  const originalDefaultZone = Settings.defaultZone
 
   beforeEach(() => {
     jest.clearAllMocks()
     mockFormDialogOpen.mockResolvedValue({ reason: 'close' })
+  })
+
+  afterEach(() => {
+    Settings.defaultZone = originalDefaultZone
   })
 
   describe('GIVEN the hook is initialized', () => {
@@ -245,57 +250,68 @@ describe('useEditFeeBillingPeriodDialog', () => {
     })
   })
 
-  // Regression: the picker built its calendar in the ambient zone, so a period
-  // seeded at local midnight published the previous UTC day on the first click.
-  describe('GIVEN an ambient zone ahead of UTC and a period seeded at local midnight', () => {
+  // Regression: the picker built its calendar in the ambient zone, so an end-of-day UTC
+  // bound opened it on the next day — the next month, on the last day of a month.
+  describe('GIVEN an ambient zone ahead of UTC and a period on the UTC day', () => {
+    const openDialogAndPickDay = async (pickerIndex: number, day: string) => {
+      const user = userEvent.setup()
+      const callback = jest.fn()
+      const dialogConfig: { children?: React.ReactNode; submit?: () => Promise<void> } = {}
+
+      // Never resolves: resolving runs the hook's close branch, which resets the
+      // form and drops the callback before the picker is driven.
+      mockFormDialogOpen.mockImplementation((config) => {
+        dialogConfig.children = config.children
+        dialogConfig.submit = config.form.submit
+
+        return new Promise(() => {})
+      })
+
+      const { result } = renderHook(() => useEditFeeBillingPeriodDialog(), {
+        wrapper: customWrapper,
+      })
+
+      act(() => {
+        result.current.openEditFeeBillingPeriodDialog({
+          fromDatetime: UTC_DAY_FROM_DATETIME,
+          toDatetime: UTC_DAY_TO_DATETIME,
+          callback,
+        })
+      })
+
+      render(<>{dialogConfig.children}</>, { wrapper: customWrapper })
+
+      const openCalendar = document.querySelectorAll('.open-picker-tooltip button')[
+        pickerIndex
+      ] as HTMLButtonElement
+
+      await user.click(openCalendar)
+      await user.click(await screen.findByRole('gridcell', { name: day }))
+
+      await act(async () => {
+        await dialogConfig.submit?.()
+      })
+
+      return callback
+    }
+
     describe('WHEN a start day is picked in the calendar', () => {
       it('THEN should record that calendar day as the UTC start of day', async () => {
-        const originalDefaultZone = Settings.defaultZone
-        const user = userEvent.setup()
-        const callback = jest.fn()
-
         Settings.defaultZone = 'Europe/Paris'
 
-        const dialogConfig: { children?: React.ReactNode; submit?: () => Promise<void> } = {}
+        const callback = await openDialogAndPickDay(0, '17')
 
-        // Never resolves: resolving runs the hook's close branch, which resets the
-        // form and drops the callback before the picker is driven.
-        mockFormDialogOpen.mockImplementation((config) => {
-          dialogConfig.children = config.children
-          dialogConfig.submit = config.form.submit
+        expect(callback).toHaveBeenCalledWith('2026-09-17T00:00:00.000Z', UTC_DAY_TO_DATETIME)
+      })
+    })
 
-          return new Promise(() => {})
-        })
+    describe('WHEN an end day is picked in the calendar', () => {
+      it('THEN should record that calendar day as the UTC end of day', async () => {
+        Settings.defaultZone = 'Europe/Paris'
 
-        const { result } = renderHook(() => useEditFeeBillingPeriodDialog(), {
-          wrapper: customWrapper,
-        })
+        const callback = await openDialogAndPickDay(1, '17')
 
-        act(() => {
-          result.current.openEditFeeBillingPeriodDialog({
-            fromDatetime: PARIS_MIDNIGHT_FROM_DATETIME,
-            toDatetime: PARIS_END_OF_DAY_TO_DATETIME,
-            callback,
-          })
-        })
-
-        render(<>{dialogConfig.children}</>, { wrapper: customWrapper })
-
-        const openFromCalendar = document.querySelectorAll('.open-picker-tooltip button')[0]
-
-        await user.click(openFromCalendar)
-        await user.click(await screen.findByRole('gridcell', { name: '17' }))
-
-        await act(async () => {
-          await dialogConfig.submit?.()
-        })
-
-        Settings.defaultZone = originalDefaultZone
-
-        expect(callback).toHaveBeenCalledWith(
-          '2026-09-17T00:00:00.000Z',
-          PARIS_END_OF_DAY_TO_DATETIME,
-        )
+        expect(callback).toHaveBeenCalledWith(UTC_DAY_FROM_DATETIME, '2026-09-17T23:59:59.999Z')
       })
     })
   })

--- a/src/components/invoices/__tests__/EditFeeBillingPeriod.test.tsx
+++ b/src/components/invoices/__tests__/EditFeeBillingPeriod.test.tsx
@@ -1,4 +1,6 @@
-import { act, renderHook } from '@testing-library/react'
+import { act, render, renderHook, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Settings } from 'luxon'
 
 import { AllTheProviders } from '~/test-utils'
 
@@ -23,6 +25,8 @@ jest.mock('~/hooks/core/useInternationalization', () => ({
 
 const FROM_DATETIME = '2024-01-01T00:00:00.000Z'
 const TO_DATETIME = '2024-01-31T23:59:59.999Z'
+const PARIS_MIDNIGHT_FROM_DATETIME = '2026-09-09T22:00:00.000Z'
+const PARIS_END_OF_DAY_TO_DATETIME = '2026-09-30T21:59:59.999Z'
 
 describe('useEditFeeBillingPeriodDialog', () => {
   const customWrapper = ({ children }: { children: React.ReactNode }) =>
@@ -237,6 +241,61 @@ describe('useEditFeeBillingPeriodDialog', () => {
 
         expect(callback).not.toHaveBeenCalled()
         expect(didSubmitSucceed).toBe(false)
+      })
+    })
+  })
+
+  // Regression: the picker built its calendar in the ambient zone, so a period
+  // seeded at local midnight published the previous UTC day on the first click.
+  describe('GIVEN an ambient zone ahead of UTC and a period seeded at local midnight', () => {
+    describe('WHEN a start day is picked in the calendar', () => {
+      it('THEN should record that calendar day as the UTC start of day', async () => {
+        const originalDefaultZone = Settings.defaultZone
+        const user = userEvent.setup()
+        const callback = jest.fn()
+
+        Settings.defaultZone = 'Europe/Paris'
+
+        const dialogConfig: { children?: React.ReactNode; submit?: () => Promise<void> } = {}
+
+        // Never resolves: resolving runs the hook's close branch, which resets the
+        // form and drops the callback before the picker is driven.
+        mockFormDialogOpen.mockImplementation((config) => {
+          dialogConfig.children = config.children
+          dialogConfig.submit = config.form.submit
+
+          return new Promise(() => {})
+        })
+
+        const { result } = renderHook(() => useEditFeeBillingPeriodDialog(), {
+          wrapper: customWrapper,
+        })
+
+        act(() => {
+          result.current.openEditFeeBillingPeriodDialog({
+            fromDatetime: PARIS_MIDNIGHT_FROM_DATETIME,
+            toDatetime: PARIS_END_OF_DAY_TO_DATETIME,
+            callback,
+          })
+        })
+
+        render(<>{dialogConfig.children}</>, { wrapper: customWrapper })
+
+        const openFromCalendar = document.querySelectorAll('.open-picker-tooltip button')[0]
+
+        await user.click(openFromCalendar)
+        await user.click(await screen.findByRole('gridcell', { name: '17' }))
+
+        await act(async () => {
+          await dialogConfig.submit?.()
+        })
+
+        Settings.defaultZone = originalDefaultZone
+
+        expect(callback).toHaveBeenCalledWith(
+          '2026-09-17T00:00:00.000Z',
+          PARIS_END_OF_DAY_TO_DATETIME,
+        )
       })
     })
   })

--- a/src/pages/createInvoice/components/FeesSection.tsx
+++ b/src/pages/createInvoice/components/FeesSection.tsx
@@ -430,8 +430,6 @@ export const FeesSection = withForm({
                       placeholder={translate('text_6453819268763979024ad0ad')}
                       onChange={(value) => {
                         const addOn = addOnData?.addOns?.collection.find((c) => c.id === value)
-                        // The row and the billing-period picker both render this period in UTC,
-                        // so an org-zone midnight would seed it on the previous displayed day.
                         const today = DateTime.utc()
                         const addonApplicableTaxes = () => {
                           if (hasTaxProvider) return undefined

--- a/src/pages/createInvoice/components/FeesSection.tsx
+++ b/src/pages/createInvoice/components/FeesSection.tsx
@@ -430,7 +430,9 @@ export const FeesSection = withForm({
                       placeholder={translate('text_6453819268763979024ad0ad')}
                       onChange={(value) => {
                         const addOn = addOnData?.addOns?.collection.find((c) => c.id === value)
-                        const today = DateTime.now()
+                        // The row and the billing-period picker both render this period in UTC,
+                        // so an org-zone midnight would seed it on the previous displayed day.
+                        const today = DateTime.utc()
                         const addonApplicableTaxes = () => {
                           if (hasTaxProvider) return undefined
                           if (!!addOn?.taxes?.length) return addOn?.taxes

--- a/src/pages/createInvoice/components/__tests__/FeesSection.test.tsx
+++ b/src/pages/createInvoice/components/__tests__/FeesSection.test.tsx
@@ -205,6 +205,14 @@ const findMenuButtonByIcon = (iconTestId: string) => {
 }
 
 describe('FeesSection', () => {
+  const originalDefaultZone = Settings.defaultZone
+  const originalNow = Settings.now
+
+  afterEach(() => {
+    Settings.defaultZone = originalDefaultZone
+    Settings.now = originalNow
+  })
+
   beforeAll(() => {
     // jsdom does not implement scrollIntoView
     Element.prototype.scrollIntoView = jest.fn()
@@ -281,11 +289,8 @@ describe('FeesSection', () => {
       // billing-period picker render it in UTC, so an org ahead of UTC seeded the
       // previous displayed day.
       it('THEN should seed the billing period on the UTC day', async () => {
-        const originalDefaultZone = Settings.defaultZone
-        const originalNow = Settings.now
         const user = userEvent.setup()
 
-        // 00:30 in Paris, still the previous day in UTC
         Settings.defaultZone = 'Europe/Paris'
         Settings.now = () => Date.UTC(2026, 8, 9, 22, 30)
 
@@ -299,9 +304,6 @@ describe('FeesSection', () => {
         })
 
         const addedFee = lastForm?.state.values.fees[0]
-
-        Settings.defaultZone = originalDefaultZone
-        Settings.now = originalNow
 
         expect(addedFee).toEqual(
           expect.objectContaining({

--- a/src/pages/createInvoice/components/__tests__/FeesSection.test.tsx
+++ b/src/pages/createInvoice/components/__tests__/FeesSection.test.tsx
@@ -1,6 +1,7 @@
 import { revalidateLogic } from '@tanstack/react-form'
 import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { Settings } from 'luxon'
 
 import { InvoiceFormInput, LocalFeeInput } from '~/components/invoices/types'
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
@@ -274,6 +275,40 @@ describe('FeesSection', () => {
           }),
         )
         expect(container.querySelector('.MuiAutocomplete-root')).toBeNull()
+      })
+
+      // Regression: the period was seeded from the ambient zone while the row and the
+      // billing-period picker render it in UTC, so an org ahead of UTC seeded the
+      // previous displayed day.
+      it('THEN should seed the billing period on the UTC day', async () => {
+        const originalDefaultZone = Settings.defaultZone
+        const originalNow = Settings.now
+        const user = userEvent.setup()
+
+        // 00:30 in Paris, still the previous day in UTC
+        Settings.defaultZone = 'Europe/Paris'
+        Settings.now = () => Date.UTC(2026, 8, 9, 22, 30)
+
+        render(<TestWrapper />, { mocks: addOnsMocks })
+
+        await user.click(screen.getByTestId(FEES_SECTION_ADD_ITEM_BUTTON_TEST_ID))
+        await user.click((await screen.findAllByRole('option'))[0])
+
+        await waitFor(() => {
+          expect(screen.getAllByTestId(FEES_SECTION_ITEM_TEST_ID)).toHaveLength(1)
+        })
+
+        const addedFee = lastForm?.state.values.fees[0]
+
+        Settings.defaultZone = originalDefaultZone
+        Settings.now = originalNow
+
+        expect(addedFee).toEqual(
+          expect.objectContaining({
+            fromDatetime: '2026-09-09T00:00:00.000Z',
+            toDatetime: '2026-09-09T23:59:59.999Z',
+          }),
+        )
       })
 
       it('THEN should clear the at-least-one-item error', async () => {


### PR DESCRIPTION
## Context

On the one-off invoice billing period, picking a start date recorded the day before the one clicked (click 17 Sep, get 16 Sep), for a user in a timezone ahead of UTC. The end date was unaffected, and a second click on the same day corrected it.

## Description

`DatePicker` declares a `defaultZone` but only applied it by mutating the global `Settings.defaultZone` from an effect, so its first render parsed the value in the ambient zone and MUI froze its calendar on that zone. Clicking a day then carried the local time-of-day onto it, and publishing `.toUTC()` landed one UTC day off (one day back in zones ahead of UTC, one day forward in zones behind it). The value is now parsed in `defaultZone` and the zone is pinned on the MUI picker, which only changes behaviour for the consumers that already pass `defaultZone`. On top of that, `FeesSection` seeded the fee period from the ambient zone while the row and the picker both render it in UTC, and `EditFeeBillingPeriod` normalised the day bounds against the ambient zone; both are now explicit. Covered by three regression tests that each fail on `main`.

<!-- Linear link -->
Fixes BIL-677