### PR TITLE
test(plans): fix usePlanForm router mock

### DIFF
--- a/src/hooks/plans/__tests__/usePlanForm.test.ts
+++ b/src/hooks/plans/__tests__/usePlanForm.test.ts
@@ -36,8 +36,8 @@ jest.mock('~/core/router', () => ({
   useNavigate: () => jest.fn(),
 }))
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({ planId: 'plan-1' }),
   useSearchParams: () => [new URLSearchParams(), jest.fn()],
 }))


### PR DESCRIPTION
`usePlanForm` now imports `useParams` / `useSearchParams` from `react-router` (since #4293), so the test's `react-router-dom` mock no longer intercepted them. The real `useSearchParams` ran outside a Router provider and every test in the file threw `(0, _reactRouter.useSearchParams) is not a function`.

Mock target moved to `react-router`. 3/3 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)