### PR TITLE
refactor(catalog): rename product type usage to metered

### DIFF
--- a/src/components/Filters/graphql/filtersElements/FiltersItemProductType.tsx
+++ b/src/components/Filters/graphql/filtersElements/FiltersItemProductType.tsx
@@ -14,7 +14,7 @@ const productTypeMapping = (productType: ProductTypeEnum): string => {
   switch (productType) {
     case ProductTypeEnum.Fixed:
       return 'text_1783980718113ritmy7z94je'
-    case ProductTypeEnum.Usage:
+    case ProductTypeEnum.Metered:
       return 'text_17839807181133l3z83156s6'
     default:
       return ''

--- a/src/components/Filters/graphql/filtersElements/__tests__/FiltersItemProductType.test.tsx
+++ b/src/components/Filters/graphql/filtersElements/__tests__/FiltersItemProductType.test.tsx
@@ -32,7 +32,7 @@ describe('FiltersItemProductType', () => {
   describe('GIVEN a selected value', () => {
     it.each([
       ['fixed', ProductTypeEnum.Fixed, 'Fixed'],
-      ['usage', ProductTypeEnum.Usage, 'Usage'],
+      ['usage', ProductTypeEnum.Metered, 'Usage'],
     ])('THEN displays the %s type label in the input', async (_, value, label) => {
       renderComponent(value)
 

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -8242,7 +8242,7 @@ export type ProductFilterValueInput = {
 
 export enum ProductTypeEnum {
   Fixed = 'fixed',
-  Usage = 'usage'
+  Metered = 'metered'
 }
 
 export type ProjectedChargeFilterUsage = {

--- a/src/pages/catalog/__tests__/fixtures.ts
+++ b/src/pages/catalog/__tests__/fixtures.ts
@@ -46,7 +46,7 @@ export const buildRateCardForRateDrawer = (
   product: {
     __typename: 'Product',
     id: 'product-1',
-    productType: ProductTypeEnum.Usage,
+    productType: ProductTypeEnum.Metered,
     billableMetric: {
       __typename: 'BillableMetric',
       id: 'bm-1',

--- a/src/pages/catalog/__tests__/useProductTableColumns.test.tsx
+++ b/src/pages/catalog/__tests__/useProductTableColumns.test.tsx
@@ -157,12 +157,12 @@ describe('useProductTableColumns', () => {
             {getColumnContent(
               columns,
               'productType',
-            )(buildProduct({ productType: ProductTypeEnum.Usage }))}
+            )(buildProduct({ productType: ProductTypeEnum.Metered }))}
           </>,
         )
 
         expect(
-          screen.getByText(PRODUCT_ITEM_TYPE_TRANSLATION_KEY[ProductTypeEnum.Usage]),
+          screen.getByText(PRODUCT_ITEM_TYPE_TRANSLATION_KEY[ProductTypeEnum.Metered]),
         ).toBeInTheDocument()
       })
     })

--- a/src/pages/catalog/details/ProductDetailsOverview.tsx
+++ b/src/pages/catalog/details/ProductDetailsOverview.tsx
@@ -29,7 +29,7 @@ export const PRODUCT_ITEM_OVERVIEW_EDIT_TEST_ID = 'product-item-overview-edit'
 
 const ITEM_TYPE_TRANSLATION_KEY: Record<ProductTypeEnum, string> = {
   [ProductTypeEnum.Fixed]: 'text_1783980718113ritmy7z94je',
-  [ProductTypeEnum.Usage]: 'text_17839807181133l3z83156s6',
+  [ProductTypeEnum.Metered]: 'text_17839807181133l3z83156s6',
 }
 
 gql`
@@ -151,7 +151,7 @@ export const ProductDetailsOverview = () => {
         <DetailsPage.InfoGrid
           grid={[
             { label: translate('text_1783980718113na6t9imp2k0'), value: productType },
-            product?.productType === ProductTypeEnum.Usage && {
+            product?.productType === ProductTypeEnum.Metered && {
               label: translate('text_178398071811327xropcsqmr'),
               value: attachedBillableMetric,
             },

--- a/src/pages/catalog/details/__tests__/ProductCategoryDetailsProducts.test.tsx
+++ b/src/pages/catalog/details/__tests__/ProductCategoryDetailsProducts.test.tsx
@@ -72,7 +72,7 @@ const productCategory = { id: 'prod-1', name: 'Object storage', code: 'object_st
 
 const collection = [
   { id: 'pitem-1', name: 'Seats', code: 'seats', productType: ProductTypeEnum.Fixed },
-  { id: 'pitem-2', name: 'Compute', code: 'compute', productType: ProductTypeEnum.Usage },
+  { id: 'pitem-2', name: 'Compute', code: 'compute', productType: ProductTypeEnum.Metered },
 ]
 
 const emptyQueryState = {

--- a/src/pages/catalog/details/__tests__/ProductDetailsOverview.test.tsx
+++ b/src/pages/catalog/details/__tests__/ProductDetailsOverview.test.tsx
@@ -65,7 +65,7 @@ const usageProduct: ProductForDetailsOverviewFragment = {
   ...fixedProduct,
   description: null,
   invoiceDisplayName: null,
-  productType: ProductTypeEnum.Usage,
+  productType: ProductTypeEnum.Metered,
   productCategory: null,
   billableMetric: {
     __typename: 'BillableMetric',

--- a/src/pages/catalog/details/__tests__/RateCardDetails.test.tsx
+++ b/src/pages/catalog/details/__tests__/RateCardDetails.test.tsx
@@ -81,7 +81,7 @@ const rateCardFixture = {
     id: 'pitem-1',
     name: 'Seats',
     code: 'seats',
-    productType: 'usage',
+    productType: 'metered',
     billableMetric: {
       __typename: 'BillableMetric',
       id: 'bm-1',

--- a/src/pages/catalog/details/__tests__/RateCardDetailsOverview.test.tsx
+++ b/src/pages/catalog/details/__tests__/RateCardDetailsOverview.test.tsx
@@ -69,7 +69,7 @@ const attachedRateCard: RateCardForDetailsOverviewFragment = {
       name: 'Compute',
       invoiceDisplayName: null,
     },
-    productType: 'usage',
+    productType: 'metered',
     billableMetric: {
       __typename: 'BillableMetric',
       id: 'bm-1',

--- a/src/pages/catalog/details/__tests__/RateCardRateDetails.test.tsx
+++ b/src/pages/catalog/details/__tests__/RateCardRateDetails.test.tsx
@@ -102,7 +102,7 @@ const rateCardFixture = {
     __typename: 'Product',
     id: 'product-1',
     name: 'API calls',
-    productType: 'usage',
+    productType: 'metered',
     productCategory: { __typename: 'ProductCategory', id: 'pcategory-1', name: 'Platform' },
     billableMetric: {
       __typename: 'BillableMetric',

--- a/src/pages/catalog/drawers/product/ProductDrawerContent.tsx
+++ b/src/pages/catalog/drawers/product/ProductDrawerContent.tsx
@@ -133,7 +133,7 @@ const ProductDrawerFormSections = withForm({
     const productTypeData = useMemo(
       () => [
         { value: ProductTypeEnum.Fixed, label: translate('text_1783980718113ritmy7z94je') },
-        { value: ProductTypeEnum.Usage, label: translate('text_17839807181133l3z83156s6') },
+        { value: ProductTypeEnum.Metered, label: translate('text_17839807181133l3z83156s6') },
       ],
       [translate],
     )
@@ -246,7 +246,7 @@ const ProductDrawerFormSections = withForm({
               )}
             </form.AppField>
 
-            {productType === ProductTypeEnum.Usage && (
+            {productType === ProductTypeEnum.Metered && (
               <form.AppField name="billableMetricId">
                 {(field) => (
                   <field.ComboBoxField

--- a/src/pages/catalog/drawers/product/__tests__/useProductDrawer.test.tsx
+++ b/src/pages/catalog/drawers/product/__tests__/useProductDrawer.test.tsx
@@ -78,7 +78,7 @@ const productFixture: ProductForDrawerFragment = {
 
 const usageProductFixture: ProductForDrawerFragment = {
   ...productFixture,
-  productType: ProductTypeEnum.Usage,
+  productType: ProductTypeEnum.Metered,
   billableMetric: { id: 'bm-1', name: 'API calls', code: 'api_calls' },
 }
 

--- a/src/pages/catalog/drawers/product/useProductDrawer.tsx
+++ b/src/pages/catalog/drawers/product/useProductDrawer.tsx
@@ -80,7 +80,7 @@ const productDrawerSchema = z
   .superRefine((values, ctx) => {
     // A usage item bills against a billable metric; the API leaves it optional
     // so the requirement is enforced here.
-    if (values.productType === ProductTypeEnum.Usage && !values.billableMetricId) {
+    if (values.productType === ProductTypeEnum.Metered && !values.billableMetricId) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['billableMetricId'],
@@ -159,7 +159,7 @@ const useProductForm = ({ onSuccess }: { onSuccess: (result: ProductFormSuccess)
               productType: value.productType as ProductTypeEnum,
               productCategoryId: value.productCategoryId || undefined,
               billableMetricId:
-                value.productType === ProductTypeEnum.Usage
+                value.productType === ProductTypeEnum.Metered
                   ? value.billableMetricId || undefined
                   : undefined,
               description: value.description || undefined,

--- a/src/pages/catalog/drawers/rateCard/__tests__/RateCardDrawerContent.test.tsx
+++ b/src/pages/catalog/drawers/rateCard/__tests__/RateCardDrawerContent.test.tsx
@@ -76,7 +76,7 @@ const mocksWithPricingUnits = buildMocks([{ id: 'pu-1', name: 'Credits', code: '
 const buildUsageSeed = (aggregationType: AggregationTypeEnum): RateCardProductSeed => ({
   value: PRODUCT_ID,
   label: 'Metered API',
-  productType: ProductTypeEnum.Usage,
+  productType: ProductTypeEnum.Metered,
   aggregationType,
   recurring: false,
 })

--- a/src/pages/catalog/drawers/rateCard/__tests__/useRateCardDrawer.create.test.tsx
+++ b/src/pages/catalog/drawers/rateCard/__tests__/useRateCardDrawer.create.test.tsx
@@ -131,7 +131,7 @@ const rateCardResult = {
     id: 'pi-1',
     name: 'Metered API',
     code: 'metered_api',
-    productType: ProductTypeEnum.Usage,
+    productType: ProductTypeEnum.Metered,
     billableMetric: {
       id: 'bm-1',
       name: 'API calls',

--- a/src/pages/catalog/drawers/rateCard/__tests__/useRateCardDrawer.test.tsx
+++ b/src/pages/catalog/drawers/rateCard/__tests__/useRateCardDrawer.test.tsx
@@ -103,7 +103,7 @@ const rateCardFixture: RateCardForDrawerFragment = {
     id: 'pi-1',
     name: 'Metered API',
     code: 'metered_api',
-    productType: ProductTypeEnum.Usage,
+    productType: ProductTypeEnum.Metered,
     billableMetric: {
       id: 'bm-1',
       name: 'API calls',

--- a/src/pages/catalog/drawers/rateCardRate/__tests__/RateCardRateDrawerContent.test.tsx
+++ b/src/pages/catalog/drawers/rateCardRate/__tests__/RateCardRateDrawerContent.test.tsx
@@ -114,7 +114,7 @@ const arrearsUsageCard: RateCardRateDrawerRateCard = {
   currency: CurrencyEnum.Usd,
   appliedPricingUnitCode: null,
   billingTiming: RateCardBillingTimingEnum.Arrears,
-  productType: ProductTypeEnum.Usage,
+  productType: ProductTypeEnum.Metered,
   aggregationType: AggregationTypeEnum.SumAgg,
 }
 

--- a/src/pages/catalog/drawers/rateCardRate/__tests__/useRateCardRateDrawer.test.tsx
+++ b/src/pages/catalog/drawers/rateCardRate/__tests__/useRateCardRateDrawer.test.tsx
@@ -462,7 +462,7 @@ describe('useRateCardRateDrawer edit flow', () => {
           currency: CurrencyEnum.Usd,
           appliedPricingUnitCode: null,
           billingTiming: RateCardBillingTimingEnum.Arrears,
-          productType: ProductTypeEnum.Usage,
+          productType: ProductTypeEnum.Metered,
           aggregationType: 'sum_agg',
         })
       })

--- a/src/pages/catalog/useProductTableColumns.tsx
+++ b/src/pages/catalog/useProductTableColumns.tsx
@@ -8,7 +8,7 @@ import { useOrganizationInfos } from '~/hooks/useOrganizationInfos'
 
 export const PRODUCT_ITEM_TYPE_TRANSLATION_KEY: Record<ProductTypeEnum, string> = {
   [ProductTypeEnum.Fixed]: 'text_1783980718113ritmy7z94je',
-  [ProductTypeEnum.Usage]: 'text_17839807181133l3z83156s6',
+  [ProductTypeEnum.Metered]: 'text_17839807181133l3z83156s6',
 }
 
 // Shared between the full product-items list and the product-details preview:


### PR DESCRIPTION
## Context

The `product_type` enum value `usage` was renamed to `metered` on the API ([LAGO-1812](https://linear.app/getlago/issue/LAGO-1812) — getlago/lago-api#6381). GraphQL codegen now emits `ProductTypeEnum.Metered` instead of `ProductTypeEnum.Usage`, breaking `tsc`.

## Description

Rename `ProductTypeEnum.Usage` → `ProductTypeEnum.Metered` everywhere: the regenerated enum in `generated/graphql.tsx`, the `Record<ProductTypeEnum, string>` translation-key maps, the product/rate-card drawers and filter, and the test fixtures. `Fixed` is unchanged.

The generated enum was edited surgically (single member) rather than via a full codegen run, to avoid sweeping in unrelated backend schema drift.

